### PR TITLE
Fixed flaky test in URIUtilsTest

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/URIUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/URIUtilsTest.java
@@ -20,7 +20,7 @@ package org.apache.pinot.common.utils;
 
 import java.net.URI;
 import java.util.Collections;
-import java.util.HashMap;
+import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.Random;
 import org.apache.commons.lang3.RandomStringUtils;
@@ -82,7 +82,7 @@ public class URIUtilsTest {
     Assert.assertEquals(uri.getPort(), 8080);
 
     // test that params get encoded
-    Map<String, String> params = new HashMap<>();
+    Map<String, String> params = new LinkedHashMap<>();
     params.put("stringParam", "aString");
     params.put("stringParamNeedsEncoding", "{\"format\":\"JSON\",\"timeout\":1000}");
     uri = URIUtils.buildURI("http", "foo", "bar", params);


### PR DESCRIPTION
`bugfix`

Context
Fixed the flaky test in [9926](https://github.com/apache/pinot/issues/9926). The cause of it is that the test passes a hashmap to `URIUtils.buildURI` and in that function, it uses a for loop to iterate through the map entry and concatenate the parameters into the URI string. However, the order of the the map entry in a hashmap is non-deterministic, so different URI string could be formed even with the same hashmap.

Fix
In the test, use `LinkedHashMap` instead of `HashMap` so the order of the entry will be deterministic in different runs.
