### PR TITLE
Fix the replication in segment assignment strategy

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/BalancedNumSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/BalancedNumSegmentAssignmentStrategy.java
@@ -26,6 +26,7 @@ import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,7 +51,11 @@ public class BalancedNumSegmentAssignmentStrategy implements SegmentAssignmentSt
     _tableNameWithType = tableConfig.getTableName();
     SegmentsValidationAndRetentionConfig validationAndRetentionConfig = tableConfig.getValidationConfig();
     Preconditions.checkState(validationAndRetentionConfig != null, "Validation Config is null");
-    _replication = validationAndRetentionConfig.getReplicationNumber();
+    // Number of replicas per partition of low-level consumers check is for the real time tables only
+    // TODO: Cleanup required once we fetch the replication number from table config depending on table type
+    _replication = tableConfig.getTableType() == TableType.REALTIME
+        ? validationAndRetentionConfig.getReplicasPerPartitionNumber()
+        : validationAndRetentionConfig.getReplicationNumber();
     LOGGER.info("Initialized BalancedNumSegmentAssignmentStrategy for table: " + "{} with replication: {}",
         _tableNameWithType, _replication);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
@@ -53,7 +53,11 @@ class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentStrategy
     _tableName = tableConfig.getTableName();
     SegmentsValidationAndRetentionConfig validationAndRetentionConfig = tableConfig.getValidationConfig();
     Preconditions.checkState(validationAndRetentionConfig != null, "Validation Config is null");
-    _replication = validationAndRetentionConfig.getReplicationNumber();
+    // Number of replicas per partition of low-level consumers check is for the real time tables only
+    // TODO: Cleanup required once we fetch the replication number from table config depending on table type
+    _replication = tableConfig.getTableType() == TableType.REALTIME
+        ? validationAndRetentionConfig.getReplicasPerPartitionNumber()
+        : validationAndRetentionConfig.getReplicationNumber();
     ReplicaGroupStrategyConfig replicaGroupStrategyConfig =
         validationAndRetentionConfig.getReplicaGroupStrategyConfig();
     _partitionColumn = replicaGroupStrategyConfig != null ? replicaGroupStrategyConfig.getPartitionColumn() : null;

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/SegmentAssignmentStrategyFactoryTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/SegmentAssignmentStrategyFactoryTest.java
@@ -97,9 +97,9 @@ public class SegmentAssignmentStrategyFactoryTest {
   }
 
   @Test
-  public void testBalancedNumSegmentAssignmentStrategyforRealtimeTables() {
-    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).build();
-
+  public void testBalancedNumSegmentAssignmentStrategyForRealtimeTables() {
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setLLC(true).build();
     InstancePartitions instancePartitions = new InstancePartitions(INSTANCE_PARTITIONS_NAME);
     instancePartitions.setInstances(0, 0, INSTANCES);
 
@@ -107,6 +107,7 @@ public class SegmentAssignmentStrategyFactoryTest {
         .getSegmentAssignmentStrategy(null, tableConfig, InstancePartitionsType.COMPLETED.toString(),
             instancePartitions);
     Assert.assertNotNull(segmentAssignmentStrategy);
+
     Assert.assertTrue(segmentAssignmentStrategy instanceof BalancedNumSegmentAssignmentStrategy);
   }
 


### PR DESCRIPTION
The Balanced and Replica group segment assignment strategy would assume replication to be fetched from only table config as tableConfig.getValidationConfig().getReplicationNumber() irrespective of whether its a realtime table or offline table
But for real time tables, if we have tableConfig.getValidationConfig().getReplicasPerPartitionNumber(), this should be preferred over table replication

No additional changes are required
Reference Issue: #9309
Also, issue #8804
