### PR TITLE
[multistage][hotfix] allow having clause in leaf-stage return extra columns

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
@@ -50,7 +50,7 @@ public final class DataBlockUtils {
     while (t.getMessage() == null) {
       t = t.getCause();
     }
-    return QueryException.getTruncatedStackTrace(t);
+    return t.getMessage() + "\n" + QueryException.getTruncatedStackTrace(t);
   }
 
   public static MetadataBlock getErrorDataBlock(Map<Integer, String> exceptions) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
@@ -174,6 +174,7 @@ public class QueryException {
     return copiedProcessingException;
   }
 
+  // TODO: getTruncatedStackTrace(Throwable) always precede by t.getMessage();
   public static String getTruncatedStackTrace(Throwable t) {
     StringWriter stringWriter = new StringWriter();
     t.printStackTrace(new PrintWriter(stringWriter));

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -202,7 +202,7 @@ public class QueryRunner {
     } catch (Exception e) {
       InstanceResponseBlock errorResponse = new InstanceResponseBlock();
       errorResponse.getExceptions().put(QueryException.QUERY_EXECUTION_ERROR_CODE,
-          QueryException.getTruncatedStackTrace(e));
+          e.getMessage() + QueryException.getTruncatedStackTrace(e));
       return errorResponse;
     }
   }

--- a/pinot-query-runtime/src/test/resources/queries/Aggregates.json
+++ b/pinot-query-runtime/src/test/resources/queries/Aggregates.json
@@ -255,7 +255,9 @@
       { "sql": "SELECT upper(string_col), count(int_col) FROM {tbl} GROUP BY upper(string_col) ORDER BY upper(string_col)" },
       { "sql": "SELECT upper(string_col), count(int_col) FROM {tbl} GROUP BY upper(string_col) ORDER BY count(int_col)" },
       { "sql": "SELECT * FROM (SELECT string_col, bool_col, min(int_col) AS m, count(int_col), count(*) AS c FROM {tbl} GROUP BY string_col, bool_col ORDER BY string_col) WHERE c < m" },
-      { "sql": "SELECT * FROM (SELECT string_col, bool_col, min(int_col) AS m, count(int_col), count(*) AS c FROM {tbl} GROUP BY string_col, bool_col ORDER BY bool_col, string_col) WHERE c < m" }
+      { "sql": "SELECT * FROM (SELECT string_col, bool_col, min(int_col) AS m, count(int_col), count(*) AS c FROM {tbl} GROUP BY string_col, bool_col ORDER BY bool_col, string_col) WHERE c < m" },
+      { "sql": "SELECT upper(string_col), count(int_col) FROM {tbl} GROUP BY upper(string_col) HAVING sum(int_col) > 0 ORDER BY upper(string_col)" },
+      { "sql": "SELECT upper(string_col), count(int_col) FROM {tbl} GROUP BY upper(string_col) HAVING sum(int_col) >= 0 AND count(int_col) >= 0 ORDER BY count(int_col)" }
     ]
   }
 }


### PR DESCRIPTION
having clause can be returned from leaf-stage as well, no dedup occur on columns. 

this follows up on a random failure on integration test after #9929 . which occurs in a special order of having clause comparing with the selection columns

This PR relaxes the precondition check to only the desired data schema.