### PR TITLE
Add back the Helix workaround for missing IS change

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -41,6 +41,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.HelixManagerFactory;
 import org.apache.helix.InstanceType;
 import org.apache.helix.NotificationContext;
+import org.apache.helix.model.ClusterConfig;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.Message;
 import org.apache.helix.model.ResourceConfig;
@@ -253,6 +254,10 @@ public class ControllerTest {
       case PINOT_ONLY:
         _helixAdmin = _helixResourceManager.getHelixAdmin();
         _propertyStore = _helixResourceManager.getPropertyStore();
+        // TODO: Enable periodic rebalance per 10 seconds as a temporary work-around for the Helix issue:
+        //       https://github.com/apache/helix/issues/331 and https://github.com/apache/helix/issues/2309.
+        //       Remove this after Helix fixing the issue.
+        configAccessor.set(scope, ClusterConfig.ClusterConfigProperty.REBALANCE_TIMER_PERIOD.name(), "10000");
         break;
       case HELIX_ONLY:
         _helixAdmin = _helixManager.getClusterManagmentTool();


### PR DESCRIPTION
Adds back the Helix workaround introduced in #4459 and removed in #9634.
Seems the issue is still not fixed in `helix-1.0.4`, so submitted a separate issue https://github.com/apache/helix/issues/2309.

This workaround can fix #9897, but currently only applied to the tests