### PR TITLE
Support disabling dictionary at runtime for an existing column

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -433,13 +433,17 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       FieldSpec fieldSpec) {
     ChunkCompressionType compressionType = segmentCreationSpec.getRawIndexCompressionType().get(fieldSpec.getName());
     if (compressionType == null) {
-      if (fieldSpec.getFieldType() == FieldSpec.FieldType.METRIC) {
-        return ChunkCompressionType.PASS_THROUGH;
-      } else {
-        return ChunkCompressionType.LZ4;
-      }
+      compressionType = getDefaultCompressionType(fieldSpec.getFieldType());
+    }
+
+    return compressionType;
+  }
+
+  public static ChunkCompressionType getDefaultCompressionType(FieldType fieldType) {
+    if (fieldType == FieldSpec.FieldType.METRIC) {
+      return ChunkCompressionType.PASS_THROUGH;
     } else {
-      return compressionType;
+      return ChunkCompressionType.LZ4;
     }
   }
 


### PR DESCRIPTION
OSS issue: https://github.com/apache/pinot/issues/9348
Label: Feature
[Document](https://docs.google.com/document/d/1Gai0DHBnyR4joG_8AcoR-27_exEBTpVfTFU04HyPdd8/edit#heading=h.liwwtls82n1z)

With this PR, we add support to disable dictionary on a dict-based column for immutable segments during segment reload. This support is added for both SV and MV columns.

Added Tests. 