### PR TITLE
[multistage] add observability logging for thread scheduling

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainScheduler.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainScheduler.java
@@ -55,4 +55,9 @@ public interface OpChainScheduler {
    *         prior to this call
    */
   OpChain next();
+
+  /**
+   * @return the number of operator chains that are awaiting execution
+   */
+  int size();
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/RoundRobinScheduler.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/RoundRobinScheduler.java
@@ -64,6 +64,7 @@ public class RoundRobinScheduler implements OpChainScheduler {
     // immediately be considered ready in case it does not need
     // read from any mailbox (e.g. with a LiteralValueOperator)
     (isNew ? _ready : _available).add(operatorChain);
+    trace("registered " + operatorChain);
   }
 
   @Override
@@ -85,6 +86,7 @@ public class RoundRobinScheduler implements OpChainScheduler {
     //
     // TODO: fix the memory leak by adding a close(opChain) callback
     _seenMail.add(mailbox);
+    trace("got mail for " + mailbox);
   }
 
   @Override
@@ -95,7 +97,14 @@ public class RoundRobinScheduler implements OpChainScheduler {
 
   @Override
   public OpChain next() {
-    return _ready.poll();
+    OpChain op = _ready.poll();
+    trace("Polled " + op);
+    return op;
+  }
+
+  @Override
+  public int size() {
+    return _ready.size() + _available.size();
   }
 
   private void computeReady() {
@@ -120,5 +129,10 @@ public class RoundRobinScheduler implements OpChainScheduler {
         availableChains.remove();
       }
     }
+  }
+
+  private void trace(String operation) {
+    LOGGER.trace("({}) Ready: {}, Available: {}, Mail: {}",
+        operation, _ready, _available, _seenMail);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainStats.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.query.runtime.operator;
+
+import com.google.common.base.Stopwatch;
+import com.google.common.base.Suppliers;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Supplier;
+import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
+
+
+/**
+ * {@code OpChainStats} tracks execution statistics for {@link OpChain}s.
+ */
+public class OpChainStats {
+
+  // use memoized supplier so that the timing doesn't start until the
+  // first time we get the timer
+  private final Supplier<ThreadResourceUsageProvider> _exTimer
+      = Suppliers.memoize(ThreadResourceUsageProvider::new)::get;
+
+  // this is used to make sure that toString() doesn't have side
+  // effects (accidentally starting the timer)
+  private volatile boolean _exTimerStarted = false;
+
+  private final Stopwatch _queuedStopwatch = Stopwatch.createUnstarted();
+  private final AtomicLong _queuedCount = new AtomicLong();
+
+  private final String _id;
+
+  public OpChainStats(String id) {
+    _id = id;
+  }
+
+  public void executing() {
+    startExecutionTimer();
+    if (_queuedStopwatch.isRunning()) {
+      _queuedStopwatch.stop();
+    }
+  }
+
+  public void queued() {
+    _queuedCount.incrementAndGet();
+    if (!_queuedStopwatch.isRunning()) {
+      _queuedStopwatch.start();
+    }
+  }
+
+  public void startExecutionTimer() {
+    _exTimerStarted = true;
+    _exTimer.get();
+  }
+
+  @Override
+  public String toString() {
+    return String.format("(%s) Queued Count: %s, Executing Time: %sms, Queued Time: %sms",
+        _id,
+        _queuedCount.get(),
+        _exTimerStarted ? TimeUnit.NANOSECONDS.toMillis(_exTimer.get().getThreadTimeNs()) : 0,
+        _queuedStopwatch.elapsed(TimeUnit.MILLISECONDS)
+    );
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -58,7 +58,7 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<Operator<Transferab
 
   public static OpChain build(StageNode node, PlanRequestContext context) {
     Operator<TransferableBlock> root = node.visit(INSTANCE, context);
-    return new OpChain(root, context.getReceivingMailboxes());
+    return new OpChain(root, context.getReceivingMailboxes(), context.getRequestId(), context.getStageId());
   }
 
   @Override

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
@@ -71,7 +71,7 @@ public class OpChainSchedulerServiceTest {
   }
 
   private OpChain getChain(Operator<TransferableBlock> operator) {
-    return new OpChain(operator, ImmutableList.of());
+    return new OpChain(operator, ImmutableList.of(), 123, 1);
   }
 
   @Test
@@ -91,7 +91,7 @@ public class OpChainSchedulerServiceTest {
 
     // When:
     scheduler.startAsync().awaitRunning();
-    scheduler.register(new OpChain(_operatorA, ImmutableList.of()));
+    scheduler.register(new OpChain(_operatorA, ImmutableList.of(), 123, 1));
 
     // Then:
     Assert.assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
@@ -114,7 +114,7 @@ public class OpChainSchedulerServiceTest {
     });
 
     // When:
-    scheduler.register(new OpChain(_operatorA, ImmutableList.of()));
+    scheduler.register(new OpChain(_operatorA, ImmutableList.of(), 123, 1));
     scheduler.startAsync().awaitRunning();
 
     // Then:
@@ -141,7 +141,7 @@ public class OpChainSchedulerServiceTest {
 
     // When:
     scheduler.startAsync().awaitRunning();
-    scheduler.register(new OpChain(_operatorA, ImmutableList.of()));
+    scheduler.register(new OpChain(_operatorA, ImmutableList.of(), 123, 1));
 
     // Then:
     Assert.assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
@@ -182,8 +182,8 @@ public class OpChainSchedulerServiceTest {
 
     // When:
     scheduler.startAsync().awaitRunning();
-    scheduler.register(new OpChain(_operatorA, ImmutableList.of()));
-    scheduler.register(new OpChain(_operatorB, ImmutableList.of()));
+    scheduler.register(new OpChain(_operatorA, ImmutableList.of(), 123, 1));
+    scheduler.register(new OpChain(_operatorB, ImmutableList.of(), 123, 1));
 
     // Then:
     Assert.assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/RoundRobinSchedulerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/RoundRobinSchedulerTest.java
@@ -56,7 +56,7 @@ public class RoundRobinSchedulerTest {
   @Test
   public void shouldScheduleNewOpChainsImmediately() {
     // Given:
-    OpChain chain = new OpChain(_operator, ImmutableList.of(MAILBOX_1));
+    OpChain chain = new OpChain(_operator, ImmutableList.of(MAILBOX_1), 123, 1);
     RoundRobinScheduler scheduler = new RoundRobinScheduler();
 
     // When:
@@ -70,7 +70,7 @@ public class RoundRobinSchedulerTest {
   @Test
   public void shouldNotScheduleRescheduledOpChainsImmediately() {
     // Given:
-    OpChain chain = new OpChain(_operator, ImmutableList.of(MAILBOX_1));
+    OpChain chain = new OpChain(_operator, ImmutableList.of(MAILBOX_1), 123, 1);
     RoundRobinScheduler scheduler = new RoundRobinScheduler();
 
     // When:
@@ -83,8 +83,8 @@ public class RoundRobinSchedulerTest {
   @Test
   public void shouldScheduleRescheduledOpChainOnDataAvailable() {
     // Given:
-    OpChain chain1 = new OpChain(_operator, ImmutableList.of(MAILBOX_1));
-    OpChain chain2 = new OpChain(_operator, ImmutableList.of(MAILBOX_2));
+    OpChain chain1 = new OpChain(_operator, ImmutableList.of(MAILBOX_1), 123, 1);
+    OpChain chain2 = new OpChain(_operator, ImmutableList.of(MAILBOX_2), 123, 1);
     RoundRobinScheduler scheduler = new RoundRobinScheduler();
 
     // When:
@@ -101,7 +101,7 @@ public class RoundRobinSchedulerTest {
   @Test
   public void shouldScheduleRescheduledOpChainOnDataAvailableBeforeRegister() {
     // Given:
-    OpChain chain = new OpChain(_operator, ImmutableList.of(MAILBOX_1));
+    OpChain chain = new OpChain(_operator, ImmutableList.of(MAILBOX_1), 123, 1);
     RoundRobinScheduler scheduler = new RoundRobinScheduler();
 
     // When:
@@ -116,7 +116,7 @@ public class RoundRobinSchedulerTest {
   @Test
   public void shouldNotScheduleRescheduledOpChainOnDataAvailableForDifferentMailbox() {
     // Given:
-    OpChain chain = new OpChain(_operator, ImmutableList.of(MAILBOX_1));
+    OpChain chain = new OpChain(_operator, ImmutableList.of(MAILBOX_1), 123, 1);
     RoundRobinScheduler scheduler = new RoundRobinScheduler();
 
     // When:
@@ -130,7 +130,7 @@ public class RoundRobinSchedulerTest {
   @Test
   public void shouldScheduleRescheduledOpChainOnDataAvailableForAnyMailbox() {
     // Given:
-    OpChain chain = new OpChain(_operator, ImmutableList.of(MAILBOX_1, MAILBOX_2));
+    OpChain chain = new OpChain(_operator, ImmutableList.of(MAILBOX_1, MAILBOX_2), 123, 1);
     RoundRobinScheduler scheduler = new RoundRobinScheduler();
 
     // When:


### PR DESCRIPTION
improves the observability for operator chain scheduling by adding logs and collecting some additional statistics.

Note:
- `DEBUG` for logs that should only happen once in the lifecycle of an operator chain
- `TRACE` for logs that could happen many times in the lifecycle of an operator chain

Tested this by enabling debug/trace logging and making sure the logs make sense