### PR TITLE
Clean up transform functions

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunction.java
@@ -33,12 +33,10 @@ import org.apache.pinot.spi.utils.ArrayCopyUtils;
 public class AdditionTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "add";
 
+  private final List<TransformFunction> _transformFunctions = new ArrayList<>();
   private DataType _resultDataType;
   private double _literalDoubleSum = 0.0;
   private BigDecimal _literalBigDecimalSum = BigDecimal.ZERO;
-  private List<TransformFunction> _transformFunctions = new ArrayList<>();
-  private double[] _doubleSums;
-  private BigDecimal[] _bigDecimalSums;
 
   @Override
   public String getName() {
@@ -89,44 +87,42 @@ public class AdditionTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    if (_doubleSums == null || _doubleSums.length < length) {
-      _doubleSums = new double[length];
+    if (_doubleValuesSV == null) {
+      _doubleValuesSV = new double[length];
     }
-
     if (_resultDataType == DataType.BIG_DECIMAL) {
       BigDecimal[] values = transformToBigDecimalValuesSV(projectionBlock);
-      ArrayCopyUtils.copy(values, _doubleSums, length);
+      ArrayCopyUtils.copy(values, _doubleValuesSV, length);
     } else {
-      Arrays.fill(_doubleSums, 0, length, _literalDoubleSum);
+      Arrays.fill(_doubleValuesSV, 0, length, _literalDoubleSum);
       for (TransformFunction transformFunction : _transformFunctions) {
         double[] values = transformFunction.transformToDoubleValuesSV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _doubleSums[i] += values[i];
+          _doubleValuesSV[i] += values[i];
         }
       }
     }
-    return _doubleSums;
+    return _doubleValuesSV;
   }
 
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    if (_bigDecimalSums == null || _bigDecimalSums.length < length) {
-      _bigDecimalSums = new BigDecimal[length];
+    if (_bigDecimalValuesSV == null) {
+      _bigDecimalValuesSV = new BigDecimal[length];
     }
-
     if (_resultDataType == DataType.DOUBLE) {
       double[] values = transformToDoubleValuesSV(projectionBlock);
-      ArrayCopyUtils.copy(values, _bigDecimalSums, length);
+      ArrayCopyUtils.copy(values, _bigDecimalValuesSV, length);
     } else {
-      Arrays.fill(_bigDecimalSums, 0, length, _literalBigDecimalSum);
+      Arrays.fill(_bigDecimalValuesSV, 0, length, _literalBigDecimalSum);
       for (TransformFunction transformFunction : _transformFunctions) {
         BigDecimal[] values = transformFunction.transformToBigDecimalValuesSV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _bigDecimalSums[i] = _bigDecimalSums[i].add(values[i]);
+          _bigDecimalValuesSV[i] = _bigDecimalValuesSV[i].add(values[i]);
         }
       }
     }
-    return _bigDecimalSums;
+    return _bigDecimalValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayAverageTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayAverageTransformFunction.java
@@ -36,7 +36,6 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 public class ArrayAverageTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "arrayAverage";
 
-  private double[] _results;
   private TransformFunction _argument;
 
   @Override
@@ -71,11 +70,9 @@ public class ArrayAverageTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
-    if (_results == null || _results.length < length) {
-      _results = new double[length];
+    if (_doubleValuesSV == null) {
+      _doubleValuesSV = new double[length];
     }
-
     switch (_argument.getResultMetadata().getDataType().getStoredType()) {
       case INT:
         int[][] intValuesMV = _argument.transformToIntValuesMV(projectionBlock);
@@ -84,7 +81,7 @@ public class ArrayAverageTransformFunction extends BaseTransformFunction {
           for (int value : intValuesMV[i]) {
             sumRes += value;
           }
-          _results[i] = sumRes / intValuesMV[i].length;
+          _doubleValuesSV[i] = sumRes / intValuesMV[i].length;
         }
         break;
       case LONG:
@@ -94,7 +91,7 @@ public class ArrayAverageTransformFunction extends BaseTransformFunction {
           for (long value : longValuesMV[i]) {
             sumRes += value;
           }
-          _results[i] = sumRes / longValuesMV[i].length;
+          _doubleValuesSV[i] = sumRes / longValuesMV[i].length;
         }
         break;
       case FLOAT:
@@ -104,7 +101,7 @@ public class ArrayAverageTransformFunction extends BaseTransformFunction {
           for (float value : floatValuesMV[i]) {
             sumRes += value;
           }
-          _results[i] = sumRes / floatValuesMV[i].length;
+          _doubleValuesSV[i] = sumRes / floatValuesMV[i].length;
         }
         break;
       case DOUBLE:
@@ -114,12 +111,12 @@ public class ArrayAverageTransformFunction extends BaseTransformFunction {
           for (double value : doubleValuesMV[i]) {
             sumRes += value;
           }
-          _results[i] = sumRes / doubleValuesMV[i].length;
+          _doubleValuesSV[i] = sumRes / doubleValuesMV[i].length;
         }
         break;
       default:
         throw new IllegalStateException();
     }
-    return _results;
+    return _doubleValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLengthTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLengthTransformFunction.java
@@ -36,7 +36,6 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 public class ArrayLengthTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "arrayLength";
 
-  private int[] _results;
   private TransformFunction _argument;
 
   @Override
@@ -68,45 +67,43 @@ public class ArrayLengthTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
-    if (_results == null || _results.length < length) {
-      _results = new int[length];
+    if (_intValuesSV == null) {
+      _intValuesSV = new int[length];
     }
-
     switch (_argument.getResultMetadata().getDataType().getStoredType()) {
       case INT:
         int[][] intValuesMV = _argument.transformToIntValuesMV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _results[i] = intValuesMV[i].length;
+          _intValuesSV[i] = intValuesMV[i].length;
         }
         break;
       case LONG:
         long[][] longValuesMV = _argument.transformToLongValuesMV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _results[i] = longValuesMV[i].length;
+          _intValuesSV[i] = longValuesMV[i].length;
         }
         break;
       case FLOAT:
         float[][] floatValuesMV = _argument.transformToFloatValuesMV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _results[i] = floatValuesMV[i].length;
+          _intValuesSV[i] = floatValuesMV[i].length;
         }
         break;
       case DOUBLE:
         double[][] doubleValuesMV = _argument.transformToDoubleValuesMV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _results[i] = doubleValuesMV[i].length;
+          _intValuesSV[i] = doubleValuesMV[i].length;
         }
         break;
       case STRING:
         String[][] stringValuesMV = _argument.transformToStringValuesMV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _results[i] = stringValuesMV[i].length;
+          _intValuesSV[i] = stringValuesMV[i].length;
         }
         break;
       default:
         throw new IllegalStateException();
     }
-    return _results;
+    return _intValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMaxTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMaxTransformFunction.java
@@ -38,11 +38,6 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 public class ArrayMaxTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "arrayMax";
 
-  private int[] _intValuesSV;
-  private long[] _longValuesSV;
-  private float[] _floatValuesSV;
-  private double[] _doubleValuesSV;
-  private String[] _stringValuesSV;
   private TransformFunction _argument;
   private TransformResultMetadata _resultMetadata;
 
@@ -78,10 +73,8 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.INT) {
       return super.transformToIntValuesSV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
-
-    if (_intValuesSV == null || _intValuesSV.length < length) {
+    if (_intValuesSV == null) {
       _intValuesSV = new int[length];
     }
     int[][] intValuesMV = _argument.transformToIntValuesMV(projectionBlock);
@@ -100,10 +93,8 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.LONG) {
       return super.transformToLongValuesSV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
-
-    if (_longValuesSV == null || _longValuesSV.length < length) {
+    if (_longValuesSV == null) {
       _longValuesSV = new long[length];
     }
     long[][] longValuesMV = _argument.transformToLongValuesMV(projectionBlock);
@@ -122,10 +113,8 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.FLOAT) {
       return super.transformToFloatValuesSV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
-
-    if (_floatValuesSV == null || _floatValuesSV.length < length) {
+    if (_floatValuesSV == null) {
       _floatValuesSV = new float[length];
     }
     float[][] floatValuesMV = _argument.transformToFloatValuesMV(projectionBlock);
@@ -144,10 +133,8 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.DOUBLE) {
       return super.transformToDoubleValuesSV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
-
-    if (_doubleValuesSV == null || _doubleValuesSV.length < length) {
+    if (_doubleValuesSV == null) {
       _doubleValuesSV = new double[length];
     }
     double[][] doubleValuesMV = _argument.transformToDoubleValuesMV(projectionBlock);
@@ -166,10 +153,8 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.STRING) {
       return super.transformToStringValuesSV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
-
-    if (_stringValuesSV == null || _stringValuesSV.length < length) {
+    if (_stringValuesSV == null) {
       _stringValuesSV = new String[length];
     }
     String[][] stringValuesMV = _argument.transformToStringValuesMV(projectionBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMinTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMinTransformFunction.java
@@ -38,11 +38,6 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 public class ArrayMinTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "arrayMin";
 
-  private int[] _intValuesSV;
-  private long[] _longValuesSV;
-  private float[] _floatValuesSV;
-  private double[] _doubleValuesSV;
-  private String[] _stringValuesSV;
   private TransformFunction _argument;
   private TransformResultMetadata _resultMetadata;
 
@@ -78,10 +73,8 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.INT) {
       return super.transformToIntValuesSV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
-
-    if (_intValuesSV == null || _intValuesSV.length < length) {
+    if (_intValuesSV == null) {
       _intValuesSV = new int[length];
     }
     int[][] intValuesMV = _argument.transformToIntValuesMV(projectionBlock);
@@ -100,13 +93,10 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.LONG) {
       return super.transformToLongValuesSV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
-
-    if (_longValuesSV == null || _longValuesSV.length < length) {
+    if (_longValuesSV == null) {
       _longValuesSV = new long[length];
     }
-
     long[][] longValuesMV = _argument.transformToLongValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       long minRes = Long.MAX_VALUE;
@@ -123,13 +113,10 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.FLOAT) {
       return super.transformToFloatValuesSV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
-
-    if (_floatValuesSV == null || _floatValuesSV.length < length) {
+    if (_floatValuesSV == null) {
       _floatValuesSV = new float[length];
     }
-
     float[][] floatValuesMV = _argument.transformToFloatValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       float minRes = Float.POSITIVE_INFINITY;
@@ -146,13 +133,10 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.DOUBLE) {
       return super.transformToDoubleValuesSV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
-
-    if (_doubleValuesSV == null || _doubleValuesSV.length < length) {
+    if (_doubleValuesSV == null) {
       _doubleValuesSV = new double[length];
     }
-
     double[][] doubleValuesMV = _argument.transformToDoubleValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       double minRes = Double.POSITIVE_INFINITY;
@@ -169,13 +153,10 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
     if (_argument.getResultMetadata().getDataType().getStoredType() != DataType.STRING) {
       return super.transformToStringValuesSV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
-
-    if (_stringValuesSV == null || _stringValuesSV.length < length) {
+    if (_stringValuesSV == null) {
       _stringValuesSV = new String[length];
     }
-
     String[][] stringValuesMV = _argument.transformToStringValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       String minRes = null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArraySumTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArraySumTransformFunction.java
@@ -36,7 +36,6 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 public class ArraySumTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "arraySum";
 
-  private double[] _results;
   private TransformFunction _argument;
 
   @Override
@@ -71,19 +70,17 @@ public class ArraySumTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
-    if (_results == null || _results.length < length) {
-      _results = new double[length];
+    if (_doubleValuesSV == null) {
+      _doubleValuesSV = new double[length];
     }
-
     double[][] doubleValuesMV = _argument.transformToDoubleValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
       double sumRes = 0;
       for (double value : doubleValuesMV[i]) {
         sumRes += value;
       }
-      _results[i] = sumRes;
+      _doubleValuesSV[i] = sumRes;
     }
-    return _results;
+    return _doubleValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
@@ -74,6 +74,9 @@ public abstract class BaseTransformFunction implements TransformFunction {
   protected static final TransformResultMetadata BYTES_MV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.BYTES, false, false);
 
+  // These buffers are used to hold the result for different result types. When the subclass overrides a method, it can
+  // reuse the buffer for that method. E.g. if transformToIntValuesSV is overridden, the result can be written into
+  // _intValuesSV.
   protected int[] _intValuesSV;
   protected long[] _longValuesSV;
   protected float[] _floatValuesSV;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -35,7 +35,6 @@ import org.apache.pinot.spi.utils.ByteArray;
  * The results are BOOLEAN type.
  */
 public abstract class BinaryOperatorTransformFunction extends BaseTransformFunction {
-
   private static final int EQUALS = 0;
   private static final int GREATER_THAN_OR_EQUAL = 1;
   private static final int GREATER_THAN = 2;
@@ -49,7 +48,6 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   protected TransformFunction _rightTransformFunction;
   protected DataType _leftStoredType;
   protected DataType _rightStoredType;
-  protected int[] _results;
 
   protected BinaryOperatorTransformFunction(TransformFunctionType transformFunctionType) {
     // translate to integer in [0, 5] for guaranteed tableswitch
@@ -109,13 +107,13 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     fillResultArray(projectionBlock);
-    return _results;
+    return _intValuesSV;
   }
 
   private void fillResultArray(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    if (_results == null || _results.length < length) {
-      _results = new int[length];
+    if (_intValuesSV == null) {
+      _intValuesSV = new int[length];
     }
     switch (_leftStoredType) {
       case INT:
@@ -286,7 +284,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     String[] leftStringValues = _leftTransformFunction.transformToStringValuesSV(projectionBlock);
     String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(leftStringValues[i].compareTo(rightStringValues[i]));
+      _intValuesSV[i] = getIntResult(leftStringValues[i].compareTo(rightStringValues[i]));
     }
   }
 
@@ -294,42 +292,42 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     byte[][] leftBytesValues = _leftTransformFunction.transformToBytesValuesSV(projectionBlock);
     byte[][] rightBytesValues = _rightTransformFunction.transformToBytesValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult((ByteArray.compare(leftBytesValues[i], rightBytesValues[i])));
+      _intValuesSV[i] = getIntResult((ByteArray.compare(leftBytesValues[i], rightBytesValues[i])));
     }
   }
 
   private void fillIntResultArray(ProjectionBlock projectionBlock, int[] leftIntValues, int length) {
     int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Integer.compare(leftIntValues[i], rightIntValues[i]));
+      _intValuesSV[i] = getIntResult(Integer.compare(leftIntValues[i], rightIntValues[i]));
     }
   }
 
   private void fillLongResultArray(ProjectionBlock projectionBlock, int[] leftValues, int length) {
     long[] rightValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Long.compare(leftValues[i], rightValues[i]));
+      _intValuesSV[i] = getIntResult(Long.compare(leftValues[i], rightValues[i]));
     }
   }
 
   private void fillFloatResultArray(ProjectionBlock projectionBlock, int[] leftValues, int length) {
     float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Double.compare(leftValues[i], rightFloatValues[i]));
+      _intValuesSV[i] = getIntResult(Double.compare(leftValues[i], rightFloatValues[i]));
     }
   }
 
   private void fillDoubleResultArray(ProjectionBlock projectionBlock, int[] leftValues, int length) {
     double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Double.compare(leftValues[i], rightDoubleValues[i]));
+      _intValuesSV[i] = getIntResult(Double.compare(leftValues[i], rightDoubleValues[i]));
     }
   }
 
   private void fillBigDecimalResultArray(ProjectionBlock projectionBlock, int[] leftValues, int length) {
     BigDecimal[] rightBigDecimalValues = _rightTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(rightBigDecimalValues[i]));
+      _intValuesSV[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(rightBigDecimalValues[i]));
     }
   }
 
@@ -337,9 +335,10 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
       try {
-        _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+        _intValuesSV[i] =
+            getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
       } catch (NumberFormatException e) {
-        _results[i] = 0;
+        _intValuesSV[i] = 0;
       }
     }
   }
@@ -347,35 +346,35 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private void fillIntResultArray(ProjectionBlock projectionBlock, long[] leftIntValues, int length) {
     int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Long.compare(leftIntValues[i], rightIntValues[i]));
+      _intValuesSV[i] = getIntResult(Long.compare(leftIntValues[i], rightIntValues[i]));
     }
   }
 
   private void fillLongResultArray(ProjectionBlock projectionBlock, long[] leftValues, int length) {
     long[] rightValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Long.compare(leftValues[i], rightValues[i]));
+      _intValuesSV[i] = getIntResult(Long.compare(leftValues[i], rightValues[i]));
     }
   }
 
   private void fillFloatResultArray(ProjectionBlock projectionBlock, long[] leftValues, int length) {
     float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(compare(leftValues[i], rightFloatValues[i]));
+      _intValuesSV[i] = getIntResult(compare(leftValues[i], rightFloatValues[i]));
     }
   }
 
   private void fillDoubleResultArray(ProjectionBlock projectionBlock, long[] leftValues, int length) {
     double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(compare(leftValues[i], rightDoubleValues[i]));
+      _intValuesSV[i] = getIntResult(compare(leftValues[i], rightDoubleValues[i]));
     }
   }
 
   private void fillBigDecimalResultArray(ProjectionBlock projectionBlock, long[] leftValues, int length) {
     BigDecimal[] rightBigDecimalValues = _rightTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(rightBigDecimalValues[i]));
+      _intValuesSV[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(rightBigDecimalValues[i]));
     }
   }
 
@@ -383,9 +382,10 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
       try {
-        _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+        _intValuesSV[i] =
+            getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
       } catch (NumberFormatException e) {
-        _results[i] = 0;
+        _intValuesSV[i] = 0;
       }
     }
   }
@@ -393,35 +393,35 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private void fillIntResultArray(ProjectionBlock projectionBlock, float[] leftValues, int length) {
     int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Double.compare(leftValues[i], rightIntValues[i]));
+      _intValuesSV[i] = getIntResult(Double.compare(leftValues[i], rightIntValues[i]));
     }
   }
 
   private void fillLongResultArray(ProjectionBlock projectionBlock, float[] leftValues, int length) {
     long[] rightValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(compare(leftValues[i], rightValues[i]));
+      _intValuesSV[i] = getIntResult(compare(leftValues[i], rightValues[i]));
     }
   }
 
   private void fillFloatResultArray(ProjectionBlock projectionBlock, float[] leftValues, int length) {
     float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Float.compare(leftValues[i], rightFloatValues[i]));
+      _intValuesSV[i] = getIntResult(Float.compare(leftValues[i], rightFloatValues[i]));
     }
   }
 
   private void fillDoubleResultArray(ProjectionBlock projectionBlock, float[] leftValues, int length) {
     double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Double.compare(leftValues[i], rightDoubleValues[i]));
+      _intValuesSV[i] = getIntResult(Double.compare(leftValues[i], rightDoubleValues[i]));
     }
   }
 
   private void fillBigDecimalResultArray(ProjectionBlock projectionBlock, float[] leftValues, int length) {
     BigDecimal[] rightBigDecimalValues = _rightTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(rightBigDecimalValues[i]));
+      _intValuesSV[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(rightBigDecimalValues[i]));
     }
   }
 
@@ -429,9 +429,10 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
       try {
-        _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+        _intValuesSV[i] =
+            getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
       } catch (NumberFormatException e) {
-        _results[i] = 0;
+        _intValuesSV[i] = 0;
       }
     }
   }
@@ -439,35 +440,35 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private void fillIntResultArray(ProjectionBlock projectionBlock, double[] leftValues, int length) {
     int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Double.compare(leftValues[i], rightIntValues[i]));
+      _intValuesSV[i] = getIntResult(Double.compare(leftValues[i], rightIntValues[i]));
     }
   }
 
   private void fillLongResultArray(ProjectionBlock projectionBlock, double[] leftValues, int length) {
     long[] rightValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(compare(leftValues[i], rightValues[i]));
+      _intValuesSV[i] = getIntResult(compare(leftValues[i], rightValues[i]));
     }
   }
 
   private void fillFloatResultArray(ProjectionBlock projectionBlock, double[] leftValues, int length) {
     float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Double.compare(leftValues[i], rightFloatValues[i]));
+      _intValuesSV[i] = getIntResult(Double.compare(leftValues[i], rightFloatValues[i]));
     }
   }
 
   private void fillDoubleResultArray(ProjectionBlock projectionBlock, double[] leftValues, int length) {
     double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(Double.compare(leftValues[i], rightDoubleValues[i]));
+      _intValuesSV[i] = getIntResult(Double.compare(leftValues[i], rightDoubleValues[i]));
     }
   }
 
   private void fillBigDecimalResultArray(ProjectionBlock projectionBlock, double[] leftValues, int length) {
     BigDecimal[] rightBigDecimalValues = _rightTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(rightBigDecimalValues[i]));
+      _intValuesSV[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(rightBigDecimalValues[i]));
     }
   }
 
@@ -475,9 +476,10 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
     String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
       try {
-        _results[i] = getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
+        _intValuesSV[i] =
+            getIntResult(BigDecimal.valueOf(leftValues[i]).compareTo(new BigDecimal(rightStringValues[i])));
       } catch (NumberFormatException e) {
-        _results[i] = 0;
+        _intValuesSV[i] = 0;
       }
     }
   }
@@ -485,42 +487,42 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
   private void fillIntResultArray(ProjectionBlock projectionBlock, BigDecimal[] leftValues, int length) {
     int[] rightIntValues = _rightTransformFunction.transformToIntValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(leftValues[i].compareTo(BigDecimal.valueOf(rightIntValues[i])));
+      _intValuesSV[i] = getIntResult(leftValues[i].compareTo(BigDecimal.valueOf(rightIntValues[i])));
     }
   }
 
   private void fillLongResultArray(ProjectionBlock projectionBlock, BigDecimal[] leftValues, int length) {
     long[] rightLongValues = _rightTransformFunction.transformToLongValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(leftValues[i].compareTo(BigDecimal.valueOf(rightLongValues[i])));
+      _intValuesSV[i] = getIntResult(leftValues[i].compareTo(BigDecimal.valueOf(rightLongValues[i])));
     }
   }
 
   private void fillFloatResultArray(ProjectionBlock projectionBlock, BigDecimal[] leftValues, int length) {
     float[] rightFloatValues = _rightTransformFunction.transformToFloatValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(leftValues[i].compareTo(BigDecimal.valueOf(rightFloatValues[i])));
+      _intValuesSV[i] = getIntResult(leftValues[i].compareTo(BigDecimal.valueOf(rightFloatValues[i])));
     }
   }
 
   private void fillDoubleResultArray(ProjectionBlock projectionBlock, BigDecimal[] leftValues, int length) {
     double[] rightDoubleValues = _rightTransformFunction.transformToDoubleValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(leftValues[i].compareTo(BigDecimal.valueOf(rightDoubleValues[i])));
+      _intValuesSV[i] = getIntResult(leftValues[i].compareTo(BigDecimal.valueOf(rightDoubleValues[i])));
     }
   }
 
   private void fillBigDecimalResultArray(ProjectionBlock projectionBlock, BigDecimal[] leftValues, int length) {
     BigDecimal[] rightBigDecimalValues = _rightTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(leftValues[i].compareTo(rightBigDecimalValues[i]));
+      _intValuesSV[i] = getIntResult(leftValues[i].compareTo(rightBigDecimalValues[i]));
     }
   }
 
   private void fillStringResultArray(ProjectionBlock projectionBlock, BigDecimal[] leftValues, int length) {
     String[] rightStringValues = _rightTransformFunction.transformToStringValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _results[i] = getIntResult(leftValues[i].compareTo(new BigDecimal(rightStringValues[i])));
+      _intValuesSV[i] = getIntResult(leftValues[i].compareTo(new BigDecimal(rightStringValues[i])));
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -63,13 +63,6 @@ public class CaseTransformFunction extends BaseTransformFunction {
   private int _numSelections;
   private TransformResultMetadata _resultMetadata;
   private int[] _selectedResults;
-  private int[] _intResults;
-  private long[] _longResults;
-  private float[] _floatResults;
-  private double[] _doubleResults;
-  private BigDecimal[] _bigDecimalResults;
-  private String[] _stringResults;
-  private byte[][] _bytesResults;
 
   @Override
   public String getName() {
@@ -289,8 +282,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     int[] selected = getSelectedArray(projectionBlock);
     int numDocs = projectionBlock.getNumDocs();
-    if (_intResults == null || _intResults.length < numDocs) {
-      _intResults = new int[numDocs];
+    if (_intValuesSV == null) {
+      _intValuesSV = new int[numDocs];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
@@ -298,17 +291,17 @@ public class CaseTransformFunction extends BaseTransformFunction {
         TransformFunction transformFunction = _elseThenStatements.get(i);
         int[] intValues = transformFunction.transformToIntValuesSV(projectionBlock);
         if (_numSelections == 1) {
-          System.arraycopy(intValues, 0, _intResults, 0, numDocs);
+          System.arraycopy(intValues, 0, _intValuesSV, 0, numDocs);
         } else {
           for (int j = 0; j < numDocs; j++) {
             if (selected[j] == i) {
-              _intResults[j] = intValues[j];
+              _intValuesSV[j] = intValues[j];
             }
           }
         }
       }
     }
-    return _intResults;
+    return _intValuesSV;
   }
 
   @Override
@@ -318,8 +311,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     int[] selected = getSelectedArray(projectionBlock);
     int numDocs = projectionBlock.getNumDocs();
-    if (_longResults == null || _longResults.length < numDocs) {
-      _longResults = new long[numDocs];
+    if (_longValuesSV == null) {
+      _longValuesSV = new long[numDocs];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
@@ -327,17 +320,17 @@ public class CaseTransformFunction extends BaseTransformFunction {
         TransformFunction transformFunction = _elseThenStatements.get(i);
         long[] longValues = transformFunction.transformToLongValuesSV(projectionBlock);
         if (_numSelections == 1) {
-          System.arraycopy(longValues, 0, _longResults, 0, numDocs);
+          System.arraycopy(longValues, 0, _longValuesSV, 0, numDocs);
         } else {
           for (int j = 0; j < numDocs; j++) {
             if (selected[j] == i) {
-              _longResults[j] = longValues[j];
+              _longValuesSV[j] = longValues[j];
             }
           }
         }
       }
     }
-    return _longResults;
+    return _longValuesSV;
   }
 
   @Override
@@ -347,8 +340,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     int[] selected = getSelectedArray(projectionBlock);
     int numDocs = projectionBlock.getNumDocs();
-    if (_floatResults == null || _floatResults.length < numDocs) {
-      _floatResults = new float[numDocs];
+    if (_floatValuesSV == null) {
+      _floatValuesSV = new float[numDocs];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
@@ -356,17 +349,17 @@ public class CaseTransformFunction extends BaseTransformFunction {
         TransformFunction transformFunction = _elseThenStatements.get(i);
         float[] floatValues = transformFunction.transformToFloatValuesSV(projectionBlock);
         if (_numSelections == 1) {
-          System.arraycopy(floatValues, 0, _floatResults, 0, numDocs);
+          System.arraycopy(floatValues, 0, _floatValuesSV, 0, numDocs);
         } else {
           for (int j = 0; j < numDocs; j++) {
             if (selected[j] == i) {
-              _floatResults[j] = floatValues[j];
+              _floatValuesSV[j] = floatValues[j];
             }
           }
         }
       }
     }
-    return _floatResults;
+    return _floatValuesSV;
   }
 
   @Override
@@ -376,8 +369,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     int[] selected = getSelectedArray(projectionBlock);
     int numDocs = projectionBlock.getNumDocs();
-    if (_doubleResults == null || _doubleResults.length < numDocs) {
-      _doubleResults = new double[numDocs];
+    if (_doubleValuesSV == null) {
+      _doubleValuesSV = new double[numDocs];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
@@ -385,17 +378,17 @@ public class CaseTransformFunction extends BaseTransformFunction {
         TransformFunction transformFunction = _elseThenStatements.get(i);
         double[] doubleValues = transformFunction.transformToDoubleValuesSV(projectionBlock);
         if (_numSelections == 1) {
-          System.arraycopy(doubleValues, 0, _doubleResults, 0, numDocs);
+          System.arraycopy(doubleValues, 0, _doubleValuesSV, 0, numDocs);
         } else {
           for (int j = 0; j < numDocs; j++) {
             if (selected[j] == i) {
-              _doubleResults[j] = doubleValues[j];
+              _doubleValuesSV[j] = doubleValues[j];
             }
           }
         }
       }
     }
-    return _doubleResults;
+    return _doubleValuesSV;
   }
 
   @Override
@@ -405,8 +398,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     int[] selected = getSelectedArray(projectionBlock);
     int numDocs = projectionBlock.getNumDocs();
-    if (_bigDecimalResults == null || _bigDecimalResults.length < numDocs) {
-      _bigDecimalResults = new BigDecimal[numDocs];
+    if (_bigDecimalValuesSV == null) {
+      _bigDecimalValuesSV = new BigDecimal[numDocs];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
@@ -414,17 +407,17 @@ public class CaseTransformFunction extends BaseTransformFunction {
         TransformFunction transformFunction = _elseThenStatements.get(i);
         BigDecimal[] bigDecimalValues = transformFunction.transformToBigDecimalValuesSV(projectionBlock);
         if (_numSelections == 1) {
-          System.arraycopy(bigDecimalValues, 0, _bigDecimalResults, 0, numDocs);
+          System.arraycopy(bigDecimalValues, 0, _bigDecimalValuesSV, 0, numDocs);
         } else {
           for (int j = 0; j < numDocs; j++) {
             if (selected[j] == i) {
-              _bigDecimalResults[j] = bigDecimalValues[j];
+              _bigDecimalValuesSV[j] = bigDecimalValues[j];
             }
           }
         }
       }
     }
-    return _bigDecimalResults;
+    return _bigDecimalValuesSV;
   }
 
   @Override
@@ -434,8 +427,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     int[] selected = getSelectedArray(projectionBlock);
     int numDocs = projectionBlock.getNumDocs();
-    if (_stringResults == null || _selectedResults.length < numDocs) {
-      _stringResults = new String[numDocs];
+    if (_stringValuesSV == null) {
+      _stringValuesSV = new String[numDocs];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
@@ -443,17 +436,17 @@ public class CaseTransformFunction extends BaseTransformFunction {
         TransformFunction transformFunction = _elseThenStatements.get(i);
         String[] stringValues = transformFunction.transformToStringValuesSV(projectionBlock);
         if (_numSelections == 1) {
-          System.arraycopy(stringValues, 0, _stringResults, 0, numDocs);
+          System.arraycopy(stringValues, 0, _stringValuesSV, 0, numDocs);
         } else {
           for (int j = 0; j < numDocs; j++) {
             if (selected[j] == i) {
-              _stringResults[j] = stringValues[j];
+              _stringValuesSV[j] = stringValues[j];
             }
           }
         }
       }
     }
-    return _stringResults;
+    return _stringValuesSV;
   }
 
   @Override
@@ -463,8 +456,8 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     int[] selected = getSelectedArray(projectionBlock);
     int numDocs = projectionBlock.getNumDocs();
-    if (_bytesResults == null || _bytesResults.length < numDocs) {
-      _bytesResults = new byte[numDocs][];
+    if (_bytesValuesSV == null) {
+      _bytesValuesSV = new byte[numDocs][];
     }
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
@@ -476,12 +469,12 @@ public class CaseTransformFunction extends BaseTransformFunction {
         } else {
           for (int j = 0; j < numDocs; j++) {
             if (selected[j] == i) {
-              _bytesResults[j] = bytesValues[j];
+              _bytesValuesSV[j] = bytesValues[j];
             }
           }
         }
       }
     }
-    return _bytesResults;
+    return _bytesValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunction.java
@@ -81,7 +81,9 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
    */
   private int[] getIntTransformResults(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    int[] results = new int[length];
+    if (_intValuesSV == null) {
+      _intValuesSV = new int[length];
+    }
     int width = _transformFunctions.length;
     RoaringBitmap[] nullBitMaps = getNullBitMaps(projectionBlock, _transformFunctions);
     int[][] data = new int[width][length];
@@ -98,14 +100,14 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
           data[j] = _transformFunctions[j].transformToIntValuesSV(projectionBlock);
         }
         hasNonNullValue = true;
-        results[i] = data[j][i];
+        _intValuesSV[i] = data[j][i];
         break;
       }
       if (!hasNonNullValue) {
-        results[i] = NULL_INT;
+        _intValuesSV[i] = NULL_INT;
       }
     }
-    return results;
+    return _intValuesSV;
   }
 
   /**
@@ -114,7 +116,9 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
    */
   private long[] getLongTransformResults(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    long[] results = new long[length];
+    if (_longValuesSV == null) {
+      _longValuesSV = new long[length];
+    }
     int width = _transformFunctions.length;
     RoaringBitmap[] nullBitMaps = getNullBitMaps(projectionBlock, _transformFunctions);
     long[][] data = new long[width][length];
@@ -131,14 +135,14 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
           data[j] = _transformFunctions[j].transformToLongValuesSV(projectionBlock);
         }
         hasNonNullValue = true;
-        results[i] = data[j][i];
+        _longValuesSV[i] = data[j][i];
         break;
       }
       if (!hasNonNullValue) {
-        results[i] = NULL_LONG;
+        _longValuesSV[i] = NULL_LONG;
       }
     }
-    return results;
+    return _longValuesSV;
   }
 
   /**
@@ -147,7 +151,9 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
    */
   private float[] getFloatTransformResults(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    float[] results = new float[length];
+    if (_floatValuesSV == null) {
+      _floatValuesSV = new float[length];
+    }
     int width = _transformFunctions.length;
     RoaringBitmap[] nullBitMaps = getNullBitMaps(projectionBlock, _transformFunctions);
     float[][] data = new float[width][length];
@@ -164,14 +170,14 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
           data[j] = _transformFunctions[j].transformToFloatValuesSV(projectionBlock);
         }
         hasNonNullValue = true;
-        results[i] = data[j][i];
+        _floatValuesSV[i] = data[j][i];
         break;
       }
       if (!hasNonNullValue) {
-        results[i] = NULL_FLOAT;
+        _floatValuesSV[i] = NULL_FLOAT;
       }
     }
-    return results;
+    return _floatValuesSV;
   }
 
   /**
@@ -180,7 +186,9 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
    */
   private double[] getDoubleTransformResults(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    double[] results = new double[length];
+    if (_doubleValuesSV == null) {
+      _doubleValuesSV = new double[length];
+    }
     int width = _transformFunctions.length;
     RoaringBitmap[] nullBitMaps = getNullBitMaps(projectionBlock, _transformFunctions);
     double[][] data = new double[width][length];
@@ -197,14 +205,14 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
           data[j] = _transformFunctions[j].transformToDoubleValuesSV(projectionBlock);
         }
         hasNonNullValue = true;
-        results[i] = data[j][i];
+        _doubleValuesSV[i] = data[j][i];
         break;
       }
       if (!hasNonNullValue) {
-        results[i] = NULL_DOUBLE;
+        _doubleValuesSV[i] = NULL_DOUBLE;
       }
     }
-    return results;
+    return _doubleValuesSV;
   }
 
   /**
@@ -213,7 +221,9 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
    */
   private BigDecimal[] getBigDecimalTransformResults(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    BigDecimal[] results = new BigDecimal[length];
+    if (_bigDecimalValuesSV == null) {
+      _bigDecimalValuesSV = new BigDecimal[length];
+    }
     int width = _transformFunctions.length;
     RoaringBitmap[] nullBitMaps = getNullBitMaps(projectionBlock, _transformFunctions);
     BigDecimal[][] data = new BigDecimal[width][length];
@@ -230,14 +240,14 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
           data[j] = _transformFunctions[j].transformToBigDecimalValuesSV(projectionBlock);
         }
         hasNonNullValue = true;
-        results[i] = data[j][i];
+        _bigDecimalValuesSV[i] = data[j][i];
         break;
       }
       if (!hasNonNullValue) {
-        results[i] = NULL_BIG_DECIMAL;
+        _bigDecimalValuesSV[i] = NULL_BIG_DECIMAL;
       }
     }
-    return results;
+    return _bigDecimalValuesSV;
   }
 
   /**
@@ -246,7 +256,9 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
    */
   private String[] getStringTransformResults(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    String[] results = new String[length];
+    if (_stringValuesSV == null) {
+      _stringValuesSV = new String[length];
+    }
     int width = _transformFunctions.length;
     RoaringBitmap[] nullBitMaps = getNullBitMaps(projectionBlock, _transformFunctions);
     String[][] data = new String[width][length];
@@ -263,14 +275,14 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
           data[j] = _transformFunctions[j].transformToStringValuesSV(projectionBlock);
         }
         hasNonNullValue = true;
-        results[i] = data[j][i];
+        _stringValuesSV[i] = data[j][i];
         break;
       }
       if (!hasNonNullValue) {
-        results[i] = NULL_STRING;
+        _stringValuesSV[i] = NULL_STRING;
       }
     }
-    return results;
+    return _stringValuesSV;
   }
 
   @Override
@@ -371,9 +383,5 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
       return super.transformToStringValuesSV(projectionBlock);
     }
     return getStringTransformResults(projectionBlock);
-  }
-
-  public static void main(String[] args) {
-    System.out.println(BigDecimal.valueOf(Long.MIN_VALUE));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
@@ -81,10 +81,8 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "dateTimeConvert";
 
   private TransformFunction _mainTransformFunction;
-  private BaseDateTimeTransformer _dateTimeTransformer;
+  private BaseDateTimeTransformer<?, ?> _dateTimeTransformer;
   private TransformResultMetadata _resultMetadata;
-  private long[] _longOutputTimes;
-  private String[] _stringOutputTimes;
 
   @Override
   public String getName() {
@@ -106,8 +104,8 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
     }
     _mainTransformFunction = firstArgument;
 
-    _dateTimeTransformer = DateTimeTransformerFactory
-        .getDateTimeTransformer(((LiteralTransformFunction) arguments.get(1)).getLiteral(),
+    _dateTimeTransformer =
+        DateTimeTransformerFactory.getDateTimeTransformer(((LiteralTransformFunction) arguments.get(1)).getLiteral(),
             ((LiteralTransformFunction) arguments.get(2)).getLiteral(),
             ((LiteralTransformFunction) arguments.get(3)).getLiteral());
     if (_dateTimeTransformer instanceof EpochToEpochTransformer
@@ -125,49 +123,43 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
 
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
-    if (_resultMetadata == LONG_SV_NO_DICTIONARY_METADATA) {
-      int length = projectionBlock.getNumDocs();
-
-      if (_longOutputTimes == null || _longOutputTimes.length < length) {
-        _longOutputTimes = new long[length];
-      }
-
-      if (_dateTimeTransformer instanceof EpochToEpochTransformer) {
-        EpochToEpochTransformer dateTimeTransformer = (EpochToEpochTransformer) _dateTimeTransformer;
-        dateTimeTransformer
-            .transform(_mainTransformFunction.transformToLongValuesSV(projectionBlock), _longOutputTimes, length);
-      } else {
-        SDFToEpochTransformer dateTimeTransformer = (SDFToEpochTransformer) _dateTimeTransformer;
-        dateTimeTransformer
-            .transform(_mainTransformFunction.transformToStringValuesSV(projectionBlock), _longOutputTimes, length);
-      }
-      return _longOutputTimes;
-    } else {
+    if (_resultMetadata != LONG_SV_NO_DICTIONARY_METADATA) {
       return super.transformToLongValuesSV(projectionBlock);
     }
+    int length = projectionBlock.getNumDocs();
+    if (_longValuesSV == null) {
+      _longValuesSV = new long[length];
+    }
+    if (_dateTimeTransformer instanceof EpochToEpochTransformer) {
+      EpochToEpochTransformer dateTimeTransformer = (EpochToEpochTransformer) _dateTimeTransformer;
+      dateTimeTransformer.transform(_mainTransformFunction.transformToLongValuesSV(projectionBlock), _longValuesSV,
+          length);
+    } else {
+      SDFToEpochTransformer dateTimeTransformer = (SDFToEpochTransformer) _dateTimeTransformer;
+      dateTimeTransformer.transform(_mainTransformFunction.transformToStringValuesSV(projectionBlock), _longValuesSV,
+          length);
+    }
+    return _longValuesSV;
   }
 
   @Override
   public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
-    if (_resultMetadata == STRING_SV_NO_DICTIONARY_METADATA) {
-      int length = projectionBlock.getNumDocs();
-
-      if (_stringOutputTimes == null || _stringOutputTimes.length < length) {
-        _stringOutputTimes = new String[length];
-      }
-
-      if (_dateTimeTransformer instanceof EpochToSDFTransformer) {
-        EpochToSDFTransformer dateTimeTransformer = (EpochToSDFTransformer) _dateTimeTransformer;
-        dateTimeTransformer
-            .transform(_mainTransformFunction.transformToLongValuesSV(projectionBlock), _stringOutputTimes, length);
-      } else {
-        SDFToSDFTransformer dateTimeTransformer = (SDFToSDFTransformer) _dateTimeTransformer;
-        dateTimeTransformer
-            .transform(_mainTransformFunction.transformToStringValuesSV(projectionBlock), _stringOutputTimes, length);
-      }
-      return _stringOutputTimes;
-    } else {
+    if (_resultMetadata != STRING_SV_NO_DICTIONARY_METADATA) {
       return super.transformToStringValuesSV(projectionBlock);
     }
+    int length = projectionBlock.getNumDocs();
+    if (_stringValuesSV == null) {
+      _stringValuesSV = new String[length];
+    }
+    if (_dateTimeTransformer instanceof EpochToSDFTransformer) {
+      EpochToSDFTransformer dateTimeTransformer = (EpochToSDFTransformer) _dateTimeTransformer;
+      dateTimeTransformer.transform(_mainTransformFunction.transformToLongValuesSV(projectionBlock), _stringValuesSV,
+          length);
+    } else {
+      SDFToSDFTransformer dateTimeTransformer = (SDFToSDFTransformer) _dateTimeTransformer;
+      dateTimeTransformer.transform(_mainTransformFunction.transformToStringValuesSV(projectionBlock), _stringValuesSV,
+          length);
+    }
+    return _stringValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeTransformFunction.java
@@ -33,12 +33,12 @@ import org.joda.time.chrono.ISOChronology;
 
 
 public abstract class DateTimeTransformFunction extends BaseTransformFunction {
-
-  private static final TransformResultMetadata METADATA =
-      new TransformResultMetadata(FieldSpec.DataType.INT, true, false);
-  private final String _name;
-  private TransformFunction _timestampsFunction;
   protected static final Chronology UTC = ISOChronology.getInstanceUTC();
+  protected static final TransformResultMetadata METADATA =
+      new TransformResultMetadata(FieldSpec.DataType.INT, true, false);
+
+  protected final String _name;
+  protected TransformFunction _timestampsFunction;
   protected Chronology _chronology;
 
   protected DateTimeTransformFunction(String name) {
@@ -51,8 +51,7 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
     _timestampsFunction = arguments.get(0);
     if (arguments.size() == 2) {
       Preconditions.checkArgument(arguments.get(1) instanceof LiteralTransformFunction,
-          "zoneId parameter %s must be a literal",
-          _name);
+          "zoneId parameter %s must be a literal", _name);
       _chronology =
           ISOChronology.getInstance(DateTimeZone.forID(((LiteralTransformFunction) arguments.get(1)).getLiteral()));
     } else {
@@ -73,7 +72,7 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_intValuesSV == null || _intValuesSV.length < numDocs) {
+    if (_intValuesSV == null) {
       _intValuesSV = new int[numDocs];
     }
     long[] timestamps = _timestampsFunction.transformToLongValuesSV(projectionBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunction.java
@@ -86,7 +86,6 @@ public class DateTruncTransformFunction extends BaseTransformFunction {
   private static final String UTC_TZ = TimeZoneKey.UTC_KEY.getId();
   private TransformFunction _mainTransformFunction;
   private TransformResultMetadata _resultMetadata;
-  private long[] _longOutputTimes;
   private DateTimeField _field;
   private TimeUnit _inputTimeUnit;
   private TimeUnit _outputTimeUnit;
@@ -130,16 +129,15 @@ public class DateTruncTransformFunction extends BaseTransformFunction {
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
-    if (_longOutputTimes == null) {
-      _longOutputTimes = new long[length];
+    if (_longValuesSV == null) {
+      _longValuesSV = new long[length];
     }
-
     long[] input = _mainTransformFunction.transformToLongValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _longOutputTimes[i] = _outputTimeUnit
-          .convert(_field.roundFloor(TimeUnit.MILLISECONDS.convert(input[i], _inputTimeUnit)), TimeUnit.MILLISECONDS);
+      _longValuesSV[i] =
+          _outputTimeUnit.convert(_field.roundFloor(TimeUnit.MILLISECONDS.convert(input[i], _inputTimeUnit)),
+              TimeUnit.MILLISECONDS);
     }
-    return _longOutputTimes;
+    return _longValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DistinctFromTransformFunction.java
@@ -94,31 +94,31 @@ public class DistinctFromTransformFunction extends BinaryOperatorTransformFuncti
 
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
-    _results = super.transformToIntValuesSV(projectionBlock);
+    _intValuesSV = super.transformToIntValuesSV(projectionBlock);
     RoaringBitmap leftNull = getNullBitMap(projectionBlock, _leftTransformFunction);
     RoaringBitmap rightNull = getNullBitMap(projectionBlock, _rightTransformFunction);
     // Both sides are not null.
     if (isEmpty(leftNull) && isEmpty(rightNull)) {
-      return _results;
+      return _intValuesSV;
     }
     // Left side is not null.
     if (isEmpty(leftNull)) {
       // Mark right null rows as distinct.
-      rightNull.forEach((IntConsumer) i -> _results[i] = _distinctResult);
-      return _results;
+      rightNull.forEach((IntConsumer) i -> _intValuesSV[i] = _distinctResult);
+      return _intValuesSV;
     }
     // Right side is not null.
     if (isEmpty(rightNull)) {
       // Mark left null rows as distinct.
-      leftNull.forEach((IntConsumer) i -> _results[i] = _distinctResult);
-      return _results;
+      leftNull.forEach((IntConsumer) i -> _intValuesSV[i] = _distinctResult);
+      return _intValuesSV;
     }
     RoaringBitmap xorNull = RoaringBitmap.xor(leftNull, rightNull);
     // For rows that with one null and one not null, mark them as distinct
-    xorNull.forEach((IntConsumer) i -> _results[i] = _distinctResult);
+    xorNull.forEach((IntConsumer) i -> _intValuesSV[i] = _distinctResult);
     RoaringBitmap andNull = RoaringBitmap.and(leftNull, rightNull);
     // For rows that are both null, mark them as not distinct.
-    andNull.forEach((IntConsumer) i -> _results[i] = _notDistinctResult);
-    return _results;
+    andNull.forEach((IntConsumer) i -> _intValuesSV[i] = _notDistinctResult);
+    return _intValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunction.java
@@ -38,8 +38,6 @@ public class DivisionTransformFunction extends BaseTransformFunction {
   private BigDecimal[] _bigDecimalLiterals;
   private TransformFunction _firstTransformFunction;
   private TransformFunction _secondTransformFunction;
-  private double[] _doubleQuotients;
-  private BigDecimal[] _bigDecimalQuotients;
 
   @Override
   public String getName() {
@@ -100,65 +98,62 @@ public class DivisionTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
-    if (_doubleQuotients == null || _doubleQuotients.length < length) {
-      _doubleQuotients = new double[length];
+    if (_doubleValuesSV == null) {
+      _doubleValuesSV = new double[length];
     }
-
     if (_resultDataType == DataType.BIG_DECIMAL) {
       BigDecimal[] values = transformToBigDecimalValuesSV(projectionBlock);
-      ArrayCopyUtils.copy(values, _doubleQuotients, length);
+      ArrayCopyUtils.copy(values, _doubleValuesSV, length);
     } else {
       if (_firstTransformFunction == null) {
-        Arrays.fill(_doubleQuotients, 0, length, _doubleLiterals[0]);
+        Arrays.fill(_doubleValuesSV, 0, length, _doubleLiterals[0]);
       } else {
         double[] values = _firstTransformFunction.transformToDoubleValuesSV(projectionBlock);
-        System.arraycopy(values, 0, _doubleQuotients, 0, length);
+        System.arraycopy(values, 0, _doubleValuesSV, 0, length);
       }
       if (_secondTransformFunction == null) {
         for (int i = 0; i < length; i++) {
-          _doubleQuotients[i] /= _doubleLiterals[1];
+          _doubleValuesSV[i] /= _doubleLiterals[1];
         }
       } else {
         double[] values = _secondTransformFunction.transformToDoubleValuesSV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _doubleQuotients[i] /= values[i];
+          _doubleValuesSV[i] /= values[i];
         }
       }
     }
-    return _doubleQuotients;
+    return _doubleValuesSV;
   }
 
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    if (_bigDecimalQuotients == null || _bigDecimalQuotients.length < length) {
-      _bigDecimalQuotients = new BigDecimal[length];
+    if (_bigDecimalValuesSV == null) {
+      _bigDecimalValuesSV = new BigDecimal[length];
     }
-
     if (_resultDataType == DataType.DOUBLE) {
       double[] values = transformToDoubleValuesSV(projectionBlock);
-      ArrayCopyUtils.copy(values, _bigDecimalQuotients, length);
+      ArrayCopyUtils.copy(values, _bigDecimalValuesSV, length);
     } else {
       if (_firstTransformFunction == null) {
-        Arrays.fill(_bigDecimalQuotients, 0, length, _bigDecimalLiterals[0]);
+        Arrays.fill(_bigDecimalValuesSV, 0, length, _bigDecimalLiterals[0]);
       } else {
         BigDecimal[] values = _firstTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
-        System.arraycopy(values, 0, _bigDecimalQuotients, 0, length);
+        System.arraycopy(values, 0, _bigDecimalValuesSV, 0, length);
       }
       if (_secondTransformFunction == null) {
         for (int i = 0; i < length; i++) {
           // todo: expose roundingMode/mathContext as parameter in DivisionTransformFunction.
-          _bigDecimalQuotients[i] = _bigDecimalQuotients[i].divide(_bigDecimalLiterals[1], RoundingMode.HALF_EVEN);
+          _bigDecimalValuesSV[i] = _bigDecimalValuesSV[i].divide(_bigDecimalLiterals[1], RoundingMode.HALF_EVEN);
         }
       } else {
         BigDecimal[] values = _secondTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
         for (int i = 0; i < length; i++) {
           // todo: expose roundingMode/mathContext as parameter in DivisionTransformFunction.
-          _bigDecimalQuotients[i] = _bigDecimalQuotients[i].divide(values[i], RoundingMode.HALF_EVEN);
+          _bigDecimalValuesSV[i] = _bigDecimalValuesSV[i].divide(values[i], RoundingMode.HALF_EVEN);
         }
       }
     }
-    return _bigDecimalQuotients;
+    return _bigDecimalValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunction.java
@@ -50,7 +50,6 @@ public class ExtractTransformFunction extends BaseTransformFunction {
     }
 
     _field = Field.valueOf(((LiteralTransformFunction) arguments.get(0)).getLiteral());
-
     _mainTransformFunction = arguments.get(1);
   }
 
@@ -62,22 +61,17 @@ public class ExtractTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-
-    if (_intValuesSV == null || _intValuesSV.length < numDocs) {
+    if (_intValuesSV == null) {
       _intValuesSV = new int[numDocs];
     }
-
     long[] timestamps = _mainTransformFunction.transformToLongValuesSV(projectionBlock);
-
     convert(timestamps, numDocs, _intValuesSV);
-
     return _intValuesSV;
   }
 
   private void convert(long[] timestamps, int numDocs, int[] output) {
     for (int i = 0; i < numDocs; i++) {
       DateTimeField accessor;
-
       switch (_field) {
         case YEAR:
           accessor = _chronology.year();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreatestTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreatestTransformFunction.java
@@ -32,7 +32,7 @@ public class GreatestTransformFunction extends SelectTupleElementTransformFuncti
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_intValuesSV == null || _intValuesSV.length < numDocs) {
+    if (_intValuesSV == null) {
       _intValuesSV = new int[numDocs];
     }
     int[] values = _arguments.get(0).transformToIntValuesSV(projectionBlock);
@@ -49,7 +49,7 @@ public class GreatestTransformFunction extends SelectTupleElementTransformFuncti
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_longValuesSV == null || _longValuesSV.length < numDocs) {
+    if (_longValuesSV == null) {
       _longValuesSV = new long[numDocs];
     }
     long[] values = _arguments.get(0).transformToLongValuesSV(projectionBlock);
@@ -66,7 +66,7 @@ public class GreatestTransformFunction extends SelectTupleElementTransformFuncti
   @Override
   public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_floatValuesSV == null || _floatValuesSV.length < numDocs) {
+    if (_floatValuesSV == null) {
       _floatValuesSV = new float[numDocs];
     }
     float[] values = _arguments.get(0).transformToFloatValuesSV(projectionBlock);
@@ -83,7 +83,7 @@ public class GreatestTransformFunction extends SelectTupleElementTransformFuncti
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_doubleValuesSV == null || _doubleValuesSV.length < numDocs) {
+    if (_doubleValuesSV == null) {
       _doubleValuesSV = new double[numDocs];
     }
     double[] values = _arguments.get(0).transformToDoubleValuesSV(projectionBlock);
@@ -100,7 +100,7 @@ public class GreatestTransformFunction extends SelectTupleElementTransformFuncti
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null || _bigDecimalValuesSV.length < numDocs) {
+    if (_bigDecimalValuesSV == null) {
       _bigDecimalValuesSV = new BigDecimal[numDocs];
     }
     BigDecimal[] values = _arguments.get(0).transformToBigDecimalValuesSV(projectionBlock);
@@ -117,7 +117,7 @@ public class GreatestTransformFunction extends SelectTupleElementTransformFuncti
   @Override
   public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_stringValuesSV == null || _stringValuesSV.length < numDocs) {
+    if (_stringValuesSV == null) {
       _stringValuesSV = new String[numDocs];
     }
     String[] values = _arguments.get(0).transformToStringValuesSV(projectionBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InIdSetTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InIdSetTransformFunction.java
@@ -43,7 +43,6 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 public class InIdSetTransformFunction extends BaseTransformFunction {
   private TransformFunction _transformFunction;
   private IdSet _idSet;
-  private int[] _results;
 
   @Override
   public String getName() {
@@ -75,52 +74,50 @@ public class InIdSetTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
-    if (_results == null || _results.length < length) {
-      _results = new int[length];
+    if (_intValuesSV == null) {
+      _intValuesSV = new int[length];
     }
-
     DataType storedType = _transformFunction.getResultMetadata().getDataType().getStoredType();
     switch (storedType) {
       case INT:
         int[] intValues = _transformFunction.transformToIntValuesSV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _results[i] = _idSet.contains(intValues[i]) ? 1 : 0;
+          _intValuesSV[i] = _idSet.contains(intValues[i]) ? 1 : 0;
         }
         break;
       case LONG:
         long[] longValues = _transformFunction.transformToLongValuesSV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _results[i] = _idSet.contains(longValues[i]) ? 1 : 0;
+          _intValuesSV[i] = _idSet.contains(longValues[i]) ? 1 : 0;
         }
         break;
       case FLOAT:
         float[] floatValues = _transformFunction.transformToFloatValuesSV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _results[i] = _idSet.contains(floatValues[i]) ? 1 : 0;
+          _intValuesSV[i] = _idSet.contains(floatValues[i]) ? 1 : 0;
         }
         break;
       case DOUBLE:
         double[] doubleValues = _transformFunction.transformToDoubleValuesSV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _results[i] = _idSet.contains(doubleValues[i]) ? 1 : 0;
+          _intValuesSV[i] = _idSet.contains(doubleValues[i]) ? 1 : 0;
         }
         break;
       case STRING:
         String[] stringValues = _transformFunction.transformToStringValuesSV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _results[i] = _idSet.contains(stringValues[i]) ? 1 : 0;
+          _intValuesSV[i] = _idSet.contains(stringValues[i]) ? 1 : 0;
         }
         break;
       case BYTES:
         byte[][] bytesValues = _transformFunction.transformToBytesValuesSV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _results[i] = _idSet.contains(bytesValues[i]) ? 1 : 0;
+          _intValuesSV[i] = _idSet.contains(bytesValues[i]) ? 1 : 0;
         }
         break;
       default:
         throw new IllegalStateException();
     }
-    return _results;
+    return _intValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
@@ -31,8 +31,6 @@ import org.roaringbitmap.PeekableIntIterator;
 
 
 public class IsNotNullTransformFunction extends BaseTransformFunction {
-
-  private int[] _results;
   private PeekableIntIterator _nullValueVectorIterator;
 
   @Override
@@ -66,13 +64,11 @@ public class IsNotNullTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    if (_results == null || _results.length < length) {
-      _results = new int[length];
+    if (_intValuesSV == null) {
+      _intValuesSV = new int[length];
     }
-
+    Arrays.fill(_intValuesSV, 1);
     int[] docIds = projectionBlock.getDocIds();
-
-    Arrays.fill(_results, 1);
     if (_nullValueVectorIterator != null) {
       int currentDocIdIndex = 0;
       while (_nullValueVectorIterator.hasNext() & currentDocIdIndex < length) {
@@ -80,7 +76,7 @@ public class IsNotNullTransformFunction extends BaseTransformFunction {
         if (_nullValueVectorIterator.hasNext()) {
           currentDocIdIndex = Arrays.binarySearch(docIds, currentDocIdIndex, length, _nullValueVectorIterator.next());
           if (currentDocIdIndex >= 0) {
-            _results[currentDocIdIndex] = 0;
+            _intValuesSV[currentDocIdIndex] = 0;
             currentDocIdIndex++;
           } else {
             currentDocIdIndex = -currentDocIdIndex - 1;
@@ -88,7 +84,6 @@ public class IsNotNullTransformFunction extends BaseTransformFunction {
         }
       }
     }
-
-    return _results;
+    return _intValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
@@ -31,8 +31,6 @@ import org.roaringbitmap.PeekableIntIterator;
 
 
 public class IsNullTransformFunction extends BaseTransformFunction {
-
-  private int[] _results;
   private PeekableIntIterator _nullValueVectorIterator;
 
   @Override
@@ -65,13 +63,11 @@ public class IsNullTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    if (_results == null || _results.length < length) {
-      _results = new int[length];
+    if (_intValuesSV == null) {
+      _intValuesSV = new int[length];
     }
-
+    Arrays.fill(_intValuesSV, 0);
     int[] docIds = projectionBlock.getDocIds();
-
-    Arrays.fill(_results, 0);
     if (_nullValueVectorIterator != null) {
       int currentDocIdIndex = 0;
       while (_nullValueVectorIterator.hasNext() & currentDocIdIndex < length) {
@@ -79,7 +75,7 @@ public class IsNullTransformFunction extends BaseTransformFunction {
         if (_nullValueVectorIterator.hasNext()) {
           currentDocIdIndex = Arrays.binarySearch(docIds, currentDocIdIndex, length, _nullValueVectorIterator.next());
           if (currentDocIdIndex >= 0) {
-            _results[currentDocIdIndex] = 1;
+            _intValuesSV[currentDocIdIndex] = 1;
             currentDocIdIndex++;
           } else {
             currentDocIdIndex = -currentDocIdIndex - 1;
@@ -87,7 +83,6 @@ public class IsNullTransformFunction extends BaseTransformFunction {
         }
       }
     }
-
-    return _results;
+    return _intValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractKeyTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractKeyTransformFunction.java
@@ -86,11 +86,9 @@ public class JsonExtractKeyTransformFunction extends BaseTransformFunction {
   @Override
   public String[][] transformToStringValuesMV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
     if (_stringValuesMV == null) {
       _stringValuesMV = new String[length][];
     }
-
     String[] jsonStrings = _jsonFieldTransformFunction.transformToStringValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
       List<String> values = JSON_PARSER_CONTEXT.parse(jsonStrings[i]).read(_jsonPath);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunction.java
@@ -57,8 +57,8 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "jsonExtractScalar";
 
   // This ObjectMapper requires special configurations, hence we can't use pinot JsonUtils here.
-  private static final ObjectMapper OBJECT_MAPPER_WITH_BIG_DECIMAL = new ObjectMapper()
-      .configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true);
+  private static final ObjectMapper OBJECT_MAPPER_WITH_BIG_DECIMAL =
+      new ObjectMapper().configure(DeserializationFeature.USE_BIG_DECIMAL_FOR_FLOATS, true);
 
   private static final ParseContext JSON_PARSER_CONTEXT_WITH_BIG_DECIMAL = JsonPath.using(
       new Configuration.ConfigurationBuilder().jsonProvider(new JacksonJsonProvider(OBJECT_MAPPER_WITH_BIG_DECIMAL))
@@ -123,12 +123,12 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_intValuesSV == null || _intValuesSV.length < numDocs) {
+    if (_intValuesSV == null) {
       _intValuesSV = new int[numDocs];
     }
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction) {
-      ((PushDownTransformFunction) _jsonFieldTransformFunction)
-          .transformToIntValuesSV(projectionBlock, _jsonPathEvaluator, _intValuesSV);
+      ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToIntValuesSV(projectionBlock,
+          _jsonPathEvaluator, _intValuesSV);
       return _intValuesSV;
     }
     // operating on the output of another transform so can't pass the evaluation down to the storage
@@ -166,12 +166,12 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_longValuesSV == null || _longValuesSV.length < numDocs) {
+    if (_longValuesSV == null) {
       _longValuesSV = new long[numDocs];
     }
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction) {
-      ((PushDownTransformFunction) _jsonFieldTransformFunction)
-          .transformToLongValuesSV(projectionBlock, _jsonPathEvaluator, _longValuesSV);
+      ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToLongValuesSV(projectionBlock,
+          _jsonPathEvaluator, _longValuesSV);
       return _longValuesSV;
     }
     return transformTransformedValuesToLongValuesSV(projectionBlock);
@@ -209,12 +209,12 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   @Override
   public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_floatValuesSV == null || _floatValuesSV.length < numDocs) {
+    if (_floatValuesSV == null) {
       _floatValuesSV = new float[numDocs];
     }
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction) {
-      ((PushDownTransformFunction) _jsonFieldTransformFunction)
-          .transformToFloatValuesSV(projectionBlock, _jsonPathEvaluator, _floatValuesSV);
+      ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToFloatValuesSV(projectionBlock,
+          _jsonPathEvaluator, _floatValuesSV);
       return _floatValuesSV;
     }
     return transformTransformedValuesToFloatValuesSV(projectionBlock);
@@ -251,12 +251,12 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_doubleValuesSV == null || _doubleValuesSV.length < numDocs) {
+    if (_doubleValuesSV == null) {
       _doubleValuesSV = new double[numDocs];
     }
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction) {
-      ((PushDownTransformFunction) _jsonFieldTransformFunction)
-          .transformToDoubleValuesSV(projectionBlock, _jsonPathEvaluator, _doubleValuesSV);
+      ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToDoubleValuesSV(projectionBlock,
+          _jsonPathEvaluator, _doubleValuesSV);
       return _doubleValuesSV;
     }
     return transformTransformedValuesToDoubleValuesSV(projectionBlock);
@@ -293,12 +293,12 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null || _bigDecimalValuesSV.length < numDocs) {
+    if (_bigDecimalValuesSV == null) {
       _bigDecimalValuesSV = new BigDecimal[numDocs];
     }
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction) {
-      ((PushDownTransformFunction) _jsonFieldTransformFunction)
-          .transformToBigDecimalValuesSV(projectionBlock, _jsonPathEvaluator, _bigDecimalValuesSV);
+      ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToBigDecimalValuesSV(projectionBlock,
+          _jsonPathEvaluator, _bigDecimalValuesSV);
       return _bigDecimalValuesSV;
     }
     return transformTransformedValuesToBigDecimalValuesSV(projectionBlock);
@@ -335,12 +335,12 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   @Override
   public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_stringValuesSV == null || _stringValuesSV.length < numDocs) {
+    if (_stringValuesSV == null) {
       _stringValuesSV = new String[numDocs];
     }
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction) {
-      ((PushDownTransformFunction) _jsonFieldTransformFunction)
-          .transformToStringValuesSV(projectionBlock, _jsonPathEvaluator, _stringValuesSV);
+      ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToStringValuesSV(projectionBlock,
+          _jsonPathEvaluator, _stringValuesSV);
       return _stringValuesSV;
     }
     return transformTransformedValuesToStringValuesSV(projectionBlock);
@@ -377,15 +377,14 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   @Override
   public int[][] transformToIntValuesMV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_intValuesMV == null || _intValuesMV.length < numDocs) {
+    if (_intValuesMV == null) {
       _intValuesMV = new int[numDocs][];
     }
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction) {
-      ((PushDownTransformFunction) _jsonFieldTransformFunction)
-          .transformToIntValuesMV(projectionBlock, _jsonPathEvaluator, _intValuesMV);
+      ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToIntValuesMV(projectionBlock,
+          _jsonPathEvaluator, _intValuesMV);
       return _intValuesMV;
     }
-
     return transformTransformedValuesToIntValuesMV(projectionBlock);
   }
 
@@ -417,15 +416,14 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   @Override
   public long[][] transformToLongValuesMV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_longValuesMV == null || _longValuesMV.length < numDocs) {
+    if (_longValuesMV == null) {
       _longValuesMV = new long[numDocs][];
     }
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction) {
-      ((PushDownTransformFunction) _jsonFieldTransformFunction)
-          .transformToLongValuesMV(projectionBlock, _jsonPathEvaluator, _longValuesMV);
+      ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToLongValuesMV(projectionBlock,
+          _jsonPathEvaluator, _longValuesMV);
       return _longValuesMV;
     }
-
     return transformTransformedValuesToLongValuesMV(projectionBlock);
   }
 
@@ -457,15 +455,14 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   @Override
   public float[][] transformToFloatValuesMV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_floatValuesMV == null || _floatValuesMV.length < numDocs) {
+    if (_floatValuesMV == null) {
       _floatValuesMV = new float[numDocs][];
     }
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction) {
-      ((PushDownTransformFunction) _jsonFieldTransformFunction)
-          .transformToFloatValuesMV(projectionBlock, _jsonPathEvaluator, _floatValuesMV);
+      ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToFloatValuesMV(projectionBlock,
+          _jsonPathEvaluator, _floatValuesMV);
       return _floatValuesMV;
     }
-
     return transformTransformedValuesToFloatValuesMV(projectionBlock);
   }
 
@@ -497,31 +494,20 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
   @Override
   public double[][] transformToDoubleValuesMV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_doubleValuesMV == null || _doubleValuesMV.length < numDocs) {
+    if (_doubleValuesMV == null) {
       _doubleValuesMV = new double[numDocs][];
     }
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction) {
-      ((PushDownTransformFunction) _jsonFieldTransformFunction)
-          .transformToDoubleValuesMV(projectionBlock, _jsonPathEvaluator, _doubleValuesMV);
+      ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToDoubleValuesMV(projectionBlock,
+          _jsonPathEvaluator, _doubleValuesMV);
       return _doubleValuesMV;
     }
-
     return transformTransformedToDoubleValuesMV(projectionBlock);
   }
 
   private double[][] transformTransformedToDoubleValuesMV(ProjectionBlock projectionBlock) {
     // operating on the output of another transform so can't pass the evaluation down to the storage
     ensureJsonPathCompiled();
-    int numDocs = projectionBlock.getNumDocs();
-    if (_doubleValuesMV == null || _doubleValuesMV.length < numDocs) {
-      _doubleValuesMV = new double[numDocs][];
-    }
-    if (_jsonFieldTransformFunction instanceof PushDownTransformFunction) {
-      ((PushDownTransformFunction) _jsonFieldTransformFunction)
-          .transformToDoubleValuesMV(projectionBlock, _jsonPathEvaluator, _doubleValuesMV);
-      return _doubleValuesMV;
-    }
-
     String[] jsonStrings = _jsonFieldTransformFunction.transformToStringValuesSV(projectionBlock);
     int length = projectionBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
@@ -551,11 +537,10 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
       _stringValuesMV = new String[numDocs][];
     }
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction) {
-      ((PushDownTransformFunction) _jsonFieldTransformFunction)
-          .transformToStringValuesMV(projectionBlock, _jsonPathEvaluator, _stringValuesMV);
+      ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToStringValuesMV(projectionBlock,
+          _jsonPathEvaluator, _stringValuesMV);
       return _stringValuesMV;
     }
-
     return transformTransformedValuesToStringValuesMV(projectionBlock);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LeastTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LeastTransformFunction.java
@@ -32,7 +32,7 @@ public class LeastTransformFunction extends SelectTupleElementTransformFunction 
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_intValuesSV == null || _intValuesSV.length < numDocs) {
+    if (_intValuesSV == null) {
       _intValuesSV = new int[numDocs];
     }
     int[] values = _arguments.get(0).transformToIntValuesSV(projectionBlock);
@@ -49,7 +49,7 @@ public class LeastTransformFunction extends SelectTupleElementTransformFunction 
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_longValuesSV == null || _longValuesSV.length < numDocs) {
+    if (_longValuesSV == null) {
       _longValuesSV = new long[numDocs];
     }
     long[] values = _arguments.get(0).transformToLongValuesSV(projectionBlock);
@@ -66,7 +66,7 @@ public class LeastTransformFunction extends SelectTupleElementTransformFunction 
   @Override
   public float[] transformToFloatValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_floatValuesSV == null || _floatValuesSV.length < numDocs) {
+    if (_floatValuesSV == null) {
       _floatValuesSV = new float[numDocs];
     }
     float[] values = _arguments.get(0).transformToFloatValuesSV(projectionBlock);
@@ -83,7 +83,7 @@ public class LeastTransformFunction extends SelectTupleElementTransformFunction 
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_doubleValuesSV == null || _doubleValuesSV.length < numDocs) {
+    if (_doubleValuesSV == null) {
       _doubleValuesSV = new double[numDocs];
     }
     double[] values = _arguments.get(0).transformToDoubleValuesSV(projectionBlock);
@@ -100,7 +100,7 @@ public class LeastTransformFunction extends SelectTupleElementTransformFunction 
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null || _bigDecimalValuesSV.length < numDocs) {
+    if (_bigDecimalValuesSV == null) {
       _bigDecimalValuesSV = new BigDecimal[numDocs];
     }
     BigDecimal[] values = _arguments.get(0).transformToBigDecimalValuesSV(projectionBlock);
@@ -117,7 +117,7 @@ public class LeastTransformFunction extends SelectTupleElementTransformFunction 
   @Override
   public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_stringValuesSV == null || _stringValuesSV.length < numDocs) {
+    if (_stringValuesSV == null) {
       _stringValuesSV = new String[numDocs];
     }
     String[] values = _arguments.get(0).transformToStringValuesSV(projectionBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MapValueTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MapValueTransformFunction.java
@@ -97,11 +97,9 @@ public class MapValueTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToDictIdsSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
-    if (_dictIds == null || _dictIds.length < length) {
+    if (_dictIds == null) {
       _dictIds = new int[length];
     }
-
     int[][] keyDictIdsMV = _keyColumnFunction.transformToDictIdsMV(projectionBlock);
     int[][] valueDictIdsMV = _valueColumnFunction.transformToDictIdsMV(projectionBlock);
     for (int i = 0; i < length; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ModuloTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ModuloTransformFunction.java
@@ -33,7 +33,6 @@ public class ModuloTransformFunction extends BaseTransformFunction {
   private TransformFunction _firstTransformFunction;
   private double _secondLiteral;
   private TransformFunction _secondTransformFunction;
-  private double[] _modulos;
 
   @Override
   public String getName() {
@@ -73,33 +72,28 @@ public class ModuloTransformFunction extends BaseTransformFunction {
     return DOUBLE_SV_NO_DICTIONARY_METADATA;
   }
 
-  @SuppressWarnings("Duplicates")
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
-    if (_modulos == null || _modulos.length < length) {
-      _modulos = new double[length];
+    if (_doubleValuesSV == null) {
+      _doubleValuesSV = new double[length];
     }
-
     if (_firstTransformFunction == null) {
-      Arrays.fill(_modulos, 0, length, _firstLiteral);
+      Arrays.fill(_doubleValuesSV, 0, length, _firstLiteral);
     } else {
       double[] values = _firstTransformFunction.transformToDoubleValuesSV(projectionBlock);
-      System.arraycopy(values, 0, _modulos, 0, length);
+      System.arraycopy(values, 0, _doubleValuesSV, 0, length);
     }
-
     if (_secondTransformFunction == null) {
       for (int i = 0; i < length; i++) {
-        _modulos[i] %= _secondLiteral;
+        _doubleValuesSV[i] %= _secondLiteral;
       }
     } else {
       double[] values = _secondTransformFunction.transformToDoubleValuesSV(projectionBlock);
       for (int i = 0; i < length; i++) {
-        _modulos[i] %= values[i];
+        _doubleValuesSV[i] %= values[i];
       }
     }
-
-    return _modulos;
+    return _doubleValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
@@ -33,12 +33,10 @@ import org.apache.pinot.spi.utils.ArrayCopyUtils;
 public class MultiplicationTransformFunction extends BaseTransformFunction {
   public static final String FUNCTION_NAME = "mult";
 
+  private final List<TransformFunction> _transformFunctions = new ArrayList<>();
   private DataType _resultDataType;
   private double _literalDoubleProduct = 1.0;
   private BigDecimal _literalBigDecimalProduct = BigDecimal.ONE;
-  private List<TransformFunction> _transformFunctions = new ArrayList<>();
-  private double[] _doubleProducts;
-  private BigDecimal[] _bigDecimalProducts;
 
   @Override
   public String getName() {
@@ -58,8 +56,8 @@ public class MultiplicationTransformFunction extends BaseTransformFunction {
         LiteralTransformFunction literalTransformFunction = (LiteralTransformFunction) argument;
         DataType dataType = literalTransformFunction.getResultMetadata().getDataType();
         if (dataType == DataType.BIG_DECIMAL) {
-          _literalBigDecimalProduct = _literalBigDecimalProduct.multiply(
-              new BigDecimal(literalTransformFunction.getLiteral()));
+          _literalBigDecimalProduct =
+              _literalBigDecimalProduct.multiply(new BigDecimal(literalTransformFunction.getLiteral()));
           _resultDataType = DataType.BIG_DECIMAL;
         } else {
           _literalDoubleProduct *= Double.parseDouble(((LiteralTransformFunction) argument).getLiteral());
@@ -90,45 +88,42 @@ public class MultiplicationTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
-    if (_doubleProducts == null || _doubleProducts.length < length) {
-      _doubleProducts = new double[length];
+    if (_doubleValuesSV == null) {
+      _doubleValuesSV = new double[length];
     }
-
     if (_resultDataType == DataType.BIG_DECIMAL) {
       BigDecimal[] values = transformToBigDecimalValuesSV(projectionBlock);
-      ArrayCopyUtils.copy(values, _doubleProducts, length);
+      ArrayCopyUtils.copy(values, _doubleValuesSV, length);
     } else {
-      Arrays.fill(_doubleProducts, 0, length, _literalDoubleProduct);
+      Arrays.fill(_doubleValuesSV, 0, length, _literalDoubleProduct);
       for (TransformFunction transformFunction : _transformFunctions) {
         double[] values = transformFunction.transformToDoubleValuesSV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _doubleProducts[i] *= values[i];
+          _doubleValuesSV[i] *= values[i];
         }
       }
     }
-    return _doubleProducts;
+    return _doubleValuesSV;
   }
 
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    if (_bigDecimalProducts == null || _bigDecimalProducts.length < length) {
-      _bigDecimalProducts = new BigDecimal[length];
+    if (_bigDecimalValuesSV == null) {
+      _bigDecimalValuesSV = new BigDecimal[length];
     }
-
     if (_resultDataType == DataType.DOUBLE) {
       double[] values = transformToDoubleValuesSV(projectionBlock);
-      ArrayCopyUtils.copy(values, _bigDecimalProducts, length);
+      ArrayCopyUtils.copy(values, _bigDecimalValuesSV, length);
     } else {
-      Arrays.fill(_bigDecimalProducts, 0, length, _literalBigDecimalProduct);
+      Arrays.fill(_bigDecimalValuesSV, 0, length, _literalBigDecimalProduct);
       for (TransformFunction transformFunction : _transformFunctions) {
         BigDecimal[] values = transformFunction.transformToBigDecimalValuesSV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _bigDecimalProducts[i] = _bigDecimalProducts[i].multiply(values[i]);
+          _bigDecimalValuesSV[i] = _bigDecimalValuesSV[i].multiply(values[i]);
         }
       }
     }
-    return _bigDecimalProducts;
+    return _bigDecimalValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/NotOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/NotOperatorTransformFunction.java
@@ -46,7 +46,6 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
  */
 public class NotOperatorTransformFunction extends BaseTransformFunction {
   private TransformFunction _argument;
-  private int[] _results;
 
   @Override
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
@@ -71,14 +70,14 @@ public class NotOperatorTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ProjectionBlock projectionBlock) {
     int numDocs = projectionBlock.getNumDocs();
-    if (_results == null) {
-      _results = new int[numDocs];
+    if (_intValuesSV == null) {
+      _intValuesSV = new int[numDocs];
     }
     int[] intValues = _argument.transformToIntValuesSV(projectionBlock);
     for (int i = 0; i < numDocs; i++) {
-      _results[i] = getLogicalNegate(intValues[i]);
+      _intValuesSV[i] = getLogicalNegate(intValues[i]);
     }
-    return _results;
+    return _intValuesSV;
   }
 
   private static int getLogicalNegate(int val) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
@@ -65,11 +65,9 @@ public class PowerTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
-    if (_doubleValuesSV == null || _doubleValuesSV.length < length) {
+    if (_doubleValuesSV == null) {
       _doubleValuesSV = new double[length];
     }
-
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
     if (_fixedExponent) {
       for (int i = 0; i < length; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RegexpExtractTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RegexpExtractTransformFunction.java
@@ -25,7 +25,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
-import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 
 
@@ -50,7 +49,6 @@ public class RegexpExtractTransformFunction extends BaseTransformFunction {
   private Pattern _regexp;
   private int _group;
   private String _defaultValue;
-  private String[] _stringOutputRegexMatches;
   private TransformResultMetadata _resultMetadata;
 
   @Override
@@ -60,15 +58,13 @@ public class RegexpExtractTransformFunction extends BaseTransformFunction {
 
   @Override
   public void init(List<TransformFunction> arguments, Map<String, DataSource> dataSourceMap) {
-    Preconditions.checkArgument(
-        arguments.size() >= 2 && arguments.size() <= 4,
+    Preconditions.checkArgument(arguments.size() >= 2 && arguments.size() <= 4,
         "REGEXP_EXTRACT takes between 2 to 4 arguments. See usage: "
             + "REGEXP_EXTRACT(`value`, `regexp`[, `group`[, `default_value`]]");
     _valueFunction = arguments.get(0);
 
     TransformFunction regexpFunction = arguments.get(1);
-    Preconditions.checkState(
-        regexpFunction instanceof LiteralTransformFunction,
+    Preconditions.checkState(regexpFunction instanceof LiteralTransformFunction,
         "`regexp` must be a literal regex expression.");
     _regexp = Pattern.compile(((LiteralTransformFunction) regexpFunction).getLiteral());
 
@@ -91,7 +87,6 @@ public class RegexpExtractTransformFunction extends BaseTransformFunction {
       _defaultValue = "";
     }
     _resultMetadata = STRING_SV_NO_DICTIONARY_METADATA;
-    _stringOutputRegexMatches = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL];
   }
 
   @Override
@@ -102,15 +97,18 @@ public class RegexpExtractTransformFunction extends BaseTransformFunction {
   @Override
   public String[] transformToStringValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
+    if (_stringValuesSV == null) {
+      _stringValuesSV = new String[length];
+    }
     String[] valuesSV = _valueFunction.transformToStringValuesSV(projectionBlock);
     for (int i = 0; i < length; i++) {
       Matcher matcher = _regexp.matcher(valuesSV[i]);
       if (matcher.find() && matcher.groupCount() >= _group) {
-        _stringOutputRegexMatches[i] = matcher.group(_group);
+        _stringValuesSV[i] = matcher.group(_group);
       } else {
-        _stringOutputRegexMatches[i] = _defaultValue;
+        _stringValuesSV[i] = _defaultValue;
       }
     }
-    return _stringOutputRegexMatches;
+    return _stringValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
@@ -85,11 +85,9 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
-    if (_doubleValuesSV == null || _doubleValuesSV.length < length) {
+    if (_doubleValuesSV == null) {
       _doubleValuesSV = new double[length];
     }
-
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
     if (_fixedScale) {
       for (int i = 0; i < length; i++) {
@@ -107,7 +105,6 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
         _doubleValuesSV[i] = (double) Math.round(leftValues[i]);
       }
     }
-
     return _doubleValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunction.java
@@ -37,8 +37,6 @@ public class SubtractionTransformFunction extends BaseTransformFunction {
   private BigDecimal[] _bigDecimalLiterals;
   private TransformFunction _firstTransformFunction;
   private TransformFunction _secondTransformFunction;
-  private double[] _doubleDifferences;
-  private BigDecimal[] _bigDecimalDifferences;
 
   @Override
   public String getName() {
@@ -99,63 +97,60 @@ public class SubtractionTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
-    if (_doubleDifferences == null || _doubleDifferences.length < length) {
-      _doubleDifferences = new double[length];
+    if (_doubleValuesSV == null) {
+      _doubleValuesSV = new double[length];
     }
-
     if (_resultDataType == DataType.BIG_DECIMAL) {
       BigDecimal[] values = transformToBigDecimalValuesSV(projectionBlock);
-      ArrayCopyUtils.copy(values, _doubleDifferences, length);
+      ArrayCopyUtils.copy(values, _doubleValuesSV, length);
     } else {
       if (_firstTransformFunction == null) {
-        Arrays.fill(_doubleDifferences, 0, length, _doubleLiterals[0]);
+        Arrays.fill(_doubleValuesSV, 0, length, _doubleLiterals[0]);
       } else {
         double[] values = _firstTransformFunction.transformToDoubleValuesSV(projectionBlock);
-        System.arraycopy(values, 0, _doubleDifferences, 0, length);
+        System.arraycopy(values, 0, _doubleValuesSV, 0, length);
       }
       if (_secondTransformFunction == null) {
         for (int i = 0; i < length; i++) {
-          _doubleDifferences[i] -= _doubleLiterals[1];
+          _doubleValuesSV[i] -= _doubleLiterals[1];
         }
       } else {
         double[] values = _secondTransformFunction.transformToDoubleValuesSV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _doubleDifferences[i] -= values[i];
+          _doubleValuesSV[i] -= values[i];
         }
       }
     }
-    return _doubleDifferences;
+    return _doubleValuesSV;
   }
 
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-    if (_bigDecimalDifferences == null || _bigDecimalDifferences.length < length) {
-      _bigDecimalDifferences = new BigDecimal[length];
+    if (_bigDecimalValuesSV == null) {
+      _bigDecimalValuesSV = new BigDecimal[length];
     }
-
     if (_resultDataType == DataType.DOUBLE) {
       double[] values = transformToDoubleValuesSV(projectionBlock);
-      ArrayCopyUtils.copy(values, _bigDecimalDifferences, length);
+      ArrayCopyUtils.copy(values, _bigDecimalValuesSV, length);
     } else {
       if (_firstTransformFunction == null) {
-        Arrays.fill(_bigDecimalDifferences, 0, length, _bigDecimalLiterals[0]);
+        Arrays.fill(_bigDecimalValuesSV, 0, length, _bigDecimalLiterals[0]);
       } else {
         BigDecimal[] values = _firstTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
-        System.arraycopy(values, 0, _bigDecimalDifferences, 0, length);
+        System.arraycopy(values, 0, _bigDecimalValuesSV, 0, length);
       }
       if (_secondTransformFunction == null) {
         for (int i = 0; i < length; i++) {
-          _bigDecimalDifferences[i] = _bigDecimalDifferences[i].subtract(_bigDecimalLiterals[1]);
+          _bigDecimalValuesSV[i] = _bigDecimalValuesSV[i].subtract(_bigDecimalLiterals[1]);
         }
       } else {
         BigDecimal[] values = _secondTransformFunction.transformToBigDecimalValuesSV(projectionBlock);
         for (int i = 0; i < length; i++) {
-          _bigDecimalDifferences[i] = _bigDecimalDifferences[i].subtract(values[i]);
+          _bigDecimalValuesSV[i] = _bigDecimalValuesSV[i].subtract(values[i]);
         }
       }
     }
-    return _bigDecimalDifferences;
+    return _bigDecimalValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TimeConversionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TimeConversionTransformFunction.java
@@ -33,7 +33,6 @@ public class TimeConversionTransformFunction extends BaseTransformFunction {
 
   private TransformFunction _mainTransformFunction;
   private TimeUnitTransformer _timeUnitTransformer;
-  private long[] _outputTimes;
 
   @Override
   public String getName() {
@@ -68,13 +67,11 @@ public class TimeConversionTransformFunction extends BaseTransformFunction {
   @Override
   public long[] transformToLongValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
-    if (_outputTimes == null || _outputTimes.length < length) {
-      _outputTimes = new long[length];
+    if (_longValuesSV == null) {
+      _longValuesSV = new long[length];
     }
-
-    _timeUnitTransformer.transform(_mainTransformFunction.transformToLongValuesSV(projectionBlock), _outputTimes,
+    _timeUnitTransformer.transform(_mainTransformFunction.transformToLongValuesSV(projectionBlock), _longValuesSV,
         length);
-    return _outputTimes;
+    return _longValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -61,6 +61,7 @@ import org.apache.pinot.core.operator.transform.function.TrigonometricTransformF
 import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.AtanTransformFunction;
 import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.CosTransformFunction;
 import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.CoshTransformFunction;
+import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.CotTransformFunction;
 import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.DegreesTransformFunction;
 import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.RadiansTransformFunction;
 import org.apache.pinot.core.operator.transform.function.TrigonometricTransformFunctions.SinTransformFunction;
@@ -211,6 +212,7 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.SIN, SinTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.COS, CosTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.TAN, TanTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.COT, CotTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.ASIN, AsinTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.ACOS, AcosTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.ATAN, AtanTransformFunction.class);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunction.java
@@ -83,11 +83,9 @@ public class TruncateDecimalTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
-    if (_doubleValuesSV == null || _doubleValuesSV.length < length) {
+    if (_doubleValuesSV == null) {
       _doubleValuesSV = new double[length];
     }
-
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(projectionBlock);
     if (_fixedScale) {
       for (int i = 0; i < length; i++) {
@@ -105,7 +103,6 @@ public class TruncateDecimalTransformFunction extends BaseTransformFunction {
         _doubleValuesSV[i] = Math.signum(leftValues[i]) * Math.floor(Math.abs(leftValues[i]));
       }
     }
-
     return _doubleValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunction.java
@@ -56,15 +56,10 @@ public class ValueInTransformFunction extends BaseTransformFunction {
   private IntSet _dictIdSet;
   private int[][] _dictIds;
   private IntSet _intValueSet;
-  private int[][] _intValues;
   private LongSet _longValueSet;
-  private long[][] _longValues;
   private FloatSet _floatValueSet;
-  private float[][] _floatValues;
   private DoubleSet _doubleValueSet;
-  private double[][] _doubleValues;
   private Set<String> _stringValueSet;
-  private String[][] _stringValues;
 
   @Override
   public String getName() {
@@ -109,7 +104,6 @@ public class ValueInTransformFunction extends BaseTransformFunction {
   @Override
   public int[][] transformToDictIdsMV(ProjectionBlock projectionBlock) {
     int length = projectionBlock.getNumDocs();
-
     if (_dictIdSet == null) {
       _dictIdSet = new IntOpenHashSet();
       assert _dictionary != null;
@@ -119,7 +113,7 @@ public class ValueInTransformFunction extends BaseTransformFunction {
           _dictIdSet.add(dictId);
         }
       }
-      if (_dictIds == null || _dictIds.length < length) {
+      if (_dictIds == null) {
         _dictIds = new int[length][];
       }
     }
@@ -135,22 +129,21 @@ public class ValueInTransformFunction extends BaseTransformFunction {
     if (_dictionary != null || _resultMetadata.getDataType().getStoredType() != DataType.INT) {
       return super.transformToIntValuesMV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
     if (_intValueSet == null) {
       _intValueSet = new IntOpenHashSet();
       for (String inValue : _stringValueSet) {
         _intValueSet.add(Integer.parseInt(inValue));
       }
-      if (_intValues == null || _intValues.length < length) {
-        _intValues = new int[length][];
+      if (_intValuesMV == null) {
+        _intValuesMV = new int[length][];
       }
     }
     int[][] unFilteredIntValues = _mainTransformFunction.transformToIntValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _intValues[i] = filterInts(_intValueSet, unFilteredIntValues[i]);
+      _intValuesMV[i] = filterInts(_intValueSet, unFilteredIntValues[i]);
     }
-    return _intValues;
+    return _intValuesMV;
   }
 
   @Override
@@ -158,22 +151,21 @@ public class ValueInTransformFunction extends BaseTransformFunction {
     if (_dictionary != null || _resultMetadata.getDataType().getStoredType() != DataType.LONG) {
       return super.transformToLongValuesMV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
     if (_longValueSet == null) {
       _longValueSet = new LongOpenHashSet();
       for (String inValue : _stringValueSet) {
         _longValueSet.add(Long.parseLong(inValue));
       }
-      if (_longValues == null || _longValues.length < length) {
-        _longValues = new long[length][];
+      if (_longValuesMV == null) {
+        _longValuesMV = new long[length][];
       }
     }
     long[][] unFilteredLongValues = _mainTransformFunction.transformToLongValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _longValues[i] = filterLongs(_longValueSet, unFilteredLongValues[i]);
+      _longValuesMV[i] = filterLongs(_longValueSet, unFilteredLongValues[i]);
     }
-    return _longValues;
+    return _longValuesMV;
   }
 
   @Override
@@ -181,22 +173,21 @@ public class ValueInTransformFunction extends BaseTransformFunction {
     if (_dictionary != null || _resultMetadata.getDataType().getStoredType() != DataType.FLOAT) {
       return super.transformToFloatValuesMV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
     if (_floatValueSet == null) {
       _floatValueSet = new FloatOpenHashSet();
       for (String inValue : _stringValueSet) {
         _floatValueSet.add(Float.parseFloat(inValue));
       }
-      if (_floatValues == null || _floatValues.length < length) {
-        _floatValues = new float[length][];
+      if (_floatValuesMV == null) {
+        _floatValuesMV = new float[length][];
       }
     }
     float[][] unFilteredFloatValues = _mainTransformFunction.transformToFloatValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _floatValues[i] = filterFloats(_floatValueSet, unFilteredFloatValues[i]);
+      _floatValuesMV[i] = filterFloats(_floatValueSet, unFilteredFloatValues[i]);
     }
-    return _floatValues;
+    return _floatValuesMV;
   }
 
   @Override
@@ -204,22 +195,21 @@ public class ValueInTransformFunction extends BaseTransformFunction {
     if (_dictionary != null || _resultMetadata.getDataType().getStoredType() != DataType.DOUBLE) {
       return super.transformToDoubleValuesMV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
     if (_doubleValueSet == null) {
       _doubleValueSet = new DoubleOpenHashSet();
       for (String inValue : _stringValueSet) {
         _doubleValueSet.add(Double.parseDouble(inValue));
       }
-      if (_doubleValues == null || _doubleValues.length < length) {
-        _doubleValues = new double[length][];
+      if (_doubleValuesMV == null) {
+        _doubleValuesMV = new double[length][];
       }
     }
     double[][] unFilteredDoubleValues = _mainTransformFunction.transformToDoubleValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _doubleValues[i] = filterDoubles(_doubleValueSet, unFilteredDoubleValues[i]);
+      _doubleValuesMV[i] = filterDoubles(_doubleValueSet, unFilteredDoubleValues[i]);
     }
-    return _doubleValues;
+    return _doubleValuesMV;
   }
 
   @Override
@@ -227,16 +217,15 @@ public class ValueInTransformFunction extends BaseTransformFunction {
     if (_dictionary != null || _resultMetadata.getDataType().getStoredType() != DataType.STRING) {
       return super.transformToStringValuesMV(projectionBlock);
     }
-
     int length = projectionBlock.getNumDocs();
-    if (_stringValues == null || _stringValues.length < length) {
-      _stringValues = new String[length][];
+    if (_stringValuesMV == null) {
+      _stringValuesMV = new String[length][];
     }
     String[][] unFilteredStringValues = _mainTransformFunction.transformToStringValuesMV(projectionBlock);
     for (int i = 0; i < length; i++) {
-      _stringValues[i] = filterStrings(_stringValueSet, unFilteredStringValues[i]);
+      _stringValuesMV[i] = filterStrings(_stringValueSet, unFilteredStringValues[i]);
     }
-    return _stringValues;
+    return _stringValuesMV;
   }
 
   private static int[] filterInts(IntSet intSet, int[] source) {


### PR DESCRIPTION
Clean up the transform functions:
- Use the value buffer from the `BaseTransformFunction`
- Remove the unnecessary length check

There are also 2 bugfixes:
- Include `cot` into the factory
- Support big_decimal conversion in `SingleParamMathTransformFunction`