### PR TITLE
add v1 ingress in helm chart

### DIFF
--- a/kubernetes/helm/pinot/templates/broker/ingress.yaml
+++ b/kubernetes/helm/pinot/templates/broker/ingress.yaml
@@ -30,4 +30,38 @@ spec:
 {{- end }}
 
 {{- if .Values.broker.ingress.v1.enabled -}}
+{{- $ingressPath := .Values.broker.ingress.v1.path -}}
+{{- $serviceName := include "pinot.broker.fullname" . -}}
+{{- $servicePort := .Values.broker.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $serviceName }}
+{{- if .Values.broker.ingress.v1.annotations }}
+  annotations:
+{{ toYaml .Values.broker.ingress.v1.annotations | indent 4 }}
+{{- end }}
+  labels:
+{{- include "pinot.brokerLabels" . | nindent 4 }}
+spec:
+{{- if .Values.broker.ingress.v1.ingressClassName }}
+  ingressClassName: {{ .Values.broker.ingress.v1.ingressClassName }}
+{{- end }}
+{{- if .Values.broker.ingress.v1.tls }}
+  tls:
+{{ toYaml .Values.broker.ingress.v1.tls | indent 4 }}
+{{- end }}
+  rules:
+    {{- range .Values.broker.ingress.v1.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+    {{- end }}
 {{- end }}

--- a/kubernetes/helm/pinot/templates/controller/ingress.yaml
+++ b/kubernetes/helm/pinot/templates/controller/ingress.yaml
@@ -30,4 +30,38 @@ spec:
 {{- end }}
 
 {{- if .Values.controller.ingress.v1.enabled -}}
+{{- $ingressPath := .Values.controller.ingress.v1.path -}}
+{{- $serviceName := include "pinot.controller.fullname" . -}}
+{{- $servicePort := .Values.controller.service.port -}}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ $serviceName }}
+{{- if .Values.controller.ingress.v1.annotations }}
+  annotations:
+{{ toYaml .Values.controller.ingress.v1.annotations | indent 4 }}
+{{- end }}
+  labels:
+{{- include "pinot.controllerLabels" . | nindent 4 }}
+spec:
+{{- if .Values.controller.ingress.v1.ingressClassName }}
+  ingressClassName: {{ .Values.controller.ingress.v1.ingressClassName }}
+{{- end }}
+{{- if .Values.controller.ingress.v1.tls }}
+  tls:
+{{ toYaml .Values.controller.ingress.v1.tls | indent 4 }}
+{{- end }}
+  rules:
+    {{- range .Values.controller.ingress.v1.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            pathType: Prefix
+            backend:
+              service:
+                name: {{ $serviceName }}
+                port:
+                  number: {{ $servicePort }}
+    {{- end }}
 {{- end }}

--- a/kubernetes/helm/pinot/values.yaml
+++ b/kubernetes/helm/pinot/values.yaml
@@ -131,6 +131,11 @@ controller:
       hosts: [ ]
     v1:
       enabled: false
+      ingressClassName: ""
+      annotations: {}
+      tls: []
+      path: /
+      hosts: []
 
   resources:
     requests:
@@ -226,6 +231,11 @@ broker:
       hosts: []
     v1:
       enabled: false
+      ingressClassName: ""
+      annotations: {}
+      tls: []
+      path: /
+      hosts: []
 
   resources:
     requests:


### PR DESCRIPTION
## Propose
This PR add v1 ingress (`apiVersion: networking.k8s.io/v1`) in helm chart for controller and broker.

## Testing
 ```console
helm template kubernetes/helm/pinot \
    --set controller.external.enabled=false \
    --set controller.ingress.v1.enabled=true \
    --set controller.ingress.v1.ingressClassName=nginx \
    --set controller.ingress.v1.hosts\[0\]=pinot-controller.example.com \
    --set controller.ingress.v1.tls\[0\].hosts\[0\]=pinot-controller.example.com \
    --set controller.ingress.v1.tls\[0\].secretName=pinot-controller-tls \
    --set broker.external.enabled=false \
    --set broker.ingress.v1.enabled=true \
    --set broker.ingress.v1.ingressClassName=nginx \
    --set broker.ingress.v1.hosts\[0\]=pinot-broker.example.com \
    --set broker.ingress.v1.tls\[0\].hosts\[0\]=pinot-broker.example.com \
    --set broker.ingress.v1.tls\[0\].secretName=pinot-broker-tls
```

Deployed and tested in Kubernetes 1.22 cluster.

## References
 - https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.25/#ingress-v1-networking-k8s-io
