### PR TITLE
Construct new IndexLoadingConfig when loading completed realtime segments

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -64,6 +64,7 @@ import org.apache.pinot.segment.local.utils.SchemaUtils;
 import org.apache.pinot.segment.local.utils.tablestate.TableStateUtils;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -543,9 +544,13 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, _tableNameWithType);
     Preconditions.checkState(tableConfig != null, "Failed to get table config for table: {}", _tableNameWithType);
     Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, tableConfig);
-    indexLoadingConfig.updateTableConfigAndSchema(tableConfig, schema);
+
+    // Construct a new indexLoadingConfig with the updated tableConfig and schema.
+    InstanceDataManagerConfig instanceDataManagerConfig = indexLoadingConfig.getInstanceDataManagerConfig();
+    IndexLoadingConfig newIndexLoadingConfig = new IndexLoadingConfig(instanceDataManagerConfig, tableConfig, schema);
+
     try {
-      addSegment(indexDir, indexLoadingConfig);
+      addSegment(indexDir, newIndexLoadingConfig);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -286,7 +286,6 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
     }, 600_000L, "Failed to remove inverted index");
   }
 
-
   @Test(expectedExceptions = IOException.class)
   public void testAddHLCTableShouldFail()
       throws IOException {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -106,9 +106,8 @@ public class IndexLoadingConfig {
    */
   public IndexLoadingConfig(InstanceDataManagerConfig instanceDataManagerConfig, TableConfig tableConfig,
       @Nullable Schema schema) {
-    _instanceDataManagerConfig = instanceDataManagerConfig;
-    extractFromInstanceConfig();
-    updateTableConfigAndSchema(tableConfig, schema);
+    extractFromInstanceConfig(instanceDataManagerConfig);
+    extractFromTableConfigAndSchema(tableConfig, schema);
   }
 
   @VisibleForTesting
@@ -124,7 +123,7 @@ public class IndexLoadingConfig {
     return _instanceDataManagerConfig;
   }
 
-  public void updateTableConfigAndSchema(TableConfig tableConfig, @Nullable Schema schema) {
+  private void extractFromTableConfigAndSchema(TableConfig tableConfig, @Nullable Schema schema) {
     if (schema != null) {
       TimestampIndexUtils.applyTimestampIndex(tableConfig, schema);
     }
@@ -300,35 +299,37 @@ public class IndexLoadingConfig {
     }
   }
 
-  private void extractFromInstanceConfig() {
-    if (_instanceDataManagerConfig == null) {
+  private void extractFromInstanceConfig(InstanceDataManagerConfig instanceDataManagerConfig) {
+    if (instanceDataManagerConfig == null) {
       return;
     }
-    _instanceId = _instanceDataManagerConfig.getInstanceId();
 
-    ReadMode instanceReadMode = _instanceDataManagerConfig.getReadMode();
+    _instanceDataManagerConfig = instanceDataManagerConfig;
+    _instanceId = instanceDataManagerConfig.getInstanceId();
+
+    ReadMode instanceReadMode = instanceDataManagerConfig.getReadMode();
     if (instanceReadMode != null) {
       _readMode = instanceReadMode;
     }
 
-    String instanceSegmentVersion = _instanceDataManagerConfig.getSegmentFormatVersion();
+    String instanceSegmentVersion = instanceDataManagerConfig.getSegmentFormatVersion();
     if (instanceSegmentVersion != null) {
       _segmentVersion = SegmentVersion.valueOf(instanceSegmentVersion.toLowerCase());
     }
 
-    _enableSplitCommit = _instanceDataManagerConfig.isEnableSplitCommit();
+    _enableSplitCommit = instanceDataManagerConfig.isEnableSplitCommit();
 
-    _isRealtimeOffHeapAllocation = _instanceDataManagerConfig.isRealtimeOffHeapAllocation();
-    _isDirectRealtimeOffHeapAllocation = _instanceDataManagerConfig.isDirectRealtimeOffHeapAllocation();
+    _isRealtimeOffHeapAllocation = instanceDataManagerConfig.isRealtimeOffHeapAllocation();
+    _isDirectRealtimeOffHeapAllocation = instanceDataManagerConfig.isDirectRealtimeOffHeapAllocation();
 
-    String avgMultiValueCount = _instanceDataManagerConfig.getAvgMultiValueCount();
+    String avgMultiValueCount = instanceDataManagerConfig.getAvgMultiValueCount();
     if (avgMultiValueCount != null) {
       _realtimeAvgMultiValueCount = Integer.valueOf(avgMultiValueCount);
     }
-    _enableSplitCommitEndWithMetadata = _instanceDataManagerConfig.isEnableSplitCommitEndWithMetadata();
+    _enableSplitCommitEndWithMetadata = instanceDataManagerConfig.isEnableSplitCommitEndWithMetadata();
     _segmentStoreURI =
-        _instanceDataManagerConfig.getConfig().getProperty(CommonConstants.Server.CONFIG_OF_SEGMENT_STORE_URI);
-    _segmentDirectoryLoader = _instanceDataManagerConfig.getSegmentDirectoryLoader();
+        instanceDataManagerConfig.getConfig().getProperty(CommonConstants.Server.CONFIG_OF_SEGMENT_STORE_URI);
+    _segmentDirectoryLoader = instanceDataManagerConfig.getSegmentDirectoryLoader();
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -57,6 +57,7 @@ public class IndexLoadingConfig {
   private static final int DEFAULT_REALTIME_AVG_MULTI_VALUE_COUNT = 2;
   public static final String READ_MODE_KEY = "readMode";
 
+  private InstanceDataManagerConfig _instanceDataManagerConfig = null;
   private ReadMode _readMode = ReadMode.DEFAULT_MODE;
   private List<String> _sortedColumns = Collections.emptyList();
   private Set<String> _invertedIndexColumns = new HashSet<>();
@@ -105,7 +106,8 @@ public class IndexLoadingConfig {
    */
   public IndexLoadingConfig(InstanceDataManagerConfig instanceDataManagerConfig, TableConfig tableConfig,
       @Nullable Schema schema) {
-    extractFromInstanceConfig(instanceDataManagerConfig);
+    _instanceDataManagerConfig = instanceDataManagerConfig;
+    extractFromInstanceConfig();
     updateTableConfigAndSchema(tableConfig, schema);
   }
 
@@ -116,6 +118,10 @@ public class IndexLoadingConfig {
 
   @VisibleForTesting
   public IndexLoadingConfig() {
+  }
+
+  public InstanceDataManagerConfig getInstanceDataManagerConfig() {
+    return _instanceDataManagerConfig;
   }
 
   public void updateTableConfigAndSchema(TableConfig tableConfig, @Nullable Schema schema) {
@@ -294,35 +300,35 @@ public class IndexLoadingConfig {
     }
   }
 
-  private void extractFromInstanceConfig(InstanceDataManagerConfig instanceDataManagerConfig) {
-    if (instanceDataManagerConfig == null) {
+  private void extractFromInstanceConfig() {
+    if (_instanceDataManagerConfig == null) {
       return;
     }
-    _instanceId = instanceDataManagerConfig.getInstanceId();
+    _instanceId = _instanceDataManagerConfig.getInstanceId();
 
-    ReadMode instanceReadMode = instanceDataManagerConfig.getReadMode();
+    ReadMode instanceReadMode = _instanceDataManagerConfig.getReadMode();
     if (instanceReadMode != null) {
       _readMode = instanceReadMode;
     }
 
-    String instanceSegmentVersion = instanceDataManagerConfig.getSegmentFormatVersion();
+    String instanceSegmentVersion = _instanceDataManagerConfig.getSegmentFormatVersion();
     if (instanceSegmentVersion != null) {
       _segmentVersion = SegmentVersion.valueOf(instanceSegmentVersion.toLowerCase());
     }
 
-    _enableSplitCommit = instanceDataManagerConfig.isEnableSplitCommit();
+    _enableSplitCommit = _instanceDataManagerConfig.isEnableSplitCommit();
 
-    _isRealtimeOffHeapAllocation = instanceDataManagerConfig.isRealtimeOffHeapAllocation();
-    _isDirectRealtimeOffHeapAllocation = instanceDataManagerConfig.isDirectRealtimeOffHeapAllocation();
+    _isRealtimeOffHeapAllocation = _instanceDataManagerConfig.isRealtimeOffHeapAllocation();
+    _isDirectRealtimeOffHeapAllocation = _instanceDataManagerConfig.isDirectRealtimeOffHeapAllocation();
 
-    String avgMultiValueCount = instanceDataManagerConfig.getAvgMultiValueCount();
+    String avgMultiValueCount = _instanceDataManagerConfig.getAvgMultiValueCount();
     if (avgMultiValueCount != null) {
       _realtimeAvgMultiValueCount = Integer.valueOf(avgMultiValueCount);
     }
-    _enableSplitCommitEndWithMetadata = instanceDataManagerConfig.isEnableSplitCommitEndWithMetadata();
+    _enableSplitCommitEndWithMetadata = _instanceDataManagerConfig.isEnableSplitCommitEndWithMetadata();
     _segmentStoreURI =
-        instanceDataManagerConfig.getConfig().getProperty(CommonConstants.Server.CONFIG_OF_SEGMENT_STORE_URI);
-    _segmentDirectoryLoader = instanceDataManagerConfig.getSegmentDirectoryLoader();
+        _instanceDataManagerConfig.getConfig().getProperty(CommonConstants.Server.CONFIG_OF_SEGMENT_STORE_URI);
+    _segmentDirectoryLoader = _instanceDataManagerConfig.getSegmentDirectoryLoader();
   }
 
   /**


### PR DESCRIPTION
Currently, when we complete realtime segments, we attempt to update the tableConfig, schema and IndexLoadingConfig. The current code uses `updateTableConfigAndSchema()` to update `IndexLoadingConfig`. However, the implementation doesn't work correctly if the user removes an index (for ex: inverted index or dictionary). The removal is never reflected in the `IndexLoadingConfig`.

This PR fixes the issue by constructing a new IndexLoadingConfig using the updated tableConfig and schema.

Added a test to remove invertedIndex for realtime segments.