### PR TITLE
[multistage] Fix leaf stage return

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -20,10 +20,8 @@ package org.apache.pinot.query.runtime;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.concurrent.ExecutorService;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -31,13 +29,10 @@ import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metrics.ServerMetrics;
-import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
-import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.query.executor.ServerQueryExecutorV1Impl;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
-import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.mailbox.MultiplexingMailboxService;
@@ -189,47 +184,10 @@ public class QueryRunner {
   private InstanceResponseBlock processServerQuery(ServerQueryRequest serverQueryRequest,
       ExecutorService executorService) {
     try {
-      InstanceResponseBlock result = _serverExecutor.execute(serverQueryRequest, executorService);
-
-      if (result.getRows() != null && serverQueryRequest.getQueryContext().getOrderByExpressions() != null) {
-        // we only re-arrange columns to match the projection in the case of order by - this is to ensure
-        // that V1 results match what the expected projection schema in the calcite logical operator; if
-        // we realize that there are other situations where we need to post-process v1 results to adhere to
-        // the expected results we should factor this out and also apply the canonicalization of the data
-        // types during this post-process step (also see LeafStageTransferableBlockOperator#canonicalizeRow)
-        DataSchema dataSchema = result.getDataSchema();
-        List<String> selectionColumns =
-            SelectionOperatorUtils.getSelectionColumns(serverQueryRequest.getQueryContext(), dataSchema);
-
-        int[] columnIndices = SelectionOperatorUtils.getColumnIndices(selectionColumns, dataSchema);
-        int numColumns = columnIndices.length;
-
-        DataSchema resultDataSchema = SelectionOperatorUtils.getSchemaForProjection(dataSchema, columnIndices);
-
-        // Extract the result rows
-        LinkedList<Object[]> rowsInSelectionResults = new LinkedList<>();
-        for (Object[] row : result.getRows()) {
-          assert row != null;
-          Object[] extractedRow = new Object[numColumns];
-          for (int i = 0; i < numColumns; i++) {
-            Object value = row[columnIndices[i]];
-            if (value != null) {
-              extractedRow[i] = value;
-            }
-          }
-
-          rowsInSelectionResults.addFirst(extractedRow);
-        }
-
-        return new InstanceResponseBlock(
-            new SelectionResultsBlock(resultDataSchema, rowsInSelectionResults),
-            serverQueryRequest.getQueryContext());
-      } else {
-        return result;
-      }
+      return _serverExecutor.execute(serverQueryRequest, executorService);
     } catch (Exception e) {
       InstanceResponseBlock errorResponse = new InstanceResponseBlock();
-      errorResponse.getExceptions().put(QueryException.QUERY_EXECUTION_ERROR_CODE, Objects.toString(e.getMessage()));
+      errorResponse.getExceptions().put(QueryException.QUERY_EXECUTION_ERROR_CODE, e.getMessage());
       return errorResponse;
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
+import com.clearspring.analytics.util.Preconditions;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -32,7 +33,8 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
-import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
+import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
+import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 
 
@@ -54,10 +56,12 @@ public class LeafStageTransferableBlockOperator extends BaseOperator<Transferabl
 
   private final InstanceResponseBlock _errorBlock;
   private final List<InstanceResponseBlock> _baseResultBlock;
+  private final DataSchema _desiredDataSchema;
   private int _currentIndex;
 
   public LeafStageTransferableBlockOperator(List<InstanceResponseBlock> baseResultBlock, DataSchema dataSchema) {
     _baseResultBlock = baseResultBlock;
+    _desiredDataSchema = dataSchema;
     _errorBlock = baseResultBlock.stream().filter(e -> !e.getExceptions().isEmpty()).findFirst().orElse(null);
     _currentIndex = 0;
   }
@@ -84,11 +88,16 @@ public class LeafStageTransferableBlockOperator extends BaseOperator<Transferabl
     } else {
       if (_currentIndex < _baseResultBlock.size()) {
         InstanceResponseBlock responseBlock = _baseResultBlock.get(_currentIndex++);
-        BaseResultsBlock resultsBlock = responseBlock.getResultsBlock();
-        if (resultsBlock != null) {
-          List<Object[]> rows =
-              toList(resultsBlock.getRows(responseBlock.getQueryContext()), responseBlock.getDataSchema());
-          return new TransferableBlock(rows, responseBlock.getDataSchema(), DataBlock.Type.ROW);
+        if (responseBlock.getResultsBlock() != null) {
+          DataSchema dataSchema = responseBlock.getDataSchema();
+          boolean requiresCleanup = responseBlock.getResultsBlock() instanceof SelectionResultsBlock
+              && dataSchema != null && responseBlock.getRows() != null && !responseBlock.getRows().isEmpty();
+
+          // 1. canonicalize data schema
+          dataSchema = requiresCleanup ? cleanUpDataSchema(responseBlock, _desiredDataSchema) : dataSchema;
+          // 2. canonicalize data block
+          List<Object[]> rows = cleanUpDataBlock(responseBlock, dataSchema, requiresCleanup);
+          return new TransferableBlock(rows, dataSchema, DataBlock.Type.ROW);
         } else {
           return new TransferableBlock(Collections.emptyList(), responseBlock.getDataSchema(), DataBlock.Type.ROW);
         }
@@ -116,23 +125,107 @@ public class LeafStageTransferableBlockOperator extends BaseOperator<Transferabl
     return resultRow;
   }
 
-  private static List<Object[]> toList(Collection<Object[]> collection, DataSchema dataSchema) {
-    if (collection == null || collection.isEmpty()) {
-      return new ArrayList<>();
-    }
-    List<Object[]> resultRows = new ArrayList<>(collection.size());
-    if (collection instanceof List) {
-      for (Object[] orgRow : collection) {
-        resultRows.add(canonicalizeRow(orgRow, dataSchema));
-      }
-    } else if (collection instanceof PriorityQueue) {
-      PriorityQueue<Object[]> priorityQueue = (PriorityQueue<Object[]>) collection;
-      while (!priorityQueue.isEmpty()) {
-        resultRows.add(canonicalizeRow(priorityQueue.poll(), dataSchema));
+  /**
+   * we re-arrange columns to match the projection in the case of order by - this is to ensure
+   * that V1 results match what the expected projection schema in the calcite logical operator; if
+   * we realize that there are other situations where we need to post-process v1 results to adhere to
+   * the expected results we should factor this out and also apply the canonicalization of the data
+   * types during this post-process step (also see LeafStageTransferableBlockOperator#canonicalizeRow)
+   *
+   * @param serverResultsBlock result block from leaf stage
+   * @param dataSchema the desired schema for send operator
+   * @return conformed collection of rows.
+   */
+  @SuppressWarnings("ConstantConditions")
+  private static List<Object[]> cleanUpDataBlock(InstanceResponseBlock serverResultsBlock, DataSchema dataSchema,
+      boolean requiresCleanUp) {
+    // Extract the result rows
+    Collection<Object[]> resultRows = serverResultsBlock.getRows();
+    List<Object[]> extractedRows = new ArrayList<>(resultRows.size());
+    if (requiresCleanUp) {
+      DataSchema resultSchema = serverResultsBlock.getDataSchema();
+      List<String> selectionColumns =
+          SelectionOperatorUtils.getSelectionColumns(serverResultsBlock.getQueryContext(), resultSchema);
+      int[] columnIndices = SelectionOperatorUtils.getColumnIndices(selectionColumns, resultSchema);
+      DataSchema adjustedDataSchema = SelectionOperatorUtils.getSchemaForProjection(resultSchema, columnIndices);
+      Preconditions.checkState(isDataSchemaColumnTypesCompatible(dataSchema.getColumnDataTypes(),
+              adjustedDataSchema.getColumnDataTypes()),
+          "Incompatible result data schema: " + "Expecting: " + dataSchema + " Actual: " + adjustedDataSchema);
+      int numColumns = columnIndices.length;
+
+      if (serverResultsBlock.getQueryContext().getOrderByExpressions() != null) {
+        // extract result row in ordered fashion
+        PriorityQueue<Object[]> priorityQueue = (PriorityQueue<Object[]>) resultRows;
+        while (!priorityQueue.isEmpty()) {
+          Object[] row = priorityQueue.poll();
+          assert row != null;
+          Object[] extractedRow = new Object[numColumns];
+          for (int colId = 0; colId < numColumns; colId++) {
+            Object value = row[columnIndices[colId]];
+            if (value != null) {
+              extractedRow[colId] = dataSchema.getColumnDataType(colId).convert(value);
+            }
+          }
+          extractedRows.add(extractedRow);
+        }
+      } else {
+        // extract result row in non-ordered fashion
+        for (Object[] row : resultRows) {
+          assert row != null;
+          Object[] extractedRow = new Object[numColumns];
+          for (int colId = 0; colId < numColumns; colId++) {
+            Object value = row[columnIndices[colId]];
+            if (value != null) {
+              extractedRow[colId] = dataSchema.getColumnDataType(colId).convert(value);
+            }
+          }
+          extractedRows.add(extractedRow);
+        }
       }
     } else {
-      throw new UnsupportedOperationException("Unsupported collection type: " + collection.getClass());
+      if (resultRows instanceof List) {
+        for (Object[] orgRow : resultRows) {
+          extractedRows.add(canonicalizeRow(orgRow, dataSchema));
+        }
+      } else if (resultRows instanceof PriorityQueue) {
+        PriorityQueue<Object[]> priorityQueue = (PriorityQueue<Object[]>) resultRows;
+        while (!priorityQueue.isEmpty()) {
+          extractedRows.add(canonicalizeRow(priorityQueue.poll(), dataSchema));
+        }
+      } else {
+        throw new UnsupportedOperationException("Unsupported collection type: " + resultRows.getClass());
+      }
     }
-    return resultRows;
+    return extractedRows;
+  }
+
+  /**
+   * @see LeafStageTransferableBlockOperator#cleanUpDataBlock(InstanceResponseBlock, DataSchema, boolean)
+   */
+  @SuppressWarnings("ConstantConditions")
+  private static DataSchema cleanUpDataSchema(InstanceResponseBlock serverResultsBlock, DataSchema desiredDataSchema) {
+    DataSchema resultSchema = serverResultsBlock.getDataSchema();
+    List<String> selectionColumns =
+        SelectionOperatorUtils.getSelectionColumns(serverResultsBlock.getQueryContext(), resultSchema);
+
+    int[] columnIndices = SelectionOperatorUtils.getColumnIndices(selectionColumns, resultSchema);
+    DataSchema adjustedResultSchema = SelectionOperatorUtils.getSchemaForProjection(resultSchema, columnIndices);
+    Preconditions.checkState(isDataSchemaColumnTypesCompatible(desiredDataSchema.getColumnDataTypes(),
+            adjustedResultSchema.getColumnDataTypes()),
+        "Incompatible result data schema: " + "Expecting: " + desiredDataSchema + " Actual: " + adjustedResultSchema);
+    return adjustedResultSchema;
+  }
+
+  private static boolean isDataSchemaColumnTypesCompatible(DataSchema.ColumnDataType[] desiredTypes,
+      DataSchema.ColumnDataType[] givenTypes) {
+    if (desiredTypes.length != givenTypes.length) {
+      return false;
+    }
+    for (int i = 0; i < desiredTypes.length; i++) {
+      if (desiredTypes[i] != givenTypes[i] && !givenTypes[i].isSuperTypeOf(desiredTypes[i])) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/pinot-query-runtime/src/test/resources/queries/Aggregates.json
+++ b/pinot-query-runtime/src/test/resources/queries/Aggregates.json
@@ -3,19 +3,19 @@
     "tables": {
       "tbl": {
         "schema": [
-          { "name": "int_col", "type": "INT" },
-          { "name": "double_col", "type": "DOUBLE" },
-          { "name": "string_col", "type": "STRING" },
-          { "name": "bool_col", "type": "BOOLEAN" }
+          {"name": "int_col", "type": "INT"},
+          {"name": "double_col", "type": "DOUBLE"},
+          {"name": "string_col", "type": "STRING"},
+          {"name": "bool_col", "type": "BOOLEAN"}
         ],
         "inputs": [
-          [ 2, 300, "a", true ],
-          [ 2, 400, "a", true ],
-          [ 3, 100, "b", false ],
-          [ 100, 1, "b", false ],
-          [ 101, 1.01, "c", false ],
-          [ 150, 1.5, "c", false ],
-          [ 175, 1.75, "c", true ]
+          [2, 300, "a", true],
+          [2, 400, "a", true],
+          [3, 100, "b", false],
+          [100, 1, "b", false],
+          [101, 1.01, "c", false],
+          [150, 1.5, "c", false],
+          [175, 1.75, "c", true]
         ]
       }
     },
@@ -147,21 +147,21 @@
     "tables": {
       "tbl": {
         "schema": [
-          { "name": "int_col", "type": "INT" },
-          { "name": "double_col", "type": "DOUBLE" },
-          { "name": "string_col", "type": "STRING" },
-          { "name": "bool_col", "type": "BOOLEAN" }
+          {"name": "int_col", "type": "INT"},
+          {"name": "double_col", "type": "DOUBLE"},
+          {"name": "string_col", "type": "STRING"},
+          {"name": "bool_col", "type": "BOOLEAN"}
         ],
         "inputs": [
-          [ 2, 300, "a", false ],
-          [ 2, 400, "a", true ],
-          [ 3, 100, "b", true ],
-          [ 0.001, 1, "b", false ],
-          [ 101, 1.01, "c", false ],
-          [ 150, 1.5, "c", true ],
-          [ 175, 1.75, "c", true ],
-          [ -10000, 1.75, "c", false ],
-          [ -2, 0.5, "c", false ]
+          [2, 300, "a", false],
+          [2, 400, "a", true],
+          [3, 100, "b", true],
+          [0.001, 1, "b", false],
+          [101, 1.01, "c", false],
+          [150, 1.5, "c", true],
+          [175, 1.75, "c", true],
+          [-10000, 1.75, "c", false],
+          [-2, 0.5, "c", false]
         ]
       }
     },
@@ -210,6 +210,47 @@
         "ignored": true,
         "sql": "select string_col, count(int_col) from {tbl} a group by string_col order by string_col having (select count(*) from {tbl} b where count(int_col) = b.int_col) > 0;"
       }
+    ]
+  },
+  "additional_aggregate": {
+    "tables": {
+      "tbl": {
+        "schema": [
+          {"name": "int_col", "type": "INT"},
+          {"name": "double_col", "type": "DOUBLE"},
+          {"name": "string_col", "type": "STRING"},
+          {"name": "bool_col", "type": "BOOLEAN"}
+        ],
+        "inputs": [
+          [2, 300, "a", false],
+          [2, 400, "a", true],
+          [3, 100, "b", true],
+          [0.001, 1, "b", false],
+          [101, 1.01, "c", false],
+          [150, 1.5, "c", true],
+          [175, 1.75, "c", true],
+          [-10000, 1.75, "c", false],
+          [-2, 0.5, "c", false]
+        ]
+      }
+    },
+    "queries": [
+      { "sql": "SELECT min(int_col), min(int_col) FROM {tbl} WHERE int_col < 100" },
+      { "sql": "SELECT min(int_col), count(int_col), count(*) FROM {tbl}" },
+      { "sql": "SELECT string_col, min(int_col), count(int_col), count(*) FROM {tbl} GROUP BY string_col" },
+      { "sql": "SELECT string_col, bool_col, min(int_col), count(int_col), count(*) FROM {tbl} GROUP BY string_col, bool_col" },
+      { "sql": "SELECT string_col, bool_col, min(int_col), count(int_col), count(*) FROM {tbl} GROUP BY bool_col, string_col" },
+      { "sql": "SELECT string_col, string_col AS alias, count(int_col), count(*) FROM {tbl} GROUP BY bool_col, string_col" },
+      { "sql": "SELECT string_col, bool_col, bool_col AS alias, sum(int_col), count(int_col), count(*) FROM {tbl} GROUP BY bool_col, string_col" },
+      { "sql": "SELECT sum(int_col), count(int_col) FROM {tbl} GROUP BY string_col" },
+      { "sql": "SELECT string_col, min(int_col), count(int_col), count(*) FROM {tbl} GROUP BY string_col ORDER BY string_col" },
+      { "sql": "SELECT string_col, bool_col, min(int_col), count(int_col), count(*) FROM {tbl} GROUP BY string_col, bool_col ORDER BY string_col" },
+      { "sql": "SELECT string_col, bool_col, min(int_col), count(int_col), count(*) FROM {tbl} GROUP BY string_col, bool_col ORDER BY bool_col, string_col" },
+      { "sql": "SELECT string_col, bool_col, min(int_col), count(int_col), count(*) FROM {tbl} GROUP BY bool_col, string_col ORDER BY bool_col, string_col" },
+      { "sql": "SELECT string_col, string_col AS alias, count(int_col), count(*) FROM {tbl} GROUP BY bool_col, string_col ORDER BY string_col" },
+      { "sql": "SELECT string_col, string_col AS alias, count(int_col), count(*) FROM {tbl} GROUP BY bool_col, string_col ORDER BY bool_col, alias"},
+      { "sql": "SELECT string_col, bool_col, bool_col AS alias, sum(int_col), count(int_col), count(*) FROM {tbl} GROUP BY bool_col, string_col ORDER BY alias" },
+      { "sql": "SELECT sum(int_col), count(int_col) FROM {tbl} GROUP BY string_col ORDER BY string_col" }
     ]
   }
 }

--- a/pinot-query-runtime/src/test/resources/queries/Aggregates.json
+++ b/pinot-query-runtime/src/test/resources/queries/Aggregates.json
@@ -250,7 +250,9 @@
       { "sql": "SELECT string_col, string_col AS alias, count(int_col), count(*) FROM {tbl} GROUP BY bool_col, string_col ORDER BY string_col" },
       { "sql": "SELECT string_col, string_col AS alias, count(int_col), count(*) FROM {tbl} GROUP BY bool_col, string_col ORDER BY bool_col, alias"},
       { "sql": "SELECT string_col, bool_col, bool_col AS alias, sum(int_col), count(int_col), count(*) FROM {tbl} GROUP BY bool_col, string_col ORDER BY alias" },
-      { "sql": "SELECT sum(int_col), count(int_col) FROM {tbl} GROUP BY string_col ORDER BY string_col" }
+      { "sql": "SELECT sum(int_col), count(int_col) FROM {tbl} GROUP BY string_col ORDER BY string_col" },
+      { "sql": "SELECT * FROM (SELECT string_col, bool_col, min(int_col) AS m, count(int_col), count(*) AS c FROM {tbl} GROUP BY string_col, bool_col ORDER BY string_col) WHERE c < m" },
+      { "sql": "SELECT * FROM (SELECT string_col, bool_col, min(int_col) AS m, count(int_col), count(*) AS c FROM {tbl} GROUP BY string_col, bool_col ORDER BY bool_col, string_col) WHERE c < m" }
     ]
   }
 }

--- a/pinot-query-runtime/src/test/resources/queries/Distincts.json
+++ b/pinot-query-runtime/src/test/resources/queries/Distincts.json
@@ -1,0 +1,39 @@
+{
+  "generate_distinct": {
+    "tables": {
+      "tbl": {
+        "schema": [
+          { "name": "intCol", "type": "INT" },
+          { "name": "doubleCol", "type": "DOUBLE" },
+          { "name": "strCol", "type": "STRING" },
+          { "name": "boolCol", "type": "BOOLEAN" }
+        ],
+        "inputs": [
+          [ 2, 300, "a", true ],
+          [ 2, 400, "a", true ],
+          [ 3, 100, "b", false ],
+          [ 100, 1, "b", false ],
+          [ 101, 1.01, "c", false ],
+          [ 150, 1.5, "c", false ],
+          [ 175, 1.75, "c", true ]
+        ]
+      }
+    },
+    "queries": [
+      { "sql":  "SELECT DISTINCT intCol FROM {tbl}" },
+      { "sql":  "SELECT intCol FROM {tbl} GROUP BY intCol" },
+      { "sql":  "SELECT DISTINCT strCol, boolCol FROM {tbl}" },
+      { "sql":  "SELECT strCol, boolCol FROM {tbl} GROUP BY strCol, boolCol" },
+      { "sql":  "SELECT strCol, boolCol FROM {tbl} GROUP BY boolCol, strCol" },
+      { "sql":  "SELECT strCol FROM {tbl} GROUP BY strCol, boolCol" },
+      { "sql":  "SELECT boolCol FROM {tbl} GROUP BY strCol, boolCol" },
+      { "sql":  "SELECT DISTINCT intCol, doubleCol FROM {tbl} ORDER BY doubleCol" },
+      { "sql":  "SELECT intCol FROM {tbl} GROUP BY intCol ORDER BY intCol" },
+      { "sql":  "SELECT DISTINCT strCol, boolCol, intCol FROM {tbl} ORDER BY intCol" },
+      { "sql":  "SELECT strCol, boolCol FROM {tbl} GROUP BY strCol, boolCol ORDER BY boolCol" },
+      { "sql":  "SELECT strCol, boolCol FROM {tbl} GROUP BY boolCol, strCol ORDER BY strCol" },
+      { "sql":  "SELECT strCol FROM {tbl} GROUP BY strCol, boolCol ORDER BY boolCol" },
+      { "sql":  "SELECT boolCol FROM {tbl} GROUP BY strCol, boolCol ORDER BY boolCol" }
+    ]
+  }
+}

--- a/pinot-query-runtime/src/test/resources/queries/Distincts.json
+++ b/pinot-query-runtime/src/test/resources/queries/Distincts.json
@@ -1,5 +1,5 @@
 {
-  "generate_distinct": {
+  "general_distinct": {
     "tables": {
       "tbl": {
         "schema": [
@@ -33,7 +33,15 @@
       { "sql":  "SELECT strCol, boolCol FROM {tbl} GROUP BY strCol, boolCol ORDER BY boolCol" },
       { "sql":  "SELECT strCol, boolCol FROM {tbl} GROUP BY boolCol, strCol ORDER BY strCol" },
       { "sql":  "SELECT strCol FROM {tbl} GROUP BY strCol, boolCol ORDER BY boolCol" },
-      { "sql":  "SELECT boolCol FROM {tbl} GROUP BY strCol, boolCol ORDER BY boolCol" }
+      { "sql":  "SELECT strCol FROM (SELECT strCol FROM {tbl} GROUP BY boolCol, strCol ORDER BY strCol) WHERE strCol <> 'foo'" },
+      { "sql":  "SELECT intCol FROM (SELECT DISTINCT intCol FROM {tbl}) WHERE intCol < 100" },
+      { "sql":  "SELECT intCol FROM (SELECT intCol FROM {tbl} GROUP BY intCol) WHERE intCol < 100" },
+      { "sql":  "SELECT strCol FROM (SELECT DISTINCT strCol, boolCol FROM {tbl}) WHERE boolCol = false" },
+      { "sql":  "SELECT strCol FROM (SELECT strCol, boolCol FROM {tbl} GROUP BY strCol, boolCol) WHERE strCol <> 'foo'" },
+      { "sql":  "SELECT strCol, boolCol FROM (SELECT strCol, boolCol FROM {tbl} GROUP BY boolCol, strCol) WHERE strCol <> 'foo'" },
+      { "sql":  "SELECT strCol FROM (SELECT strCol FROM {tbl} GROUP BY strCol, boolCol) WHERE strCol != 'lol'" },
+      { "sql":  "SELECT intCol FROM (SELECT DISTINCT intCol, doubleCol FROM {tbl} ORDER BY doubleCol) WHERE doubleCol < 100" },
+      { "sql":  "SELECT strCol FROM (SELECT DISTINCT strCol, boolCol, intCol FROM {tbl} ORDER BY intCol) WHERE intCol > 10" }
     ]
   }
 }

--- a/pinot-query-runtime/src/test/resources/queries/LexicalStructure.json
+++ b/pinot-query-runtime/src/test/resources/queries/LexicalStructure.json
@@ -135,11 +135,22 @@
         "inputs": [["1"]]
       }
     },
-    "queries": [{
-      "psql": "4.1.2.6",
-      "description": "numeric constant supports",
-      "sql": "SELECT data, 42, 3.5, 4., .001, 5e2, 1.925e-3 FROM {tbl}"
-    }]
+    "queries": [
+      {
+        "ignored": true,
+        "comments": "numeric constant without specific type will cast all floating points into BIG DECIMAL which is not supported by type-hoisting on leaf stage",
+        "psql": "4.1.2.6",
+        "description": "numeric constant supports",
+        "sql": "SELECT data, 42, 3.5, 4., .001, 5e2, 1.925e-3 FROM {tbl}"
+      },
+      {
+        "ignored": true,
+        "comments": "floating point comparison missing precision checker",
+        "psql": "4.1.2.6",
+        "description": "numeric constant supports",
+        "sql": "SELECT data, 42, CAST(3.5 AS FLOAT), CAST(4. AS FLOAT), CAST(.001 AS FLOAT), CAST(5e2 AS FLOAT), CAST(1.925e-3 AS FLOAT) FROM {tbl}"
+      }
+    ]
   },
   "constant_casting": {
     "tables": {

--- a/pinot-query-runtime/src/test/resources/queries/SelectExpressions.json
+++ b/pinot-query-runtime/src/test/resources/queries/SelectExpressions.json
@@ -37,7 +37,15 @@
       { "sql": "SELECT intCol as \"from\" FROM {tbl1}"},
       { "sql": "SELECT intCol as key, SUM(doubleCol + floatCol) AS aggSum FROM {tbl1} GROUP BY intCol"},
       { "sql": "SELECT intCol, SUM(avgVal) FROM (SELECT strCol, intCol, AVG(doubleCol) AS avgVal FROM {tbl1} GROUP BY intCol, strCol) GROUP BY intCol"},
-      { "sql": "SELECT strCol, MAX(sumVal), MAX(sumVal + avgVal) AS transVal FROM (SELECT strCol, intCol, SUM(floatCol + 2 * intCol) AS sumVal, AVG(doubleCol) AS avgVal FROM {tbl1} GROUP BY strCol, intCol) GROUP BY strCol ORDER BY MAX(sumVal)" }
+      { "sql": "SELECT strCol, MAX(sumVal), MAX(sumVal + avgVal) AS transVal FROM (SELECT strCol, intCol, SUM(floatCol + 2 * intCol) AS sumVal, AVG(doubleCol) AS avgVal FROM {tbl1} GROUP BY strCol, intCol) GROUP BY strCol ORDER BY MAX(sumVal)" },
+      { "sql": "SELECT intCol, intCol FROM {tbl} WHERE intCol < 100" },
+      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl}" },
+      { "sql": "SELECT intCol, intCol FROM {tbl} WHERE intCol < 100 ORDER BY doubleCol" },
+      { "sql": "SELECT intCol, intCol FROM {tbl} WHERE intCol < 100 ORDER BY intCol" },
+      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl} ORDER BY intCol" },
+      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl} ORDER BY strCol, intCol" },
+      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl} ORDER BY floatCol, intCol" },
+      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl} ORDER BY floatCol" }
     ]
   }
 }

--- a/pinot-query-runtime/src/test/resources/queries/SelectExpressions.json
+++ b/pinot-query-runtime/src/test/resources/queries/SelectExpressions.json
@@ -38,14 +38,19 @@
       { "sql": "SELECT intCol as key, SUM(doubleCol + floatCol) AS aggSum FROM {tbl1} GROUP BY intCol"},
       { "sql": "SELECT intCol, SUM(avgVal) FROM (SELECT strCol, intCol, AVG(doubleCol) AS avgVal FROM {tbl1} GROUP BY intCol, strCol) GROUP BY intCol"},
       { "sql": "SELECT strCol, MAX(sumVal), MAX(sumVal + avgVal) AS transVal FROM (SELECT strCol, intCol, SUM(floatCol + 2 * intCol) AS sumVal, AVG(doubleCol) AS avgVal FROM {tbl1} GROUP BY strCol, intCol) GROUP BY strCol ORDER BY MAX(sumVal)" },
-      { "sql": "SELECT intCol, intCol FROM {tbl} WHERE intCol < 100" },
-      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl}" },
-      { "sql": "SELECT intCol, intCol FROM {tbl} WHERE intCol < 100 ORDER BY doubleCol" },
-      { "sql": "SELECT intCol, intCol FROM {tbl} WHERE intCol < 100 ORDER BY intCol" },
-      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl} ORDER BY intCol" },
-      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl} ORDER BY strCol, intCol" },
-      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl} ORDER BY floatCol, intCol" },
-      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl} ORDER BY floatCol" }
+      { "sql": "SELECT intCol, intCol FROM {tbl1} WHERE intCol < 100" },
+      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl1}" },
+      { "sql": "SELECT intCol, intCol FROM {tbl1} WHERE intCol < 100 ORDER BY doubleCol" },
+      { "sql": "SELECT intCol, intCol FROM {tbl1} WHERE intCol < 100 ORDER BY intCol" },
+      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl1} ORDER BY intCol" },
+      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl1} ORDER BY strCol, intCol" },
+      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl1} ORDER BY floatCol, intCol" },
+      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl1} ORDER BY floatCol" },
+
+      { "sql": "SELECT intCol + alias FROM (SELECT intCol, intCol as alias FROM {tbl1}) WHERE intCol < 100" },
+      { "sql": "SELECT intCol, intCol, doubleCol, strCol, strCol FROM {tbl1}" },
+      { "sql": "SELECT {tbl1}.intCol, {tbl1}.intCol, {tbl1}.doubleCol, {tbl2}.strCol, {tbl2}.strCol FROM {tbl1}, {tbl2} WHERE {tbl1}.intCol = {tbl2}.intCol" },
+      { "sql": "SELECT {tbl2}.intCol, {tbl2}.intCol FROM {tbl1}, {tbl2} WHERE {tbl1}.intCol = {tbl2}.intCol AND {tbl1}.intCol < 100 ORDER BY {tbl1}.doubleCol" }
     ]
   }
 }


### PR DESCRIPTION
this is a break-out PR from POC https://github.com/apache/pinot/pull/9886

this PR creates leaf stage operator handling various different base result blocks that doesn't conform with calcite composed V2 leaf stage data schema
- selection only blocks (as well as selection order by) is handled
- other result block should only return confirmed schema. Thus only a preconditions check is added.
