### PR TITLE
load startree index via segment reader interface

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -197,13 +197,10 @@ public class ImmutableSegmentLoader {
       }
     }
 
-    // FIXME: star tree only works with local SegmentDirectory
     // Load star-tree index if it exists
     StarTreeIndexContainer starTreeIndexContainer = null;
-    if (segmentMetadata.getStarTreeV2MetadataList() != null && localIndexDir != null) {
-      starTreeIndexContainer =
-          new StarTreeIndexContainer(SegmentDirectoryPaths.findSegmentDirectory(localIndexDir), segmentMetadata,
-              indexContainerMap, indexLoadingConfig.getReadMode());
+    if (segmentMetadata.getStarTreeV2MetadataList() != null) {
+      starTreeIndexContainer = new StarTreeIndexContainer(segmentReader, segmentMetadata, indexContainerMap);
     }
 
     ImmutableSegmentImpl segment =

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collections;
@@ -357,6 +358,18 @@ public class SegmentLocalFSDirectory extends SegmentDirectory {
     @Override
     public String toString() {
       return _segmentDirectory.toString();
+    }
+
+    @Override
+    public PinotDataBuffer getStarTreeIndex()
+        throws IOException {
+      return _columnIndexDirectory.getStarTreeIndex();
+    }
+
+    @Override
+    public InputStream getStarTreeIndexMap()
+        throws IOException {
+      return _columnIndexDirectory.getStarTreeIndexMap();
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
@@ -22,8 +22,10 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.io.BufferedWriter;
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.FileWriter;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.PrintWriter;
 import java.io.RandomAccessFile;
 import java.nio.ByteOrder;
@@ -41,6 +43,7 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
+import org.apache.pinot.segment.spi.index.startree.StarTreeV2Constants;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.ColumnIndexDirectory;
 import org.apache.pinot.segment.spi.store.ColumnIndexType;
@@ -84,6 +87,9 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
   private final File _indexFile;
   private final Map<IndexKey, IndexEntry> _columnEntries;
   private final List<PinotDataBuffer> _allocBuffers;
+  // Different from the other column-index entries, starTree index is multi-column index and has its own index map,
+  // thus manage it separately.
+  private PinotDataBuffer _starTreeIndexDataBuffer;
 
   // For V3 segment format, the index cleanup consists of two steps: mark and sweep.
   // The removeIndex() method marks an index to be removed; and the index info is
@@ -207,6 +213,21 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
       throws IOException, ConfigurationException {
     loadMap();
     mapBufferEntries();
+    if (_segmentMetadata.getStarTreeV2MetadataList() != null) {
+      loadStarTreeIndex();
+    }
+  }
+
+  private void loadStarTreeIndex()
+      throws IOException {
+    File indexFile = new File(_segmentDirectory, StarTreeV2Constants.INDEX_FILE_NAME);
+    if (_readMode == ReadMode.heap) {
+      _starTreeIndexDataBuffer =
+          PinotDataBuffer.loadFile(indexFile, 0, indexFile.length(), ByteOrder.BIG_ENDIAN, "Star-tree V2 data buffer");
+    } else {
+      _starTreeIndexDataBuffer = PinotDataBuffer.mapFile(indexFile, true, 0, indexFile.length(), ByteOrder.BIG_ENDIAN,
+          "Star-tree V2 data buffer");
+    }
   }
 
   private void loadMap()
@@ -346,6 +367,9 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
     for (PinotDataBuffer buf : _allocBuffers) {
       buf.close();
     }
+    if (_starTreeIndexDataBuffer != null) {
+      _starTreeIndexDataBuffer.close();
+    }
     // Cleanup removed indices after closing and flushing buffers, so
     // that potential index updates can be persisted across cleanups.
     if (_shouldCleanupRemovedIndices) {
@@ -387,6 +411,18 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
       }
     }
     return columns;
+  }
+
+  @Override
+  public PinotDataBuffer getStarTreeIndex()
+      throws IOException {
+    return _starTreeIndexDataBuffer;
+  }
+
+  @Override
+  public InputStream getStarTreeIndexMap()
+      throws IOException {
+    return new FileInputStream(new File(_segmentDirectory, StarTreeV2Constants.INDEX_MAP_FILE_NAME));
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexContainer.java
@@ -19,44 +19,30 @@
 package org.apache.pinot.segment.local.startree.v2.store;
 
 import java.io.Closeable;
-import java.io.File;
 import java.io.IOException;
-import java.nio.ByteOrder;
+import java.io.InputStream;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
-import org.apache.pinot.segment.spi.index.startree.StarTreeV2Constants;
-import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
-import org.apache.pinot.spi.utils.ReadMode;
-
-import static org.apache.pinot.segment.local.startree.v2.store.StarTreeIndexMapUtils.IndexKey;
-import static org.apache.pinot.segment.local.startree.v2.store.StarTreeIndexMapUtils.IndexValue;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
 
 
 /**
  * The {@code StarTreeIndexContainer} class contains the indexes for multiple star-trees.
  */
 public class StarTreeIndexContainer implements Closeable {
-  private final PinotDataBuffer _dataBuffer;
   private final List<StarTreeV2> _starTrees;
 
-  public StarTreeIndexContainer(File segmentDirectory, SegmentMetadataImpl segmentMetadata,
-      Map<String, ColumnIndexContainer> indexContainerMap, ReadMode readMode)
+  public StarTreeIndexContainer(SegmentDirectory.Reader segmentReader, SegmentMetadataImpl segmentMetadata,
+      Map<String, ColumnIndexContainer> indexContainerMap)
       throws IOException {
-    File indexFile = new File(segmentDirectory, StarTreeV2Constants.INDEX_FILE_NAME);
-    if (readMode == ReadMode.heap) {
-      _dataBuffer = PinotDataBuffer.loadFile(indexFile, 0, indexFile.length(), ByteOrder.LITTLE_ENDIAN,
-          "Star-tree V2 data buffer");
-    } else {
-      _dataBuffer = PinotDataBuffer.mapFile(indexFile, true, 0, indexFile.length(), ByteOrder.LITTLE_ENDIAN,
-          "Star-tree V2 data buffer");
+    try (InputStream inputStream = segmentReader.getStarTreeIndexMap()) {
+      _starTrees = StarTreeLoaderUtils.loadStarTreeV2(segmentReader.getStarTreeIndex(),
+          StarTreeIndexMapUtils.loadFromInputStream(inputStream, segmentMetadata.getStarTreeV2MetadataList().size()),
+          segmentMetadata, indexContainerMap);
     }
-    File indexMapFile = new File(segmentDirectory, StarTreeV2Constants.INDEX_MAP_FILE_NAME);
-    List<Map<IndexKey, IndexValue>> indexMapList =
-        StarTreeIndexMapUtils.loadFromFile(indexMapFile, segmentMetadata.getStarTreeV2MetadataList().size());
-    _starTrees = StarTreeLoaderUtils.loadStarTreeV2(_dataBuffer, indexMapList, segmentMetadata, indexContainerMap);
   }
 
   public List<StarTreeV2> getStarTrees() {
@@ -66,6 +52,6 @@ public class StarTreeIndexContainer implements Closeable {
   @Override
   public void close()
       throws IOException {
-    _dataBuffer.close();
+    // The startree index buffer is owned by segment reader now.
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexMapUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexMapUtils.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -166,17 +167,15 @@ public class StarTreeIndexMapUtils {
   }
 
   /**
-   * Loads the index maps for multiple star-trees from a file.
+   * Loads the index maps for multiple star-trees from an input stream.
    */
-  public static List<Map<IndexKey, IndexValue>> loadFromFile(File indexMapFile, int numStarTrees) {
-    Preconditions.checkState(indexMapFile.exists(), "Star-tree index map file does not exist");
-
+  public static List<Map<IndexKey, IndexValue>> loadFromInputStream(InputStream indexMapInputStream, int numStarTrees) {
     List<Map<IndexKey, IndexValue>> indexMaps = new ArrayList<>(numStarTrees);
     for (int i = 0; i < numStarTrees; i++) {
       indexMaps.add(new HashMap<>());
     }
 
-    PropertiesConfiguration configuration = CommonsConfigurationUtils.fromFile(indexMapFile);
+    PropertiesConfiguration configuration = CommonsConfigurationUtils.fromInputStream(indexMapInputStream);
     for (String key : CommonsConfigurationUtils.getKeys(configuration)) {
       String[] split = StringUtils.split(key, KEY_SEPARATOR);
       int starTreeId = Integer.parseInt(split[0]);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.local.segment.store;
 import com.google.common.collect.ImmutableMap;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.PrintWriter;
 import java.util.Arrays;
@@ -54,6 +55,7 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 
 public class SingleFileIndexDirectoryTest {
@@ -82,6 +84,7 @@ public class SingleFileIndexDirectoryTest {
   void writeMetadata() {
     SegmentMetadataImpl meta = Mockito.mock(SegmentMetadataImpl.class);
     Mockito.when(meta.getVersion()).thenReturn(SegmentVersion.v3);
+    Mockito.when(meta.getStarTreeV2MetadataList()).thenReturn(null);
     _segmentMetadata = meta;
   }
 
@@ -389,6 +392,16 @@ public class SingleFileIndexDirectoryTest {
       assertEquals(sfd.getColumnsWithIndex(ColumnIndexType.H3_INDEX), new HashSet<>(Collections.emptySet()));
       assertEquals(sfd.getColumnsWithIndex(ColumnIndexType.TEXT_INDEX),
           new HashSet<>(Collections.singletonList("bar")));
+    }
+  }
+
+  @Test(expectedExceptions = FileNotFoundException.class, expectedExceptionsMessageRegExp = ".*star_tree_index.*")
+  public void testLoadStarTreeIndex()
+      throws Exception {
+    Mockito.when(_segmentMetadata.getStarTreeV2MetadataList()).thenReturn(Collections.emptyList());
+    try (SingleFileIndexDirectory ignore = new SingleFileIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap)) {
+      // Trying to load startree index but not able to find the file.
+      fail();
     }
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/ColumnIndexDirectory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/ColumnIndexDirectory.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.spi.store;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Set;
 import org.apache.pinot.segment.spi.FetchContext;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
@@ -103,5 +104,18 @@ public abstract class ColumnIndexDirectory implements Closeable {
    * An instruction to release the fetched buffers for columns in this context, after operating on this segment.
    */
   public void releaseBuffer(FetchContext fetchContext) {
+  }
+
+  public PinotDataBuffer getStarTreeIndex()
+      throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * The caller should close the input stream.
+   */
+  public InputStream getStarTreeIndexMap()
+      throws IOException {
+    throw new UnsupportedOperationException();
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.spi.store;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
 import java.net.URI;
 import java.nio.file.Path;
 import java.util.Set;
@@ -185,6 +186,19 @@ public abstract class SegmentDirectory implements Closeable {
     }
 
     public abstract String toString();
+
+    public PinotDataBuffer getStarTreeIndex()
+        throws IOException {
+      throw new UnsupportedOperationException();
+    }
+
+    /**
+     * The caller should close the input stream.
+     */
+    public InputStream getStarTreeIndexMap()
+        throws IOException {
+      throw new UnsupportedOperationException();
+    }
   }
 
   /**

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_offline_table_config.json
@@ -24,6 +24,36 @@
     }
   ],
   "tableIndexConfig": {
+    "starTreeIndexConfigs": [
+      {
+        "dimensionsSplitOrder": [
+          "AirlineID",
+          "Origin",
+          "Dest"
+        ],
+        "skipStarNodeCreationForDimensions": [],
+        "functionColumnPairs": [
+          "COUNT__*",
+          "MAX__ArrDelay"
+        ],
+        "maxLeafRecords": 10
+      },
+      {
+        "dimensionsSplitOrder": [
+          "Carrier",
+          "CancellationCode",
+          "Origin",
+          "Dest"
+        ],
+        "skipStarNodeCreationForDimensions": [],
+        "functionColumnPairs": [
+          "MAX__CarrierDelay",
+          "AVG__CarrierDelay"
+        ],
+        "maxLeafRecords": 10
+      }
+    ],
+    "enableDynamicStarTreeCreation": true,
     "loadMode": "MMAP"
   },
   "metadata": {


### PR DESCRIPTION
Loading startree index via SegmentReader interface to decouple from File objects, as done for the other index types.