### PR TITLE
Pulsar Connection handler should not spin up a consumer / reader

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarConfig.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarConfig.java
@@ -38,14 +38,14 @@ public class PulsarConfig {
   public static final String TLS_TRUST_CERTS_FILE_PATH = "tlsTrustCertsFilePath";
   public static final String ENABLE_KEY_VALUE_STITCH = "enableKeyValueStitch";
 
-  private String _pulsarTopicName;
-  private String _subscriberId;
-  private String _bootstrapServers;
-  private MessageId _initialMessageId;
-  private SubscriptionInitialPosition _subscriptionInitialPosition;
-  private String _authenticationToken;
-  private String _tlsTrustCertsFilePath;
-  private boolean _enableKeyValueStitch;
+  private final String _pulsarTopicName;
+  private final String _subscriberId;
+  private final String _bootstrapServers;
+  private final MessageId _initialMessageId;
+  private final SubscriptionInitialPosition _subscriptionInitialPosition;
+  private final String _authenticationToken;
+  private final String _tlsTrustCertsFilePath;
+  private final boolean _enableKeyValueStitch;
 
   public PulsarConfig(StreamConfig streamConfig, String subscriberId) {
     Map<String, String> streamConfigMap = streamConfig.getStreamConfigsMap();

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConnectionHandler.java
@@ -47,7 +47,7 @@ public class PulsarPartitionLevelConnectionHandler {
   public PulsarPartitionLevelConnectionHandler(String clientId, StreamConfig streamConfig) {
     _config = new PulsarConfig(streamConfig, clientId);
     _clientId = clientId;
-    
+
     try {
       ClientBuilder pulsarClientBuilder = PulsarClient.builder().serviceUrl(_config.getBootstrapServers());
       if (_config.getTlsTrustCertsFilePath() != null) {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConnectionHandler.java
@@ -24,6 +24,7 @@ import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pulsar.client.api.Authentication;
 import org.apache.pulsar.client.api.AuthenticationFactory;
 import org.apache.pulsar.client.api.ClientBuilder;
+import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClient;
 import org.apache.pulsar.client.api.Reader;
 import org.slf4j.Logger;
@@ -38,20 +39,15 @@ public class PulsarPartitionLevelConnectionHandler {
 
   protected final PulsarConfig _config;
   protected final String _clientId;
-  protected final int _partition;
-  protected final String _topic;
   protected PulsarClient _pulsarClient = null;
-  protected Reader<byte[]> _reader = null;
 
   /**
    * Creates a new instance of {@link PulsarClient} and {@link Reader}
    */
-  public PulsarPartitionLevelConnectionHandler(String clientId, StreamConfig streamConfig, int partition) {
+  public PulsarPartitionLevelConnectionHandler(String clientId, StreamConfig streamConfig) {
     _config = new PulsarConfig(streamConfig, clientId);
     _clientId = clientId;
-    _partition = partition;
-    _topic = _config.getPulsarTopicName();
-
+    
     try {
       ClientBuilder pulsarClientBuilder = PulsarClient.builder().serviceUrl(_config.getBootstrapServers());
       if (_config.getTlsTrustCertsFilePath() != null) {
@@ -64,13 +60,22 @@ public class PulsarPartitionLevelConnectionHandler {
       }
 
       _pulsarClient = pulsarClientBuilder.build();
-
-      _reader = _pulsarClient.newReader().topic(getPartitionedTopicName(partition))
-          .startMessageId(_config.getInitialMessageId()).startMessageIdInclusive().create();
-
-      LOGGER.info("Created consumer with id {} for topic {}", _reader, _config.getPulsarTopicName());
+      LOGGER.info("Created pulsar client {}", _pulsarClient);
     } catch (Exception e) {
       LOGGER.error("Could not create pulsar consumer", e);
+    }
+  }
+
+  protected Reader<byte[]> createReaderForPartition(String topic, int partition, MessageId initialMessageId) {
+    if (_pulsarClient == null) {
+      throw new RuntimeException("Failed to create reader as no pulsar client found for topic " + topic);
+    }
+    try {
+      return _pulsarClient.newReader().topic(getPartitionedTopicName(topic, partition)).startMessageId(initialMessageId)
+          .startMessageIdInclusive().create();
+    } catch (Exception e) {
+      LOGGER.error("Failed to create pulsar consumer client for topic " + topic + " partition " + partition, e);
+      return null;
     }
   }
 
@@ -79,18 +84,14 @@ public class PulsarPartitionLevelConnectionHandler {
    * as suffix.
    * The method fetches the names of N partitioned topic and returns the topic name of {@param partition}
    */
-  protected String getPartitionedTopicName(int partition)
+  protected String getPartitionedTopicName(String topic, int partition)
       throws Exception {
-    List<String> partitionTopicList = _pulsarClient.getPartitionsForTopic(_topic).get();
+    List<String> partitionTopicList = _pulsarClient.getPartitionsForTopic(topic).get();
     return partitionTopicList.get(partition);
   }
 
   public void close()
       throws IOException {
-    if (_reader != null) {
-      _reader.close();
-    }
-
     if (_pulsarClient != null) {
       _pulsarClient.close();
     }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConsumer.java
@@ -35,6 +35,7 @@ import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.Reader;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -46,11 +47,18 @@ public class PulsarPartitionLevelConsumer extends PulsarPartitionLevelConnection
     implements PartitionGroupConsumer {
   private static final Logger LOGGER = LoggerFactory.getLogger(PulsarPartitionLevelConsumer.class);
   private final ExecutorService _executorService;
+  private final Reader _reader;
   private boolean _enableKeyValueStitch = false;
 
   public PulsarPartitionLevelConsumer(String clientId, StreamConfig streamConfig,
       PartitionGroupConsumptionStatus partitionGroupConsumptionStatus) {
-    super(clientId, streamConfig, partitionGroupConsumptionStatus.getPartitionGroupId());
+    super(clientId, streamConfig);
+    PulsarConfig config = new PulsarConfig(streamConfig, clientId);
+    _reader = createReaderForPartition(config.getPulsarTopicName(),
+        partitionGroupConsumptionStatus.getPartitionGroupId(),
+        config.getInitialMessageId());
+    LOGGER.info("Created pulsar reader with id {} for topic {} partition {}", _reader, _config.getPulsarTopicName(),
+        partitionGroupConsumptionStatus.getPartitionGroupId());
     _executorService = Executors.newSingleThreadExecutor();
     _enableKeyValueStitch = _config.getEnableKeyValueStitch();
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConsumer.java
@@ -136,6 +136,7 @@ public class PulsarPartitionLevelConsumer extends PulsarPartitionLevelConnection
   @Override
   public void close()
       throws IOException {
+    _reader.close();
     super.close();
     shutdownAndAwaitTermination();
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarStreamMetadataProvider.java
@@ -100,8 +100,8 @@ public class PulsarStreamMetadataProvider extends PulsarPartitionLevelConnection
       }
       return new MessageIdStreamOffset(offset);
     } catch (PulsarClientException e) {
-      LOGGER.error("Cannot fetch offsets for partition " + _partition + " and topic " + _topic
-          + " and offsetCriteria " + offsetCriteria, e);
+      LOGGER.error("Cannot fetch offsets for partition " + _partition + " and topic " + _topic + " and offsetCriteria "
+          + offsetCriteria, e);
       return null;
     }
   }


### PR DESCRIPTION
Pulsar Connection handler should not spin up a consumer / reader. It should only manage the `PulsarClient` which deals with the pulsar connection. Some minor improvements like using `final` variables in `PulsarConfig`. 

Label: `bugfix` 
