### PR TITLE
[multistage] fix decimal types

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
@@ -38,13 +38,19 @@ public final class DataBlockUtils {
   static final int VERSION_TYPE_SHIFT = 5;
 
   public static MetadataBlock getErrorDataBlock(Exception e) {
-    String errorMessage = e.getMessage() == null ? e.toString() : e.getMessage();
     if (e instanceof ProcessingException) {
-      return getErrorDataBlock(Collections.singletonMap(((ProcessingException) e).getErrorCode(), errorMessage));
+      return getErrorDataBlock(Collections.singletonMap(((ProcessingException) e).getErrorCode(), extractErrorMsg(e)));
     } else {
       // TODO: Pass in meaningful error code.
-      return getErrorDataBlock(Collections.singletonMap(QueryException.UNKNOWN_ERROR_CODE, errorMessage));
+      return getErrorDataBlock(Collections.singletonMap(QueryException.UNKNOWN_ERROR_CODE, extractErrorMsg(e)));
     }
+  }
+
+  private static String extractErrorMsg(Throwable t) {
+    while (t.getMessage() == null) {
+      t = t.getCause();
+    }
+    return QueryException.getTruncatedStackTrace(t);
   }
 
   public static MetadataBlock getErrorDataBlock(Map<Integer, String> exceptions) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTest.java
@@ -55,8 +55,8 @@ public class DataBlockTest {
     // Assert processing exception and original exception both matches.
     String actual = dataBlock.getExceptions().get(QueryException.QUERY_EXECUTION_ERROR.getErrorCode());
     Assert.assertEquals(actual, expected);
-    Assert.assertEquals(dataBlock.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE),
-        originalException.getMessage());
+    Assert.assertTrue(dataBlock.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE)
+        .contains(originalException.getMessage()));
   }
 
   @Test(dataProvider = "testTypeNullPercentile")

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -334,7 +334,7 @@ public class HashJoinOperatorTest {
     }
     Assert.assertTrue(result.isErrorBlock());
     MetadataBlock errorBlock = (MetadataBlock) result.getDataBlock();
-    Assert.assertTrue(errorBlock.getExceptions().get(1000).matches(".*notEquals.*"));
+    Assert.assertTrue(errorBlock.getExceptions().get(1000).contains("notEquals"));
   }
 
   @Test
@@ -501,7 +501,7 @@ public class HashJoinOperatorTest {
     }
     Assert.assertTrue(result.isErrorBlock());
     Assert.assertTrue(result.getDataBlock().getExceptions().get(QueryException.UNKNOWN_ERROR_CODE)
-        .matches("testInnerJoinRightError"));
+        .contains("testInnerJoinRightError"));
   }
 
   @Test
@@ -529,8 +529,8 @@ public class HashJoinOperatorTest {
       result = join.nextBlock();
     }
     Assert.assertTrue(result.isErrorBlock());
-    Assert.assertTrue(
-        result.getDataBlock().getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).matches("testInnerJoinLeftError"));
+    Assert.assertTrue(result.getDataBlock().getExceptions().get(QueryException.UNKNOWN_ERROR_CODE)
+        .contains("testInnerJoinLeftError"));
   }
 
   @Test

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -288,7 +288,7 @@ public class MailboxReceiveOperatorTest {
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     Assert.assertTrue(receivedBlock.isErrorBlock());
     MetadataBlock error = (MetadataBlock) receivedBlock.getDataBlock();
-    Assert.assertEquals(error.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE), "errorBlock");
+    Assert.assertTrue(error.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("errorBlock"));
   }
 
   @Test
@@ -461,7 +461,7 @@ public class MailboxReceiveOperatorTest {
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     Assert.assertTrue(receivedBlock.isErrorBlock());
     MetadataBlock error = (MetadataBlock) receivedBlock.getDataBlock();
-    Assert.assertEquals(error.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE), "mailboxError");
+    Assert.assertTrue(error.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("mailboxError"));
   }
 
   // TODO: Exception should be passed as an errorBlock.

--- a/pinot-query-runtime/src/test/resources/queries/LexicalStructure.json
+++ b/pinot-query-runtime/src/test/resources/queries/LexicalStructure.json
@@ -135,11 +135,18 @@
         "inputs": [["1"]]
       }
     },
-    "queries": [{
-      "psql": "4.1.2.6",
-      "description": "numeric constant supports",
-      "sql": "SELECT data, 42, 3.5, 4., .001, 5e2, 1.925e-3 FROM {tbl}"
-    }]
+    "queries": [
+      {
+        "psql": "4.1.2.6",
+        "description": "numeric constant supports",
+        "sql": "SELECT data, 42, 3.5, 4., .001, 5e2, 1.925e-3 FROM {tbl}"
+      },
+      {
+        "psql": "4.1.2.6",
+        "description": "numeric constant supports",
+        "sql": "SELECT data, 42, CAST(3.5 AS FLOAT), CAST(4. AS FLOAT), CAST(.001 AS FLOAT), CAST(5e2 AS FLOAT), CAST(1.925e-3 AS FLOAT) FROM {tbl}"
+      }
+    ]
   },
   "constant_casting": {
     "tables": {

--- a/pinot-query-runtime/src/test/resources/queries/MathFuncs.json
+++ b/pinot-query-runtime/src/test/resources/queries/MathFuncs.json
@@ -435,5 +435,95 @@
         "sql": "SELECT ceil(2.0) FROM {numTbl}"
       }
     ]
+  },
+  "decimal_type_conversion": {
+    "tables": {
+      "numTbl": {
+        "schema": [
+          {"name": "intCol", "type": "INT"},
+          {"name": "longCol", "type": "LONG"},
+          {"name": "doubleCol", "type": "DOUBLE"},
+          {"name": "floatCol", "type": "FLOAT"}
+        ],
+        "inputs": [
+          [0, 0, 0.1, 3.2],
+          [123, 321, 4.2, 3.0],
+          [-456, -2, 1.1, 7.7],
+          [123, -456, 3.6, 9.1]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "description": "test addition on doubleCol plus large decimal DOES NOT convert to BigDecimal",
+        "sql": "SELECT doubleCol + 1e250 FROM {numTbl}"
+      },
+      {
+        "ignored": true,
+        "comments": "Pinot hoist type to double but H2 doesn't",
+        "description": "test addition on floatCol plus large decimal to convert to double",
+        "sql": "SELECT floatCol + 1e50 FROM {numTbl}"
+      },
+      {
+        "description": "test addition on intCol plus large decimal to convert to long",
+        "sql": "SELECT intCol + 1e40 FROM {numTbl}"
+      },
+      {
+        "description": "test addition on longCol plus large decimal to convert to float/double",
+        "sql": "SELECT longCol + 1e20 FROM {numTbl}"
+      },
+      {
+        "description": "test on doubleCol plus large decimal DOES NOT convert to BigDecimal",
+        "sql": "SELECT doubleCol - 1e250 FROM {numTbl}"
+      },
+      {
+        "ignored": true,
+        "comments": "Pinot hoist type to double but H2 doesn't",
+        "description": "test on floatCol plus large decimal to convert to double",
+        "sql": "SELECT floatCol - 1e50 FROM {numTbl}"
+      },
+      {
+        "description": "test on intCol plus large decimal to convert to long",
+        "sql": "SELECT intCol - 1e40 FROM {numTbl}"
+      },
+      {
+        "description": "test on longCol plus large decimal to convert to float/double",
+        "sql": "SELECT longCol - 1e20 FROM {numTbl}"
+      },
+      {
+        "description": "test on doubleCol plus large decimal to convert to bigDecimal",
+        "sql": "SELECT doubleCol * 1e50 FROM {numTbl}"
+      },
+      {
+        "ignored": true,
+        "comments": "Pinot hoist type to double but H2 doesn't",
+        "description": "test on floatCol plus large decimal to convert to double",
+        "sql": "SELECT floatCol * 1e50 FROM {numTbl}"
+      },
+      {
+        "description": "test on intCol plus large decimal to convert to long",
+        "sql": "SELECT intCol * 1e10 FROM {numTbl}"
+      },
+      {
+        "description": "test on longCol plus large decimal to convert to float/double",
+        "sql": "SELECT longCol * 1e20 FROM {numTbl}"
+      },
+      {
+        "description": "test on doubleCol plus large decimal to convert to bigDecimal",
+        "sql": "SELECT doubleCol / 1e50 FROM {numTbl}"
+      },
+      {
+        "description": "test on floatCol plus large decimal to convert to double",
+        "sql": "SELECT floatCol / 1e50 FROM {numTbl}"
+      },
+      {
+        "description": "test on intCol plus large decimal DOES NOT convert to floating point",
+        "sql": "SELECT intCol / 1e10 FROM {numTbl}"
+      },
+      {
+        "description": "test on longCol plus large decimal DOES NOT convert to floating point",
+        "sql": "SELECT longCol / 1e20 FROM {numTbl}"
+      }
+    ]
   }
 }


### PR DESCRIPTION
calcite creates decimal types based on precision of literals. 

- This PR makes it honor precision hoisting.
- Also made error propagation include stack trace.