### PR TITLE
fallback if no broker found for the specified table name

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/DynamicBrokerSelector.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/DynamicBrokerSelector.java
@@ -87,21 +87,21 @@ public class DynamicBrokerSelector implements BrokerSelector, IZkDataListener {
   @Nullable
   @Override
   public String selectBroker(String table) {
-    if (table == null) {
-      List<String> list = _allBrokerListRef.get();
+    if (table != null) {
+      String tableName =
+          table.replace(ExternalViewReader.OFFLINE_SUFFIX, "").replace(ExternalViewReader.REALTIME_SUFFIX, "");
+      List<String> list = _tableToBrokerListMapRef.get().get(tableName);
       if (list != null && !list.isEmpty()) {
         return list.get(RANDOM.nextInt(list.size()));
-      } else {
-        return null;
       }
     }
-    String tableName = table.replace(ExternalViewReader.OFFLINE_SUFFIX, "")
-        .replace(ExternalViewReader.REALTIME_SUFFIX, "");
-    List<String> list = _tableToBrokerListMapRef.get().get(tableName);
+    // Return a one randomly if table is null or no broker is found for the specified table.
+    List<String> list = _allBrokerListRef.get();
     if (list != null && !list.isEmpty()) {
       return list.get(RANDOM.nextInt(list.size()));
+    } else {
+      return null;
     }
-    return null;
   }
 
   @Override


### PR DESCRIPTION
Try to fix a test failure caused by changes in https://github.com/apache/pinot/pull/9902

Previously, `null` was provided to DynamicBrokerSelector to get a random broker. With the new changes in #9902 now `db.mytable` is passed to DynamicBrokerSelector. However, DynamicBrokerSelector has no brokers for the this table name, although it has brokers for `mytable` w/o the db name.
