### PR TITLE
Merge new columns in existing record with default merge strategy

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
@@ -34,26 +34,18 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 public class PartialUpsertHandler {
   // _column2Mergers maintains the mapping of merge strategies per columns.
   private final Map<String, PartialUpsertMerger> _column2Mergers = new HashMap<>();
-  private final UpsertConfig.Strategy _defaultPartialUpsertStrategy;
+  private final PartialUpsertMerger _defaultPartialUpsertMerger;
   private final String _comparisonColumn;
   private final List<String> _primaryKeyColumns;
 
   public PartialUpsertHandler(Schema schema, Map<String, UpsertConfig.Strategy> partialUpsertStrategies,
       UpsertConfig.Strategy defaultPartialUpsertStrategy, String comparisonColumn) {
-    _defaultPartialUpsertStrategy = defaultPartialUpsertStrategy;
+    _defaultPartialUpsertMerger = PartialUpsertMergerFactory.getMerger(defaultPartialUpsertStrategy);
     _comparisonColumn = comparisonColumn;
     _primaryKeyColumns = schema.getPrimaryKeyColumns();
 
     for (Map.Entry<String, UpsertConfig.Strategy> entry : partialUpsertStrategies.entrySet()) {
       _column2Mergers.put(entry.getKey(), PartialUpsertMergerFactory.getMerger(entry.getValue()));
-    }
-    // For all physical columns (including date time columns) except for primary key columns and comparison column.
-    // If no comparison column is configured, use main time column as the comparison time.
-    for (String columnName : schema.getPhysicalColumnNames()) {
-      if (!_primaryKeyColumns.contains(columnName) && !_column2Mergers.containsKey(columnName)
-          && !_comparisonColumn.equals(columnName)) {
-        _column2Mergers.put(columnName, PartialUpsertMergerFactory.getMerger(_defaultPartialUpsertStrategy));
-      }
     }
   }
 
@@ -80,8 +72,7 @@ public class PartialUpsertHandler {
             newRecord.putValue(column, previousRecord.getValue(column));
             newRecord.removeNullValueField(column);
           } else {
-            PartialUpsertMerger merger = _column2Mergers.getOrDefault(column,
-                PartialUpsertMergerFactory.getMerger(_defaultPartialUpsertStrategy));
+            PartialUpsertMerger merger = _column2Mergers.getOrDefault(column, _defaultPartialUpsertMerger);
             newRecord.putValue(column,
                 merger.merge(previousRecord.getValue(column), newRecord.getValue(column)));
           }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandlerTest.java
@@ -66,7 +66,7 @@ public class PartialUpsertHandlerTest {
 
     // newRecord is default null value, while previousRecord is not.
     // field1 should not be incremented since the newRecord is null.
-    // special case: field2 should be overrided by null value because we didn't enabled default partial upsert strategy.
+    // special case: field2 should be merged based on default partial upsert strategy.
     previousRecord.clear();
     incomingRecord.clear();
     previousRecord.putValue("field1", 1);
@@ -76,7 +76,8 @@ public class PartialUpsertHandlerTest {
     newRecord = handler.merge(previousRecord, incomingRecord);
     assertFalse(newRecord.isNullValue("field1"));
     assertEquals(newRecord.getValue("field1"), 1);
-    assertTrue(newRecord.isNullValue("field2"));
+    assertFalse(newRecord.isNullValue("field2"));
+    assertEquals(newRecord.getValue("field2"), 2);
 
     // neither of records is null.
     previousRecord.clear();


### PR DESCRIPTION
Related to #9771 

After a schema evolves (eg. new column added), the column is not treated as an upsert column by the partition upsert manager because it is not part of `PartialUpsertHandler#column2Mergers`. This PR attempts to fix this by iterating through all columns in the record and applying a default merge strategy on all columns, except primary key and comparison column. 

Note: This PR can handle schema evolution of adding new columns without restarting the server, as long as there are no changes to the upsert config. Any change made to the `upsertConfig: {}`  section in the table config of a partial upsert enabled table will require a server restart to correctly reload all segments and the metadata. 

Labels: `bugfix` 
