### PR TITLE
[multistage] [bugfix] Throw error when GrpcMailbox receiving buffer is full

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcReceivingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcReceivingMailbox.java
@@ -94,7 +94,6 @@ public class GrpcReceivingMailbox implements ReceivingMailbox<TransferableBlock>
     return isInitialized() && _contentStreamObserver.isCompleted();
   }
 
-  // TODO: fix busy wait. This should be guarded by timeout.
   private boolean waitForInitialize()
       throws Exception {
     if (_initializationLatch.getCount() > 0) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentStreamObserver.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentStreamObserver.java
@@ -43,6 +43,14 @@ import org.slf4j.LoggerFactory;
  */
 public class MailboxContentStreamObserver implements StreamObserver<Mailbox.MailboxContent> {
   private static final Logger LOGGER = LoggerFactory.getLogger(MailboxContentStreamObserver.class);
+
+  private static Mailbox.MailboxContent createErrorContent(Throwable e)
+      throws IOException {
+    return Mailbox.MailboxContent.newBuilder().setPayload(ByteString.copyFrom(
+            TransferableBlockUtils.getErrorTransferableBlock(new RuntimeException(e)).getDataBlock().toBytes()))
+        .putMetadata(ChannelUtils.MAILBOX_METADATA_END_OF_STREAM_KEY, "true").build();
+  }
+
   private static final int DEFAULT_MAILBOX_QUEUE_CAPACITY = 5;
   private final GrpcMailboxService _mailboxService;
   private final StreamObserver<Mailbox.MailboxStatus> _responseObserver;
@@ -50,6 +58,7 @@ public class MailboxContentStreamObserver implements StreamObserver<Mailbox.Mail
 
   private final AtomicBoolean _isCompleted = new AtomicBoolean(false);
   private final ArrayBlockingQueue<Mailbox.MailboxContent> _receivingBuffer;
+  private Mailbox.MailboxContent _errorContent = null;
   private StringMailboxIdentifier _mailboxId;
   private Consumer<MailboxIdentifier> _gotMailCallback;
 
@@ -73,6 +82,9 @@ public class MailboxContentStreamObserver implements StreamObserver<Mailbox.Mail
    * to indicate when to call this method.
    */
   public Mailbox.MailboxContent poll() {
+    if (_errorContent != null) {
+      return _errorContent;
+    }
     if (isCompleted()) {
       return null;
     }
@@ -93,7 +105,19 @@ public class MailboxContentStreamObserver implements StreamObserver<Mailbox.Mail
 
     if (!mailboxContent.getMetadataMap().containsKey(ChannelUtils.MAILBOX_METADATA_BEGIN_OF_STREAM_KEY)) {
       // when the receiving end receives a message put it in the mailbox queue.
-      _receivingBuffer.offer(mailboxContent);
+      // TODO: pass a timeout to _receivingBuffer.
+      if (!_receivingBuffer.offer(mailboxContent)) {
+        // TODO: close the stream.
+        RuntimeException e = new RuntimeException("Mailbox receivingBuffer is full:" + _mailboxId);
+        LOGGER.error(e.getMessage());
+        try {
+          _errorContent = createErrorContent(e);
+        } catch (IOException ioe) {
+          e = new RuntimeException("Unable to encode exception for cascade reporting: " + e, ioe);
+          LOGGER.error(e.getMessage());
+          throw e;
+        }
+      }
       _gotMailCallback.accept(_mailboxId);
 
       if (_isEnabledFeedback) {
@@ -116,11 +140,9 @@ public class MailboxContentStreamObserver implements StreamObserver<Mailbox.Mail
   @Override
   public void onError(Throwable e) {
     try {
-      _receivingBuffer.offer(Mailbox.MailboxContent.newBuilder()
-          .setPayload(ByteString.copyFrom(
-              TransferableBlockUtils.getErrorTransferableBlock(new RuntimeException(e)).getDataBlock().toBytes()))
-          .putMetadata(ChannelUtils.MAILBOX_METADATA_END_OF_STREAM_KEY, "true").build());
+      _errorContent = createErrorContent(e);
       _gotMailCallback.accept(_mailboxId);
+      // TODO: close the stream.
       throw new RuntimeException(e);
     } catch (IOException ioe) {
       throw new RuntimeException("Unable to encode exception for cascade reporting: " + e, ioe);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxStatusStreamObserver.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxStatusStreamObserver.java
@@ -37,7 +37,6 @@ import org.slf4j.LoggerFactory;
 public class MailboxStatusStreamObserver implements StreamObserver<Mailbox.MailboxStatus> {
   private static final Logger LOGGER = LoggerFactory.getLogger(MailboxStatusStreamObserver.class);
   private static final int DEFAULT_MAILBOX_QUEUE_CAPACITY = 5;
-  private static final long DEFAULT_MAILBOX_POLL_TIMEOUT_MS = 1000L;
   private final AtomicInteger _bufferSize = new AtomicInteger(5);
   private final AtomicBoolean _isCompleted = new AtomicBoolean(false);
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/GrpcMailboxServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/GrpcMailboxServiceTest.java
@@ -27,7 +27,6 @@ import java.util.function.Consumer;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.query.mailbox.channel.MailboxContentStreamObserver;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.service.QueryConfig;
 import org.apache.pinot.query.testutils.QueryTestUtils;
@@ -49,28 +48,6 @@ public class GrpcMailboxServiceTest {
 
   private GrpcMailboxService _mailboxService1;
   private GrpcMailboxService _mailboxService2;
-
-  private TransferableBlock getTestTransferableBlock() {
-    List<Object[]> rows = new ArrayList<>();
-    rows.add(createRow(0, "test_string"));
-    return new TransferableBlock(rows, TEST_DATA_SCHEMA, DataBlock.Type.ROW);
-  }
-
-  private TransferableBlock getTooLargeTransferableBlock() {
-    final int size = 1_000_000;
-    List<Object[]> rows = new ArrayList<>(size);
-    for (int i = 0; i < size; i++) {
-      rows.add(createRow(0, "test_string"));
-    }
-    return new TransferableBlock(rows, TEST_DATA_SCHEMA, DataBlock.Type.ROW);
-  }
-
-  private Object[] createRow(int intValue, String stringValue) {
-    Object[] row = new Object[2];
-    row[0] = intValue;
-    row[1] = stringValue;
-    return row;
-  }
 
   @BeforeClass
   public void setUp()
@@ -147,30 +124,25 @@ public class GrpcMailboxServiceTest {
     Assert.assertFalse(receivedDataBlock.getExceptions().isEmpty());
   }
 
-  @Test(timeOut = 10_000L)
-  public void testReceivingBufferFull()
-      throws Exception {
-    MailboxContentStreamObserver.DEFAULT_MAILBOX_QUEUE_CAPACITY = 1;
+  private TransferableBlock getTestTransferableBlock() {
+    List<Object[]> rows = new ArrayList<>();
+    rows.add(createRow(0, "test_string"));
+    return new TransferableBlock(rows, TEST_DATA_SCHEMA, DataBlock.Type.ROW);
+  }
 
-    StringMailboxIdentifier mailboxId = new StringMailboxIdentifier(
-        "exception", "localhost", _mailboxService1.getMailboxPort(), "localhost", _mailboxService2.getMailboxPort());
+  private TransferableBlock getTooLargeTransferableBlock() {
+    final int size = 1_000_000;
+    List<Object[]> rows = new ArrayList<>(size);
+    for (int i = 0; i < size; i++) {
+      rows.add(createRow(0, "test_string"));
+    }
+    return new TransferableBlock(rows, TEST_DATA_SCHEMA, DataBlock.Type.ROW);
+  }
 
-    SendingMailbox<TransferableBlock> sendingMailbox = _mailboxService1.getSendingMailbox(mailboxId);
-    TransferableBlock testContent = getTestTransferableBlock();
-    sendingMailbox.send(testContent);
-    sendingMailbox.send(testContent);
-
-    ReceivingMailbox<TransferableBlock> receivingMailbox = _mailboxService2.getReceivingMailbox(mailboxId);
-    CountDownLatch gotData = new CountDownLatch(1);
-    _mail2GotData.set(ignored -> gotData.countDown());
-
-    // When:
-    gotData.await();
-    TransferableBlock receivedContent = receivingMailbox.receive();
-    // Then:
-    Assert.assertNotNull(receivedContent);
-    DataBlock receivedDataBlock = receivedContent.getDataBlock();
-    Assert.assertTrue(receivedDataBlock instanceof MetadataBlock);
-    Assert.assertFalse(receivedDataBlock.getExceptions().isEmpty());
+  private Object[] createRow(int intValue, String stringValue) {
+    Object[] row = new Object[2];
+    row[0] = intValue;
+    row[1] = stringValue;
+    return row;
   }
 }


### PR DESCRIPTION
We silently drop data block when  GrpcMailbox receiving buffer is full today. This will return incorrect result silently. 

This PR serves as a bandaid to throw error instead of returning incorrect result. 

Unfortunately, it is very hard to test this until underlying mailbox error handling and async issue are fixed.