### PR TITLE
pin versions-maven-plugin to 2.13.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1750,6 +1750,11 @@
         </executions>
       </plugin>
       <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>versions-maven-plugin</artifactId>
+        <version>2.13.0</version>
+      </plugin>
+      <plugin>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.2.1</version>
         <configuration>


### PR DESCRIPTION
`bugfix`

I'm not sure how often this repo is hitting this yet, but our fork got bit by builds randomly failing yesterday. https://github.com/apache/pinot/actions/runs/3702140693/jobs/6272088585 is an example of this failure.

See https://github.com/mojohaus/versions/issues/848 and https://github.com/aws/aws-sdk-java-v2/pull/3623 for more context, but TLDR, latest version of versions-maven-plugin is broken.