### PR TITLE
add table sort function for table size

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -74,6 +74,10 @@ type Props = {
   tooltipData?: string[]
 };
 
+// These sort functions are applied to any columns with these names. Otherwise, we just
+// sort on the raw data. Ideally users of this class would pass in custom sort functions
+// for their columns, but this pattern already existed, so we're at least making the
+// improvement to pull this out to a common variable.
 let staticSortFunctions: Map<string, TableSortFunction> = new Map()
 staticSortFunctions.set("Number of Segments", sortNumberOfSegments);
 staticSortFunctions.set("Estimated Size", sortBytes);

--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -35,7 +35,7 @@ import TableContainer from '@material-ui/core/TableContainer';
 import TableHead from '@material-ui/core/TableHead';
 import TableRow from '@material-ui/core/TableRow';
 import { TablePagination, Tooltip } from '@material-ui/core';
-import { TableData } from 'Models';
+import {TableData, TableSortFunction} from 'Models';
 import IconButton from '@material-ui/core/IconButton';
 import FirstPageIcon from '@material-ui/icons/FirstPage';
 import KeyboardArrowLeft from '@material-ui/icons/KeyboardArrowLeft';
@@ -47,6 +47,7 @@ import { Link } from 'react-router-dom';
 import Chip from '@material-ui/core/Chip';
 import { get, has, orderBy } from 'lodash';
 import app_state from '../app_state';
+import { sortBytes, sortNumberOfSegments } from '../utils/SortFunctions'
 import Utils from '../utils/Utils';
 import TableToolbar from './TableToolbar';
 import SimpleAccordion from './SimpleAccordion';
@@ -72,6 +73,11 @@ type Props = {
   },
   tooltipData?: string[]
 };
+
+let staticSortFunctions: Map<string, TableSortFunction> = new Map()
+staticSortFunctions.set("Number of Segments", sortNumberOfSegments);
+staticSortFunctions.set("Estimated Size", sortBytes);
+staticSortFunctions.set("Reported Size", sortBytes);
 
 const StyledTableRow = withStyles((theme) =>
   createStyles({
@@ -464,13 +470,8 @@ export default function CustomizedTables({
                     className={classes.head}
                     key={index}
                     onClick={() => {
-                      if(column === 'Number of Segments'){
-                        const data = finalData.sort((a,b)=>{
-                          const aSegmentInt = parseInt(a[column+app_state.columnNameSeparator+index]);
-                          const bSegmentInt = parseInt(b[column+app_state.columnNameSeparator+index]);
-                          const result = order ? (aSegmentInt > bSegmentInt) : (aSegmentInt < bSegmentInt);
-                          return result ? 1 : -1;
-                        });
+                      if (staticSortFunctions.has(column)) {
+                        finalData.sort((a, b) => staticSortFunctions.get(column)(a, b, column, index, order));
                         setFinalData(finalData);
                       } else {
                         setFinalData(orderBy(finalData, column+app_state.columnNameSeparator+index, order ? 'asc' : 'desc'));

--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -223,6 +223,8 @@ declare module 'Models' {
     }
   }
 
+  export type TableSortFunction = (a: any, b: any, column: string, index: number, order: boolean) => number;
+
   export const enum SEGMENT_STATUS {
     ONLINE = "ONLINE",
     OFFLINE = "OFFLINE",

--- a/pinot-controller/src/main/resources/app/utils/SortFunctions.tsx
+++ b/pinot-controller/src/main/resources/app/utils/SortFunctions.tsx
@@ -1,0 +1,29 @@
+import {TableSortFunction} from "Models";
+import app_state from "../app_state";
+
+
+const valuesToResultNumber = (aRes: any, bRes: any, order: boolean): number => {
+    const result = order ? aRes > bRes : aRes < bRes;
+    return result ? 1 : -1;
+}
+
+export const sortNumberOfSegments: TableSortFunction = (a: any, b: any, column: string, index: number, order: boolean) => {
+    const aSegmentInt = parseInt(a[column+app_state.columnNameSeparator+index]);
+    const bSegmentInt = parseInt(b[column+app_state.columnNameSeparator+index]);
+    const result = order ? (aSegmentInt > bSegmentInt) : (aSegmentInt < bSegmentInt);
+    return result ? 1 : -1;
+}
+
+export const sortBytes: TableSortFunction = (a: any, b: any, column: string, index: number, order: boolean) => {
+    const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+    const [aValue, aUnit] = a[column+app_state.columnNameSeparator+index].split(" ");
+    const [bValue, bUnit] = b[column+app_state.columnNameSeparator+index].split(" ");
+    const aUnitIndex = sizes.indexOf(aUnit);
+    const bUnitIndex = sizes.indexOf(bUnit);
+
+    if (sizes.indexOf(aUnit) === sizes.indexOf(bUnit)) {
+        return valuesToResultNumber(parseFloat(aValue), parseFloat(bValue), order);
+    } else {
+        return valuesToResultNumber(aUnitIndex, bUnitIndex, order);
+    }
+}

--- a/pinot-controller/src/main/resources/app/utils/SortFunctions.tsx
+++ b/pinot-controller/src/main/resources/app/utils/SortFunctions.tsx
@@ -2,6 +2,8 @@ import {TableSortFunction} from "Models";
 import app_state from "../app_state";
 
 
+// table sorting requires a 1/-1 result. This helper function helps calculate this
+// from any two results.
 const valuesToResultNumber = (aRes: any, bRes: any, order: boolean): number => {
     const result = order ? aRes > bRes : aRes < bRes;
     return result ? 1 : -1;
@@ -10,8 +12,7 @@ const valuesToResultNumber = (aRes: any, bRes: any, order: boolean): number => {
 export const sortNumberOfSegments: TableSortFunction = (a: any, b: any, column: string, index: number, order: boolean) => {
     const aSegmentInt = parseInt(a[column+app_state.columnNameSeparator+index]);
     const bSegmentInt = parseInt(b[column+app_state.columnNameSeparator+index]);
-    const result = order ? (aSegmentInt > bSegmentInt) : (aSegmentInt < bSegmentInt);
-    return result ? 1 : -1;
+    return valuesToResultNumber(aSegmentInt, bSegmentInt, order);
 }
 
 export const sortBytes: TableSortFunction = (a: any, b: any, column: string, index: number, order: boolean) => {

--- a/pinot-controller/src/main/resources/app/utils/SortFunctions.tsx
+++ b/pinot-controller/src/main/resources/app/utils/SortFunctions.tsx
@@ -1,3 +1,22 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
 import {TableSortFunction} from "Models";
 import app_state from "../app_state";
 


### PR DESCRIPTION
addresses #9843

this is a `ui` `bugfix`

This is probably not the greatest way to do this. Transforming the data from bytes -> humanized -> bytes just to sort it feels hacky. But short of reworking `CustomTable` to track real vs display value, this is probably the fastest way to get this.

I tested by creating some fake tables locally and force committing them to get different sizes. I can't test on a bigger cluster until next week, so someone else might want to ensure this looks good as well.


https://user-images.githubusercontent.com/4760722/203428724-e8d781e1-d68e-43e5-a514-ca4eec5b1df3.mov

