### PR TITLE
Use Pulsar AdminClient to delete unused subscriptions

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
@@ -100,12 +100,13 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
   public StreamPartitionMsgOffset fetchStreamPartitionOffset(OffsetCriteria offsetCriteria, long timeoutMillis) {
     Preconditions.checkNotNull(offsetCriteria);
     Consumer consumer = null;
+    String subscription = "Pinot_" + UUID.randomUUID();
     try {
       MessageId offset = null;
       consumer =
           _pulsarClient.newConsumer().topic(_topic)
               .subscriptionInitialPosition(PulsarUtils.offsetCriteriaToSubscription(offsetCriteria))
-              .subscriptionName("Pinot_" + UUID.randomUUID()).subscribe();
+              .subscriptionName(subscription).subscribe();
 
       if (offsetCriteria.isLargest()) {
         offset = consumer.getLastMessageId();
@@ -121,6 +122,7 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
       return null;
     } finally {
       closeConsumer(consumer);
+      deleteSubscription(_topic, subscription);
     }
   }
 
@@ -203,5 +205,6 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
   public void close()
       throws IOException {
     super.close();
+    _pulsarAdminClient.close();
   }
 }


### PR DESCRIPTION
`PulsarStreamMetadataProvider` creates a `Consumer` instance with a random subscription name to fetch stream related metadata. However, this subscription is not deleted when the consumer is closed. This subscription is not really shared across pinot consumer sessions and thus, can be safely deleted. 

Identified and fixed leaky open consumers in `PulsarStreamMetadataProvider`. 

Related issue: #9854 

Labels: `bugfix` 