### PR TITLE
[feature] Add pinot-clp-log plugin to encode user-specified fields with CLP during ingestion

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -270,6 +270,7 @@ com.uber:h3:4.0.0
 com.yahoo.datasketches:memory:0.8.3
 com.yahoo.datasketches:sketches-core:0.8.3
 com.yammer.metrics:metrics-core:2.2.0
+com.yscope.clp:clp-ffi:0.1
 com.zaxxer:HikariCP-java7:2.4.13
 commons-cli:commons-cli:1.2
 commons-codec:commons-codec:1.15

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -270,7 +270,7 @@ com.uber:h3:4.0.0
 com.yahoo.datasketches:memory:0.8.3
 com.yahoo.datasketches:sketches-core:0.8.3
 com.yammer.metrics:metrics-core:2.2.0
-com.yscope.clp:clp-ffi:0.1
+com.yscope.clp:clp-ffi:0.2
 com.zaxxer:HikariCP-java7:2.4.13
 commons-cli:commons-cli:1.2
 commons-codec:commons-codec:1.15

--- a/pinot-distribution/pinot-assembly.xml
+++ b/pinot-distribution/pinot-assembly.xml
@@ -148,6 +148,12 @@
     </file>
     <file>
       <source>
+        ${pinot.root}/pinot-plugins/pinot-input-format/pinot-clp-log/target/pinot-clp-log-${project.version}-shaded.jar
+      </source>
+      <destName>plugins/pinot-input-format/pinot-clp-log/pinot-clp-log-${project.version}-shaded.jar</destName>
+    </file>
+    <file>
+      <source>
         ${pinot.root}/pinot-plugins/pinot-input-format/pinot-confluent-avro/target/pinot-confluent-avro-${project.version}-shaded.jar
       </source>
       <destName>plugins/pinot-input-format/pinot-confluent-avro/pinot-confluent-avro-${project.version}-shaded.jar

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
@@ -25,7 +25,7 @@
   <parent>
     <artifactId>pinot-input-format</artifactId>
     <groupId>org.apache.pinot</groupId>
-    <version>0.12.0-SNAPSHOT</version>
+    <version>0.13.0-SNAPSHOT</version>
     <relativePath>..</relativePath>
   </parent>
 

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
@@ -42,14 +42,6 @@
       <groupId>com.yscope.clp</groupId>
       <artifactId>clp-ffi</artifactId>
       <version>0.2</version>
-      <exclusions>
-        <!-- Exclude junit due to mitigate a bug in clp-ffi where junit is not marked as a test
-        dependency -->
-        <exclusion>
-          <groupId>org.junit.jupiter</groupId>
-          <artifactId>junit-jupiter-engine</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
@@ -42,51 +42,14 @@
       <groupId>com.yscope.clp</groupId>
       <artifactId>clp-ffi</artifactId>
       <version>0.1</version>
-    </dependency>
-
-    <dependency>
-      <groupId>org.testng</groupId>
-      <artifactId>testng</artifactId>
-      <scope>test</scope>
+      <exclusions>
+        <!-- Exclude junit due to mitigate a bug in clp-ffi where junit is not marked as a test
+        dependency -->
+        <exclusion>
+          <groupId>org.junit.jupiter</groupId>
+          <artifactId>junit-jupiter-engine</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
   </dependencies>
-
-  <build>
-    <pluginManagement>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-surefire-plugin</artifactId>
-          <version>2.22.2</version>
-        </plugin>
-      </plugins>
-    </pluginManagement>
-  </build>
-
-  <profiles>
-    <profile>
-      <id>build-shaded-jar</id>
-      <activation>
-        <property>
-          <name>skipShade</name>
-          <value>!true</value>
-        </property>
-      </activation>
-      <build>
-        <plugins>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>${phase.prop}</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-        </plugins>
-      </build>
-    </profile>
-  </profiles>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>com.yscope.clp</groupId>
       <artifactId>clp-ffi</artifactId>
-      <version>0.1</version>
+      <version>0.2</version>
       <exclusions>
         <!-- Exclude junit due to mitigate a bug in clp-ffi where junit is not marked as a test
         dependency -->

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>pinot-input-format</artifactId>
+    <groupId>org.apache.pinot</groupId>
+    <version>0.12.0-SNAPSHOT</version>
+    <relativePath>..</relativePath>
+  </parent>
+
+  <artifactId>pinot-clp-log</artifactId>
+  <name>Pinot CLP Log</name>
+  <url>https://pinot.apache.org/</url>
+  <properties>
+    <pinot.root>${basedir}/../../..</pinot.root>
+    <phase.prop>package</phase.prop>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>com.yscope.clp</groupId>
+      <artifactId>clp-ffi</artifactId>
+      <version>0.1</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>2.22.2</version>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+  </build>
+
+  <profiles>
+    <profile>
+      <id>build-shaded-jar</id>
+      <activation>
+        <property>
+          <name>skipShade</name>
+          <value>!true</value>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>${phase.prop}</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogMessageDecoder.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogMessageDecoder.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.clplog;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.util.Arrays;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordExtractor;
+import org.apache.pinot.spi.data.readers.RecordExtractorConfig;
+import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.stream.StreamMessageDecoder;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * An implementation of StreamMessageDecoder to read log events from a stream. This is an experimental feature.
+ * It allows us to encode user-specified fields of a log event using CLP. See {@link CLPLogRecordExtractor} for more
+ * details. The implementation is based on {@link org.apache.pinot.plugin.inputformat.json.JSONMessageDecoder}.
+ */
+public class CLPLogMessageDecoder implements StreamMessageDecoder<byte[]> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(CLPLogMessageDecoder.class);
+
+  private RecordExtractor<Map<String, Object>> _recordExtractor;
+
+  @Override
+  public void init(Map<String, String> props, Set<String> fieldsToRead, String topicName)
+      throws Exception {
+    String recordExtractorClass = null;
+    String recordExtractorConfigClass = null;
+    if (null != props) {
+      recordExtractorClass = props.get(RECORD_EXTRACTOR_CONFIG_KEY);
+      recordExtractorConfigClass = props.get(RECORD_EXTRACTOR_CONFIG_CONFIG_KEY);
+    }
+    if (null == recordExtractorClass) {
+      recordExtractorClass = CLPLogRecordExtractor.class.getName();
+      recordExtractorConfigClass = CLPLogRecordExtractorConfig.class.getName();
+    }
+    _recordExtractor = PluginManager.get().createInstance(recordExtractorClass);
+    RecordExtractorConfig config = PluginManager.get().createInstance(recordExtractorConfigClass);
+    config.init(props);
+    _recordExtractor.init(fieldsToRead, config);
+  }
+
+  @Override
+  public GenericRow decode(byte[] payload, GenericRow destination) {
+    try {
+      JsonNode message = JsonUtils.bytesToJsonNode(payload);
+      Map<String, Object> from = JsonUtils.jsonNodeToMap(message);
+      _recordExtractor.extract(from, destination);
+      return destination;
+    } catch (Exception e) {
+      LOGGER.error("Caught exception while decoding row, discarding row. Payload is {}", new String(payload), e);
+      return null;
+    }
+  }
+
+  @Override
+  public GenericRow decode(byte[] payload, int offset, int length, GenericRow destination) {
+    return decode(Arrays.copyOfRange(payload, offset, offset + length), destination);
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.plugin.inputformat.clplog;
 
+import com.yscope.clp.compressorfrontend.BuiltInVariableHandlingRuleVersions;
 import com.yscope.clp.compressorfrontend.EncodedMessage;
 import com.yscope.clp.compressorfrontend.MessageEncoder;
 import java.io.IOException;
@@ -90,7 +91,8 @@ public class CLPLogRecordExtractor extends BaseRecordExtractor<Map<String, Objec
     }
 
     _clpEncodedMessage = new EncodedMessage();
-    _clpMessageEncoder = new MessageEncoder();
+    _clpMessageEncoder = new MessageEncoder(BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
+        BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
   }
 
   @Override

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractor.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.clplog;
+
+import com.yscope.clp.compressorfrontend.EncodedMessage;
+import com.yscope.clp.compressorfrontend.MessageEncoder;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.readers.BaseRecordExtractor;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordExtractorConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * A record extractor for log events. For configuration options, see {@link CLPLogRecordExtractorConfig}. This is an
+ * experimental feature.
+ * <p></p>
+ * The goal of this record extractor is to allow us to encode the fields specified in
+ * {@link CLPLogRecordExtractorConfig} using CLP. CLP is a compressor designed to encode unstructured log messages in a
+ * way that makes them more compressible. It does this by decomposing a message into three fields:
+ * <ul>
+ *   <li>the message's static text, called a log type;</li>
+ *   <li>repetitive variable values, called dictionary variables; and</li>
+ *   <li>non-repetitive variable values (called encoded variables since we encode them specially if possible).</li>
+ * </ul>
+ * For instance, if the field "message" is encoded, then the extractor will output:
+ * <ul>
+ *   <li>message_logtype</li>
+ *   <li>message_dictionaryVars</li>
+ *   <li>message_encodedVars</li>
+ * </ul>
+ * This class' implementation is based on {@link org.apache.pinot.plugin.inputformat.json.JSONRecordExtractor}.
+ */
+public class CLPLogRecordExtractor extends BaseRecordExtractor<Map<String, Object>> {
+  private static final Logger LOGGER = LoggerFactory.getLogger(CLPLogRecordExtractor.class);
+
+  private static final String LOGTYPE_COLUMN_SUFFIX = "_logtype";
+  private static final String DICTIONARY_VARS_COLUMN_SUFFIX = "_dictionaryVars";
+  private static final String ENCODED_VARS_COLUMN_SUFFIX = "_encodedVars";
+
+  private Set<String> _fields;
+  private boolean _extractAll = false;
+  private CLPLogRecordExtractorConfig _config;
+
+  private EncodedMessage _clpEncodedMessage;
+  private MessageEncoder _clpMessageEncoder;
+
+  @Override
+  public void init(Set<String> fields, @Nullable RecordExtractorConfig recordExtractorConfig) {
+    _config = (CLPLogRecordExtractorConfig) recordExtractorConfig;
+    if (fields == null || fields.isEmpty()) {
+      _extractAll = true;
+      _fields = Collections.emptySet();
+    } else {
+      _fields = new HashSet<>(fields);
+      // Remove the fields to be CLP-encoded to make it easier to work with them
+      // in `extract`
+      _fields.removeAll(_config.getFieldsForClpEncoding());
+    }
+
+    _clpEncodedMessage = new EncodedMessage();
+    _clpMessageEncoder = new MessageEncoder();
+  }
+
+  @Override
+  public GenericRow extract(Map<String, Object> from, GenericRow to) {
+    Set<String> clpEncodedFieldNames = _config.getFieldsForClpEncoding();
+
+    if (_extractAll) {
+      for (Map.Entry<String, Object> recordEntry : from.entrySet()) {
+        String recordKey = recordEntry.getKey();
+        Object recordValue = recordEntry.getValue();
+        if (clpEncodedFieldNames.contains(recordKey)) {
+          encodeFieldWithClp(recordKey, recordValue, to);
+        } else {
+          if (null != recordValue) {
+            recordValue = convert(recordValue);
+          }
+          to.putValue(recordKey, recordValue);
+        }
+      }
+    } else {
+      // Handle un-encoded fields
+      for (String fieldName : _fields) {
+        Object value = from.get(fieldName);
+        if (null != value) {
+          value = convert(value);
+        }
+        to.putValue(fieldName, value);
+      }
+
+      // Handle encoded fields
+      for (String fieldName : _config.getFieldsForClpEncoding()) {
+        Object value = from.get(fieldName);
+        encodeFieldWithClp(fieldName, value, to);
+      }
+    }
+    return to;
+  }
+
+  /**
+   * Encodes a field with CLP
+   * <p></p>
+   * Given a field "x", this will output three fields: "x_logtype", "x_dictionaryVars", "x_encodedVars"
+   * @param key Key of the field to encode
+   * @param value Value of the field to encode
+   * @param to The output row
+   */
+  private void encodeFieldWithClp(String key, Object value, GenericRow to) {
+    String logtype = null;
+    Object[] dictVars = null;
+    Object[] encodedVars = null;
+    if (null != value) {
+      if (!(value instanceof String)) {
+        LOGGER.error("Can't encode value of type {} with CLP. name: '{}', value: '{}'", value.getClass().getName(), key,
+            value);
+      } else {
+        String valueAsString = (String) value;
+        try {
+          _clpMessageEncoder.encodeMessage(valueAsString, _clpEncodedMessage);
+          logtype = _clpEncodedMessage.getLogTypeAsString();
+          encodedVars = _clpEncodedMessage.getEncodedVarsAsBoxedLongs();
+          dictVars = _clpEncodedMessage.getDictionaryVarsAsStrings();
+        } catch (IOException e) {
+          LOGGER.error("Can't encode field with CLP. name: '{}', value: '{}', error: {}", key, valueAsString,
+              e.getMessage());
+        }
+      }
+    }
+
+    to.putValue(key + LOGTYPE_COLUMN_SUFFIX, logtype);
+    to.putValue(key + DICTIONARY_VARS_COLUMN_SUFFIX, dictVars);
+    to.putValue(key + ENCODED_VARS_COLUMN_SUFFIX, encodedVars);
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorConfig.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.clplog;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.spi.data.readers.RecordExtractorConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Configuration for the CLPLogRecordExtractor. There is one configuration property:
+ * <p></p>
+ * <b>fieldsForClpEncoding</b> - A comma-separated list of fields that should be encoded using CLP. Each field encoded
+ * by {@link CLPLogRecordExtractor} will result in three output fields prefixed with the original field's name.
+ * See {@link CLPLogRecordExtractor} for details. If <b>fieldsForCLPEncoding</b> is empty, no fields will be encoded.
+ * <p></p>
+ * Each property can be set as part of a table's indexing configuration by adding
+ * {@code stream.kafka.decoder.prop.[configurationKeyName]} to {@code streamConfigs}.
+ */
+public class CLPLogRecordExtractorConfig implements RecordExtractorConfig {
+  private static final Logger LOGGER = LoggerFactory.getLogger(CLPLogRecordExtractorConfig.class);
+
+  private static final String FIELDS_FOR_CLP_ENCODING_CONFIG_KEY = "fieldsForClpEncoding";
+  private static final String FIELDS_FOR_CLP_ENCODING_SEPARATOR = ",";
+  private final Set<String> _fieldsForClpEncoding = new HashSet<>();
+
+  @Override
+  public void init(Map<String, String> props) {
+    RecordExtractorConfig.super.init(props);
+    if (null == props) {
+      return;
+    }
+
+    String concatenatedFieldNames = props.get(FIELDS_FOR_CLP_ENCODING_CONFIG_KEY);
+    if (null == concatenatedFieldNames) {
+      return;
+    }
+    String[] fieldNames = concatenatedFieldNames.split(FIELDS_FOR_CLP_ENCODING_SEPARATOR);
+    for (String fieldName : fieldNames) {
+      if (fieldName.isEmpty()) {
+        LOGGER.warn("Ignoring empty field name in {}", FIELDS_FOR_CLP_ENCODING_CONFIG_KEY);
+      } else {
+        _fieldsForClpEncoding.add(fieldName);
+      }
+    }
+  }
+
+  public Set<String> getFieldsForClpEncoding() {
+    return _fieldsForClpEncoding;
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorConfig.java
@@ -37,10 +37,11 @@ import org.slf4j.LoggerFactory;
  * {@code stream.kafka.decoder.prop.[configurationKeyName]} to {@code streamConfigs}.
  */
 public class CLPLogRecordExtractorConfig implements RecordExtractorConfig {
+  public static final String FIELDS_FOR_CLP_ENCODING_CONFIG_KEY = "fieldsForClpEncoding";
+  public static final String FIELDS_FOR_CLP_ENCODING_SEPARATOR = ",";
+
   private static final Logger LOGGER = LoggerFactory.getLogger(CLPLogRecordExtractorConfig.class);
 
-  private static final String FIELDS_FOR_CLP_ENCODING_CONFIG_KEY = "fieldsForClpEncoding";
-  private static final String FIELDS_FOR_CLP_ENCODING_SEPARATOR = ",";
   private final Set<String> _fieldsForClpEncoding = new HashSet<>();
 
   @Override

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/test/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/test/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorTest.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.clplog;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.yscope.clp.compressorfrontend.MessageDecoder;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.fail;
+
+
+public class CLPLogRecordExtractorTest {
+  @Test
+  void testCLPEncoding() {
+    // Setup decoder
+    CLPLogMessageDecoder messageDecoder = new CLPLogMessageDecoder();
+    Map<String, String> props = new HashMap<>();
+    Set<String> fieldsToRead = new HashSet<>();
+    // Add two fields for CLP encoding
+    props.put("fieldsForClpEncoding", "message1,message2");
+    fieldsToRead.add("message1_logtype");
+    fieldsToRead.add("message1_encodedVars");
+    fieldsToRead.add("message1_dictionaryVars");
+    fieldsToRead.add("message2_logtype");
+    fieldsToRead.add("message2_encodedVars");
+    fieldsToRead.add("message2_dictionaryVars");
+    // Add an unencoded field
+    fieldsToRead.add("timestamp");
+    try {
+      messageDecoder.init(props, fieldsToRead, null);
+    } catch (Exception e) {
+      fail(e.toString());
+    }
+
+    // Assemble record
+    Map<String, Object> record = new HashMap<>();
+    record.put("timestamp", 10);
+    String message1 = "Started job_123 on node-987: 4 cores, 8 threads and 51.4% memory used.";
+    record.put("message1", message1);
+    String message2 = "Stopped job_123 on node-987: 3 cores, 6 threads and 22.0% memory used.";
+    record.put("message2", message2);
+    byte[] recordBytes = null;
+    try {
+      recordBytes = new ObjectMapper().writeValueAsBytes(record);
+    } catch (JsonProcessingException e) {
+      fail(e.toString());
+    }
+
+    // Test decode
+    GenericRow row = new GenericRow();
+    messageDecoder.decode(recordBytes, row);
+    assertEquals(row.getValue("timestamp"), 10);
+    try {
+      // Validate message1 field
+      assertNull(row.getValue("message1"));
+      String logtype = (String) row.getValue("message1_logtype");
+      assertNotEquals(logtype, null);
+      String[] dictionaryVars = (String[]) row.getValue("message1_dictionaryVars");
+      assertNotEquals(dictionaryVars, null);
+      Long[] encodedVars = (Long[]) row.getValue("message1_encodedVars");
+      assertNotEquals(encodedVars, null);
+      long[] encodedVarsAsPrimitives = Arrays.stream(encodedVars).mapToLong(Long::longValue).toArray();
+      String decodedMessage = MessageDecoder.decodeMessage(logtype, dictionaryVars, encodedVarsAsPrimitives);
+      assertEquals(message1, decodedMessage);
+
+      // Validate message2 field
+      assertNull(row.getValue("message2"));
+      logtype = (String) row.getValue("message2_logtype");
+      assertNotEquals(logtype, null);
+      dictionaryVars = (String[]) row.getValue("message2_dictionaryVars");
+      assertNotEquals(dictionaryVars, null);
+      encodedVars = (Long[]) row.getValue("message2_encodedVars");
+      assertNotEquals(encodedVars, null);
+      encodedVarsAsPrimitives = Arrays.stream(encodedVars).mapToLong(Long::longValue).toArray();
+      decodedMessage = MessageDecoder.decodeMessage(logtype, dictionaryVars, encodedVarsAsPrimitives);
+      assertEquals(message2, decodedMessage);
+    } catch (ClassCastException e) {
+      fail(e.getMessage(), e);
+    } catch (IOException e) {
+      fail("Could not decode message with CLP - " + e.getMessage());
+    }
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/test/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/test/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.plugin.inputformat.clplog;
 
+import com.yscope.clp.compressorfrontend.BuiltInVariableHandlingRuleVersions;
 import com.yscope.clp.compressorfrontend.MessageDecoder;
 import java.io.IOException;
 import java.util.Arrays;
@@ -172,7 +173,10 @@ public class CLPLogRecordExtractorTest {
       Long[] encodedVars = (Long[]) row.getValue(fieldName + ENCODED_VARS_COLUMN_SUFFIX);
       assertNotEquals(encodedVars, null);
       long[] encodedVarsAsPrimitives = Arrays.stream(encodedVars).mapToLong(Long::longValue).toArray();
-      String decodedMessage = MessageDecoder.decodeMessage(logtype, dictionaryVars, encodedVarsAsPrimitives);
+
+      MessageDecoder messageDecoder = new MessageDecoder(BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
+          BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
+      String decodedMessage = messageDecoder.decodeMessage(logtype, dictionaryVars, encodedVarsAsPrimitives);
       assertEquals(expectedFieldValue, decodedMessage);
     } catch (ClassCastException e) {
       fail(e.getMessage(), e);

--- a/pinot-plugins/pinot-input-format/pom.xml
+++ b/pinot-plugins/pinot-input-format/pom.xml
@@ -42,6 +42,7 @@
   <modules>
     <module>pinot-avro</module>
     <module>pinot-avro-base</module>
+    <module>pinot-clp-log</module>
     <module>pinot-confluent-avro</module>
     <module>pinot-orc</module>
     <module>pinot-json</module>


### PR DESCRIPTION
At a high-level, the plugin takes two inputs: a JSON record and a list of fields (unstructured log messages) to encode with [CLP](https://github.com/y-scope/clp). The plugin will extract and encode the user-specified fields into CLP's three-column format and store the output in a Pinot `GenericRow` object.

This is part of the change requested in #9819 and described in this [design doc](https://docs.google.com/document/d/1nHZb37re4mUwEA258x3a2pgX13EWLWMJ0uLEDk1dUyU).

# Release notes
* New plugin added: `pinot-clp-log` to encode user-specified fields with CLP during ingestion.
* Users can use the plugin by specifying these configuration options in their `tableIndexConfig.streamConfigs`:

  ```json
  "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.clplog.CLPLogMessageDecoder",
  "stream.kafka.decoder.prop.fieldsForClpEncoding": "<field-names>"
  ```
   
   where `<field-names>` is a comma-separated list of fields you wish to encode with CLP.

# Testing performed
* Validated fields are encoded correctly using the added unit test.
* Created a table with the following settings:

```json
"tableIndexConfig": {
    ...,
    "streamConfigs": {
        ...,
        "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.inputformat.clplog.CLPLogMessageDecoder",
        "stream.kafka.decoder.prop.fieldsForClpEncoding": "message",
    }
}
```

* Ingested logs through Kafka and ensured log events containing the message field were transformed such that the `message` field was replaced with CLP's three fields: `message_logtype`, `message_dictionaryVars`, and `message_encodedVars`.
