### PR TITLE
Fix issues for realtime table reload

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -538,10 +538,14 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    * Replaces a committed LLC REALTIME segment.
    */
   public void replaceLLSegment(String segmentName, IndexLoadingConfig indexLoadingConfig) {
+    File indexDir = new File(_indexDir, segmentName);
+    // Use the latest table config and schema to load the segment
+    TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, _tableNameWithType);
+    Preconditions.checkState(tableConfig != null, "Failed to get table config for table: {}", _tableNameWithType);
+    Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, tableConfig);
+    indexLoadingConfig.updateTableConfigAndSchema(tableConfig, schema);
     try {
-      File indexDir = new File(_indexDir, segmentName);
-      Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
-      addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, schema));
+      addSegment(indexDir, indexLoadingConfig);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -105,7 +105,7 @@ public class IndexLoadingConfig {
   public IndexLoadingConfig(InstanceDataManagerConfig instanceDataManagerConfig, TableConfig tableConfig,
       @Nullable Schema schema) {
     extractFromInstanceConfig(instanceDataManagerConfig);
-    extractFromTableConfigAndSchema(tableConfig, schema);
+    updateTableConfigAndSchema(tableConfig, schema);
   }
 
   @VisibleForTesting
@@ -117,7 +117,7 @@ public class IndexLoadingConfig {
   public IndexLoadingConfig() {
   }
 
-  private void extractFromTableConfigAndSchema(TableConfig tableConfig, @Nullable Schema schema) {
+  public void updateTableConfigAndSchema(TableConfig tableConfig, @Nullable Schema schema) {
     if (schema != null) {
       TimestampIndexUtils.applyTimestampIndex(tableConfig, schema);
     }
@@ -512,8 +512,8 @@ public class IndexLoadingConfig {
    */
   @VisibleForTesting
   public void setForwardIndexDisabledColumns(Set<String> forwardIndexDisabledColumns) {
-    _forwardIndexDisabledColumns = forwardIndexDisabledColumns == null ? Collections.emptySet()
-        : forwardIndexDisabledColumns;
+    _forwardIndexDisabledColumns =
+        forwardIndexDisabledColumns == null ? Collections.emptySet() : forwardIndexDisabledColumns;
   }
 
   public Set<String> getNoDictionaryColumns() {


### PR DESCRIPTION
Fix #9761

Fix 2 issues:
1. When loading the just committed segment, we should pull the latest table config
2. Ignore the invalid freshness value from the empty consuming segment (before the first message being ingested)