### PR TITLE
Update cardinality when converting raw column to dict based

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -610,15 +610,14 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
 
   public String reloadTableAndValidateResponse(String tableName, TableType tableType, boolean forceDownload)
       throws IOException {
-    String jobId = null;
     String response =
         sendPostRequest(_controllerRequestURLBuilder.forTableReload(tableName, tableType, forceDownload), null);
     String tableNameWithType = TableNameBuilder.forType(tableType).tableNameWithType(tableName);
     JsonNode tableLevelDetails =
         JsonUtils.stringToJsonNode(StringEscapeUtils.unescapeJava(response.split(": ")[1])).get(tableNameWithType);
     String isZKWriteSuccess = tableLevelDetails.get("reloadJobMetaZKStorageStatus").asText();
-    assertEquals("SUCCESS", isZKWriteSuccess);
-    jobId = tableLevelDetails.get("reloadJobId").asText();
+    assertEquals(isZKWriteSuccess, "SUCCESS");
+    String jobId = tableLevelDetails.get("reloadJobId").asText();
     String jobStatusResponse = sendGetRequest(_controllerRequestURLBuilder.forControllerJobStatus(jobId));
     JsonNode jobStatus = JsonUtils.stringToJsonNode(jobStatusResponse);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -20,10 +20,12 @@ package org.apache.pinot.integration.tests;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.BufferedReader;
+import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.PropertyKey;
 import org.apache.helix.model.ExternalView;
@@ -604,6 +606,37 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
       }
       return true;
     }, 30_000L, "Failed to wait for all segments come back online");
+  }
+
+  public String reloadTableAndValidateResponse(String tableName, TableType tableType, boolean forceDownload)
+      throws IOException {
+    String jobId = null;
+    String response =
+        sendPostRequest(_controllerRequestURLBuilder.forTableReload(tableName, tableType, forceDownload), null);
+    String tableNameWithType = TableNameBuilder.forType(tableType).tableNameWithType(tableName);
+    JsonNode tableLevelDetails =
+        JsonUtils.stringToJsonNode(StringEscapeUtils.unescapeJava(response.split(": ")[1])).get(tableNameWithType);
+    String isZKWriteSuccess = tableLevelDetails.get("reloadJobMetaZKStorageStatus").asText();
+    assertEquals("SUCCESS", isZKWriteSuccess);
+    jobId = tableLevelDetails.get("reloadJobId").asText();
+    String jobStatusResponse = sendGetRequest(_controllerRequestURLBuilder.forControllerJobStatus(jobId));
+    JsonNode jobStatus = JsonUtils.stringToJsonNode(jobStatusResponse);
+
+    // Validate all fields are present
+    assertEquals(jobStatus.get("metadata").get("jobId").asText(), jobId);
+    assertEquals(jobStatus.get("metadata").get("jobType").asText(), "RELOAD_ALL_SEGMENTS");
+    assertEquals(jobStatus.get("metadata").get("tableName").asText(), tableNameWithType);
+    return jobId;
+  }
+
+  public boolean isReloadJobCompleted(String reloadJobId)
+      throws Exception {
+    String jobStatusResponse = sendGetRequest(_controllerRequestURLBuilder.forControllerJobStatus(reloadJobId));
+    JsonNode jobStatus = JsonUtils.stringToJsonNode(jobStatusResponse);
+
+    assertEquals(jobStatus.get("metadata").get("jobId").asText(), reloadJobId);
+    assertEquals(jobStatus.get("metadata").get("jobType").asText(), "RELOAD_ALL_SEGMENTS");
+    return jobStatus.get("totalSegmentCount").asInt() == jobStatus.get("successCount").asInt();
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.http.HttpStatus;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
@@ -41,6 +42,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -206,7 +208,7 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
   @Override
   public void tearDown()
       throws Exception {
-    FileUtils.deleteDirectory(new File(CONSUMER_DIRECTORY));
+     FileUtils.deleteDirectory(new File(CONSUMER_DIRECTORY));
     super.tearDown();
   }
 
@@ -298,6 +300,98 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
   public void testReload()
       throws Exception {
     testReload(false);
+  }
+
+  private String reloadRealtimeTable(String tableName, boolean forceDownload)
+      throws IOException {
+    String jobId = null;
+    String response =
+        sendPostRequest(_controllerRequestURLBuilder.forTableReload(tableName, TableType.REALTIME, forceDownload),
+            null);
+    String tableNameWithType = TableNameBuilder.REALTIME.tableNameWithType(tableName);
+    JsonNode tableLevelDetails =
+        JsonUtils.stringToJsonNode(StringEscapeUtils.unescapeJava(response.split(": ")[1])).get(tableNameWithType);
+    String isZKWriteSuccess = tableLevelDetails.get("reloadJobMetaZKStorageStatus").asText();
+    assertEquals("SUCCESS", isZKWriteSuccess);
+    jobId = tableLevelDetails.get("reloadJobId").asText();
+    String jobStatusResponse = sendGetRequest(_controllerRequestURLBuilder.forControllerJobStatus(jobId));
+    JsonNode jobStatus = JsonUtils.stringToJsonNode(jobStatusResponse);
+
+    // Validate all fields are present
+    assertEquals(jobStatus.get("metadata").get("jobId").asText(), jobId);
+    assertEquals(jobStatus.get("metadata").get("jobType").asText(), "RELOAD_ALL_SEGMENTS");
+    assertEquals(jobStatus.get("metadata").get("tableName").asText(), tableNameWithType);
+    return jobId;
+  }
+
+  private boolean isReloadJobCompleted(String reloadJobId)
+      throws Exception {
+    String jobStatusResponse = sendGetRequest(_controllerRequestURLBuilder.forControllerJobStatus(reloadJobId));
+    JsonNode jobStatus = JsonUtils.stringToJsonNode(jobStatusResponse);
+
+    assertEquals(jobStatus.get("metadata").get("jobId").asText(), reloadJobId);
+    assertEquals(jobStatus.get("metadata").get("jobType").asText(), "RELOAD_ALL_SEGMENTS");
+    return jobStatus.get("totalSegmentCount").asInt() == jobStatus.get("successCount").asInt();
+  }
+
+  @Test
+  public void testDisableDictionaryAndReload()
+      throws Exception {
+    TableConfig tableConfig = getRealtimeTableConfig();
+    tableConfig.getIndexingConfig().getNoDictionaryColumns().add("AirTime");
+    updateTableConfig(tableConfig);
+    String enableDictReloadId = reloadRealtimeTable(getTableName(), false);
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        return isReloadJobCompleted(enableDictReloadId);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 60_000L, "Failed to reload.");
+
+    assertEquals(5, 5);
+  }
+
+  @Test
+  public void testEnableDisableDictionaryAndReload()
+      throws Exception {
+    String query = "SELECT * FROM myTable WHERE ActualElapsedTime > 0";
+    JsonNode queryResponse = postQuery(query);
+    long numTotalDocsBefore = queryResponse.get("totalDocs").asLong();
+
+    // Enable dictionary.
+    TableConfig tableConfig = getRealtimeTableConfig();
+    tableConfig.getIndexingConfig().getNoDictionaryColumns().remove("ActualElapsedTime");
+    updateTableConfig(tableConfig);
+    String enableDictReloadId = reloadRealtimeTable(getTableName(), false);
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        return isReloadJobCompleted(enableDictReloadId);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 60_000L, "Failed to reload.");
+
+    queryResponse = postQuery(query);
+    long numTotalDocsAfter = queryResponse.get("totalDocs").asLong();
+    assertEquals(numTotalDocsBefore, numTotalDocsAfter);
+
+    // Disable dictionary.
+    tableConfig = getRealtimeTableConfig();
+    tableConfig.getIndexingConfig().getNoDictionaryColumns().add("ActualElapsedTime");
+    updateTableConfig(tableConfig);
+    String disableDictReloadId = reloadRealtimeTable(getTableName(), false);
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        return isReloadJobCompleted(disableDictReloadId);
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }, 60_000L, "Failed to reload.");
+
+    queryResponse = postQuery(query);
+    numTotalDocsAfter = queryResponse.get("totalDocs").asLong();
+    assertEquals(numTotalDocsBefore, numTotalDocsAfter);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -41,7 +41,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.helix.model.IdealState;
 import org.apache.http.Header;
 import org.apache.http.HttpStatus;
@@ -465,7 +464,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     TableConfig tableConfig = getOfflineTableConfig();
     tableConfig.getIndexingConfig().setInvertedIndexColumns(getInvertedIndexColumns());
     updateTableConfig(tableConfig);
-    String reloadJobId = reloadOfflineTableAndValidateResponse(getTableName(), false);
+    String reloadJobId = reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
     TestUtils.waitForCondition(aVoid -> {
       try {
         JsonNode queryResponse = postQuery(TEST_UPDATED_INVERTED_INDEX_QUERY);
@@ -535,7 +534,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     tableConfig = getOfflineTableConfig();
     tableConfig.getIndexingConfig().setInvertedIndexColumns(getInvertedIndexColumns());
     updateTableConfig(tableConfig);
-    String reloadId = reloadOfflineTableAndValidateResponse(getTableName(), true);
+    String reloadId = reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, true);
     TestUtils.waitForCondition(aVoid -> {
       try {
         JsonNode queryResponse = postQuery(TEST_UPDATED_INVERTED_INDEX_QUERY);
@@ -561,8 +560,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     TableConfig tableConfig = getOfflineTableConfig();
     tableConfig.getIndexingConfig().setInvertedIndexColumns(UPDATED_INVERTED_INDEX_COLUMNS);
     updateTableConfig(tableConfig);
-    String reloadJobId =
-        reloadOfflineTableAndValidateResponse(TableNameBuilder.OFFLINE.tableNameWithType(getTableName()), false);
+    String reloadJobId = reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
 
     // It takes a while to reload multiple segments, thus we retry the query for some time.
     // After all segments are reloaded, the inverted index is added on DivActualElapsedTime.
@@ -1030,7 +1028,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     TableConfig tableConfig = getOfflineTableConfig();
     tableConfig.getIndexingConfig().setRangeIndexColumns(UPDATED_RANGE_INDEX_COLUMNS);
     updateTableConfig(tableConfig);
-    String reloadJobId = reloadOfflineTableAndValidateResponse(getTableName(), false);
+    String reloadJobId = reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
     TestUtils.waitForCondition(aVoid -> {
       try {
         JsonNode queryResponse = postQuery(TEST_UPDATED_RANGE_INDEX_QUERY);
@@ -1048,7 +1046,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     tableConfig = getOfflineTableConfig();
     tableConfig.getIndexingConfig().setRangeIndexColumns(getRangeIndexColumns());
     updateTableConfig(tableConfig);
-    reloadJobId = reloadOfflineTableAndValidateResponse(getTableName(), false);
+    reloadJobId = reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
     TestUtils.waitForCondition(aVoid -> {
       try {
         JsonNode queryResponse = postQuery(TEST_UPDATED_RANGE_INDEX_QUERY);
@@ -1075,7 +1073,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     TableConfig tableConfig = getOfflineTableConfig();
     tableConfig.getIndexingConfig().setBloomFilterColumns(UPDATED_BLOOM_FILTER_COLUMNS);
     updateTableConfig(tableConfig);
-    String reloadJobId = reloadOfflineTableAndValidateResponse(getTableName(), false);
+    String reloadJobId = reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
     TestUtils.waitForCondition(aVoid -> {
       try {
         JsonNode queryResponse = postQuery(TEST_UPDATED_BLOOM_FILTER_QUERY);
@@ -1093,7 +1091,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     tableConfig = getOfflineTableConfig();
     tableConfig.getIndexingConfig().setBloomFilterColumns(getBloomFilterColumns());
     updateTableConfig(tableConfig);
-    reloadJobId = reloadOfflineTableAndValidateResponse(getTableName(), false);
+    reloadJobId = reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
     TestUtils.waitForCondition(aVoid -> {
       try {
         JsonNode queryResponse = postQuery(TEST_UPDATED_BLOOM_FILTER_QUERY);
@@ -1142,7 +1140,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     indexingConfig.setStarTreeIndexConfigs(Collections.singletonList(STAR_TREE_INDEX_CONFIG_1));
     indexingConfig.setEnableDynamicStarTreeCreation(true);
     updateTableConfig(tableConfig);
-    String reloadJobId = reloadOfflineTableAndValidateResponse(getTableName(), false);
+    String reloadJobId = reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
 
     TestUtils.waitForCondition(aVoid -> {
       try {
@@ -1160,7 +1158,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     validateReloadJobSuccess(reloadJobId);
 
     // Reload again should have no effect
-    reloadOfflineTableAndValidateResponse(getTableName(), false);
+    reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
     firstQueryResponse = postQuery(TEST_STAR_TREE_QUERY_1);
     assertEquals(firstQueryResponse.get("resultTable").get("rows").get(0).get(0).asInt(), firstQueryResult);
     assertEquals(firstQueryResponse.get("totalDocs").asLong(), numTotalDocs);
@@ -1188,7 +1186,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // Update table config with a different star-tree index config and trigger reload
     indexingConfig.setStarTreeIndexConfigs(Collections.singletonList(STAR_TREE_INDEX_CONFIG_2));
     updateTableConfig(tableConfig);
-    String reloadId = reloadOfflineTableAndValidateResponse(getTableName(), false);
+    String reloadId = reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
 
     TestUtils.waitForCondition(aVoid -> {
       try {
@@ -1210,7 +1208,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(firstQueryResponse.get("numDocsScanned").asInt(), firstQueryResult);
 
     // Reload again should have no effect
-    reloadOfflineTableAndValidateResponse(getTableName(), false);
+    reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
     firstQueryResponse = postQuery(TEST_STAR_TREE_QUERY_1);
     assertEquals(firstQueryResponse.get("resultTable").get("rows").get(0).get(0).asInt(), firstQueryResult);
     assertEquals(firstQueryResponse.get("totalDocs").asLong(), numTotalDocs);
@@ -1235,7 +1233,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // Remove the star-tree index config and trigger reload
     indexingConfig.setStarTreeIndexConfigs(null);
     updateTableConfig(tableConfig);
-    reloadJobId = reloadOfflineTableAndValidateResponse(getTableName(), false);
+    reloadJobId = reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
 
     TestUtils.waitForCondition(aVoid -> {
       try {
@@ -1258,7 +1256,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(firstQueryResponse.get("numDocsScanned").asInt(), firstQueryResult);
 
     // Reload again should have no effect
-    reloadOfflineTableAndValidateResponse(getTableName(), false);
+    reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
     firstQueryResponse = postQuery(TEST_STAR_TREE_QUERY_1);
     assertEquals(firstQueryResponse.get("resultTable").get("rows").get(0).get(0).asInt(), firstQueryResult);
     assertEquals(firstQueryResponse.get("totalDocs").asLong(), numTotalDocs);
@@ -1395,7 +1393,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     updateTableConfig(tableConfig);
 
     // Trigger reload
-    String reloadJobId = reloadOfflineTableAndValidateResponse(getTableName(), false);
+    String reloadJobId = reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
 
     TestUtils.waitForCondition(aVoid -> {
       try {
@@ -1434,7 +1432,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     addSchema(schema);
 
     // Trigger reload
-    String reloadJobId = reloadOfflineTableAndValidateResponse(getTableName(), false);
+    String reloadJobId = reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
 
     TestUtils.waitForCondition(aVoid -> {
       try {
@@ -1465,7 +1463,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     addSchema(createSchema());
 
     // Trigger reload
-    String reloadJobId = reloadOfflineTableAndValidateResponse(getTableName(), false);
+    String reloadJobId = reloadTableAndValidateResponse(getTableName(), TableType.OFFLINE, false);
 
     TestUtils.waitForCondition(aVoid -> {
       try {
@@ -2750,27 +2748,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     Properties jdbcProps = new Properties();
     jdbcProps.put(PinotConnection.BROKER_LIST, "localhost:" + brokerPort);
     return pinotDriver.connect("jdbc:pinot://localhost:" + controllerPort, jdbcProps);
-  }
-
-  private String reloadOfflineTableAndValidateResponse(String tableName, boolean forceDownload)
-      throws IOException {
-    String jobId = null;
-    String response =
-        sendPostRequest(_controllerRequestURLBuilder.forTableReload(tableName, TableType.OFFLINE, forceDownload), null);
-    String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
-    JsonNode tableLevelDetails =
-        JsonUtils.stringToJsonNode(StringEscapeUtils.unescapeJava(response.split(": ")[1])).get(tableNameWithType);
-    String isZKWriteSuccess = tableLevelDetails.get("reloadJobMetaZKStorageStatus").asText();
-    assertEquals("SUCCESS", isZKWriteSuccess);
-    jobId = tableLevelDetails.get("reloadJobId").asText();
-    String jobStatusResponse = sendGetRequest(_controllerRequestURLBuilder.forControllerJobStatus(jobId));
-    JsonNode jobStatus = JsonUtils.stringToJsonNode(jobStatusResponse);
-
-    // Validate all fields are present
-    assertEquals(jobStatus.get("metadata").get("jobId").asText(), jobId);
-    assertEquals(jobStatus.get("metadata").get("jobType").asText(), "RELOAD_ALL_SEGMENTS");
-    assertEquals(jobStatus.get("metadata").get("tableName").asText(), tableNameWithType);
-    return jobId;
   }
 
   private boolean validateReloadJobSuccess(String reloadJobId)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
@@ -62,6 +62,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.CARDINALITY;
 import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.DICTIONARY_ELEMENT_SIZE;
 import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.HAS_DICTIONARY;
 import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.getKeyFor;
@@ -712,7 +713,10 @@ public class ForwardIndexHandler implements IndexHandler {
     }
 
     LOGGER.info("Creating a new dictionary for segment={} and column={}", segmentName, column);
-    SegmentDictionaryCreator dictionaryCreator = buildDictionary(column, existingColMetadata, segmentWriter);
+    AbstractColumnStatisticsCollector statsCollector =
+        getStatsCollector(column, existingColMetadata.getDataType().getStoredType());
+    SegmentDictionaryCreator dictionaryCreator =
+        buildDictionary(column, existingColMetadata, segmentWriter, statsCollector);
     LoaderUtils.writeIndexToV3Format(segmentWriter, column, dictionaryFile, ColumnIndexType.DICTIONARY);
 
     LOGGER.info("Built dictionary. Rewriting dictionary enabled forward index for segment={} and column={}",
@@ -732,6 +736,10 @@ public class ForwardIndexHandler implements IndexHandler {
     metadataProperties.put(getKeyFor(column, HAS_DICTIONARY), String.valueOf(true));
     metadataProperties.put(getKeyFor(column, DICTIONARY_ELEMENT_SIZE),
         String.valueOf(dictionaryCreator.getNumBytesPerEntry()));
+    // If realtime segments were completed when the column was RAW, the cardinality value is populated as Integer
+    // .MIN_VALUE. When dictionary is enabled for this column later, cardinality value should be rightly populated so
+    // that the dictionary can be loaded.
+    metadataProperties.put(getKeyFor(column, CARDINALITY), String.valueOf(statsCollector.getCardinality()));
     updateMetadataProperties(indexDir, metadataProperties);
 
     // We remove indexes that have to be rewritten when a dictEnabled is toggled. Note that the respective index
@@ -745,13 +753,11 @@ public class ForwardIndexHandler implements IndexHandler {
   }
 
   private SegmentDictionaryCreator buildDictionary(String column, ColumnMetadata existingColMetadata,
-      SegmentDirectory.Writer segmentWriter)
+      SegmentDirectory.Writer segmentWriter, AbstractColumnStatisticsCollector statsCollector)
       throws Exception {
     int numDocs = existingColMetadata.getTotalDocs();
 
     try (ForwardIndexReader reader = LoaderUtils.getForwardIndexReader(segmentWriter, existingColMetadata)) {
-      AbstractColumnStatisticsCollector statsCollector = getStatsCollector(column, reader.getStoredType());
-
       // Note: Special Null handling is not necessary here. This is because, the existing default null value in the
       // raw forwardIndex will be retained as such while created the dictionary and dict-based forward index. Also,
       // null value vectors maintain a bitmap of docIds. No handling is necessary there.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
@@ -290,7 +290,7 @@ public class ForwardIndexHandler implements IndexHandler {
     // dictionary will only be allowed if FST and inverted index are also disabled.
     if (_indexLoadingConfig.getInvertedIndexColumns().contains(column) || _indexLoadingConfig.getFSTIndexColumns()
         .contains(column)) {
-      LOGGER.warn("Cannot disabled dictionary as column={} has FST index or inverted index or both.", column);
+      LOGGER.warn("Cannot disable dictionary as column={} has FST index or inverted index or both.", column);
       return false;
     }
 


### PR DESCRIPTION
Fixes the issue #9874

Fixes two issues:

1. If segment name contained "%", update to `metadata.properties` file was failing because Commons Configuration 1.10 does not support file path containing '%'
2. If segments created by realtime consumption and a column is RAW, the cardinality value is populated as Integer.MIN_VALUE. When dictionary is enabled on this column later, loading the column fails and cardinality is invalid. So, this PR updates cardinality while enabling dictionary.
3. Added a test to enable disable dictionary for a column where the segment is created through realtime consumption.

Also tested manually. Results are below.

Tested manually using breakpoints and REST API calls in `LLCRealtimeClusterIntegrationTest`.

Created a realtime segment. The metadata.properties file is as follow for noDictionary column `ActualElapsedTime`

SegmentName = mytable__0__0__20221202T0322Z

> column.ActualElapsedTime.cardinality = -2147483648
> column.ActualElapsedTime.totalDocs = 10
> column.ActualElapsedTime.dataType = INT
> column.ActualElapsedTime.bitsPerElement = 31
> column.ActualElapsedTime.lengthOfEachEntry = 0
> column.ActualElapsedTime.columnType = METRIC
> column.ActualElapsedTime.isSorted = false
> column.ActualElapsedTime.hasDictionary = false
> column.ActualElapsedTime.isSingleValues = true
> column.ActualElapsedTime.maxNumberOfMultiValues = 0
> column.ActualElapsedTime.totalNumberOfEntries = 10
> column.ActualElapsedTime.isAutoGenerated = false
> column.ActualElapsedTime.minValue = -9999
> column.ActualElapsedTime.maxValue = 147
> column.ActualElapsedTime.defaultNullValue = 0


Now, issued a REST call to enable dictionary for ActualElapsedTime. Issued reloadSegment. Verified that dictionary load also succeeds. The updated metadata is as follows:

> column.ActualElapsedTime.cardinality = 7
> column.ActualElapsedTime.totalDocs = 10
> column.ActualElapsedTime.dataType = INT
> column.ActualElapsedTime.bitsPerElement = 31
> column.ActualElapsedTime.lengthOfEachEntry = 0
> column.ActualElapsedTime.columnType = METRIC
> column.ActualElapsedTime.isSorted = false
> column.ActualElapsedTime.hasDictionary = true
> column.ActualElapsedTime.isSingleValues = true
> column.ActualElapsedTime.maxNumberOfMultiValues = 0
> column.ActualElapsedTime.totalNumberOfEntries = 10
> column.ActualElapsedTime.isAutoGenerated = false
> column.ActualElapsedTime.minValue = -9999
> column.ActualElapsedTime.maxValue = 147
> column.ActualElapsedTime.defaultNullValue = 0