### PR TITLE
ADLS file system upgrade

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -39,7 +39,7 @@
     <dependency>
       <groupId>com.microsoft.azure</groupId>
       <artifactId>azure-data-lake-store-sdk</artifactId>
-      <version>2.3.9</version>
+      <version>2.3.10</version>
     </dependency>
     <dependency>
       <groupId>com.azure</groupId>

--- a/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSTest.java
@@ -21,14 +21,11 @@ package org.apache.pinot.plugin.filesystem.test;
 import com.azure.core.http.rest.PagedIterable;
 import com.azure.core.http.rest.SimpleResponse;
 import com.azure.core.util.Context;
-import com.azure.storage.blob.BlobClient;
-import com.azure.storage.blob.BlobContainerClient;
-import com.azure.storage.blob.BlobServiceClient;
-import com.azure.storage.blob.specialized.BlobInputStream;
 import com.azure.storage.file.datalake.DataLakeDirectoryClient;
 import com.azure.storage.file.datalake.DataLakeFileClient;
 import com.azure.storage.file.datalake.DataLakeFileSystemClient;
 import com.azure.storage.file.datalake.DataLakeServiceClient;
+import com.azure.storage.file.datalake.models.DataLakeFileOpenInputStreamResult;
 import com.azure.storage.file.datalake.models.DataLakeStorageException;
 import com.azure.storage.file.datalake.models.PathItem;
 import com.azure.storage.file.datalake.models.PathProperties;
@@ -39,10 +36,11 @@ import java.net.URISyntaxException;
 import java.time.Instant;
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
+import java.util.stream.Stream;
 import org.apache.pinot.plugin.filesystem.ADLSGen2PinotFS;
+import org.apache.pinot.plugin.filesystem.AzurePinotFSUtil;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.FileMetadata;
 import org.mockito.Mock;
@@ -65,17 +63,13 @@ public class ADLSGen2PinotFSTest {
   @Mock
   private DataLakeDirectoryClient _mockDirectoryClient;
   @Mock
-  private BlobServiceClient _mockBlobServiceClient;
-  @Mock
-  private BlobContainerClient _mockBlobContainerClient;
-  @Mock
-  private BlobClient _mockBlobClient;
-  @Mock
-  private BlobInputStream _mockBlobInputStream;
-  @Mock
   private DataLakeServiceClient _mockServiceClient;
   @Mock
   private DataLakeFileClient _mockFileClient;
+  @Mock
+  private DataLakeFileOpenInputStreamResult _mockFileOpenInputStreamResult;
+  @Mock
+  private InputStream _mockInputStream;
   @Mock
   private DataLakeStorageException _mockDataLakeStorageException;
   @Mock
@@ -95,8 +89,8 @@ public class ADLSGen2PinotFSTest {
   @BeforeMethod
   public void setup()
       throws URISyntaxException {
-    MockitoAnnotations.initMocks(this);
-    _adlsGen2PinotFsUnderTest = new ADLSGen2PinotFS(_mockFileSystemClient, _mockBlobServiceClient);
+    MockitoAnnotations.openMocks(this);
+    _adlsGen2PinotFsUnderTest = new ADLSGen2PinotFS(_mockFileSystemClient);
     _mockURI = new URI("mock://mock");
   }
 
@@ -104,7 +98,7 @@ public class ADLSGen2PinotFSTest {
   public void tearDown() {
     verifyNoMoreInteractions(_mockDataLakeStorageException, _mockServiceClient, _mockFileSystemClient,
         _mockSimpleResponse, _mockDirectoryClient, _mockPathItem, _mockPagedIterable, _mockPathProperties,
-        _mockFileClient, _mockBlobContainerClient, _mockBlobClient, _mockBlobServiceClient, _mockBlobInputStream);
+        _mockFileClient, _mockFileOpenInputStreamResult, _mockInputStream);
   }
 
   @Test(expectedExceptions = NullPointerException.class)
@@ -195,7 +189,7 @@ public class ADLSGen2PinotFSTest {
   public void testListFiles()
       throws IOException {
     when(_mockFileSystemClient.listPaths(any(), any())).thenReturn(_mockPagedIterable);
-    when(_mockPagedIterable.stream()).thenReturn(Collections.singletonList(_mockPathItem).stream());
+    when(_mockPagedIterable.stream()).thenReturn(Stream.of(_mockPathItem));
     when(_mockPathItem.getName()).thenReturn("foo");
 
     String[] actual = _adlsGen2PinotFsUnderTest.listFiles(_mockURI, true);
@@ -210,7 +204,7 @@ public class ADLSGen2PinotFSTest {
   public void testListFilesWithMetadata()
       throws IOException {
     when(_mockFileSystemClient.listPaths(any(), any())).thenReturn(_mockPagedIterable);
-    when(_mockPagedIterable.stream()).thenReturn(Collections.singletonList(_mockPathItem).stream());
+    when(_mockPagedIterable.stream()).thenReturn(Stream.of(_mockPathItem));
     when(_mockPathItem.getName()).thenReturn("foo");
     when(_mockPathItem.isDirectory()).thenReturn(false);
     when(_mockPathItem.getContentLength()).thenReturn(1024L);
@@ -268,7 +262,7 @@ public class ADLSGen2PinotFSTest {
     when(_mockDirectoryClient.getProperties()).thenReturn(_mockPathProperties);
     when(_mockPathProperties.getMetadata()).thenReturn(metadata);
     when(_mockFileSystemClient.listPaths(any(), any())).thenReturn(_mockPagedIterable);
-    when(_mockPagedIterable.stream()).thenReturn(Collections.singletonList(_mockPathItem).stream());
+    when(_mockPagedIterable.stream()).thenReturn(Stream.of(_mockPathItem));
     when(_mockPathItem.getName()).thenReturn("foo");
     when(_mockFileSystemClient.deleteDirectoryWithResponse(eq(""), eq(true), eq(null), eq(null), eq(Context.NONE)))
         .thenReturn(_mockSimpleResponse);
@@ -358,8 +352,7 @@ public class ADLSGen2PinotFSTest {
   }
 
   @Test
-  public void testExistsException()
-      throws IOException {
+  public void testExistsException() {
     when(_mockFileSystemClient.getDirectoryClient(any())).thenReturn(_mockDirectoryClient);
     when(_mockDirectoryClient.getProperties()).thenThrow(_mockDataLakeStorageException);
     when(_mockDataLakeStorageException.getStatusCode()).thenReturn(123);
@@ -441,17 +434,15 @@ public class ADLSGen2PinotFSTest {
   @Test
   public void open()
       throws IOException {
-    when(_mockFileSystemClient.getFileSystemName()).thenReturn(MOCK_FILE_SYSTEM_NAME);
-    when(_mockBlobServiceClient.getBlobContainerClient(MOCK_FILE_SYSTEM_NAME)).thenReturn(_mockBlobContainerClient);
-    when(_mockBlobContainerClient.getBlobClient(any())).thenReturn(_mockBlobClient);
-    when(_mockBlobClient.openInputStream()).thenReturn(_mockBlobInputStream);
+    when(_mockFileSystemClient.getFileClient(any())).thenReturn(_mockFileClient);
+    when(_mockFileClient.openInputStream()).thenReturn(_mockFileOpenInputStreamResult);
+    when(_mockFileOpenInputStreamResult.getInputStream()).thenReturn(_mockInputStream);
 
     InputStream actual = _adlsGen2PinotFsUnderTest.open(_mockURI);
-    Assert.assertEquals(actual, _mockBlobInputStream);
+    Assert.assertEquals(actual, _mockInputStream);
 
-    verify(_mockFileSystemClient).getFileSystemName();
-    verify(_mockBlobServiceClient).getBlobContainerClient(MOCK_FILE_SYSTEM_NAME);
-    verify(_mockBlobContainerClient).getBlobClient(any());
-    verify(_mockBlobClient).openInputStream();
+    verify(_mockFileSystemClient).getFileClient(AzurePinotFSUtil.convertUriToUrlEncodedAzureStylePath(_mockURI));
+    verify(_mockFileClient).openInputStream();
+    verify(_mockFileOpenInputStreamResult).getInputStream();
   }
 }


### PR DESCRIPTION
1. upgrade azure-data-lake-store-sdk version to 2.3.10
2. use DataLakeFileSystemClient for open method as well
3. support a new auth type `NONE`, meaning no cred is added.