### PR TITLE
Add back auth token for UploadSegmentCommand

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
@@ -186,7 +186,8 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
         }
 
         LOGGER.info("Uploading segment tar file: {}", segmentTarFile);
-        List<Header> headerList = makeAuthHeaders(_authProvider);
+        List<Header> headerList =
+            makeAuthHeaders(makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password));
 
         FileInputStream fileInputStream = new FileInputStream(segmentTarFile);
         fileUploadDownloadClient.uploadSegment(uploadSegmentHttpURI, segmentTarFile.getName(),


### PR DESCRIPTION
`bugfix`
The auth token used in the auth headers was removed in https://github.com/startreedata/pinot/commit/66ed9b7167241da15c171d667006a3f00a13734c.  This broke some application tests. This PR creates the auth header as it previous was.

I tested this locally with a custom image and it resolved the issue.