### PR TITLE
[MergeRollupTask] include partition info into segment name

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -105,6 +105,7 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
   private static final int DEFAULT_MAX_NUM_RECORDS_PER_TASK = 50_000_000;
   private static final int DEFAULT_NUM_PARALLEL_BUCKETS = 1;
   private static final String REFRESH = "REFRESH";
+  private static final String DELIMITER_IN_SEGMENT_NAME = "_";
 
   // This is the metric that keeps track of the task delay in the number of time buckets. For example, if we see this
   // number to be 7 and merge task is configured with "bucketTimePeriod = 1d", this means that we have 7 days of
@@ -349,7 +350,7 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
           for (List<SegmentZKMetadata> selectedSegmentsPerBucket : selectedSegmentsForAllBuckets) {
             pinotTaskConfigsForTable.addAll(
                 createPinotTaskConfigs(selectedSegmentsPerBucket, offlineTableName, maxNumRecordsPerTask, mergeLevel,
-                    mergeConfigs, taskConfigs));
+                    null, mergeConfigs, taskConfigs));
           }
         } else {
           // For partitioned table, schedule separate tasks for each partitionId (partitionId is constructed from
@@ -383,16 +384,18 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
               }
             }
 
-            for (List<SegmentZKMetadata> partitionedSegments : partitionToSegments.values()) {
+            for (Map.Entry<List<Integer>, List<SegmentZKMetadata>> entry : partitionToSegments.entrySet()) {
+              List<Integer> partition = entry.getKey();
+              List<SegmentZKMetadata> partitionedSegments = entry.getValue();
               pinotTaskConfigsForTable.addAll(
                   createPinotTaskConfigs(partitionedSegments, offlineTableName, maxNumRecordsPerTask, mergeLevel,
-                      mergeConfigs, taskConfigs));
+                      partition, mergeConfigs, taskConfigs));
             }
 
             if (!outlierSegments.isEmpty()) {
               pinotTaskConfigsForTable.addAll(
                   createPinotTaskConfigs(outlierSegments, offlineTableName, maxNumRecordsPerTask, mergeLevel,
-                      mergeConfigs, taskConfigs));
+                      null, mergeConfigs, taskConfigs));
             }
           }
         }
@@ -516,8 +519,8 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
    * Create pinot task configs with selected segments and configs
    */
   private List<PinotTaskConfig> createPinotTaskConfigs(List<SegmentZKMetadata> selectedSegments,
-      String offlineTableName, int maxNumRecordsPerTask, String mergeLevel, Map<String, String> mergeConfigs,
-      Map<String, String> taskConfigs) {
+      String offlineTableName, int maxNumRecordsPerTask, String mergeLevel, List<Integer> partition,
+      Map<String, String> mergeConfigs, Map<String, String> taskConfigs) {
     int numRecordsPerTask = 0;
     List<List<String>> segmentNamesList = new ArrayList<>();
     List<List<String>> downloadURLsList = new ArrayList<>();
@@ -539,6 +542,13 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
     }
 
     List<PinotTaskConfig> pinotTaskConfigs = new ArrayList<>();
+    StringBuilder partitionSuffixBuilder = new StringBuilder();
+    if (partition != null && !partition.isEmpty()) {
+      for (int columnPartition : partition) {
+        partitionSuffixBuilder.append(DELIMITER_IN_SEGMENT_NAME).append(columnPartition);
+      }
+    }
+    String partitionSuffix = partitionSuffixBuilder.toString();
     for (int i = 0; i < segmentNamesList.size(); i++) {
       Map<String, String> configs = new HashMap<>();
       configs.put(MinionConstants.TABLE_NAME_KEY, offlineTableName);
@@ -563,7 +573,8 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
           mergeConfigs.get(MergeTask.MAX_NUM_RECORDS_PER_SEGMENT_KEY));
 
       configs.put(MergeRollupTask.SEGMENT_NAME_PREFIX_KEY,
-          MergeRollupTask.MERGED_SEGMENT_NAME_PREFIX + mergeLevel + "_" + System.currentTimeMillis() + "_" + i + "_"
+          MergeRollupTask.MERGED_SEGMENT_NAME_PREFIX + mergeLevel + DELIMITER_IN_SEGMENT_NAME
+              + System.currentTimeMillis() + partitionSuffix + DELIMITER_IN_SEGMENT_NAME + i + DELIMITER_IN_SEGMENT_NAME
               + TableNameBuilder.extractRawTableName(offlineTableName));
       pinotTaskConfigs.add(new PinotTaskConfig(MergeRollupTask.TASK_TYPE, configs));
     }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -106,7 +106,6 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
   private static final int DEFAULT_NUM_PARALLEL_BUCKETS = 1;
   private static final String REFRESH = "REFRESH";
   private static final String DELIMITER_IN_SEGMENT_NAME = "_";
-  private static final int MAX_INVALID_PARTITION_SEQ = -1;
 
   // This is the metric that keeps track of the task delay in the number of time buckets. For example, if we see this
   // number to be 7 and merge task is configured with "bucketTimePeriod = 1d", this means that we have 7 days of
@@ -351,7 +350,7 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
           for (List<SegmentZKMetadata> selectedSegmentsPerBucket : selectedSegmentsForAllBuckets) {
             pinotTaskConfigsForTable.addAll(
                 createPinotTaskConfigs(selectedSegmentsPerBucket, offlineTableName, maxNumRecordsPerTask, mergeLevel,
-                    MAX_INVALID_PARTITION_SEQ, mergeConfigs, taskConfigs));
+                    null, mergeConfigs, taskConfigs));
           }
         } else {
           // For partitioned table, schedule separate tasks for each partitionId (partitionId is constructed from
@@ -385,18 +384,18 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
               }
             }
 
-            int partitionSeq = 0;
-            for (List<SegmentZKMetadata> partitionedSegments : partitionToSegments.values()) {
+            for (Map.Entry<List<Integer>, List<SegmentZKMetadata>> entry : partitionToSegments.entrySet()) {
+              List<Integer> partition = entry.getKey();
+              List<SegmentZKMetadata> partitionedSegments = entry.getValue();
               pinotTaskConfigsForTable.addAll(
                   createPinotTaskConfigs(partitionedSegments, offlineTableName, maxNumRecordsPerTask, mergeLevel,
-                      partitionSeq, mergeConfigs, taskConfigs));
-              partitionSeq++;
+                      partition, mergeConfigs, taskConfigs));
             }
 
             if (!outlierSegments.isEmpty()) {
               pinotTaskConfigsForTable.addAll(
                   createPinotTaskConfigs(outlierSegments, offlineTableName, maxNumRecordsPerTask, mergeLevel,
-                      MAX_INVALID_PARTITION_SEQ, mergeConfigs, taskConfigs));
+                      null, mergeConfigs, taskConfigs));
             }
           }
         }
@@ -520,7 +519,7 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
    * Create pinot task configs with selected segments and configs
    */
   private List<PinotTaskConfig> createPinotTaskConfigs(List<SegmentZKMetadata> selectedSegments,
-      String offlineTableName, int maxNumRecordsPerTask, String mergeLevel, int partitionSeq,
+      String offlineTableName, int maxNumRecordsPerTask, String mergeLevel, List<Integer> partition,
       Map<String, String> mergeConfigs, Map<String, String> taskConfigs) {
     int numRecordsPerTask = 0;
     List<List<String>> segmentNamesList = new ArrayList<>();
@@ -543,10 +542,15 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
     }
 
     List<PinotTaskConfig> pinotTaskConfigs = new ArrayList<>();
-    String partitionSeqSuffix = "";
-    if (partitionSeq > MAX_INVALID_PARTITION_SEQ) {
-      partitionSeqSuffix = DELIMITER_IN_SEGMENT_NAME + partitionSeq;
+
+    StringBuilder partitionSuffixBuilder = new StringBuilder();
+    if (partition != null && !partition.isEmpty()) {
+      for (int columnPartition : partition) {
+        partitionSuffixBuilder.append(DELIMITER_IN_SEGMENT_NAME).append(columnPartition);
+      }
     }
+    String partitionSuffix = partitionSuffixBuilder.toString();
+
     for (int i = 0; i < segmentNamesList.size(); i++) {
       Map<String, String> configs = new HashMap<>();
       configs.put(MinionConstants.TABLE_NAME_KEY, offlineTableName);
@@ -575,7 +579,7 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
       // To prevent such name conflict, we include a partitionSeqSuffix to the segment name.
       configs.put(MergeRollupTask.SEGMENT_NAME_PREFIX_KEY,
           MergeRollupTask.MERGED_SEGMENT_NAME_PREFIX + mergeLevel + DELIMITER_IN_SEGMENT_NAME
-              + System.currentTimeMillis() + partitionSeqSuffix + DELIMITER_IN_SEGMENT_NAME + i
+              + System.currentTimeMillis() + partitionSuffix + DELIMITER_IN_SEGMENT_NAME + i
               + DELIMITER_IN_SEGMENT_NAME + TableNameBuilder.extractRawTableName(offlineTableName));
       pinotTaskConfigs.add(new PinotTaskConfig(MergeRollupTask.TASK_TYPE, configs));
     }


### PR DESCRIPTION
Name conflict happens when the `createPinotTaskConfigs` method is invoked more than once during the same epoch millisecond. 

We include partition info into segment name to prevent name conflict.

See https://apache-pinot.slack.com/archives/C011C9JHN7R/p1666906931122029?thread_ts=1666896766.602909&cid=C011C9JHN7R for the problem and the discussion.
