### PR TITLE
report minion task metadata last update time as metric

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -112,8 +112,8 @@ rules:
   labels:
     taskType: "$1"
     status: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.minionTaskMetadataLastUpdateTimeMs.(\\w+)_(\\w+)\\.(\\w+)\"><>(\\w+)"
-  name: "pinot_controller_minionTaskMetadataLastUpdateTimeMs_$4"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.timeMsSinceLastMinionTaskMetadataUpdate.(\\w+)_(\\w+)\\.(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_timeMsSinceLastMinionTaskMetadataUpdate_$4"
   cache: true
   labels:
     table: "$1"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -112,6 +112,13 @@ rules:
   labels:
     taskType: "$1"
     status: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.minionTaskMetadataLastUpdateTimeMs.(\\w+)_(\\w+)\\.(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_minionTaskMetadataLastUpdateTimeMs_$4"
+  cache: true
+  labels:
+    table: "$1"
+    tableType: "$2"
+    taskType: "$3"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.pinotLeadControllerResourceEnabled\"><>(\\w+)"
   name: "pinot_controller_pinotLeadControllerResourceEnabled_$1"
   cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -101,6 +101,13 @@ rules:
   labels:
     taskType: "$1"
     status: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.minionTaskMetadataLastUpdateTimeMs.(\\w+)_(\\w+)\\.(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_minionTaskMetadataLastUpdateTimeMs_$4"
+  cache: true
+  labels:
+    table: "$1"
+    tableType: "$2"
+    taskType: "$3"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.pinotLeadControllerResourceEnabled\"><>(\\w+)"
   name: "pinot_controller_pinotLeadControllerResourceEnabled_$1"
   cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -101,8 +101,8 @@ rules:
   labels:
     taskType: "$1"
     status: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.minionTaskMetadataLastUpdateTimeMs.(\\w+)_(\\w+)\\.(\\w+)\"><>(\\w+)"
-  name: "pinot_controller_minionTaskMetadataLastUpdateTimeMs_$4"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.timeMsSinceLastMinionTaskMetadataUpdate.(\\w+)_(\\w+)\\.(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_timeMsSinceLastMinionTaskMetadataUpdate_$4"
   cache: true
   labels:
     table: "$1"

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -52,6 +52,7 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   OFFLINE_TABLE_COUNT("TableCount", true),
   DISABLED_TABLE_COUNT("TableCount", true),
   PERIODIC_TASK_NUM_TABLES_PROCESSED("PeriodicTaskNumTablesProcessed", true),
+  MINION_TASK_METADATA_LAST_UPDATE_TIME_MS("MinionTaskMetadataLastUpdateTimeMs", true),
   NUM_MINION_TASKS_IN_PROGRESS("NumMinionTasksInProgress", true),
   NUM_MINION_SUBTASKS_WAITING("NumMinionSubtasksWaiting", true),
   NUM_MINION_SUBTASKS_RUNNING("NumMinionSubtasksRunning", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -52,7 +52,7 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   OFFLINE_TABLE_COUNT("TableCount", true),
   DISABLED_TABLE_COUNT("TableCount", true),
   PERIODIC_TASK_NUM_TABLES_PROCESSED("PeriodicTaskNumTablesProcessed", true),
-  MINION_TASK_METADATA_LAST_UPDATE_TIME_MS("MinionTaskMetadataLastUpdateTimeMs", true),
+  TIME_MS_SINCE_LAST_MINION_TASK_METADATA_UPDATE("TimeMsSinceLastMinionTaskMetadataUpdate", false),
   NUM_MINION_TASKS_IN_PROGRESS("NumMinionTasksInProgress", true),
   NUM_MINION_SUBTASKS_WAITING("NumMinionSubtasksWaiting", true),
   NUM_MINION_SUBTASKS_RUNNING("NumMinionSubtasksRunning", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
@@ -21,7 +21,6 @@ package org.apache.pinot.common.minion;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.helix.AccessOption;
 import org.apache.helix.store.HelixPropertyStore;
@@ -74,9 +73,8 @@ public final class MinionTaskMetadataUtils {
    * @return a map storing the last update time (in ms) of all minion task metadata: (tableNameWithType -> taskType
    *         -> last update time in ms)
    */
-  @Nonnull
   public static Map<String, Map<String, Long>> getAllTaskMetadataLastUpdateTimeMs(
-      @Nonnull HelixPropertyStore<ZNRecord> propertyStore) {
+      HelixPropertyStore<ZNRecord> propertyStore) {
     Map<String, Map<String, Long>> tableTaskLastUpdateTimeMsMap = new HashMap<>();
     String propertyStorePathForMinionTaskMetadataPrefix =
         ZKMetadataProvider.getPropertyStorePathForMinionTaskMetadataPrefix();

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
@@ -96,6 +96,8 @@ public final class MinionTaskMetadataUtils {
       }
       // the new path is MINION_TASK_METADATA/${tableNameWthType}/${taskType}
       // the old path is MINION_TASK_METADATA/${taskType}/${tableNameWthType}
+      // The variable tableNameWithTypeOrTaskType stores the first level child name of MINION_TASK_METADATA, that's why
+      // when it ends with OFFLINE or REALTIME, it is a new path.
       boolean isNewPath =
           tableNameWithTypeOrTaskType.endsWith(TableType.OFFLINE.toString()) || tableNameWithTypeOrTaskType.endsWith(
               TableType.REALTIME.toString());

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
@@ -114,8 +114,8 @@ public final class MinionTaskMetadataUtils {
     return tableTaskLastUpdateTimeMsMap;
   }
 
-  private static void saveOrUpdateTaskMetadataLastUpdateTime(String tableNameWithType, String taskType, long newLastUpdateTimeMs,
-      Map<String, Map<String, Long>> tableTaskLastUpdateTimeMsMap) {
+  private static void saveOrUpdateTaskMetadataLastUpdateTime(String tableNameWithType, String taskType,
+      long newLastUpdateTimeMs, Map<String, Map<String, Long>> tableTaskLastUpdateTimeMsMap) {
     tableTaskLastUpdateTimeMsMap
         .computeIfAbsent(tableNameWithType, tnt -> new HashMap<>())
         .compute(taskType, (tt, lastUpdateTimeMs) -> {

--- a/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/minion/MinionTaskMetadataUtils.java
@@ -18,13 +18,18 @@
  */
 package org.apache.pinot.common.minion;
 
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.helix.AccessOption;
 import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.zkclient.exception.ZkException;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.StringUtil;
 import org.apache.zookeeper.data.Stat;
 
 
@@ -61,6 +66,66 @@ public final class MinionTaskMetadataUtils {
       znRecord.setVersion(stat.getVersion());
     }
     return znRecord;
+  }
+
+  /**
+   * Gets the last update time (in ms) of all minion task metadata.
+   * @param propertyStore the property store where all minion task metadata is stored.
+   * @return a map storing the last update time (in ms) of all minion task metadata: (tableNameWithType -> taskType
+   *         -> last update time in ms)
+   */
+  @Nonnull
+  public static Map<String, Map<String, Long>> getAllTaskMetadataLastUpdateTimeMs(
+      @Nonnull HelixPropertyStore<ZNRecord> propertyStore) {
+    Map<String, Map<String, Long>> tableTaskLastUpdateTimeMsMap = new HashMap<>();
+    String propertyStorePathForMinionTaskMetadataPrefix =
+        ZKMetadataProvider.getPropertyStorePathForMinionTaskMetadataPrefix();
+    // the old and new path may exist at the same time
+    List<String> tableNameWithTypeOrTaskTypes =
+        propertyStore.getChildNames(propertyStorePathForMinionTaskMetadataPrefix, AccessOption.PERSISTENT);
+    if (tableNameWithTypeOrTaskTypes == null || tableNameWithTypeOrTaskTypes.isEmpty()) {
+      return tableTaskLastUpdateTimeMsMap;
+    }
+    for (String tableNameWithTypeOrTaskType : tableNameWithTypeOrTaskTypes) {
+      String metadataNodeDirectParentPath =
+          StringUtil.join("/", propertyStorePathForMinionTaskMetadataPrefix, tableNameWithTypeOrTaskType);
+      List<String> metadataNodeNames =
+          propertyStore.getChildNames(metadataNodeDirectParentPath, AccessOption.PERSISTENT);
+      if (metadataNodeNames == null || metadataNodeNames.isEmpty()) {
+        continue;
+      }
+      // the new path is MINION_TASK_METADATA/${tableNameWthType}/${taskType}
+      // the old path is MINION_TASK_METADATA/${taskType}/${tableNameWthType}
+      boolean isNewPath =
+          tableNameWithTypeOrTaskType.endsWith(TableType.OFFLINE.toString()) || tableNameWithTypeOrTaskType.endsWith(
+              TableType.REALTIME.toString());
+      for (String metadataNodeName : metadataNodeNames) {
+        String metadataNodePath = StringUtil.join("/", metadataNodeDirectParentPath, metadataNodeName);
+        Stat stat = propertyStore.getStat(metadataNodePath, AccessOption.PERSISTENT);
+        if (isNewPath) {
+          saveOrUpdateTaskMetadataLastUpdateTime(tableNameWithTypeOrTaskType, metadataNodeName, stat.getMtime(),
+              tableTaskLastUpdateTimeMsMap);
+        } else {
+          saveOrUpdateTaskMetadataLastUpdateTime(metadataNodeName, tableNameWithTypeOrTaskType, stat.getMtime(),
+              tableTaskLastUpdateTimeMsMap);
+        }
+      }
+    }
+    return tableTaskLastUpdateTimeMsMap;
+  }
+
+  private static void saveOrUpdateTaskMetadataLastUpdateTime(String tableNameWithType, String taskType, long newLastUpdateTimeMs,
+      Map<String, Map<String, Long>> tableTaskLastUpdateTimeMsMap) {
+    tableTaskLastUpdateTimeMsMap
+        .computeIfAbsent(tableNameWithType, tnt -> new HashMap<>())
+        .compute(taskType, (tt, lastUpdateTimeMs) -> {
+          if (lastUpdateTimeMs == null) {
+            return newLastUpdateTimeMs;
+          } else {
+            // the metadata may be saved in two different places, use the larger one
+            return Math.max(lastUpdateTimeMs, newLastUpdateTimeMs);
+          }
+        });
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/FakePropertyStore.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/helix/FakePropertyStore.java
@@ -31,6 +31,7 @@ import org.apache.zookeeper.data.Stat;
 
 public class FakePropertyStore extends ZkHelixPropertyStore<ZNRecord> {
   private Map<String, ZNRecord> _contents = new HashMap<>();
+  private Map<String, Stat> _statMap = new HashMap<>();
   private IZkDataListener _listener = null;
 
   public FakePropertyStore() {
@@ -40,6 +41,11 @@ public class FakePropertyStore extends ZkHelixPropertyStore<ZNRecord> {
   @Override
   public ZNRecord get(String path, Stat stat, int options) {
     return _contents.get(path);
+  }
+
+  @Override
+  public Stat getStat(String path, int options) {
+    return _statMap.get(path);
   }
 
   @Override
@@ -62,9 +68,9 @@ public class FakePropertyStore extends ZkHelixPropertyStore<ZNRecord> {
   }
 
   @Override
-  public boolean set(String path, ZNRecord stat, int expectedVersion, int options) {
+  public boolean set(String path, ZNRecord record, int expectedVersion, int options) {
     try {
-      setContents(path, stat);
+      setContentAndStat(path, record);
       return true;
     } catch (Exception e) {
       return false;
@@ -72,9 +78,9 @@ public class FakePropertyStore extends ZkHelixPropertyStore<ZNRecord> {
   }
 
   @Override
-  public boolean set(String path, ZNRecord stat, int options) {
+  public boolean set(String path, ZNRecord record, int options) {
     try {
-      setContents(path, stat);
+      setContentAndStat(path, record);
       return true;
     } catch (Exception e) {
       return false;
@@ -88,11 +94,14 @@ public class FakePropertyStore extends ZkHelixPropertyStore<ZNRecord> {
     return true;
   }
 
-  public void setContents(String path, ZNRecord contents)
+  public void setContentAndStat(String path, ZNRecord record)
       throws Exception {
-    _contents.put(path, contents);
+    _contents.put(path, record);
+    Stat stat = new Stat();
+    stat.setMtime(System.currentTimeMillis());
+    _statMap.put(path, stat);
     if (_listener != null) {
-      _listener.handleDataChange(path, contents);
+      _listener.handleDataChange(path, record);
     }
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
@@ -136,7 +136,6 @@ public class MinionTaskMetadataUtilsTest {
     assertEquals(taskTypeLastUpdateMsMap.size(), 1);
     lastUpdateTimeMs = taskTypeLastUpdateMsMap.get(TASK_TYPE);
     assertTrue(lastUpdateTimeMs >= tsAfterNewPathSet && lastUpdateTimeMs <= tsAfterOldPathSet);
-
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/minion/MinionTaskMetadataUtilsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.minion;
 
+import java.util.Map;
 import org.apache.helix.AccessOption;
 import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -74,6 +75,68 @@ public class MinionTaskMetadataUtilsTest {
     propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
     assertEquals(MinionTaskMetadataUtils.fetchTaskMetadata(propertyStore, TASK_TYPE, TABLE_NAME_WITH_TYPE),
         NEW_TASK_METADATA.toZNRecord());
+  }
+
+  @Test
+  public void testGetAllTaskMetadataLastUpdateTimeMs() {
+    // no task metadata exists
+    HelixPropertyStore<ZNRecord> propertyStore = new FakePropertyStore();
+    assertTrue(MinionTaskMetadataUtils.getAllTaskMetadataLastUpdateTimeMs(propertyStore).isEmpty());
+
+    // only the old metadata path exists
+    propertyStore = new FakePropertyStore();
+    long tsBeforeSet = System.currentTimeMillis();
+    propertyStore.set(OLD_MINION_METADATA_PATH, OLD_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    long tsAfterSet = System.currentTimeMillis();
+    Map<String, Map<String, Long>> allTaskMetadataLastUpdateTimeMs =
+        MinionTaskMetadataUtils.getAllTaskMetadataLastUpdateTimeMs(propertyStore);
+    assertEquals(allTaskMetadataLastUpdateTimeMs.size(), 1);
+    Map<String, Long> taskTypeLastUpdateMsMap = allTaskMetadataLastUpdateTimeMs.get(TABLE_NAME_WITH_TYPE);
+    assertEquals(taskTypeLastUpdateMsMap.size(), 1);
+    long lastUpdateTimeMs = taskTypeLastUpdateMsMap.get(TASK_TYPE);
+    assertTrue(lastUpdateTimeMs >= tsBeforeSet && lastUpdateTimeMs <= tsAfterSet);
+
+    // only the new metadata path exists
+    propertyStore = new FakePropertyStore();
+    tsBeforeSet = System.currentTimeMillis();
+    propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    tsAfterSet = System.currentTimeMillis();
+    allTaskMetadataLastUpdateTimeMs =
+        MinionTaskMetadataUtils.getAllTaskMetadataLastUpdateTimeMs(propertyStore);
+    assertEquals(allTaskMetadataLastUpdateTimeMs.size(), 1);
+    taskTypeLastUpdateMsMap = allTaskMetadataLastUpdateTimeMs.get(TABLE_NAME_WITH_TYPE);
+    assertEquals(taskTypeLastUpdateMsMap.size(), 1);
+    lastUpdateTimeMs = taskTypeLastUpdateMsMap.get(TASK_TYPE);
+    assertTrue(lastUpdateTimeMs >= tsBeforeSet && lastUpdateTimeMs <= tsAfterSet);
+
+    // if two metadata paths exist at the same time, the newly updated one will be used.
+    // the new metadata path is updated later
+    propertyStore = new FakePropertyStore();
+    propertyStore.set(OLD_MINION_METADATA_PATH, OLD_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    long tsAfterOldPathSet = System.currentTimeMillis();
+    propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    long tsAfterNewPathSet = System.currentTimeMillis();
+    allTaskMetadataLastUpdateTimeMs =
+        MinionTaskMetadataUtils.getAllTaskMetadataLastUpdateTimeMs(propertyStore);
+    assertEquals(allTaskMetadataLastUpdateTimeMs.size(), 1);
+    taskTypeLastUpdateMsMap = allTaskMetadataLastUpdateTimeMs.get(TABLE_NAME_WITH_TYPE);
+    assertEquals(taskTypeLastUpdateMsMap.size(), 1);
+    lastUpdateTimeMs = taskTypeLastUpdateMsMap.get(TASK_TYPE);
+    assertTrue(lastUpdateTimeMs >= tsAfterOldPathSet && lastUpdateTimeMs <= tsAfterNewPathSet);
+    // the old metadata path is updated later
+    propertyStore = new FakePropertyStore();
+    propertyStore.set(NEW_MINION_METADATA_PATH, NEW_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    tsAfterNewPathSet = System.currentTimeMillis();
+    propertyStore.set(OLD_MINION_METADATA_PATH, OLD_TASK_METADATA.toZNRecord(), EXPECTED_VERSION, ACCESS_OPTION);
+    tsAfterOldPathSet = System.currentTimeMillis();
+    allTaskMetadataLastUpdateTimeMs =
+        MinionTaskMetadataUtils.getAllTaskMetadataLastUpdateTimeMs(propertyStore);
+    assertEquals(allTaskMetadataLastUpdateTimeMs.size(), 1);
+    taskTypeLastUpdateMsMap = allTaskMetadataLastUpdateTimeMs.get(TABLE_NAME_WITH_TYPE);
+    assertEquals(taskTypeLastUpdateMsMap.size(), 1);
+    lastUpdateTimeMs = taskTypeLastUpdateMsMap.get(TASK_TYPE);
+    assertTrue(lastUpdateTimeMs >= tsAfterNewPathSet && lastUpdateTimeMs <= tsAfterOldPathSet);
+
   }
 
   @Test

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -37,7 +37,6 @@ import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.lang3.StringUtils;
@@ -842,7 +841,6 @@ public class PinotHelixTaskResourceManager {
    * @return a map storing the last update time (in ms) of all minion task metadata: (tableNameWithType -> taskType
    *         -> last update time in ms)
    */
-  @Nonnull
   public Map<String, Map<String, Long>> getTaskMetadataLastUpdateTimeMs() {
     ZkHelixPropertyStore<ZNRecord> propertyStore = _helixResourceManager.getPropertyStore();
     return MinionTaskMetadataUtils.getAllTaskMetadataLastUpdateTimeMs(propertyStore);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -37,6 +37,7 @@ import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.Executor;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.lang3.StringUtils;
@@ -834,6 +835,17 @@ public class PinotHelixTaskResourceManager {
   public void deleteTaskMetadataByTable(String taskType, String tableNameWithType) {
     ZkHelixPropertyStore<ZNRecord> propertyStore = _helixResourceManager.getPropertyStore();
     MinionTaskMetadataUtils.deleteTaskMetadata(propertyStore, taskType, tableNameWithType);
+  }
+
+  /**
+   * Gets the last update time (in ms) of all minion task metadata.
+   * @return a map storing the last update time (in ms) of all minion task metadata: (tableNameWithType -> taskType
+   *         -> last update time in ms)
+   */
+  @Nonnull
+  public Map<String, Map<String, Long>> getTaskMetadataLastUpdateTimeMs() {
+    ZkHelixPropertyStore<ZNRecord> propertyStore = _helixResourceManager.getPropertyStore();
+    return MinionTaskMetadataUtils.getAllTaskMetadataLastUpdateTimeMs(propertyStore);
   }
 
   @JsonPropertyOrder({"taskState", "subtaskCount", "startTime", "executionStartTime", "finishTime", "subtaskInfos"})

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitter.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.controller.helix.core.minion;
 
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import org.apache.pinot.common.metrics.ControllerGauge;
@@ -65,6 +66,15 @@ public class TaskMetricsEmitter extends BasePeriodicTask {
     if (!_leadControllerManager.isLeaderForTable(TASK_NAME)) {
       return;
     }
+
+    Map<String, Map<String, Long>> taskMetadataLastUpdateTime =
+        _helixTaskResourceManager.getTaskMetadataLastUpdateTimeMs();
+    taskMetadataLastUpdateTime.forEach((tableNameWithType, taskTypeLastUpdateTime) -> {
+      taskTypeLastUpdateTime.forEach((taskType, lastUpdateTimeMs) -> {
+        _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.MINION_TASK_METADATA_LAST_UPDATE_TIME_MS,
+            tableNameWithType + "." + taskType, lastUpdateTimeMs);
+      });
+    });
 
     // The call to get task types can take time if there are a lot of tasks.
     // Potential optimization is to call it every (say) 30m if we detect a barrage of

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitter.java
@@ -69,12 +69,11 @@ public class TaskMetricsEmitter extends BasePeriodicTask {
 
     Map<String, Map<String, Long>> taskMetadataLastUpdateTime =
         _helixTaskResourceManager.getTaskMetadataLastUpdateTimeMs();
-    taskMetadataLastUpdateTime.forEach((tableNameWithType, taskTypeLastUpdateTime) -> {
-      taskTypeLastUpdateTime.forEach((taskType, lastUpdateTimeMs) -> {
-        _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.MINION_TASK_METADATA_LAST_UPDATE_TIME_MS,
-            tableNameWithType + "." + taskType, lastUpdateTimeMs);
-      });
-    });
+    taskMetadataLastUpdateTime.forEach((tableNameWithType, taskTypeLastUpdateTime) ->
+        taskTypeLastUpdateTime.forEach((taskType, lastUpdateTimeMs) ->
+            _controllerMetrics.addOrUpdateGauge(
+                ControllerGauge.TIME_MS_SINCE_LAST_MINION_TASK_METADATA_UPDATE.getGaugeName() +
+                "." + tableNameWithType + "." + taskType, () -> System.currentTimeMillis() - lastUpdateTimeMs)));
 
     // The call to get task types can take time if there are a lot of tasks.
     // Potential optimization is to call it every (say) 30m if we detect a barrage of

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitter.java
@@ -72,8 +72,8 @@ public class TaskMetricsEmitter extends BasePeriodicTask {
     taskMetadataLastUpdateTime.forEach((tableNameWithType, taskTypeLastUpdateTime) ->
         taskTypeLastUpdateTime.forEach((taskType, lastUpdateTimeMs) ->
             _controllerMetrics.addOrUpdateGauge(
-                ControllerGauge.TIME_MS_SINCE_LAST_MINION_TASK_METADATA_UPDATE.getGaugeName() +
-                "." + tableNameWithType + "." + taskType, () -> System.currentTimeMillis() - lastUpdateTimeMs)));
+                ControllerGauge.TIME_MS_SINCE_LAST_MINION_TASK_METADATA_UPDATE.getGaugeName() + "."
+                    + tableNameWithType + "." + taskType, () -> System.currentTimeMillis() - lastUpdateTimeMs)));
 
     // The call to get task types can take time if there are a lot of tasks.
     // Potential optimization is to call it every (say) 30m if we detect a barrage of


### PR DESCRIPTION
Report minion task metadata last update time as metric. This metric is helpful when we are going to track/debug minion tasks.

The following figure shows the emitted metric.
<img width="1274" alt="Screen Shot 2022-12-15 at 11 50 10 PM" src="https://user-images.githubusercontent.com/9796617/208050863-9558f3ec-0188-4261-b8a5-d95143fae551.png">



