### PR TITLE
[DRAFT] check aggregate functions for type safety before running query

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/ExpressionContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/ExpressionContext.java
@@ -104,6 +104,19 @@ public class ExpressionContext {
     }
   }
 
+  public <T> T visit(ExpressionContextVisitor<T> visitor) {
+    switch (_type) {
+      case LITERAL:
+        return visitor.visitLiteral(_literal);
+      case IDENTIFIER:
+        return visitor.visitIdentifier(_identifier);
+      case FUNCTION:
+        return visitor.visitFunction(_function);
+      default:
+        throw new IllegalStateException("Unexpected _type " + _type);
+    }
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/ExpressionContextVisitor.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/ExpressionContextVisitor.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.common.request.context;
+
+public interface ExpressionContextVisitor<T> {
+
+  T visitLiteral(LiteralContext literal);
+
+  T visitIdentifier(String identifier);
+
+  T visitFunction(FunctionContext function);
+
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -1483,4 +1483,47 @@ public enum PinotDataType {
         throw new IllegalStateException("Cannot convert ColumnDataType: " + columnDataType + " to PinotDataType");
     }
   }
+
+  public static ColumnDataType toColumnDataType(PinotDataType dataType) {
+    switch (dataType) {
+      case INTEGER:
+        return ColumnDataType.INT;
+      case LONG:
+        return ColumnDataType.LONG;
+      case FLOAT:
+        return ColumnDataType.FLOAT;
+      case DOUBLE:
+        return ColumnDataType.DOUBLE;
+      case BIG_DECIMAL:
+        return ColumnDataType.BIG_DECIMAL;
+      case BOOLEAN:
+        return ColumnDataType.BOOLEAN;
+      case TIMESTAMP:
+        return ColumnDataType.TIMESTAMP;
+      case STRING:
+        return ColumnDataType.STRING;
+      case JSON:
+        return ColumnDataType.JSON;
+      case BYTES:
+        return ColumnDataType.BYTES;
+      case PRIMITIVE_INT_ARRAY:
+      case INTEGER_ARRAY:
+        return ColumnDataType.INT_ARRAY;
+      case PRIMITIVE_LONG_ARRAY:
+      case LONG_ARRAY:
+        return ColumnDataType.LONG_ARRAY;
+      case PRIMITIVE_FLOAT_ARRAY:
+      case FLOAT_ARRAY:
+        return ColumnDataType.FLOAT_ARRAY;
+      case PRIMITIVE_DOUBLE_ARRAY:
+      case DOUBLE_ARRAY:
+        return ColumnDataType.DOUBLE_ARRAY;
+      case STRING_ARRAY:
+        return ColumnDataType.STRING_ARRAY;
+      case OBJECT:
+        return ColumnDataType.OBJECT;
+      default:
+        throw new IllegalArgumentException("Cannot convert PinotDataType " + dataType + " to ColumnDataType");
+    }
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
@@ -48,11 +48,14 @@ public class IsNotNullTransformFunction extends BaseTransformFunction {
           "Only column names are supported in IS_NOT_NULL. Support for functions is planned for future release");
     }
     String columnName = ((IdentifierTransformFunction) transformFunction).getColumnName();
-    NullValueVectorReader nullValueVectorReader = dataSourceMap.get(columnName).getNullValueVector();
-    if (nullValueVectorReader != null) {
-      _nullValueVectorIterator = nullValueVectorReader.getNullBitmap().getIntIterator();
-    } else {
-      _nullValueVectorIterator = null;
+    DataSource dataSource = dataSourceMap.get(columnName);
+    if (dataSource != null) {
+      NullValueVectorReader nullValueVectorReader = dataSource.getNullValueVector();
+      if (nullValueVectorReader != null) {
+        _nullValueVectorIterator = nullValueVectorReader.getNullBitmap().getIntIterator();
+      } else {
+        _nullValueVectorIterator = null;
+      }
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
@@ -47,11 +47,14 @@ public class IsNullTransformFunction extends BaseTransformFunction {
           "Only column names are supported in IS_NULL. Support for functions is planned for future release");
     }
     String columnName = ((IdentifierTransformFunction) transformFunction).getColumnName();
-    NullValueVectorReader nullValueVectorReader = dataSourceMap.get(columnName).getNullValueVector();
-    if (nullValueVectorReader != null) {
-      _nullValueVectorIterator = nullValueVectorReader.getNullBitmap().getIntIterator();
-    } else {
-      _nullValueVectorIterator = null;
+    DataSource dataSource = dataSourceMap.get(columnName);
+    if (dataSource != null) {
+      NullValueVectorReader nullValueVectorReader = dataSource.getNullValueVector();
+      if (nullValueVectorReader != null) {
+        _nullValueVectorIterator = nullValueVectorReader.getNullBitmap().getIntIterator();
+      } else {
+        _nullValueVectorIterator = null;
+      }
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -124,6 +124,19 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
   ColumnDataType getFinalResultColumnType();
 
   /**
+   * Validates that this function can operate on the given input types
+   *
+   * @param inputs the input types
+   * @return whether or not these types are valid
+   */
+  default boolean validateInputTypes(List<ColumnDataType> inputs) {
+    // TODO: in a follow-up PR we should go through and implement this for every
+    // aggregation function, for now we just return true so we can focus on the
+    // framework for validating input types
+    return true;
+  }
+
+  /**
    * Extracts the final result used in the broker response from the given intermediate result.
    * TODO: Support serializing/deserializing null values in DataTable and use null as the empty intermediate result
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumAggregationFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.math.BigDecimal;
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -287,6 +288,11 @@ public class SumAggregationFunction extends BaseSingleInputAggregationFunction<D
   @Override
   public ColumnDataType getFinalResultColumnType() {
     return ColumnDataType.DOUBLE;
+  }
+
+  @Override
+  public boolean validateInputTypes(List<ColumnDataType> inputs) {
+    return inputs.size() == 1 && inputs.get(0).isNumber();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
@@ -18,8 +18,10 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -78,5 +80,10 @@ public class SumMVAggregationFunction extends SumAggregationFunction {
         groupByResultHolder.setValueForKey(groupKey, sum);
       }
     }
+  }
+
+  @Override
+  public boolean validateInputTypes(List<DataSchema.ColumnDataType> inputs) {
+    return inputs.size() == 1 && inputs.get(0).isNumberArray();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/utils/ExpressionTypeResolver.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/utils/ExpressionTypeResolver.java
@@ -1,0 +1,139 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.core.query.utils;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.primitives.Primitives;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.pinot.common.function.FunctionInfo;
+import org.apache.pinot.common.function.FunctionRegistry;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.ExpressionContextVisitor;
+import org.apache.pinot.common.request.context.FunctionContext;
+import org.apache.pinot.common.request.context.LiteralContext;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.PinotDataType;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.core.operator.transform.function.TransformFunction;
+import org.apache.pinot.core.operator.transform.function.TransformFunctionFactory;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionFactory;
+import org.apache.pinot.core.query.aggregation.function.DistinctAggregationFunction;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.Schema;
+
+
+public class ExpressionTypeResolver implements ExpressionContextVisitor<PinotDataType> {
+
+  private final Schema _schema;
+  private final QueryContext _queryContext;
+
+  public ExpressionTypeResolver(Schema schema, QueryContext queryContext) {
+    _schema = schema;
+    _queryContext = queryContext;
+  }
+
+  @Override
+  public PinotDataType visitLiteral(LiteralContext literal) {
+    return PinotDataType.getPinotDataTypeForIngestion(new DimensionFieldSpec("ignored", literal.getType(), true));
+  }
+
+  @Override
+  public PinotDataType visitIdentifier(String identifier) {
+    if (identifier.equals("*")) {
+      // handle this specially, as star should not be the input to any function
+      // other than COUNT, which accepts all inputs
+      return PinotDataType.OBJECT;
+    }
+    return PinotDataType.getPinotDataTypeForIngestion(_schema.getFieldSpecFor(identifier));
+  }
+
+  @Override
+  public PinotDataType visitFunction(FunctionContext function) {
+    List<DataSchema.ColumnDataType> argumentTypes =
+        function.getArguments()
+            .stream()
+            .map(ec -> ec.visit(this))
+            .map(PinotDataType::toColumnDataType)
+            .collect(Collectors.toList());
+
+    String name = function.getFunctionName();
+    switch (function.getType()) {
+      case TRANSFORM:
+        FunctionInfo info = FunctionRegistry.getFunctionInfo(name, argumentTypes.size());
+        return info != null ? validateScalar(name, info, argumentTypes) : validateTransform(function);
+      case AGGREGATION:
+        return validateAggregate(function, argumentTypes);
+      default:
+        throw new UnsupportedOperationException("Illegal function type: " + function.getType());
+    }
+  }
+
+  private PinotDataType validateScalar(String name, FunctionInfo info, List<DataSchema.ColumnDataType> argumentTypes) {
+    Class<?>[] parameterTypes = info.getMethod().getParameterTypes();
+    for (int i = 0; i < parameterTypes.length; i++) {
+      DataSchema.ColumnDataType paramType = argumentTypes.get(i);
+      if (!paramType.canAssignTo(parameterTypes[i])) {
+        throw new IllegalArgumentException("Scalar Function " + name + " does not support input types: "
+            + argumentTypes);
+      }
+    }
+    return typeFromClass(info.getMethod().getReturnType());
+  }
+
+  private static PinotDataType typeFromClass(Class<?> clazz) {
+    clazz = Primitives.wrap(clazz);
+    return clazz.isArray()
+        ? PinotDataType.getMultiValueType(Primitives.wrap(clazz.getComponentType()))
+        : PinotDataType.getSingleValueType(clazz);
+  }
+
+  private PinotDataType validateTransform(FunctionContext function) {
+    // try Transform Function - note that we pass an ImmutableMap.of for the data source map
+    // so that we can call this function without access to the data; at the moment, the data
+    // source map is only used in IsNullTransformFunction and IsNotNullTransformFunction to
+    // get the null bitmap - this is not necessary for calling getResultMetadata
+    // TODO: split TransformFunction#init into two functions so that it is clear that one
+    // TODO: only initializes the getResultMetadata part and does not rely on DataSource
+    TransformFunction transformFunction =
+        TransformFunctionFactory.get(_queryContext, ExpressionContext.forFunction(function), ImmutableMap.of());
+    if (transformFunction != null) {
+      TransformResultMetadata resultMetadata = transformFunction.getResultMetadata();
+      return PinotDataType.getPinotDataTypeForIngestion(
+          new DimensionFieldSpec("ignored", resultMetadata.getDataType(), resultMetadata.isSingleValue()));
+    }
+    throw new IllegalArgumentException("Could not find function with name " + function.getFunctionName());
+  }
+
+  private PinotDataType validateAggregate(FunctionContext function, List<DataSchema.ColumnDataType> argumentTypes) {
+    AggregationFunction<?, ?> agg = AggregationFunctionFactory.getAggregationFunction(function, _queryContext);
+    if (!agg.validateInputTypes(argumentTypes)) {
+      throw new IllegalArgumentException("Aggregate Function " + function.getFunctionName()
+          + " does not support input types: " + argumentTypes);
+    } else if (agg instanceof DistinctAggregationFunction) {
+      // DISTINCT is a top-level aggregation and should never feed into anything else,
+      // just like with "*" we just return OBJECT
+      return PinotDataType.OBJECT;
+    }
+    return PinotDataType.getPinotDataTypeForExecution(agg.getFinalResultColumnType());
+  }
+}


### PR DESCRIPTION
Fixes #8409 - if you issue a query with a function that does not match the expected signature you will get the following error message as response:
```
[
  {
    "errorCode": 200,
    "message": "QueryExecutionError:\njava.lang.IllegalArgumentException: Function sum does not support input types: [STRING]\n\tat org.apache.pinot.core.query.utils.ExpressionTypeResolver.visitFunction(ExpressionTypeResolver.java:113)\n\tat org.apache.pinot.core.query.utils.ExpressionTypeResolver.visitFunction(ExpressionTypeResolver.java:47)\n\tat org.apache.pinot.common.request.context.ExpressionContext.visit(ExpressionContext.java:114)\n\tat org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2.lambda$makeSegmentPlanNode$0(InstancePlanMakerImplV2.java:241)"
  }
]
```

This PR works by introducing a visitor that traverses an Expression Context graph and resolves all input/output types recursively to make sure that aggregate functions can be properly resolved.

**NOTE:** this does not verify the validity of scalar or transform functions.