### PR TITLE
Fixed flaky test in PluginManagerTest

### DIFF
--- a/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
-import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.jar.JarEntry;
@@ -96,25 +95,16 @@ public class PluginManagerTest {
     HashMap<String, File> actualPluginsMap = PluginManager.get().getPluginsToLoad(pluginsDirs, pluginsToInclude);
     Assert.assertEquals(actualPluginsMap.size(), 3);
 
-    HashSet<String> actualPluginNames = new HashSet<>();
-    HashSet<String> actualPluginPaths = new HashSet<>();
-
+    HashMap<String, String> actualPluginNamesAndPaths = new HashMap<>();
     for (Map.Entry<String, File> entry : actualPluginsMap.entrySet()) {
-      actualPluginNames.add(entry.getKey());
-      actualPluginPaths.add(entry.getValue().getAbsolutePath());
+      actualPluginNamesAndPaths.put(entry.getKey(), entry.getValue().getAbsolutePath());
     }
+    HashMap<String, String> expectedPluginNamesAndPaths = new HashMap<>();
+    expectedPluginNamesAndPaths.put("p1", _p1.getParentFile().getAbsolutePath());
+    expectedPluginNamesAndPaths.put("p2", _p2.getParentFile().getAbsolutePath());
+    expectedPluginNamesAndPaths.put("p3", _p3.getParentFile().getAbsolutePath());
 
-    HashSet<String> expectedPluginNames = new HashSet<>();
-    expectedPluginNames.add("p1");
-    expectedPluginNames.add("p2");
-    expectedPluginNames.add("p3");
-    HashSet<String> expectedPluginPaths = new HashSet<>();
-    expectedPluginPaths.add(_p1.getParentFile().getAbsolutePath());
-    expectedPluginPaths.add(_p2.getParentFile().getAbsolutePath());
-    expectedPluginPaths.add(_p3.getParentFile().getAbsolutePath());
-
-    Assert.assertEquals(actualPluginNames, expectedPluginNames);
-    Assert.assertEquals(actualPluginPaths, expectedPluginPaths);
+    Assert.assertEquals(actualPluginNamesAndPaths, expectedPluginNamesAndPaths);
   }
 
   @Test

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/plugin/PluginManagerTest.java
@@ -22,7 +22,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.net.URL;
-import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.jar.JarEntry;
@@ -96,19 +96,19 @@ public class PluginManagerTest {
     HashMap<String, File> actualPluginsMap = PluginManager.get().getPluginsToLoad(pluginsDirs, pluginsToInclude);
     Assert.assertEquals(actualPluginsMap.size(), 3);
 
-    ArrayList<String> actualPluginNames = new ArrayList<>();
-    ArrayList<String> actualPluginPaths = new ArrayList<>();
+    HashSet<String> actualPluginNames = new HashSet<>();
+    HashSet<String> actualPluginPaths = new HashSet<>();
 
     for (Map.Entry<String, File> entry : actualPluginsMap.entrySet()) {
       actualPluginNames.add(entry.getKey());
       actualPluginPaths.add(entry.getValue().getAbsolutePath());
     }
 
-    ArrayList<String> expectedPluginNames = new ArrayList<>();
+    HashSet<String> expectedPluginNames = new HashSet<>();
     expectedPluginNames.add("p1");
     expectedPluginNames.add("p2");
     expectedPluginNames.add("p3");
-    ArrayList<String> expectedPluginPaths = new ArrayList<>();
+    HashSet<String> expectedPluginPaths = new HashSet<>();
     expectedPluginPaths.add(_p1.getParentFile().getAbsolutePath());
     expectedPluginPaths.add(_p2.getParentFile().getAbsolutePath());
     expectedPluginPaths.add(_p3.getParentFile().getAbsolutePath());


### PR DESCRIPTION
`bugfix`

Context
Fixed the flaky test in [9924](https://github.com/apache/pinot/issues/9924). The cause of it is that the test writes keys and values of a hashmap in to a list in a for loop, however, the order of the the map entry in a hashmap is non-deterministic.

Fix
Since the purpose of the test is not checking the order, it's more reasonable to write the keys and values in to hashsets than arraylists.