### PR TITLE
[multistage][bugfix] handle the case when dataschema does not have columns

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtils.java
@@ -76,9 +76,13 @@ public final class TransferableBlockUtils {
   public static Iterator<TransferableBlock> splitBlock(TransferableBlock block, DataBlock.Type type, int maxBlockSize) {
     List<TransferableBlock> blockChunks = new ArrayList<>();
     if (type == DataBlock.Type.ROW) {
-      // Use estimated row size, this estimate is not accurate and is used to estimate numRowsPerChunk only.
-      int estimatedRowSizeInBytes = block.getDataSchema().getColumnNames().length * MEDIAN_COLUMN_SIZE_BYTES;
-      int numRowsPerChunk = maxBlockSize / estimatedRowSizeInBytes;
+      // Use 1 row per chunk when block.getDataSchema().size() is 0, we may want to fine tune it.
+      int numRowsPerChunk = 1;
+      if (block.getDataSchema().size() != 0) {
+        // Use estimated row size, this estimate is not accurate and is used to estimate numRowsPerChunk only.
+        int estimatedRowSizeInBytes = block.getDataSchema().size() * MEDIAN_COLUMN_SIZE_BYTES;
+        numRowsPerChunk = maxBlockSize / estimatedRowSizeInBytes;
+      }
       Preconditions.checkState(numRowsPerChunk > 0, "row size too large for query engine to handle, abort!");
 
       int totalNumRows = block.getNumRows();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtilsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.runtime.blocks;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.pinot.common.datablock.BaseDataBlock;
@@ -54,6 +55,20 @@ public class TransferableBlockUtilsTest {
     }
     return new DataSchema(columnNames.toArray(new String[0]),
         columnDataTypes.toArray(new DataSchema.ColumnDataType[0]));
+  }
+
+  @Test
+  public void testSplitEmptyBlock() {
+    DataSchema dataSchema = getDataSchema();
+    Iterator<TransferableBlock> transferableBlockIterator = TransferableBlockUtils.splitBlock(
+        new TransferableBlock(Collections.emptyList(), dataSchema, DataBlock.Type.ROW), DataBlock.Type.ROW,
+        dataSchema.size() * TEST_EST_BYTES_PER_COLUMN + 1);
+    Assert.assertFalse(transferableBlockIterator.hasNext());
+
+    dataSchema = new DataSchema(new String[0], new DataSchema.ColumnDataType[0]);
+    transferableBlockIterator = TransferableBlockUtils.splitBlock(
+        new TransferableBlock(Collections.emptyList(), dataSchema, DataBlock.Type.ROW), DataBlock.Type.ROW, 1);
+    Assert.assertFalse(transferableBlockIterator.hasNext());
   }
 
   @DataProvider

--- a/pinot-query-runtime/src/test/resources/queries/SelectHaving.json
+++ b/pinot-query-runtime/src/test/resources/queries/SelectHaving.json
@@ -55,8 +55,6 @@
         "sql":"SELECT 1 AS one FROM {test_having} HAVING 1 > 2;"
       },
       {
-        "ignored": true,
-        "comment": "Runtime failure: java.lang.ArithmeticException: / by zero",
         "sql":"SELECT 1 AS one FROM {test_having} HAVING 1 < 2;"
       },
       {


### PR DESCRIPTION
Previously, the splitBlock logic throws `Runtime failure: java.lang.ArithmeticException: / by zero`. This PR fixes this issue.
