### PR TITLE
Allow collections for MV transform functions

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
@@ -20,6 +20,7 @@ package org.apache.pinot.common.function;
 
 import java.math.BigDecimal;
 import java.sql.Timestamp;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -80,6 +81,7 @@ public class FunctionUtils {
     put(Double[].class, PinotDataType.DOUBLE_ARRAY);
     put(String[].class, PinotDataType.STRING_ARRAY);
     put(Object.class, PinotDataType.OBJECT);
+    put(Object[].class, PinotDataType.OBJECT_ARRAY);
   }};
 
   private static final Map<Class<?>, DataType> DATA_TYPE_MAP = new HashMap<Class<?>, DataType>() {{
@@ -140,6 +142,9 @@ public class FunctionUtils {
    */
   @Nullable
   public static PinotDataType getArgumentType(Class<?> clazz) {
+    if (Collection.class.isAssignableFrom(clazz)) {
+      return PinotDataType.COLLECTION;
+    }
     return ARGUMENT_TYPE_MAP.get(clazz);
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.core.JsonParseException;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.Base64;
+import java.util.Collection;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -923,6 +924,8 @@ public enum PinotDataType {
     }
   },
 
+  COLLECTION,
+
   OBJECT_ARRAY;
 
   /**
@@ -1201,6 +1204,9 @@ public enum PinotDataType {
   }
 
   private static Object[] toObjectArray(Object array) {
+    if (array instanceof Collection) {
+      return ((Collection<?>) array).toArray();
+    }
     Class<?> componentType = array.getClass().getComponentType();
     if (componentType.isPrimitive()) {
       if (componentType == int.class) {
@@ -1301,6 +1307,7 @@ public enum PinotDataType {
       case BYTES_ARRAY:
         return BYTES;
       case OBJECT_ARRAY:
+      case COLLECTION:
         return OBJECT;
       case BOOLEAN_ARRAY:
         return BOOLEAN;

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
@@ -144,7 +144,11 @@ public class PinotDataTypeTest {
         {TIMESTAMP_ARRAY, TIMESTAMP_ARRAY, new Timestamp[] { new Timestamp(1000000L), new Timestamp(2000000L) },
         new Timestamp[] { new Timestamp(1000000L), new Timestamp(2000000L) }},
         {BYTES_ARRAY, BYTES_ARRAY, new byte[][] { "foo".getBytes(UTF_8), "bar".getBytes(UTF_8) },
-            new byte[][] { "foo".getBytes(UTF_8), "bar".getBytes(UTF_8) }}
+            new byte[][] { "foo".getBytes(UTF_8), "bar".getBytes(UTF_8) }},
+        {COLLECTION, STRING_ARRAY, Arrays.asList("test1", "test2"), new String[] {"test1", "test2"}},
+        {COLLECTION, FLOAT_ARRAY, Arrays.asList(1.0f, 2.0f), new Float[] {1.0f, 2.0f}},
+        {OBJECT_ARRAY, STRING_ARRAY, new Object[] {"test1", "test2"}, new String[] {"test1", "test2"}},
+        {OBJECT_ARRAY, FLOAT_ARRAY, new Object[] {1.0f, 2.0f}, new Float[] {1.0f, 2.0f}},
     };
   }
 


### PR DESCRIPTION
Fix for issues like
```
Caused by: java.lang.RuntimeException: Caught exception while executing function: arrayIndexOfString(subject,'History')
	at org.apache.pinot.segment.local.function.InbuiltFunctionEvaluator$FunctionExecutionNode.execute(InbuiltFunctionEvaluator.java:254) ~[classes/:?]
	at org.apache.pinot.segment.local.function.InbuiltFunctionEvaluator$FunctionExecutionNode.execute(InbuiltFunctionEvaluator.java:240) ~[classes/:?]
	at org.apache.pinot.segment.local.function.InbuiltFunctionEvaluator$FunctionExecutionNode.execute(InbuiltFunctionEvaluator.java:240) ~[classes/:?]
	... 31 more
Caused by: java.lang.IllegalArgumentException: Cannot convert value from class: class [Ljava.lang.Object; to class: class [Ljava.lang.String;
	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:383) ~[guava-20.0.jar:?]
	at org.apache.pinot.common.function.FunctionInvoker.convertTypes(FunctionInvoker.java:108) ~[classes/:?]
	at org.apache.pinot.segment.local.function.InbuiltFunctionEvaluator$FunctionExecutionNode.execute(InbuiltFunctionEvaluator.java:251) ~[classes/:?]
	at org.apache.pinot.segment.local.function.InbuiltFunctionEvaluator$FunctionExecutionNode.execute(InbuiltFunctionEvaluator.java:240) ~[classes/:?]
	at org.apache.pinot.segment.local.function.InbuiltFunctionEvaluator$FunctionExecutionNode.execute(InbuiltFunctionEvaluator.java:240) ~[classes/:?]
	... 31 more
```

When using arrayIndexOfX on MV columns