### PR TITLE
[feature] Add default trust manager to perf QueryRunner

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/DefaultTrustManager.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/DefaultTrustManager.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.tools.perf;
+
+import java.security.cert.CertificateException;
+import java.security.cert.X509Certificate;
+import javax.net.ssl.X509TrustManager;
+
+public class DefaultTrustManager implements X509TrustManager {
+
+  @Override
+  public void checkClientTrusted(X509Certificate[] arg0, String arg1)
+      throws CertificateException {
+  }
+
+  @Override
+  public void checkServerTrusted(X509Certificate[] arg0, String arg1)
+      throws CertificateException {
+  }
+
+  @Override
+  public X509Certificate[] getAcceptedIssuers() {
+    return null;
+  }
+}

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
@@ -22,6 +22,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.FileInputStream;
+import java.security.SecureRandom;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -34,6 +35,9 @@ import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.concurrent.ThreadSafe;
+import javax.net.ssl.KeyManager;
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.TrustManager;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.math.stat.descriptive.DescriptiveStatistics;
 import org.apache.pinot.tools.AbstractBaseCommand;
@@ -156,6 +160,11 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
       printUsage();
       return false;
     }
+
+    SSLContext ctx = SSLContext.getInstance("TLS");
+    ctx.init(new KeyManager[0], new TrustManager[] {new DefaultTrustManager()}, new SecureRandom());
+    SSLContext.setDefault(ctx);
+
 
     LOGGER.info("Start query runner targeting broker: {}:{}", _brokerHost, _brokerPort);
     PerfBenchmarkDriverConf conf = new PerfBenchmarkDriverConf();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/QueryRunner.java
@@ -103,6 +103,10 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
   @CommandLine.Option(names = {"-verbose"}, required = false, description = "Enable verbose query logging (default: "
       + "false).")
   private boolean _verbose = false;
+  @CommandLine.Option(names = {"-useTLS"}, required = false, description = "Use default trust manager (default: "
+      + "false).")
+  private boolean _useTLS = false;
+
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, help = true, description = "Print "
       + "this message.")
   private boolean _help;
@@ -161,10 +165,11 @@ public class QueryRunner extends AbstractBaseCommand implements Command {
       return false;
     }
 
-    SSLContext ctx = SSLContext.getInstance("TLS");
-    ctx.init(new KeyManager[0], new TrustManager[] {new DefaultTrustManager()}, new SecureRandom());
-    SSLContext.setDefault(ctx);
-
+    if (_useTLS) {
+      SSLContext ctx = SSLContext.getInstance("TLS");
+      ctx.init(new KeyManager[0], new TrustManager[]{new DefaultTrustManager()}, new SecureRandom());
+      SSLContext.setDefault(ctx);
+    }
 
     LOGGER.info("Start query runner targeting broker: {}:{}", _brokerHost, _brokerPort);
     PerfBenchmarkDriverConf conf = new PerfBenchmarkDriverConf();


### PR DESCRIPTION
Add default trust manager to perf query runner to handle expired certification. 
Most coded up by @saurabhd336 