### PR TITLE
[multistage] improve scheduling to be more mailbox-aware

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -33,7 +34,6 @@ import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.data.table.Key;
-import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
@@ -55,7 +55,7 @@ import org.roaringbitmap.RoaringBitmap;
  * Note: This class performs aggregation over the double value of input.
  * If the input is single value, the output type will be input type. Otherwise, the output type will be double.
  */
-public class AggregateOperator extends BaseOperator<TransferableBlock> {
+public class AggregateOperator extends V2Operator {
   private static final String EXPLAIN_NAME = "AGGREGATE_OPERATOR";
 
   private final Operator<TransferableBlock> _inputOperator;
@@ -110,8 +110,7 @@ public class AggregateOperator extends BaseOperator<TransferableBlock> {
 
   @Override
   public List<Operator> getChildOperators() {
-    // WorkerExecutor doesn't use getChildOperators, returns null here.
-    return null;
+    return ImmutableList.of(_inputOperator);
   }
 
   @Nullable

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -18,13 +18,13 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
-import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
@@ -45,7 +45,7 @@ import org.apache.pinot.query.runtime.operator.utils.FunctionInvokeUtils;
     3) All boolean scalar functions we have that take tranformOperand.
     Note: Scalar functions are the ones we have in v1 engine and only do function name and arg # matching.
  */
-public class FilterOperator extends BaseOperator<TransferableBlock> {
+public class FilterOperator extends V2Operator {
   private static final String EXPLAIN_NAME = "FILTER";
   private final Operator<TransferableBlock> _upstreamOperator;
   private final TransformOperand _filterOperand;
@@ -61,8 +61,7 @@ public class FilterOperator extends BaseOperator<TransferableBlock> {
 
   @Override
   public List<Operator> getChildOperators() {
-    // WorkerExecutor doesn't use getChildOperators, returns null here.
-    return null;
+    return ImmutableList.of(_upstreamOperator);
   }
 
   @Nullable

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -19,12 +19,14 @@
 package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.PriorityQueue;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
@@ -32,7 +34,6 @@ import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
-import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
@@ -40,6 +41,7 @@ import org.apache.pinot.core.operator.blocks.results.DistinctResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
+import org.apache.pinot.query.mailbox.MailboxIdentifier;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 
 
@@ -56,7 +58,7 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
  *       thus requires canonicalization.</li>
  * </ul>
  */
-public class LeafStageTransferableBlockOperator extends BaseOperator<TransferableBlock> {
+public class LeafStageTransferableBlockOperator extends V2Operator {
   private static final String EXPLAIN_NAME = "LEAF_STAGE_TRANSFER_OPERATOR";
 
   private final InstanceResponseBlock _errorBlock;
@@ -73,7 +75,7 @@ public class LeafStageTransferableBlockOperator extends BaseOperator<Transferabl
 
   @Override
   public List<Operator> getChildOperators() {
-    return null;
+    return ImmutableList.of();
   }
 
   @Nullable
@@ -103,6 +105,11 @@ public class LeafStageTransferableBlockOperator extends BaseOperator<Transferabl
         return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock());
       }
     }
+  }
+
+  @Override
+  public ScheduleResult shouldSchedule(Set<MailboxIdentifier> availableMail) {
+    return new ScheduleResult(true);
   }
 
   /**

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -18,19 +18,21 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
-import org.apache.pinot.core.operator.BaseOperator;
+import org.apache.pinot.query.mailbox.MailboxIdentifier;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 
 
-public class LiteralValueOperator extends BaseOperator<TransferableBlock> {
+public class LiteralValueOperator extends V2Operator {
   private static final String EXPLAIN_NAME = "LITERAL_VALUE_PROVIDER";
 
   private final DataSchema _dataSchema;
@@ -45,8 +47,12 @@ public class LiteralValueOperator extends BaseOperator<TransferableBlock> {
 
   @Override
   public List<Operator> getChildOperators() {
-    // WorkerExecutor doesn't use getChildOperators, returns null here.
-    return null;
+    return ImmutableList.of();
+  }
+
+  @Override
+  public ScheduleResult shouldSchedule(Set<MailboxIdentifier> availableMail) {
+    return new ScheduleResult(true);
   }
 
   @Nullable

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
 import java.util.List;
@@ -28,7 +29,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.core.common.Operator;
-import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.query.mailbox.MailboxIdentifier;
 import org.apache.pinot.query.mailbox.MailboxService;
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 /**
  * This {@code MailboxSendOperator} is created to send {@link TransferableBlock}s to the receiving end.
  */
-public class MailboxSendOperator extends BaseOperator<TransferableBlock> {
+public class MailboxSendOperator extends V2Operator {
   private static final Logger LOGGER = LoggerFactory.getLogger(MailboxSendOperator.class);
 
   private static final String EXPLAIN_NAME = "MAILBOX_SEND";
@@ -111,8 +111,7 @@ public class MailboxSendOperator extends BaseOperator<TransferableBlock> {
 
   @Override
   public List<Operator> getChildOperators() {
-    // WorkerExecutor doesn't use getChildOperators, returns null here.
-    return null;
+    return ImmutableList.of(_dataTableBlockBaseOperator);
   }
 
   @Nullable

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/ScheduledOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/ScheduledOperator.java
@@ -16,46 +16,39 @@
  * specific language governing permissions and limitations
  * under the License.
  */
+
 package org.apache.pinot.query.runtime.operator;
 
-import java.util.HashSet;
-import java.util.List;
+import com.google.common.collect.ImmutableSet;
 import java.util.Set;
 import org.apache.pinot.query.mailbox.MailboxIdentifier;
 
 
 /**
- * An {@code OpChain} represents a chain of operators that are separated
- * by send/receive stages.
+ * {@code ScheduledOperator}s are operators that expose additional information
+ * to help scheduling logic.
  */
-public class OpChain {
+public interface ScheduledOperator {
 
-  private final V2Operator _root;
-  private final Set<MailboxIdentifier> _receivingMailbox;
-  private final OpChainStats _stats;
-  private final String _id;
+  /**
+   * @param availableMail the mail available to be consumed
+   * @return the mailboxes that this operator would read from if scheduled - an
+   * empty set indicates that this operator should not be scheduled
+   */
+  ScheduleResult shouldSchedule(Set<MailboxIdentifier> availableMail);
 
-  public OpChain(V2Operator root, List<MailboxIdentifier> receivingMailboxes, long requestId, int stageId) {
-    _root = root;
-    _receivingMailbox = new HashSet<>(receivingMailboxes);
-    _id = String.format("%s_%s", requestId, stageId);
-    _stats = new OpChainStats(_id);
-  }
+  class ScheduleResult {
+    public final boolean _shouldSchedule;
+    public final Set<MailboxIdentifier> _mailboxes;
 
-  public V2Operator getRoot() {
-    return _root;
-  }
+    public ScheduleResult(Set<MailboxIdentifier> mailboxes) {
+      _shouldSchedule = !mailboxes.isEmpty();
+      _mailboxes = mailboxes;
+    }
 
-  public Set<MailboxIdentifier> getReceivingMailbox() {
-    return _receivingMailbox;
-  }
-
-  public OpChainStats getStats() {
-    return _stats;
-  }
-
-  @Override
-  public String toString() {
-    return "OpChain{ " + _id + "}";
+    public ScheduleResult(boolean shouldSchedule) {
+      _shouldSchedule = shouldSchedule;
+      _mailboxes = ImmutableSet.of();
+    }
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.collect.ImmutableList;
 import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
@@ -29,7 +30,6 @@ import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
-import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
@@ -37,7 +37,7 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.roaringbitmap.RoaringBitmap;
 
 
-public class SortOperator extends BaseOperator<TransferableBlock> {
+public class SortOperator extends V2Operator {
   private static final String EXPLAIN_NAME = "SORT";
   private final Operator<TransferableBlock> _upstreamOperator;
   private final int _fetch;
@@ -75,8 +75,7 @@ public class SortOperator extends BaseOperator<TransferableBlock> {
 
   @Override
   public List<Operator> getChildOperators() {
-    // WorkerExecutor doesn't use getChildOperators, returns null here.
-    return null;
+    return ImmutableList.of(_upstreamOperator);
   }
 
   @Nullable

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -19,13 +19,13 @@
 package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
-import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
@@ -43,7 +43,7 @@ import org.apache.pinot.query.runtime.operator.utils.FunctionInvokeUtils;
  * Note: Function transform only runs functions from v1 engine scalar function factory, which only does argument count
  * and canonicalized function name matching (lower case).
  */
-public class TransformOperator extends BaseOperator<TransferableBlock> {
+public class TransformOperator extends V2Operator {
   private static final String EXPLAIN_NAME = "TRANSFORM";
   private final Operator<TransferableBlock> _upstreamOperator;
   private final List<TransformOperand> _transformOperandsList;
@@ -68,8 +68,7 @@ public class TransformOperator extends BaseOperator<TransferableBlock> {
 
   @Override
   public List<Operator> getChildOperators() {
-    // WorkerExecutor doesn't use getChildOperators, returns null here.
-    return null;
+    return ImmutableList.of(_upstreamOperator);
   }
 
   @Nullable

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
@@ -24,10 +24,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import org.apache.pinot.core.common.Operator;
-import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.OpChain;
+import org.apache.pinot.query.runtime.operator.V2Operator;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -44,9 +43,9 @@ public class OpChainSchedulerServiceTest {
   private AutoCloseable _mocks;
 
   @Mock
-  private Operator<TransferableBlock> _operatorA;
+  private V2Operator _operatorA;
   @Mock
-  private Operator<TransferableBlock> _operatorB;
+  private V2Operator _operatorB;
   @Mock
   private OpChainScheduler _scheduler;
 
@@ -70,7 +69,7 @@ public class OpChainSchedulerServiceTest {
     _executor = Executors.newFixedThreadPool(numThreads);
   }
 
-  private OpChain getChain(Operator<TransferableBlock> operator) {
+  private OpChain getChain(V2Operator operator) {
     return new OpChain(operator, ImmutableList.of(), 123, 1);
   }
 


### PR DESCRIPTION
This should fix https://github.com/apache/pinot/issues/9959 by making the scheduling mechanism aware of which mailbox an op chain needs to read from if it potentially reads from multiple.

Review guide:
- main change is in `RoundRobinScheduler.java` where we take advantage of the new API for `shouldSchedule`
- make all V2 operators properly implement `getChildren`
- make all V2 operators implement new interface `V2Operator` (cc @61yao this could be a good place to add `close`)
- only schedule `HashJoinOperator` when the appropriate mailbox has data (e.g. right until broadcast table is built, and only then allow left to trigger selections)