### PR TITLE
[pinot-spark-connector] Fix empty data table handling in GRPC reader

### DIFF
--- a/pinot-connectors/pinot-spark-connector/src/test/scala/org/apache/pinot/connector/spark/ExampleSparkPinotConnectorTest.scala
+++ b/pinot-connectors/pinot-spark-connector/src/test/scala/org/apache/pinot/connector/spark/ExampleSparkPinotConnectorTest.scala
@@ -42,6 +42,7 @@ object ExampleSparkPinotConnectorTest extends Logging {
     readHybridWithFilters()
     readHybridViaGrpc()
     readRealtimeViaGrpc()
+    readRealtimeWithFilterViaGrpc()
     readHybridWithFiltersViaGrpc()
     readRealtimeWithSelectionColumns()
     applyJustSomeFilters()
@@ -159,6 +160,21 @@ object ExampleSparkPinotConnectorTest extends Logging {
       .option("tableType", "realtime")
       .option("useGrpcServer", "true")
       .load()
+
+    data.show()
+  }
+
+  def readRealtimeWithFilterViaGrpc()(implicit spark: SparkSession): Unit = {
+    import spark.implicits._
+    log.info("## Reading `airlineStats_REALTIME` table... ##")
+    val data = spark.read
+      .format("pinot")
+      .option("table", "airlineStats")
+      .option("tableType", "realtime")
+      .option("useGrpcServer", "true")
+      .load()
+      .filter($"DestWac" === 5)
+      .select($"FlightNum", $"Origin", $"DestStateName")
 
     data.show()
   }


### PR DESCRIPTION
Fixes a bug where an exception is thrown when all of the data tables retuned in a Spark 'split' is empty.

When the Spark reader pushes down a filter which effectively reduces the returned data for all the segments to zero, GRPC data fetcher (`PinotGrpcServerDataFetcher`) wrongly assumes that there was an error. This behavior was introduced when porting logic from the non-GRPC fetcher (`PinotServerDataFetcher`) where the assumption is correct. Http and GRPC interfaces differ in behavior where the HTTP interface will return empty instances of datatables whereas with GRPC you only get metadata.

I'm updating the error handling to remove this assumption and record an error when there is actual exception thrown by the GRPC server.

`bugfix`
