### PR TITLE
Distinct Count HLL pre-aggregation in realtime segments

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountHLLValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountHLLValueAggregator.java
@@ -34,9 +34,10 @@ import org.apache.pinot.spi.utils.CommonConstants;
 public class DistinctCountHLLValueAggregator implements ValueAggregator<Object, HyperLogLog> {
   public static final DataType AGGREGATED_VALUE_TYPE = DataType.BYTES;
   private int _log2m = CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M;
-  private int _log2m_byte_size = 180;
+  private int _log2mByteSize = 180;
 
-  public DistinctCountHLLValueAggregator() {}
+  public DistinctCountHLLValueAggregator() {
+  }
 
   public DistinctCountHLLValueAggregator(List<ExpressionContext> arguments) {
     // length 1 means we use the default _log2m of 8
@@ -49,7 +50,7 @@ public class DistinctCountHLLValueAggregator implements ValueAggregator<Object, 
 
     _log2m = Integer.parseInt(log2mLiteral);
     try {
-      _log2m_byte_size = (new HyperLogLog(_log2m)).getBytes().length;
+      _log2mByteSize = (new HyperLogLog(_log2m)).getBytes().length;
     } catch (IOException e) {
       throw new RuntimeException(e);
     }
@@ -78,7 +79,7 @@ public class DistinctCountHLLValueAggregator implements ValueAggregator<Object, 
     } else {
       initialValue = new HyperLogLog(_log2m);
       initialValue.offer(rawValue);
-      _maxByteSize = Math.max(_maxByteSize, _log2m_byte_size);
+      _maxByteSize = Math.max(_maxByteSize, _log2mByteSize);
     }
     return initialValue;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountHLLValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountHLLValueAggregator.java
@@ -20,6 +20,11 @@ package org.apache.pinot.segment.local.aggregator;
 
 import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import com.google.common.base.Preconditions;
+import java.io.IOException;
+import java.util.List;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -28,7 +33,27 @@ import org.apache.pinot.spi.utils.CommonConstants;
 
 public class DistinctCountHLLValueAggregator implements ValueAggregator<Object, HyperLogLog> {
   public static final DataType AGGREGATED_VALUE_TYPE = DataType.BYTES;
-  private static final int DEFAULT_LOG2M_BYTE_SIZE = 180;
+  private int _log2m = CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M;
+  private int _log2m_byte_size = 180;
+
+  public DistinctCountHLLValueAggregator() {}
+
+  public DistinctCountHLLValueAggregator(List<ExpressionContext> arguments) {
+    // length 1 means we use the default _log2m of 8
+    if (arguments.size() <= 1) {
+      return;
+    }
+
+    String log2mLiteral = arguments.get(1).getLiteralString();
+    Preconditions.checkState(StringUtils.isNumeric(log2mLiteral), "log2m argument must be a numeric literal");
+
+    _log2m = Integer.parseInt(log2mLiteral);
+    try {
+      _log2m_byte_size = (new HyperLogLog(_log2m)).getBytes().length;
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
 
   // Byte size won't change once we get the initial aggregated value
   private int _maxByteSize;
@@ -51,10 +76,9 @@ public class DistinctCountHLLValueAggregator implements ValueAggregator<Object, 
       initialValue = deserializeAggregatedValue(bytes);
       _maxByteSize = Math.max(_maxByteSize, bytes.length);
     } else {
-      // TODO: Handle configurable log2m for StarTreeBuilder
-      initialValue = new HyperLogLog(CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M);
+      initialValue = new HyperLogLog(_log2m);
       initialValue.offer(rawValue);
-      _maxByteSize = Math.max(_maxByteSize, DEFAULT_LOG2M_BYTE_SIZE);
+      _maxByteSize = Math.max(_maxByteSize, _log2m_byte_size);
     }
     return initialValue;
   }
@@ -100,6 +124,9 @@ public class DistinctCountHLLValueAggregator implements ValueAggregator<Object, 
 
   @Override
   public HyperLogLog deserializeAggregatedValue(byte[] bytes) {
+    if (bytes == null || bytes.length == 0) {
+      return new HyperLogLog(_log2m);
+    }
     return CustomSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytes);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountHLLValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountHLLValueAggregator.java
@@ -23,7 +23,7 @@ import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.List;
-import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang.math.NumberUtils;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
@@ -46,7 +46,8 @@ public class DistinctCountHLLValueAggregator implements ValueAggregator<Object, 
     }
 
     String log2mLiteral = arguments.get(1).getLiteralString();
-    Preconditions.checkState(StringUtils.isNumeric(log2mLiteral), "log2m argument must be a numeric literal");
+    Preconditions.checkState(NumberUtils.isNumber(log2mLiteral), "log2m argument must be a number "
+        + "literal, but instead was " + log2mLiteral);
 
     _log2m = Integer.parseInt(log2mLiteral);
     try {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/SumValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/SumValueAggregator.java
@@ -37,11 +37,17 @@ public class SumValueAggregator implements ValueAggregator<Number, Double> {
 
   @Override
   public Double getInitialAggregatedValue(Number rawValue) {
+    if (rawValue == null) {
+      return 0.0;
+    }
     return rawValue.doubleValue();
   }
 
   @Override
   public Double applyRawValue(Double value, Number rawValue) {
+    if (rawValue == null) {
+      return value;
+    }
     return value + rawValue.doubleValue();
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
@@ -18,8 +18,11 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+import java.util.List;
 
 
 /**
@@ -36,7 +39,7 @@ public class ValueAggregatorFactory {
    * @param aggregationType Aggregation type
    * @return Value aggregator
    */
-  public static ValueAggregator getValueAggregator(AggregationFunctionType aggregationType) {
+  public static ValueAggregator getValueAggregator(AggregationFunctionType aggregationType, List<ExpressionContext> arguments) {
     switch (aggregationType) {
       case COUNT:
         return new CountValueAggregator();
@@ -56,7 +59,7 @@ public class ValueAggregatorFactory {
         return new DistinctCountBitmapValueAggregator();
       case DISTINCTCOUNTHLL:
       case DISTINCTCOUNTRAWHLL:
-        return new DistinctCountHLLValueAggregator();
+        return new DistinctCountHLLValueAggregator(arguments);
       case PERCENTILEEST:
       case PERCENTILERAWEST:
         return new PercentileEstValueAggregator();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
@@ -38,7 +38,8 @@ public class ValueAggregatorFactory {
    * @param aggregationType Aggregation type
    * @return Value aggregator
    */
-  public static ValueAggregator getValueAggregator(AggregationFunctionType aggregationType, List<ExpressionContext> arguments) {
+  public static ValueAggregator getValueAggregator(AggregationFunctionType aggregationType,
+      List<ExpressionContext> arguments) {
     switch (aggregationType) {
       case COUNT:
         return new CountValueAggregator();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
@@ -18,11 +18,10 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import java.util.List;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
-
-import java.util.List;
 
 
 /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/DefaultMutableIndexProvider.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/DefaultMutableIndexProvider.java
@@ -54,14 +54,14 @@ public class DefaultMutableIndexProvider implements MutableIndexProvider {
     boolean isSingleValue = context.getFieldSpec().isSingleValueField();
     if (!context.hasDictionary()) {
       if (isSingleValue) {
-        String allocationContext =
-            buildAllocationContext(context.getSegmentName(), context.getFieldSpec().getName(),
-                V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION);
-        // We consider BYTES with a specific maxLength as being also fixed width maxLength's purpose doubles as the fixed width
+        String allocationContext = buildAllocationContext(context.getSegmentName(), context.getFieldSpec().getName(),
+            V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION);
+        // We consider BYTES with a specific maxLength as being also fixed width maxLength's purpose doubles as the
+        // fixed width
         // when used on a BYTES field.
         if (storedType.isFixedWidth() || (storedType.getStoredType() == BYTES && maxLength > 0)) {
           return new FixedByteSVMutableForwardIndex(false, storedType, maxLength, context.getCapacity(),
-                  context.getMemoryManager(), allocationContext);
+              context.getMemoryManager(), allocationContext);
         } else {
           // RealtimeSegmentStatsHistory does not have the stats for no-dictionary columns from previous consuming
           // segments
@@ -69,35 +69,32 @@ public class DefaultMutableIndexProvider implements MutableIndexProvider {
           //       columns as well
           // TODO: Use the stats to get estimated average length
           // Use a smaller capacity as opposed to segment flush size
-          int initialCapacity = Math.min(context.getCapacity(),
-              NODICT_VARIABLE_WIDTH_ESTIMATED_NUMBER_OF_VALUES_DEFAULT);
+          int initialCapacity =
+              Math.min(context.getCapacity(), NODICT_VARIABLE_WIDTH_ESTIMATED_NUMBER_OF_VALUES_DEFAULT);
           return new VarByteSVMutableForwardIndex(storedType, context.getMemoryManager(), allocationContext,
               initialCapacity, NODICT_VARIABLE_WIDTH_ESTIMATED_AVERAGE_VALUE_LENGTH_DEFAULT);
         }
       } else {
         // TODO: Add support for variable width (bytes, string, big decimal) MV RAW column types
         assert storedType.isFixedWidth();
-        String allocationContext =
-            buildAllocationContext(context.getSegmentName(), context.getFieldSpec().getName(),
-                V1Constants.Indexes.RAW_MV_FORWARD_INDEX_FILE_EXTENSION);
+        String allocationContext = buildAllocationContext(context.getSegmentName(), context.getFieldSpec().getName(),
+            V1Constants.Indexes.RAW_MV_FORWARD_INDEX_FILE_EXTENSION);
         // TODO: Start with a smaller capacity on FixedByteMVForwardIndexReaderWriter and let it expand
         return new FixedByteMVMutableForwardIndex(MAX_MULTI_VALUES_PER_ROW, context.getAvgNumMultiValues(),
-            context.getCapacity(), storedType.size(), context.getMemoryManager(), allocationContext, false,
-            storedType);
+            context.getCapacity(), storedType.size(), context.getMemoryManager(), allocationContext, false, storedType);
       }
     } else {
       if (isSingleValue) {
-        String allocationContext = buildAllocationContext(segmentName, column,
-            V1Constants.Indexes.UNSORTED_SV_FORWARD_INDEX_FILE_EXTENSION);
+        String allocationContext =
+            buildAllocationContext(segmentName, column, V1Constants.Indexes.UNSORTED_SV_FORWARD_INDEX_FILE_EXTENSION);
         return new FixedByteSVMutableForwardIndex(true, INT, context.getCapacity(), context.getMemoryManager(),
             allocationContext);
       } else {
-        String allocationContext = buildAllocationContext(segmentName, column,
-            V1Constants.Indexes.UNSORTED_MV_FORWARD_INDEX_FILE_EXTENSION);
+        String allocationContext =
+            buildAllocationContext(segmentName, column, V1Constants.Indexes.UNSORTED_MV_FORWARD_INDEX_FILE_EXTENSION);
         // TODO: Start with a smaller capacity on FixedByteMVForwardIndexReaderWriter and let it expand
         return new FixedByteMVMutableForwardIndex(MAX_MULTI_VALUES_PER_ROW, context.getAvgNumMultiValues(),
-            context.getCapacity(), Integer.BYTES,
-            context.getMemoryManager(), allocationContext, true, INT);
+            context.getCapacity(), Integer.BYTES, context.getMemoryManager(), allocationContext, true, INT);
       }
     }
   }
@@ -130,8 +127,7 @@ public class DefaultMutableIndexProvider implements MutableIndexProvider {
     }
     // NOTE: preserve 10% buffer for cardinality to reduce the chance of re-sizing the dictionary
     int estimatedCardinality = (int) (context.getEstimatedCardinality() * 1.1);
-    String dictionaryAllocationContext =
-        buildAllocationContext(segmentName, column, V1Constants.Dict.FILE_EXTENSION);
+    String dictionaryAllocationContext = buildAllocationContext(segmentName, column, V1Constants.Dict.FILE_EXTENSION);
     return MutableDictionaryFactory.getMutableDictionary(storedType, context.isOffHeap(), context.getMemoryManager(),
         dictionaryColumnSize, Math.min(estimatedCardinality, context.getCapacity()), dictionaryAllocationContext);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -349,8 +349,8 @@ public class MutableSegmentImpl implements MutableSegment {
           //  it is beyond the scope of realtime index pluggability to do this refactoring, so realtime
           //  text indexes remain statically defined. Revisit this after this refactoring has been done.
           RealtimeLuceneTextIndex luceneTextIndex =
-              new RealtimeLuceneTextIndex(column, new File(config.getConsumerDir()), _segmentName,
-                  stopWordsInclude, stopWordsExclude);
+              new RealtimeLuceneTextIndex(column, new File(config.getConsumerDir()), _segmentName, stopWordsInclude,
+                  stopWordsExclude);
           if (_realtimeLuceneReaders == null) {
             _realtimeLuceneReaders = new RealtimeLuceneIndexRefreshState.RealtimeLuceneReaders(_segmentName);
           }
@@ -1279,8 +1279,8 @@ public class MutableSegmentImpl implements MutableSegment {
 
     Map<String, Pair<String, ValueAggregator>> columnNameToAggregator = new HashMap<>();
     for (String metricName : segmentConfig.getSchema().getMetricNames()) {
-      columnNameToAggregator.put(metricName,
-              Pair.of(metricName, ValueAggregatorFactory.getValueAggregator(AggregationFunctionType.SUM, Collections.EMPTY_LIST)));
+      columnNameToAggregator.put(metricName, Pair.of(metricName,
+          ValueAggregatorFactory.getValueAggregator(AggregationFunctionType.SUM, Collections.EMPTY_LIST)));
     }
     return columnNameToAggregator;
   }
@@ -1300,12 +1300,14 @@ public class MutableSegmentImpl implements MutableSegment {
 
       switch (functionContext.getFunctionName().toLowerCase()) {
         case "distinctcounthll":
-          Preconditions.checkState(functionContext.getArguments().size() >= 1 && functionContext.getArguments().size() <= 2,
-                  "distinctcounthll function can have max two arguments: %s", config);
+          Preconditions.checkState(
+              functionContext.getArguments().size() >= 1 && functionContext.getArguments().size() <= 2,
+              "distinctcounthll function can have max two arguments: %s", config);
           break;
         default:
           Preconditions.checkState(functionContext.getArguments().size() == 1,
-                  "aggregation function can only have one argument: %s", config);
+              "aggregation function can only have one argument: %s", config);
+          break;
       }
 
       ExpressionContext argument = functionContext.getArguments().get(0);
@@ -1315,8 +1317,8 @@ public class MutableSegmentImpl implements MutableSegment {
       AggregationFunctionType functionType =
           AggregationFunctionType.getAggregationFunctionType(functionContext.getFunctionName());
 
-      columnNameToAggregator.put(config.getColumnName(),
-              Pair.of(argument.getIdentifier(), ValueAggregatorFactory.getValueAggregator(functionType, functionContext.getArguments())));
+      columnNameToAggregator.put(config.getColumnName(), Pair.of(argument.getIdentifier(),
+          ValueAggregatorFactory.getValueAggregator(functionType, functionContext.getArguments())));
     }
 
     return columnNameToAggregator;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
@@ -63,13 +63,14 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
 
   /**
    * @param storedType Data type of the values
-   * @param fixedLength Fixed length of values if known: only used for BYTES field and specifically Hyperloglog values for now.
+   * @param fixedLength Fixed length of values if known: only used for BYTES field and specifically Hyperloglog
+   *                    values for now.
    * @param numRowsPerChunk Number of rows to pack in one chunk before a new chunk is created.
    * @param memoryManager Memory manager to be used for allocating memory.
    * @param allocationContext Allocation allocationContext.
    */
-  public FixedByteSVMutableForwardIndex(boolean dictionaryEncoded, DataType storedType, int fixedLength, int numRowsPerChunk,
-                                        PinotDataBufferMemoryManager memoryManager, String allocationContext) {
+  public FixedByteSVMutableForwardIndex(boolean dictionaryEncoded, DataType storedType, int fixedLength,
+      int numRowsPerChunk, PinotDataBufferMemoryManager memoryManager, String allocationContext) {
     _dictionaryEncoded = dictionaryEncoded;
     _storedType = storedType;
     if (storedType == DataType.BYTES) {
@@ -85,7 +86,7 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
   }
 
   public FixedByteSVMutableForwardIndex(boolean dictionaryEncoded, DataType valueType, int numRowsPerChunk,
-                                        PinotDataBufferMemoryManager memoryManager, String allocationContext) {
+      PinotDataBufferMemoryManager memoryManager, String allocationContext) {
     this(dictionaryEncoded, valueType, -1, numRowsPerChunk, memoryManager, allocationContext);
   }
 
@@ -227,7 +228,7 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
 
   @Override
   public void close()
-          throws IOException {
+      throws IOException {
     for (WriterWithOffset writer : _writers) {
       writer.close();
     }
@@ -241,11 +242,11 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
     // NOTE: PinotDataBuffer is tracked in the PinotDataBufferMemoryManager. No need to track it inside the class.
     PinotDataBuffer buffer = _memoryManager.allocate(_chunkSizeInBytes, _allocationContext);
     _writers.add(
-            new WriterWithOffset(new FixedByteSingleValueMultiColWriter(buffer, /*cols=*/1, new int[]{_valueSizeInBytes}),
-                    _capacityInRows));
-    _readers.add(new ReaderWithOffset(
-            new FixedByteSingleValueMultiColReader(buffer, _numRowsPerChunk, new int[]{_valueSizeInBytes}),
+        new WriterWithOffset(new FixedByteSingleValueMultiColWriter(buffer, /*cols=*/1, new int[]{_valueSizeInBytes}),
             _capacityInRows));
+    _readers.add(new ReaderWithOffset(
+        new FixedByteSingleValueMultiColReader(buffer, _numRowsPerChunk, new int[]{_valueSizeInBytes}),
+        _capacityInRows));
     _capacityInRows += _numRowsPerChunk;
   }
 
@@ -274,7 +275,7 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
 
     @Override
     public void close()
-            throws IOException {
+        throws IOException {
       _writer.close();
     }
 
@@ -313,7 +314,7 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
 
     @Override
     public void close()
-            throws IOException {
+        throws IOException {
       _reader.close();
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
@@ -63,20 +63,30 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
 
   /**
    * @param storedType Data type of the values
+   * @param fixedLength Fixed length of values if known: only used for BYTES field and specifically Hyperloglog values for now.
    * @param numRowsPerChunk Number of rows to pack in one chunk before a new chunk is created.
    * @param memoryManager Memory manager to be used for allocating memory.
    * @param allocationContext Allocation allocationContext.
    */
-  public FixedByteSVMutableForwardIndex(boolean dictionaryEncoded, DataType storedType, int numRowsPerChunk,
-      PinotDataBufferMemoryManager memoryManager, String allocationContext) {
+  public FixedByteSVMutableForwardIndex(boolean dictionaryEncoded, DataType storedType, int fixedLength, int numRowsPerChunk,
+                                        PinotDataBufferMemoryManager memoryManager, String allocationContext) {
     _dictionaryEncoded = dictionaryEncoded;
     _storedType = storedType;
-    _valueSizeInBytes = storedType.size();
+    if (storedType == DataType.BYTES) {
+      _valueSizeInBytes = fixedLength;
+    } else {
+      _valueSizeInBytes = storedType.size();
+    }
     _numRowsPerChunk = numRowsPerChunk;
     _chunkSizeInBytes = numRowsPerChunk * _valueSizeInBytes;
     _memoryManager = memoryManager;
     _allocationContext = allocationContext;
     addBuffer();
+  }
+
+  public FixedByteSVMutableForwardIndex(boolean dictionaryEncoded, DataType valueType, int numRowsPerChunk,
+                                        PinotDataBufferMemoryManager memoryManager, String allocationContext) {
+    this(dictionaryEncoded, valueType, -1, numRowsPerChunk, memoryManager, allocationContext);
   }
 
   @Override
@@ -195,13 +205,29 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
     getWriterForRow(docId).setDouble(docId, value);
   }
 
+  @Override
+  public byte[] getBytes(int docId) {
+    int bufferId = getBufferId(docId);
+    return _readers.get(bufferId).getBytes(docId);
+  }
+
+  @Override
+  public void setBytes(int docId, byte[] value) {
+    if (value.length != _valueSizeInBytes) {
+      throw new IllegalArgumentException("Expected value size to be " + _valueSizeInBytes + " but was " + value.length);
+    }
+
+    addBufferIfNeeded(docId);
+    getWriterForRow(docId).setBytes(docId, value);
+  }
+
   private WriterWithOffset getWriterForRow(int row) {
     return _writers.get(getBufferId(row));
   }
 
   @Override
   public void close()
-      throws IOException {
+          throws IOException {
     for (WriterWithOffset writer : _writers) {
       writer.close();
     }
@@ -215,11 +241,11 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
     // NOTE: PinotDataBuffer is tracked in the PinotDataBufferMemoryManager. No need to track it inside the class.
     PinotDataBuffer buffer = _memoryManager.allocate(_chunkSizeInBytes, _allocationContext);
     _writers.add(
-        new WriterWithOffset(new FixedByteSingleValueMultiColWriter(buffer, /*cols=*/1, new int[]{_valueSizeInBytes}),
-            _capacityInRows));
+            new WriterWithOffset(new FixedByteSingleValueMultiColWriter(buffer, /*cols=*/1, new int[]{_valueSizeInBytes}),
+                    _capacityInRows));
     _readers.add(new ReaderWithOffset(
-        new FixedByteSingleValueMultiColReader(buffer, _numRowsPerChunk, new int[]{_valueSizeInBytes}),
-        _capacityInRows));
+            new FixedByteSingleValueMultiColReader(buffer, _numRowsPerChunk, new int[]{_valueSizeInBytes}),
+            _capacityInRows));
     _capacityInRows += _numRowsPerChunk;
   }
 
@@ -248,7 +274,7 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
 
     @Override
     public void close()
-        throws IOException {
+            throws IOException {
       _writer.close();
     }
 
@@ -267,6 +293,10 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
     public void setDouble(int row, double value) {
       _writer.setDouble(row - _startRowId, 0, value);
     }
+
+    public void setBytes(int row, byte[] value) {
+      _writer.setBytes(row - _startRowId, 0, value);
+    }
   }
 
   /**
@@ -283,7 +313,7 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
 
     @Override
     public void close()
-        throws IOException {
+            throws IOException {
       _reader.close();
     }
 
@@ -305,6 +335,10 @@ public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
 
     public BigDecimal getBigDecimal(int row) {
       return BigDecimalUtils.deserialize(_reader.getBytes(row - _startRowId, 0));
+    }
+
+    public byte[] getBytes(int row) {
+      return _reader.getBytes(row - _startRowId, 0);
     }
 
     public FixedByteSingleValueMultiColReader getReader() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/BaseSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/BaseSingleTreeBuilder.java
@@ -21,13 +21,7 @@ package org.apache.pinot.segment.local.startree.v2.builder;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import java.util.*;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.segment.local.aggregator.ValueAggregator;
@@ -142,7 +136,7 @@ abstract class BaseSingleTreeBuilder implements SingleTreeBuilder {
     for (AggregationFunctionColumnPair functionColumnPair : functionColumnPairs) {
       _metrics[index] = functionColumnPair.toColumnName();
       _functionColumnPairs[index] = functionColumnPair;
-      _valueAggregators[index] = ValueAggregatorFactory.getValueAggregator(functionColumnPair.getFunctionType());
+      _valueAggregators[index] = ValueAggregatorFactory.getValueAggregator(functionColumnPair.getFunctionType(), Collections.EMPTY_LIST);
 
       // Ignore the column for COUNT aggregation function
       if (_valueAggregators[index].getAggregationType() != AggregationFunctionType.COUNT) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/BaseSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/BaseSingleTreeBuilder.java
@@ -21,7 +21,14 @@ package org.apache.pinot.segment.local.startree.v2.builder;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
-import java.util.*;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration.Configuration;
 import org.apache.pinot.segment.local.aggregator.ValueAggregator;
@@ -136,7 +143,8 @@ abstract class BaseSingleTreeBuilder implements SingleTreeBuilder {
     for (AggregationFunctionColumnPair functionColumnPair : functionColumnPairs) {
       _metrics[index] = functionColumnPair.toColumnName();
       _functionColumnPairs[index] = functionColumnPair;
-      _valueAggregators[index] = ValueAggregatorFactory.getValueAggregator(functionColumnPair.getFunctionType(), Collections.EMPTY_LIST);
+      _valueAggregators[index] =
+          ValueAggregatorFactory.getValueAggregator(functionColumnPair.getFunctionType(), Collections.EMPTY_LIST);
 
       // Ignore the column for COUNT aggregation function
       if (_valueAggregators[index].getAggregationType() != AggregationFunctionType.COUNT) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -102,8 +102,8 @@ public final class TableConfigUtils {
   // hardcode the value here to avoid pulling the entire pinot-kinesis module as dependency.
   private static final String KINESIS_STREAM_TYPE = "kinesis";
   private static final EnumSet<AggregationFunctionType> SUPPORTED_INGESTION_AGGREGATIONS =
-          EnumSet.of(AggregationFunctionType.SUM, AggregationFunctionType.MIN, AggregationFunctionType.MAX,
-                  AggregationFunctionType.COUNT, AggregationFunctionType.DISTINCTCOUNTHLL);
+      EnumSet.of(AggregationFunctionType.SUM, AggregationFunctionType.MIN, AggregationFunctionType.MAX,
+          AggregationFunctionType.COUNT, AggregationFunctionType.DISTINCTCOUNTHLL);
 
   /**
    * @see TableConfigUtils#validate(TableConfig, Schema, String, boolean)
@@ -123,7 +123,7 @@ public final class TableConfigUtils {
    * TODO: Add more validations for each section (e.g. validate conditions are met for aggregateMetrics)
    */
   public static void validate(TableConfig tableConfig, @Nullable Schema schema, @Nullable String typesToSkip,
-                              boolean disableGroovy) {
+      boolean disableGroovy) {
     Set<ValidationType> skipTypes = parseTypesToSkipString(typesToSkip);
     if (tableConfig.getTableType() == TableType.REALTIME) {
       Preconditions.checkState(schema != null, "Schema should not be null for REALTIME table");
@@ -150,7 +150,7 @@ public final class TableConfigUtils {
 
   private static Set<ValidationType> parseTypesToSkipString(@Nullable String typesToSkip) {
     return typesToSkip == null ? Collections.emptySet()
-            : Arrays.stream(typesToSkip.split(",")).map(s -> ValidationType.valueOf(s.toUpperCase()))
+        : Arrays.stream(typesToSkip.split(",")).map(s -> ValidationType.valueOf(s.toUpperCase()))
             .collect(Collectors.toSet());
   }
 
@@ -188,7 +188,7 @@ public final class TableConfigUtils {
 
     if (segmentsConfig == null) {
       throw new IllegalStateException(
-              String.format("Table: %s, \"segmentsConfig\" field is missing in table config", tableName));
+          String.format("Table: %s, \"segmentsConfig\" field is missing in table config", tableName));
     }
 
     String segmentPushType = IngestionConfigUtils.getBatchSegmentIngestionType(tableConfig);
@@ -235,12 +235,12 @@ public final class TableConfigUtils {
     // timeColumnName can be null in OFFLINE table
     if (timeColumnName != null && !timeColumnName.isEmpty() && schema != null) {
       Preconditions.checkState(schema.getSpecForTimeColumn(timeColumnName) != null,
-              "Cannot find valid fieldSpec for timeColumn: %s from the table config: %s, in the schema: %s", timeColumnName,
-              tableConfig.getTableName(), schema.getSchemaName());
+          "Cannot find valid fieldSpec for timeColumn: %s from the table config: %s, in the schema: %s", timeColumnName,
+          tableConfig.getTableName(), schema.getSchemaName());
     }
     if (tableConfig.isDimTable()) {
       Preconditions.checkState(tableConfig.getTableType() == TableType.OFFLINE,
-              "Dimension table must be of OFFLINE table type.");
+          "Dimension table must be of OFFLINE table type.");
       Preconditions.checkState(schema != null, "Dimension table must have an associated schema");
       Preconditions.checkState(!schema.getPrimaryKeyColumns().isEmpty(), "Dimension table must have primary key[s]");
     }
@@ -248,9 +248,9 @@ public final class TableConfigUtils {
     String peerSegmentDownloadScheme = validationConfig.getPeerSegmentDownloadScheme();
     if (peerSegmentDownloadScheme != null) {
       if (!CommonConstants.HTTP_PROTOCOL.equalsIgnoreCase(peerSegmentDownloadScheme)
-              && !CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(peerSegmentDownloadScheme)) {
+          && !CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(peerSegmentDownloadScheme)) {
         throw new IllegalStateException("Invalid value '" + peerSegmentDownloadScheme
-                + "' for peerSegmentDownloadScheme. Must be one of http or https");
+            + "' for peerSegmentDownloadScheme. Must be one of http or https");
       }
     }
 
@@ -292,19 +292,19 @@ public final class TableConfigUtils {
         }
         if (tableConfig.isDimTable()) {
           Preconditions.checkState(cfg.getSegmentIngestionType().equalsIgnoreCase("REFRESH"),
-                  "Dimension tables must have segment ingestion type REFRESH");
+              "Dimension tables must have segment ingestion type REFRESH");
         }
       }
       if (tableConfig.isDimTable()) {
         Preconditions.checkState(ingestionConfig.getBatchIngestionConfig() != null,
-                "Dimension tables must have batch ingestion configuration");
+            "Dimension tables must have batch ingestion configuration");
       }
 
       // Stream
       if (ingestionConfig.getStreamIngestionConfig() != null) {
         IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
         Preconditions.checkState(indexingConfig == null || MapUtils.isEmpty(indexingConfig.getStreamConfigs()),
-                "Should not use indexingConfig#getStreamConfigs if ingestionConfig#StreamIngestionConfig is provided");
+            "Should not use indexingConfig#getStreamConfigs if ingestionConfig#StreamIngestionConfig is provided");
         List<Map<String, String>> streamConfigMaps = ingestionConfig.getStreamIngestionConfig().getStreamConfigMaps();
         Preconditions.checkState(streamConfigMaps.size() == 1, "Only 1 stream is supported in REALTIME table");
         try {
@@ -322,7 +322,7 @@ public final class TableConfigUtils {
         if (filterFunction != null) {
           if (disableGroovy && FunctionEvaluatorFactory.isGroovyExpression(filterFunction)) {
             throw new IllegalStateException(
-                    "Groovy filter functions are disabled for table config. Found '" + filterFunction + "'");
+                "Groovy filter functions are disabled for table config. Found '" + filterFunction + "'");
           }
           try {
             FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction);
@@ -337,7 +337,7 @@ public final class TableConfigUtils {
       Set<String> aggregationSourceColumns = new HashSet<>();
       if (!CollectionUtils.isEmpty(aggregationConfigs)) {
         Preconditions.checkState(!tableConfig.getIndexingConfig().isAggregateMetrics(),
-                "aggregateMetrics cannot be set with AggregationConfig");
+            "aggregateMetrics cannot be set with AggregationConfig");
         Set<String> aggregationColumns = new HashSet<>();
         for (AggregationConfig aggregationConfig : aggregationConfigs) {
           String columnName = aggregationConfig.getColumnName();
@@ -345,15 +345,15 @@ public final class TableConfigUtils {
           String aggregationFunction = aggregationConfig.getAggregationFunction();
           if (columnName == null || aggregationFunction == null) {
             throw new IllegalStateException(
-                    "columnName/aggregationFunction cannot be null in AggregationConfig " + aggregationConfig);
+                "columnName/aggregationFunction cannot be null in AggregationConfig " + aggregationConfig);
           }
 
           if (schema != null) {
             fieldSpec = schema.getFieldSpecFor(columnName);
             Preconditions.checkState(fieldSpec != null, "The destination column '" + columnName
-                    + "' of the aggregation function must be present in the schema");
+                + "' of the aggregation function must be present in the schema");
             Preconditions.checkState(fieldSpec.getFieldType() == FieldSpec.FieldType.METRIC,
-                    "The destination column '" + columnName + "' of the aggregation function must be a metric column");
+                "The destination column '" + columnName + "' of the aggregation function must be a metric column");
           }
 
           if (!aggregationColumns.add(columnName)) {
@@ -364,10 +364,10 @@ public final class TableConfigUtils {
             expressionContext = RequestContextUtils.getExpression(aggregationConfig.getAggregationFunction());
           } catch (Exception e) {
             throw new IllegalStateException(
-                    "Invalid aggregation function '" + aggregationFunction + "' for column '" + columnName + "'", e);
+                "Invalid aggregation function '" + aggregationFunction + "' for column '" + columnName + "'", e);
           }
           Preconditions.checkState(expressionContext.getType() == ExpressionContext.Type.FUNCTION,
-                  "aggregation function must be a function for: %s", aggregationConfig);
+              "aggregation function must be a function for: %s", aggregationConfig);
 
           FunctionContext functionContext = expressionContext.getFunction();
           validateIngestionAggregation(functionContext.getFunctionName());
@@ -375,14 +375,15 @@ public final class TableConfigUtils {
           List<ExpressionContext> arguments = functionContext.getArguments();
           switch (functionContext.getFunctionName()) {
             case "distinctcounthll":
-              Preconditions.checkState(functionContext.getArguments().size() >= 1 && functionContext.getArguments().size() <= 2,
-                      "distinctcounthll function can have max two arguments: %s", aggregationConfig);
+              Preconditions.checkState(
+                  functionContext.getArguments().size() >= 1 && functionContext.getArguments().size() <= 2,
+                  "distinctcounthll function can have max two arguments: %s", aggregationConfig);
 
               int log2m = CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M;
               if (functionContext.getArguments().size() == 2) {
                 Preconditions.checkState(
-                        StringUtils.isNumeric(functionContext.getArguments().get(1).getLiteralString()),
-                        "distinctcounthll function second argument must be a number");
+                    StringUtils.isNumeric(functionContext.getArguments().get(1).getLiteralString()),
+                    "distinctcounthll function second argument must be a number");
 
                 log2m = Integer.parseInt(functionContext.getArguments().get(1).getLiteralString());
               }
@@ -394,40 +395,44 @@ public final class TableConfigUtils {
                 throw new RuntimeException(e);
               }
 
-              String destinationColumn  = aggregationConfig.getColumnName();
+              String destinationColumn = aggregationConfig.getColumnName();
               FieldSpec destinationFieldSpec = schema.getFieldSpecFor(destinationColumn);
 
               if (destinationFieldSpec == null) {
-                throw new RuntimeException("couldn't find field config for " + destinationColumn + ". Unable to validate aggregation config for distinctcounthll");
+                throw new RuntimeException("couldn't find field config for " + destinationColumn
+                    + ". Unable to validate aggregation config for distinctcounthll");
               } else {
                 int maxLength = destinationFieldSpec.getMaxLength();
-                Preconditions.checkState(maxLength == expectedBytesForHLL, "destination field for distinctcounthll must have maxLength property set to " + expectedBytesForHLL + ", the size of a HLL object with log2m of " + log2m);
+                Preconditions.checkState(maxLength == expectedBytesForHLL,
+                    "destination field for distinctcounthll must have maxLength property set to " + expectedBytesForHLL
+                        + ", the size of a HLL object with log2m of " + log2m);
                 break;
               }
             default:
               Preconditions.checkState(functionContext.getArguments().size() == 1,
-                      "aggregation function can only have one argument: %s", aggregationConfig);
+                  "aggregation function can only have one argument: %s", aggregationConfig);
+              break;
           }
 
           ExpressionContext argument = functionContext.getArguments().get(0);
           Preconditions.checkState(argument.getType() == ExpressionContext.Type.IDENTIFIER,
-                  "aggregator function argument must be an identifier: %s", aggregationConfig);
+              "aggregator function argument must be an identifier: %s", aggregationConfig);
 
           AggregationFunctionType functionType =
-                  AggregationFunctionType.getAggregationFunctionType(functionContext.getFunctionName());
+              AggregationFunctionType.getAggregationFunctionType(functionContext.getFunctionName());
           ValueAggregator valueAggregator = ValueAggregatorFactory.getValueAggregator(functionType, arguments);
 
           if (schema != null && fieldSpec != null) {
             Preconditions.checkState(valueAggregator.getAggregatedValueType() == fieldSpec.getDataType(),
-                    "aggregator function datatype (%s) must be the same as the schema datatype (%s) for %s",
-                    valueAggregator.getAggregatedValueType(), fieldSpec.getDataType(), fieldSpec.getName());
+                "aggregator function datatype (%s) must be the same as the schema datatype (%s) for %s",
+                valueAggregator.getAggregatedValueType(), fieldSpec.getDataType(), fieldSpec.getName());
           }
 
           aggregationSourceColumns.add(argument.getIdentifier());
         }
         if (schema != null) {
           Preconditions.checkState(new HashSet<>(schema.getMetricNames()).equals(aggregationColumns),
-                  "all metric columns must be aggregated");
+              "all metric columns must be aggregated");
         }
       }
 
@@ -439,15 +444,15 @@ public final class TableConfigUtils {
           String columnName = transformConfig.getColumnName();
           if (schema != null) {
             Preconditions.checkState(
-                    schema.getFieldSpecFor(columnName) != null || aggregationSourceColumns.contains(columnName),
-                    "The destination column '" + columnName
-                            + "' of the transform function must be present in the schema or as a source column for "
-                            + "aggregations");
+                schema.getFieldSpecFor(columnName) != null || aggregationSourceColumns.contains(columnName),
+                "The destination column '" + columnName
+                    + "' of the transform function must be present in the schema or as a source column for "
+                    + "aggregations");
           }
           String transformFunction = transformConfig.getTransformFunction();
           if (columnName == null || transformFunction == null) {
             throw new IllegalStateException(
-                    "columnName/transformFunction cannot be null in TransformConfig " + transformConfig);
+                "columnName/transformFunction cannot be null in TransformConfig " + transformConfig);
           }
           if (!transformColumns.add(columnName)) {
             throw new IllegalStateException("Duplicate transform config found for column '" + columnName + "'");
@@ -455,20 +460,20 @@ public final class TableConfigUtils {
           FunctionEvaluator expressionEvaluator;
           if (disableGroovy && FunctionEvaluatorFactory.isGroovyExpression(transformFunction)) {
             throw new IllegalStateException(
-                    "Groovy transform functions are disabled for table config. Found '" + transformFunction
-                            + "' for column '" + columnName + "'");
+                "Groovy transform functions are disabled for table config. Found '" + transformFunction
+                    + "' for column '" + columnName + "'");
           }
           try {
             expressionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction);
           } catch (Exception e) {
             throw new IllegalStateException(
-                    "Invalid transform function '" + transformFunction + "' for column '" + columnName + "'", e);
+                "Invalid transform function '" + transformFunction + "' for column '" + columnName + "'", e);
           }
           List<String> arguments = expressionEvaluator.getArguments();
           if (arguments.contains(columnName)) {
             throw new IllegalStateException(
-                    "Arguments of a transform function '" + arguments + "' cannot contain the destination column '"
-                            + columnName + "'");
+                "Arguments of a transform function '" + arguments + "' cannot contain the destination column '"
+                    + columnName + "'");
           }
         }
       }
@@ -482,8 +487,8 @@ public final class TableConfigUtils {
           for (String prefix : prefixesToRename.keySet()) {
             for (String field : fieldNames) {
               Preconditions.checkState(!field.startsWith(prefix),
-                      "Fields in the schema may not begin with any prefix specified in the prefixesToRename"
-                              + " config. Name conflict with field: " + field + " and prefix: " + prefix);
+                  "Fields in the schema may not begin with any prefix specified in the prefixesToRename"
+                      + " config. Name conflict with field: " + field + " and prefix: " + prefix);
             }
           }
         }
@@ -505,7 +510,7 @@ public final class TableConfigUtils {
       }
     }
     throw new IllegalStateException(
-            String.format("aggregation function %s must be one of %s", name, SUPPORTED_INGESTION_AGGREGATIONS));
+        String.format("aggregation function %s must be one of %s", name, SUPPORTED_INGESTION_AGGREGATIONS));
   }
 
   @VisibleForTesting
@@ -517,7 +522,7 @@ public final class TableConfigUtils {
         Map<String, String> taskTypeConfig = taskConfigEntry.getValue();
         // Task configuration cannot be null.
         Preconditions.checkNotNull(taskTypeConfig,
-                String.format("Task configuration for \"%s\" cannot be null!", taskTypeConfigName));
+            String.format("Task configuration for \"%s\" cannot be null!", taskTypeConfigName));
         // Schedule key for task config has to be set.
         if (taskTypeConfig.containsKey(SCHEDULE_KEY)) {
           String cronExprStr = taskTypeConfig.get(SCHEDULE_KEY);
@@ -525,7 +530,7 @@ public final class TableConfigUtils {
             CronScheduleBuilder.cronSchedule(cronExprStr);
           } catch (Exception e) {
             throw new IllegalStateException(
-                    String.format("Task %s contains an invalid cron schedule: %s", taskTypeConfigName, cronExprStr), e);
+                String.format("Task %s contains an invalid cron schedule: %s", taskTypeConfigName, cronExprStr), e);
           }
         }
         // Task Specific validation for REALTIME_TO_OFFLINE_TASK_TYPE
@@ -533,23 +538,23 @@ public final class TableConfigUtils {
         if (taskTypeConfigName.equals(REALTIME_TO_OFFLINE_TASK_TYPE)) {
           // check table is not upsert
           Preconditions.checkState(tableConfig.getUpsertMode() == UpsertConfig.Mode.NONE,
-                  "RealtimeToOfflineTask doesn't support upsert table!");
+              "RealtimeToOfflineTask doesn't support upsert table!");
           // check no malformed period
           TimeUtils.convertPeriodToMillis(taskTypeConfig.getOrDefault("bufferTimePeriod", "2d"));
           TimeUtils.convertPeriodToMillis(taskTypeConfig.getOrDefault("bucketTimePeriod", "1d"));
           TimeUtils.convertPeriodToMillis(taskTypeConfig.getOrDefault("roundBucketTimePeriod", "1s"));
           // check mergeType is correct
           Preconditions.checkState(ImmutableSet.of("CONCAT", "ROLLUP", "DEDUP")
-                          .contains(taskTypeConfig.getOrDefault("mergeType", "CONCAT").toUpperCase()),
-                  "MergeType must be one of [CONCAT, ROLLUP, DEDUP]!");
+                  .contains(taskTypeConfig.getOrDefault("mergeType", "CONCAT").toUpperCase()),
+              "MergeType must be one of [CONCAT, ROLLUP, DEDUP]!");
           // check no mis-configured columns
           Set<String> columnNames = schema.getColumnNames();
           for (Map.Entry<String, String> entry : taskTypeConfig.entrySet()) {
             if (entry.getKey().endsWith(".aggregationType")) {
               Preconditions.checkState(columnNames.contains(StringUtils.removeEnd(entry.getKey(), ".aggregationType")),
-                      String.format("Column \"%s\" not found in schema!", entry.getKey()));
+                  String.format("Column \"%s\" not found in schema!", entry.getKey()));
               Preconditions.checkState(ImmutableSet.of("SUM", "MAX", "MIN").contains(entry.getValue().toUpperCase()),
-                      String.format("Column \"%s\" has invalid aggregate type: %s", entry.getKey(), entry.getValue()));
+                  String.format("Column \"%s\" has invalid aggregate type: %s", entry.getKey(), entry.getValue()));
             }
           }
         }
@@ -568,7 +573,7 @@ public final class TableConfigUtils {
   @VisibleForTesting
   static void validateUpsertAndDedupConfig(TableConfig tableConfig, Schema schema) {
     if (tableConfig.getUpsertMode() == UpsertConfig.Mode.NONE && (tableConfig.getDedupConfig() == null
-            || !tableConfig.getDedupConfig().isDedupEnabled())) {
+        || !tableConfig.getDedupConfig().isDedupEnabled())) {
       return;
     }
 
@@ -577,31 +582,31 @@ public final class TableConfigUtils {
 
     // check both upsert and dedup are not enabled simultaneously
     Preconditions.checkState(!(isUpsertEnabled && isDedupEnabled),
-            "A table can have either Upsert or Dedup enabled, but not both");
+        "A table can have either Upsert or Dedup enabled, but not both");
     // check table type is realtime
     Preconditions.checkState(tableConfig.getTableType() == TableType.REALTIME,
-            "Upsert/Dedup table is for realtime table only.");
+        "Upsert/Dedup table is for realtime table only.");
     // primary key exists
     Preconditions.checkState(CollectionUtils.isNotEmpty(schema.getPrimaryKeyColumns()),
-            "Upsert/Dedup table must have primary key columns in the schema");
+        "Upsert/Dedup table must have primary key columns in the schema");
     // consumer type must be low-level
     Map<String, String> streamConfigsMap = IngestionConfigUtils.getStreamConfigMap(tableConfig);
     StreamConfig streamConfig = new StreamConfig(tableConfig.getTableName(), streamConfigsMap);
     Preconditions.checkState(streamConfig.hasLowLevelConsumerType() && !streamConfig.hasHighLevelConsumerType(),
-            "Upsert/Dedup table must use low-level streaming consumer type");
+        "Upsert/Dedup table must use low-level streaming consumer type");
     // replica group is configured for routing
     Preconditions.checkState(tableConfig.getRoutingConfig() != null
-                    && RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equalsIgnoreCase(
-                    tableConfig.getRoutingConfig().getInstanceSelectorType()),
-            "Upsert/Dedup table must use strict replica-group (i.e. strictReplicaGroup) based routing");
+            && RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equalsIgnoreCase(
+            tableConfig.getRoutingConfig().getInstanceSelectorType()),
+        "Upsert/Dedup table must use strict replica-group (i.e. strictReplicaGroup) based routing");
 
     // specifically for upsert
     if (tableConfig.getUpsertMode() != UpsertConfig.Mode.NONE) {
 
       // no startree index
       Preconditions.checkState(CollectionUtils.isEmpty(tableConfig.getIndexingConfig().getStarTreeIndexConfigs())
-                      && !tableConfig.getIndexingConfig().isEnableDefaultStarTree(),
-              "The upsert table cannot have star-tree index.");
+              && !tableConfig.getIndexingConfig().isEnableDefaultStarTree(),
+          "The upsert table cannot have star-tree index.");
 
       // comparison column exists
       if (tableConfig.getUpsertConfig().getComparisonColumn() != null) {
@@ -619,14 +624,14 @@ public final class TableConfigUtils {
    */
   @VisibleForTesting
   static void validateInstancePartitionsTypeMapConfig(TableConfig tableConfig) {
-    if (MapUtils.isEmpty(tableConfig.getInstancePartitionsMap())
-            || MapUtils.isEmpty(tableConfig.getInstanceAssignmentConfigMap())) {
+    if (MapUtils.isEmpty(tableConfig.getInstancePartitionsMap()) || MapUtils.isEmpty(
+        tableConfig.getInstanceAssignmentConfigMap())) {
       return;
     }
     for (InstancePartitionsType instancePartitionsType : tableConfig.getInstancePartitionsMap().keySet()) {
       Preconditions.checkState(!tableConfig.getInstanceAssignmentConfigMap().containsKey(instancePartitionsType),
-              String.format("Both InstanceAssignmentConfigMap and InstancePartitionsMap set for %s",
-                      instancePartitionsType));
+          String.format("Both InstanceAssignmentConfigMap and InstancePartitionsMap set for %s",
+              instancePartitionsType));
     }
   }
 
@@ -638,13 +643,13 @@ public final class TableConfigUtils {
   private static void validateAggregateMetricsForUpsertConfig(TableConfig config) {
     boolean isAggregateMetricsEnabledInIndexingConfig = config.getIndexingConfig().isAggregateMetrics();
     boolean hasAggregationConfigs = config.getIngestionConfig() != null && CollectionUtils.isNotEmpty(
-            config.getIngestionConfig().getAggregationConfigs());
+        config.getIngestionConfig().getAggregationConfigs());
     boolean bothAggregationConfigsEnabled = isAggregateMetricsEnabledInIndexingConfig && hasAggregationConfigs;
     boolean anyOneAggregationConfigsEnabled = isAggregateMetricsEnabledInIndexingConfig || hasAggregationConfigs;
     Preconditions.checkState(!bothAggregationConfigsEnabled,
-            "Metrics aggregation cannot be enabled in the Indexing Config and Ingestion Config at the same time");
+        "Metrics aggregation cannot be enabled in the Indexing Config and Ingestion Config at the same time");
     Preconditions.checkState(!anyOneAggregationConfigsEnabled,
-            "Metrics aggregation and upsert cannot be enabled together");
+        "Metrics aggregation and upsert cannot be enabled together");
   }
 
   /**
@@ -663,7 +668,7 @@ public final class TableConfigUtils {
     }
 
     Preconditions.checkState(tableConfig.getIndexingConfig().isNullHandlingEnabled(),
-            "Null handling must be enabled for partial upsert tables");
+        "Null handling must be enabled for partial upsert tables");
 
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
     assert upsertConfig != null;
@@ -677,10 +682,10 @@ public final class TableConfigUtils {
 
       if (upsertConfig.getComparisonColumn() != null) {
         Preconditions.checkState(!upsertConfig.getComparisonColumn().equals(column),
-                "Merger cannot be applied to comparison column");
+            "Merger cannot be applied to comparison column");
       } else {
         Preconditions.checkState(!tableConfig.getValidationConfig().getTimeColumnName().equals(column),
-                "Merger cannot be applied to time column");
+            "Merger cannot be applied to time column");
       }
 
       FieldSpec fieldSpec = schema.getFieldSpecFor(column);
@@ -688,12 +693,12 @@ public final class TableConfigUtils {
 
       if (columnStrategy == UpsertConfig.Strategy.INCREMENT) {
         Preconditions.checkState(fieldSpec.getDataType().getStoredType().isNumeric(),
-                "INCREMENT merger cannot be applied to non-numeric column: %s", column);
+            "INCREMENT merger cannot be applied to non-numeric column: %s", column);
         Preconditions.checkState(!schema.getDateTimeNames().contains(column),
-                "INCREMENT merger cannot be applied to date time column: %s", column);
+            "INCREMENT merger cannot be applied to date time column: %s", column);
       } else if (columnStrategy == UpsertConfig.Strategy.APPEND || columnStrategy == UpsertConfig.Strategy.UNION) {
         Preconditions.checkState(!fieldSpec.isSingleValueField(),
-                "%s merger cannot be applied to single-value column: %s", columnStrategy.toString(), column);
+            "%s merger cannot be applied to single-value column: %s", columnStrategy.toString(), column);
       }
     }
   }
@@ -718,22 +723,22 @@ public final class TableConfigUtils {
       String segmentAge = tierConfig.getSegmentAge();
       if (segmentSelectorType.equalsIgnoreCase(TierFactory.TIME_SEGMENT_SELECTOR_TYPE)) {
         Preconditions.checkState(segmentAge != null,
-                "Must provide 'segmentAge' for segmentSelectorType: %s in tier: %s", segmentSelectorType, tierName);
+            "Must provide 'segmentAge' for segmentSelectorType: %s in tier: %s", segmentSelectorType, tierName);
         Preconditions.checkState(TimeUtils.isPeriodValid(segmentAge),
-                "segmentAge: %s must be a valid period string (eg. 30d, 24h) in tier: %s", segmentAge, tierName);
+            "segmentAge: %s must be a valid period string (eg. 30d, 24h) in tier: %s", segmentAge, tierName);
       } else if (!segmentSelectorType.equalsIgnoreCase(TierFactory.FIXED_SEGMENT_SELECTOR_TYPE)) {
         throw new IllegalStateException(
-                "Unsupported segmentSelectorType: " + segmentSelectorType + " in tier: " + tierName);
+            "Unsupported segmentSelectorType: " + segmentSelectorType + " in tier: " + tierName);
       }
 
       String storageType = tierConfig.getStorageType();
       String serverTag = tierConfig.getServerTag();
       if (storageType.equalsIgnoreCase(TierFactory.PINOT_SERVER_STORAGE_TYPE)) {
         Preconditions.checkState(serverTag != null, "Must provide 'serverTag' for storageType: %s in tier: %s",
-                storageType, tierName);
+            storageType, tierName);
         Preconditions.checkState(TagNameUtils.isServerTag(serverTag),
-                "serverTag: %s must have a valid server tag format (<tenantName>_OFFLINE or <tenantName>_REALTIME) in "
-                        + "tier: %s", serverTag, tierName);
+            "serverTag: %s must have a valid server tag format (<tenantName>_OFFLINE or <tenantName>_REALTIME) in "
+                + "tier: %s", serverTag, tierName);
       } else {
         throw new IllegalStateException("Unsupported storageType: " + storageType + " in tier: " + tierName);
       }
@@ -773,7 +778,7 @@ public final class TableConfigUtils {
       for (String columnName : indexingConfig.getInvertedIndexColumns()) {
         if (noDictionaryColumnsSet.contains(columnName)) {
           throw new IllegalStateException("Cannot create an Inverted index on column " + columnName
-                  + " specified in the noDictionaryColumns config");
+              + " specified in the noDictionaryColumns config");
         }
         columnNameToConfigMap.put(columnName, "Inverted Index Config");
       }
@@ -800,7 +805,7 @@ public final class TableConfigUtils {
       }
     }
     if (indexingConfig.getSegmentPartitionConfig() != null
-            && indexingConfig.getSegmentPartitionConfig().getColumnPartitionMap() != null) {
+        && indexingConfig.getSegmentPartitionConfig().getColumnPartitionMap() != null) {
       for (String columnName : indexingConfig.getSegmentPartitionConfig().getColumnPartitionMap().keySet()) {
         columnNameToConfigMap.put(columnName, "Segment Partition Config");
       }
@@ -832,7 +837,7 @@ public final class TableConfigUtils {
             columnPair = AggregationFunctionColumnPair.fromColumnName(functionColumnPair);
           } catch (Exception e) {
             throw new IllegalStateException("Invalid StarTreeIndex config: " + functionColumnPair + ". Must be"
-                    + "in the form <Aggregation function>__<Column name>");
+                + "in the form <Aggregation function>__<Column name>");
           }
           String columnName = columnPair.getColumn();
           if (!columnName.equals(AggregationFunctionColumnPair.STAR)) {
@@ -853,10 +858,10 @@ public final class TableConfigUtils {
       String configName = entry.getValue();
       FieldSpec columnFieldSpec = schema.getFieldSpecFor(columnName);
       Preconditions.checkState(columnFieldSpec != null,
-              "Column Name " + columnName + " defined in " + configName + " must be a valid column defined in the schema");
+          "Column Name " + columnName + " defined in " + configName + " must be a valid column defined in the schema");
       if (configName.equals(STAR_TREE_CONFIG_NAME)) {
         Preconditions.checkState(columnFieldSpec.isSingleValueField(),
-                "Column Name " + columnName + " defined in " + configName + " must be a single value column");
+            "Column Name " + columnName + " defined in " + configName + " must be a single value column");
       }
     }
 
@@ -865,8 +870,8 @@ public final class TableConfigUtils {
     if (indexingConfig.getRangeIndexColumns() != null) {
       for (String rangeIndexCol : indexingConfig.getRangeIndexColumns()) {
         Preconditions.checkState(
-                schema.getFieldSpecFor(rangeIndexCol).getDataType().isNumeric() || !noDictionaryColumnsSet.contains(
-                        rangeIndexCol), "Cannot create a range index on non-numeric/no-dictionary column " + rangeIndexCol);
+            schema.getFieldSpecFor(rangeIndexCol).getDataType().isNumeric() || !noDictionaryColumnsSet.contains(
+                rangeIndexCol), "Cannot create a range index on non-numeric/no-dictionary column " + rangeIndexCol);
       }
     }
 
@@ -880,8 +885,8 @@ public final class TableConfigUtils {
             continue;
           default:
             throw new IllegalStateException(
-                    "var length dictionary can only be created for columns of type STRING and BYTES. Invalid for column "
-                            + varLenDictCol);
+                "var length dictionary can only be created for columns of type STRING and BYTES. Invalid for column "
+                    + varLenDictCol);
         }
       }
     }
@@ -889,8 +894,8 @@ public final class TableConfigUtils {
     for (String jsonIndexColumn : jsonIndexColumns) {
       FieldSpec fieldSpec = schema.getFieldSpecFor(jsonIndexColumn);
       Preconditions.checkState(
-              fieldSpec.isSingleValueField() && fieldSpec.getDataType().getStoredType() == DataType.STRING,
-              "Json index can only be created for single value String column. Invalid for column: %s", jsonIndexColumn);
+          fieldSpec.isSingleValueField() && fieldSpec.getDataType().getStoredType() == DataType.STRING,
+          "Json index can only be created for single value String column. Invalid for column: %s", jsonIndexColumn);
     }
   }
 
@@ -901,7 +906,7 @@ public final class TableConfigUtils {
    * Validates index compatibility for forward index disabled columns
    */
   private static void validateFieldConfigList(@Nullable List<FieldConfig> fieldConfigList,
-                                              @Nullable IndexingConfig indexingConfigs, @Nullable Schema schema) {
+      @Nullable IndexingConfig indexingConfigs, @Nullable Schema schema) {
     if (fieldConfigList == null || schema == null) {
       return;
     }
@@ -910,7 +915,7 @@ public final class TableConfigUtils {
       String columnName = fieldConfig.getName();
       FieldSpec fieldConfigColSpec = schema.getFieldSpecFor(columnName);
       Preconditions.checkState(fieldConfigColSpec != null,
-              "Column Name " + columnName + " defined in field config list must be a valid column defined in the schema");
+          "Column Name " + columnName + " defined in field config list must be a valid column defined in the schema");
 
       if (indexingConfigs != null) {
         List<String> noDictionaryColumns = indexingConfigs.getNoDictionaryColumns();
@@ -918,10 +923,10 @@ public final class TableConfigUtils {
           case DICTIONARY:
             if (noDictionaryColumns != null) {
               Preconditions.checkArgument(!noDictionaryColumns.contains(columnName),
-                      "FieldConfig encoding type is different from indexingConfig for column: " + columnName);
+                  "FieldConfig encoding type is different from indexingConfig for column: " + columnName);
             }
             Preconditions.checkArgument(fieldConfig.getCompressionCodec() == null,
-                    "Set compression codec to null for dictionary encoding type");
+                "Set compression codec to null for dictionary encoding type");
             break;
           default:
             break;
@@ -929,7 +934,7 @@ public final class TableConfigUtils {
 
         // Validate the forward index disabled compatibility with other indexes if enabled for this column
         validateForwardIndexDisabledIndexCompatibility(columnName, fieldConfig, indexingConfigs, noDictionaryColumns,
-                schema);
+            schema);
       }
 
       if (CollectionUtils.isNotEmpty(fieldConfig.getIndexTypes())) {
@@ -937,18 +942,18 @@ public final class TableConfigUtils {
           switch (indexType) {
             case FST:
               Preconditions.checkArgument(fieldConfig.getEncodingType() == FieldConfig.EncodingType.DICTIONARY,
-                      "FST Index is only enabled on dictionary encoded columns");
+                  "FST Index is only enabled on dictionary encoded columns");
               Preconditions.checkState(fieldConfigColSpec.isSingleValueField()
-                              && fieldConfigColSpec.getDataType().getStoredType() == DataType.STRING,
-                      "FST Index is only supported for single value string columns");
+                      && fieldConfigColSpec.getDataType().getStoredType() == DataType.STRING,
+                  "FST Index is only supported for single value string columns");
               break;
             case TEXT:
               Preconditions.checkState(fieldConfigColSpec.getDataType().getStoredType() == DataType.STRING,
-                      "TEXT Index is only supported for string columns");
+                  "TEXT Index is only supported for string columns");
               break;
             case TIMESTAMP:
               Preconditions.checkState(fieldConfigColSpec.getDataType() == DataType.TIMESTAMP,
-                      "TIMESTAMP Index is only supported for timestamp columns");
+                  "TIMESTAMP Index is only supported for timestamp columns");
               break;
             default:
               break;
@@ -967,7 +972,7 @@ public final class TableConfigUtils {
    *       multi-value column (since mulit-value defaults to index v1).
    */
   private static void validateForwardIndexDisabledIndexCompatibility(String columnName, FieldConfig fieldConfig,
-                                                                     IndexingConfig indexingConfigs, List<String> noDictionaryColumns, Schema schema) {
+      IndexingConfig indexingConfigs, List<String> noDictionaryColumns, Schema schema) {
     Map<String, String> fieldConfigProperties = fieldConfig.getProperties();
     if (fieldConfigProperties == null) {
       return;
@@ -979,20 +984,22 @@ public final class TableConfigUtils {
     }
 
     FieldSpec fieldSpec = schema.getFieldSpecFor(columnName);
-    Preconditions.checkState(fieldConfig.getEncodingType() == FieldConfig.EncodingType.DICTIONARY
-                    || noDictionaryColumns == null || !noDictionaryColumns.contains(columnName),
-            String.format("Forward index disabled column %s must have dictionary enabled", columnName));
-    Preconditions.checkState(indexingConfigs.getInvertedIndexColumns() != null
-                    && indexingConfigs.getInvertedIndexColumns().contains(columnName),
-            String.format("Forward index disabled column %s must have inverted index enabled", columnName));
+    Preconditions.checkState(
+        fieldConfig.getEncodingType() == FieldConfig.EncodingType.DICTIONARY || noDictionaryColumns == null
+            || !noDictionaryColumns.contains(columnName),
+        String.format("Forward index disabled column %s must have dictionary enabled", columnName));
+    Preconditions.checkState(
+        indexingConfigs.getInvertedIndexColumns() != null && indexingConfigs.getInvertedIndexColumns()
+            .contains(columnName),
+        String.format("Forward index disabled column %s must have inverted index enabled", columnName));
     if (indexingConfigs.getRangeIndexColumns() != null && indexingConfigs.getRangeIndexColumns().contains(columnName)) {
       Preconditions.checkState(fieldSpec.isSingleValueField(), String.format("Feature not supported for multi-value "
-              + "columns with range index. Cannot disable forward index for column %s. Disable range index on this "
-              + "column to use this feature", columnName));
+          + "columns with range index. Cannot disable forward index for column %s. Disable range index on this "
+          + "column to use this feature", columnName));
       Preconditions.checkState(indexingConfigs.getRangeIndexVersion() == BitSlicedRangeIndexCreator.VERSION,
-              String.format("Feature not supported for single-value columns with range index version < 2. Cannot disable "
-                      + "forward index for column %s. Either disable range index or create range index with"
-                      + " version >= 2 to use this feature", columnName));
+          String.format("Feature not supported for single-value columns with range index version < 2. Cannot disable "
+              + "forward index for column %s. Either disable range index or create range index with"
+              + " version >= 2 to use this feature", columnName));
     }
   }
 
@@ -1006,10 +1013,10 @@ public final class TableConfigUtils {
     indexingConfig.setSortedColumn(sanitizeListBasedIndexingColumns(indexingConfig.getSortedColumn()));
     indexingConfig.setBloomFilterColumns(sanitizeListBasedIndexingColumns(indexingConfig.getBloomFilterColumns()));
     indexingConfig.setOnHeapDictionaryColumns(
-            sanitizeListBasedIndexingColumns(indexingConfig.getOnHeapDictionaryColumns()));
+        sanitizeListBasedIndexingColumns(indexingConfig.getOnHeapDictionaryColumns()));
     indexingConfig.setRangeIndexColumns(sanitizeListBasedIndexingColumns(indexingConfig.getRangeIndexColumns()));
     indexingConfig.setVarLengthDictionaryColumns(
-            sanitizeListBasedIndexingColumns(indexingConfig.getVarLengthDictionaryColumns()));
+        sanitizeListBasedIndexingColumns(indexingConfig.getVarLengthDictionaryColumns()));
     return indexingConfig;
   }
 
@@ -1048,7 +1055,7 @@ public final class TableConfigUtils {
         requestReplication = tableConfig.getReplication();
         if (requestReplication < defaultTableMinReplicas) {
           LOGGER.info("Creating table with minimum replication factor of: {} instead of requested replication: {}",
-                  defaultTableMinReplicas, requestReplication);
+              defaultTableMinReplicas, requestReplication);
           segmentsConfig.setReplication(String.valueOf(defaultTableMinReplicas));
         }
       } catch (NumberFormatException e) {
@@ -1062,8 +1069,8 @@ public final class TableConfigUtils {
         replicasPerPartition = tableConfig.getReplication();
         if (replicasPerPartition < defaultTableMinReplicas) {
           LOGGER.info(
-                  "Creating table with minimum replicasPerPartition of: {} instead of requested replicasPerPartition: {}",
-                  defaultTableMinReplicas, replicasPerPartition);
+              "Creating table with minimum replicasPerPartition of: {} instead of requested replicasPerPartition: {}",
+              defaultTableMinReplicas, replicasPerPartition);
           segmentsConfig.setReplicasPerPartition(String.valueOf(defaultTableMinReplicas));
         }
       } catch (NumberFormatException e) {
@@ -1086,18 +1093,18 @@ public final class TableConfigUtils {
         // set a default storage quota
         tableConfig.setQuotaConfig(new QuotaConfig(maxAllowedSize, null));
         LOGGER.info("Assigning default storage quota ({}) for dimension table: {}", maxAllowedSize,
-                tableConfig.getTableName());
+            tableConfig.getTableName());
       } else {
         if (quotaConfig.getStorage() == null) {
           // set a default storage quota and keep the RPS value
           tableConfig.setQuotaConfig(new QuotaConfig(maxAllowedSize, quotaConfig.getMaxQueriesPerSecond()));
           LOGGER.info("Assigning default storage quota ({}) for dimension table: {}", maxAllowedSize,
-                  tableConfig.getTableName());
+              tableConfig.getTableName());
         } else {
           if (quotaConfig.getStorageInBytes() > maxAllowedSizeInBytes) {
             throw new IllegalStateException(
-                    String.format("Invalid storage quota: %d, max allowed size: %d", quotaConfig.getStorageInBytes(),
-                            maxAllowedSizeInBytes));
+                String.format("Invalid storage quota: %d, max allowed size: %d", quotaConfig.getStorageInBytes(),
+                    maxAllowedSizeInBytes));
           }
         }
       }
@@ -1108,11 +1115,11 @@ public final class TableConfigUtils {
    * Consistency checks across the offline and realtime counterparts of a hybrid table
    */
   public static void verifyHybridTableConfigs(String rawTableName, TableConfig offlineTableConfig,
-                                              TableConfig realtimeTableConfig) {
+      TableConfig realtimeTableConfig) {
     Preconditions.checkNotNull(offlineTableConfig,
-            "Found null offline table config in hybrid table check for table: %s", rawTableName);
+        "Found null offline table config in hybrid table check for table: %s", rawTableName);
     Preconditions.checkNotNull(realtimeTableConfig,
-            "Found null realtime table config in hybrid table check for table: %s", rawTableName);
+        "Found null realtime table config in hybrid table check for table: %s", rawTableName);
     LOGGER.info("Validating realtime and offline configs for the hybrid table: {}", rawTableName);
     SegmentsValidationAndRetentionConfig offlineSegmentConfig = offlineTableConfig.getValidationConfig();
     SegmentsValidationAndRetentionConfig realtimeSegmentConfig = realtimeTableConfig.getValidationConfig();
@@ -1120,13 +1127,13 @@ public final class TableConfigUtils {
     String realtimeTimeColumnName = realtimeSegmentConfig.getTimeColumnName();
     if (offlineTimeColumnName == null || realtimeTimeColumnName == null) {
       throw new IllegalStateException(String.format(
-              "'timeColumnName' cannot be null for table: %s! Offline time column name: %s. Realtime time column name: %s",
-              rawTableName, offlineTimeColumnName, realtimeTimeColumnName));
+          "'timeColumnName' cannot be null for table: %s! Offline time column name: %s. Realtime time column name: %s",
+          rawTableName, offlineTimeColumnName, realtimeTimeColumnName));
     }
     if (!offlineTimeColumnName.equals(realtimeTimeColumnName)) {
       throw new IllegalStateException(String.format(
-              "Time column names are different for table: %s! Offline time column name: %s. Realtime time column name: %s",
-              rawTableName, offlineTimeColumnName, realtimeTimeColumnName));
+          "Time column names are different for table: %s! Offline time column name: %s. Realtime time column name: %s",
+          rawTableName, offlineTimeColumnName, realtimeTimeColumnName));
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pinot.segment.local.utils;
 
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.EnumSet;
@@ -40,6 +42,8 @@ import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.common.utils.config.TagNameUtils;
+import org.apache.pinot.segment.local.aggregator.ValueAggregator;
+import org.apache.pinot.segment.local.aggregator.ValueAggregatorFactory;
 import org.apache.pinot.segment.local.function.FunctionEvaluator;
 import org.apache.pinot.segment.local.function.FunctionEvaluatorFactory;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.BitSlicedRangeIndexCreator;
@@ -98,8 +102,8 @@ public final class TableConfigUtils {
   // hardcode the value here to avoid pulling the entire pinot-kinesis module as dependency.
   private static final String KINESIS_STREAM_TYPE = "kinesis";
   private static final EnumSet<AggregationFunctionType> SUPPORTED_INGESTION_AGGREGATIONS =
-      EnumSet.of(AggregationFunctionType.SUM, AggregationFunctionType.MIN, AggregationFunctionType.MAX,
-          AggregationFunctionType.COUNT);
+          EnumSet.of(AggregationFunctionType.SUM, AggregationFunctionType.MIN, AggregationFunctionType.MAX,
+                  AggregationFunctionType.COUNT, AggregationFunctionType.DISTINCTCOUNTHLL);
 
   /**
    * @see TableConfigUtils#validate(TableConfig, Schema, String, boolean)
@@ -119,7 +123,7 @@ public final class TableConfigUtils {
    * TODO: Add more validations for each section (e.g. validate conditions are met for aggregateMetrics)
    */
   public static void validate(TableConfig tableConfig, @Nullable Schema schema, @Nullable String typesToSkip,
-      boolean disableGroovy) {
+                              boolean disableGroovy) {
     Set<ValidationType> skipTypes = parseTypesToSkipString(typesToSkip);
     if (tableConfig.getTableType() == TableType.REALTIME) {
       Preconditions.checkState(schema != null, "Schema should not be null for REALTIME table");
@@ -146,7 +150,7 @@ public final class TableConfigUtils {
 
   private static Set<ValidationType> parseTypesToSkipString(@Nullable String typesToSkip) {
     return typesToSkip == null ? Collections.emptySet()
-        : Arrays.stream(typesToSkip.split(",")).map(s -> ValidationType.valueOf(s.toUpperCase()))
+            : Arrays.stream(typesToSkip.split(",")).map(s -> ValidationType.valueOf(s.toUpperCase()))
             .collect(Collectors.toSet());
   }
 
@@ -184,7 +188,7 @@ public final class TableConfigUtils {
 
     if (segmentsConfig == null) {
       throw new IllegalStateException(
-          String.format("Table: %s, \"segmentsConfig\" field is missing in table config", tableName));
+              String.format("Table: %s, \"segmentsConfig\" field is missing in table config", tableName));
     }
 
     String segmentPushType = IngestionConfigUtils.getBatchSegmentIngestionType(tableConfig);
@@ -231,12 +235,12 @@ public final class TableConfigUtils {
     // timeColumnName can be null in OFFLINE table
     if (timeColumnName != null && !timeColumnName.isEmpty() && schema != null) {
       Preconditions.checkState(schema.getSpecForTimeColumn(timeColumnName) != null,
-          "Cannot find valid fieldSpec for timeColumn: %s from the table config: %s, in the schema: %s", timeColumnName,
-          tableConfig.getTableName(), schema.getSchemaName());
+              "Cannot find valid fieldSpec for timeColumn: %s from the table config: %s, in the schema: %s", timeColumnName,
+              tableConfig.getTableName(), schema.getSchemaName());
     }
     if (tableConfig.isDimTable()) {
       Preconditions.checkState(tableConfig.getTableType() == TableType.OFFLINE,
-          "Dimension table must be of OFFLINE table type.");
+              "Dimension table must be of OFFLINE table type.");
       Preconditions.checkState(schema != null, "Dimension table must have an associated schema");
       Preconditions.checkState(!schema.getPrimaryKeyColumns().isEmpty(), "Dimension table must have primary key[s]");
     }
@@ -244,9 +248,9 @@ public final class TableConfigUtils {
     String peerSegmentDownloadScheme = validationConfig.getPeerSegmentDownloadScheme();
     if (peerSegmentDownloadScheme != null) {
       if (!CommonConstants.HTTP_PROTOCOL.equalsIgnoreCase(peerSegmentDownloadScheme)
-          && !CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(peerSegmentDownloadScheme)) {
+              && !CommonConstants.HTTPS_PROTOCOL.equalsIgnoreCase(peerSegmentDownloadScheme)) {
         throw new IllegalStateException("Invalid value '" + peerSegmentDownloadScheme
-            + "' for peerSegmentDownloadScheme. Must be one of http or https");
+                + "' for peerSegmentDownloadScheme. Must be one of http or https");
       }
     }
 
@@ -288,19 +292,19 @@ public final class TableConfigUtils {
         }
         if (tableConfig.isDimTable()) {
           Preconditions.checkState(cfg.getSegmentIngestionType().equalsIgnoreCase("REFRESH"),
-              "Dimension tables must have segment ingestion type REFRESH");
+                  "Dimension tables must have segment ingestion type REFRESH");
         }
       }
       if (tableConfig.isDimTable()) {
         Preconditions.checkState(ingestionConfig.getBatchIngestionConfig() != null,
-            "Dimension tables must have batch ingestion configuration");
+                "Dimension tables must have batch ingestion configuration");
       }
 
       // Stream
       if (ingestionConfig.getStreamIngestionConfig() != null) {
         IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
         Preconditions.checkState(indexingConfig == null || MapUtils.isEmpty(indexingConfig.getStreamConfigs()),
-            "Should not use indexingConfig#getStreamConfigs if ingestionConfig#StreamIngestionConfig is provided");
+                "Should not use indexingConfig#getStreamConfigs if ingestionConfig#StreamIngestionConfig is provided");
         List<Map<String, String>> streamConfigMaps = ingestionConfig.getStreamIngestionConfig().getStreamConfigMaps();
         Preconditions.checkState(streamConfigMaps.size() == 1, "Only 1 stream is supported in REALTIME table");
         try {
@@ -318,7 +322,7 @@ public final class TableConfigUtils {
         if (filterFunction != null) {
           if (disableGroovy && FunctionEvaluatorFactory.isGroovyExpression(filterFunction)) {
             throw new IllegalStateException(
-                "Groovy filter functions are disabled for table config. Found '" + filterFunction + "'");
+                    "Groovy filter functions are disabled for table config. Found '" + filterFunction + "'");
           }
           try {
             FunctionEvaluatorFactory.getExpressionEvaluator(filterFunction);
@@ -333,22 +337,23 @@ public final class TableConfigUtils {
       Set<String> aggregationSourceColumns = new HashSet<>();
       if (!CollectionUtils.isEmpty(aggregationConfigs)) {
         Preconditions.checkState(!tableConfig.getIndexingConfig().isAggregateMetrics(),
-            "aggregateMetrics cannot be set with AggregationConfig");
+                "aggregateMetrics cannot be set with AggregationConfig");
         Set<String> aggregationColumns = new HashSet<>();
         for (AggregationConfig aggregationConfig : aggregationConfigs) {
           String columnName = aggregationConfig.getColumnName();
+          FieldSpec fieldSpec = null;
           String aggregationFunction = aggregationConfig.getAggregationFunction();
           if (columnName == null || aggregationFunction == null) {
             throw new IllegalStateException(
-                "columnName/aggregationFunction cannot be null in AggregationConfig " + aggregationConfig);
+                    "columnName/aggregationFunction cannot be null in AggregationConfig " + aggregationConfig);
           }
 
           if (schema != null) {
-            FieldSpec fieldSpec = schema.getFieldSpecFor(columnName);
+            fieldSpec = schema.getFieldSpecFor(columnName);
             Preconditions.checkState(fieldSpec != null, "The destination column '" + columnName
-                + "' of the aggregation function must be present in the schema");
+                    + "' of the aggregation function must be present in the schema");
             Preconditions.checkState(fieldSpec.getFieldType() == FieldSpec.FieldType.METRIC,
-                "The destination column '" + columnName + "' of the aggregation function must be a metric column");
+                    "The destination column '" + columnName + "' of the aggregation function must be a metric column");
           }
 
           if (!aggregationColumns.add(columnName)) {
@@ -359,25 +364,70 @@ public final class TableConfigUtils {
             expressionContext = RequestContextUtils.getExpression(aggregationConfig.getAggregationFunction());
           } catch (Exception e) {
             throw new IllegalStateException(
-                "Invalid aggregation function '" + aggregationFunction + "' for column '" + columnName + "'", e);
+                    "Invalid aggregation function '" + aggregationFunction + "' for column '" + columnName + "'", e);
           }
           Preconditions.checkState(expressionContext.getType() == ExpressionContext.Type.FUNCTION,
-              "aggregation function must be a function for: %s", aggregationConfig);
+                  "aggregation function must be a function for: %s", aggregationConfig);
 
           FunctionContext functionContext = expressionContext.getFunction();
           validateIngestionAggregation(functionContext.getFunctionName());
-          Preconditions.checkState(functionContext.getArguments().size() == 1,
-              "aggregation function can only have one argument: %s", aggregationConfig);
+
+          List<ExpressionContext> arguments = functionContext.getArguments();
+          switch (functionContext.getFunctionName()) {
+            case "distinctcounthll":
+              Preconditions.checkState(functionContext.getArguments().size() >= 1 && functionContext.getArguments().size() <= 2,
+                      "distinctcounthll function can have max two arguments: %s", aggregationConfig);
+
+              int log2m = CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M;
+              if (functionContext.getArguments().size() == 2) {
+                Preconditions.checkState(
+                        StringUtils.isNumeric(functionContext.getArguments().get(1).getLiteralString()),
+                        "distinctcounthll function second argument must be a number");
+
+                log2m = Integer.parseInt(functionContext.getArguments().get(1).getLiteralString());
+              }
+
+              int expectedBytesForHLL;
+              try {
+                expectedBytesForHLL = (new HyperLogLog(log2m)).getBytes().length;
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+
+              String destinationColumn  = aggregationConfig.getColumnName();
+              FieldSpec destinationFieldSpec = schema.getFieldSpecFor(destinationColumn);
+
+              if (destinationFieldSpec == null) {
+                throw new RuntimeException("couldn't find field config for " + destinationColumn + ". Unable to validate aggregation config for distinctcounthll");
+              } else {
+                int maxLength = destinationFieldSpec.getMaxLength();
+                Preconditions.checkState(maxLength == expectedBytesForHLL, "destination field for distinctcounthll must have maxLength property set to " + expectedBytesForHLL + ", the size of a HLL object with log2m of " + log2m);
+                break;
+              }
+            default:
+              Preconditions.checkState(functionContext.getArguments().size() == 1,
+                      "aggregation function can only have one argument: %s", aggregationConfig);
+          }
 
           ExpressionContext argument = functionContext.getArguments().get(0);
           Preconditions.checkState(argument.getType() == ExpressionContext.Type.IDENTIFIER,
-              "aggregator function argument must be a identifier: %s", aggregationConfig);
+                  "aggregator function argument must be an identifier: %s", aggregationConfig);
+
+          AggregationFunctionType functionType =
+                  AggregationFunctionType.getAggregationFunctionType(functionContext.getFunctionName());
+          ValueAggregator valueAggregator = ValueAggregatorFactory.getValueAggregator(functionType, arguments);
+
+          if (schema != null && fieldSpec != null) {
+            Preconditions.checkState(valueAggregator.getAggregatedValueType() == fieldSpec.getDataType(),
+                    "aggregator function datatype (%s) must be the same as the schema datatype (%s) for %s",
+                    valueAggregator.getAggregatedValueType(), fieldSpec.getDataType(), fieldSpec.getName());
+          }
 
           aggregationSourceColumns.add(argument.getIdentifier());
         }
         if (schema != null) {
           Preconditions.checkState(new HashSet<>(schema.getMetricNames()).equals(aggregationColumns),
-              "all metric columns must be aggregated");
+                  "all metric columns must be aggregated");
         }
       }
 
@@ -389,15 +439,15 @@ public final class TableConfigUtils {
           String columnName = transformConfig.getColumnName();
           if (schema != null) {
             Preconditions.checkState(
-                schema.getFieldSpecFor(columnName) != null || aggregationSourceColumns.contains(columnName),
-                "The destination column '" + columnName
-                    + "' of the transform function must be present in the schema or as a source column for "
-                    + "aggregations");
+                    schema.getFieldSpecFor(columnName) != null || aggregationSourceColumns.contains(columnName),
+                    "The destination column '" + columnName
+                            + "' of the transform function must be present in the schema or as a source column for "
+                            + "aggregations");
           }
           String transformFunction = transformConfig.getTransformFunction();
           if (columnName == null || transformFunction == null) {
             throw new IllegalStateException(
-                "columnName/transformFunction cannot be null in TransformConfig " + transformConfig);
+                    "columnName/transformFunction cannot be null in TransformConfig " + transformConfig);
           }
           if (!transformColumns.add(columnName)) {
             throw new IllegalStateException("Duplicate transform config found for column '" + columnName + "'");
@@ -405,20 +455,20 @@ public final class TableConfigUtils {
           FunctionEvaluator expressionEvaluator;
           if (disableGroovy && FunctionEvaluatorFactory.isGroovyExpression(transformFunction)) {
             throw new IllegalStateException(
-                "Groovy transform functions are disabled for table config. Found '" + transformFunction
-                    + "' for column '" + columnName + "'");
+                    "Groovy transform functions are disabled for table config. Found '" + transformFunction
+                            + "' for column '" + columnName + "'");
           }
           try {
             expressionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(transformFunction);
           } catch (Exception e) {
             throw new IllegalStateException(
-                "Invalid transform function '" + transformFunction + "' for column '" + columnName + "'", e);
+                    "Invalid transform function '" + transformFunction + "' for column '" + columnName + "'", e);
           }
           List<String> arguments = expressionEvaluator.getArguments();
           if (arguments.contains(columnName)) {
             throw new IllegalStateException(
-                "Arguments of a transform function '" + arguments + "' cannot contain the destination column '"
-                    + columnName + "'");
+                    "Arguments of a transform function '" + arguments + "' cannot contain the destination column '"
+                            + columnName + "'");
           }
         }
       }
@@ -432,8 +482,8 @@ public final class TableConfigUtils {
           for (String prefix : prefixesToRename.keySet()) {
             for (String field : fieldNames) {
               Preconditions.checkState(!field.startsWith(prefix),
-                  "Fields in the schema may not begin with any prefix specified in the prefixesToRename"
-                      + " config. Name conflict with field: " + field + " and prefix: " + prefix);
+                      "Fields in the schema may not begin with any prefix specified in the prefixesToRename"
+                              + " config. Name conflict with field: " + field + " and prefix: " + prefix);
             }
           }
         }
@@ -450,12 +500,12 @@ public final class TableConfigUtils {
    */
   public static void validateIngestionAggregation(String name) {
     for (AggregationFunctionType functionType : SUPPORTED_INGESTION_AGGREGATIONS) {
-      if (functionType.getName().equals(name)) {
+      if (functionType.getName().toLowerCase().equals(name)) {
         return;
       }
     }
     throw new IllegalStateException(
-        String.format("aggregation function %s must be one of %s", name, SUPPORTED_INGESTION_AGGREGATIONS));
+            String.format("aggregation function %s must be one of %s", name, SUPPORTED_INGESTION_AGGREGATIONS));
   }
 
   @VisibleForTesting
@@ -467,7 +517,7 @@ public final class TableConfigUtils {
         Map<String, String> taskTypeConfig = taskConfigEntry.getValue();
         // Task configuration cannot be null.
         Preconditions.checkNotNull(taskTypeConfig,
-            String.format("Task configuration for \"%s\" cannot be null!", taskTypeConfigName));
+                String.format("Task configuration for \"%s\" cannot be null!", taskTypeConfigName));
         // Schedule key for task config has to be set.
         if (taskTypeConfig.containsKey(SCHEDULE_KEY)) {
           String cronExprStr = taskTypeConfig.get(SCHEDULE_KEY);
@@ -475,7 +525,7 @@ public final class TableConfigUtils {
             CronScheduleBuilder.cronSchedule(cronExprStr);
           } catch (Exception e) {
             throw new IllegalStateException(
-                String.format("Task %s contains an invalid cron schedule: %s", taskTypeConfigName, cronExprStr), e);
+                    String.format("Task %s contains an invalid cron schedule: %s", taskTypeConfigName, cronExprStr), e);
           }
         }
         // Task Specific validation for REALTIME_TO_OFFLINE_TASK_TYPE
@@ -483,23 +533,23 @@ public final class TableConfigUtils {
         if (taskTypeConfigName.equals(REALTIME_TO_OFFLINE_TASK_TYPE)) {
           // check table is not upsert
           Preconditions.checkState(tableConfig.getUpsertMode() == UpsertConfig.Mode.NONE,
-              "RealtimeToOfflineTask doesn't support upsert table!");
+                  "RealtimeToOfflineTask doesn't support upsert table!");
           // check no malformed period
           TimeUtils.convertPeriodToMillis(taskTypeConfig.getOrDefault("bufferTimePeriod", "2d"));
           TimeUtils.convertPeriodToMillis(taskTypeConfig.getOrDefault("bucketTimePeriod", "1d"));
           TimeUtils.convertPeriodToMillis(taskTypeConfig.getOrDefault("roundBucketTimePeriod", "1s"));
           // check mergeType is correct
           Preconditions.checkState(ImmutableSet.of("CONCAT", "ROLLUP", "DEDUP")
-                  .contains(taskTypeConfig.getOrDefault("mergeType", "CONCAT").toUpperCase()),
-              "MergeType must be one of [CONCAT, ROLLUP, DEDUP]!");
+                          .contains(taskTypeConfig.getOrDefault("mergeType", "CONCAT").toUpperCase()),
+                  "MergeType must be one of [CONCAT, ROLLUP, DEDUP]!");
           // check no mis-configured columns
           Set<String> columnNames = schema.getColumnNames();
           for (Map.Entry<String, String> entry : taskTypeConfig.entrySet()) {
             if (entry.getKey().endsWith(".aggregationType")) {
               Preconditions.checkState(columnNames.contains(StringUtils.removeEnd(entry.getKey(), ".aggregationType")),
-                  String.format("Column \"%s\" not found in schema!", entry.getKey()));
+                      String.format("Column \"%s\" not found in schema!", entry.getKey()));
               Preconditions.checkState(ImmutableSet.of("SUM", "MAX", "MIN").contains(entry.getValue().toUpperCase()),
-                  String.format("Column \"%s\" has invalid aggregate type: %s", entry.getKey(), entry.getValue()));
+                      String.format("Column \"%s\" has invalid aggregate type: %s", entry.getKey(), entry.getValue()));
             }
           }
         }
@@ -518,7 +568,7 @@ public final class TableConfigUtils {
   @VisibleForTesting
   static void validateUpsertAndDedupConfig(TableConfig tableConfig, Schema schema) {
     if (tableConfig.getUpsertMode() == UpsertConfig.Mode.NONE && (tableConfig.getDedupConfig() == null
-        || !tableConfig.getDedupConfig().isDedupEnabled())) {
+            || !tableConfig.getDedupConfig().isDedupEnabled())) {
       return;
     }
 
@@ -527,31 +577,31 @@ public final class TableConfigUtils {
 
     // check both upsert and dedup are not enabled simultaneously
     Preconditions.checkState(!(isUpsertEnabled && isDedupEnabled),
-        "A table can have either Upsert or Dedup enabled, but not both");
+            "A table can have either Upsert or Dedup enabled, but not both");
     // check table type is realtime
     Preconditions.checkState(tableConfig.getTableType() == TableType.REALTIME,
-        "Upsert/Dedup table is for realtime table only.");
+            "Upsert/Dedup table is for realtime table only.");
     // primary key exists
     Preconditions.checkState(CollectionUtils.isNotEmpty(schema.getPrimaryKeyColumns()),
-        "Upsert/Dedup table must have primary key columns in the schema");
+            "Upsert/Dedup table must have primary key columns in the schema");
     // consumer type must be low-level
     Map<String, String> streamConfigsMap = IngestionConfigUtils.getStreamConfigMap(tableConfig);
     StreamConfig streamConfig = new StreamConfig(tableConfig.getTableName(), streamConfigsMap);
     Preconditions.checkState(streamConfig.hasLowLevelConsumerType() && !streamConfig.hasHighLevelConsumerType(),
-        "Upsert/Dedup table must use low-level streaming consumer type");
+            "Upsert/Dedup table must use low-level streaming consumer type");
     // replica group is configured for routing
     Preconditions.checkState(tableConfig.getRoutingConfig() != null
-            && RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equalsIgnoreCase(
-            tableConfig.getRoutingConfig().getInstanceSelectorType()),
-        "Upsert/Dedup table must use strict replica-group (i.e. strictReplicaGroup) based routing");
+                    && RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE.equalsIgnoreCase(
+                    tableConfig.getRoutingConfig().getInstanceSelectorType()),
+            "Upsert/Dedup table must use strict replica-group (i.e. strictReplicaGroup) based routing");
 
     // specifically for upsert
     if (tableConfig.getUpsertMode() != UpsertConfig.Mode.NONE) {
 
       // no startree index
       Preconditions.checkState(CollectionUtils.isEmpty(tableConfig.getIndexingConfig().getStarTreeIndexConfigs())
-              && !tableConfig.getIndexingConfig().isEnableDefaultStarTree(),
-          "The upsert table cannot have star-tree index.");
+                      && !tableConfig.getIndexingConfig().isEnableDefaultStarTree(),
+              "The upsert table cannot have star-tree index.");
 
       // comparison column exists
       if (tableConfig.getUpsertConfig().getComparisonColumn() != null) {
@@ -570,13 +620,13 @@ public final class TableConfigUtils {
   @VisibleForTesting
   static void validateInstancePartitionsTypeMapConfig(TableConfig tableConfig) {
     if (MapUtils.isEmpty(tableConfig.getInstancePartitionsMap())
-        || MapUtils.isEmpty(tableConfig.getInstanceAssignmentConfigMap())) {
+            || MapUtils.isEmpty(tableConfig.getInstanceAssignmentConfigMap())) {
       return;
     }
     for (InstancePartitionsType instancePartitionsType : tableConfig.getInstancePartitionsMap().keySet()) {
       Preconditions.checkState(!tableConfig.getInstanceAssignmentConfigMap().containsKey(instancePartitionsType),
-          String.format("Both InstanceAssignmentConfigMap and InstancePartitionsMap set for %s",
-              instancePartitionsType));
+              String.format("Both InstanceAssignmentConfigMap and InstancePartitionsMap set for %s",
+                      instancePartitionsType));
     }
   }
 
@@ -588,13 +638,13 @@ public final class TableConfigUtils {
   private static void validateAggregateMetricsForUpsertConfig(TableConfig config) {
     boolean isAggregateMetricsEnabledInIndexingConfig = config.getIndexingConfig().isAggregateMetrics();
     boolean hasAggregationConfigs = config.getIngestionConfig() != null && CollectionUtils.isNotEmpty(
-        config.getIngestionConfig().getAggregationConfigs());
+            config.getIngestionConfig().getAggregationConfigs());
     boolean bothAggregationConfigsEnabled = isAggregateMetricsEnabledInIndexingConfig && hasAggregationConfigs;
     boolean anyOneAggregationConfigsEnabled = isAggregateMetricsEnabledInIndexingConfig || hasAggregationConfigs;
     Preconditions.checkState(!bothAggregationConfigsEnabled,
-        "Metrics aggregation cannot be enabled in the Indexing Config and Ingestion Config at the same time");
+            "Metrics aggregation cannot be enabled in the Indexing Config and Ingestion Config at the same time");
     Preconditions.checkState(!anyOneAggregationConfigsEnabled,
-        "Metrics aggregation and upsert cannot be enabled together");
+            "Metrics aggregation and upsert cannot be enabled together");
   }
 
   /**
@@ -613,7 +663,7 @@ public final class TableConfigUtils {
     }
 
     Preconditions.checkState(tableConfig.getIndexingConfig().isNullHandlingEnabled(),
-        "Null handling must be enabled for partial upsert tables");
+            "Null handling must be enabled for partial upsert tables");
 
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
     assert upsertConfig != null;
@@ -627,10 +677,10 @@ public final class TableConfigUtils {
 
       if (upsertConfig.getComparisonColumn() != null) {
         Preconditions.checkState(!upsertConfig.getComparisonColumn().equals(column),
-            "Merger cannot be applied to comparison column");
+                "Merger cannot be applied to comparison column");
       } else {
         Preconditions.checkState(!tableConfig.getValidationConfig().getTimeColumnName().equals(column),
-            "Merger cannot be applied to time column");
+                "Merger cannot be applied to time column");
       }
 
       FieldSpec fieldSpec = schema.getFieldSpecFor(column);
@@ -638,12 +688,12 @@ public final class TableConfigUtils {
 
       if (columnStrategy == UpsertConfig.Strategy.INCREMENT) {
         Preconditions.checkState(fieldSpec.getDataType().getStoredType().isNumeric(),
-            "INCREMENT merger cannot be applied to non-numeric column: %s", column);
+                "INCREMENT merger cannot be applied to non-numeric column: %s", column);
         Preconditions.checkState(!schema.getDateTimeNames().contains(column),
-            "INCREMENT merger cannot be applied to date time column: %s", column);
+                "INCREMENT merger cannot be applied to date time column: %s", column);
       } else if (columnStrategy == UpsertConfig.Strategy.APPEND || columnStrategy == UpsertConfig.Strategy.UNION) {
         Preconditions.checkState(!fieldSpec.isSingleValueField(),
-            "%s merger cannot be applied to single-value column: %s", columnStrategy.toString(), column);
+                "%s merger cannot be applied to single-value column: %s", columnStrategy.toString(), column);
       }
     }
   }
@@ -668,22 +718,22 @@ public final class TableConfigUtils {
       String segmentAge = tierConfig.getSegmentAge();
       if (segmentSelectorType.equalsIgnoreCase(TierFactory.TIME_SEGMENT_SELECTOR_TYPE)) {
         Preconditions.checkState(segmentAge != null,
-            "Must provide 'segmentAge' for segmentSelectorType: %s in tier: %s", segmentSelectorType, tierName);
+                "Must provide 'segmentAge' for segmentSelectorType: %s in tier: %s", segmentSelectorType, tierName);
         Preconditions.checkState(TimeUtils.isPeriodValid(segmentAge),
-            "segmentAge: %s must be a valid period string (eg. 30d, 24h) in tier: %s", segmentAge, tierName);
+                "segmentAge: %s must be a valid period string (eg. 30d, 24h) in tier: %s", segmentAge, tierName);
       } else if (!segmentSelectorType.equalsIgnoreCase(TierFactory.FIXED_SEGMENT_SELECTOR_TYPE)) {
         throw new IllegalStateException(
-            "Unsupported segmentSelectorType: " + segmentSelectorType + " in tier: " + tierName);
+                "Unsupported segmentSelectorType: " + segmentSelectorType + " in tier: " + tierName);
       }
 
       String storageType = tierConfig.getStorageType();
       String serverTag = tierConfig.getServerTag();
       if (storageType.equalsIgnoreCase(TierFactory.PINOT_SERVER_STORAGE_TYPE)) {
         Preconditions.checkState(serverTag != null, "Must provide 'serverTag' for storageType: %s in tier: %s",
-            storageType, tierName);
+                storageType, tierName);
         Preconditions.checkState(TagNameUtils.isServerTag(serverTag),
-            "serverTag: %s must have a valid server tag format (<tenantName>_OFFLINE or <tenantName>_REALTIME) in "
-                + "tier: %s", serverTag, tierName);
+                "serverTag: %s must have a valid server tag format (<tenantName>_OFFLINE or <tenantName>_REALTIME) in "
+                        + "tier: %s", serverTag, tierName);
       } else {
         throw new IllegalStateException("Unsupported storageType: " + storageType + " in tier: " + tierName);
       }
@@ -723,7 +773,7 @@ public final class TableConfigUtils {
       for (String columnName : indexingConfig.getInvertedIndexColumns()) {
         if (noDictionaryColumnsSet.contains(columnName)) {
           throw new IllegalStateException("Cannot create an Inverted index on column " + columnName
-              + " specified in the noDictionaryColumns config");
+                  + " specified in the noDictionaryColumns config");
         }
         columnNameToConfigMap.put(columnName, "Inverted Index Config");
       }
@@ -750,7 +800,7 @@ public final class TableConfigUtils {
       }
     }
     if (indexingConfig.getSegmentPartitionConfig() != null
-        && indexingConfig.getSegmentPartitionConfig().getColumnPartitionMap() != null) {
+            && indexingConfig.getSegmentPartitionConfig().getColumnPartitionMap() != null) {
       for (String columnName : indexingConfig.getSegmentPartitionConfig().getColumnPartitionMap().keySet()) {
         columnNameToConfigMap.put(columnName, "Segment Partition Config");
       }
@@ -782,7 +832,7 @@ public final class TableConfigUtils {
             columnPair = AggregationFunctionColumnPair.fromColumnName(functionColumnPair);
           } catch (Exception e) {
             throw new IllegalStateException("Invalid StarTreeIndex config: " + functionColumnPair + ". Must be"
-                + "in the form <Aggregation function>__<Column name>");
+                    + "in the form <Aggregation function>__<Column name>");
           }
           String columnName = columnPair.getColumn();
           if (!columnName.equals(AggregationFunctionColumnPair.STAR)) {
@@ -803,10 +853,10 @@ public final class TableConfigUtils {
       String configName = entry.getValue();
       FieldSpec columnFieldSpec = schema.getFieldSpecFor(columnName);
       Preconditions.checkState(columnFieldSpec != null,
-          "Column Name " + columnName + " defined in " + configName + " must be a valid column defined in the schema");
+              "Column Name " + columnName + " defined in " + configName + " must be a valid column defined in the schema");
       if (configName.equals(STAR_TREE_CONFIG_NAME)) {
         Preconditions.checkState(columnFieldSpec.isSingleValueField(),
-            "Column Name " + columnName + " defined in " + configName + " must be a single value column");
+                "Column Name " + columnName + " defined in " + configName + " must be a single value column");
       }
     }
 
@@ -815,8 +865,8 @@ public final class TableConfigUtils {
     if (indexingConfig.getRangeIndexColumns() != null) {
       for (String rangeIndexCol : indexingConfig.getRangeIndexColumns()) {
         Preconditions.checkState(
-            schema.getFieldSpecFor(rangeIndexCol).getDataType().isNumeric() || !noDictionaryColumnsSet.contains(
-                rangeIndexCol), "Cannot create a range index on non-numeric/no-dictionary column " + rangeIndexCol);
+                schema.getFieldSpecFor(rangeIndexCol).getDataType().isNumeric() || !noDictionaryColumnsSet.contains(
+                        rangeIndexCol), "Cannot create a range index on non-numeric/no-dictionary column " + rangeIndexCol);
       }
     }
 
@@ -830,8 +880,8 @@ public final class TableConfigUtils {
             continue;
           default:
             throw new IllegalStateException(
-                "var length dictionary can only be created for columns of type STRING and BYTES. Invalid for column "
-                    + varLenDictCol);
+                    "var length dictionary can only be created for columns of type STRING and BYTES. Invalid for column "
+                            + varLenDictCol);
         }
       }
     }
@@ -839,8 +889,8 @@ public final class TableConfigUtils {
     for (String jsonIndexColumn : jsonIndexColumns) {
       FieldSpec fieldSpec = schema.getFieldSpecFor(jsonIndexColumn);
       Preconditions.checkState(
-          fieldSpec.isSingleValueField() && fieldSpec.getDataType().getStoredType() == DataType.STRING,
-          "Json index can only be created for single value String column. Invalid for column: %s", jsonIndexColumn);
+              fieldSpec.isSingleValueField() && fieldSpec.getDataType().getStoredType() == DataType.STRING,
+              "Json index can only be created for single value String column. Invalid for column: %s", jsonIndexColumn);
     }
   }
 
@@ -851,7 +901,7 @@ public final class TableConfigUtils {
    * Validates index compatibility for forward index disabled columns
    */
   private static void validateFieldConfigList(@Nullable List<FieldConfig> fieldConfigList,
-      @Nullable IndexingConfig indexingConfigs, @Nullable Schema schema) {
+                                              @Nullable IndexingConfig indexingConfigs, @Nullable Schema schema) {
     if (fieldConfigList == null || schema == null) {
       return;
     }
@@ -860,7 +910,7 @@ public final class TableConfigUtils {
       String columnName = fieldConfig.getName();
       FieldSpec fieldConfigColSpec = schema.getFieldSpecFor(columnName);
       Preconditions.checkState(fieldConfigColSpec != null,
-          "Column Name " + columnName + " defined in field config list must be a valid column defined in the schema");
+              "Column Name " + columnName + " defined in field config list must be a valid column defined in the schema");
 
       if (indexingConfigs != null) {
         List<String> noDictionaryColumns = indexingConfigs.getNoDictionaryColumns();
@@ -868,10 +918,10 @@ public final class TableConfigUtils {
           case DICTIONARY:
             if (noDictionaryColumns != null) {
               Preconditions.checkArgument(!noDictionaryColumns.contains(columnName),
-                  "FieldConfig encoding type is different from indexingConfig for column: " + columnName);
+                      "FieldConfig encoding type is different from indexingConfig for column: " + columnName);
             }
             Preconditions.checkArgument(fieldConfig.getCompressionCodec() == null,
-                "Set compression codec to null for dictionary encoding type");
+                    "Set compression codec to null for dictionary encoding type");
             break;
           default:
             break;
@@ -879,7 +929,7 @@ public final class TableConfigUtils {
 
         // Validate the forward index disabled compatibility with other indexes if enabled for this column
         validateForwardIndexDisabledIndexCompatibility(columnName, fieldConfig, indexingConfigs, noDictionaryColumns,
-            schema);
+                schema);
       }
 
       if (CollectionUtils.isNotEmpty(fieldConfig.getIndexTypes())) {
@@ -887,18 +937,18 @@ public final class TableConfigUtils {
           switch (indexType) {
             case FST:
               Preconditions.checkArgument(fieldConfig.getEncodingType() == FieldConfig.EncodingType.DICTIONARY,
-                  "FST Index is only enabled on dictionary encoded columns");
+                      "FST Index is only enabled on dictionary encoded columns");
               Preconditions.checkState(fieldConfigColSpec.isSingleValueField()
-                      && fieldConfigColSpec.getDataType().getStoredType() == DataType.STRING,
-                  "FST Index is only supported for single value string columns");
+                              && fieldConfigColSpec.getDataType().getStoredType() == DataType.STRING,
+                      "FST Index is only supported for single value string columns");
               break;
             case TEXT:
               Preconditions.checkState(fieldConfigColSpec.getDataType().getStoredType() == DataType.STRING,
-                  "TEXT Index is only supported for string columns");
+                      "TEXT Index is only supported for string columns");
               break;
             case TIMESTAMP:
               Preconditions.checkState(fieldConfigColSpec.getDataType() == DataType.TIMESTAMP,
-                  "TIMESTAMP Index is only supported for timestamp columns");
+                      "TIMESTAMP Index is only supported for timestamp columns");
               break;
             default:
               break;
@@ -917,7 +967,7 @@ public final class TableConfigUtils {
    *       multi-value column (since mulit-value defaults to index v1).
    */
   private static void validateForwardIndexDisabledIndexCompatibility(String columnName, FieldConfig fieldConfig,
-      IndexingConfig indexingConfigs, List<String> noDictionaryColumns, Schema schema) {
+                                                                     IndexingConfig indexingConfigs, List<String> noDictionaryColumns, Schema schema) {
     Map<String, String> fieldConfigProperties = fieldConfig.getProperties();
     if (fieldConfigProperties == null) {
       return;
@@ -930,19 +980,19 @@ public final class TableConfigUtils {
 
     FieldSpec fieldSpec = schema.getFieldSpecFor(columnName);
     Preconditions.checkState(fieldConfig.getEncodingType() == FieldConfig.EncodingType.DICTIONARY
-            || noDictionaryColumns == null || !noDictionaryColumns.contains(columnName),
-        String.format("Forward index disabled column %s must have dictionary enabled", columnName));
+                    || noDictionaryColumns == null || !noDictionaryColumns.contains(columnName),
+            String.format("Forward index disabled column %s must have dictionary enabled", columnName));
     Preconditions.checkState(indexingConfigs.getInvertedIndexColumns() != null
-            && indexingConfigs.getInvertedIndexColumns().contains(columnName),
-        String.format("Forward index disabled column %s must have inverted index enabled", columnName));
+                    && indexingConfigs.getInvertedIndexColumns().contains(columnName),
+            String.format("Forward index disabled column %s must have inverted index enabled", columnName));
     if (indexingConfigs.getRangeIndexColumns() != null && indexingConfigs.getRangeIndexColumns().contains(columnName)) {
       Preconditions.checkState(fieldSpec.isSingleValueField(), String.format("Feature not supported for multi-value "
-          + "columns with range index. Cannot disable forward index for column %s. Disable range index on this "
-          + "column to use this feature", columnName));
+              + "columns with range index. Cannot disable forward index for column %s. Disable range index on this "
+              + "column to use this feature", columnName));
       Preconditions.checkState(indexingConfigs.getRangeIndexVersion() == BitSlicedRangeIndexCreator.VERSION,
-          String.format("Feature not supported for single-value columns with range index version < 2. Cannot disable "
-              + "forward index for column %s. Either disable range index or create range index with"
-              + " version >= 2 to use this feature", columnName));
+              String.format("Feature not supported for single-value columns with range index version < 2. Cannot disable "
+                      + "forward index for column %s. Either disable range index or create range index with"
+                      + " version >= 2 to use this feature", columnName));
     }
   }
 
@@ -956,10 +1006,10 @@ public final class TableConfigUtils {
     indexingConfig.setSortedColumn(sanitizeListBasedIndexingColumns(indexingConfig.getSortedColumn()));
     indexingConfig.setBloomFilterColumns(sanitizeListBasedIndexingColumns(indexingConfig.getBloomFilterColumns()));
     indexingConfig.setOnHeapDictionaryColumns(
-        sanitizeListBasedIndexingColumns(indexingConfig.getOnHeapDictionaryColumns()));
+            sanitizeListBasedIndexingColumns(indexingConfig.getOnHeapDictionaryColumns()));
     indexingConfig.setRangeIndexColumns(sanitizeListBasedIndexingColumns(indexingConfig.getRangeIndexColumns()));
     indexingConfig.setVarLengthDictionaryColumns(
-        sanitizeListBasedIndexingColumns(indexingConfig.getVarLengthDictionaryColumns()));
+            sanitizeListBasedIndexingColumns(indexingConfig.getVarLengthDictionaryColumns()));
     return indexingConfig;
   }
 
@@ -998,7 +1048,7 @@ public final class TableConfigUtils {
         requestReplication = tableConfig.getReplication();
         if (requestReplication < defaultTableMinReplicas) {
           LOGGER.info("Creating table with minimum replication factor of: {} instead of requested replication: {}",
-              defaultTableMinReplicas, requestReplication);
+                  defaultTableMinReplicas, requestReplication);
           segmentsConfig.setReplication(String.valueOf(defaultTableMinReplicas));
         }
       } catch (NumberFormatException e) {
@@ -1012,8 +1062,8 @@ public final class TableConfigUtils {
         replicasPerPartition = tableConfig.getReplication();
         if (replicasPerPartition < defaultTableMinReplicas) {
           LOGGER.info(
-              "Creating table with minimum replicasPerPartition of: {} instead of requested replicasPerPartition: {}",
-              defaultTableMinReplicas, replicasPerPartition);
+                  "Creating table with minimum replicasPerPartition of: {} instead of requested replicasPerPartition: {}",
+                  defaultTableMinReplicas, replicasPerPartition);
           segmentsConfig.setReplicasPerPartition(String.valueOf(defaultTableMinReplicas));
         }
       } catch (NumberFormatException e) {
@@ -1036,18 +1086,18 @@ public final class TableConfigUtils {
         // set a default storage quota
         tableConfig.setQuotaConfig(new QuotaConfig(maxAllowedSize, null));
         LOGGER.info("Assigning default storage quota ({}) for dimension table: {}", maxAllowedSize,
-            tableConfig.getTableName());
+                tableConfig.getTableName());
       } else {
         if (quotaConfig.getStorage() == null) {
           // set a default storage quota and keep the RPS value
           tableConfig.setQuotaConfig(new QuotaConfig(maxAllowedSize, quotaConfig.getMaxQueriesPerSecond()));
           LOGGER.info("Assigning default storage quota ({}) for dimension table: {}", maxAllowedSize,
-              tableConfig.getTableName());
+                  tableConfig.getTableName());
         } else {
           if (quotaConfig.getStorageInBytes() > maxAllowedSizeInBytes) {
             throw new IllegalStateException(
-                String.format("Invalid storage quota: %d, max allowed size: %d", quotaConfig.getStorageInBytes(),
-                    maxAllowedSizeInBytes));
+                    String.format("Invalid storage quota: %d, max allowed size: %d", quotaConfig.getStorageInBytes(),
+                            maxAllowedSizeInBytes));
           }
         }
       }
@@ -1058,11 +1108,11 @@ public final class TableConfigUtils {
    * Consistency checks across the offline and realtime counterparts of a hybrid table
    */
   public static void verifyHybridTableConfigs(String rawTableName, TableConfig offlineTableConfig,
-      TableConfig realtimeTableConfig) {
+                                              TableConfig realtimeTableConfig) {
     Preconditions.checkNotNull(offlineTableConfig,
-        "Found null offline table config in hybrid table check for table: %s", rawTableName);
+            "Found null offline table config in hybrid table check for table: %s", rawTableName);
     Preconditions.checkNotNull(realtimeTableConfig,
-        "Found null realtime table config in hybrid table check for table: %s", rawTableName);
+            "Found null realtime table config in hybrid table check for table: %s", rawTableName);
     LOGGER.info("Validating realtime and offline configs for the hybrid table: {}", rawTableName);
     SegmentsValidationAndRetentionConfig offlineSegmentConfig = offlineTableConfig.getValidationConfig();
     SegmentsValidationAndRetentionConfig realtimeSegmentConfig = realtimeTableConfig.getValidationConfig();
@@ -1070,13 +1120,13 @@ public final class TableConfigUtils {
     String realtimeTimeColumnName = realtimeSegmentConfig.getTimeColumnName();
     if (offlineTimeColumnName == null || realtimeTimeColumnName == null) {
       throw new IllegalStateException(String.format(
-          "'timeColumnName' cannot be null for table: %s! Offline time column name: %s. Realtime time column name: %s",
-          rawTableName, offlineTimeColumnName, realtimeTimeColumnName));
+              "'timeColumnName' cannot be null for table: %s! Offline time column name: %s. Realtime time column name: %s",
+              rawTableName, offlineTimeColumnName, realtimeTimeColumnName));
     }
     if (!offlineTimeColumnName.equals(realtimeTimeColumnName)) {
       throw new IllegalStateException(String.format(
-          "Time column names are different for table: %s! Offline time column name: %s. Realtime time column name: %s",
-          rawTableName, offlineTimeColumnName, realtimeTimeColumnName));
+              "Time column names are different for table: %s! Offline time column name: %s. Realtime time column name: %s",
+              rawTableName, offlineTimeColumnName, realtimeTimeColumnName));
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *  http://www.apache.org/licenses/LICENSE-2.0
+ *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
@@ -54,41 +54,41 @@ public class MutableSegmentImplIngestionAggregationTest {
 
   private static final Schema.SchemaBuilder getSchemaBuilder() {
     return new Schema.SchemaBuilder().setSchemaName("testSchema")
-            .addSingleValueDimension(DIMENSION_1, FieldSpec.DataType.INT)
-            .addSingleValueDimension(DIMENSION_2, FieldSpec.DataType.STRING)
-            .addDateTime(TIME_COLUMN1, FieldSpec.DataType.INT, "1:DAYS:EPOCH", "1:DAYS")
-            .addDateTime(TIME_COLUMN2, FieldSpec.DataType.INT, "1:HOURS:EPOCH", "1:HOURS");
+        .addSingleValueDimension(DIMENSION_1, FieldSpec.DataType.INT)
+        .addSingleValueDimension(DIMENSION_2, FieldSpec.DataType.STRING)
+        .addDateTime(TIME_COLUMN1, FieldSpec.DataType.INT, "1:DAYS:EPOCH", "1:DAYS")
+        .addDateTime(TIME_COLUMN2, FieldSpec.DataType.INT, "1:HOURS:EPOCH", "1:HOURS");
   }
 
   private static final Set<String> VAR_LENGTH_SET = Collections.singleton(DIMENSION_2);
   private static final Set<String> INVERTED_INDEX_SET =
-          new HashSet<>(Arrays.asList(DIMENSION_1, DIMENSION_2, TIME_COLUMN1, TIME_COLUMN2));
+      new HashSet<>(Arrays.asList(DIMENSION_1, DIMENSION_2, TIME_COLUMN1, TIME_COLUMN2));
 
   private static final List<String> STRING_VALUES =
-          Collections.unmodifiableList(Arrays.asList("aa", "bbb", "cc", "ddd", "ee", "fff", "gg", "hhh", "ii", "jjj"));
+      Collections.unmodifiableList(Arrays.asList("aa", "bbb", "cc", "ddd", "ee", "fff", "gg", "hhh", "ii", "jjj"));
 
   @Test
   public void testSameSrcDifferentAggregations()
-          throws Exception {
+      throws Exception {
     String m1 = "metric_MAX";
     String m2 = "metric_MIN";
 
     Schema schema =
-            getSchemaBuilder().addMetric(m2, FieldSpec.DataType.DOUBLE).addMetric(m1, FieldSpec.DataType.DOUBLE).build();
+        getSchemaBuilder().addMetric(m2, FieldSpec.DataType.DOUBLE).addMetric(m1, FieldSpec.DataType.DOUBLE).build();
     MutableSegmentImpl mutableSegmentImpl =
-            MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m2, m1)),
-                    VAR_LENGTH_SET, INVERTED_INDEX_SET,
-                    Arrays.asList(new AggregationConfig(m1, "MAX(metric)"), new AggregationConfig(m2, "MIN(metric)")));
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m2, m1)),
+            VAR_LENGTH_SET, INVERTED_INDEX_SET,
+            Arrays.asList(new AggregationConfig(m1, "MAX(metric)"), new AggregationConfig(m2, "MIN(metric)")));
 
     Map<String, Double> expectedMin = new HashMap<>();
     Map<String, Double> expectedMax = new HashMap<>();
     for (List<Metric> metrics : addRows(1, mutableSegmentImpl)) {
       expectedMin.put(metrics.get(0).getKey(),
-              Math.min(expectedMin.getOrDefault(metrics.get(0).getKey(), Double.POSITIVE_INFINITY),
-                      (Integer) metrics.get(0).getValue()));
+          Math.min(expectedMin.getOrDefault(metrics.get(0).getKey(), Double.POSITIVE_INFINITY),
+              (Integer) metrics.get(0).getValue()));
       expectedMax.put(metrics.get(0).getKey(),
-              Math.max(expectedMax.getOrDefault(metrics.get(0).getKey(), Double.NEGATIVE_INFINITY),
-                      (Integer) metrics.get(0).getValue()));
+          Math.max(expectedMax.getOrDefault(metrics.get(0).getKey(), Double.NEGATIVE_INFINITY),
+              (Integer) metrics.get(0).getValue()));
     }
 
     GenericRow reuse = new GenericRow();
@@ -104,24 +104,24 @@ public class MutableSegmentImplIngestionAggregationTest {
 
   @Test
   public void testSameAggregationDifferentSrc()
-          throws Exception {
+      throws Exception {
     String m1 = "sum1";
     String m2 = "sum2";
 
     Schema schema =
-            getSchemaBuilder().addMetric(m1, FieldSpec.DataType.INT).addMetric(m2, FieldSpec.DataType.LONG).build();
+        getSchemaBuilder().addMetric(m1, FieldSpec.DataType.INT).addMetric(m2, FieldSpec.DataType.LONG).build();
     MutableSegmentImpl mutableSegmentImpl =
-            MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m2, m1)),
-                    VAR_LENGTH_SET, INVERTED_INDEX_SET,
-                    Arrays.asList(new AggregationConfig(m1, "SUM(metric)"), new AggregationConfig(m2, "SUM(metric_2)")));
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m2, m1)),
+            VAR_LENGTH_SET, INVERTED_INDEX_SET,
+            Arrays.asList(new AggregationConfig(m1, "SUM(metric)"), new AggregationConfig(m2, "SUM(metric_2)")));
 
     Map<String, Integer> expectedSum1 = new HashMap<>();
     Map<String, Long> expectedSum2 = new HashMap<>();
     for (List<Metric> metrics : addRows(2, mutableSegmentImpl)) {
       expectedSum1.put(metrics.get(0).getKey(),
-              expectedSum1.getOrDefault(metrics.get(0).getKey(), 0) + (Integer) (metrics.get(0).getValue()));
+          expectedSum1.getOrDefault(metrics.get(0).getKey(), 0) + (Integer) (metrics.get(0).getValue()));
       expectedSum2.put(metrics.get(1).getKey(),
-              expectedSum2.getOrDefault(metrics.get(1).getKey(), 0L) + ((Integer) metrics.get(1).getValue()).longValue());
+          expectedSum2.getOrDefault(metrics.get(1).getKey(), 0L) + ((Integer) metrics.get(1).getValue()).longValue());
     }
 
     GenericRow reuse = new GenericRow();
@@ -135,19 +135,15 @@ public class MutableSegmentImplIngestionAggregationTest {
     mutableSegmentImpl.destroy();
   }
 
-
   @Test
   public void testValuesAreNull()
-          throws Exception {
+      throws Exception {
     String m1 = "sum1";
 
-    Schema schema =
-            getSchemaBuilder().addMetric(m1, FieldSpec.DataType.INT).build();
+    Schema schema = getSchemaBuilder().addMetric(m1, FieldSpec.DataType.INT).build();
     MutableSegmentImpl mutableSegmentImpl =
-            MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m1)),
-                    VAR_LENGTH_SET, INVERTED_INDEX_SET,
-                    Arrays.asList(new AggregationConfig(m1, "SUM(metric)")));
-
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m1)), VAR_LENGTH_SET,
+            INVERTED_INDEX_SET, Arrays.asList(new AggregationConfig(m1, "SUM(metric)")));
 
     Set<String> keys = new HashSet<>();
 
@@ -182,16 +178,16 @@ public class MutableSegmentImplIngestionAggregationTest {
   }
 
   @Test
-  public void testDISTINCTCOUNTHLL() throws Exception {
+  public void testDISTINCTCOUNTHLL()
+      throws Exception {
     String m1 = "metric_DISTINCTCOUNTHLL";
     Schema schema = getSchemaBuilder().addMetric(m1, FieldSpec.DataType.BYTES).build();
     // Size of hll object for when log2m is 12
     schema.getFieldSpecFor(m1).setMaxLength(2740);
 
     MutableSegmentImpl mutableSegmentImpl =
-            MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m1)),
-                    VAR_LENGTH_SET, INVERTED_INDEX_SET,
-                    Arrays.asList(new AggregationConfig(m1, "DISTINCTCOUNTHLL(metric, 12)")));
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m1)), VAR_LENGTH_SET,
+            INVERTED_INDEX_SET, Arrays.asList(new AggregationConfig(m1, "DISTINCTCOUNTHLL(metric, 12)")));
 
     Map<String, HLLTestData> expected = new HashMap<>();
     List<Metric> metrics = addRowsDistinctCountHLL(998, mutableSegmentImpl);
@@ -199,27 +195,35 @@ public class MutableSegmentImplIngestionAggregationTest {
       expected.put(metric.getKey(), (HLLTestData) metric.getValue());
     }
 
-    List<ExpressionContext> arguments = List.of(ExpressionContext.forIdentifier("distinctcounthll"), ExpressionContext.forIdentifier("12"));
+    List<ExpressionContext> arguments =
+        List.of(ExpressionContext.forIdentifier("distinctcounthll"), ExpressionContext.forIdentifier("12"));
     DistinctCountHLLValueAggregator valueAggregator = new DistinctCountHLLValueAggregator(arguments);
 
     Set<Integer> integers = new HashSet<>();
 
     /*
-    Assert that the distinct count is within an error margin. We assert on the cardinality of the HLL in the docID and the
-    HLL we made, but also on the cardinality of the HLL in the docID and the actual cardinality from the set of integers.
+    Assert that the distinct count is within an error margin. We assert on the cardinality of the HLL in the docID
+    and the
+    HLL we made, but also on the cardinality of the HLL in the docID and the actual cardinality from the set of
+    integers.
      */
     GenericRow reuse = new GenericRow();
     for (int docId = 0; docId < expected.size(); docId++) {
       GenericRow row = mutableSegmentImpl.getRecord(docId, reuse);
       String key = buildKey(row);
 
-      integers.addAll(expected.get(key).integers);
+      integers.addAll(expected.get(key).getIntegers());
 
-      HyperLogLog expectedHLL = expected.get(key).hll;
+      HyperLogLog expectedHLL = expected.get(key).getHll();
       HyperLogLog actualHLL = valueAggregator.deserializeAggregatedValue((byte[]) row.getValue(m1));
 
-      Assert.assertEquals(actualHLL.cardinality(), expectedHLL.cardinality(), (int) (expectedHLL.cardinality() * 0.04), "The HLL cardinality from the index is within a tolerable error margin (4%) of the cardinality of the expected HLL.");
-      Assert.assertEquals(actualHLL.cardinality(), expected.get(key).integers.size(), (int) (expected.get(key).integers.size()) * 0.04, "The HLL cardinality from the index is within a tolerable error margin (4%) of the actual cardinality of the integers.");
+      Assert.assertEquals(actualHLL.cardinality(), expectedHLL.cardinality(), (int) (expectedHLL.cardinality() * 0.04),
+          "The HLL cardinality from the index is within a tolerable error margin (4%) of the cardinality of the "
+              + "expected HLL.");
+      Assert.assertEquals(actualHLL.cardinality(), expected.get(key).getIntegers().size(),
+          expected.get(key).getIntegers().size() * 0.04,
+          "The HLL cardinality from the index is within a tolerable error margin (4%) of the actual cardinality of "
+              + "the integers.");
     }
 
     /*
@@ -228,34 +232,35 @@ public class MutableSegmentImplIngestionAggregationTest {
     HyperLogLog togetherHLL = new HyperLogLog(12);
     expected.forEach((key, value) -> {
       try {
-        togetherHLL.addAll(value.hll);
+        togetherHLL.addAll(value.getHll());
       } catch (CardinalityMergeException e) {
         e.printStackTrace();
         throw new RuntimeException(e);
       }
     });
 
-    Assert.assertEquals(togetherHLL.cardinality(), integers.size(), (int) (integers.size() * 0.04), "The aggregated HLL cardinality is within a tolerable error margin (4%) of the actual cardinality of the integers.");
+    Assert.assertEquals(togetherHLL.cardinality(), integers.size(), (int) (integers.size() * 0.04),
+        "The aggregated HLL cardinality is within a tolerable error margin (4%) of the actual cardinality of the "
+            + "integers.");
     mutableSegmentImpl.destroy();
   }
 
   @Test
   public void testCOUNT()
-          throws Exception {
+      throws Exception {
     String m1 = "count1";
     String m2 = "count2";
 
     Schema schema =
-            getSchemaBuilder().addMetric(m1, FieldSpec.DataType.LONG).addMetric(m2, FieldSpec.DataType.LONG).build();
+        getSchemaBuilder().addMetric(m1, FieldSpec.DataType.LONG).addMetric(m2, FieldSpec.DataType.LONG).build();
     MutableSegmentImpl mutableSegmentImpl =
-            MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m1, m2)),
-                    VAR_LENGTH_SET, INVERTED_INDEX_SET,
-                    Arrays.asList(new AggregationConfig(m1, "COUNT(metric)"), new AggregationConfig(m2, "COUNT(*)")));
+        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m1, m2)),
+            VAR_LENGTH_SET, INVERTED_INDEX_SET,
+            Arrays.asList(new AggregationConfig(m1, "COUNT(metric)"), new AggregationConfig(m2, "COUNT(*)")));
 
     Map<String, Long> expectedCount = new HashMap<>();
     for (List<Metric> metrics : addRows(3, mutableSegmentImpl)) {
-      expectedCount.put(metrics.get(0).getKey(),
-              expectedCount.getOrDefault(metrics.get(0).getKey(), 0L) + 1L);
+      expectedCount.put(metrics.get(0).getKey(), expectedCount.getOrDefault(metrics.get(0).getKey(), 0L) + 1L);
     }
 
     GenericRow reuse = new GenericRow();
@@ -271,7 +276,7 @@ public class MutableSegmentImplIngestionAggregationTest {
 
   private String buildKey(GenericRow row) {
     return row.getValue(DIMENSION_1) + KEY_SEPARATOR + row.getValue(DIMENSION_2) + KEY_SEPARATOR + row.getValue(
-            TIME_COLUMN1) + KEY_SEPARATOR + row.getValue(TIME_COLUMN2);
+        TIME_COLUMN1) + KEY_SEPARATOR + row.getValue(TIME_COLUMN2);
   }
 
   private GenericRow getRow(Random random, Integer multiplicationFactor) {
@@ -286,20 +291,20 @@ public class MutableSegmentImplIngestionAggregationTest {
   }
 
   private class HLLTestData {
-    private HyperLogLog hll;
-    private Set<Integer> integers;
+    private HyperLogLog _hyperLogLog;
+    private Set<Integer> _integers;
 
-    public HLLTestData(HyperLogLog hll, Set<Integer> integers) {
-      this.hll = hll;
-      this.integers = integers;
+    public HLLTestData(HyperLogLog hyperLogLog, Set<Integer> integers) {
+      _hyperLogLog = hyperLogLog;
+      _integers = integers;
     }
 
     public HyperLogLog getHll() {
-      return hll;
+      return _hyperLogLog;
     }
 
     public Set<Integer> getIntegers() {
-      return integers;
+      return _integers;
     }
   }
 
@@ -322,7 +327,7 @@ public class MutableSegmentImplIngestionAggregationTest {
   }
 
   private List<Metric> addRowsDistinctCountHLL(long seed, MutableSegmentImpl mutableSegmentImpl)
-          throws Exception {
+      throws Exception {
     List<Metric> metrics = new ArrayList<>();
 
     Random random = new Random(seed);
@@ -353,7 +358,8 @@ public class MutableSegmentImplIngestionAggregationTest {
       mutableSegmentImpl.index(row, defaultMetadata);
     }
 
-    distinctMap.forEach((key, value) -> metrics.add(new Metric(key, new HLLTestData(hllMap.get(key), distinctMap.get(key)))));
+    distinctMap.forEach(
+        (key, value) -> metrics.add(new Metric(key, new HLLTestData(hllMap.get(key), distinctMap.get(key)))));
 
     int numDocsIndexed = mutableSegmentImpl.getNumDocsIndexed();
     Assert.assertEquals(numDocsIndexed, hllMap.keySet().size());
@@ -365,10 +371,9 @@ public class MutableSegmentImplIngestionAggregationTest {
   }
 
   private List<List<Metric>> addRows(long seed, MutableSegmentImpl mutableSegmentImpl)
-          throws Exception {
+      throws Exception {
     List<List<Metric>> metrics = new ArrayList<>();
     Set<String> keys = new HashSet<>();
-
 
     Random random = new Random(seed);
     StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(System.currentTimeMillis(), new GenericRow());

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
@@ -197,7 +197,7 @@ public class MutableSegmentImplIngestionAggregationTest {
 
     ArrayList<ExpressionContext> arguments = new ArrayList<ExpressionContext>();
     arguments.add(ExpressionContext.forIdentifier("distinctcounthll"));
-    arguments.add(ExpressionContext.forIdentifier("12"));
+    arguments.add(ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "12"));
 
     DistinctCountHLLValueAggregator valueAggregator = new DistinctCountHLLValueAggregator(arguments);
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
@@ -7,7 +7,7 @@
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
  *
- *   http://www.apache.org/licenses/LICENSE-2.0
+ *  http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
  * software distributed under the License is distributed on an
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.segment.local.indexsegment.mutable;
 
+import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -27,6 +29,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.segment.local.aggregator.DistinctCountHLLValueAggregator;
 import org.apache.pinot.spi.config.table.ingestion.AggregationConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
@@ -50,41 +54,41 @@ public class MutableSegmentImplIngestionAggregationTest {
 
   private static final Schema.SchemaBuilder getSchemaBuilder() {
     return new Schema.SchemaBuilder().setSchemaName("testSchema")
-        .addSingleValueDimension(DIMENSION_1, FieldSpec.DataType.INT)
-        .addSingleValueDimension(DIMENSION_2, FieldSpec.DataType.STRING)
-        .addDateTime(TIME_COLUMN1, FieldSpec.DataType.INT, "1:DAYS:EPOCH", "1:DAYS")
-        .addDateTime(TIME_COLUMN2, FieldSpec.DataType.INT, "1:HOURS:EPOCH", "1:HOURS");
+            .addSingleValueDimension(DIMENSION_1, FieldSpec.DataType.INT)
+            .addSingleValueDimension(DIMENSION_2, FieldSpec.DataType.STRING)
+            .addDateTime(TIME_COLUMN1, FieldSpec.DataType.INT, "1:DAYS:EPOCH", "1:DAYS")
+            .addDateTime(TIME_COLUMN2, FieldSpec.DataType.INT, "1:HOURS:EPOCH", "1:HOURS");
   }
 
   private static final Set<String> VAR_LENGTH_SET = Collections.singleton(DIMENSION_2);
   private static final Set<String> INVERTED_INDEX_SET =
-      new HashSet<>(Arrays.asList(DIMENSION_1, DIMENSION_2, TIME_COLUMN1, TIME_COLUMN2));
+          new HashSet<>(Arrays.asList(DIMENSION_1, DIMENSION_2, TIME_COLUMN1, TIME_COLUMN2));
 
   private static final List<String> STRING_VALUES =
-      Collections.unmodifiableList(Arrays.asList("aa", "bbb", "cc", "ddd", "ee", "fff", "gg", "hhh", "ii", "jjj"));
+          Collections.unmodifiableList(Arrays.asList("aa", "bbb", "cc", "ddd", "ee", "fff", "gg", "hhh", "ii", "jjj"));
 
   @Test
   public void testSameSrcDifferentAggregations()
-      throws Exception {
+          throws Exception {
     String m1 = "metric_MAX";
     String m2 = "metric_MIN";
 
     Schema schema =
-        getSchemaBuilder().addMetric(m2, FieldSpec.DataType.DOUBLE).addMetric(m1, FieldSpec.DataType.DOUBLE).build();
+            getSchemaBuilder().addMetric(m2, FieldSpec.DataType.DOUBLE).addMetric(m1, FieldSpec.DataType.DOUBLE).build();
     MutableSegmentImpl mutableSegmentImpl =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m2, m1)),
-            VAR_LENGTH_SET, INVERTED_INDEX_SET,
-            Arrays.asList(new AggregationConfig(m1, "MAX(metric)"), new AggregationConfig(m2, "MIN(metric)")));
+            MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m2, m1)),
+                    VAR_LENGTH_SET, INVERTED_INDEX_SET,
+                    Arrays.asList(new AggregationConfig(m1, "MAX(metric)"), new AggregationConfig(m2, "MIN(metric)")));
 
     Map<String, Double> expectedMin = new HashMap<>();
     Map<String, Double> expectedMax = new HashMap<>();
     for (List<Metric> metrics : addRows(1, mutableSegmentImpl)) {
       expectedMin.put(metrics.get(0).getKey(),
-          Math.min(expectedMin.getOrDefault(metrics.get(0).getKey(), Double.POSITIVE_INFINITY),
-              metrics.get(0).getValue()));
+              Math.min(expectedMin.getOrDefault(metrics.get(0).getKey(), Double.POSITIVE_INFINITY),
+                      (Integer) metrics.get(0).getValue()));
       expectedMax.put(metrics.get(0).getKey(),
-          Math.max(expectedMax.getOrDefault(metrics.get(0).getKey(), Double.NEGATIVE_INFINITY),
-              metrics.get(0).getValue()));
+              Math.max(expectedMax.getOrDefault(metrics.get(0).getKey(), Double.NEGATIVE_INFINITY),
+                      (Integer) metrics.get(0).getValue()));
     }
 
     GenericRow reuse = new GenericRow();
@@ -100,24 +104,24 @@ public class MutableSegmentImplIngestionAggregationTest {
 
   @Test
   public void testSameAggregationDifferentSrc()
-      throws Exception {
+          throws Exception {
     String m1 = "sum1";
     String m2 = "sum2";
 
     Schema schema =
-        getSchemaBuilder().addMetric(m1, FieldSpec.DataType.INT).addMetric(m2, FieldSpec.DataType.LONG).build();
+            getSchemaBuilder().addMetric(m1, FieldSpec.DataType.INT).addMetric(m2, FieldSpec.DataType.LONG).build();
     MutableSegmentImpl mutableSegmentImpl =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m2, m1)),
-            VAR_LENGTH_SET, INVERTED_INDEX_SET,
-            Arrays.asList(new AggregationConfig(m1, "SUM(metric)"), new AggregationConfig(m2, "SUM(metric_2)")));
+            MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m2, m1)),
+                    VAR_LENGTH_SET, INVERTED_INDEX_SET,
+                    Arrays.asList(new AggregationConfig(m1, "SUM(metric)"), new AggregationConfig(m2, "SUM(metric_2)")));
 
     Map<String, Integer> expectedSum1 = new HashMap<>();
     Map<String, Long> expectedSum2 = new HashMap<>();
     for (List<Metric> metrics : addRows(2, mutableSegmentImpl)) {
       expectedSum1.put(metrics.get(0).getKey(),
-          expectedSum1.getOrDefault(metrics.get(0).getKey(), 0) + metrics.get(0).getValue());
+              expectedSum1.getOrDefault(metrics.get(0).getKey(), 0) + (Integer) (metrics.get(0).getValue()));
       expectedSum2.put(metrics.get(1).getKey(),
-          expectedSum2.getOrDefault(metrics.get(1).getKey(), 0L) + metrics.get(1).getValue().longValue());
+              expectedSum2.getOrDefault(metrics.get(1).getKey(), 0L) + ((Integer) metrics.get(1).getValue()).longValue());
     }
 
     GenericRow reuse = new GenericRow();
@@ -131,23 +135,127 @@ public class MutableSegmentImplIngestionAggregationTest {
     mutableSegmentImpl.destroy();
   }
 
+
+  @Test
+  public void testValuesAreNull()
+          throws Exception {
+    String m1 = "sum1";
+
+    Schema schema =
+            getSchemaBuilder().addMetric(m1, FieldSpec.DataType.INT).build();
+    MutableSegmentImpl mutableSegmentImpl =
+            MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m1)),
+                    VAR_LENGTH_SET, INVERTED_INDEX_SET,
+                    Arrays.asList(new AggregationConfig(m1, "SUM(metric)")));
+
+
+    Set<String> keys = new HashSet<>();
+
+    long seed = 2;
+    Random random = new Random(seed);
+    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(System.currentTimeMillis(), null);
+
+    for (int i = 0; i < NUM_ROWS; i++) {
+      // Generate random int to prevent overflow
+      GenericRow row = getRow(random, 1);
+      row.putValue(METRIC, null);
+      mutableSegmentImpl.index(row, defaultMetadata);
+
+      String key = buildKey(row);
+      keys.add(key);
+    }
+
+    int numDocsIndexed = mutableSegmentImpl.getNumDocsIndexed();
+    Assert.assertEquals(numDocsIndexed, keys.size());
+
+    // Assert that aggregation happened.
+    Assert.assertTrue(numDocsIndexed < NUM_ROWS);
+
+    GenericRow reuse = new GenericRow();
+    for (int docId = 0; docId < keys.size(); docId++) {
+      GenericRow row = mutableSegmentImpl.getRecord(docId, reuse);
+      String key = buildKey(row);
+      Assert.assertEquals(row.getValue(m1), 0, key);
+    }
+
+    mutableSegmentImpl.destroy();
+  }
+
+  @Test
+  public void testDISTINCTCOUNTHLL() throws Exception {
+    String m1 = "metric_DISTINCTCOUNTHLL";
+    Schema schema = getSchemaBuilder().addMetric(m1, FieldSpec.DataType.BYTES).build();
+    // Size of hll object for when log2m is 12
+    schema.getFieldSpecFor(m1).setMaxLength(2740);
+
+    MutableSegmentImpl mutableSegmentImpl =
+            MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m1)),
+                    VAR_LENGTH_SET, INVERTED_INDEX_SET,
+                    Arrays.asList(new AggregationConfig(m1, "DISTINCTCOUNTHLL(metric, 12)")));
+
+    Map<String, HLLTestData> expected = new HashMap<>();
+    List<Metric> metrics = addRowsDistinctCountHLL(998, mutableSegmentImpl);
+    for (Metric metric : metrics) {
+      expected.put(metric.getKey(), (HLLTestData) metric.getValue());
+    }
+
+    List<ExpressionContext> arguments = List.of(ExpressionContext.forIdentifier("distinctcounthll"), ExpressionContext.forIdentifier("12"));
+    DistinctCountHLLValueAggregator valueAggregator = new DistinctCountHLLValueAggregator(arguments);
+
+    Set<Integer> integers = new HashSet<>();
+
+    /*
+    Assert that the distinct count is within an error margin. We assert on the cardinality of the HLL in the docID and the
+    HLL we made, but also on the cardinality of the HLL in the docID and the actual cardinality from the set of integers.
+     */
+    GenericRow reuse = new GenericRow();
+    for (int docId = 0; docId < expected.size(); docId++) {
+      GenericRow row = mutableSegmentImpl.getRecord(docId, reuse);
+      String key = buildKey(row);
+
+      integers.addAll(expected.get(key).integers);
+
+      HyperLogLog expectedHLL = expected.get(key).hll;
+      HyperLogLog actualHLL = valueAggregator.deserializeAggregatedValue((byte[]) row.getValue(m1));
+
+      Assert.assertEquals(actualHLL.cardinality(), expectedHLL.cardinality(), (int) (expectedHLL.cardinality() * 0.04), "The HLL cardinality from the index is within a tolerable error margin (4%) of the cardinality of the expected HLL.");
+      Assert.assertEquals(actualHLL.cardinality(), expected.get(key).integers.size(), (int) (expected.get(key).integers.size()) * 0.04, "The HLL cardinality from the index is within a tolerable error margin (4%) of the actual cardinality of the integers.");
+    }
+
+    /*
+    Assert that the aggregated HyperLogLog is also within the error margin
+     */
+    HyperLogLog togetherHLL = new HyperLogLog(12);
+    expected.forEach((key, value) -> {
+      try {
+        togetherHLL.addAll(value.hll);
+      } catch (CardinalityMergeException e) {
+        e.printStackTrace();
+        throw new RuntimeException(e);
+      }
+    });
+
+    Assert.assertEquals(togetherHLL.cardinality(), integers.size(), (int) (integers.size() * 0.04), "The aggregated HLL cardinality is within a tolerable error margin (4%) of the actual cardinality of the integers.");
+    mutableSegmentImpl.destroy();
+  }
+
   @Test
   public void testCOUNT()
-      throws Exception {
+          throws Exception {
     String m1 = "count1";
     String m2 = "count2";
 
     Schema schema =
-        getSchemaBuilder().addMetric(m1, FieldSpec.DataType.LONG).addMetric(m2, FieldSpec.DataType.LONG).build();
+            getSchemaBuilder().addMetric(m1, FieldSpec.DataType.LONG).addMetric(m2, FieldSpec.DataType.LONG).build();
     MutableSegmentImpl mutableSegmentImpl =
-        MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m1, m2)),
-            VAR_LENGTH_SET, INVERTED_INDEX_SET,
-            Arrays.asList(new AggregationConfig(m1, "COUNT(metric)"), new AggregationConfig(m2, "COUNT(*)")));
+            MutableSegmentImplTestUtils.createMutableSegmentImpl(schema, new HashSet<>(Arrays.asList(m1, m2)),
+                    VAR_LENGTH_SET, INVERTED_INDEX_SET,
+                    Arrays.asList(new AggregationConfig(m1, "COUNT(metric)"), new AggregationConfig(m2, "COUNT(*)")));
 
     Map<String, Long> expectedCount = new HashMap<>();
     for (List<Metric> metrics : addRows(3, mutableSegmentImpl)) {
       expectedCount.put(metrics.get(0).getKey(),
-          expectedCount.getOrDefault(metrics.get(0).getKey(), 0L) + 1L);
+              expectedCount.getOrDefault(metrics.get(0).getKey(), 0L) + 1L);
     }
 
     GenericRow reuse = new GenericRow();
@@ -163,25 +271,43 @@ public class MutableSegmentImplIngestionAggregationTest {
 
   private String buildKey(GenericRow row) {
     return row.getValue(DIMENSION_1) + KEY_SEPARATOR + row.getValue(DIMENSION_2) + KEY_SEPARATOR + row.getValue(
-        TIME_COLUMN1) + KEY_SEPARATOR + row.getValue(TIME_COLUMN2);
+            TIME_COLUMN1) + KEY_SEPARATOR + row.getValue(TIME_COLUMN2);
   }
 
-  private GenericRow getRow(Random random) {
+  private GenericRow getRow(Random random, Integer multiplicationFactor) {
     GenericRow row = new GenericRow();
 
-    row.putValue(DIMENSION_1, random.nextInt(10));
+    row.putValue(DIMENSION_1, random.nextInt(2 * multiplicationFactor));
     row.putValue(DIMENSION_2, STRING_VALUES.get(random.nextInt(STRING_VALUES.size())));
-    row.putValue(TIME_COLUMN1, random.nextInt(10));
-    row.putValue(TIME_COLUMN2, random.nextInt(5));
+    row.putValue(TIME_COLUMN1, random.nextInt(2 * multiplicationFactor));
+    row.putValue(TIME_COLUMN2, random.nextInt(2 * multiplicationFactor));
 
     return row;
   }
 
+  private class HLLTestData {
+    private HyperLogLog hll;
+    private Set<Integer> integers;
+
+    public HLLTestData(HyperLogLog hll, Set<Integer> integers) {
+      this.hll = hll;
+      this.integers = integers;
+    }
+
+    public HyperLogLog getHll() {
+      return hll;
+    }
+
+    public Set<Integer> getIntegers() {
+      return integers;
+    }
+  }
+
   private class Metric {
     private final String _key;
-    private final Integer _value;
+    private final Object _value;
 
-    Metric(String key, Integer value) {
+    Metric(String key, Object value) {
       _key = key;
       _value = value;
     }
@@ -190,13 +316,56 @@ public class MutableSegmentImplIngestionAggregationTest {
       return _key;
     }
 
-    public Integer getValue() {
+    public Object getValue() {
       return _value;
     }
   }
 
+  private List<Metric> addRowsDistinctCountHLL(long seed, MutableSegmentImpl mutableSegmentImpl)
+          throws Exception {
+    List<Metric> metrics = new ArrayList<>();
+
+    Random random = new Random(seed);
+    StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(System.currentTimeMillis(), null);
+
+    HashMap<String, HyperLogLog> hllMap = new HashMap<>();
+    HashMap<String, Set<Integer>> distinctMap = new HashMap<>();
+
+    Integer rows = 500000;
+
+    for (int i = 0; i < (rows); i++) {
+      GenericRow row = getRow(random, 1);
+      String key = buildKey(row);
+
+      int metricValue = random.nextInt(5000000);
+      row.putValue(METRIC, metricValue);
+
+      if (hllMap.containsKey(key)) {
+        hllMap.get(key).offer(row.getValue(METRIC));
+        distinctMap.get(key).add(metricValue);
+      } else {
+        HyperLogLog hll = new HyperLogLog(12);
+        hll.offer(row.getValue(METRIC));
+        hllMap.put(key, hll);
+        distinctMap.put(key, new HashSet<>(metricValue));
+      }
+
+      mutableSegmentImpl.index(row, defaultMetadata);
+    }
+
+    distinctMap.forEach((key, value) -> metrics.add(new Metric(key, new HLLTestData(hllMap.get(key), distinctMap.get(key)))));
+
+    int numDocsIndexed = mutableSegmentImpl.getNumDocsIndexed();
+    Assert.assertEquals(numDocsIndexed, hllMap.keySet().size());
+
+    // Assert that aggregation happened.
+    Assert.assertTrue(numDocsIndexed < NUM_ROWS);
+
+    return metrics;
+  }
+
   private List<List<Metric>> addRows(long seed, MutableSegmentImpl mutableSegmentImpl)
-      throws Exception {
+          throws Exception {
     List<List<Metric>> metrics = new ArrayList<>();
     Set<String> keys = new HashSet<>();
 
@@ -205,8 +374,8 @@ public class MutableSegmentImplIngestionAggregationTest {
     StreamMessageMetadata defaultMetadata = new StreamMessageMetadata(System.currentTimeMillis(), new GenericRow());
 
     for (int i = 0; i < NUM_ROWS; i++) {
-      GenericRow row = getRow(random);
-      // This needs to be relatively low since it will tend to overflow with the Int-to-Double conversion.
+      // Generate random int to prevent overflow
+      GenericRow row = getRow(random, 1);
       Integer metricValue = random.nextInt(10000);
       Integer metric2Value = random.nextInt();
       row.putValue(METRIC, metricValue);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplIngestionAggregationTest.java
@@ -195,8 +195,10 @@ public class MutableSegmentImplIngestionAggregationTest {
       expected.put(metric.getKey(), (HLLTestData) metric.getValue());
     }
 
-    List<ExpressionContext> arguments =
-        List.of(ExpressionContext.forIdentifier("distinctcounthll"), ExpressionContext.forIdentifier("12"));
+    ArrayList<ExpressionContext> arguments = new ArrayList<ExpressionContext>();
+    arguments.add(ExpressionContext.forIdentifier("distinctcounthll"));
+    arguments.add(ExpressionContext.forIdentifier("12"));
+
     DistinctCountHLLValueAggregator valueAggregator = new DistinctCountHLLValueAggregator(arguments);
 
     Set<Integer> integers = new HashSet<>();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/mutable/FixedByteSVMutableForwardIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/mutable/FixedByteSVMutableForwardIndexTest.java
@@ -42,13 +42,13 @@ public class FixedByteSVMutableForwardIndexTest {
 
   @AfterClass
   public void tearDown()
-          throws Exception {
+      throws Exception {
     _memoryManager.close();
   }
 
   @Test
   public void testDictId()
-          throws IOException {
+      throws IOException {
     Random r = new Random();
     final long seed = r.nextLong();
     r = new Random(seed);
@@ -64,7 +64,7 @@ public class FixedByteSVMutableForwardIndexTest {
   }
 
   private void testDictId(final Random random, final int rows, final int div)
-          throws IOException {
+      throws IOException {
     FixedByteSVMutableForwardIndex readerWriter;
     readerWriter = new FixedByteSVMutableForwardIndex(true, DataType.INT, rows / div, _memoryManager, "Int");
     int[] data = new int[rows];
@@ -115,7 +115,8 @@ public class FixedByteSVMutableForwardIndexTest {
   }
 
   @Test
-  public void testBytes() throws IOException {
+  public void testBytes()
+      throws IOException {
     int rows = 10;
     Random r = new Random();
     final long seed = r.nextLong();
@@ -125,19 +126,22 @@ public class FixedByteSVMutableForwardIndexTest {
     }
   }
 
-  private void testBytes(final Random random, final int rows, final int div) throws IOException {
-    int HLL_log2m_12_size = 2740;
+  private void testBytes(final Random random, final int rows, final int div)
+      throws IOException {
+    int hllLog2m12Size = 2740;
     int log2m = 12;
 
     FixedByteSVMutableForwardIndex readerWriter;
-    readerWriter = new FixedByteSVMutableForwardIndex(false, DataType.BYTES, HLL_log2m_12_size, rows / div, _memoryManager, "Long");
+    readerWriter =
+        new FixedByteSVMutableForwardIndex(false, DataType.BYTES, hllLog2m12Size, rows / div, _memoryManager,
+            "Long");
     byte[][] data = new byte[rows][];
 
     for (int i = 0; i < rows; i++) {
       HyperLogLog hll = new HyperLogLog(log2m);
       hll.offer(random.nextLong());
       data[i] = hll.getBytes();
-      Assert.assertEquals(data[i].length, HLL_log2m_12_size);
+      Assert.assertEquals(data[i].length, hllLog2m12Size);
       readerWriter.setBytes(i, data[i]);
       Assert.assertEquals(readerWriter.getBytes(i).length, data[i].length);
       Assert.assertEquals(readerWriter.getBytes(i), data[i]);
@@ -173,7 +177,7 @@ public class FixedByteSVMutableForwardIndexTest {
     }
 
     // Ensure that rows not written default to an empty byte array.
-    byte[] emptyBytes = new byte[HLL_log2m_12_size];
+    byte[] emptyBytes = new byte[hllLog2m12Size];
     start = rows * 2;
     for (int i = 0; i < 2 * rows; i++) {
       byte[] bytes = readerWriter.getBytes(start + i);
@@ -184,7 +188,7 @@ public class FixedByteSVMutableForwardIndexTest {
 
   @Test
   public void testLong()
-          throws IOException {
+      throws IOException {
     int rows = 10;
     Random r = new Random();
     final long seed = r.nextLong();
@@ -195,7 +199,7 @@ public class FixedByteSVMutableForwardIndexTest {
   }
 
   private void testLong(final Random random, final int rows, final int div)
-          throws IOException {
+      throws IOException {
     FixedByteSVMutableForwardIndex readerWriter;
     readerWriter = new FixedByteSVMutableForwardIndex(false, DataType.LONG, rows / div, _memoryManager, "Long");
     long[] data = new long[rows];

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -85,7 +85,7 @@ public class TableConfigUtilsTest {
 
     // null schema only
     tableConfig =
-            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, null);
       Assert.fail("Should fail for null schema in REALTIME table");
@@ -106,7 +106,7 @@ public class TableConfigUtilsTest {
     // timeColumnName not present in schema
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).build();
     tableConfig =
-            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for timeColumnName not present in schema for REALTIME table");
@@ -116,9 +116,9 @@ public class TableConfigUtilsTest {
 
     // timeColumnName not present as valid time spec schema
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-            .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.LONG).build();
+        .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.LONG).build();
     tableConfig =
-            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid fieldSpec for timeColumnName in schema for REALTIME table");
@@ -128,9 +128,9 @@ public class TableConfigUtilsTest {
 
     // valid
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-            .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
     tableConfig =
-            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // OFFLINE table
@@ -140,7 +140,7 @@ public class TableConfigUtilsTest {
 
     // null schema only - allowed in OFFLINE
     tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     TableConfigUtils.validate(tableConfig, null);
 
     // null timeColumnName only - allowed in OFFLINE
@@ -151,7 +151,7 @@ public class TableConfigUtilsTest {
     // non-null schema and timeColumnName, but timeColumnName not present in schema
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).build();
     tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for timeColumnName not present in schema for OFFLINE table");
@@ -161,9 +161,9 @@ public class TableConfigUtilsTest {
 
     // non-null schema nd timeColumnName, but timeColumnName not present as a time spec in schema
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-            .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.STRING).build();
+        .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.STRING).build();
     tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for timeColumnName not present in schema for OFFLINE table");
@@ -178,9 +178,9 @@ public class TableConfigUtilsTest {
 
     // valid
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-            .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
     tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     TableConfigUtils.validate(tableConfig, schema);
   }
 
@@ -188,9 +188,9 @@ public class TableConfigUtilsTest {
   public void validateDimensionTableConfig() {
     // dimension table with REALTIME type (should be OFFLINE)
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-            .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.STRING).build();
+        .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.STRING).build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setIsDimTable(true)
-            .setTimeColumnName(TIME_COLUMN).build();
+        .setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail with a Dimension table of type REALTIME");
@@ -200,7 +200,7 @@ public class TableConfigUtilsTest {
 
     // dimension table without a schema
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIsDimTable(true)
-            .setTimeColumnName(TIME_COLUMN).build();
+        .setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, null);
       Assert.fail("Should fail with a Dimension table without a schema");
@@ -210,9 +210,9 @@ public class TableConfigUtilsTest {
 
     // dimension table without a Primary Key
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-            .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.STRING).build();
+        .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.STRING).build();
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIsDimTable(true)
-            .setTimeColumnName(TIME_COLUMN).build();
+        .setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail with a Dimension without a primary key");
@@ -222,8 +222,8 @@ public class TableConfigUtilsTest {
 
     // valid dimension table
     schema =
-            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-                    .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+            .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIsDimTable(true).build();
     TableConfigUtils.validate(tableConfig, schema);
   }
@@ -233,7 +233,7 @@ public class TableConfigUtilsTest {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).build();
     // null ingestion config
     TableConfig tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(null).build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(null).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // null filter config, transform config
@@ -286,25 +286,25 @@ public class TableConfigUtilsTest {
 
     // using a transformation column in an aggregation
     schema =
-            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addMetric("twiceSum", FieldSpec.DataType.DOUBLE).build();
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addMetric("twiceSum", FieldSpec.DataType.DOUBLE).build();
     ingestionConfig.setTransformConfigs(Collections.singletonList(new TransformConfig("twice", "col * 2")));
     ingestionConfig.setAggregationConfigs(Collections.singletonList(new AggregationConfig("twiceSum", "SUM(twice)")));
     TableConfigUtils.validate(tableConfig, schema);
 
     // valid transform configs
     schema =
-            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-                    .build();
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+            .build();
     ingestionConfig.setAggregationConfigs(null);
     ingestionConfig.setTransformConfigs(Collections.singletonList(new TransformConfig("myCol", "reverse(anotherCol)")));
     TableConfigUtils.validate(tableConfig, schema);
 
     // valid transform configs
     schema =
-            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-                    .addMetric("transformedCol", FieldSpec.DataType.LONG).build();
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+            .addMetric("transformedCol", FieldSpec.DataType.LONG).build();
     ingestionConfig.setTransformConfigs(Arrays.asList(new TransformConfig("myCol", "reverse(anotherCol)"),
-            new TransformConfig("transformedCol", "Groovy({x+y}, x, y)")));
+        new TransformConfig("transformedCol", "Groovy({x+y}, x, y)")));
     TableConfigUtils.validate(tableConfig, schema);
 
     // invalid transform config since Groovy is disabled
@@ -373,7 +373,7 @@ public class TableConfigUtilsTest {
 
     // input field name used as destination field
     ingestionConfig.setTransformConfigs(
-            Collections.singletonList(new TransformConfig("myCol", "Groovy({x + y + myCol}, x, myCol, y)")));
+        Collections.singletonList(new TransformConfig("myCol", "Groovy({x + y + myCol}, x, myCol, y)")));
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail due to use of myCol as arguments and columnName");
@@ -383,7 +383,7 @@ public class TableConfigUtilsTest {
 
     // duplicate transform config
     ingestionConfig.setTransformConfigs(
-            Arrays.asList(new TransformConfig("myCol", "reverse(x)"), new TransformConfig("myCol", "lower(y)")));
+        Arrays.asList(new TransformConfig("myCol", "reverse(x)"), new TransformConfig("myCol", "lower(y)")));
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail due to duplicate transform config");
@@ -393,15 +393,15 @@ public class TableConfigUtilsTest {
 
     // derived columns - should pass
     ingestionConfig.setTransformConfigs(Arrays.asList(new TransformConfig("transformedCol", "reverse(x)"),
-            new TransformConfig("myCol", "lower(transformedCol)")));
+        new TransformConfig("myCol", "lower(transformedCol)")));
     TableConfigUtils.validate(tableConfig, schema);
 
     // invalid field name in schema with matching prefix from complexConfigType's prefixesToRename
     ingestionConfig.setTransformConfigs(null);
     ingestionConfig.setComplexTypeConfig(
-            new ComplexTypeConfig(null, ".", null, Collections.singletonMap("after.", "")));
+        new ComplexTypeConfig(null, ".", null, Collections.singletonMap("after.", "")));
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-            .addMultiValueDimension("after.test", FieldSpec.DataType.STRING).build();
+        .addMultiValueDimension("after.test", FieldSpec.DataType.STRING).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail due to name conflict from field name in schema with a prefix in prefixesToRename");
@@ -413,12 +413,12 @@ public class TableConfigUtilsTest {
   @Test
   public void ingestionAggregationConfigsTest() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-            .addDateTime("timeColumn", FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
+        .addDateTime("timeColumn", FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setAggregationConfigs(Collections.singletonList(new AggregationConfig("d1", "SUM(s1)")));
     TableConfig tableConfig =
-            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeColumn")
-                    .setIngestionConfig(ingestionConfig).build();
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeColumn")
+            .setIngestionConfig(ingestionConfig).build();
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, schema);
       Assert.fail("Should fail due to destination column not being in schema");
@@ -453,7 +453,7 @@ public class TableConfigUtilsTest {
     }
 
     ingestionConfig.setAggregationConfigs(
-            Arrays.asList(new AggregationConfig("m1", "SUM(s1)"), new AggregationConfig("m1", "SUM(s2)")));
+        Arrays.asList(new AggregationConfig("m1", "SUM(s1)"), new AggregationConfig("m1", "SUM(s2)")));
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, schema);
       Assert.fail("Should fail due to duplicate destination column");
@@ -498,8 +498,8 @@ public class TableConfigUtilsTest {
     List<AggregationConfig> aggregationConfigs = Arrays.asList(new AggregationConfig("d1", "DISTINCTCOUNTHLLMV(s1)"));
     ingestionConfig.setAggregationConfigs(aggregationConfigs);
     tableConfig =
-            new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
-                    .setIngestionConfig(ingestionConfig).build();
+        new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
+            .setIngestionConfig(ingestionConfig).build();
 
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, schema);
@@ -520,14 +520,14 @@ public class TableConfigUtilsTest {
       aggregationConfigs = Arrays.asList(new AggregationConfig("d1", "DISTINCTCOUNTHLL(s1, " + entry.getKey() + ")"));
       ingestionConfig.setAggregationConfigs(aggregationConfigs);
       tableConfig =
-              new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
-                      .setIngestionConfig(ingestionConfig).build();
+          new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
+              .setIngestionConfig(ingestionConfig).build();
 
       try {
         TableConfigUtils.validateIngestionConfig(tableConfig, schema);
       } catch (IllegalStateException e) {
         Assert.fail(
-                "The HLL object size based on the log2m doesn't match the destination BYTES field's maxLength property");
+            "The HLL object size based on the log2m doesn't match the destination BYTES field's maxLength property");
       }
     }
 
@@ -536,8 +536,8 @@ public class TableConfigUtilsTest {
     aggregationConfigs = Arrays.asList(new AggregationConfig("d1", "DISTINCTCOUNTHLL(s1)"));
     ingestionConfig.setAggregationConfigs(aggregationConfigs);
     tableConfig =
-            new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
-                    .setIngestionConfig(ingestionConfig).build();
+        new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
+            .setIngestionConfig(ingestionConfig).build();
 
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, schema);
@@ -548,8 +548,8 @@ public class TableConfigUtilsTest {
     aggregationConfigs = Arrays.asList(new AggregationConfig("d1", "s1 + s2"));
     ingestionConfig.setAggregationConfigs(aggregationConfigs);
     tableConfig =
-            new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
-                    .setIngestionConfig(ingestionConfig).build();
+        new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
+            .setIngestionConfig(ingestionConfig).build();
 
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, schema);
@@ -565,8 +565,8 @@ public class TableConfigUtilsTest {
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(Arrays.asList(streamConfigs, streamConfigs)));
     TableConfig tableConfig =
-            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeColumn")
-                    .setIngestionConfig(ingestionConfig).build();
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeColumn")
+            .setIngestionConfig(ingestionConfig).build();
 
     // only 1 stream config allowed
     try {
@@ -602,9 +602,9 @@ public class TableConfigUtilsTest {
     IngestionConfig ingestionConfig = new IngestionConfig();
     // TODO: Check if we should allow duplicate config maps
     ingestionConfig.setBatchIngestionConfig(
-            new BatchIngestionConfig(Arrays.asList(batchConfigMap, batchConfigMap), null, null));
+        new BatchIngestionConfig(Arrays.asList(batchConfigMap, batchConfigMap), null, null));
     TableConfig tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(ingestionConfig).build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(ingestionConfig).build();
     TableConfigUtils.validateIngestionConfig(tableConfig, null);
   }
 
@@ -621,9 +621,9 @@ public class TableConfigUtilsTest {
     // valid dimension table ingestion config
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setBatchIngestionConfig(
-            new BatchIngestionConfig(Collections.singletonList(batchConfigMap), "REFRESH", null));
+        new BatchIngestionConfig(Collections.singletonList(batchConfigMap), "REFRESH", null));
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIsDimTable(true)
-            .setIngestionConfig(ingestionConfig).build();
+        .setIngestionConfig(ingestionConfig).build();
     TableConfigUtils.validateIngestionConfig(tableConfig, null);
 
     // dimension tables should have batch ingestion config
@@ -637,7 +637,7 @@ public class TableConfigUtilsTest {
 
     // dimension tables should have batch ingestion config of type REFRESH
     ingestionConfig.setBatchIngestionConfig(
-            new BatchIngestionConfig(Collections.singletonList(batchConfigMap), "APPEND", null));
+        new BatchIngestionConfig(Collections.singletonList(batchConfigMap), "APPEND", null));
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, null);
       Assert.fail("Should fail for Dimension table with ingestion type APPEND (should be REFRESH)");
@@ -649,45 +649,45 @@ public class TableConfigUtilsTest {
   @Test
   public void validateTierConfigs() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-            .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
+        .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
     // null tier configs
     TableConfig tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(null).build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(null).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // empty tier configs
     tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(Collections.emptyList())
-                    .build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(Collections.emptyList())
+            .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // 1 tier configs
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-            Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-                    TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
+        Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // 2 tier configs, case insensitive check
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-            Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE.toLowerCase(), "30d", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
-                    new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE.toLowerCase(), "tier2_tag_OFFLINE", null, null))).build();
+        Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE.toLowerCase(), "30d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
+            new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE.toLowerCase(), "tier2_tag_OFFLINE", null, null))).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     //realtime table
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
-            .setTierConfigList(Lists.newArrayList(
-                    new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE.toLowerCase(), "tier1_tag_OFFLINE", null, null),
-                    new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE.toLowerCase(), "40d", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
+        .setTierConfigList(Lists.newArrayList(
+            new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE.toLowerCase(), "tier1_tag_OFFLINE", null, null),
+            new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE.toLowerCase(), "40d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // tier name empty
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-            Lists.newArrayList(new TierConfig("", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-                    TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
+        Lists.newArrayList(new TierConfig("", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should have failed due to empty tier name");
@@ -697,10 +697,10 @@ public class TableConfigUtilsTest {
 
     // tier name repeats
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-            Lists.newArrayList(new TierConfig("sameTierName", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
-                    new TierConfig("sameTierName", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "100d", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
+        Lists.newArrayList(new TierConfig("sameTierName", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
+            new TierConfig("sameTierName", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "100d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should have failed due to duplicate tier name");
@@ -710,10 +710,10 @@ public class TableConfigUtilsTest {
 
     // segmentSelectorType invalid
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-            Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
-                    new TierConfig("tier2", "unsupportedSegmentSelector", "40d", null, TierFactory.PINOT_SERVER_STORAGE_TYPE,
-                            "tier2_tag_OFFLINE", null, null))).build();
+        Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
+            new TierConfig("tier2", "unsupportedSegmentSelector", "40d", null, TierFactory.PINOT_SERVER_STORAGE_TYPE,
+                "tier2_tag_OFFLINE", null, null))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should have failed due to invalid segmentSelectorType");
@@ -723,10 +723,10 @@ public class TableConfigUtilsTest {
 
     // segmentAge not provided for TIME segmentSelectorType
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-            Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, null, null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
-                    new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
+        Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, null, null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
+            new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should have failed due to missing segmentAge");
@@ -736,10 +736,10 @@ public class TableConfigUtilsTest {
 
     // segmentAge invalid
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-            Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
-                    new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "3600", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
+        Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
+            new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "3600", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
 
     try {
       TableConfigUtils.validate(tableConfig, schema);
@@ -750,26 +750,26 @@ public class TableConfigUtilsTest {
 
     // fixedSegmentSelector
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-            Lists.newArrayList(new TierConfig("tier1", TierFactory.FIXED_SEGMENT_SELECTOR_TYPE, null, null,
-                    TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
+        Lists.newArrayList(new TierConfig("tier1", TierFactory.FIXED_SEGMENT_SELECTOR_TYPE, null, null,
+            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
     TableConfigUtils.validate(tableConfig, schema);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-            Lists.newArrayList(new TierConfig("tier1", TierFactory.FIXED_SEGMENT_SELECTOR_TYPE, "30d", Lists.newArrayList(),
-                    TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
+        Lists.newArrayList(new TierConfig("tier1", TierFactory.FIXED_SEGMENT_SELECTOR_TYPE, "30d", Lists.newArrayList(),
+            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
     TableConfigUtils.validate(tableConfig, schema);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-            Lists.newArrayList(
-                    new TierConfig("tier1", TierFactory.FIXED_SEGMENT_SELECTOR_TYPE, null, Lists.newArrayList("seg0", "seg1"),
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
+        Lists.newArrayList(
+            new TierConfig("tier1", TierFactory.FIXED_SEGMENT_SELECTOR_TYPE, null, Lists.newArrayList("seg0", "seg1"),
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // storageType invalid
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-            Lists.newArrayList(
-                    new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null, "unsupportedStorageType",
-                            "tier1_tag_OFFLINE", null, null),
-                    new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
+        Lists.newArrayList(
+            new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null, "unsupportedStorageType",
+                "tier1_tag_OFFLINE", null, null),
+            new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
 
     try {
       TableConfigUtils.validate(tableConfig, schema);
@@ -780,10 +780,10 @@ public class TableConfigUtilsTest {
 
     // serverTag not provided for PINOT_SERVER storageType
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-            Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
-                    new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, null, null, null))).build();
+        Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
+            new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, null, null, null))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should have failed due to ");
@@ -793,10 +793,10 @@ public class TableConfigUtilsTest {
 
     // serverTag invalid
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-            Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag", null, null),
-                    new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
-                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
+        Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag", null, null),
+            new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
+                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should have failed due to invalid server tag");
@@ -840,11 +840,11 @@ public class TableConfigUtilsTest {
   @Test
   public void testValidateFieldConfig() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-            .addSingleValueDimension("myCol1", FieldSpec.DataType.STRING)
-            .addMultiValueDimension("myCol2", FieldSpec.DataType.INT)
-            .addSingleValueDimension("intCol", FieldSpec.DataType.INT).build();
+        .addSingleValueDimension("myCol1", FieldSpec.DataType.STRING)
+        .addMultiValueDimension("myCol2", FieldSpec.DataType.INT)
+        .addSingleValueDimension("intCol", FieldSpec.DataType.INT).build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
+        .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
 
     try {
       FieldConfig fieldConfig = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
@@ -856,20 +856,20 @@ public class TableConfigUtilsTest {
 
     try {
       FieldConfig fieldConfig =
-              new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
+          new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for with conflicting encoding type of myCol1");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(),
-              "FieldConfig encoding type is different from indexingConfig for column: myCol1");
+          "FieldConfig encoding type is different from indexingConfig for column: myCol1");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
+        .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
     try {
       FieldConfig fieldConfig =
-              new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.FST, null, null);
+          new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.FST, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since FST index is enabled on RAW encoding type");
@@ -880,7 +880,7 @@ public class TableConfigUtilsTest {
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
       FieldConfig fieldConfig =
-              new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
+          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since FST index is enabled on multi value column");
@@ -891,7 +891,7 @@ public class TableConfigUtilsTest {
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
       FieldConfig fieldConfig =
-              new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
+          new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since FST index is enabled on non String column");
@@ -900,10 +900,10 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setNoDictionaryColumns(Arrays.asList("myCol2", "intCol")).build();
+        .setNoDictionaryColumns(Arrays.asList("myCol2", "intCol")).build();
     try {
       FieldConfig fieldConfig =
-              new FieldConfig("intCol", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.TEXT, null, null);
+          new FieldConfig("intCol", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.TEXT, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since TEXT index is enabled on non String column");
@@ -912,22 +912,22 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
+        .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
     try {
       FieldConfig fieldConfig =
-              new FieldConfig("myCol21", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.FST, null, null);
+          new FieldConfig("myCol21", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.FST, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since field name is not present in schema");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(),
-              "Column Name myCol21 defined in field config list must be a valid column defined in the schema");
+          "Column Name myCol21 defined in field config list must be a valid column defined in the schema");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
       FieldConfig fieldConfig = new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, Collections.emptyList(),
-              FieldConfig.CompressionCodec.SNAPPY, null);
+          FieldConfig.CompressionCodec.SNAPPY, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since dictionary encoding does not support compression codec snappy");
@@ -938,7 +938,7 @@ public class TableConfigUtilsTest {
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
       FieldConfig fieldConfig = new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, Collections.emptyList(),
-              FieldConfig.CompressionCodec.ZSTANDARD, null);
+          FieldConfig.CompressionCodec.ZSTANDARD, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since dictionary encoding does not support compression codec zstandard");
@@ -947,13 +947,13 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
+        .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
     try {
       // Enable forward index disabled flag for a raw column
       Map<String, String> fieldConfigProperties = new HashMap<>();
       fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null,
-              fieldConfigProperties);
+      FieldConfig fieldConfig =
+          new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, fieldConfigProperties);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for myCol1 without dictionary and with forward index disabled");
@@ -965,8 +965,8 @@ public class TableConfigUtilsTest {
       // Enable forward index disabled flag for a column without inverted index
       Map<String, String> fieldConfigProperties = new HashMap<>();
       fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig = new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, null, null, null, null,
-              fieldConfigProperties);
+      FieldConfig fieldConfig =
+          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, null, null, null, null, fieldConfigProperties);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for conflicting myCol2 with forward index disabled but no inverted index");
@@ -975,13 +975,14 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setNoDictionaryColumns(Arrays.asList("myCol1")).setInvertedIndexColumns(Arrays.asList("myCol2")).build();
+        .setNoDictionaryColumns(Arrays.asList("myCol1")).setInvertedIndexColumns(Arrays.asList("myCol2")).build();
     try {
       // Enable forward index disabled flag for a column with inverted index
       Map<String, String> fieldConfigProperties = new HashMap<>();
       fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig = new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY,
-              FieldConfig.IndexType.INVERTED, null, null, null, fieldConfigProperties);
+      FieldConfig fieldConfig =
+          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.INVERTED, null, null,
+              null, fieldConfigProperties);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -989,14 +990,15 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setNoDictionaryColumns(Arrays.asList("myCol1")).setInvertedIndexColumns(Arrays.asList("myCol2"))
-            .setSortedColumn("myCol2").build();
+        .setNoDictionaryColumns(Arrays.asList("myCol1")).setInvertedIndexColumns(Arrays.asList("myCol2"))
+        .setSortedColumn("myCol2").build();
     try {
       // Enable forward index disabled flag for a column with inverted index and is sorted
       Map<String, String> fieldConfigProperties = new HashMap<>();
       fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig = new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY,
-              FieldConfig.IndexType.INVERTED, null, null, null, fieldConfigProperties);
+      FieldConfig fieldConfig =
+          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.INVERTED, null, null,
+              null, fieldConfigProperties);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1004,52 +1006,54 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setNoDictionaryColumns(Arrays.asList("myCol1")).setInvertedIndexColumns(Arrays.asList("myCol2"))
-            .setRangeIndexColumns(Arrays.asList("myCol2")).build();
+        .setNoDictionaryColumns(Arrays.asList("myCol1")).setInvertedIndexColumns(Arrays.asList("myCol2"))
+        .setRangeIndexColumns(Arrays.asList("myCol2")).build();
     try {
       // Enable forward index disabled flag for a multi-value column with inverted index and range index
       Map<String, String> fieldConfigProperties = new HashMap<>();
       fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig = new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY,
-              FieldConfig.IndexType.INVERTED, Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE),
-              null, null, fieldConfigProperties);
+      FieldConfig fieldConfig =
+          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.INVERTED,
+              Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE), null, null,
+              fieldConfigProperties);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for MV myCol2 with forward index disabled but has range and inverted index");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(), "Feature not supported for multi-value columns with range index. "
-              + "Cannot disable forward index for column myCol2. Disable range index on this column to use this feature");
+          + "Cannot disable forward index for column myCol2. Disable range index on this column to use this feature");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setInvertedIndexColumns(Arrays.asList("myCol1")).setRangeIndexColumns(Arrays.asList("myCol1")).build();
+        .setInvertedIndexColumns(Arrays.asList("myCol1")).setRangeIndexColumns(Arrays.asList("myCol1")).build();
     try {
       // Enable forward index disabled flag for a singe-value column with inverted index and range index v1
       Map<String, String> fieldConfigProperties = new HashMap<>();
       fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
-      FieldConfig fieldConfig = new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY,
-              FieldConfig.IndexType.INVERTED, Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE),
-              null, null, fieldConfigProperties);
+      FieldConfig fieldConfig =
+          new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.INVERTED,
+              Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE), null, null,
+              fieldConfigProperties);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       tableConfig.getIndexingConfig().setRangeIndexVersion(1);
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for SV myCol1 with forward index disabled but has range v1 and inverted index");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(), "Feature not supported for single-value columns with range index version "
-              + "< 2. Cannot disable forward index for column myCol1. Either disable range index or create range index "
-              + "with version >= 2 to use this feature");
+          + "< 2. Cannot disable forward index for column myCol1. Either disable range index or create range index "
+          + "with version >= 2 to use this feature");
     }
   }
 
   @Test
   public void testValidateIndexingConfig() {
     Schema schema =
-            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-                    .addSingleValueDimension("bytesCol", FieldSpec.DataType.BYTES)
-                    .addSingleValueDimension("intCol", FieldSpec.DataType.INT)
-                    .addMultiValueDimension("multiValCol", FieldSpec.DataType.STRING).build();
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+            .addSingleValueDimension("bytesCol", FieldSpec.DataType.BYTES)
+            .addSingleValueDimension("intCol", FieldSpec.DataType.INT)
+            .addMultiValueDimension("multiValCol", FieldSpec.DataType.STRING).build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setBloomFilterColumns(Arrays.asList("myCol2")).build();
+        .setBloomFilterColumns(Arrays.asList("myCol2")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid Bloom filter column name");
@@ -1058,12 +1062,12 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setInvertedIndexColumns(Arrays.asList(""))
-                    .build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setInvertedIndexColumns(Arrays.asList(""))
+            .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setInvertedIndexColumns(Arrays.asList("myCol2")).build();
+        .setInvertedIndexColumns(Arrays.asList("myCol2")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid Inverted Index column name");
@@ -1072,12 +1076,12 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setNoDictionaryColumns(Arrays.asList(""))
-                    .build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setNoDictionaryColumns(Arrays.asList(""))
+            .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setNoDictionaryColumns(Arrays.asList("myCol2")).build();
+        .setNoDictionaryColumns(Arrays.asList("myCol2")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid No Dictionary column name");
@@ -1086,12 +1090,12 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setOnHeapDictionaryColumns(Arrays.asList(""))
-                    .build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setOnHeapDictionaryColumns(Arrays.asList(""))
+            .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setOnHeapDictionaryColumns(Arrays.asList("myCol2")).build();
+        .setOnHeapDictionaryColumns(Arrays.asList("myCol2")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid On Heap Dictionary column name");
@@ -1100,13 +1104,13 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(Arrays.asList(""))
-                    .build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(Arrays.asList(""))
+            .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(Arrays.asList("myCol2"))
-                    .build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(Arrays.asList("myCol2"))
+            .build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid Range Index column name");
@@ -1126,11 +1130,11 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setVarLengthDictionaryColumns(Arrays.asList("")).build();
+        .setVarLengthDictionaryColumns(Arrays.asList("")).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setVarLengthDictionaryColumns(Arrays.asList("myCol2")).build();
+        .setVarLengthDictionaryColumns(Arrays.asList("myCol2")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid Var Length Dictionary column name");
@@ -1143,8 +1147,8 @@ public class TableConfigUtilsTest {
     partitionConfigMap.put("myCol2", columnPartitionConfig);
     SegmentPartitionConfig partitionConfig = new SegmentPartitionConfig(partitionConfigMap);
     tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setSegmentPartitionConfig(partitionConfig)
-                    .build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setSegmentPartitionConfig(partitionConfig)
+            .build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid Segment Partition column name");
@@ -1154,9 +1158,9 @@ public class TableConfigUtilsTest {
 
     // Although this config makes no sense, it should pass the validation phase
     StarTreeIndexConfig starTreeIndexConfig =
-            new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol"), 1);
+        new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol"), 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1164,9 +1168,9 @@ public class TableConfigUtilsTest {
     }
 
     starTreeIndexConfig =
-            new StarTreeIndexConfig(Arrays.asList("myCol2"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol"), 1);
+        new StarTreeIndexConfig(Arrays.asList("myCol2"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol"), 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid StarTreeIndex config column name in dimension split order");
@@ -1175,9 +1179,9 @@ public class TableConfigUtilsTest {
     }
 
     starTreeIndexConfig =
-            new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol2"), Arrays.asList("SUM__myCol"), 1);
+        new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol2"), Arrays.asList("SUM__myCol"), 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid StarTreeIndex config column name in skip star node for dimension");
@@ -1186,9 +1190,9 @@ public class TableConfigUtilsTest {
     }
 
     starTreeIndexConfig =
-            new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol2"), 1);
+        new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol2"), 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid StarTreeIndex config column name in function column pair");
@@ -1197,9 +1201,9 @@ public class TableConfigUtilsTest {
     }
 
     starTreeIndexConfig = new StarTreeIndexConfig(Arrays.asList("multiValCol"), Arrays.asList("multiValCol"),
-            Arrays.asList("SUM__multiValCol"), 1);
+        Arrays.asList("SUM__multiValCol"), 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for multi-value column name in StarTreeIndex config");
@@ -1209,7 +1213,7 @@ public class TableConfigUtilsTest {
 
     FieldConfig fieldConfig = new FieldConfig("myCol2", null, Collections.emptyList(), null, null);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setFieldConfigList(Arrays.asList(fieldConfig)).build();
+        .setFieldConfigList(Arrays.asList(fieldConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid column name in Field Config List");
@@ -1219,7 +1223,7 @@ public class TableConfigUtilsTest {
 
     List<String> columnList = Arrays.asList("myCol");
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setNoDictionaryColumns(columnList)
-            .setInvertedIndexColumns(columnList).build();
+        .setInvertedIndexColumns(columnList).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for valid column name in both no dictionary and inverted index column config");
@@ -1228,7 +1232,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setJsonIndexColumns(Arrays.asList("non-existent-column")).build();
+        .setJsonIndexColumns(Arrays.asList("non-existent-column")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for non existent column in Json index config");
@@ -1237,8 +1241,8 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setJsonIndexColumns(Arrays.asList("intCol"))
-                    .build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setJsonIndexColumns(Arrays.asList("intCol"))
+            .build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for Json index defined on non string column");
@@ -1247,7 +1251,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setJsonIndexColumns(Arrays.asList("multiValCol")).build();
+        .setJsonIndexColumns(Arrays.asList("multiValCol")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for Json index defined on multi-value column");
@@ -1256,7 +1260,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(columnList).build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(columnList).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1264,7 +1268,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(columnList)
-            .setNoDictionaryColumns(columnList).build();
+        .setNoDictionaryColumns(columnList).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for range index defined on non numeric/no-dictionary column");
@@ -1273,7 +1277,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setVarLengthDictionaryColumns(Arrays.asList("intCol")).build();
+        .setVarLengthDictionaryColumns(Arrays.asList("intCol")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for Var length dictionary defined for non string/bytes column");
@@ -1282,7 +1286,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setJsonIndexColumns(Arrays.asList("multiValCol")).build();
+        .setJsonIndexColumns(Arrays.asList("multiValCol")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for Json Index defined on a multi value column");
@@ -1294,11 +1298,11 @@ public class TableConfigUtilsTest {
   @Test
   public void testValidateRetentionConfig() {
     Schema schema =
-            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-                    .build();
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+            .build();
     TableConfig tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRetentionTimeUnit("hours")
-                    .setRetentionTimeValue("24").build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRetentionTimeUnit("hours")
+            .setRetentionTimeValue("24").build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1306,7 +1310,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRetentionTimeUnit("abc").build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRetentionTimeUnit("abc").build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid retention time unit value");
@@ -1318,10 +1322,10 @@ public class TableConfigUtilsTest {
   @Test
   public void testValidateDedupConfig() {
     Schema schema =
-            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-                    .build();
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+            .build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).build();
+        .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1330,7 +1334,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-            .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).build();
+        .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1339,11 +1343,11 @@ public class TableConfigUtilsTest {
     }
 
     schema =
-            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-                    .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+            .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
     Map<String, String> streamConfigs = getStreamConfigs();
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-            .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).setStreamConfigs(streamConfigs).build();
+        .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1353,28 +1357,28 @@ public class TableConfigUtilsTest {
 
     streamConfigs.put("stream.kafka.consumer.type", "simple");
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-            .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).setStreamConfigs(streamConfigs).build();
+        .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
     } catch (IllegalStateException e) {
       Assert.assertEquals(e.getMessage(),
-              "Upsert/Dedup table must use strict replica-group (i.e. strictReplicaGroup) based routing");
+          "Upsert/Dedup table must use strict replica-group (i.e. strictReplicaGroup) based routing");
     }
     StarTreeIndexConfig starTreeIndexConfig = new StarTreeIndexConfig(Lists.newArrayList("myCol"), null,
-            Collections.singletonList(
-                    new AggregationFunctionColumnPair(AggregationFunctionType.COUNT, "myCol").toColumnName()), 10);
+        Collections.singletonList(
+            new AggregationFunctionColumnPair(AggregationFunctionType.COUNT, "myCol").toColumnName()), 10);
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-            .setDedupConfig(new DedupConfig(true, HashFunction.NONE))
-            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-            .setStarTreeIndexConfigs(Lists.newArrayList(starTreeIndexConfig)).setStreamConfigs(streamConfigs).build();
+        .setDedupConfig(new DedupConfig(true, HashFunction.NONE))
+        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+        .setStarTreeIndexConfigs(Lists.newArrayList(starTreeIndexConfig)).setStreamConfigs(streamConfigs).build();
     TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
 
     // Dedup and upsert can't be enabled simultaneously
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-            .setDedupConfig(new DedupConfig(true, HashFunction.NONE))
-            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-            .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL)).setStreamConfigs(streamConfigs).build();
+        .setDedupConfig(new DedupConfig(true, HashFunction.NONE))
+        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL)).setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1386,11 +1390,11 @@ public class TableConfigUtilsTest {
   @Test
   public void testValidateUpsertConfig() {
     Schema schema =
-            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-                    .build();
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+            .build();
     UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
     TableConfig tableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig).build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1399,7 +1403,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig).build();
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1408,19 +1412,19 @@ public class TableConfigUtilsTest {
     }
 
     schema =
-            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-                    .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+            .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
     } catch (IllegalStateException e) {
       Assert.assertEquals(e.getMessage(),
-              "Could not find streamConfigs for REALTIME table: " + TABLE_NAME + "_REALTIME");
+          "Could not find streamConfigs for REALTIME table: " + TABLE_NAME + "_REALTIME");
     }
 
     Map<String, String> streamConfigs = getStreamConfigs();
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig)
-            .setStreamConfigs(streamConfigs).build();
+        .setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1430,26 +1434,26 @@ public class TableConfigUtilsTest {
 
     streamConfigs.put("stream.kafka.consumer.type", "simple");
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig)
-            .setStreamConfigs(streamConfigs).build();
+        .setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
     } catch (IllegalStateException e) {
       Assert.assertEquals(e.getMessage(),
-              "Upsert/Dedup table must use strict replica-group (i.e. strictReplicaGroup) based routing");
+          "Upsert/Dedup table must use strict replica-group (i.e. strictReplicaGroup) based routing");
     }
 
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig)
-            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-            .setStreamConfigs(streamConfigs).build();
+        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+        .setStreamConfigs(streamConfigs).build();
     TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
 
     StarTreeIndexConfig starTreeIndexConfig = new StarTreeIndexConfig(Lists.newArrayList("myCol"), null,
-            Collections.singletonList(
-                    new AggregationFunctionColumnPair(AggregationFunctionType.COUNT, "myCol").toColumnName()), 10);
+        Collections.singletonList(
+            new AggregationFunctionColumnPair(AggregationFunctionType.COUNT, "myCol").toColumnName()), 10);
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig)
-            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-            .setStarTreeIndexConfigs(Lists.newArrayList(starTreeIndexConfig)).setStreamConfigs(streamConfigs).build();
+        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+        .setStarTreeIndexConfigs(Lists.newArrayList(starTreeIndexConfig)).setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1459,8 +1463,8 @@ public class TableConfigUtilsTest {
 
     //With Aggregate Metrics
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig)
-            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-            .setStreamConfigs(streamConfigs).setAggregateMetrics(true).build();
+        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+        .setStreamConfigs(streamConfigs).setAggregateMetrics(true).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1472,8 +1476,8 @@ public class TableConfigUtilsTest {
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setAggregationConfigs(Collections.singletonList(new AggregationConfig("twiceSum", "SUM(twice)")));
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig)
-            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-            .setStreamConfigs(streamConfigs).setIngestionConfig(ingestionConfig).build();
+        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+        .setStreamConfigs(streamConfigs).setIngestionConfig(ingestionConfig).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1483,24 +1487,24 @@ public class TableConfigUtilsTest {
 
     //With aggregation Configs in Ingestion Config and IndexingConfig at the same time
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig)
-            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-            .setStreamConfigs(streamConfigs).setAggregateMetrics(true).setIngestionConfig(ingestionConfig).build();
+        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+        .setStreamConfigs(streamConfigs).setAggregateMetrics(true).setIngestionConfig(ingestionConfig).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
     } catch (IllegalStateException e) {
       Assert.assertEquals(e.getMessage(),
-              "Metrics aggregation cannot be enabled in the Indexing Config and Ingestion Config at the same time");
+          "Metrics aggregation cannot be enabled in the Indexing Config and Ingestion Config at the same time");
     }
   }
 
   @Test
   public void testValidatePartialUpsertConfig() {
     Schema schema =
-            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol1", FieldSpec.DataType.LONG)
-                    .addSingleValueDimension("myCol2", FieldSpec.DataType.STRING)
-                    .addDateTime("myTimeCol", FieldSpec.DataType.LONG, "1:DAYS:EPOCH", "1:DAYS")
-                    .setPrimaryKeyColumns(Lists.newArrayList("myCol1")).build();
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol1", FieldSpec.DataType.LONG)
+            .addSingleValueDimension("myCol2", FieldSpec.DataType.STRING)
+            .addDateTime("myTimeCol", FieldSpec.DataType.LONG, "1:DAYS:EPOCH", "1:DAYS")
+            .setPrimaryKeyColumns(Lists.newArrayList("myCol1")).build();
 
     Map<String, String> streamConfigs = getStreamConfigs();
     streamConfigs.put("stream.kafka.consumer.type", "simple");
@@ -1511,10 +1515,10 @@ public class TableConfigUtilsTest {
     partialUpsertConfig.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.OVERWRITE);
     partialUpsertConfig.setComparisonColumn("myCol2");
     TableConfig tableConfig =
-            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(partialUpsertConfig)
-                    .setNullHandlingEnabled(true)
-                    .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-                    .setStreamConfigs(streamConfigs).build();
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(partialUpsertConfig)
+            .setNullHandlingEnabled(true)
+            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+            .setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema);
       Assert.fail();
@@ -1526,9 +1530,9 @@ public class TableConfigUtilsTest {
     partialUpsertConfig.setPartialUpsertStrategies(partialUpsertStratgies);
     partialUpsertConfig.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.OVERWRITE);
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("myCol2")
-            .setUpsertConfig(partialUpsertConfig).setNullHandlingEnabled(true)
-            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-            .setStreamConfigs(streamConfigs).build();
+        .setUpsertConfig(partialUpsertConfig).setNullHandlingEnabled(true)
+        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+        .setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema);
       Assert.fail();
@@ -1538,9 +1542,9 @@ public class TableConfigUtilsTest {
 
     partialUpsertStratgies.put("myCol1", UpsertConfig.Strategy.INCREMENT);
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeCol")
-            .setUpsertConfig(partialUpsertConfig).setNullHandlingEnabled(false)
-            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-            .setStreamConfigs(streamConfigs).build();
+        .setUpsertConfig(partialUpsertConfig).setNullHandlingEnabled(false)
+        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+        .setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema);
       Assert.fail();
@@ -1596,16 +1600,16 @@ public class TableConfigUtilsTest {
   @Test
   public void testTaskConfig() {
     Schema schema =
-            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-                    .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
-                    .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
+        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+            .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+            .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
     Map<String, String> realtimeToOfflineTaskConfig =
-            ImmutableMap.of("schedule", "0 */10 * ? * * *", "bucketTimePeriod", "6h", "bufferTimePeriod", "5d", "mergeType",
-                    "rollup", "myCol.aggregationType", "max");
+        ImmutableMap.of("schedule", "0 */10 * ? * * *", "bucketTimePeriod", "6h", "bufferTimePeriod", "5d", "mergeType",
+            "rollup", "myCol.aggregationType", "max");
     Map<String, String> segmentGenerationAndPushTaskConfig = ImmutableMap.of("schedule", "0 */10 * ? * * *");
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTaskConfig(
-            new TableTaskConfig(ImmutableMap.of("RealtimeToOfflineSegmentsTask", realtimeToOfflineTaskConfig,
-                    "SegmentGenerationAndPushTask", segmentGenerationAndPushTaskConfig))).build();
+        new TableTaskConfig(ImmutableMap.of("RealtimeToOfflineSegmentsTask", realtimeToOfflineTaskConfig,
+            "SegmentGenerationAndPushTask", segmentGenerationAndPushTaskConfig))).build();
 
     // validate valid config
     TableConfigUtils.validateTaskConfigs(tableConfig, schema);
@@ -1614,8 +1618,8 @@ public class TableConfigUtilsTest {
     HashMap<String, String> invalidScheduleConfig = new HashMap<>(segmentGenerationAndPushTaskConfig);
     invalidScheduleConfig.put("schedule", "garbage");
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTaskConfig(new TableTaskConfig(
-            ImmutableMap.of("RealtimeToOfflineSegmentsTask", realtimeToOfflineTaskConfig, "SegmentGenerationAndPushTask",
-                    invalidScheduleConfig))).build();
+        ImmutableMap.of("RealtimeToOfflineSegmentsTask", realtimeToOfflineTaskConfig, "SegmentGenerationAndPushTask",
+            invalidScheduleConfig))).build();
     try {
       TableConfigUtils.validateTaskConfigs(tableConfig, schema);
       Assert.fail();
@@ -1625,9 +1629,9 @@ public class TableConfigUtilsTest {
 
     // invalid Upsert config with RealtimeToOfflineTask
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
-            .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL)).setTaskConfig(new TableTaskConfig(
-                    ImmutableMap.of("RealtimeToOfflineSegmentsTask", realtimeToOfflineTaskConfig,
-                            "SegmentGenerationAndPushTask", segmentGenerationAndPushTaskConfig))).build();
+        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL)).setTaskConfig(new TableTaskConfig(
+            ImmutableMap.of("RealtimeToOfflineSegmentsTask", realtimeToOfflineTaskConfig,
+                "SegmentGenerationAndPushTask", segmentGenerationAndPushTaskConfig))).build();
     try {
       TableConfigUtils.validateTaskConfigs(tableConfig, schema);
       Assert.fail();
@@ -1641,8 +1645,8 @@ public class TableConfigUtilsTest {
     HashMap<String, String> invalidPeriodConfig = new HashMap<>(realtimeToOfflineTaskConfig);
     invalidPeriodConfig.put("roundBucketTimePeriod", "garbage");
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTaskConfig(new TableTaskConfig(
-            ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidPeriodConfig, "SegmentGenerationAndPushTask",
-                    segmentGenerationAndPushTaskConfig))).build();
+        ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidPeriodConfig, "SegmentGenerationAndPushTask",
+            segmentGenerationAndPushTaskConfig))).build();
     try {
       TableConfigUtils.validateTaskConfigs(tableConfig, schema);
       Assert.fail();
@@ -1654,8 +1658,8 @@ public class TableConfigUtilsTest {
     HashMap<String, String> invalidMergeType = new HashMap<>(realtimeToOfflineTaskConfig);
     invalidMergeType.put("mergeType", "garbage");
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTaskConfig(new TableTaskConfig(
-            ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidMergeType, "SegmentGenerationAndPushTask",
-                    segmentGenerationAndPushTaskConfig))).build();
+        ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidMergeType, "SegmentGenerationAndPushTask",
+            segmentGenerationAndPushTaskConfig))).build();
     try {
       TableConfigUtils.validateTaskConfigs(tableConfig, schema);
       Assert.fail();
@@ -1667,8 +1671,8 @@ public class TableConfigUtilsTest {
     HashMap<String, String> invalidColumnConfig = new HashMap<>(realtimeToOfflineTaskConfig);
     invalidColumnConfig.put("score.aggregationType", "max");
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTaskConfig(new TableTaskConfig(
-            ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidColumnConfig, "SegmentGenerationAndPushTask",
-                    segmentGenerationAndPushTaskConfig))).build();
+        ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidColumnConfig, "SegmentGenerationAndPushTask",
+            segmentGenerationAndPushTaskConfig))).build();
     try {
       TableConfigUtils.validateTaskConfigs(tableConfig, schema);
       Assert.fail();
@@ -1680,8 +1684,8 @@ public class TableConfigUtilsTest {
     HashMap<String, String> invalidAggConfig = new HashMap<>(realtimeToOfflineTaskConfig);
     invalidAggConfig.put("myCol.aggregationType", "garbage");
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTaskConfig(new TableTaskConfig(
-            ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidAggConfig, "SegmentGenerationAndPushTask",
-                    segmentGenerationAndPushTaskConfig))).build();
+        ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidAggConfig, "SegmentGenerationAndPushTask",
+            segmentGenerationAndPushTaskConfig))).build();
     try {
       TableConfigUtils.validateTaskConfigs(tableConfig, schema);
       Assert.fail();
@@ -1695,25 +1699,22 @@ public class TableConfigUtilsTest {
     InstanceAssignmentConfig instanceAssignmentConfig = Mockito.mock(InstanceAssignmentConfig.class);
 
     TableConfig tableConfigWithoutInstancePartitionsMap =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-                    .build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
 
     // Call validate with a table-config without any instance partitions or instance assignment config
     TableConfigUtils.validateInstancePartitionsTypeMapConfig(tableConfigWithoutInstancePartitionsMap);
 
     TableConfig tableConfigWithInstancePartitionsMap =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-                    .setInstancePartitionsMap(ImmutableMap.of(InstancePartitionsType.OFFLINE, "test_OFFLINE"))
-                    .build();
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+            .setInstancePartitionsMap(ImmutableMap.of(InstancePartitionsType.OFFLINE, "test_OFFLINE")).build();
 
     // Call validate with a table-config with instance partitions set but not instance assignment config
     TableConfigUtils.validateInstancePartitionsTypeMapConfig(tableConfigWithInstancePartitionsMap);
 
-    TableConfig invalidTableConfig =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-                    .setInstancePartitionsMap(ImmutableMap.of(InstancePartitionsType.OFFLINE, "test_OFFLINE"))
-                    .setInstanceAssignmentConfigMap(ImmutableMap.of(InstancePartitionsType.OFFLINE, instanceAssignmentConfig))
-                    .build();
+    TableConfig invalidTableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setInstancePartitionsMap(ImmutableMap.of(InstancePartitionsType.OFFLINE, "test_OFFLINE"))
+        .setInstanceAssignmentConfigMap(ImmutableMap.of(InstancePartitionsType.OFFLINE, instanceAssignmentConfig))
+        .build();
     try {
       // Call validate with instance partitions and config set for the same type
       TableConfigUtils.validateInstancePartitionsTypeMapConfig(invalidTableConfig);
@@ -1728,7 +1729,7 @@ public class TableConfigUtilsTest {
     streamConfigs.put("stream.kafka.consumer.type", "highLevel");
     streamConfigs.put("stream.kafka.topic.name", "test");
     streamConfigs.put("stream.kafka.decoder.class.name",
-            "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder");
+        "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder");
     return streamConfigs;
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -85,7 +85,7 @@ public class TableConfigUtilsTest {
 
     // null schema only
     tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, null);
       Assert.fail("Should fail for null schema in REALTIME table");
@@ -106,7 +106,7 @@ public class TableConfigUtilsTest {
     // timeColumnName not present in schema
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).build();
     tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for timeColumnName not present in schema for REALTIME table");
@@ -116,9 +116,9 @@ public class TableConfigUtilsTest {
 
     // timeColumnName not present as valid time spec schema
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-        .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.LONG).build();
+            .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.LONG).build();
     tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid fieldSpec for timeColumnName in schema for REALTIME table");
@@ -128,9 +128,9 @@ public class TableConfigUtilsTest {
 
     // valid
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-        .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
+            .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
     tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // OFFLINE table
@@ -140,7 +140,7 @@ public class TableConfigUtilsTest {
 
     // null schema only - allowed in OFFLINE
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     TableConfigUtils.validate(tableConfig, null);
 
     // null timeColumnName only - allowed in OFFLINE
@@ -151,7 +151,7 @@ public class TableConfigUtilsTest {
     // non-null schema and timeColumnName, but timeColumnName not present in schema
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).build();
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for timeColumnName not present in schema for OFFLINE table");
@@ -161,9 +161,9 @@ public class TableConfigUtilsTest {
 
     // non-null schema nd timeColumnName, but timeColumnName not present as a time spec in schema
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-        .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.STRING).build();
+            .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.STRING).build();
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for timeColumnName not present in schema for OFFLINE table");
@@ -178,9 +178,9 @@ public class TableConfigUtilsTest {
 
     // valid
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-        .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
+            .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).build();
     TableConfigUtils.validate(tableConfig, schema);
   }
 
@@ -188,9 +188,9 @@ public class TableConfigUtilsTest {
   public void validateDimensionTableConfig() {
     // dimension table with REALTIME type (should be OFFLINE)
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-        .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.STRING).build();
+            .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.STRING).build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setIsDimTable(true)
-        .setTimeColumnName(TIME_COLUMN).build();
+            .setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail with a Dimension table of type REALTIME");
@@ -200,7 +200,7 @@ public class TableConfigUtilsTest {
 
     // dimension table without a schema
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIsDimTable(true)
-        .setTimeColumnName(TIME_COLUMN).build();
+            .setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, null);
       Assert.fail("Should fail with a Dimension table without a schema");
@@ -210,9 +210,9 @@ public class TableConfigUtilsTest {
 
     // dimension table without a Primary Key
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-        .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.STRING).build();
+            .addSingleValueDimension(TIME_COLUMN, FieldSpec.DataType.STRING).build();
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIsDimTable(true)
-        .setTimeColumnName(TIME_COLUMN).build();
+            .setTimeColumnName(TIME_COLUMN).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail with a Dimension without a primary key");
@@ -222,8 +222,8 @@ public class TableConfigUtilsTest {
 
     // valid dimension table
     schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-            .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
+            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+                    .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIsDimTable(true).build();
     TableConfigUtils.validate(tableConfig, schema);
   }
@@ -233,7 +233,7 @@ public class TableConfigUtilsTest {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).build();
     // null ingestion config
     TableConfig tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(null).build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(null).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // null filter config, transform config
@@ -286,25 +286,25 @@ public class TableConfigUtilsTest {
 
     // using a transformation column in an aggregation
     schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addMetric("twiceSum", FieldSpec.DataType.DOUBLE).build();
+            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addMetric("twiceSum", FieldSpec.DataType.DOUBLE).build();
     ingestionConfig.setTransformConfigs(Collections.singletonList(new TransformConfig("twice", "col * 2")));
     ingestionConfig.setAggregationConfigs(Collections.singletonList(new AggregationConfig("twiceSum", "SUM(twice)")));
     TableConfigUtils.validate(tableConfig, schema);
 
     // valid transform configs
     schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-            .build();
+            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+                    .build();
     ingestionConfig.setAggregationConfigs(null);
     ingestionConfig.setTransformConfigs(Collections.singletonList(new TransformConfig("myCol", "reverse(anotherCol)")));
     TableConfigUtils.validate(tableConfig, schema);
 
     // valid transform configs
     schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-            .addMetric("transformedCol", FieldSpec.DataType.LONG).build();
+            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+                    .addMetric("transformedCol", FieldSpec.DataType.LONG).build();
     ingestionConfig.setTransformConfigs(Arrays.asList(new TransformConfig("myCol", "reverse(anotherCol)"),
-        new TransformConfig("transformedCol", "Groovy({x+y}, x, y)")));
+            new TransformConfig("transformedCol", "Groovy({x+y}, x, y)")));
     TableConfigUtils.validate(tableConfig, schema);
 
     // invalid transform config since Groovy is disabled
@@ -373,7 +373,7 @@ public class TableConfigUtilsTest {
 
     // input field name used as destination field
     ingestionConfig.setTransformConfigs(
-        Collections.singletonList(new TransformConfig("myCol", "Groovy({x + y + myCol}, x, myCol, y)")));
+            Collections.singletonList(new TransformConfig("myCol", "Groovy({x + y + myCol}, x, myCol, y)")));
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail due to use of myCol as arguments and columnName");
@@ -383,7 +383,7 @@ public class TableConfigUtilsTest {
 
     // duplicate transform config
     ingestionConfig.setTransformConfigs(
-        Arrays.asList(new TransformConfig("myCol", "reverse(x)"), new TransformConfig("myCol", "lower(y)")));
+            Arrays.asList(new TransformConfig("myCol", "reverse(x)"), new TransformConfig("myCol", "lower(y)")));
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail due to duplicate transform config");
@@ -393,15 +393,15 @@ public class TableConfigUtilsTest {
 
     // derived columns - should pass
     ingestionConfig.setTransformConfigs(Arrays.asList(new TransformConfig("transformedCol", "reverse(x)"),
-        new TransformConfig("myCol", "lower(transformedCol)")));
+            new TransformConfig("myCol", "lower(transformedCol)")));
     TableConfigUtils.validate(tableConfig, schema);
 
     // invalid field name in schema with matching prefix from complexConfigType's prefixesToRename
     ingestionConfig.setTransformConfigs(null);
     ingestionConfig.setComplexTypeConfig(
-        new ComplexTypeConfig(null, ".", null, Collections.singletonMap("after.", "")));
+            new ComplexTypeConfig(null, ".", null, Collections.singletonMap("after.", "")));
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-        .addMultiValueDimension("after.test", FieldSpec.DataType.STRING).build();
+            .addMultiValueDimension("after.test", FieldSpec.DataType.STRING).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail due to name conflict from field name in schema with a prefix in prefixesToRename");
@@ -413,12 +413,12 @@ public class TableConfigUtilsTest {
   @Test
   public void ingestionAggregationConfigsTest() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-        .addDateTime("timeColumn", FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
+            .addDateTime("timeColumn", FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setAggregationConfigs(Collections.singletonList(new AggregationConfig("d1", "SUM(s1)")));
     TableConfig tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeColumn")
-            .setIngestionConfig(ingestionConfig).build();
+            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeColumn")
+                    .setIngestionConfig(ingestionConfig).build();
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, schema);
       Assert.fail("Should fail due to destination column not being in schema");
@@ -453,7 +453,7 @@ public class TableConfigUtilsTest {
     }
 
     ingestionConfig.setAggregationConfigs(
-        Arrays.asList(new AggregationConfig("m1", "SUM(s1)"), new AggregationConfig("m1", "SUM(s2)")));
+            Arrays.asList(new AggregationConfig("m1", "SUM(s1)"), new AggregationConfig("m1", "SUM(s2)")));
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, schema);
       Assert.fail("Should fail due to duplicate destination column");
@@ -465,23 +465,6 @@ public class TableConfigUtilsTest {
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, schema);
       Assert.fail("Should fail due to invalid aggregation function");
-    } catch (IllegalStateException e) {
-      // expected
-    }
-
-    ingestionConfig.setAggregationConfigs(
-        Collections.singletonList(new AggregationConfig("m1", "DISTINCTCOUNTHLL(s1)")));
-    try {
-      TableConfigUtils.validateIngestionConfig(tableConfig, schema);
-      Assert.fail("Should fail due to not supported aggregation function");
-    } catch (IllegalStateException e) {
-      // expected
-    }
-
-    ingestionConfig.setAggregationConfigs(Collections.singletonList(new AggregationConfig("m1", "s1 + s2")));
-    try {
-      TableConfigUtils.validateIngestionConfig(tableConfig, schema);
-      Assert.fail("Should fail due to multiple arguments");
     } catch (IllegalStateException e) {
       // expected
     }
@@ -507,6 +490,73 @@ public class TableConfigUtilsTest {
     } catch (IllegalStateException e) {
       // expected
     }
+
+    schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addMetric("d1", FieldSpec.DataType.BYTES).build();
+    schema.getFieldSpecFor("d1").setMaxLength(180);
+
+    // distinctcounthllmv is not supported, we expect this to not validate
+    List<AggregationConfig> aggregationConfigs = Arrays.asList(new AggregationConfig("d1", "DISTINCTCOUNTHLLMV(s1)"));
+    ingestionConfig.setAggregationConfigs(aggregationConfigs);
+    tableConfig =
+            new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
+                    .setIngestionConfig(ingestionConfig).build();
+
+    try {
+      TableConfigUtils.validateIngestionConfig(tableConfig, schema);
+      Assert.fail("Should fail due to not supported aggregation function");
+    } catch (IllegalStateException e) {
+      // expected
+    }
+
+    // Test the distinctcounthll validation for various log2m sizes
+    HashMap<Integer, Integer> log2mToExpectedSize = new HashMap<>();
+    log2mToExpectedSize.put(8, 180);
+    log2mToExpectedSize.put(12, 2740);
+
+    for (Map.Entry<Integer, Integer> entry : log2mToExpectedSize.entrySet()) {
+      // set the max length to the HLL expected bytes size
+      schema.getFieldSpecFor("d1").setMaxLength(entry.getValue());
+
+      aggregationConfigs = Arrays.asList(new AggregationConfig("d1", "DISTINCTCOUNTHLL(s1, " + entry.getKey() + ")"));
+      ingestionConfig.setAggregationConfigs(aggregationConfigs);
+      tableConfig =
+              new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
+                      .setIngestionConfig(ingestionConfig).build();
+
+      try {
+        TableConfigUtils.validateIngestionConfig(tableConfig, schema);
+      } catch (IllegalStateException e) {
+        Assert.fail(
+                "The HLL object size based on the log2m doesn't match the destination BYTES field's maxLength property");
+      }
+    }
+
+    // distinctcounthll, expect not specified log2m argument to default to 8
+    schema.getFieldSpecFor("d1").setMaxLength(180);
+    aggregationConfigs = Arrays.asList(new AggregationConfig("d1", "DISTINCTCOUNTHLL(s1)"));
+    ingestionConfig.setAggregationConfigs(aggregationConfigs);
+    tableConfig =
+            new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
+                    .setIngestionConfig(ingestionConfig).build();
+
+    try {
+      TableConfigUtils.validateIngestionConfig(tableConfig, schema);
+    } catch (IllegalStateException e) {
+      Assert.fail("Log2m defaulted to 8 but BYTES schema maxLength is not the expected size of 180");
+    }
+
+    aggregationConfigs = Arrays.asList(new AggregationConfig("d1", "s1 + s2"));
+    ingestionConfig.setAggregationConfigs(aggregationConfigs);
+    tableConfig =
+            new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
+                    .setIngestionConfig(ingestionConfig).build();
+
+    try {
+      TableConfigUtils.validateIngestionConfig(tableConfig, schema);
+      Assert.fail("Should fail due to multiple arguments");
+    } catch (IllegalStateException e) {
+      // expected
+    }
   }
 
   @Test
@@ -515,8 +565,8 @@ public class TableConfigUtilsTest {
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(Arrays.asList(streamConfigs, streamConfigs)));
     TableConfig tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeColumn")
-            .setIngestionConfig(ingestionConfig).build();
+            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeColumn")
+                    .setIngestionConfig(ingestionConfig).build();
 
     // only 1 stream config allowed
     try {
@@ -552,9 +602,9 @@ public class TableConfigUtilsTest {
     IngestionConfig ingestionConfig = new IngestionConfig();
     // TODO: Check if we should allow duplicate config maps
     ingestionConfig.setBatchIngestionConfig(
-        new BatchIngestionConfig(Arrays.asList(batchConfigMap, batchConfigMap), null, null));
+            new BatchIngestionConfig(Arrays.asList(batchConfigMap, batchConfigMap), null, null));
     TableConfig tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(ingestionConfig).build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIngestionConfig(ingestionConfig).build();
     TableConfigUtils.validateIngestionConfig(tableConfig, null);
   }
 
@@ -571,9 +621,9 @@ public class TableConfigUtilsTest {
     // valid dimension table ingestion config
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setBatchIngestionConfig(
-        new BatchIngestionConfig(Collections.singletonList(batchConfigMap), "REFRESH", null));
+            new BatchIngestionConfig(Collections.singletonList(batchConfigMap), "REFRESH", null));
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setIsDimTable(true)
-        .setIngestionConfig(ingestionConfig).build();
+            .setIngestionConfig(ingestionConfig).build();
     TableConfigUtils.validateIngestionConfig(tableConfig, null);
 
     // dimension tables should have batch ingestion config
@@ -587,7 +637,7 @@ public class TableConfigUtilsTest {
 
     // dimension tables should have batch ingestion config of type REFRESH
     ingestionConfig.setBatchIngestionConfig(
-        new BatchIngestionConfig(Collections.singletonList(batchConfigMap), "APPEND", null));
+            new BatchIngestionConfig(Collections.singletonList(batchConfigMap), "APPEND", null));
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, null);
       Assert.fail("Should fail for Dimension table with ingestion type APPEND (should be REFRESH)");
@@ -599,45 +649,45 @@ public class TableConfigUtilsTest {
   @Test
   public void validateTierConfigs() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-        .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
+            .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS").build();
     // null tier configs
     TableConfig tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(null).build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(null).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // empty tier configs
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(Collections.emptyList())
-            .build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(Collections.emptyList())
+                    .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // 1 tier configs
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-        Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
+            Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                    TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // 2 tier configs, case insensitive check
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-        Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE.toLowerCase(), "30d", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
-            new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE.toLowerCase(), "tier2_tag_OFFLINE", null, null))).build();
+            Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE.toLowerCase(), "30d", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
+                    new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE.toLowerCase(), "tier2_tag_OFFLINE", null, null))).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     //realtime table
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
-        .setTierConfigList(Lists.newArrayList(
-            new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE.toLowerCase(), "tier1_tag_OFFLINE", null, null),
-            new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE.toLowerCase(), "40d", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
+            .setTierConfigList(Lists.newArrayList(
+                    new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE.toLowerCase(), "tier1_tag_OFFLINE", null, null),
+                    new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE.toLowerCase(), "40d", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // tier name empty
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-        Lists.newArrayList(new TierConfig("", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
+            Lists.newArrayList(new TierConfig("", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                    TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should have failed due to empty tier name");
@@ -647,10 +697,10 @@ public class TableConfigUtilsTest {
 
     // tier name repeats
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-        Lists.newArrayList(new TierConfig("sameTierName", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
-            new TierConfig("sameTierName", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "100d", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
+            Lists.newArrayList(new TierConfig("sameTierName", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
+                    new TierConfig("sameTierName", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "100d", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should have failed due to duplicate tier name");
@@ -660,10 +710,10 @@ public class TableConfigUtilsTest {
 
     // segmentSelectorType invalid
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-        Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
-            new TierConfig("tier2", "unsupportedSegmentSelector", "40d", null, TierFactory.PINOT_SERVER_STORAGE_TYPE,
-                "tier2_tag_OFFLINE", null, null))).build();
+            Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
+                    new TierConfig("tier2", "unsupportedSegmentSelector", "40d", null, TierFactory.PINOT_SERVER_STORAGE_TYPE,
+                            "tier2_tag_OFFLINE", null, null))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should have failed due to invalid segmentSelectorType");
@@ -673,10 +723,10 @@ public class TableConfigUtilsTest {
 
     // segmentAge not provided for TIME segmentSelectorType
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-        Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, null, null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
-            new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
+            Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, null, null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
+                    new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should have failed due to missing segmentAge");
@@ -686,10 +736,10 @@ public class TableConfigUtilsTest {
 
     // segmentAge invalid
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-        Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
-            new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "3600", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
+            Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
+                    new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "3600", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
 
     try {
       TableConfigUtils.validate(tableConfig, schema);
@@ -700,26 +750,26 @@ public class TableConfigUtilsTest {
 
     // fixedSegmentSelector
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-        Lists.newArrayList(new TierConfig("tier1", TierFactory.FIXED_SEGMENT_SELECTOR_TYPE, null, null,
-            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
+            Lists.newArrayList(new TierConfig("tier1", TierFactory.FIXED_SEGMENT_SELECTOR_TYPE, null, null,
+                    TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
     TableConfigUtils.validate(tableConfig, schema);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-        Lists.newArrayList(new TierConfig("tier1", TierFactory.FIXED_SEGMENT_SELECTOR_TYPE, "30d", Lists.newArrayList(),
-            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
+            Lists.newArrayList(new TierConfig("tier1", TierFactory.FIXED_SEGMENT_SELECTOR_TYPE, "30d", Lists.newArrayList(),
+                    TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
     TableConfigUtils.validate(tableConfig, schema);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-        Lists.newArrayList(
-            new TierConfig("tier1", TierFactory.FIXED_SEGMENT_SELECTOR_TYPE, null, Lists.newArrayList("seg0", "seg1"),
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
+            Lists.newArrayList(
+                    new TierConfig("tier1", TierFactory.FIXED_SEGMENT_SELECTOR_TYPE, null, Lists.newArrayList("seg0", "seg1"),
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null))).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     // storageType invalid
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-        Lists.newArrayList(
-            new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null, "unsupportedStorageType",
-                "tier1_tag_OFFLINE", null, null),
-            new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
+            Lists.newArrayList(
+                    new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null, "unsupportedStorageType",
+                            "tier1_tag_OFFLINE", null, null),
+                    new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
 
     try {
       TableConfigUtils.validate(tableConfig, schema);
@@ -730,10 +780,10 @@ public class TableConfigUtilsTest {
 
     // serverTag not provided for PINOT_SERVER storageType
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-        Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
-            new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, null, null, null))).build();
+            Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag_OFFLINE", null, null),
+                    new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, null, null, null))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should have failed due to ");
@@ -743,10 +793,10 @@ public class TableConfigUtilsTest {
 
     // serverTag invalid
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTierConfigList(
-        Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag", null, null),
-            new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
-                TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
+            Lists.newArrayList(new TierConfig("tier1", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "30d", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier1_tag", null, null),
+                    new TierConfig("tier2", TierFactory.TIME_SEGMENT_SELECTOR_TYPE, "40d", null,
+                            TierFactory.PINOT_SERVER_STORAGE_TYPE, "tier2_tag_OFFLINE", null, null))).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should have failed due to invalid server tag");
@@ -790,11 +840,11 @@ public class TableConfigUtilsTest {
   @Test
   public void testValidateFieldConfig() {
     Schema schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME)
-        .addSingleValueDimension("myCol1", FieldSpec.DataType.STRING)
-        .addMultiValueDimension("myCol2", FieldSpec.DataType.INT)
-        .addSingleValueDimension("intCol", FieldSpec.DataType.INT).build();
+            .addSingleValueDimension("myCol1", FieldSpec.DataType.STRING)
+            .addMultiValueDimension("myCol2", FieldSpec.DataType.INT)
+            .addSingleValueDimension("intCol", FieldSpec.DataType.INT).build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
+            .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
 
     try {
       FieldConfig fieldConfig = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null, null);
@@ -806,20 +856,20 @@ public class TableConfigUtilsTest {
 
     try {
       FieldConfig fieldConfig =
-          new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
+              new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for with conflicting encoding type of myCol1");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(),
-          "FieldConfig encoding type is different from indexingConfig for column: myCol1");
+              "FieldConfig encoding type is different from indexingConfig for column: myCol1");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
+            .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
     try {
       FieldConfig fieldConfig =
-          new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.FST, null, null);
+              new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.FST, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since FST index is enabled on RAW encoding type");
@@ -830,7 +880,7 @@ public class TableConfigUtilsTest {
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
       FieldConfig fieldConfig =
-          new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
+              new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since FST index is enabled on multi value column");
@@ -841,7 +891,7 @@ public class TableConfigUtilsTest {
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
       FieldConfig fieldConfig =
-          new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
+              new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, FieldConfig.IndexType.FST, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since FST index is enabled on non String column");
@@ -850,10 +900,10 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setNoDictionaryColumns(Arrays.asList("myCol2", "intCol")).build();
+            .setNoDictionaryColumns(Arrays.asList("myCol2", "intCol")).build();
     try {
       FieldConfig fieldConfig =
-          new FieldConfig("intCol", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.TEXT, null, null);
+              new FieldConfig("intCol", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.TEXT, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since TEXT index is enabled on non String column");
@@ -862,22 +912,22 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
+            .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
     try {
       FieldConfig fieldConfig =
-          new FieldConfig("myCol21", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.FST, null, null);
+              new FieldConfig("myCol21", FieldConfig.EncodingType.RAW, FieldConfig.IndexType.FST, null, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since field name is not present in schema");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(),
-          "Column Name myCol21 defined in field config list must be a valid column defined in the schema");
+              "Column Name myCol21 defined in field config list must be a valid column defined in the schema");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
       FieldConfig fieldConfig = new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, Collections.emptyList(),
-          FieldConfig.CompressionCodec.SNAPPY, null);
+              FieldConfig.CompressionCodec.SNAPPY, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since dictionary encoding does not support compression codec snappy");
@@ -888,7 +938,7 @@ public class TableConfigUtilsTest {
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
       FieldConfig fieldConfig = new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, Collections.emptyList(),
-          FieldConfig.CompressionCodec.ZSTANDARD, null);
+              FieldConfig.CompressionCodec.ZSTANDARD, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since dictionary encoding does not support compression codec zstandard");
@@ -897,13 +947,13 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
+            .setNoDictionaryColumns(Arrays.asList("myCol1")).build();
     try {
       // Enable forward index disabled flag for a raw column
       Map<String, String> fieldConfigProperties = new HashMap<>();
       fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
       FieldConfig fieldConfig = new FieldConfig("myCol1", FieldConfig.EncodingType.RAW, null, null, null, null,
-          fieldConfigProperties);
+              fieldConfigProperties);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for myCol1 without dictionary and with forward index disabled");
@@ -916,7 +966,7 @@ public class TableConfigUtilsTest {
       Map<String, String> fieldConfigProperties = new HashMap<>();
       fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
       FieldConfig fieldConfig = new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY, null, null, null, null,
-          fieldConfigProperties);
+              fieldConfigProperties);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for conflicting myCol2 with forward index disabled but no inverted index");
@@ -925,13 +975,13 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setNoDictionaryColumns(Arrays.asList("myCol1")).setInvertedIndexColumns(Arrays.asList("myCol2")).build();
+            .setNoDictionaryColumns(Arrays.asList("myCol1")).setInvertedIndexColumns(Arrays.asList("myCol2")).build();
     try {
       // Enable forward index disabled flag for a column with inverted index
       Map<String, String> fieldConfigProperties = new HashMap<>();
       fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
       FieldConfig fieldConfig = new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY,
-          FieldConfig.IndexType.INVERTED, null, null, null, fieldConfigProperties);
+              FieldConfig.IndexType.INVERTED, null, null, null, fieldConfigProperties);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -939,14 +989,14 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setNoDictionaryColumns(Arrays.asList("myCol1")).setInvertedIndexColumns(Arrays.asList("myCol2"))
-        .setSortedColumn("myCol2").build();
+            .setNoDictionaryColumns(Arrays.asList("myCol1")).setInvertedIndexColumns(Arrays.asList("myCol2"))
+            .setSortedColumn("myCol2").build();
     try {
       // Enable forward index disabled flag for a column with inverted index and is sorted
       Map<String, String> fieldConfigProperties = new HashMap<>();
       fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
       FieldConfig fieldConfig = new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY,
-          FieldConfig.IndexType.INVERTED, null, null, null, fieldConfigProperties);
+              FieldConfig.IndexType.INVERTED, null, null, null, fieldConfigProperties);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -954,52 +1004,52 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setNoDictionaryColumns(Arrays.asList("myCol1")).setInvertedIndexColumns(Arrays.asList("myCol2"))
-        .setRangeIndexColumns(Arrays.asList("myCol2")).build();
+            .setNoDictionaryColumns(Arrays.asList("myCol1")).setInvertedIndexColumns(Arrays.asList("myCol2"))
+            .setRangeIndexColumns(Arrays.asList("myCol2")).build();
     try {
       // Enable forward index disabled flag for a multi-value column with inverted index and range index
       Map<String, String> fieldConfigProperties = new HashMap<>();
       fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
       FieldConfig fieldConfig = new FieldConfig("myCol2", FieldConfig.EncodingType.DICTIONARY,
-          FieldConfig.IndexType.INVERTED, Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE),
-          null, null, fieldConfigProperties);
+              FieldConfig.IndexType.INVERTED, Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE),
+              null, null, fieldConfigProperties);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for MV myCol2 with forward index disabled but has range and inverted index");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(), "Feature not supported for multi-value columns with range index. "
-          + "Cannot disable forward index for column myCol2. Disable range index on this column to use this feature");
+              + "Cannot disable forward index for column myCol2. Disable range index on this column to use this feature");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setInvertedIndexColumns(Arrays.asList("myCol1")).setRangeIndexColumns(Arrays.asList("myCol1")).build();
+            .setInvertedIndexColumns(Arrays.asList("myCol1")).setRangeIndexColumns(Arrays.asList("myCol1")).build();
     try {
       // Enable forward index disabled flag for a singe-value column with inverted index and range index v1
       Map<String, String> fieldConfigProperties = new HashMap<>();
       fieldConfigProperties.put(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString());
       FieldConfig fieldConfig = new FieldConfig("myCol1", FieldConfig.EncodingType.DICTIONARY,
-          FieldConfig.IndexType.INVERTED, Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE),
-          null, null, fieldConfigProperties);
+              FieldConfig.IndexType.INVERTED, Arrays.asList(FieldConfig.IndexType.INVERTED, FieldConfig.IndexType.RANGE),
+              null, null, fieldConfigProperties);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       tableConfig.getIndexingConfig().setRangeIndexVersion(1);
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for SV myCol1 with forward index disabled but has range v1 and inverted index");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(), "Feature not supported for single-value columns with range index version "
-          + "< 2. Cannot disable forward index for column myCol1. Either disable range index or create range index "
-          + "with version >= 2 to use this feature");
+              + "< 2. Cannot disable forward index for column myCol1. Either disable range index or create range index "
+              + "with version >= 2 to use this feature");
     }
   }
 
   @Test
   public void testValidateIndexingConfig() {
     Schema schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-            .addSingleValueDimension("bytesCol", FieldSpec.DataType.BYTES)
-            .addSingleValueDimension("intCol", FieldSpec.DataType.INT)
-            .addMultiValueDimension("multiValCol", FieldSpec.DataType.STRING).build();
+            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+                    .addSingleValueDimension("bytesCol", FieldSpec.DataType.BYTES)
+                    .addSingleValueDimension("intCol", FieldSpec.DataType.INT)
+                    .addMultiValueDimension("multiValCol", FieldSpec.DataType.STRING).build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setBloomFilterColumns(Arrays.asList("myCol2")).build();
+            .setBloomFilterColumns(Arrays.asList("myCol2")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid Bloom filter column name");
@@ -1008,12 +1058,12 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setInvertedIndexColumns(Arrays.asList(""))
-            .build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setInvertedIndexColumns(Arrays.asList(""))
+                    .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setInvertedIndexColumns(Arrays.asList("myCol2")).build();
+            .setInvertedIndexColumns(Arrays.asList("myCol2")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid Inverted Index column name");
@@ -1022,12 +1072,12 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setNoDictionaryColumns(Arrays.asList(""))
-            .build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setNoDictionaryColumns(Arrays.asList(""))
+                    .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setNoDictionaryColumns(Arrays.asList("myCol2")).build();
+            .setNoDictionaryColumns(Arrays.asList("myCol2")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid No Dictionary column name");
@@ -1036,12 +1086,12 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setOnHeapDictionaryColumns(Arrays.asList(""))
-            .build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setOnHeapDictionaryColumns(Arrays.asList(""))
+                    .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setOnHeapDictionaryColumns(Arrays.asList("myCol2")).build();
+            .setOnHeapDictionaryColumns(Arrays.asList("myCol2")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid On Heap Dictionary column name");
@@ -1050,13 +1100,13 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(Arrays.asList(""))
-            .build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(Arrays.asList(""))
+                    .build();
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(Arrays.asList("myCol2"))
-            .build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(Arrays.asList("myCol2"))
+                    .build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid Range Index column name");
@@ -1076,11 +1126,11 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setVarLengthDictionaryColumns(Arrays.asList("")).build();
+            .setVarLengthDictionaryColumns(Arrays.asList("")).build();
     TableConfigUtils.validate(tableConfig, schema);
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setVarLengthDictionaryColumns(Arrays.asList("myCol2")).build();
+            .setVarLengthDictionaryColumns(Arrays.asList("myCol2")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid Var Length Dictionary column name");
@@ -1093,8 +1143,8 @@ public class TableConfigUtilsTest {
     partitionConfigMap.put("myCol2", columnPartitionConfig);
     SegmentPartitionConfig partitionConfig = new SegmentPartitionConfig(partitionConfigMap);
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setSegmentPartitionConfig(partitionConfig)
-            .build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setSegmentPartitionConfig(partitionConfig)
+                    .build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid Segment Partition column name");
@@ -1104,9 +1154,9 @@ public class TableConfigUtilsTest {
 
     // Although this config makes no sense, it should pass the validation phase
     StarTreeIndexConfig starTreeIndexConfig =
-        new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol"), 1);
+            new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol"), 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+            .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1114,9 +1164,9 @@ public class TableConfigUtilsTest {
     }
 
     starTreeIndexConfig =
-        new StarTreeIndexConfig(Arrays.asList("myCol2"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol"), 1);
+            new StarTreeIndexConfig(Arrays.asList("myCol2"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol"), 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+            .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid StarTreeIndex config column name in dimension split order");
@@ -1125,9 +1175,9 @@ public class TableConfigUtilsTest {
     }
 
     starTreeIndexConfig =
-        new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol2"), Arrays.asList("SUM__myCol"), 1);
+            new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol2"), Arrays.asList("SUM__myCol"), 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+            .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid StarTreeIndex config column name in skip star node for dimension");
@@ -1136,9 +1186,9 @@ public class TableConfigUtilsTest {
     }
 
     starTreeIndexConfig =
-        new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol2"), 1);
+            new StarTreeIndexConfig(Arrays.asList("myCol"), Arrays.asList("myCol"), Arrays.asList("SUM__myCol2"), 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+            .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid StarTreeIndex config column name in function column pair");
@@ -1147,9 +1197,9 @@ public class TableConfigUtilsTest {
     }
 
     starTreeIndexConfig = new StarTreeIndexConfig(Arrays.asList("multiValCol"), Arrays.asList("multiValCol"),
-        Arrays.asList("SUM__multiValCol"), 1);
+            Arrays.asList("SUM__multiValCol"), 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
+            .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for multi-value column name in StarTreeIndex config");
@@ -1159,7 +1209,7 @@ public class TableConfigUtilsTest {
 
     FieldConfig fieldConfig = new FieldConfig("myCol2", null, Collections.emptyList(), null, null);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setFieldConfigList(Arrays.asList(fieldConfig)).build();
+            .setFieldConfigList(Arrays.asList(fieldConfig)).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid column name in Field Config List");
@@ -1169,7 +1219,7 @@ public class TableConfigUtilsTest {
 
     List<String> columnList = Arrays.asList("myCol");
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setNoDictionaryColumns(columnList)
-        .setInvertedIndexColumns(columnList).build();
+            .setInvertedIndexColumns(columnList).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for valid column name in both no dictionary and inverted index column config");
@@ -1178,7 +1228,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setJsonIndexColumns(Arrays.asList("non-existent-column")).build();
+            .setJsonIndexColumns(Arrays.asList("non-existent-column")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for non existent column in Json index config");
@@ -1187,8 +1237,8 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setJsonIndexColumns(Arrays.asList("intCol"))
-            .build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setJsonIndexColumns(Arrays.asList("intCol"))
+                    .build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for Json index defined on non string column");
@@ -1197,7 +1247,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setJsonIndexColumns(Arrays.asList("multiValCol")).build();
+            .setJsonIndexColumns(Arrays.asList("multiValCol")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for Json index defined on multi-value column");
@@ -1206,7 +1256,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(columnList).build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(columnList).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1214,7 +1264,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRangeIndexColumns(columnList)
-        .setNoDictionaryColumns(columnList).build();
+            .setNoDictionaryColumns(columnList).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for range index defined on non numeric/no-dictionary column");
@@ -1223,7 +1273,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setVarLengthDictionaryColumns(Arrays.asList("intCol")).build();
+            .setVarLengthDictionaryColumns(Arrays.asList("intCol")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for Var length dictionary defined for non string/bytes column");
@@ -1232,7 +1282,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setJsonIndexColumns(Arrays.asList("multiValCol")).build();
+            .setJsonIndexColumns(Arrays.asList("multiValCol")).build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for Json Index defined on a multi value column");
@@ -1244,11 +1294,11 @@ public class TableConfigUtilsTest {
   @Test
   public void testValidateRetentionConfig() {
     Schema schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-            .build();
+            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+                    .build();
     TableConfig tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRetentionTimeUnit("hours")
-            .setRetentionTimeValue("24").build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRetentionTimeUnit("hours")
+                    .setRetentionTimeValue("24").build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
     } catch (Exception e) {
@@ -1256,7 +1306,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRetentionTimeUnit("abc").build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setRetentionTimeUnit("abc").build();
     try {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail for invalid retention time unit value");
@@ -1268,10 +1318,10 @@ public class TableConfigUtilsTest {
   @Test
   public void testValidateDedupConfig() {
     Schema schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-            .build();
+            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+                    .build();
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-        .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).build();
+            .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1280,7 +1330,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).build();
+            .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1289,11 +1339,11 @@ public class TableConfigUtilsTest {
     }
 
     schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-            .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
+            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+                    .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
     Map<String, String> streamConfigs = getStreamConfigs();
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).setStreamConfigs(streamConfigs).build();
+            .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1303,28 +1353,28 @@ public class TableConfigUtilsTest {
 
     streamConfigs.put("stream.kafka.consumer.type", "simple");
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).setStreamConfigs(streamConfigs).build();
+            .setDedupConfig(new DedupConfig(true, HashFunction.NONE)).setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
     } catch (IllegalStateException e) {
       Assert.assertEquals(e.getMessage(),
-          "Upsert/Dedup table must use strict replica-group (i.e. strictReplicaGroup) based routing");
+              "Upsert/Dedup table must use strict replica-group (i.e. strictReplicaGroup) based routing");
     }
     StarTreeIndexConfig starTreeIndexConfig = new StarTreeIndexConfig(Lists.newArrayList("myCol"), null,
-        Collections.singletonList(
-            new AggregationFunctionColumnPair(AggregationFunctionType.COUNT, "myCol").toColumnName()), 10);
+            Collections.singletonList(
+                    new AggregationFunctionColumnPair(AggregationFunctionType.COUNT, "myCol").toColumnName()), 10);
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setDedupConfig(new DedupConfig(true, HashFunction.NONE))
-        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-        .setStarTreeIndexConfigs(Lists.newArrayList(starTreeIndexConfig)).setStreamConfigs(streamConfigs).build();
+            .setDedupConfig(new DedupConfig(true, HashFunction.NONE))
+            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+            .setStarTreeIndexConfigs(Lists.newArrayList(starTreeIndexConfig)).setStreamConfigs(streamConfigs).build();
     TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
 
     // Dedup and upsert can't be enabled simultaneously
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setDedupConfig(new DedupConfig(true, HashFunction.NONE))
-        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL)).setStreamConfigs(streamConfigs).build();
+            .setDedupConfig(new DedupConfig(true, HashFunction.NONE))
+            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+            .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL)).setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1336,11 +1386,11 @@ public class TableConfigUtilsTest {
   @Test
   public void testValidateUpsertConfig() {
     Schema schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-            .build();
+            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+                    .build();
     UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
     TableConfig tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig).build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1349,7 +1399,7 @@ public class TableConfigUtilsTest {
     }
 
     tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig).build();
+            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1358,19 +1408,19 @@ public class TableConfigUtilsTest {
     }
 
     schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-            .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
+            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+                    .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
     } catch (IllegalStateException e) {
       Assert.assertEquals(e.getMessage(),
-          "Could not find streamConfigs for REALTIME table: " + TABLE_NAME + "_REALTIME");
+              "Could not find streamConfigs for REALTIME table: " + TABLE_NAME + "_REALTIME");
     }
 
     Map<String, String> streamConfigs = getStreamConfigs();
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig)
-        .setStreamConfigs(streamConfigs).build();
+            .setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1380,26 +1430,26 @@ public class TableConfigUtilsTest {
 
     streamConfigs.put("stream.kafka.consumer.type", "simple");
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig)
-        .setStreamConfigs(streamConfigs).build();
+            .setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
     } catch (IllegalStateException e) {
       Assert.assertEquals(e.getMessage(),
-          "Upsert/Dedup table must use strict replica-group (i.e. strictReplicaGroup) based routing");
+              "Upsert/Dedup table must use strict replica-group (i.e. strictReplicaGroup) based routing");
     }
 
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig)
-        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-        .setStreamConfigs(streamConfigs).build();
+            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+            .setStreamConfigs(streamConfigs).build();
     TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
 
     StarTreeIndexConfig starTreeIndexConfig = new StarTreeIndexConfig(Lists.newArrayList("myCol"), null,
-        Collections.singletonList(
-            new AggregationFunctionColumnPair(AggregationFunctionType.COUNT, "myCol").toColumnName()), 10);
+            Collections.singletonList(
+                    new AggregationFunctionColumnPair(AggregationFunctionType.COUNT, "myCol").toColumnName()), 10);
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig)
-        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-        .setStarTreeIndexConfigs(Lists.newArrayList(starTreeIndexConfig)).setStreamConfigs(streamConfigs).build();
+            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+            .setStarTreeIndexConfigs(Lists.newArrayList(starTreeIndexConfig)).setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1409,8 +1459,8 @@ public class TableConfigUtilsTest {
 
     //With Aggregate Metrics
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig)
-        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-        .setStreamConfigs(streamConfigs).setAggregateMetrics(true).build();
+            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+            .setStreamConfigs(streamConfigs).setAggregateMetrics(true).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1422,8 +1472,8 @@ public class TableConfigUtilsTest {
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setAggregationConfigs(Collections.singletonList(new AggregationConfig("twiceSum", "SUM(twice)")));
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig)
-        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-        .setStreamConfigs(streamConfigs).setIngestionConfig(ingestionConfig).build();
+            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+            .setStreamConfigs(streamConfigs).setIngestionConfig(ingestionConfig).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
@@ -1433,24 +1483,24 @@ public class TableConfigUtilsTest {
 
     //With aggregation Configs in Ingestion Config and IndexingConfig at the same time
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(upsertConfig)
-        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-        .setStreamConfigs(streamConfigs).setAggregateMetrics(true).setIngestionConfig(ingestionConfig).build();
+            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+            .setStreamConfigs(streamConfigs).setAggregateMetrics(true).setIngestionConfig(ingestionConfig).build();
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail();
     } catch (IllegalStateException e) {
       Assert.assertEquals(e.getMessage(),
-          "Metrics aggregation cannot be enabled in the Indexing Config and Ingestion Config at the same time");
+              "Metrics aggregation cannot be enabled in the Indexing Config and Ingestion Config at the same time");
     }
   }
 
   @Test
   public void testValidatePartialUpsertConfig() {
     Schema schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol1", FieldSpec.DataType.LONG)
-            .addSingleValueDimension("myCol2", FieldSpec.DataType.STRING)
-            .addDateTime("myTimeCol", FieldSpec.DataType.LONG, "1:DAYS:EPOCH", "1:DAYS")
-            .setPrimaryKeyColumns(Lists.newArrayList("myCol1")).build();
+            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol1", FieldSpec.DataType.LONG)
+                    .addSingleValueDimension("myCol2", FieldSpec.DataType.STRING)
+                    .addDateTime("myTimeCol", FieldSpec.DataType.LONG, "1:DAYS:EPOCH", "1:DAYS")
+                    .setPrimaryKeyColumns(Lists.newArrayList("myCol1")).build();
 
     Map<String, String> streamConfigs = getStreamConfigs();
     streamConfigs.put("stream.kafka.consumer.type", "simple");
@@ -1461,10 +1511,10 @@ public class TableConfigUtilsTest {
     partialUpsertConfig.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.OVERWRITE);
     partialUpsertConfig.setComparisonColumn("myCol2");
     TableConfig tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(partialUpsertConfig)
-            .setNullHandlingEnabled(true)
-            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-            .setStreamConfigs(streamConfigs).build();
+            new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(partialUpsertConfig)
+                    .setNullHandlingEnabled(true)
+                    .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+                    .setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema);
       Assert.fail();
@@ -1476,9 +1526,9 @@ public class TableConfigUtilsTest {
     partialUpsertConfig.setPartialUpsertStrategies(partialUpsertStratgies);
     partialUpsertConfig.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.OVERWRITE);
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("myCol2")
-        .setUpsertConfig(partialUpsertConfig).setNullHandlingEnabled(true)
-        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-        .setStreamConfigs(streamConfigs).build();
+            .setUpsertConfig(partialUpsertConfig).setNullHandlingEnabled(true)
+            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+            .setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema);
       Assert.fail();
@@ -1488,9 +1538,9 @@ public class TableConfigUtilsTest {
 
     partialUpsertStratgies.put("myCol1", UpsertConfig.Strategy.INCREMENT);
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeCol")
-        .setUpsertConfig(partialUpsertConfig).setNullHandlingEnabled(false)
-        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
-        .setStreamConfigs(streamConfigs).build();
+            .setUpsertConfig(partialUpsertConfig).setNullHandlingEnabled(false)
+            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+            .setStreamConfigs(streamConfigs).build();
     try {
       TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema);
       Assert.fail();
@@ -1546,16 +1596,16 @@ public class TableConfigUtilsTest {
   @Test
   public void testTaskConfig() {
     Schema schema =
-        new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
-            .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
-            .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
+            new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+                    .addDateTime(TIME_COLUMN, FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+                    .setPrimaryKeyColumns(Lists.newArrayList("myCol")).build();
     Map<String, String> realtimeToOfflineTaskConfig =
-        ImmutableMap.of("schedule", "0 */10 * ? * * *", "bucketTimePeriod", "6h", "bufferTimePeriod", "5d", "mergeType",
-            "rollup", "myCol.aggregationType", "max");
+            ImmutableMap.of("schedule", "0 */10 * ? * * *", "bucketTimePeriod", "6h", "bufferTimePeriod", "5d", "mergeType",
+                    "rollup", "myCol.aggregationType", "max");
     Map<String, String> segmentGenerationAndPushTaskConfig = ImmutableMap.of("schedule", "0 */10 * ? * * *");
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTaskConfig(
-        new TableTaskConfig(ImmutableMap.of("RealtimeToOfflineSegmentsTask", realtimeToOfflineTaskConfig,
-            "SegmentGenerationAndPushTask", segmentGenerationAndPushTaskConfig))).build();
+            new TableTaskConfig(ImmutableMap.of("RealtimeToOfflineSegmentsTask", realtimeToOfflineTaskConfig,
+                    "SegmentGenerationAndPushTask", segmentGenerationAndPushTaskConfig))).build();
 
     // validate valid config
     TableConfigUtils.validateTaskConfigs(tableConfig, schema);
@@ -1564,8 +1614,8 @@ public class TableConfigUtilsTest {
     HashMap<String, String> invalidScheduleConfig = new HashMap<>(segmentGenerationAndPushTaskConfig);
     invalidScheduleConfig.put("schedule", "garbage");
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTaskConfig(new TableTaskConfig(
-        ImmutableMap.of("RealtimeToOfflineSegmentsTask", realtimeToOfflineTaskConfig, "SegmentGenerationAndPushTask",
-            invalidScheduleConfig))).build();
+            ImmutableMap.of("RealtimeToOfflineSegmentsTask", realtimeToOfflineTaskConfig, "SegmentGenerationAndPushTask",
+                    invalidScheduleConfig))).build();
     try {
       TableConfigUtils.validateTaskConfigs(tableConfig, schema);
       Assert.fail();
@@ -1575,9 +1625,9 @@ public class TableConfigUtilsTest {
 
     // invalid Upsert config with RealtimeToOfflineTask
     tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
-        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL)).setTaskConfig(new TableTaskConfig(
-            ImmutableMap.of("RealtimeToOfflineSegmentsTask", realtimeToOfflineTaskConfig,
-                "SegmentGenerationAndPushTask", segmentGenerationAndPushTaskConfig))).build();
+            .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL)).setTaskConfig(new TableTaskConfig(
+                    ImmutableMap.of("RealtimeToOfflineSegmentsTask", realtimeToOfflineTaskConfig,
+                            "SegmentGenerationAndPushTask", segmentGenerationAndPushTaskConfig))).build();
     try {
       TableConfigUtils.validateTaskConfigs(tableConfig, schema);
       Assert.fail();
@@ -1591,8 +1641,8 @@ public class TableConfigUtilsTest {
     HashMap<String, String> invalidPeriodConfig = new HashMap<>(realtimeToOfflineTaskConfig);
     invalidPeriodConfig.put("roundBucketTimePeriod", "garbage");
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTaskConfig(new TableTaskConfig(
-        ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidPeriodConfig, "SegmentGenerationAndPushTask",
-            segmentGenerationAndPushTaskConfig))).build();
+            ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidPeriodConfig, "SegmentGenerationAndPushTask",
+                    segmentGenerationAndPushTaskConfig))).build();
     try {
       TableConfigUtils.validateTaskConfigs(tableConfig, schema);
       Assert.fail();
@@ -1604,8 +1654,8 @@ public class TableConfigUtilsTest {
     HashMap<String, String> invalidMergeType = new HashMap<>(realtimeToOfflineTaskConfig);
     invalidMergeType.put("mergeType", "garbage");
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTaskConfig(new TableTaskConfig(
-        ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidMergeType, "SegmentGenerationAndPushTask",
-            segmentGenerationAndPushTaskConfig))).build();
+            ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidMergeType, "SegmentGenerationAndPushTask",
+                    segmentGenerationAndPushTaskConfig))).build();
     try {
       TableConfigUtils.validateTaskConfigs(tableConfig, schema);
       Assert.fail();
@@ -1617,8 +1667,8 @@ public class TableConfigUtilsTest {
     HashMap<String, String> invalidColumnConfig = new HashMap<>(realtimeToOfflineTaskConfig);
     invalidColumnConfig.put("score.aggregationType", "max");
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTaskConfig(new TableTaskConfig(
-        ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidColumnConfig, "SegmentGenerationAndPushTask",
-            segmentGenerationAndPushTaskConfig))).build();
+            ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidColumnConfig, "SegmentGenerationAndPushTask",
+                    segmentGenerationAndPushTaskConfig))).build();
     try {
       TableConfigUtils.validateTaskConfigs(tableConfig, schema);
       Assert.fail();
@@ -1630,8 +1680,8 @@ public class TableConfigUtilsTest {
     HashMap<String, String> invalidAggConfig = new HashMap<>(realtimeToOfflineTaskConfig);
     invalidAggConfig.put("myCol.aggregationType", "garbage");
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).setTaskConfig(new TableTaskConfig(
-        ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidAggConfig, "SegmentGenerationAndPushTask",
-            segmentGenerationAndPushTaskConfig))).build();
+            ImmutableMap.of("RealtimeToOfflineSegmentsTask", invalidAggConfig, "SegmentGenerationAndPushTask",
+                    segmentGenerationAndPushTaskConfig))).build();
     try {
       TableConfigUtils.validateTaskConfigs(tableConfig, schema);
       Assert.fail();
@@ -1645,25 +1695,25 @@ public class TableConfigUtilsTest {
     InstanceAssignmentConfig instanceAssignmentConfig = Mockito.mock(InstanceAssignmentConfig.class);
 
     TableConfig tableConfigWithoutInstancePartitionsMap =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+                    .build();
 
     // Call validate with a table-config without any instance partitions or instance assignment config
     TableConfigUtils.validateInstancePartitionsTypeMapConfig(tableConfigWithoutInstancePartitionsMap);
 
     TableConfig tableConfigWithInstancePartitionsMap =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setInstancePartitionsMap(ImmutableMap.of(InstancePartitionsType.OFFLINE, "test_OFFLINE"))
-            .build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+                    .setInstancePartitionsMap(ImmutableMap.of(InstancePartitionsType.OFFLINE, "test_OFFLINE"))
+                    .build();
 
     // Call validate with a table-config with instance partitions set but not instance assignment config
     TableConfigUtils.validateInstancePartitionsTypeMapConfig(tableConfigWithInstancePartitionsMap);
 
     TableConfig invalidTableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .setInstancePartitionsMap(ImmutableMap.of(InstancePartitionsType.OFFLINE, "test_OFFLINE"))
-            .setInstanceAssignmentConfigMap(ImmutableMap.of(InstancePartitionsType.OFFLINE, instanceAssignmentConfig))
-            .build();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+                    .setInstancePartitionsMap(ImmutableMap.of(InstancePartitionsType.OFFLINE, "test_OFFLINE"))
+                    .setInstanceAssignmentConfigMap(ImmutableMap.of(InstancePartitionsType.OFFLINE, instanceAssignmentConfig))
+                    .build();
     try {
       // Call validate with instance partitions and config set for the same type
       TableConfigUtils.validateInstancePartitionsTypeMapConfig(invalidTableConfig);
@@ -1678,7 +1728,7 @@ public class TableConfigUtilsTest {
     streamConfigs.put("stream.kafka.consumer.type", "highLevel");
     streamConfigs.put("stream.kafka.topic.name", "test");
     streamConfigs.put("stream.kafka.decoder.class.name",
-        "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder");
+            "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder");
     return streamConfigs;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -69,7 +69,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   protected DataType _dataType;
   protected boolean _isSingleValueField = true;
 
-  // NOTE: for STRING column, this is the max number of characters; for BYTES column, this is the max number of bytes
+  // NOTE: for STRING column, this is the max number of characters; for BYTES column, this is the fixed number of bytes
   private int _maxLength = DEFAULT_MAX_LENGTH;
 
   protected Object _defaultNullValue;


### PR DESCRIPTION
This adds support for distinct count hll pre-aggregation. It introduces a new property on the fieldSpec, fixedLength in bytes so that BYTES data type can be treated as fixed length and we can utilize the FixedByteSVMutableForwardIndex.
When used for Hyperloglog data values, the fixedLength should represent in bytes the size of the Hyperloglog object when serialized.

Hyperloglog w/ log2m of 8 has a size of 180 bytes, with a log2m of 12 has a size of 2740 bytes. I unit tested using log2m of 12 because that's the size one of our use cases require

**Unit tests**
unit tests for the fixedByte mutable forward indexes' getBytes() and setBytes() new implementation
unit tests for aggregating rows and asserting on their Hyperloglog objects

**Other testing**
At Stripe, we use this already for one of our pinot tables and it has worked well for us.

**Backward-incompatible**: yes
