### PR TITLE
Fix the executor config wiring issue for Multi-stage engine

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -73,8 +73,7 @@ import org.slf4j.LoggerFactory;
  */
 public class QueryRunner {
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryRunner.class);
-
-  private static final String PINOT_SERVER_QUERY = "pinot.server.query.executor";
+  private static final String PINOT_V1_SERVER_QUERY_CONFIG_PREFIX = "pinot.server.query.executor";
 
   // This is a temporary before merging the 2 type of executor.
   private ServerQueryExecutorV1Impl _serverExecutor;
@@ -103,14 +102,10 @@ public class QueryRunner {
               new NamedThreadFactory("query_worker_on_" + _port + "_port")));
       _mailboxService = MultiplexingMailboxService.newInstance(_hostname, _port, config, _scheduler::onDataAvailable);
       _serverExecutor = new ServerQueryExecutorV1Impl();
-      _serverExecutor.init(getQueryExecutorConfig(config), instanceDataManager, serverMetrics);
+      _serverExecutor.init(config.subset(PINOT_V1_SERVER_QUERY_CONFIG_PREFIX), instanceDataManager, serverMetrics);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
-  }
-
-  private PinotConfiguration getQueryExecutorConfig(PinotConfiguration pinotConfiguration) {
-    return pinotConfiguration.subset(PINOT_SERVER_QUERY);
   }
 
   public void start()

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -73,6 +73,9 @@ import org.slf4j.LoggerFactory;
  */
 public class QueryRunner {
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryRunner.class);
+
+  private static final String PINOT_SERVER_QUERY = "pinot.server.query.executor";
+
   // This is a temporary before merging the 2 type of executor.
   private ServerQueryExecutorV1Impl _serverExecutor;
   private HelixManager _helixManager;
@@ -100,10 +103,14 @@ public class QueryRunner {
               new NamedThreadFactory("query_worker_on_" + _port + "_port")));
       _mailboxService = MultiplexingMailboxService.newInstance(_hostname, _port, config, _scheduler::onDataAvailable);
       _serverExecutor = new ServerQueryExecutorV1Impl();
-      _serverExecutor.init(config, instanceDataManager, serverMetrics);
+      _serverExecutor.init(getQueryExecutorConfig(config), instanceDataManager, serverMetrics);
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
+  }
+
+  private PinotConfiguration getQueryExecutorConfig(PinotConfiguration pinotConfiguration) {
+    return pinotConfiguration.subset(PINOT_SERVER_QUERY);
   }
 
   public void start()


### PR DESCRIPTION
Multi-stage engine initialization code has a bug when passing the pinot execution config. This makes the executor config not correctly wired. This PR fixes the issue.