### PR TITLE
[Clean up] Do not cache PropertiesConfiguration within SegmentMetadataImpl

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/InvertedIndexAndDictionaryBasedForwardIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/InvertedIndexAndDictionaryBasedForwardIndexCreator.java
@@ -37,6 +37,7 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.ColumnIndexType;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.segment.spi.utils.SegmentMetadataUtils;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.ByteArray;
@@ -45,11 +46,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.DICTIONARY_ELEMENT_SIZE;
-import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.HAS_DICTIONARY;
-import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.MAX_MULTI_VALUE_ELEMENTS;
-import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.TOTAL_NUMBER_OF_ENTRIES;
-import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.getKeyFor;
+import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.*;
 
 
 /**
@@ -228,7 +225,7 @@ public class InvertedIndexAndDictionaryBasedForwardIndexCreator implements AutoC
       try {
         LOGGER.info("Created forward index from inverted index and dictionary. Updating metadata properties for "
             + "segment: {}, column: {}, property list: {}", segmentName, _columnName, metadataProperties);
-        ForwardIndexHandler.updateMetadataProperties(_segmentMetadata.getIndexDir(), metadataProperties);
+        SegmentMetadataUtils.updateMetadataProperties(_segmentMetadata, metadataProperties);
       } catch (Exception e) {
         throw new IOException(
             String.format("Failed to update metadata properties for segment: %s, column: %s", segmentName, _columnName),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/StarTreeBuilderUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/StarTreeBuilderUtils.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.segment.local.startree;
 
 import java.io.File;
-import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.ArrayList;
@@ -32,13 +31,12 @@ import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.startree.v2.builder.StarTreeV2BuilderConfig;
 import org.apache.pinot.segment.spi.SegmentMetadata;
-import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2Constants;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2Metadata;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
+import org.apache.pinot.segment.spi.utils.SegmentMetadataUtils;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
-import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -261,19 +259,13 @@ public class StarTreeBuilderUtils {
    */
   public static void removeStarTrees(File indexDir)
       throws Exception {
-    File segmentDirectory = SegmentDirectoryPaths.findSegmentDirectory(indexDir);
-
     // Remove the star-tree metadata
-    PropertiesConfiguration metadataProperties =
-        CommonsConfigurationUtils.fromFile(new File(segmentDirectory, V1Constants.MetadataKeys.METADATA_FILE_NAME));
+    PropertiesConfiguration metadataProperties = SegmentMetadataUtils.getPropertiesConfiguration(indexDir);
     metadataProperties.subset(StarTreeV2Constants.MetadataKey.STAR_TREE_SUBSET).clear();
-    // Commons Configuration 1.10 does not support file path containing '%'.
-    // Explicitly providing the output stream for the file bypasses the problem.
-    try (FileOutputStream fileOutputStream = new FileOutputStream(metadataProperties.getFile())) {
-      metadataProperties.save(fileOutputStream);
-    }
+    SegmentMetadataUtils.savePropertiesConfiguration(metadataProperties);
 
     // Remove the index file and index map file
+    File segmentDirectory = SegmentDirectoryPaths.findSegmentDirectory(indexDir);
     FileUtils.forceDelete(new File(segmentDirectory, StarTreeV2Constants.INDEX_FILE_NAME));
     FileUtils.forceDelete(new File(segmentDirectory, StarTreeV2Constants.INDEX_MAP_FILE_NAME));
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/MultipleTreesBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/MultipleTreesBuilder.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import java.io.Closeable;
 import java.io.File;
 import java.io.FileNotFoundException;
-import java.io.FileOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +40,7 @@ import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2Constants;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2Constants.MetadataKey;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
+import org.apache.pinot.segment.spi.utils.SegmentMetadataUtils;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.utils.ReadMode;
@@ -144,11 +144,7 @@ public class MultipleTreesBuilder implements Closeable {
       }
 
       // Save the metadata and index maps to the disk
-      // Commons Configuration 1.10 does not support file path containing '%'.
-      // Explicitly providing the output stream for the file bypasses the problem.
-      try (FileOutputStream fileOutputStream = new FileOutputStream(_metadataProperties.getFile())) {
-        _metadataProperties.save(fileOutputStream);
-      }
+      SegmentMetadataUtils.savePropertiesConfiguration(_metadataProperties);
       StarTreeIndexMapUtils
           .storeToFile(indexMaps, new File(_segmentDirectory, StarTreeV2Constants.INDEX_MAP_FILE_NAME));
       FileUtils.forceDelete(starTreeIndexDir);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexMapUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexMapUtils.java
@@ -20,8 +20,6 @@ package org.apache.pinot.segment.local.startree.v2.store;
 
 import com.google.common.base.Preconditions;
 import java.io.File;
-import java.io.FileOutputStream;
-import java.io.IOException;
 import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -30,7 +28,6 @@ import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
-import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
@@ -141,11 +138,10 @@ public class StarTreeIndexMapUtils {
   /**
    * Stores the index maps for multiple star-trees into a file.
    */
-  public static void storeToFile(List<Map<IndexKey, IndexValue>> indexMaps, File indexMapFile)
-      throws ConfigurationException {
+  public static void storeToFile(List<Map<IndexKey, IndexValue>> indexMaps, File indexMapFile) {
     Preconditions.checkState(!indexMapFile.exists(), "Star-tree index map file already exists");
 
-    PropertiesConfiguration configuration = new PropertiesConfiguration(indexMapFile);
+    PropertiesConfiguration configuration = CommonsConfigurationUtils.fromFile(indexMapFile);
     int numStarTrees = indexMaps.size();
     for (int i = 0; i < numStarTrees; i++) {
       Map<IndexKey, IndexValue> indexMap = indexMaps.get(i);
@@ -156,14 +152,7 @@ public class StarTreeIndexMapUtils {
         configuration.addProperty(key.getPropertyName(i, SIZE_SUFFIX), value._size);
       }
     }
-
-    // Commons Configuration 1.10 does not support file path containing '%'.
-    // Explicitly providing the output stream for the file bypasses the problem.
-    try (FileOutputStream fileOutputStream = new FileOutputStream(configuration.getFile())) {
-      configuration.save(fileOutputStream);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+    CommonsConfigurationUtils.saveToFile(configuration, indexMapFile);
   }
 
   /**

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -55,6 +55,7 @@ import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
 import org.apache.pinot.segment.spi.store.ColumnIndexType;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
+import org.apache.pinot.segment.spi.utils.SegmentMetadataUtils;
 import org.apache.pinot.spi.config.table.BloomFilterConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -1820,9 +1821,8 @@ public class SegmentPreProcessorTest {
     return driver.getOutputDirectory();
   }
 
-  private static void removeMinMaxValuesFromMetadataFile(File indexDir)
-      throws Exception {
-    PropertiesConfiguration configuration = SegmentMetadataImpl.getPropertiesConfiguration(indexDir);
+  private static void removeMinMaxValuesFromMetadataFile(File indexDir) {
+    PropertiesConfiguration configuration = SegmentMetadataUtils.getPropertiesConfiguration(indexDir);
     Iterator<String> keys = configuration.getKeys();
     while (keys.hasNext()) {
       String key = keys.next();
@@ -1832,7 +1832,7 @@ public class SegmentPreProcessorTest {
         configuration.clearProperty(key);
       }
     }
-    configuration.save();
+    SegmentMetadataUtils.savePropertiesConfiguration(configuration);
   }
 
   private static Map<String, Consumer<IndexLoadingConfig>> createConfigPrepFunctions() {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/utils/SegmentMetadataUtils.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/utils/SegmentMetadataUtils.java
@@ -1,0 +1,60 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.utils;
+
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.util.Map;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
+
+
+public class SegmentMetadataUtils {
+  private SegmentMetadataUtils() {
+  }
+
+  public static PropertiesConfiguration getPropertiesConfiguration(File indexDir) {
+    File metadataFile = SegmentDirectoryPaths.findMetadataFile(indexDir);
+    Preconditions.checkNotNull(metadataFile, "Cannot find segment metadata file under directory: %s", indexDir);
+    return CommonsConfigurationUtils.fromFile(metadataFile);
+  }
+
+  public static PropertiesConfiguration getPropertiesConfiguration(SegmentMetadata segmentMetadata) {
+    File indexDir = segmentMetadata.getIndexDir();
+    Preconditions.checkState(indexDir != null, "Cannot get PropertiesConfiguration from in-memory segment: %s",
+        segmentMetadata.getName());
+    return getPropertiesConfiguration(indexDir);
+  }
+
+  public static void savePropertiesConfiguration(PropertiesConfiguration propertiesConfiguration) {
+    File metadataFile = propertiesConfiguration.getFile();
+    Preconditions.checkState(metadataFile != null, "Cannot save PropertiesConfiguration not loaded from file");
+    CommonsConfigurationUtils.saveToFile(propertiesConfiguration, metadataFile);
+  }
+
+  public static void updateMetadataProperties(SegmentMetadata segmentMetadata, Map<String, String> metadataProperties) {
+    PropertiesConfiguration propertiesConfiguration = SegmentMetadataUtils.getPropertiesConfiguration(segmentMetadata);
+    for (Map.Entry<String, String> entry : metadataProperties.entrySet()) {
+      propertiesConfiguration.setProperty(entry.getKey(), entry.getValue());
+    }
+    SegmentMetadataUtils.savePropertiesConfiguration(propertiesConfiguration);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -21,6 +21,8 @@ package org.apache.pinot.spi.env;
 import java.io.File;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
 import java.io.InputStream;
 import java.util.Arrays;
 import java.util.Iterator;
@@ -73,6 +75,16 @@ public abstract class CommonsConfigurationUtils {
       propertiesConfiguration.load(inputStream);
       return propertiesConfiguration;
     } catch (ConfigurationException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  public static void saveToFile(PropertiesConfiguration propertiesConfiguration, File file) {
+    // Commons Configuration 1.10 does not support file path containing '%'.
+    // Explicitly providing the output stream for save bypasses the problem.
+    try (FileOutputStream fileOutputStream = new FileOutputStream(file)) {
+      propertiesConfiguration.save(fileOutputStream);
+    } catch (ConfigurationException | IOException e) {
       throw new RuntimeException(e);
     }
   }


### PR DESCRIPTION
Also introduce `SegmentMetadataUtils` to read and save the `PropertiesConfiguration`