### PR TITLE
[multistage] remove limit from in-memory mailbox queue

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/partitioning/FieldSelectionKeySelector.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/partitioning/FieldSelectionKeySelector.java
@@ -74,6 +74,14 @@ public class FieldSelectionKeySelector implements KeySelector<Object[], Object[]
     // this is necessary because calcite always sorts _columnIndices for a hash
     // broadcast, which may reorder the columns differently for different sides
     // of a join
+    //
+    // the result of hashcode sums will follow the Irwin-Hall distribution, which
+    // is notably not a normal distribution although likely acceptable in the case
+    // when there are either many inputs or not many partitions
+    // also see: https://en.wikipedia.org/wiki/Irwin–Hall_distribution
+    // also see: https://github.com/apache/pinot/issues/9998
+    //
+    // TODO: consider better hashing algorithms than hashCode sum, such as XOR'ing
     int hashCode = 0;
     for (int columnIndex : _columnIndices) {
       hashCode += input[columnIndex].hashCode();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/InMemoryMailboxServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/InMemoryMailboxServiceTest.java
@@ -32,6 +32,7 @@ public class InMemoryMailboxServiceTest {
 
   private static final DataSchema TEST_DATA_SCHEMA = new DataSchema(new String[]{"foo", "bar"},
       new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
+  private static final int NUM_ENTRIES = 5;
 
   @Test
   public void testHappyPath()
@@ -44,13 +45,13 @@ public class InMemoryMailboxServiceTest {
     InMemorySendingMailbox sendingMailbox = (InMemorySendingMailbox) mailboxService.getSendingMailbox(mailboxId);
 
     // Sends are non-blocking as long as channel capacity is not breached
-    for (int i = 0; i < InMemoryMailboxService.DEFAULT_CHANNEL_CAPACITY; i++) {
-      sendingMailbox.send(getTestTransferableBlock(i, i + 1 == InMemoryMailboxService.DEFAULT_CHANNEL_CAPACITY));
+    for (int i = 0; i < NUM_ENTRIES; i++) {
+      sendingMailbox.send(getTestTransferableBlock(i, i + 1 == NUM_ENTRIES));
     }
     sendingMailbox.complete();
 
     // Iterate 1 less time than the loop above
-    for (int i = 0; i + 1 < InMemoryMailboxService.DEFAULT_CHANNEL_CAPACITY; i++) {
+    for (int i = 0; i + 1 < NUM_ENTRIES; i++) {
       TransferableBlock receivedBlock = receivingMailbox.receive();
       List<Object[]> receivedContainer = receivedBlock.getContainer();
       Assert.assertEquals(receivedContainer.size(), 1);


### PR DESCRIPTION
this PR removes the limit from the in-memory mailbox queue so that we'll never time out when attempting to send data in-memory to the receiver

this is part of the improved scheduling model and prevents situations where the sending thread is preventing the receiving thread from being scheduled.

also: added TODO comment in FieldSelectionKeySelector cc @61yao 