### PR TITLE
Use gson JSONParser for asserting JSON equality deterministically

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/PinotDataTypeTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.utils;
 
+import com.google.gson.JsonParser;
 import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.Arrays;
@@ -230,11 +231,11 @@ public class PinotDataTypeTest {
     assertEquals(OBJECT.toTimestamp(new NumberObject("123")).getTime(), 123L);
     assertEquals(OBJECT.toString(new NumberObject("123")), "123");
 
-    // check if a well formed JSON string string can be converted to JSON.
-    assertEquals(OBJECT.toJson(getGenericTestObject()),
-        "{\"bytes\":\"AAE=\",\"map\":{\"key1\":\"value\",\"key2\":null,\"array\":[-5.4,4,\"2\"]},"
-            + "\"timestamp\":1620324238610}");
-
+    // check if a well formed JSON string can be converted to JSON.
+    JsonParser parser = new JsonParser();
+    assertEquals(parser.parse(OBJECT.toJson(getGenericTestObject())),
+            parser.parse("{\"bytes\":\"AAE=\",\"map\":{\"key1\":\"value\",\"key2\":null,\""
+            + "array\":[-5.4,4,\"2\"]},\"timestamp\":1620324238610}"));
     // check if a Java string (which does not represent JSON) can be converted into JSON.
     assertEquals(OBJECT.toJson("test"), "\"test\"");
     assertEquals(OBJECT_ARRAY.getSingleValueType(), OBJECT);


### PR DESCRIPTION
The test `org.apache.pinot.common.utils.PinotDataTypeTest#testObject` was detected to be flaky, using the [NonDex](https://github.com/TestingResearchIllinois/NonDex) tool.

Command to reproduce using Nondex: 
`edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.pinot.common.utils.PinotDataTypeTest#testObject -Dlicense.skip=true -Drat.skip=true`

The following assertion failed:
```
assertEquals(OBJECT.toJson(getGenericTestObject()),
        "{\"bytes\":\"AAE=\",\"map\":{\"key1\":\"value\",\"key2\":null,\"array\":[-5.4,4,\"2\"]},"
            + "\"timestamp\":1620324238610}");
```
The test fails due to non-deterministic ordering of the Json objects that are being compared for equality.

Error log:
```
[ERROR]   java.lang.AssertionError: expected [{"bytes":"AAE=","map":{"key1":"value","key2":null,"array":[-5.4,4,"2"]},"timestamp":1620324238610}] but found [{"map":{"key1":"value","key2":null,"array":[-5.4,4,"2"]},"bytes":"AAE=","timestamp":1620324238610}]
	at org.testng.Assert.fail(Assert.java:93)
	at org.testng.Assert.failNotEquals(Assert.java:512)
	at org.testng.Assert.assertEqualsImpl(Assert.java:134)
	at org.testng.Assert.assertEquals(Assert.java:115)
	at org.testng.Assert.assertEquals(Assert.java:189)
	at org.testng.Assert.assertEquals(Assert.java:199)
	at org.apache.pinot.common.utils.PinotDataTypeTest.testObject(PinotDataTypeTest.java:234)
```

Changes proposed in this pull request:
  -
The flakiness of the test is because the json string created by `OBJECT.toJson(getGenericTestObject())` does not have deterministic ordering of its elements.
Using the gson [JsonParser](https://stackoverflow.com/questions/2253750/testing-two-json-objects-for-equality-ignoring-child-order-in-java/9065247#9065247).parseString(), the json strings are converted to json parse trees. 
The generated parse trees are then compared for equality in the assertions, ignoring the order of the child elements. 
The tests pass using [NonDex](https://github.com/TestingResearchIllinois/NonDex) after this change.
