### PR TITLE
bugfix dir check for HadoopPinotFS.copyFromLocalDir

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-hdfs/src/main/java/org/apache/pinot/plugin/filesystem/HadoopPinotFS.java
@@ -214,18 +214,17 @@ public class HadoopPinotFS extends BasePinotFS {
   public void copyFromLocalFile(File srcFile, URI dstUri)
       throws Exception {
     if (srcFile.isDirectory()) {
-      throw new IllegalArgumentException(srcFile.getAbsolutePath() + " is a direactory");
+      throw new IllegalArgumentException(srcFile.getAbsolutePath() + " is a directory");
     }
     _hadoopFS.copyFromLocalFile(new Path(srcFile.toURI()), new Path(dstUri));
   }
 
   public void copyFromLocalDir(File srcFile, URI dstUri)
       throws Exception {
-    Path srcPath = new Path(srcFile.toURI());
-    if (!_hadoopFS.isDirectory(srcPath)) {
+    if (!srcFile.isDirectory()) {
       throw new IllegalArgumentException(srcFile.getAbsolutePath() + " is not a directory");
     }
-    _hadoopFS.copyFromLocalFile(srcPath, new Path(dstUri));
+    _hadoopFS.copyFromLocalFile(new Path(srcFile.toURI()), new Path(dstUri));
   }
 
   @Override


### PR DESCRIPTION
fix the dir check in HadoopPinotFS.copyFromLocalDir and refine a bit on the UT cases. 