### PR TITLE
UI: fix blank screen when redirect to unknown app route

### DIFF
--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -1073,8 +1073,8 @@ const getURLWithoutAccessToken = (fallbackUrl = '/'): string => {
 
     if(!validateRedirectPath(url)) {
       // constructed redirect url is not a valid app route
-      // fallback to root path "/"
-      url = "/";
+      // redirect to fallBackUrl
+      url = fallbackUrl;
     }
   } else {
     url = fallbackUrl;


### PR DESCRIPTION
### Issue
- sometimes when login via OIDC auth flow the UI just shows blank screen.
- The reason is that after removing access_token from url the final constructed redirect url does not matches any known app route.

### Solution 
- verify if the redirect url matches known app routes. if not then redirect to fallBackUrl otherwise continue with the generated redirect url.