### PR TITLE
Combine the read access for replication config

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstanceAssignmentConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstanceAssignmentConfigUtils.java
@@ -106,7 +106,7 @@ public class InstanceAssignmentConfigUtils {
 
     InstanceReplicaGroupPartitionConfig replicaGroupPartitionConfig;
     SegmentsValidationAndRetentionConfig segmentConfig = tableConfig.getValidationConfig();
-    int numReplicaGroups = segmentConfig.getReplicationNumber();
+    int numReplicaGroups = tableConfig.getReplicationNumber();
     ReplicaGroupStrategyConfig replicaGroupStrategyConfig = segmentConfig.getReplicaGroupStrategyConfig();
     Preconditions.checkState(replicaGroupStrategyConfig != null, "Failed to find the replica-group strategy config");
     String partitionColumn = replicaGroupStrategyConfig.getPartitionColumn();

--- a/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstanceAssignmentConfigUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/assignment/InstanceAssignmentConfigUtils.java
@@ -106,7 +106,7 @@ public class InstanceAssignmentConfigUtils {
 
     InstanceReplicaGroupPartitionConfig replicaGroupPartitionConfig;
     SegmentsValidationAndRetentionConfig segmentConfig = tableConfig.getValidationConfig();
-    int numReplicaGroups = tableConfig.getReplicationNumber();
+    int numReplicaGroups = tableConfig.getReplication();
     ReplicaGroupStrategyConfig replicaGroupStrategyConfig = segmentConfig.getReplicaGroupStrategyConfig();
     Preconditions.checkState(replicaGroupStrategyConfig != null, "Failed to find the replica-group strategy config");
     String partitionColumn = replicaGroupStrategyConfig.getPartitionColumn();

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigTest.java
@@ -22,31 +22,38 @@ import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.testng.AssertJUnit.assertEquals;
 import static org.testng.AssertJUnit.assertTrue;
 
 
 public class TableConfigTest {
+
+  private static final String TEST_OFFLINE_TABLE_NAME = "testllc_OFFLINE";
+  private static final String TEST_REALTIME_HLC_TABLE_NAME = "testhlc_REALTIME";
+  private static final String TEST_REALTIME_LLC_TABLE_NAME = "testllc_REALTIME";
 
   @DataProvider
   public Object[][] configs()
       throws IOException {
     try (Stream<Path> configs = Files.list(Paths.get("src/test/resources/testConfigs"))) {
       return configs.map(path -> {
-            try {
-              return Files.readAllBytes(path);
-            } catch (IOException e) {
-              throw new RuntimeException(e);
-            }
-          })
-          .map(config -> new Object[]{config})
-          .toArray(Object[][]::new);
+        try {
+          return Files.readAllBytes(path);
+        } catch (IOException e) {
+          throw new RuntimeException(e);
+        }
+      }).map(config -> new Object[]{config}).toArray(Object[][]::new);
     }
   }
 
@@ -55,5 +62,50 @@ public class TableConfigTest {
       throws IOException {
     TableConfig tableConfig = JsonUtils.DEFAULT_READER.forType(TableConfig.class).readValue(config);
     assertTrue(StringUtils.isNotBlank(tableConfig.getTableName()));
+  }
+
+  @Test
+  public void testGetReplication() {
+    TableConfig offlineTableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TEST_OFFLINE_TABLE_NAME).setNumReplicas(2).build();
+    assertEquals(2, offlineTableConfig.getReplicationNumber());
+
+    offlineTableConfig.getValidationConfig().setReplication("4");
+    assertEquals(4, offlineTableConfig.getReplicationNumber());
+
+    offlineTableConfig.getValidationConfig().setReplicasPerPartition("3");
+    assertEquals(4, offlineTableConfig.getReplicationNumber());
+
+    TableConfig realtimeHLCTableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TEST_REALTIME_HLC_TABLE_NAME)
+            .setStreamConfigs(getStreamConfigMap("highlevel")).setNumReplicas(2).build();
+    assertEquals(2, realtimeHLCTableConfig.getReplicationNumber());
+
+    realtimeHLCTableConfig.getValidationConfig().setReplication("4");
+    assertEquals(4, realtimeHLCTableConfig.getReplicationNumber());
+
+    realtimeHLCTableConfig.getValidationConfig().setReplicasPerPartition("3");
+    assertEquals(4, realtimeHLCTableConfig.getReplicationNumber());
+
+    TableConfig realtimeLLCTableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TEST_REALTIME_LLC_TABLE_NAME)
+            .setStreamConfigs(getStreamConfigMap("lowlevel")).setLLC(true).setNumReplicas(2).build();
+
+    assertEquals(2, realtimeLLCTableConfig.getReplicationNumber());
+
+    realtimeLLCTableConfig.getValidationConfig().setReplication("4");
+    assertEquals(2, realtimeLLCTableConfig.getReplicationNumber());
+
+    realtimeLLCTableConfig.getValidationConfig().setReplicasPerPartition("3");
+    assertEquals(3, realtimeLLCTableConfig.getReplicationNumber());
+  }
+
+  private Map<String, String> getStreamConfigMap(String consumerType) {
+    Map<String, String> configMap = new HashMap<>();
+    configMap.put("streamType", "kafka");
+    configMap.put("stream.kafka.consumer.type", consumerType);
+    configMap.put("stream.kafka.topic.name", "test");
+    configMap.put("stream.kafka.decoder.class.name", "test");
+    return configMap;
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigTest.java
@@ -68,36 +68,36 @@ public class TableConfigTest {
   public void testGetReplication() {
     TableConfig offlineTableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(TEST_OFFLINE_TABLE_NAME).setNumReplicas(2).build();
-    assertEquals(2, offlineTableConfig.getReplicationNumber());
+    assertEquals(2, offlineTableConfig.getReplication());
 
     offlineTableConfig.getValidationConfig().setReplication("4");
-    assertEquals(4, offlineTableConfig.getReplicationNumber());
+    assertEquals(4, offlineTableConfig.getReplication());
 
     offlineTableConfig.getValidationConfig().setReplicasPerPartition("3");
-    assertEquals(4, offlineTableConfig.getReplicationNumber());
+    assertEquals(4, offlineTableConfig.getReplication());
 
     TableConfig realtimeHLCTableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(TEST_REALTIME_HLC_TABLE_NAME)
             .setStreamConfigs(getStreamConfigMap("highlevel")).setNumReplicas(2).build();
-    assertEquals(2, realtimeHLCTableConfig.getReplicationNumber());
+    assertEquals(2, realtimeHLCTableConfig.getReplication());
 
     realtimeHLCTableConfig.getValidationConfig().setReplication("4");
-    assertEquals(4, realtimeHLCTableConfig.getReplicationNumber());
+    assertEquals(4, realtimeHLCTableConfig.getReplication());
 
     realtimeHLCTableConfig.getValidationConfig().setReplicasPerPartition("3");
-    assertEquals(4, realtimeHLCTableConfig.getReplicationNumber());
+    assertEquals(4, realtimeHLCTableConfig.getReplication());
 
     TableConfig realtimeLLCTableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(TEST_REALTIME_LLC_TABLE_NAME)
             .setStreamConfigs(getStreamConfigMap("lowlevel")).setLLC(true).setNumReplicas(2).build();
 
-    assertEquals(2, realtimeLLCTableConfig.getReplicationNumber());
+    assertEquals(2, realtimeLLCTableConfig.getReplication());
 
     realtimeLLCTableConfig.getValidationConfig().setReplication("4");
-    assertEquals(2, realtimeLLCTableConfig.getReplicationNumber());
+    assertEquals(2, realtimeLLCTableConfig.getReplication());
 
     realtimeLLCTableConfig.getValidationConfig().setReplicasPerPartition("3");
-    assertEquals(3, realtimeLLCTableConfig.getReplicationNumber());
+    assertEquals(3, realtimeLLCTableConfig.getReplication());
   }
 
   private Map<String, String> getStreamConfigMap(String consumerType) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -98,7 +98,6 @@ import org.apache.pinot.controller.util.TableIngestionStatusHelper;
 import org.apache.pinot.controller.util.TableMetadataReader;
 import org.apache.pinot.core.auth.ManualAuthorization;
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
-import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableStats;
 import org.apache.pinot.spi.config.table.TableStatus;
@@ -811,9 +810,7 @@ public class PinotTableRestletResource {
     String tableNameWithType =
         ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableType, LOGGER).get(0);
     TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
-    SegmentsValidationAndRetentionConfig segmentsConfig =
-        tableConfig != null ? tableConfig.getValidationConfig() : null;
-    int numReplica = segmentsConfig == null ? 1 : tableConfig.getReplicationNumber();
+    int numReplica = tableConfig == null ? 1 : tableConfig.getReplication();
 
     String segmentsMetadata;
     try {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -813,7 +813,7 @@ public class PinotTableRestletResource {
     TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
     SegmentsValidationAndRetentionConfig segmentsConfig =
         tableConfig != null ? tableConfig.getValidationConfig() : null;
-    int numReplica = segmentsConfig == null ? 1 : Integer.parseInt(segmentsConfig.getReplication());
+    int numReplica = segmentsConfig == null ? 1 : tableConfig.getReplicationNumber();
 
     String segmentsMetadata;
     try {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -143,7 +143,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
       _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.REPLICATION_FROM_CONFIG, 0);
       return;
     }
-    int replication = tableConfig.getReplicationNumber();
+    int replication = tableConfig.getReplication();
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.REPLICATION_FROM_CONFIG, replication);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -143,12 +143,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
       _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.REPLICATION_FROM_CONFIG, 0);
       return;
     }
-    int replication;
-    if (tableConfig.getTableType() == TableType.REALTIME) {
-      replication = tableConfig.getValidationConfig().getReplicasPerPartitionNumber();
-    } else {
-      replication = tableConfig.getValidationConfig().getReplicationNumber();
-    }
+    int replication = tableConfig.getReplicationNumber();
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.REPLICATION_FROM_CONFIG, replication);
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1480,7 +1480,7 @@ public class PinotHelixResourceManager {
         // now lets build an ideal state
         LOGGER.info("building empty ideal state for table : " + tableNameWithType);
         final IdealState offlineIdealState = PinotTableIdealStateBuilder.buildEmptyIdealStateFor(tableNameWithType,
-            tableConfig.getReplicationNumber(), _enableBatchMessageMode);
+            tableConfig.getReplication(), _enableBatchMessageMode);
         LOGGER.info("adding table via the admin");
 
         try {
@@ -1793,7 +1793,7 @@ public class PinotHelixResourceManager {
 
         // Update IdealState replication
         IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, tableNameWithType);
-        String replicationConfigured = Integer.toString(tableConfig.getReplicationNumber());
+        String replicationConfigured = Integer.toString(tableConfig.getReplication());
         if (!idealState.getReplicas().equals(replicationConfigured)) {
           HelixHelper.updateIdealState(_helixZkManager, tableNameWithType, is -> {
             assert is != null;
@@ -3740,7 +3740,7 @@ public class PinotHelixResourceManager {
       Set<String> serverInstances = getAllInstancesForServerTenant(tenantConfig.getServer());
       return serverInstances.size();
     }
-    return tableConfig.getReplicationNumber();
+    return tableConfig.getReplication();
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -136,7 +136,6 @@ import org.apache.pinot.controller.helix.core.rebalance.RebalanceResult;
 import org.apache.pinot.controller.helix.core.rebalance.TableRebalancer;
 import org.apache.pinot.controller.helix.core.util.ZKMetadataUtils;
 import org.apache.pinot.controller.helix.starter.HelixConfig;
-import org.apache.pinot.segment.local.utils.ReplicationUtils;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.spi.config.ConfigUtils;
 import org.apache.pinot.spi.config.instance.Instance;
@@ -1474,7 +1473,6 @@ public class PinotHelixResourceManager {
     }
 
     validateTableTenantConfig(tableConfig);
-    SegmentsValidationAndRetentionConfig segmentsConfig = tableConfig.getValidationConfig();
     TableType tableType = tableConfig.getTableType();
 
     switch (tableType) {
@@ -1482,7 +1480,7 @@ public class PinotHelixResourceManager {
         // now lets build an ideal state
         LOGGER.info("building empty ideal state for table : " + tableNameWithType);
         final IdealState offlineIdealState = PinotTableIdealStateBuilder.buildEmptyIdealStateFor(tableNameWithType,
-            Integer.parseInt(segmentsConfig.getReplication()), _enableBatchMessageMode);
+            tableConfig.getReplicationNumber(), _enableBatchMessageMode);
         LOGGER.info("adding table via the admin");
 
         try {
@@ -1795,7 +1793,7 @@ public class PinotHelixResourceManager {
 
         // Update IdealState replication
         IdealState idealState = _helixAdmin.getResourceIdealState(_helixClusterName, tableNameWithType);
-        String replicationConfigured = segmentsConfig.getReplication();
+        String replicationConfigured = Integer.toString(tableConfig.getReplicationNumber());
         if (!idealState.getReplicas().equals(replicationConfigured)) {
           HelixHelper.updateIdealState(_helixZkManager, tableNameWithType, is -> {
             assert is != null;
@@ -3742,12 +3740,7 @@ public class PinotHelixResourceManager {
       Set<String> serverInstances = getAllInstancesForServerTenant(tenantConfig.getServer());
       return serverInstances.size();
     }
-
-    if (ReplicationUtils.useReplicasPerPartition(tableConfig)) {
-      return Integer.parseInt(tableConfig.getValidationConfig().getReplicasPerPartition());
-    }
-
-    return tableConfig.getValidationConfig().getReplicationNumber();
+    return tableConfig.getReplicationNumber();
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -92,31 +92,25 @@ public class PinotTableIdealStateBuilder {
     List<String> realtimeInstances = HelixHelper.getInstancesWithTag(helixManager,
         TagNameUtils.extractConsumingServerTag(realtimeTableConfig.getTenantConfig()));
     IdealState idealState = buildEmptyRealtimeIdealStateFor(realtimeTableName, 1, enableBatchMessageMode);
-    if (realtimeInstances.size() % Integer.parseInt(realtimeTableConfig.getValidationConfig().getReplication()) != 0) {
+    if (realtimeInstances.size() % realtimeTableConfig.getReplicationNumber() != 0) {
       throw new RuntimeException(
           "Number of instance in current tenant should be an integer multiples of the number of replications");
     }
     setupInstanceConfigForHighLevelConsumer(realtimeTableName, realtimeInstances.size(),
-        Integer.parseInt(realtimeTableConfig.getValidationConfig().getReplication()),
-        IngestionConfigUtils.getStreamConfigMap(realtimeTableConfig), zkHelixPropertyStore, realtimeInstances);
+        realtimeTableConfig.getReplicationNumber(), IngestionConfigUtils.getStreamConfigMap(realtimeTableConfig),
+        zkHelixPropertyStore, realtimeInstances);
     return idealState;
   }
 
   public static void buildLowLevelRealtimeIdealStateFor(PinotLLCRealtimeSegmentManager pinotLLCRealtimeSegmentManager,
       String realtimeTableName, TableConfig realtimeTableConfig, IdealState idealState,
       boolean enableBatchMessageMode) {
-
     // Validate replicasPerPartition here.
-    final String replicasPerPartitionStr = realtimeTableConfig.getValidationConfig().getReplicasPerPartition();
-    if (replicasPerPartitionStr == null || replicasPerPartitionStr.isEmpty()) {
-      throw new RuntimeException("Null or empty value for replicasPerPartition, expected a number");
-    }
     final int nReplicas;
     try {
-      nReplicas = Integer.valueOf(replicasPerPartitionStr);
+      nReplicas = realtimeTableConfig.getReplicationNumber();
     } catch (NumberFormatException e) {
-      throw new InvalidTableConfigException(
-          "Invalid value for replicasPerPartition, expected a number: " + replicasPerPartitionStr, e);
+      throw new InvalidTableConfigException("Invalid value for replicasPerPartition, expected a number.", e);
     }
     if (idealState == null) {
       idealState = buildEmptyRealtimeIdealStateFor(realtimeTableName, nReplicas, enableBatchMessageMode);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotTableIdealStateBuilder.java
@@ -92,12 +92,12 @@ public class PinotTableIdealStateBuilder {
     List<String> realtimeInstances = HelixHelper.getInstancesWithTag(helixManager,
         TagNameUtils.extractConsumingServerTag(realtimeTableConfig.getTenantConfig()));
     IdealState idealState = buildEmptyRealtimeIdealStateFor(realtimeTableName, 1, enableBatchMessageMode);
-    if (realtimeInstances.size() % realtimeTableConfig.getReplicationNumber() != 0) {
+    if (realtimeInstances.size() % realtimeTableConfig.getReplication() != 0) {
       throw new RuntimeException(
           "Number of instance in current tenant should be an integer multiples of the number of replications");
     }
     setupInstanceConfigForHighLevelConsumer(realtimeTableName, realtimeInstances.size(),
-        realtimeTableConfig.getReplicationNumber(), IngestionConfigUtils.getStreamConfigMap(realtimeTableConfig),
+        realtimeTableConfig.getReplication(), IngestionConfigUtils.getStreamConfigMap(realtimeTableConfig),
         zkHelixPropertyStore, realtimeInstances);
     return idealState;
   }
@@ -108,7 +108,7 @@ public class PinotTableIdealStateBuilder {
     // Validate replicasPerPartition here.
     final int nReplicas;
     try {
-      nReplicas = realtimeTableConfig.getReplicationNumber();
+      nReplicas = realtimeTableConfig.getReplication();
     } catch (NumberFormatException e) {
       throw new InvalidTableConfigException("Invalid value for replicasPerPartition, expected a number.", e);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseSegmentAssignment.java
@@ -75,7 +75,7 @@ public abstract class BaseSegmentAssignment implements SegmentAssignment {
     _helixManager = helixManager;
     _tableNameWithType = tableConfig.getTableName();
     _tableConfig = tableConfig;
-    _replication = getReplication(tableConfig);
+    _replication = tableConfig.getReplicationNumber();
     ReplicaGroupStrategyConfig replicaGroupStrategyConfig =
         tableConfig.getValidationConfig().getReplicaGroupStrategyConfig();
     _partitionColumn = replicaGroupStrategyConfig != null ? replicaGroupStrategyConfig.getPartitionColumn() : null;
@@ -88,11 +88,6 @@ public abstract class BaseSegmentAssignment implements SegmentAssignment {
           _partitionColumn, _tableNameWithType);
     }
   }
-
-  /**
-   * Returns the replication of the table.
-   */
-  protected abstract int getReplication(TableConfig tableConfig);
 
   /**
    * Rebalances tiers and returns a pair of tier assignments and non-tier assignment.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseSegmentAssignment.java
@@ -75,7 +75,7 @@ public abstract class BaseSegmentAssignment implements SegmentAssignment {
     _helixManager = helixManager;
     _tableNameWithType = tableConfig.getTableName();
     _tableConfig = tableConfig;
-    _replication = tableConfig.getReplicationNumber();
+    _replication = tableConfig.getReplication();
     ReplicaGroupStrategyConfig replicaGroupStrategyConfig =
         tableConfig.getValidationConfig().getReplicaGroupStrategyConfig();
     _partitionColumn = replicaGroupStrategyConfig != null ? replicaGroupStrategyConfig.getPartitionColumn() : null;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineSegmentAssignment.java
@@ -30,7 +30,6 @@ import org.apache.pinot.common.tier.Tier;
 import org.apache.pinot.controller.helix.core.assignment.segment.strategy.AllServersSegmentAssignmentStrategy;
 import org.apache.pinot.controller.helix.core.assignment.segment.strategy.SegmentAssignmentStrategy;
 import org.apache.pinot.controller.helix.core.assignment.segment.strategy.SegmentAssignmentStrategyFactory;
-import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.utils.RebalanceConfigConstants;
 
@@ -39,11 +38,6 @@ import org.apache.pinot.spi.utils.RebalanceConfigConstants;
  * Segment assignment for offline table.
  */
 public class OfflineSegmentAssignment extends BaseSegmentAssignment {
-
-  @Override
-  protected int getReplication(TableConfig tableConfig) {
-    return tableConfig.getValidationConfig().getReplicationNumber();
-  }
 
   @Override
   public List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
@@ -31,7 +31,6 @@ import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.tier.Tier;
 import org.apache.pinot.controller.helix.core.assignment.segment.strategy.SegmentAssignmentStrategy;
 import org.apache.pinot.controller.helix.core.assignment.segment.strategy.SegmentAssignmentStrategyFactory;
-import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.spi.utils.RebalanceConfigConstants;
@@ -73,11 +72,6 @@ import org.apache.pinot.spi.utils.RebalanceConfigConstants;
  * </ul>
  */
 public class RealtimeSegmentAssignment extends BaseSegmentAssignment {
-
-  @Override
-  protected int getReplication(TableConfig tableConfig) {
-    return tableConfig.getValidationConfig().getReplicasPerPartitionNumber();
-  }
 
   @Override
   public List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/BalancedNumSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/BalancedNumSegmentAssignmentStrategy.java
@@ -26,7 +26,6 @@ import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
 import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -51,11 +50,7 @@ public class BalancedNumSegmentAssignmentStrategy implements SegmentAssignmentSt
     _tableNameWithType = tableConfig.getTableName();
     SegmentsValidationAndRetentionConfig validationAndRetentionConfig = tableConfig.getValidationConfig();
     Preconditions.checkState(validationAndRetentionConfig != null, "Validation Config is null");
-    // Number of replicas per partition of low-level consumers check is for the real time tables only
-    // TODO: Cleanup required once we fetch the replication number from table config depending on table type
-    _replication = tableConfig.getTableType() == TableType.REALTIME
-        ? validationAndRetentionConfig.getReplicasPerPartitionNumber()
-        : validationAndRetentionConfig.getReplicationNumber();
+    _replication = tableConfig.getReplicationNumber();
     LOGGER.info("Initialized BalancedNumSegmentAssignmentStrategy for table: " + "{} with replication: {}",
         _tableNameWithType, _replication);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/BalancedNumSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/BalancedNumSegmentAssignmentStrategy.java
@@ -50,7 +50,7 @@ public class BalancedNumSegmentAssignmentStrategy implements SegmentAssignmentSt
     _tableNameWithType = tableConfig.getTableName();
     SegmentsValidationAndRetentionConfig validationAndRetentionConfig = tableConfig.getValidationConfig();
     Preconditions.checkState(validationAndRetentionConfig != null, "Validation Config is null");
-    _replication = tableConfig.getReplicationNumber();
+    _replication = tableConfig.getReplication();
     LOGGER.info("Initialized BalancedNumSegmentAssignmentStrategy for table: " + "{} with replication: {}",
         _tableNameWithType, _replication);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
@@ -53,7 +53,7 @@ class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentStrategy
     _tableName = tableConfig.getTableName();
     SegmentsValidationAndRetentionConfig validationAndRetentionConfig = tableConfig.getValidationConfig();
     Preconditions.checkState(validationAndRetentionConfig != null, "Validation Config is null");
-    _replication = tableConfig.getReplicationNumber();
+    _replication = tableConfig.getReplication();
     ReplicaGroupStrategyConfig replicaGroupStrategyConfig =
         validationAndRetentionConfig.getReplicaGroupStrategyConfig();
     _partitionColumn = replicaGroupStrategyConfig != null ? replicaGroupStrategyConfig.getPartitionColumn() : null;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategy.java
@@ -53,11 +53,7 @@ class ReplicaGroupSegmentAssignmentStrategy implements SegmentAssignmentStrategy
     _tableName = tableConfig.getTableName();
     SegmentsValidationAndRetentionConfig validationAndRetentionConfig = tableConfig.getValidationConfig();
     Preconditions.checkState(validationAndRetentionConfig != null, "Validation Config is null");
-    // Number of replicas per partition of low-level consumers check is for the real time tables only
-    // TODO: Cleanup required once we fetch the replication number from table config depending on table type
-    _replication = tableConfig.getTableType() == TableType.REALTIME
-        ? validationAndRetentionConfig.getReplicasPerPartitionNumber()
-        : validationAndRetentionConfig.getReplicationNumber();
+    _replication = tableConfig.getReplicationNumber();
     ReplicaGroupStrategyConfig replicaGroupStrategyConfig =
         validationAndRetentionConfig.getReplicaGroupStrategyConfig();
     _partitionColumn = replicaGroupStrategyConfig != null ? replicaGroupStrategyConfig.getPartitionColumn() : null;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1339,7 +1339,7 @@ public class PinotLLCRealtimeSegmentManager {
   private int getNumReplicas(TableConfig tableConfig, InstancePartitions instancePartitions) {
     if (instancePartitions.getNumReplicaGroups() == 1) {
       // Non-replica-group based
-      return tableConfig.getReplicationNumber();
+      return tableConfig.getReplication();
     } else {
       // Replica-group based
       return instancePartitions.getNumReplicaGroups();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1339,7 +1339,7 @@ public class PinotLLCRealtimeSegmentManager {
   private int getNumReplicas(TableConfig tableConfig, InstancePartitions instancePartitions) {
     if (instancePartitions.getNumReplicaGroups() == 1) {
       // Non-replica-group based
-      return tableConfig.getValidationConfig().getReplicasPerPartitionNumber();
+      return tableConfig.getReplicationNumber();
     } else {
       // Replica-group based
       return instancePartitions.getNumReplicaGroups();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -229,7 +229,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     sendPostRequest(_createTableUrl, tableJSONConfigString);
     // table creation should succeed
     TableConfig tableConfig = getTableConfig(tableName, "OFFLINE");
-    assertEquals(tableConfig.getValidationConfig().getReplicationNumber(),
+    assertEquals(tableConfig.getReplicationNumber(),
         Math.max(tableReplication, DEFAULT_MIN_NUM_REPLICAS));
 
     DEFAULT_INSTANCE.addDummySchema(tableName);
@@ -237,8 +237,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
         _realtimeBuilder.setTableName(tableName).setNumReplicas(tableReplication).build().toJsonString();
     sendPostRequest(_createTableUrl, tableJSONConfigString);
     tableConfig = getTableConfig(tableName, "REALTIME");
-    assertEquals(tableConfig.getValidationConfig().getReplicationNumber(),
-        Math.max(tableReplication, DEFAULT_MIN_NUM_REPLICAS));
+    assertEquals(tableConfig.getReplicationNumber(), Math.max(tableReplication, DEFAULT_MIN_NUM_REPLICAS));
 
     DEFAULT_INSTANCE.getHelixResourceManager().deleteOfflineTable(tableName);
     DEFAULT_INSTANCE.getHelixResourceManager().deleteRealtimeTable(tableName);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -229,7 +229,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     sendPostRequest(_createTableUrl, tableJSONConfigString);
     // table creation should succeed
     TableConfig tableConfig = getTableConfig(tableName, "OFFLINE");
-    assertEquals(tableConfig.getReplicationNumber(),
+    assertEquals(tableConfig.getReplication(),
         Math.max(tableReplication, DEFAULT_MIN_NUM_REPLICAS));
 
     DEFAULT_INSTANCE.addDummySchema(tableName);
@@ -237,7 +237,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
         _realtimeBuilder.setTableName(tableName).setNumReplicas(tableReplication).build().toJsonString();
     sendPostRequest(_createTableUrl, tableJSONConfigString);
     tableConfig = getTableConfig(tableName, "REALTIME");
-    assertEquals(tableConfig.getReplicationNumber(), Math.max(tableReplication, DEFAULT_MIN_NUM_REPLICAS));
+    assertEquals(tableConfig.getReplication(), Math.max(tableReplication, DEFAULT_MIN_NUM_REPLICAS));
 
     DEFAULT_INSTANCE.getHelixResourceManager().deleteOfflineTable(tableName);
     DEFAULT_INSTANCE.getHelixResourceManager().deleteRealtimeTable(tableName);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
@@ -306,9 +306,9 @@ public class TableConfigsRestletResourceTest extends ControllerTest {
     response = sendGetRequest(DEFAULT_INSTANCE.getControllerRequestURLBuilder().forTableConfigsGet(tableName));
     tableConfigsResponse = JsonUtils.stringToObject(response, TableConfigs.class);
     Assert.assertEquals(tableConfigsResponse.getTableName(), tableName);
-    Assert.assertEquals(tableConfigsResponse.getOffline().getReplicationNumber(),
+    Assert.assertEquals(tableConfigsResponse.getOffline().getReplication(),
         DEFAULT_MIN_NUM_REPLICAS);
-    Assert.assertEquals(tableConfigsResponse.getRealtime().getReplicationNumber(),
+    Assert.assertEquals(tableConfigsResponse.getRealtime().getReplication(),
         DEFAULT_MIN_NUM_REPLICAS);
     sendDeleteRequest(DEFAULT_INSTANCE.getControllerRequestURLBuilder().forTableConfigsDelete(tableName));
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/TableConfigsRestletResourceTest.java
@@ -306,9 +306,9 @@ public class TableConfigsRestletResourceTest extends ControllerTest {
     response = sendGetRequest(DEFAULT_INSTANCE.getControllerRequestURLBuilder().forTableConfigsGet(tableName));
     tableConfigsResponse = JsonUtils.stringToObject(response, TableConfigs.class);
     Assert.assertEquals(tableConfigsResponse.getTableName(), tableName);
-    Assert.assertEquals(tableConfigsResponse.getOffline().getValidationConfig().getReplicationNumber(),
+    Assert.assertEquals(tableConfigsResponse.getOffline().getReplicationNumber(),
         DEFAULT_MIN_NUM_REPLICAS);
-    Assert.assertEquals(tableConfigsResponse.getRealtime().getValidationConfig().getReplicasPerPartitionNumber(),
+    Assert.assertEquals(tableConfigsResponse.getRealtime().getReplicationNumber(),
         DEFAULT_MIN_NUM_REPLICAS);
     sendDeleteRequest(DEFAULT_INSTANCE.getControllerRequestURLBuilder().forTableConfigsDelete(tableName));
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/PinotResourceManagerTest.java
@@ -79,15 +79,16 @@ public class PinotResourceManagerTest {
     Schema dummySchema = TEST_INSTANCE.createDummySchema(invalidRealtimeTable);
     TEST_INSTANCE.addSchema(dummySchema);
 
-    Map<String, String> streamConfigs = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
     // Missing replicasPerPartition
     TableConfig invalidRealtimeTableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setStreamConfigs(streamConfigs).setTableName(invalidRealtimeTable)
+        new TableConfigBuilder(TableType.REALTIME).setTableName(invalidRealtimeTable)
             .setSchemaName(dummySchema.getSchemaName()).build();
+
     try {
       TEST_INSTANCE.getHelixResourceManager().addTable(invalidRealtimeTableConfig);
       Assert.fail(
-          "Table creation should have thrown exception due to missing replicasPerPartition in validation config");
+          "Table creation should have thrown exception due to missing stream config and replicasPerPartition in "
+              + "validation config");
     } catch (Exception e) {
       // expected
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupSegmentAssignmentTest.java
@@ -30,6 +30,7 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
@@ -79,9 +80,10 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
           System.currentTimeMillis()).getSegmentName());
     }
 
+    Map<String, String> streamConfigs = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS)
-            .setLLC(true).build();
+            .setLLC(true).setStreamConfigs(streamConfigs).build();
     _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig);
 
     _instancePartitionsMap = new TreeMap<>();
@@ -113,9 +115,10 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
 
   @Test
   public void testReplicationForSegmentAssignment() {
+    Map<String, String> streamConfigs = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS)
-            .setLLC(true).build();
+            .setLLC(true).setStreamConfigs(streamConfigs).build();
     // Update the replication by changing the NUM_REPLICAS_PER_PARTITION
     tableConfig.getValidationConfig().setReplicasPerPartition(NUM_REPLICAS_PER_PARTITION);
     SegmentAssignment segmentAssignment =

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupTieredSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupTieredSegmentAssignmentTest.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.tier.Tier;
 import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.common.tier.TierSegmentSelector;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.TierConfig;
@@ -117,9 +118,11 @@ public class RealtimeNonReplicaGroupTieredSegmentAssignmentTest {
             TierFactory.PINOT_SERVER_STORAGE_TYPE, TAG_B_NAME, null, null),
         new TierConfig(TIER_C_NAME, TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
             TierFactory.PINOT_SERVER_STORAGE_TYPE, TAG_C_NAME, null, null));
+
+    Map<String, String> streamConfigs = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS)
-            .setTierConfigList(tierConfigList).setLLC(true).build();
+            .setTierConfigList(tierConfigList).setLLC(true).setStreamConfigs(streamConfigs).build();
     _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(null, tableConfig);
 
     _instancePartitionsMap = new TreeMap<>();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
@@ -31,6 +31,7 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -83,9 +84,11 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
           System.currentTimeMillis()).getSegmentName());
     }
 
+    Map<String, String> streamConfigs = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS)
-            .setLLC(true).setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
+            .setLLC(true).setStreamConfigs(streamConfigs)
+            .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
             .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(PARTITION_COLUMN, 1)).build();
     _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig);
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/SegmentAssignmentStrategyFactoryTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/SegmentAssignmentStrategyFactoryTest.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentTestUtils;
+import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -98,14 +99,15 @@ public class SegmentAssignmentStrategyFactoryTest {
 
   @Test
   public void testBalancedNumSegmentAssignmentStrategyForRealtimeTables() {
-    TableConfig tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setLLC(true).build();
+    Map<String, String> streamConfigs = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setLLC(true)
+        .setStreamConfigs(streamConfigs).build();
     InstancePartitions instancePartitions = new InstancePartitions(INSTANCE_PARTITIONS_NAME);
     instancePartitions.setInstances(0, 0, INSTANCES);
 
-    SegmentAssignmentStrategy segmentAssignmentStrategy = SegmentAssignmentStrategyFactory
-        .getSegmentAssignmentStrategy(null, tableConfig, InstancePartitionsType.COMPLETED.toString(),
-            instancePartitions);
+    SegmentAssignmentStrategy segmentAssignmentStrategy =
+        SegmentAssignmentStrategyFactory.getSegmentAssignmentStrategy(null, tableConfig,
+            InstancePartitionsType.COMPLETED.toString(), instancePartitions);
     Assert.assertNotNull(segmentAssignmentStrategy);
 
     Assert.assertTrue(segmentAssignmentStrategy instanceof BalancedNumSegmentAssignmentStrategy);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.controller.helix.core.retention;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.model.IdealState;
@@ -34,6 +35,7 @@ import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.PinotTableIdealStateBuilder;
 import org.apache.pinot.controller.helix.core.SegmentDeletionManager;
+import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
@@ -152,8 +154,10 @@ public class RetentionManagerTest {
   }
 
   private TableConfig createRealtimeTableConfig1(int replicaCount) {
+    Map<String, String> streamConfigs = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
     return new TableConfigBuilder(TableType.REALTIME).setTableName(TEST_TABLE_NAME).setLLC(true)
-        .setRetentionTimeUnit("DAYS").setRetentionTimeValue("5").setNumReplicas(replicaCount).build();
+        .setStreamConfigs(streamConfigs).setRetentionTimeUnit("DAYS").setRetentionTimeValue("5")
+        .setNumReplicas(replicaCount).build();
   }
 
   private void setupPinotHelixResourceManager(TableConfig tableConfig, final List<String> removedSegments,
@@ -233,7 +237,7 @@ public class RetentionManagerTest {
 
   private PinotHelixResourceManager setupSegmentMetadata(TableConfig tableConfig, final long now, final int nSegments,
       List<String> segmentsToBeDeleted) {
-    final int replicaCount = Integer.valueOf(tableConfig.getValidationConfig().getReplicasPerPartition());
+    final int replicaCount = tableConfig.getReplicationNumber();
 
     List<SegmentZKMetadata> segmentsZKMetadata = new ArrayList<>();
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/retention/RetentionManagerTest.java
@@ -237,7 +237,7 @@ public class RetentionManagerTest {
 
   private PinotHelixResourceManager setupSegmentMetadata(TableConfig tableConfig, final long now, final int nSegments,
       List<String> segmentsToBeDeleted) {
-    final int replicaCount = tableConfig.getReplicationNumber();
+    final int replicaCount = tableConfig.getReplication();
 
     List<SegmentZKMetadata> segmentsZKMetadata = new ArrayList<>();
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -995,7 +995,7 @@ public final class TableConfigUtils {
     if (verifyReplication) {
       int requestReplication;
       try {
-        requestReplication = tableConfig.getReplicationNumber();
+        requestReplication = tableConfig.getReplication();
         if (requestReplication < defaultTableMinReplicas) {
           LOGGER.info("Creating table with minimum replication factor of: {} instead of requested replication: {}",
               defaultTableMinReplicas, requestReplication);
@@ -1009,7 +1009,7 @@ public final class TableConfigUtils {
     if (verifyReplicasPerPartition) {
       int replicasPerPartition;
       try {
-        replicasPerPartition = tableConfig.getReplicationNumber();
+        replicasPerPartition = tableConfig.getReplication();
         if (replicasPerPartition < defaultTableMinReplicas) {
           LOGGER.info(
               "Creating table with minimum replicasPerPartition of: {} instead of requested replicasPerPartition: {}",

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -972,6 +972,9 @@ public final class TableConfigUtils {
   }
 
   /**
+   * TODO: After deprecating "replicasPerPartition", we can change this function's behavior to always overwrite
+   * config to "replication" only.
+   *
    * Ensure that the table config has the minimum number of replicas set as per cluster configs.
    * If is doesn't, set the required amount of replication in the table config
    */
@@ -992,7 +995,7 @@ public final class TableConfigUtils {
     if (verifyReplication) {
       int requestReplication;
       try {
-        requestReplication = segmentsConfig.getReplicationNumber();
+        requestReplication = tableConfig.getReplicationNumber();
         if (requestReplication < defaultTableMinReplicas) {
           LOGGER.info("Creating table with minimum replication factor of: {} instead of requested replication: {}",
               defaultTableMinReplicas, requestReplication);
@@ -1004,12 +1007,9 @@ public final class TableConfigUtils {
     }
 
     if (verifyReplicasPerPartition) {
-      String replicasPerPartitionStr = segmentsConfig.getReplicasPerPartition();
-      if (replicasPerPartitionStr == null) {
-        throw new IllegalStateException("Field replicasPerPartition needs to be specified");
-      }
+      int replicasPerPartition;
       try {
-        int replicasPerPartition = Integer.parseInt(replicasPerPartitionStr);
+        replicasPerPartition = tableConfig.getReplicationNumber();
         if (replicasPerPartition < defaultTableMinReplicas) {
           LOGGER.info(
               "Creating table with minimum replicasPerPartition of: {} instead of requested replicasPerPartition: {}",
@@ -1017,7 +1017,7 @@ public final class TableConfigUtils {
           segmentsConfig.setReplicasPerPartition(String.valueOf(defaultTableMinReplicas));
         }
       } catch (NumberFormatException e) {
-        throw new IllegalStateException("Invalid value for replicasPerPartition: '" + replicasPerPartitionStr + "'", e);
+        throw new IllegalStateException("Invalid replicasPerPartition number", e);
       }
     }
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -125,7 +125,7 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   }
 
   /**
-   * @deprecated Use {@link TableConfig#getReplicationNumber()}
+   * Try to Use {@link TableConfig#getReplication()}
    */
   public String getReplication() {
     return _replication;
@@ -146,7 +146,7 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   }
 
   /**
-   * @deprecated Use {@link TableConfig#getReplicationNumber()}
+   * Try to Use {@link TableConfig#getReplication()}
    */
   public String getReplicasPerPartition() {
     return _replicasPerPartition;
@@ -173,7 +173,7 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   }
 
   /**
-   * @deprecated Use {@link TableConfig#getReplicationNumber()}
+   * Try to Use {@link TableConfig#getReplication()}
    */
   @JsonIgnore
   public int getReplicationNumber() {
@@ -181,7 +181,7 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   }
 
   /**
-   * @deprecated Use {@link TableConfig#getReplicationNumber()}
+   * Try to Use {@link TableConfig#getReplication()}
    */
   @JsonIgnore
   public int getReplicasPerPartitionNumber() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -124,6 +124,9 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
     _segmentPushType = segmentPushType;
   }
 
+  /**
+   * @deprecated Use {@link TableConfig#getReplicationNumber()}
+   */
   public String getReplication() {
     return _replication;
   }
@@ -142,6 +145,9 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
     _schemaName = schemaName;
   }
 
+  /**
+   * @deprecated Use {@link TableConfig#getReplicationNumber()}
+   */
   public String getReplicasPerPartition() {
     return _replicasPerPartition;
   }
@@ -166,11 +172,17 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
     _completionConfig = completionConfig;
   }
 
+  /**
+   * @deprecated Use {@link TableConfig#getReplicationNumber()}
+   */
   @JsonIgnore
   public int getReplicationNumber() {
     return Integer.parseInt(_replication);
   }
 
+  /**
+   * @deprecated Use {@link TableConfig#getReplicationNumber()}
+   */
   @JsonIgnore
   public int getReplicasPerPartitionNumber() {
     return Integer.parseInt(_replicasPerPartition);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -358,8 +358,7 @@ public class TableConfig extends BaseJsonConfig {
   }
 
   @JsonIgnore
-  public int getReplicationNumber() {
-    Preconditions.checkNotNull(_validationConfig, "Validation config should not be null.");
+  public int getReplication() {
     int replication = 0;
     if (_tableType == TableType.REALTIME) {
       StreamConfig streamConfig = new StreamConfig(_tableName, IngestionConfigUtils.getStreamConfigMap(this));

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotNumReplicaChanger.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotNumReplicaChanger.java
@@ -53,7 +53,7 @@ public class PinotNumReplicaChanger extends PinotZKChanger {
     // Get the number of replicas in the tableconfig.
     final String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
     final TableConfig offlineTableConfig = ZKMetadataProvider.getOfflineTableConfig(_propertyStore, offlineTableName);
-    final int newNumReplicas = Integer.parseInt(offlineTableConfig.getValidationConfig().getReplication());
+    final int newNumReplicas = offlineTableConfig.getReplicationNumber();
 
     // Now get the idealstate, and get the number of replicas in it.
     IdealState currentIdealState = _helixAdmin.getResourceIdealState(_clusterName, offlineTableName);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotNumReplicaChanger.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotNumReplicaChanger.java
@@ -53,7 +53,7 @@ public class PinotNumReplicaChanger extends PinotZKChanger {
     // Get the number of replicas in the tableconfig.
     final String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
     final TableConfig offlineTableConfig = ZKMetadataProvider.getOfflineTableConfig(_propertyStore, offlineTableName);
-    final int newNumReplicas = offlineTableConfig.getReplicationNumber();
+    final int newNumReplicas = offlineTableConfig.getReplication();
 
     // Now get the idealstate, and get the number of replicas in it.
     IdealState currentIdealState = _helixAdmin.getResourceIdealState(_clusterName, offlineTableName);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RealtimeProvisioningHelperCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RealtimeProvisioningHelperCommand.java
@@ -221,7 +221,7 @@ public class RealtimeProvisioningHelperCommand extends AbstractBaseAdminCommand 
 
     StringBuilder note = new StringBuilder();
     note.append("\nNote:\n");
-    int numReplicas = tableConfig.getReplicationNumber();
+    int numReplicas = tableConfig.getReplication();
     int tableRetentionHours = (int) TimeUnit.valueOf(tableConfig.getValidationConfig().getRetentionTimeUnit())
         .toHours(Long.parseLong(tableConfig.getValidationConfig().getRetentionTimeValue()));
     if (_retentionHours > 0) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RealtimeProvisioningHelperCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RealtimeProvisioningHelperCommand.java
@@ -221,7 +221,7 @@ public class RealtimeProvisioningHelperCommand extends AbstractBaseAdminCommand 
 
     StringBuilder note = new StringBuilder();
     note.append("\nNote:\n");
-    int numReplicas = tableConfig.getValidationConfig().getReplicasPerPartitionNumber();
+    int numReplicas = tableConfig.getReplicationNumber();
     int tableRetentionHours = (int) TimeUnit.valueOf(tableConfig.getValidationConfig().getRetentionTimeUnit())
         .toHours(Long.parseLong(tableConfig.getValidationConfig().getRetentionTimeValue()));
     if (_retentionHours > 0) {


### PR DESCRIPTION
Currently, we have a separate configuration for replication. Offline and HLC reads from `replication` and LLC reads from `replicasPerPartition`. This PR combines the read access for the replication config.