### PR TITLE
[flaky-test] Fixed flaky test in LoggerUtilsTest.java

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/LoggerUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/LoggerUtilsTest.java
@@ -37,8 +37,8 @@ public class LoggerUtilsTest {
   public void testGetAllLoggers() {
     List<String> allLoggers = LoggerUtils.getAllLoggers();
     assertEquals(allLoggers.size(), 2);
-    assertEquals(allLoggers.get(0), ROOT);
-    assertEquals(allLoggers.get(1), PINOT);
+    assertTrue(allLoggers.contains(ROOT));
+    assertTrue(allLoggers.contains(PINOT));
   }
 
   @Test


### PR DESCRIPTION
`bugfix`

I did not open an issue for this PR because I think the bug and fix are very minor. `org.apache.pinot.common.utils.LoggerUtilsTest#testGetAllLoggers `is a flaky test found by Nondex similar as [9928](https://github.com/apache/pinot/pull/9928) and [9925](https://github.com/apache/pinot/pull/9925). Here the list returned by `LoggerUtils.getAllLoggers();` is formed from a hashmap, and thus the order of its content is non-deterministic. Since the test here is not testing against the order, it's more reasonable to use `contains`.

Here is the test log:

```
[INFO] -------------------------------------------------------
[INFO]  T E S T S
[INFO] -------------------------------------------------------
[INFO] Running org.apache.pinot.common.utils.LoggerUtilsTest
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 1.776 s <<< FAILURE! - in org.apache.pinot.common.utils.LoggerUtilsTest
[ERROR] org.apache.pinot.common.utils.LoggerUtilsTest.testGetAllLoggers  Time elapsed: 0.032 s  <<< FAILURE!
java.lang.AssertionError: expected [root] but found [org.apache.pinot]
        at org.testng.Assert.fail(Assert.java:93)
        at org.testng.Assert.failNotEquals(Assert.java:512)
        at org.testng.Assert.assertEqualsImpl(Assert.java:134)
        at org.testng.Assert.assertEquals(Assert.java:115)
        at org.testng.Assert.assertEquals(Assert.java:189)
        at org.testng.Assert.assertEquals(Assert.java:199)
        at org.apache.pinot.common.utils.LoggerUtilsTest.testGetAllLoggers(LoggerUtilsTest.java:40)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.base/java.lang.reflect.Method.invoke(Method.java:566)
        at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:108)
        at org.testng.internal.Invoker.invokeMethod(Invoker.java:661)
        at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:869)
        at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1193)
        at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:126)
        at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:109)
        at org.testng.TestRunner.privateRun(TestRunner.java:744)
        at org.testng.TestRunner.run(TestRunner.java:602)
        at org.testng.SuiteRunner.runTest(SuiteRunner.java:380)
        at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:375)
        at org.testng.SuiteRunner.privateRun(SuiteRunner.java:340)
        at org.testng.SuiteRunner.run(SuiteRunner.java:289)
        at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
        at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
        at org.testng.TestNG.runSuitesSequentially(TestNG.java:1301)
        at org.testng.TestNG.runSuitesLocally(TestNG.java:1226)
        at org.testng.TestNG.runSuites(TestNG.java:1144)
        at org.testng.TestNG.run(TestNG.java:1115)
        at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:136)
        at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeSingleClass(TestNGDirectoryTestSuite.java:112)
        at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:99)
        at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:145)
        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:428)
        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
        at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:562)
        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:548)

[INFO] 
[INFO] Results:
[INFO] 
[ERROR] Failures: 
[ERROR]   LoggerUtilsTest.testGetAllLoggers:40 expected [root] but found [org.apache.pinot]
[INFO] 
[ERROR] Tests run: 1, Failures: 1, Errors: 0, Skipped: 0
```