### PR TITLE
fix timezone_hour/timezone_minute functions

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -325,7 +325,16 @@ public class DateTimeFunctions {
    */
   @ScalarFunction
   public static int timezoneHour(String timezoneId) {
-    return new DateTime(DateTimeZone.forID(timezoneId).getOffset(null), DateTimeZone.UTC).getHourOfDay();
+    return timezoneHour(timezoneId, 0);
+  }
+
+  /**
+   * Returns the hour of the time zone offset, for the UTC timestamp at {@code millis}. This will
+   * properly handle daylight savings time.
+   */
+  @ScalarFunction
+  public static int timezoneHour(String timezoneId, long millis) {
+    return (int) TimeUnit.MILLISECONDS.toHours(DateTimeZone.forID(timezoneId).getOffset(millis));
   }
 
   /**
@@ -333,7 +342,16 @@ public class DateTimeFunctions {
    */
   @ScalarFunction
   public static int timezoneMinute(String timezoneId) {
-    return new DateTime(DateTimeZone.forID(timezoneId).getOffset(null), DateTimeZone.UTC).getMinuteOfHour();
+    return timezoneMinute(timezoneId, 0);
+  }
+
+  /**
+   * Returns the minute of the time zone offset, for the UTC timestamp at {@code millis}. This will
+   * properly handle daylight savings time
+   */
+  @ScalarFunction
+  public static int timezoneMinute(String timezoneId, long millis) {
+    return (int) TimeUnit.MILLISECONDS.toMinutes(DateTimeZone.forID(timezoneId).getOffset(millis)) % 60;
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
@@ -255,18 +255,31 @@ public class DateTimeFunctionsTest {
 
     GenericRow row122 = new GenericRow();
     row122.putValue("tz", "Pacific/Marquesas");
-    inputs.add(new Object[]{"timezone_hour(tz)", expectedArguments, row122, 14});
-    inputs.add(new Object[]{"timezone_minute(tz)", expectedArguments, row122, 30});
+    inputs.add(new Object[]{"timezone_hour(tz)", expectedArguments, row122, -9});
+    inputs.add(new Object[]{"timezone_minute(tz)", expectedArguments, row122, -30});
 
     GenericRow row123 = new GenericRow();
     row123.putValue("tz", "Etc/GMT+12");
-    inputs.add(new Object[]{"timezone_hour(tz)", expectedArguments, row123, 12});
+    inputs.add(new Object[]{"timezone_hour(tz)", expectedArguments, row123, -12});
     inputs.add(new Object[]{"timezone_minute(tz)", expectedArguments, row123, 0});
 
     GenericRow row124 = new GenericRow();
     row124.putValue("tz", "Etc/GMT+1");
-    inputs.add(new Object[]{"timezone_hour(tz)", expectedArguments, row124, 23});
+    inputs.add(new Object[]{"timezone_hour(tz)", expectedArguments, row124, -1});
     inputs.add(new Object[]{"timezone_minute(tz)", expectedArguments, row124, 0});
+
+    GenericRow row125 = new GenericRow();
+    row125.putValue("tz", "America/Toronto");
+    inputs.add(new Object[]{"timezone_hour(tz)", expectedArguments, row125, -5});
+    inputs.add(new Object[]{"timezone_minute(tz)", expectedArguments, row125, 0});
+
+    // standard time (2022-01-01 6:23:01)
+    inputs.add(new Object[]{"timezone_hour(tz, 1641046981000)", expectedArguments, row125, -5});
+    inputs.add(new Object[]{"timezone_minute(tz, 1641046981000)", expectedArguments, row125, 0});
+
+    // daylight savings time (2022-07-01 6:23:01)
+    inputs.add(new Object[]{"timezone_hour(tz, 1656685381000)", expectedArguments, row125, -4});
+    inputs.add(new Object[]{"timezone_minute(tz, 1656685381000)", expectedArguments, row125, 0});
 
     // Convenience extraction functions
     expectedArguments = Collections.singletonList("millis");


### PR DESCRIPTION
**NOTE**: this is technically a backwards incompatible change, but the previous behavior was bogus so I hope this is OK (if you were to try to use it the way it's documented it would return completely wrong values)

The original code returned incorrect values (the hours were basically mod 24, instead of returning negative when it should).

Confirmed behavior with Postgres (note that postgres just returns the current timezone because all timestamps are stored in UTC, it uses the UTC timestamp to figure out if it's daylight savings or standard time):

```sql
set timezone='America/Toronto';
SELECT EXTRACT(timezone_hour FROM TIMESTAMP WITH TIME ZONE '2022-01-01 6:23:01-08') FROM foo;
 extract
---------
      -5
SELECT EXTRACT(timezone_hour FROM TIMESTAMP WITH TIME ZONE '2022-07-01 6:23:01-08') FROM foo;
 extract
---------
      -4
(1 row)
----------------------------------------
----------------------------------------

set timezone='Etc/GMT+12';
SELECT EXTRACT(timezone_hour FROM TIMESTAMP WITH TIME ZONE '2022-01-01 6:23:01-08') FROM foo;
 extract
---------
     -12
(1 row)
----------------------------------------
----------------------------------------

set timezone='Asia/Shanghai';
SELECT EXTRACT(timezone_hour FROM TIMESTAMP WITH TIME ZONE '2022-07-01 6:23:01-08') FROM foo;
 extract
---------
       8
(1 row)
```