### PR TITLE
UI: fix segment status color remains same in different table page

### DIFF
--- a/pinot-controller/src/main/resources/app/components/SegmentStatusRenderer.tsx
+++ b/pinot-controller/src/main/resources/app/components/SegmentStatusRenderer.tsx
@@ -83,7 +83,7 @@ export const SegmentStatusRenderer = ({
 
   useEffect(() => {
     initializeValues();
-  }, []);
+  }, [status]);
 
   const initializeValues = () => {
     switch (status) {


### PR DESCRIPTION
### What does this PR do?
- fix segment status color remains same in different table page

### Screenshot

before 

https://user-images.githubusercontent.com/41536903/205152186-65e4441e-0d89-4107-8521-5c5938cdb40c.mp4



after

https://user-images.githubusercontent.com/41536903/205152206-343924f4-5dc1-442c-9246-40c9424241f8.mp4



