### PR TITLE
[multistage] add defensive scheduling, enable for tests

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -94,16 +94,16 @@ public class QueryRunner {
     _port = config.getProperty(QueryConfig.KEY_OF_QUERY_RUNNER_PORT, QueryConfig.DEFAULT_QUERY_RUNNER_PORT);
     _helixManager = helixManager;
     try {
-      long releaseTs = config.getProperty(
+      long releaseMs = config.getProperty(
           QueryConfig.KEY_OF_SCHEDULER_RELEASE_TIMEOUT_MS,
           QueryConfig.DEFAULT_SCHEDULER_RELEASE_TIMEOUT_MS);
 
       _scheduler = new OpChainSchedulerService(
-          new RoundRobinScheduler(releaseTs),
+          new RoundRobinScheduler(releaseMs),
           Executors.newFixedThreadPool(
               ResourceManager.DEFAULT_QUERY_WORKER_THREADS,
               new NamedThreadFactory("query_worker_on_" + _port + "_port")),
-          releaseTs);
+          releaseMs);
       _mailboxService = MultiplexingMailboxService.newInstance(_hostname, _port, config, _scheduler::onDataAvailable);
       _serverExecutor = new ServerQueryExecutorV1Impl();
       _serverExecutor.init(config, instanceDataManager, serverMetrics);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -94,10 +94,16 @@ public class QueryRunner {
     _port = config.getProperty(QueryConfig.KEY_OF_QUERY_RUNNER_PORT, QueryConfig.DEFAULT_QUERY_RUNNER_PORT);
     _helixManager = helixManager;
     try {
-      _scheduler = new OpChainSchedulerService(new RoundRobinScheduler(),
+      long releaseTs = config.getProperty(
+          QueryConfig.KEY_OF_SCHEDULER_RELEASE_TIMEOUT_MS,
+          QueryConfig.DEFAULT_SCHEDULER_RELEASE_TIMEOUT_MS);
+
+      _scheduler = new OpChainSchedulerService(
+          new RoundRobinScheduler(releaseTs),
           Executors.newFixedThreadPool(
               ResourceManager.DEFAULT_QUERY_WORKER_THREADS,
-              new NamedThreadFactory("query_worker_on_" + _port + "_port")));
+              new NamedThreadFactory("query_worker_on_" + _port + "_port")),
+          releaseTs);
       _mailboxService = MultiplexingMailboxService.newInstance(_hostname, _port, config, _scheduler::onDataAvailable);
       _serverExecutor = new ServerQueryExecutorV1Impl();
       _serverExecutor.init(config, instanceDataManager, serverMetrics);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/RoundRobinScheduler.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/RoundRobinScheduler.java
@@ -85,7 +85,8 @@ public class RoundRobinScheduler implements OpChainScheduler {
     if (isNew) {
       _ready.add(operatorChain);
     } else {
-      _available.add(new AvailableEntry(operatorChain, _ticker.get() + _releaseTimeout));
+      long releaseTs = _releaseTimeout < 0 ? Long.MAX_VALUE : _ticker.get() + _releaseTimeout;
+      _available.add(new AvailableEntry(operatorChain, releaseTs));
     }
     trace("registered " + operatorChain);
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/RoundRobinScheduler.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/RoundRobinScheduler.java
@@ -25,6 +25,8 @@ import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.Queue;
 import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import org.apache.pinot.query.mailbox.MailboxIdentifier;
 import org.apache.pinot.query.runtime.operator.OpChain;
 import org.slf4j.Logger;
@@ -39,12 +41,16 @@ import org.slf4j.LoggerFactory;
  */
 public class RoundRobinScheduler implements OpChainScheduler {
   private static final Logger LOGGER = LoggerFactory.getLogger(RoundRobinScheduler.class);
+  private static final long DEFAULT_RELEASE_TIMEOUT = TimeUnit.MINUTES.toMillis(1);
+
+  private final long _releaseTimeout;
+  private final Supplier<Long> _ticker;
 
   // the _available queue contains operator chains that are available
   // to this scheduler but do not have any data available to schedule
   // while the _ready queue contains the operator chains that are ready
   // to be scheduled (have data, or are first-time scheduled)
-  private final Queue<OpChain> _available = new LinkedList<>();
+  private final Queue<AvailableEntry> _available = new LinkedList<>();
   private final Queue<OpChain> _ready = new LinkedList<>();
 
   // using a Set here is acceptable because calling hasNext() and
@@ -58,12 +64,29 @@ public class RoundRobinScheduler implements OpChainScheduler {
   @VisibleForTesting
   final Set<MailboxIdentifier> _seenMail = new HashSet<>();
 
+  public RoundRobinScheduler() {
+    this(DEFAULT_RELEASE_TIMEOUT);
+  }
+
+  public RoundRobinScheduler(long releaseTimeout) {
+    this(releaseTimeout, System::currentTimeMillis);
+  }
+
+  public RoundRobinScheduler(long releaseTimeoutMs, Supplier<Long> ticker) {
+    _releaseTimeout = releaseTimeoutMs;
+    _ticker = ticker;
+  }
+
   @Override
   public void register(OpChain operatorChain, boolean isNew) {
     // the first time an operator chain is scheduled, it should
     // immediately be considered ready in case it does not need
     // read from any mailbox (e.g. with a LiteralValueOperator)
-    (isNew ? _ready : _available).add(operatorChain);
+    if (isNew) {
+      _ready.add(operatorChain);
+    } else {
+      _available.add(new AvailableEntry(operatorChain, _ticker.get() + _releaseTimeout));
+    }
     trace("registered " + operatorChain);
   }
 
@@ -108,7 +131,7 @@ public class RoundRobinScheduler implements OpChainScheduler {
   }
 
   private void computeReady() {
-    Iterator<OpChain> availableChains = _available.iterator();
+    Iterator<AvailableEntry> availableChains = _available.iterator();
 
     // the algorithm here iterates through all available chains and checks
     // to see whether or not any of the available chains have seen mail for
@@ -117,15 +140,20 @@ public class RoundRobinScheduler implements OpChainScheduler {
     // mailboxes that it would consume from (after it is scheduled, all
     // mail available to it will have been consumed).
     while (availableChains.hasNext()) {
-      OpChain chain = availableChains.next();
-      Sets.SetView<MailboxIdentifier> intersect = Sets.intersection(chain.getReceivingMailbox(), _seenMail);
+      AvailableEntry chain = availableChains.next();
+      Sets.SetView<MailboxIdentifier> intersect = Sets.intersection(chain._opChain.getReceivingMailbox(), _seenMail);
 
       if (!intersect.isEmpty()) {
         // use an immutable copy because set views use the underlying sets
         // directly, which would cause a concurrent modification exception
         // when removing data from _seenMail
         _seenMail.removeAll(intersect.immutableCopy());
-        _ready.add(chain);
+        _ready.add(chain._opChain);
+        availableChains.remove();
+      } else if (_ticker.get() > chain._releaseTs) {
+        LOGGER.warn("({}) Scheduling operator chain reading from {} after timeout. Ready: {}, Available: {}, Mail: {}.",
+            chain._opChain, chain._opChain.getReceivingMailbox(), _ready, _available, _seenMail);
+        _ready.add(chain._opChain);
         availableChains.remove();
       }
     }
@@ -134,5 +162,21 @@ public class RoundRobinScheduler implements OpChainScheduler {
   private void trace(String operation) {
     LOGGER.trace("({}) Ready: {}, Available: {}, Mail: {}",
         operation, _ready, _available, _seenMail);
+  }
+
+  private static class AvailableEntry {
+
+    final OpChain _opChain;
+    final long _releaseTs;
+
+    private AvailableEntry(OpChain opChain, long releaseTs) {
+      _opChain = opChain;
+      _releaseTs = releaseTs;
+    }
+
+    @Override
+    public String toString() {
+      return _opChain.toString();
+    }
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
@@ -59,6 +59,6 @@ public class OpChain {
 
   @Override
   public String toString() {
-    return "OpChain{ " + _id + "}";
+    return "OpChain{" + _id + "}";
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
@@ -18,9 +18,6 @@
  */
 package org.apache.pinot.query.service;
 
-import java.util.concurrent.TimeUnit;
-
-
 /**
  * Configuration for setting up query runtime.
  */
@@ -65,8 +62,15 @@ public class QueryConfig {
   /**
    * Configuration keys for managing the scheduler
    */
+
+  /**
+   * The maximum time that a operator chain will be held in the queue without being scheduled for execution.
+   * This is intended as a defensive measure for situations where we notice that an operator is not being
+   * scheduled when it otherwise should be. The default value, -1, indicates that we should never release
+   * an operator chain despite any amount of time elapsed.
+   */
   public static final String KEY_OF_SCHEDULER_RELEASE_TIMEOUT_MS = "pinot.query.scheduler.release.timeout.ms";
-  public static final long DEFAULT_SCHEDULER_RELEASE_TIMEOUT_MS = TimeUnit.MINUTES.toSeconds(1);
+  public static final long DEFAULT_SCHEDULER_RELEASE_TIMEOUT_MS = -1;
 
   private QueryConfig() {
     // do not instantiate.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
@@ -18,6 +18,9 @@
  */
 package org.apache.pinot.query.service;
 
+import java.util.concurrent.TimeUnit;
+
+
 /**
  * Configuration for setting up query runtime.
  */
@@ -58,6 +61,12 @@ public class QueryConfig {
    */
   public static final String KEY_OF_SERVER_RESPONSE_STATUS_ERROR = "ERROR";
   public static final String KEY_OF_SERVER_RESPONSE_STATUS_OK = "OK";
+
+  /**
+   * Configuration keys for managing the scheduler
+   */
+  public static final String KEY_OF_SCHEDULER_RELEASE_TIMEOUT_MS = "pinot.query.scheduler.release.timeout.ms";
+  public static final long DEFAULT_SCHEDULER_RELEASE_TIMEOUT_MS = TimeUnit.MINUTES.toSeconds(1);
 
   private QueryConfig() {
     // do not instantiate.

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
@@ -81,6 +81,7 @@ public class QueryServerEnclosure {
       _runnerConfig.put(QueryConfig.KEY_OF_QUERY_RUNNER_PORT, _queryRunnerPort);
       _runnerConfig.put(QueryConfig.KEY_OF_QUERY_RUNNER_HOSTNAME,
           String.format("Server_%s", QueryConfig.DEFAULT_QUERY_RUNNER_HOSTNAME));
+      _runnerConfig.put(QueryConfig.KEY_OF_SCHEDULER_RELEASE_TIMEOUT_MS, 100);
       _queryRunner = new QueryRunner();
       _scheduler = new OpChainSchedulerService(new RoundRobinScheduler(),
           Executors.newFixedThreadPool(

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/RoundRobinSchedulerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/RoundRobinSchedulerTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.runtime.executor;
 
 import com.google.common.collect.ImmutableList;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.query.mailbox.MailboxIdentifier;
 import org.apache.pinot.query.mailbox.StringMailboxIdentifier;
@@ -96,6 +97,22 @@ public class RoundRobinSchedulerTest {
     Assert.assertTrue(scheduler.hasNext());
     Assert.assertEquals(scheduler.next(), chain1);
     Assert.assertFalse(scheduler.hasNext());
+  }
+
+  @Test
+  public void shouldScheduleRescheduledOpChainAfterTimeout() {
+    // Given:
+    OpChain chain1 = new OpChain(_operator, ImmutableList.of(MAILBOX_1), 123, 1);
+    AtomicLong ticker = new AtomicLong(0);
+    RoundRobinScheduler scheduler = new RoundRobinScheduler(100, ticker::get);
+
+    // When:
+    scheduler.register(chain1, false);
+    ticker.set(101);
+
+    // Then:
+    Assert.assertTrue(scheduler.hasNext());
+    Assert.assertEquals(scheduler.next(), chain1);
   }
 
   @Test


### PR DESCRIPTION
Adds a configuration that allows `RoundRobinScheduler` to mark operators as ready after a certain timeout. If the operator is marked ready due to a timeout, log the information around what happened during the timeout.

Only enable this for tests at the moment so that we can debug why some tests are failing.