### PR TITLE
Ability to initialize S3PinotFs with serverSideEncryption properties when passing client directly

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -175,10 +175,6 @@ public class S3PinotFS extends BasePinotFS {
     }
   }
 
-  private void setAwsKmsProperties(String ssekmsKeyId, String ssekmsEncryptionContext) {
-
-  }
-
   boolean isNullOrEmpty(String target) {
     return target == null || target.isEmpty();
   }


### PR DESCRIPTION
When using init method below, we cannot initialize serverSideEncryption properties. 
```
public void init(S3Client s3Client) {
    _s3Client = s3Client;
  }
```
Adding a new init method, which takes server side encryption props along with the S3Client.