### PR TITLE
feat: add compressed file support for ORCRecordReader

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReader.java
@@ -82,8 +82,8 @@ public class ORCRecordReader implements RecordReader {
     Reader orcReader = OrcFile.createReader(new Path(orcFile.getAbsolutePath()),
         OrcFile.readerOptions(configuration).filesystem(FileSystem.getLocal(configuration)));
     TypeDescription orcSchema = orcReader.getSchema();
-    Preconditions
-        .checkState(orcSchema.getCategory() == TypeDescription.Category.STRUCT, "ORC schema must be of type: STRUCT");
+    Preconditions.checkState(orcSchema.getCategory() == TypeDescription.Category.STRUCT,
+        "ORC schema must be of type: STRUCT");
     _orcFields = orcSchema.getFieldNames();
     _orcFieldTypes = orcSchema.getChildren();
 
@@ -130,9 +130,8 @@ public class ORCRecordReader implements RecordReader {
       // Maps always have two child columns for its keys and values
       List<TypeDescription> children = fieldType.getChildren();
       TypeDescription.Category keyCategory = children.get(0).getCategory();
-      Preconditions
-          .checkState(isSupportedSingleValueType(keyCategory), "Illegal map key field type: %s (field %s)", keyCategory,
-              field);
+      Preconditions.checkState(isSupportedSingleValueType(keyCategory), "Illegal map key field type: %s (field %s)",
+          keyCategory, field);
       initFieldsToRead(orcReaderInclude, children.get(1), field);
     } else if (category == TypeDescription.Category.STRUCT) {
       List<String> childrenFieldNames = fieldType.getFieldNames();
@@ -143,9 +142,8 @@ public class ORCRecordReader implements RecordReader {
       }
     } else {
       // Single-value field
-      Preconditions
-          .checkState(isSupportedSingleValueType(category), "Illegal single-value field type: %s (field %s)", category,
-              field);
+      Preconditions.checkState(isSupportedSingleValueType(category), "Illegal single-value field type: %s (field %s)",
+          category, field);
     }
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/main/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReader.java
@@ -20,10 +20,7 @@ package org.apache.pinot.plugin.inputformat.orc;
 
 import com.google.common.base.Preconditions;
 import java.io.File;
-import java.io.InputStream;
 import java.io.IOException;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -81,7 +78,7 @@ public class ORCRecordReader implements RecordReader {
   public void init(File dataFile, @Nullable Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
       throws IOException {
     Configuration configuration = new Configuration();
-    File orcFile = unpackIfRequired(dataFile);
+    File orcFile = RecordReaderUtils.unpackIfRequired(dataFile, "orc");
     Reader orcReader = OrcFile.createReader(new Path(orcFile.getAbsolutePath()),
         OrcFile.readerOptions(configuration).filesystem(FileSystem.getLocal(configuration)));
     TypeDescription orcSchema = orcReader.getSchema();
@@ -109,18 +106,6 @@ public class ORCRecordReader implements RecordReader {
     _rowBatch = orcSchema.createRowBatch();
     _hasNext = _orcRecordReader.nextBatch(_rowBatch);
     _nextRowId = 0;
-  }
-
-  private File unpackIfRequired(File dataFile) throws IOException {
-    if (RecordReaderUtils.isGZippedFile(dataFile)) {
-      try(final InputStream inputStream = RecordReaderUtils.getInputStream(dataFile)) {
-        File targetFile = new File(String.format("%s.orc", dataFile.getAbsolutePath()));
-        Files.copy(inputStream, targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        return targetFile;
-      }
-    } else {
-      return dataFile;
-    }
   }
 
   /**

--- a/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReaderTest.java
@@ -17,6 +17,7 @@ package org.apache.pinot.plugin.inputformat.orc;
  * specific language governing permissions and limitations
  * under the License.
  */
+
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
@@ -46,9 +47,9 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public class ORCRecordReaderTest extends AbstractRecordReaderTest {
   private final File _dataFile = new File(_tempDir, "data.orc");
 
-  private void compressGzip(String sourcePath, String targetPath) throws IOException {
-    try (GZIPOutputStream gos = new GZIPOutputStream(
-            new FileOutputStream(Paths.get(targetPath).toFile()))) {
+  private void compressGzip(String sourcePath, String targetPath)
+      throws IOException {
+    try (GZIPOutputStream gos = new GZIPOutputStream(new FileOutputStream(Paths.get(targetPath).toFile()))) {
       Files.copy(Paths.get(sourcePath), gos);
     }
   }
@@ -160,7 +161,7 @@ public class ORCRecordReaderTest extends AbstractRecordReaderTest {
 
   @Test
   public void testGzipORCRecordReader()
-          throws Exception {
+      throws Exception {
     String gzipFileName = "data.orc.gz";
     compressGzip(_dataFile.getAbsolutePath(), String.format("%s/%s", _tempDir, gzipFileName));
     final File gzDataFile = new File(_tempDir, gzipFileName);

--- a/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReaderTest.java
@@ -26,7 +26,6 @@ import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;

--- a/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-orc/src/test/java/org/apache/pinot/plugin/inputformat/orc/ORCRecordReaderTest.java
@@ -18,8 +18,14 @@ package org.apache.pinot.plugin.inputformat.orc;
  * under the License.
  */
 import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.GZIPOutputStream;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hive.ql.exec.vector.BytesColumnVector;
@@ -32,12 +38,20 @@ import org.apache.orc.TypeDescription;
 import org.apache.orc.Writer;
 import org.apache.pinot.spi.data.readers.AbstractRecordReaderTest;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.testng.annotations.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
 
 public class ORCRecordReaderTest extends AbstractRecordReaderTest {
   private final File _dataFile = new File(_tempDir, "data.orc");
+
+  private void compressGzip(String sourcePath, String targetPath) throws IOException {
+    try (GZIPOutputStream gos = new GZIPOutputStream(
+            new FileOutputStream(Paths.get(targetPath).toFile()))) {
+      Files.copy(Paths.get(sourcePath), gos);
+    }
+  }
 
   @Override
   protected RecordReader createRecordReader()
@@ -142,5 +156,18 @@ public class ORCRecordReaderTest extends AbstractRecordReaderTest {
       rowBatch.reset();
     }
     writer.close();
+  }
+
+  @Test
+  public void testGzipORCRecordReader()
+          throws Exception {
+    String gzipFileName = "data.orc.gz";
+    compressGzip(_dataFile.getAbsolutePath(), String.format("%s/%s", _tempDir, gzipFileName));
+    final File gzDataFile = new File(_tempDir, gzipFileName);
+    ORCRecordReader orcRecordReader = new ORCRecordReader();
+    orcRecordReader.init(gzDataFile, _sourceFields, null);
+    checkValue(orcRecordReader, _records, _primaryKeys);
+    orcRecordReader.rewind();
+    checkValue(orcRecordReader, _records, _primaryKeys);
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetAvroRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetAvroRecordReader.java
@@ -29,8 +29,7 @@ import org.apache.pinot.plugin.inputformat.avro.AvroRecordExtractor;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
-
-import static org.apache.pinot.plugin.inputformat.parquet.ParquetUtils.unpackIfRequired;
+import org.apache.pinot.spi.data.readers.RecordReaderUtils;
 
 
 /**
@@ -50,7 +49,7 @@ public class ParquetAvroRecordReader implements RecordReader {
   @Override
   public void init(File dataFile, @Nullable Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
       throws IOException {
-    File parquetFile = unpackIfRequired(dataFile);
+    File parquetFile = RecordReaderUtils.unpackIfRequired(dataFile, "parquet");
     _dataFilePath = new Path(parquetFile.getAbsolutePath());
     _parquetReader = ParquetUtils.getParquetAvroReader(_dataFilePath);
     _recordExtractor = new AvroRecordExtractor();

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetAvroRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetAvroRecordReader.java
@@ -30,6 +30,8 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 
+import static org.apache.pinot.plugin.inputformat.parquet.ParquetUtils.unpackIfRequired;
+
 
 /**
  * Avro Record reader for Parquet file. This reader doesn't read parquet file with incompatible Avro schemas,
@@ -48,7 +50,8 @@ public class ParquetAvroRecordReader implements RecordReader {
   @Override
   public void init(File dataFile, @Nullable Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
       throws IOException {
-    _dataFilePath = new Path(dataFile.getAbsolutePath());
+    File parquetFile = unpackIfRequired(dataFile);
+    _dataFilePath = new Path(parquetFile.getAbsolutePath());
     _parquetReader = ParquetUtils.getParquetAvroReader(_dataFilePath);
     _recordExtractor = new AvroRecordExtractor();
     _recordExtractor.init(fieldsToRead, null);

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordReader.java
@@ -38,6 +38,8 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 
+import static org.apache.pinot.plugin.inputformat.parquet.ParquetUtils.unpackIfRequired;
+
 
 /**
  * Record reader for Native Parquet file.
@@ -58,7 +60,8 @@ public class ParquetNativeRecordReader implements RecordReader {
   @Override
   public void init(File dataFile, @Nullable Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
       throws IOException {
-    _dataFilePath = new Path(dataFile.getAbsolutePath());
+    File parquetFile = unpackIfRequired(dataFile);
+    _dataFilePath = new Path(parquetFile.getAbsolutePath());
     _hadoopConf = ParquetUtils.getParquetHadoopConfiguration();
     _recordExtractor = new ParquetNativeRecordExtractor();
     _recordExtractor.init(fieldsToRead, null);

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordReader.java
@@ -65,19 +65,16 @@ public class ParquetNativeRecordReader implements RecordReader {
     _recordExtractor = new ParquetNativeRecordExtractor();
     _recordExtractor.init(fieldsToRead, null);
 
-    _parquetReadOptions = ParquetReadOptions.builder()
-        .withMetadataFilter(ParquetMetadataConverter.NO_FILTER)
-        .build();
+    _parquetReadOptions = ParquetReadOptions.builder().withMetadataFilter(ParquetMetadataConverter.NO_FILTER).build();
 
-    _parquetFileReader = ParquetFileReader.open(HadoopInputFile.fromPath(_dataFilePath, _hadoopConf),
-        _parquetReadOptions);
+    _parquetFileReader =
+        ParquetFileReader.open(HadoopInputFile.fromPath(_dataFilePath, _hadoopConf), _parquetReadOptions);
     _schema = _parquetFileReader.getFooter().getFileMetaData().getSchema();
     _pageReadStore = _parquetFileReader.readNextRowGroup();
     _columnIO = new ColumnIOFactory().getColumnIO(_schema);
     _parquetRecordReader = _columnIO.getRecordReader(_pageReadStore, new GroupRecordConverter(_schema));
     _currentPageIdx = 0;
   }
-
 
   @Override
   public boolean hasNext() {
@@ -121,8 +118,8 @@ public class ParquetNativeRecordReader implements RecordReader {
   public void rewind()
       throws IOException {
     _parquetFileReader.close();
-    _parquetFileReader = ParquetFileReader.open(HadoopInputFile.fromPath(_dataFilePath, _hadoopConf),
-        _parquetReadOptions);
+    _parquetFileReader =
+        ParquetFileReader.open(HadoopInputFile.fromPath(_dataFilePath, _hadoopConf), _parquetReadOptions);
     _pageReadStore = _parquetFileReader.readNextRowGroup();
     _parquetRecordReader = _columnIO.getRecordReader(_pageReadStore, new GroupRecordConverter(_schema));
     _currentPageIdx = 0;

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordReader.java
@@ -37,8 +37,7 @@ import org.apache.parquet.schema.MessageType;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
-
-import static org.apache.pinot.plugin.inputformat.parquet.ParquetUtils.unpackIfRequired;
+import org.apache.pinot.spi.data.readers.RecordReaderUtils;
 
 
 /**
@@ -60,7 +59,7 @@ public class ParquetNativeRecordReader implements RecordReader {
   @Override
   public void init(File dataFile, @Nullable Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
       throws IOException {
-    File parquetFile = unpackIfRequired(dataFile);
+    File parquetFile = RecordReaderUtils.unpackIfRequired(dataFile, "parquet");
     _dataFilePath = new Path(parquetFile.getAbsolutePath());
     _hadoopConf = ParquetUtils.getParquetHadoopConfiguration();
     _recordExtractor = new ParquetNativeRecordExtractor();

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReader.java
@@ -26,8 +26,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
-
-import static org.apache.pinot.plugin.inputformat.parquet.ParquetUtils.unpackIfRequired;
+import org.apache.pinot.spi.data.readers.RecordReaderUtils;
 
 
 /**
@@ -41,7 +40,7 @@ public class ParquetRecordReader implements RecordReader {
   @Override
   public void init(File dataFile, @Nullable Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
       throws IOException {
-    File parquetFile = unpackIfRequired(dataFile);
+    File parquetFile = RecordReaderUtils.unpackIfRequired(dataFile, "parquet");
     if (recordReaderConfig != null && ((ParquetRecordReaderConfig) recordReaderConfig).useParquetAvroRecordReader()) {
       _internalParquetRecordReader = new ParquetAvroRecordReader();
     } else if (recordReaderConfig != null

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReader.java
@@ -27,6 +27,8 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 
+import static org.apache.pinot.plugin.inputformat.parquet.ParquetUtils.unpackIfRequired;
+
 
 /**
  * Pinot Record reader for Parquet file.<p>
@@ -39,6 +41,7 @@ public class ParquetRecordReader implements RecordReader {
   @Override
   public void init(File dataFile, @Nullable Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
       throws IOException {
+    File parquetFile = unpackIfRequired(dataFile);
     if (recordReaderConfig != null && ((ParquetRecordReaderConfig) recordReaderConfig).useParquetAvroRecordReader()) {
       _internalParquetRecordReader = new ParquetAvroRecordReader();
     } else if (recordReaderConfig != null
@@ -47,14 +50,14 @@ public class ParquetRecordReader implements RecordReader {
       _internalParquetRecordReader = new ParquetNativeRecordReader();
     } else {
       // No reader type specified. Determine using file metadata
-      if (ParquetUtils.hasAvroSchemaInFileMetadata(new Path(dataFile.getAbsolutePath()))) {
+      if (ParquetUtils.hasAvroSchemaInFileMetadata(new Path(parquetFile.getAbsolutePath()))) {
         _internalParquetRecordReader = new ParquetAvroRecordReader();
       } else {
         _useAvroParquetRecordReader = false;
         _internalParquetRecordReader = new ParquetNativeRecordReader();
       }
     }
-    _internalParquetRecordReader.init(dataFile, fieldsToRead, recordReaderConfig);
+    _internalParquetRecordReader.init(parquetFile, fieldsToRead, recordReaderConfig);
   }
 
   @Override

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetUtils.java
@@ -59,8 +59,8 @@ public class ParquetUtils {
    */
   public static ParquetWriter<GenericRecord> getParquetAvroWriter(Path path, Schema schema)
       throws IOException {
-    return AvroParquetWriter.<GenericRecord>builder(path).withSchema(schema)
-        .withConf(getParquetHadoopConfiguration()).build();
+    return AvroParquetWriter.<GenericRecord>builder(path).withSchema(schema).withConf(getParquetHadoopConfiguration())
+        .build();
   }
 
   /**
@@ -85,7 +85,8 @@ public class ParquetUtils {
     }
   }
 
-  public static boolean hasAvroSchemaInFileMetadata(Path path) throws IOException {
+  public static boolean hasAvroSchemaInFileMetadata(Path path)
+      throws IOException {
     ParquetMetadata footer =
         ParquetFileReader.readFooter(getParquetHadoopConfiguration(), path, ParquetMetadataConverter.NO_FILTER);
     Map<String, String> metaData = footer.getFileMetaData().getKeyValueMetaData();

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetUtils.java
@@ -18,11 +18,7 @@
  */
 package org.apache.pinot.plugin.inputformat.parquet;
 
-import java.io.File;
 import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.StandardCopyOption;
 import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -38,7 +34,6 @@ import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.schema.MessageType;
-import org.apache.pinot.spi.data.readers.RecordReaderUtils;
 
 
 public class ParquetUtils {
@@ -106,17 +101,5 @@ public class ParquetUtils {
     conf.set("fs.defaultFS", DEFAULT_FS);
     conf.set("fs.file.impl", org.apache.hadoop.fs.LocalFileSystem.class.getName());
     return conf;
-  }
-
-  public static File unpackIfRequired(File dataFile) throws IOException {
-    if (RecordReaderUtils.isGZippedFile(dataFile)) {
-      try(final InputStream inputStream = RecordReaderUtils.getInputStream(dataFile)) {
-        File targetFile = new File(String.format("%s.parquet", dataFile.getAbsolutePath()));
-        Files.copy(inputStream, targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
-        return targetFile;
-      }
-    } else {
-      return dataFile;
-    }
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetUtils.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetUtils.java
@@ -18,7 +18,11 @@
  */
 package org.apache.pinot.plugin.inputformat.parquet;
 
+import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -34,6 +38,7 @@ import org.apache.parquet.hadoop.ParquetReader;
 import org.apache.parquet.hadoop.ParquetWriter;
 import org.apache.parquet.hadoop.metadata.ParquetMetadata;
 import org.apache.parquet.schema.MessageType;
+import org.apache.pinot.spi.data.readers.RecordReaderUtils;
 
 
 public class ParquetUtils {
@@ -101,5 +106,17 @@ public class ParquetUtils {
     conf.set("fs.defaultFS", DEFAULT_FS);
     conf.set("fs.file.impl", org.apache.hadoop.fs.LocalFileSystem.class.getName());
     return conf;
+  }
+
+  public static File unpackIfRequired(File dataFile) throws IOException {
+    if (RecordReaderUtils.isGZippedFile(dataFile)) {
+      try(final InputStream inputStream = RecordReaderUtils.getInputStream(dataFile)) {
+        File targetFile = new File(String.format("%s.parquet", dataFile.getAbsolutePath()));
+        Files.copy(inputStream, targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        return targetFile;
+      }
+    } else {
+      return dataFile;
+    }
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordReaderTest.java
@@ -56,8 +56,8 @@ public class ParquetNativeRecordReaderTest extends AbstractRecordReaderTest {
       }
       records.add(record);
     }
-    try (ParquetWriter<GenericRecord> writer = ParquetUtils
-        .getParquetAvroWriter(new Path(_dataFile.getAbsolutePath()), schema)) {
+    try (ParquetWriter<GenericRecord> writer = ParquetUtils.getParquetAvroWriter(new Path(_dataFile.getAbsolutePath()),
+        schema)) {
       for (GenericRecord record : records) {
         writer.write(record);
       }

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
@@ -69,17 +69,17 @@ public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
       }
       records.add(record);
     }
-    try (ParquetWriter<GenericRecord> writer = ParquetUtils
-        .getParquetAvroWriter(new Path(_dataFile.getAbsolutePath()), schema)) {
+    try (ParquetWriter<GenericRecord> writer = ParquetUtils.getParquetAvroWriter(new Path(_dataFile.getAbsolutePath()),
+        schema)) {
       for (GenericRecord record : records) {
         writer.write(record);
       }
     }
   }
 
-  private void compressGzip(String sourcePath, String targetPath) throws IOException {
-    try (GZIPOutputStream gos = new GZIPOutputStream(
-            new FileOutputStream(Paths.get(targetPath).toFile()))) {
+  private void compressGzip(String sourcePath, String targetPath)
+      throws IOException {
+    try (GZIPOutputStream gos = new GZIPOutputStream(new FileOutputStream(Paths.get(targetPath).toFile()))) {
       Files.copy(Paths.get(sourcePath), gos);
     }
   }
@@ -120,7 +120,6 @@ public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
     parquetRecordReader.init(avroParquetFile, null, null);
     // Should be avro since file metadata has avro schema
     Assert.assertTrue(parquetRecordReader.useAvroParquetRecordReader());
-
 
     final ParquetRecordReader parquetRecordReader2 = new ParquetRecordReader();
     File nativeParquetFile = new File(getClass().getClassLoader().getResource("users.parquet").getFile());
@@ -173,7 +172,7 @@ public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
 
   @Test
   public void testGzipParquetRecordReader()
-          throws IOException {
+      throws IOException {
     compressGzip(_dataFile.getAbsolutePath(), String.format("%s/%s", _tempDir, _gzipFileName));
     final File gzDataFile = new File(_tempDir, _gzipFileName);
     ParquetRecordReader recordReader = new ParquetRecordReader();
@@ -183,7 +182,7 @@ public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
 
   @Test
   public void testGzipParquetAvroRecordReader()
-          throws IOException {
+      throws IOException {
     ParquetAvroRecordReader avroRecordReader = new ParquetAvroRecordReader();
     compressGzip(_dataFile.getAbsolutePath(), String.format("%s/%s", _tempDir, _gzipFileName));
     final File gzDataFile = new File(_tempDir, _gzipFileName);
@@ -193,11 +192,11 @@ public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
 
   @Test
   public void testGzipParquetNativeRecordReader()
-          throws IOException {
+      throws IOException {
     ParquetNativeRecordReader nativeRecordReader = new ParquetNativeRecordReader();
 
-    final String gzParquetFileWithInt96AndDecimal
-            = String.format("%s.gz", _testParquetFileWithInt96AndDecimal.getAbsolutePath());
+    final String gzParquetFileWithInt96AndDecimal =
+        String.format("%s.gz", _testParquetFileWithInt96AndDecimal.getAbsolutePath());
     compressGzip(_testParquetFileWithInt96AndDecimal.getAbsolutePath(), gzParquetFileWithInt96AndDecimal);
     final File gzTestParquetFileWithInt96AndDecimal = new File(gzParquetFileWithInt96AndDecimal);
     nativeRecordReader.init(gzTestParquetFileWithInt96AndDecimal, ImmutableSet.of(), new ParquetRecordReaderConfig());

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
@@ -28,7 +28,6 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.zip.GZIPOutputStream;
-
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
@@ -20,10 +20,15 @@ package org.apache.pinot.plugin.inputformat.parquet;
 
 import com.google.common.collect.ImmutableSet;
 import java.io.File;
+import java.io.FileOutputStream;
 import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.zip.GZIPOutputStream;
+
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericRecord;
@@ -40,6 +45,7 @@ import org.testng.annotations.Test;
 
 public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
   private final File _dataFile = new File(_tempDir, "data.parquet");
+  private final String _gzipFileName = "data.parquet.gz";
   private final File _testParquetFileWithInt96AndDecimal =
       new File(getClass().getClassLoader().getResource("test-file-with-int96-and-decimal.snappy.parquet").getFile());
 
@@ -68,6 +74,13 @@ public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
       for (GenericRecord record : records) {
         writer.write(record);
       }
+    }
+  }
+
+  private void compressGzip(String sourcePath, String targetPath) throws IOException {
+    try (GZIPOutputStream gos = new GZIPOutputStream(
+            new FileOutputStream(Paths.get(targetPath).toFile()))) {
+      Files.copy(Paths.get(sourcePath), gos);
     }
   }
 
@@ -156,5 +169,43 @@ public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
     }
     Assert.assertEquals(recordsRead, totalRecords,
         "Message read from ParquetRecordReader doesn't match the expected number.");
+  }
+
+  @Test
+  public void testGzipParquetRecordReader()
+          throws IOException {
+    compressGzip(_dataFile.getAbsolutePath(), String.format("%s/%s", _tempDir, _gzipFileName));
+    final File gzDataFile = new File(_tempDir, _gzipFileName);
+    ParquetRecordReader recordReader = new ParquetRecordReader();
+    recordReader.init(gzDataFile, _sourceFields, null);
+    testReadParquetFile(recordReader, SAMPLE_RECORDS_SIZE);
+  }
+
+  @Test
+  public void testGzipParquetAvroRecordReader()
+          throws IOException {
+    ParquetAvroRecordReader avroRecordReader = new ParquetAvroRecordReader();
+    compressGzip(_dataFile.getAbsolutePath(), String.format("%s/%s", _tempDir, _gzipFileName));
+    final File gzDataFile = new File(_tempDir, _gzipFileName);
+    avroRecordReader.init(gzDataFile, null, new ParquetRecordReaderConfig());
+    testReadParquetFile(avroRecordReader, SAMPLE_RECORDS_SIZE);
+  }
+
+  @Test
+  public void testGzipParquetNativeRecordReader()
+          throws IOException {
+    ParquetNativeRecordReader nativeRecordReader = new ParquetNativeRecordReader();
+
+    final String gzParquetFileWithInt96AndDecimal
+            = String.format("%s.gz", _testParquetFileWithInt96AndDecimal.getAbsolutePath());
+    compressGzip(_testParquetFileWithInt96AndDecimal.getAbsolutePath(), gzParquetFileWithInt96AndDecimal);
+    final File gzTestParquetFileWithInt96AndDecimal = new File(gzParquetFileWithInt96AndDecimal);
+    nativeRecordReader.init(gzTestParquetFileWithInt96AndDecimal, ImmutableSet.of(), new ParquetRecordReaderConfig());
+    testReadParquetFile(nativeRecordReader, 1965);
+
+    compressGzip(_dataFile.getAbsolutePath(), String.format("%s/%s", _tempDir, _gzipFileName));
+    final File gzDataFile = new File(_tempDir, _gzipFileName);
+    nativeRecordReader.init(gzDataFile, ImmutableSet.of(), new ParquetRecordReaderConfig());
+    testReadParquetFile(nativeRecordReader, SAMPLE_RECORDS_SIZE);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderUtils.java
@@ -61,9 +61,10 @@ public class RecordReaderUtils {
     }
   }
 
-  public static File unpackIfRequired(File dataFile, String extension) throws IOException {
+  public static File unpackIfRequired(File dataFile, String extension)
+      throws IOException {
     if (isGZippedFile(dataFile)) {
-      try(final InputStream inputStream = getInputStream(dataFile)) {
+      try (final InputStream inputStream = getInputStream(dataFile)) {
         File targetFile = new File(String.format("%s.%s", dataFile.getAbsolutePath(), extension));
         Files.copy(inputStream, targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
         return targetFile;
@@ -74,7 +75,7 @@ public class RecordReaderUtils {
   }
 
   private static boolean isGZippedFile(File file)
-          throws IOException {
+      throws IOException {
     int magic = 0;
     try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
       magic = raf.read() & 0xff | ((raf.read() << 8) & 0xff00);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderUtils.java
@@ -27,6 +27,8 @@ import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.StandardCopyOption;
 import java.util.zip.GZIPInputStream;
 
 
@@ -59,7 +61,19 @@ public class RecordReaderUtils {
     }
   }
 
-  public static boolean isGZippedFile(File file)
+  public static File unpackIfRequired(File dataFile, String extension) throws IOException {
+    if (isGZippedFile(dataFile)) {
+      try(final InputStream inputStream = getInputStream(dataFile)) {
+        File targetFile = new File(String.format("%s.%s", dataFile.getAbsolutePath(), extension));
+        Files.copy(inputStream, targetFile.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        return targetFile;
+      }
+    } else {
+      return dataFile;
+    }
+  }
+
+  private static boolean isGZippedFile(File file)
           throws IOException {
     int magic = 0;
     try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderUtils.java
@@ -25,6 +25,7 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.io.RandomAccessFile;
 import java.nio.charset.StandardCharsets;
 import java.util.zip.GZIPInputStream;
 
@@ -56,5 +57,14 @@ public class RecordReaderUtils {
       fileInputStream.close();
       return new FileInputStream(dataFile);
     }
+  }
+
+  public static boolean isGZippedFile(File file)
+          throws IOException {
+    int magic = 0;
+    try (RandomAccessFile raf = new RandomAccessFile(file, "r")) {
+      magic = raf.read() & 0xff | ((raf.read() << 8) & 0xff00);
+    }
+    return magic == GZIPInputStream.GZIP_MAGIC;
   }
 }


### PR DESCRIPTION
This is WIP on https://github.com/apache/pinot/issues/9847
The aim of this change is to support gz compressed files for `ORCRecordReader` and `ParquetAvroRecordReader` in order to achieve the feature parity with other types like csv/json format.