### PR TITLE
[checkstyle] add json config to not wrap automatically

### DIFF
--- a/config/codestyle-intellij.xml
+++ b/config/codestyle-intellij.xml
@@ -79,6 +79,10 @@
   <option name="THROWS_LIST_WRAP" value="1"/>
   <option name="THROWS_KEYWORD_WRAP" value="2"/>
   <option name="WRAP_COMMENTS" value="true"/>
+  <JSON>
+    <option name="OBJECT_WRAPPING" value="5" />
+    <option name="ARRAY_WRAPPING" value="5" />
+  </JSON>
   <XML>
     <option name="XML_LEGACY_SETTINGS_IMPORTED" value="true"/>
   </XML>


### PR DESCRIPTION
most of the JSON format should not auto wrap. otherwise slim arr/object structure will be too long to read.

This PR change the setting from `Always wrap` to `Chop down if too long`, this way the following JSON will stay unchanged.
```
{
  "input": [
    [ 150, 1.5, "c"],
    [ 175, 1.75, "c"]
  ],
  "queries": [ { "sql": "SELECT * FROM tbl" } ]
}
```

instead of being auto formatted into:
```
{
  "input": [
    [
      150,
      1.5,
      "c"
    ],
    [
      175,
      1.75,
      "c"
    ]
  ],
  "queries": [
    {
      "sql": "SELECT * FROM tbl"
    }
  ]
}
```