### PR TITLE
Fix race condition when 2 segment upload occurred for the same segment

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -193,7 +193,6 @@ public class SegmentDeletionManager {
       long effectiveDeletionDelay = Math.min(deletionDelay * 2, MAX_DELETION_DELAY_SECONDS);
       LOGGER.info("Postponing deletion of {} segments from table {}", segmentsToRetryLater.size(), tableName);
       deleteSegmentsWithDelay(tableName, segmentsToRetryLater, deletedSegmentsRetentionMs, effectiveDeletionDelay);
-      return;
     }
   }
 


### PR DESCRIPTION
There is a race condition when it took too much time for the 1st segment upload to process (due to slow PinotFS access), which leads to the 2nd attempt of segment upload, and the 2nd segment upload succeeded. In this case, when the 1st upload comes back, it shouldn't blindly delete the segment when it failed to update the zk metadata. Instead, the 1st attempt should validate the upload start time one more time. If the upload start time doesn't match with the one persisted in zk metadata, segment deletion should be skipped.