### PR TITLE
[Issue 7519] Adds support for multiple filtered/unfiltered aggregations with GROUP BY

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
@@ -122,6 +122,13 @@ public class FilteredGroupByOperator extends BaseOperator<GroupByResultsBlock> {
       // Perform aggregation group-by on all the blocks
       DefaultGroupByExecutor groupByExecutor;
       if (groupKeyGenerator == null) {
+        // The group key generator should be shared across all AggregationFunctions so that agg results can be
+        // aligned. Given that filtered aggregations are stored as an iterable of iterables so that all filtered aggs
+        // with the same filter can share transform blocks, rather than a singular flat iterable in the case where
+        // aggs are all non-filtered, sharing a GroupKeyGenerator across all aggs cannot be accomplished by allowing
+        // the GroupByExecutor to have sole ownership of the GroupKeyGenerator. Therefore, we allow constructing a
+        // GroupByExecutor with a pre-existing GroupKeyGenerator so that the GroupKeyGenerator can be shared across
+        // loop iterations i.e. across all aggs.
         groupByExecutor = new DefaultGroupByExecutor(_queryContext, filteredAggFunctions, _groupByExpressions,
             transformOperator);
         groupKeyGenerator = groupByExecutor.getGroupKeyGenerator();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
@@ -171,7 +171,7 @@ public class FilteredGroupByOperator extends BaseOperator<GroupByResultsBlock> {
     if (_queryContext.getOrderByExpressions() != null && minGroupTrimSize > 0) {
       int trimSize = GroupByUtils.getTableCapacity(_queryContext.getLimit(), minGroupTrimSize);
       if (groupKeyGenerator.getNumKeys() > trimSize) {
-        TableResizer tableResizer =  new TableResizer(_dataSchema, _queryContext);
+        TableResizer tableResizer = new TableResizer(_dataSchema, _queryContext);
         Collection<IntermediateRecord> intermediateRecords =
             tableResizer.trimInSegmentResults(groupKeyGenerator, groupByResultHolders, trimSize);
         GroupByResultsBlock resultsBlock = new GroupByResultsBlock(_dataSchema, intermediateRecords);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
@@ -90,7 +90,6 @@ public class FilteredGroupByOperator extends BaseOperator<GroupByResultsBlock> {
       ExpressionContext groupByExpression = groupByExpressions[i];
       columnNames[i] = groupByExpression.toString();
       columnDataTypes[i] = DataSchema.ColumnDataType.fromDataTypeSV(
-          // TODO(egalpin): is this actually correct?
           aggFunctionsWithTransformOperator.get(i).getRight().getResultMetadata(groupByExpression).getDataType());
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
@@ -1,0 +1,219 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.query;
+
+import java.util.Collection;
+import java.util.IdentityHashMap;
+import java.util.List;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.data.table.IntermediateRecord;
+import org.apache.pinot.core.data.table.TableResizer;
+import org.apache.pinot.core.operator.BaseOperator;
+import org.apache.pinot.core.operator.ExecutionStatistics;
+import org.apache.pinot.core.operator.blocks.TransformBlock;
+import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
+import org.apache.pinot.core.operator.transform.TransformOperator;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
+import org.apache.pinot.core.query.aggregation.groupby.DefaultGroupByExecutor;
+import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.util.GroupByUtils;
+import org.apache.pinot.spi.trace.Tracing;
+
+
+/**
+ * The <code>FilteredGroupByOperator</code> class provides the operator for group-by query on a single segment when
+ * there are 1 or more filter expressions on aggregations.
+ */
+@SuppressWarnings("rawtypes")
+public class FilteredGroupByOperator extends BaseOperator<GroupByResultsBlock> {
+  private static final String EXPLAIN_NAME = "GROUP_BY_FILTERED";
+
+  @Nullable
+  private final AggregationFunction[] _aggregationFunctions;
+  private final List<Pair<AggregationFunction[], TransformOperator>> _aggFunctionsWithTransformOperator;
+  private final ExpressionContext[] _groupByExpressions;
+  private final long _numTotalDocs;
+  private long _numDocsScanned;
+  private long _numEntriesScannedInFilter;
+  private long _numEntriesScannedPostFilter;
+  private final DataSchema _dataSchema;
+  private final QueryContext _queryContext;
+  private TableResizer _tableResizer;
+  private GroupKeyGenerator _groupKeyGenerator = null;
+
+  public FilteredGroupByOperator(
+      @Nullable AggregationFunction[] aggregationFunctions,
+      List<Pair<AggregationFunction[], TransformOperator>> aggFunctionsWithTransformOperator,
+      ExpressionContext[] groupByExpressions,
+      long numTotalDocs,
+      QueryContext queryContext) {
+    _aggregationFunctions = aggregationFunctions;
+    _aggFunctionsWithTransformOperator = aggFunctionsWithTransformOperator;
+    _groupByExpressions = groupByExpressions;
+    _numTotalDocs = numTotalDocs;
+    _queryContext = queryContext;
+    _tableResizer = null;
+
+    // NOTE: The indexedTable expects that the data schema will have group by columns before aggregation columns
+    int numGroupByExpressions = groupByExpressions.length;
+    int numAggregationFunctions = aggregationFunctions.length;
+    int numColumns = numGroupByExpressions + numAggregationFunctions;
+    String[] columnNames = new String[numColumns];
+    DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numColumns];
+
+    // Extract column names and data types for group-by columns
+    for (int i = 0; i < numGroupByExpressions; i++) {
+      ExpressionContext groupByExpression = groupByExpressions[i];
+      columnNames[i] = groupByExpression.toString();
+      columnDataTypes[i] = DataSchema.ColumnDataType.fromDataTypeSV(
+          // TODO(egalpin): is this actually correct?
+          aggFunctionsWithTransformOperator.get(i).getRight().getResultMetadata(groupByExpression).getDataType());
+    }
+
+    // Extract column names and data types for aggregation functions
+    for (int i = 0; i < numAggregationFunctions; i++) {
+      AggregationFunction aggregationFunction = aggregationFunctions[i];
+      int index = numGroupByExpressions + i;
+      columnNames[index] = aggregationFunction.getResultColumnName();
+      columnDataTypes[index] = aggregationFunction.getIntermediateResultColumnType();
+    }
+
+    _dataSchema = new DataSchema(columnNames, columnDataTypes);
+  }
+
+  @Override
+  protected GroupByResultsBlock getNextBlock() {
+    // TODO(egalpin): Support Startree query resolution when possible, even with FILTER expressions
+    assert _aggregationFunctions != null;
+    boolean numGroupsLimitReached = false;
+    int numAggregations = _aggregationFunctions.length;
+
+    GroupByResultHolder[] groupByResultHolders = new GroupByResultHolder[numAggregations];
+    IdentityHashMap<AggregationFunction, Integer> resultHolderIndexMap = new IdentityHashMap<>(numAggregations);
+    for (int i = 0; i < numAggregations; i++) {
+      resultHolderIndexMap.put(_aggregationFunctions[i], i);
+    }
+
+    for (Pair<AggregationFunction[], TransformOperator> filteredAggregation : _aggFunctionsWithTransformOperator) {
+      TransformOperator transformOperator = filteredAggregation.getRight();
+      AggregationFunction[] filteredAggFunctions = filteredAggregation.getLeft();
+
+      // Perform aggregation group-by on all the blocks
+      DefaultGroupByExecutor groupByExecutor;
+      if (_groupKeyGenerator == null) {
+        groupByExecutor = new DefaultGroupByExecutor(_queryContext, filteredAggFunctions, _groupByExpressions,
+            transformOperator);
+        _groupKeyGenerator = groupByExecutor.getGroupKeyGenerator();
+      } else {
+        groupByExecutor = new DefaultGroupByExecutor(_queryContext, filteredAggFunctions, _groupByExpressions,
+            transformOperator, _groupKeyGenerator);
+      }
+
+      int numDocsScanned = 0;
+      TransformBlock transformBlock;
+      while ((transformBlock = transformOperator.nextBlock()) != null) {
+        numDocsScanned += transformBlock.getNumDocs();
+        groupByExecutor.process(transformBlock);
+      }
+
+      _numDocsScanned += numDocsScanned;
+      _numEntriesScannedInFilter += transformOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
+      _numEntriesScannedPostFilter += (long) numDocsScanned * transformOperator.getNumColumnsProjected();
+      GroupByResultHolder[] filterGroupByResults = groupByExecutor.getGroupByResultHolders();
+      for (int i = 0; i < filteredAggFunctions.length; i++) {
+        groupByResultHolders[resultHolderIndexMap.get(filteredAggFunctions[i])] = filterGroupByResults[i];
+      }
+    }
+
+    for (GroupByResultHolder groupByResultHolder : groupByResultHolders) {
+      groupByResultHolder.ensureCapacity(_groupKeyGenerator.getNumKeys());
+    }
+
+    // Check if the groups limit is reached
+    numGroupsLimitReached = _groupKeyGenerator.getNumKeys() >= _queryContext.getNumGroupsLimit();
+    Tracing.activeRecording().setNumGroups(_queryContext.getNumGroupsLimit(), _groupKeyGenerator.getNumKeys());
+
+    // Trim the groups when iff:
+    // - Query has ORDER BY clause
+    // - Segment group trim is enabled
+    // - There are more groups than the trim size
+    // TODO: Currently the groups are not trimmed if there is no ordering specified. Consider ordering on group-by
+    //       columns if no ordering is specified.
+    int minGroupTrimSize = _queryContext.getMinSegmentGroupTrimSize();
+    if (_queryContext.getOrderByExpressions() != null && minGroupTrimSize > 0) {
+      int trimSize = GroupByUtils.getTableCapacity(_queryContext.getLimit(), minGroupTrimSize);
+      if (_groupKeyGenerator.getNumKeys() > trimSize) {
+        if (_tableResizer == null) {
+          _tableResizer = new TableResizer(_dataSchema, _queryContext);
+        }
+        Collection<IntermediateRecord> intermediateRecords =
+            _tableResizer.trimInSegmentResults(_groupKeyGenerator, groupByResultHolders, trimSize);
+        GroupByResultsBlock resultsBlock = new GroupByResultsBlock(_dataSchema, intermediateRecords);
+        resultsBlock.setNumGroupsLimitReached(numGroupsLimitReached);
+        return resultsBlock;
+      }
+    }
+
+    AggregationGroupByResult aggGroupByResult =
+        new AggregationGroupByResult(_groupKeyGenerator, _aggregationFunctions, groupByResultHolders);
+    GroupByResultsBlock resultsBlock = new GroupByResultsBlock(_dataSchema, aggGroupByResult);
+    resultsBlock.setNumGroupsLimitReached(numGroupsLimitReached);
+    return resultsBlock;
+  }
+
+  @Override
+  public List<Operator> getChildOperators() {
+    return _aggFunctionsWithTransformOperator.stream().map(Pair::getRight).collect(Collectors.toList());
+  }
+
+  @Override
+  public ExecutionStatistics getExecutionStatistics() {
+    return new ExecutionStatistics(_numDocsScanned, _numEntriesScannedInFilter, _numEntriesScannedPostFilter,
+        _numTotalDocs);
+  }
+
+  @Override
+  public String toExplainString() {
+    StringBuilder stringBuilder = new StringBuilder(EXPLAIN_NAME).append("(groupKeys:");
+    if (_groupByExpressions.length > 0) {
+      stringBuilder.append(_groupByExpressions[0].toString());
+      for (int i = 1; i < _groupByExpressions.length; i++) {
+        stringBuilder.append(", ").append(_groupByExpressions[i].toString());
+      }
+    }
+
+    stringBuilder.append(", aggregations:");
+    if (_aggregationFunctions.length > 0) {
+      stringBuilder.append(_aggregationFunctions[0].toExplainString());
+      for (int i = 1; i < _aggregationFunctions.length; i++) {
+        stringBuilder.append(", ").append(_aggregationFunctions[i].toExplainString());
+      }
+    }
+
+    return stringBuilder.append(')').toString();
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -89,7 +89,7 @@ public class AggregationPlanNode implements PlanNode {
             filterOperatorPair.getRight(), null);
 
     List<Pair<AggregationFunction[], TransformOperator>> aggToTransformOpList =
-        AggregationFunctionUtils.buildFilteredAggTranformPairs(_indexSegment, _queryContext,
+        AggregationFunctionUtils.buildFilteredAggTransformPairs(_indexSegment, _queryContext,
             filterOperatorPair.getRight(), transformOperator, null);
     return new FilteredAggregationOperator(_queryContext.getAggregationFunctions(), aggToTransformOpList, numTotalDocs);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -18,21 +18,15 @@
  */
 package org.apache.pinot.core.plan;
 
-import com.google.common.base.MoreObjects;
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.EnumSet;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.common.request.context.FilterContext;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
-import org.apache.pinot.core.operator.filter.CombinedFilterOperator;
 import org.apache.pinot.core.operator.query.AggregationOperator;
 import org.apache.pinot.core.operator.query.FastFilteredCountOperator;
 import org.apache.pinot.core.operator.query.FilteredAggregationOperator;
@@ -50,9 +44,6 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 
-import static org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils.buildFilterOperator;
-import static org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils.buildFilteredAggTranformPairs;
-import static org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils.buildTransformOperatorForFilteredAggregates;
 import static org.apache.pinot.segment.spi.AggregationFunctionType.*;
 
 
@@ -91,13 +82,15 @@ public class AggregationPlanNode implements PlanNode {
   private FilteredAggregationOperator buildFilteredAggOperator() {
     int numTotalDocs = _indexSegment.getSegmentMetadata().getTotalDocs();
     // Build the operator chain for the main predicate
-    Pair<FilterPlanNode, BaseFilterOperator> filterOperatorPair = buildFilterOperator(_indexSegment, _queryContext);
+    Pair<FilterPlanNode, BaseFilterOperator> filterOperatorPair =
+        AggregationFunctionUtils.buildFilterOperator(_indexSegment, _queryContext);
     TransformOperator transformOperator =
-        buildTransformOperatorForFilteredAggregates(_indexSegment, _queryContext, filterOperatorPair.getRight(), null);
+        AggregationFunctionUtils.buildTransformOperatorForFilteredAggregates(_indexSegment, _queryContext,
+            filterOperatorPair.getRight(), null);
 
     List<Pair<AggregationFunction[], TransformOperator>> aggToTransformOpList =
-        buildFilteredAggTranformPairs(_indexSegment, _queryContext, filterOperatorPair.getRight(), transformOperator,
-            null);
+        AggregationFunctionUtils.buildFilteredAggTranformPairs(_indexSegment, _queryContext,
+            filterOperatorPair.getRight(), transformOperator, null);
     return new FilteredAggregationOperator(_queryContext.getAggregationFunctions(), aggToTransformOpList, numTotalDocs);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.core.plan;
 
+import com.google.common.base.MoreObjects;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.List;
@@ -48,6 +50,9 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 
+import static org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils.buildFilterOperator;
+import static org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils.buildFilteredAggTranformPairs;
+import static org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils.buildTransformOperatorForFilteredAggregates;
 import static org.apache.pinot.segment.spi.AggregationFunctionType.*;
 
 
@@ -77,7 +82,7 @@ public class AggregationPlanNode implements PlanNode {
   @Override
   public Operator<AggregationResultsBlock> run() {
     assert _queryContext.getAggregationFunctions() != null;
-    return _queryContext.isHasFilteredAggregations() ? buildFilteredAggOperator() : buildNonFilteredAggOperator();
+    return _queryContext.hasFilteredAggregations() ? buildFilteredAggOperator() : buildNonFilteredAggOperator();
   }
 
   /**
@@ -86,81 +91,14 @@ public class AggregationPlanNode implements PlanNode {
   private FilteredAggregationOperator buildFilteredAggOperator() {
     int numTotalDocs = _indexSegment.getSegmentMetadata().getTotalDocs();
     // Build the operator chain for the main predicate
-    Pair<FilterPlanNode, BaseFilterOperator> filterOperatorPair = buildFilterOperator(_queryContext.getFilter());
-    TransformOperator transformOperator = buildTransformOperatorForFilteredAggregates(filterOperatorPair.getRight());
+    Pair<FilterPlanNode, BaseFilterOperator> filterOperatorPair = buildFilterOperator(_indexSegment, _queryContext);
+    TransformOperator transformOperator =
+        buildTransformOperatorForFilteredAggregates(_indexSegment, _queryContext, filterOperatorPair.getRight(), null);
 
-    return buildFilterOperatorInternal(filterOperatorPair.getRight(), transformOperator, numTotalDocs);
-  }
-
-  /**
-   * Build a FilteredAggregationOperator given the parameters.
-   * @param mainPredicateFilterOperator Filter operator corresponding to the main predicate
-   * @param mainTransformOperator Transform operator corresponding to the main predicate
-   * @param numTotalDocs Number of total docs
-   */
-  private FilteredAggregationOperator buildFilterOperatorInternal(BaseFilterOperator mainPredicateFilterOperator,
-      TransformOperator mainTransformOperator, int numTotalDocs) {
-    Map<FilterContext, Pair<List<AggregationFunction>, TransformOperator>> filterContextToAggFuncsMap = new HashMap<>();
-    List<AggregationFunction> nonFilteredAggregationFunctions = new ArrayList<>();
-    List<Pair<AggregationFunction, FilterContext>> aggregationFunctions =
-        _queryContext.getFilteredAggregationFunctions();
-
-    // For each aggregation function, check if the aggregation function is a filtered agg.
-    // If it is, populate the corresponding filter operator and corresponding transform operator
-    for (Pair<AggregationFunction, FilterContext> inputPair : aggregationFunctions) {
-      if (inputPair.getLeft() != null) {
-        FilterContext currentFilterExpression = inputPair.getRight();
-        if (filterContextToAggFuncsMap.get(currentFilterExpression) != null) {
-          filterContextToAggFuncsMap.get(currentFilterExpression).getLeft().add(inputPair.getLeft());
-          continue;
-        }
-        Pair<FilterPlanNode, BaseFilterOperator> pair = buildFilterOperator(currentFilterExpression);
-        BaseFilterOperator wrappedFilterOperator =
-            new CombinedFilterOperator(mainPredicateFilterOperator, pair.getRight(), _queryContext.getQueryOptions());
-        TransformOperator newTransformOperator = buildTransformOperatorForFilteredAggregates(wrappedFilterOperator);
-        // For each transform operator, associate it with the underlying expression. This allows
-        // fetching the relevant TransformOperator when resolving blocks during aggregation
-        // execution
-        List<AggregationFunction> aggFunctionList = new ArrayList<>();
-        aggFunctionList.add(inputPair.getLeft());
-        filterContextToAggFuncsMap.put(currentFilterExpression, Pair.of(aggFunctionList, newTransformOperator));
-      } else {
-        nonFilteredAggregationFunctions.add(inputPair.getLeft());
-      }
-    }
-    List<Pair<AggregationFunction[], TransformOperator>> aggToTransformOpList = new ArrayList<>();
-    // Convert to array since FilteredAggregationOperator expects it
-    for (Pair<List<AggregationFunction>, TransformOperator> pair : filterContextToAggFuncsMap.values()) {
-      List<AggregationFunction> aggregationFunctionList = pair.getLeft();
-      if (aggregationFunctionList == null) {
-        throw new IllegalStateException("Null aggregation list seen");
-      }
-      aggToTransformOpList.add(Pair.of(aggregationFunctionList.toArray(new AggregationFunction[0]), pair.getRight()));
-    }
-    aggToTransformOpList.add(
-        Pair.of(nonFilteredAggregationFunctions.toArray(new AggregationFunction[0]), mainTransformOperator));
-
+    List<Pair<AggregationFunction[], TransformOperator>> aggToTransformOpList =
+        buildFilteredAggTranformPairs(_indexSegment, _queryContext, filterOperatorPair.getRight(), transformOperator,
+            null);
     return new FilteredAggregationOperator(_queryContext.getAggregationFunctions(), aggToTransformOpList, numTotalDocs);
-  }
-
-  /**
-   * Build a filter operator from the given FilterContext.
-   *
-   * It returns the FilterPlanNode to allow reusing plan level components such as predicate
-   * evaluator map
-   */
-  private Pair<FilterPlanNode, BaseFilterOperator> buildFilterOperator(FilterContext filterContext) {
-    FilterPlanNode filterPlanNode = new FilterPlanNode(_indexSegment, _queryContext, filterContext);
-    return Pair.of(filterPlanNode, filterPlanNode.run());
-  }
-
-  private TransformOperator buildTransformOperatorForFilteredAggregates(BaseFilterOperator filterOperator) {
-    AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
-    Set<ExpressionContext> expressionsToTransform =
-        AggregationFunctionUtils.collectExpressionsToTransform(aggregationFunctions, null);
-
-    return new TransformPlanNode(_indexSegment, _queryContext, expressionsToTransform,
-        DocIdSetPlanNode.MAX_DOC_PER_CALL, filterOperator).run();
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
@@ -59,13 +59,13 @@ public class GroupByPlanNode implements PlanNode {
     assert _queryContext.getGroupByExpressions() != null;
 
     if (_queryContext.hasFilteredAggregations()) {
-      return filteredGroupByPlan();
+      return buildFilteredGroupByPlan();
     }
 
-    return nonFilteredGroupByPlan();
+    return buildNonFilteredGroupByPlan();
   }
 
-  private FilteredGroupByOperator filteredGroupByPlan() {
+  private FilteredGroupByOperator buildFilteredGroupByPlan() {
     int numTotalDocs = _indexSegment.getSegmentMetadata().getTotalDocs();
     // Build the operator chain for the main predicate so the filter plan can be run only one time
     Pair<FilterPlanNode, BaseFilterOperator> filterOperatorPair =
@@ -82,7 +82,7 @@ public class GroupByPlanNode implements PlanNode {
         _queryContext.getGroupByExpressions().toArray(new ExpressionContext[0]), numTotalDocs, _queryContext);
   }
 
-  private GroupByOperator nonFilteredGroupByPlan() {
+  private GroupByOperator buildNonFilteredGroupByPlan() {
     int numTotalDocs = _indexSegment.getSegmentMetadata().getTotalDocs();
     AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
     ExpressionContext[] groupByExpressions = _queryContext.getGroupByExpressions().toArray(new ExpressionContext[0]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
@@ -61,7 +61,6 @@ public class GroupByPlanNode implements PlanNode {
     if (_queryContext.hasFilteredAggregations()) {
       return buildFilteredGroupByPlan();
     }
-
     return buildNonFilteredGroupByPlan();
   }
 
@@ -76,7 +75,7 @@ public class GroupByPlanNode implements PlanNode {
             filterOperatorPair.getRight(), groupByExpressions);
 
     List<Pair<AggregationFunction[], TransformOperator>> aggToTransformOpList =
-        AggregationFunctionUtils.buildFilteredAggTranformPairs(_indexSegment, _queryContext,
+        AggregationFunctionUtils.buildFilteredAggTransformPairs(_indexSegment, _queryContext,
             filterOperatorPair.getRight(), transformOperator, groupByExpressions);
     return new FilteredGroupByOperator(_queryContext.getAggregationFunctions(), aggToTransformOpList,
         _queryContext.getGroupByExpressions().toArray(new ExpressionContext[0]), numTotalDocs, _queryContext);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
@@ -18,20 +18,14 @@
  */
 package org.apache.pinot.core.plan;
 
-import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.common.request.context.FilterContext;
 import org.apache.pinot.core.common.Operator;
-import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
-import org.apache.pinot.core.operator.filter.CombinedFilterOperator;
-import org.apache.pinot.core.operator.query.FilteredAggregationOperator;
 import org.apache.pinot.core.operator.query.FilteredGroupByOperator;
 import org.apache.pinot.core.operator.query.GroupByOperator;
 import org.apache.pinot.core.operator.transform.TransformOperator;
@@ -44,10 +38,6 @@ import org.apache.pinot.core.startree.plan.StarTreeTransformPlanNode;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
-
-import static org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils.buildFilterOperator;
-import static org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils.buildFilteredAggTranformPairs;
-import static org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils.buildTransformOperatorForFilteredAggregates;
 
 
 /**
@@ -78,15 +68,16 @@ public class GroupByPlanNode implements PlanNode {
   private FilteredGroupByOperator filteredGroupByPlan() {
     int numTotalDocs = _indexSegment.getSegmentMetadata().getTotalDocs();
     // Build the operator chain for the main predicate so the filter plan can be run only one time
-    Pair<FilterPlanNode, BaseFilterOperator> filterOperatorPair = buildFilterOperator(_indexSegment, _queryContext);
+    Pair<FilterPlanNode, BaseFilterOperator> filterOperatorPair =
+        AggregationFunctionUtils.buildFilterOperator(_indexSegment, _queryContext);
     ExpressionContext[] groupByExpressions = _queryContext.getGroupByExpressions().toArray(new ExpressionContext[0]);
     TransformOperator transformOperator =
-        buildTransformOperatorForFilteredAggregates(_indexSegment, _queryContext, filterOperatorPair.getRight(),
-            groupByExpressions);
+        AggregationFunctionUtils.buildTransformOperatorForFilteredAggregates(_indexSegment, _queryContext,
+            filterOperatorPair.getRight(), groupByExpressions);
 
     List<Pair<AggregationFunction[], TransformOperator>> aggToTransformOpList =
-        buildFilteredAggTranformPairs(_indexSegment, _queryContext, filterOperatorPair.getRight(), transformOperator,
-            groupByExpressions);
+        AggregationFunctionUtils.buildFilteredAggTranformPairs(_indexSegment, _queryContext,
+            filterOperatorPair.getRight(), transformOperator, groupByExpressions);
     return new FilteredGroupByOperator(_queryContext.getAggregationFunctions(), aggToTransformOpList,
         _queryContext.getGroupByExpressions().toArray(new ExpressionContext[0]), numTotalDocs, _queryContext);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -26,13 +27,24 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.FilterContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
+import org.apache.pinot.core.operator.filter.BaseFilterOperator;
+import org.apache.pinot.core.operator.filter.CombinedFilterOperator;
+import org.apache.pinot.core.operator.query.FilteredGroupByOperator;
+import org.apache.pinot.core.operator.transform.TransformOperator;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.core.plan.FilterPlanNode;
+import org.apache.pinot.core.plan.TransformPlanNode;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
 
 
@@ -71,11 +83,13 @@ public class AggregationFunctionUtils {
    * <p>NOTE: We don't need to consider order-by columns here as the ordering is only allowed for aggregation functions
    *          or group-by expressions.
    */
-  public static Set<ExpressionContext> collectExpressionsToTransform(AggregationFunction[] aggregationFunctions,
+  public static Set<ExpressionContext> collectExpressionsToTransform(@Nullable AggregationFunction[] aggregationFunctions,
       @Nullable ExpressionContext[] groupByExpressions) {
     Set<ExpressionContext> expressions = new HashSet<>();
-    for (AggregationFunction aggregationFunction : aggregationFunctions) {
-      expressions.addAll(aggregationFunction.getInputExpressions());
+    if (aggregationFunctions != null) {
+      for (AggregationFunction aggregationFunction : aggregationFunctions) {
+        expressions.addAll(aggregationFunction.getInputExpressions());
+      }
     }
     if (groupByExpressions != null) {
       expressions.addAll(Arrays.asList(groupByExpressions));
@@ -165,4 +179,87 @@ public class AggregationFunctionUtils {
         throw new IllegalStateException("Illegal column data type in final result: " + columnDataType);
     }
   }
+
+  /**
+   * Build a filter operator from the given FilterContext.
+   *
+   * It returns the FilterPlanNode to allow reusing plan level components such as predicate
+   * evaluator map
+   */
+  public static Pair<FilterPlanNode, BaseFilterOperator> buildFilterOperator(IndexSegment indexSegment,
+      QueryContext queryContext, FilterContext filterContext) {
+    FilterPlanNode filterPlanNode = new FilterPlanNode(indexSegment, queryContext, filterContext);
+    return Pair.of(filterPlanNode, filterPlanNode.run());
+  }
+
+  public static Pair<FilterPlanNode, BaseFilterOperator> buildFilterOperator(IndexSegment indexSegment,
+      QueryContext queryContext) {
+    return buildFilterOperator(indexSegment, queryContext, queryContext.getFilter());
+  }
+
+  public static TransformOperator buildTransformOperatorForFilteredAggregates(IndexSegment indexSegment,
+      QueryContext queryContext, BaseFilterOperator filterOperator, @Nullable ExpressionContext[] groupByExpressions) {
+    AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
+    Set<ExpressionContext> expressionsToTransform =
+        AggregationFunctionUtils.collectExpressionsToTransform(aggregationFunctions, groupByExpressions);
+
+    return new TransformPlanNode(indexSegment, queryContext, expressionsToTransform,
+        DocIdSetPlanNode.MAX_DOC_PER_CALL, filterOperator).run();
+  }
+
+  /**
+   * Build pairs of filtered aggregation functions and corresponding transform operator
+   * @param mainPredicateFilterOperator Filter operator corresponding to the main predicate
+   * @param mainTransformOperator Transform operator corresponding to the main predicate
+   */
+  public static List<Pair<AggregationFunction[], TransformOperator>> buildFilteredAggTranformPairs(
+      IndexSegment indexSegment, QueryContext queryContext, BaseFilterOperator mainPredicateFilterOperator,
+      TransformOperator mainTransformOperator, @Nullable ExpressionContext[] groupByExpressions) {
+    Map<FilterContext, Pair<List<AggregationFunction>, TransformOperator>> filterContextToAggFuncsMap = new HashMap<>();
+    List<AggregationFunction> nonFilteredAggregationFunctions = new ArrayList<>();
+    List<Pair<AggregationFunction, FilterContext>> aggregationFunctions =
+        queryContext.getFilteredAggregationFunctions();
+    List<Pair<AggregationFunction[], TransformOperator>> aggToTransformOpList = new ArrayList<>();
+
+    // For each aggregation function, check if the aggregation function is a filtered agg.
+    // If it is, populate the corresponding filter operator and corresponding transform operator
+    for (Pair<AggregationFunction, FilterContext> inputPair : aggregationFunctions) {
+      if (inputPair.getLeft() != null) {
+        FilterContext currentFilterExpression = inputPair.getRight();
+        if (filterContextToAggFuncsMap.get(currentFilterExpression) != null) {
+          filterContextToAggFuncsMap.get(currentFilterExpression).getLeft().add(inputPair.getLeft());
+          continue;
+        }
+        Pair<FilterPlanNode, BaseFilterOperator> filterPlanOpPair =
+            buildFilterOperator(indexSegment, queryContext, currentFilterExpression);
+        BaseFilterOperator wrappedFilterOperator =
+            new CombinedFilterOperator(mainPredicateFilterOperator, filterPlanOpPair.getRight(),
+                queryContext.getQueryOptions());
+        TransformOperator newTransformOperator =
+            buildTransformOperatorForFilteredAggregates(indexSegment, queryContext, wrappedFilterOperator,
+                groupByExpressions);
+        // For each transform operator, associate it with the underlying expression. This allows
+        // fetching the relevant TransformOperator when resolving blocks during aggregation
+        // execution
+        List<AggregationFunction> aggFunctionList = new ArrayList<>();
+        aggFunctionList.add(inputPair.getLeft());
+        filterContextToAggFuncsMap.put(currentFilterExpression, Pair.of(aggFunctionList, newTransformOperator));
+      } else {
+        nonFilteredAggregationFunctions.add(inputPair.getLeft());
+      }
+    }
+    // Convert to array since FilteredGroupByOperator expects it
+    for (Pair<List<AggregationFunction>, TransformOperator> pair : filterContextToAggFuncsMap.values()) {
+      List<AggregationFunction> aggregationFunctionList = pair.getLeft();
+      if (aggregationFunctionList == null) {
+        throw new IllegalStateException("Null aggregation list seen");
+      }
+      aggToTransformOpList.add(Pair.of(aggregationFunctionList.toArray(new AggregationFunction[0]), pair.getRight()));
+    }
+    aggToTransformOpList.add(
+        Pair.of(nonFilteredAggregationFunctions.toArray(new AggregationFunction[0]), mainTransformOperator));
+
+    return aggToTransformOpList;
+  }
+
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -37,7 +37,6 @@ import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.operator.blocks.TransformBlock;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.operator.filter.CombinedFilterOperator;
-import org.apache.pinot.core.operator.query.FilteredGroupByOperator;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.plan.FilterPlanNode;
@@ -83,8 +82,8 @@ public class AggregationFunctionUtils {
    * <p>NOTE: We don't need to consider order-by columns here as the ordering is only allowed for aggregation functions
    *          or group-by expressions.
    */
-  public static Set<ExpressionContext> collectExpressionsToTransform(@Nullable AggregationFunction[] aggregationFunctions,
-      @Nullable ExpressionContext[] groupByExpressions) {
+  public static Set<ExpressionContext> collectExpressionsToTransform(
+      @Nullable AggregationFunction[] aggregationFunctions, @Nullable ExpressionContext[] groupByExpressions) {
     Set<ExpressionContext> expressions = new HashSet<>();
     if (aggregationFunctions != null) {
       for (AggregationFunction aggregationFunction : aggregationFunctions) {
@@ -261,5 +260,4 @@ public class AggregationFunctionUtils {
 
     return aggToTransformOpList;
   }
-
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -83,13 +83,12 @@ public class AggregationFunctionUtils {
    *          or group-by expressions.
    */
   public static Set<ExpressionContext> collectExpressionsToTransform(
-      @Nullable AggregationFunction[] aggregationFunctions, @Nullable ExpressionContext[] groupByExpressions) {
+      AggregationFunction[] aggregationFunctions, @Nullable ExpressionContext[] groupByExpressions) {
     Set<ExpressionContext> expressions = new HashSet<>();
-    if (aggregationFunctions != null) {
-      for (AggregationFunction aggregationFunction : aggregationFunctions) {
-        expressions.addAll(aggregationFunction.getInputExpressions());
-      }
+    for (AggregationFunction aggregationFunction : aggregationFunctions) {
+      expressions.addAll(aggregationFunction.getInputExpressions());
     }
+
     if (groupByExpressions != null) {
       expressions.addAll(Arrays.asList(groupByExpressions));
     }
@@ -199,6 +198,7 @@ public class AggregationFunctionUtils {
   public static TransformOperator buildTransformOperatorForFilteredAggregates(IndexSegment indexSegment,
       QueryContext queryContext, BaseFilterOperator filterOperator, @Nullable ExpressionContext[] groupByExpressions) {
     AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
+    assert aggregationFunctions != null;
     Set<ExpressionContext> expressionsToTransform =
         AggregationFunctionUtils.collectExpressionsToTransform(aggregationFunctions, groupByExpressions);
 
@@ -222,6 +222,7 @@ public class AggregationFunctionUtils {
 
     // For each aggregation function, check if the aggregation function is a filtered agg.
     // If it is, populate the corresponding filter operator and corresponding transform operator
+    assert aggregationFunctions != null;
     for (Pair<AggregationFunction, FilterContext> inputPair : aggregationFunctions) {
       if (inputPair.getLeft() != null) {
         FilterContext currentFilterExpression = inputPair.getRight();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -82,13 +82,12 @@ public class AggregationFunctionUtils {
    * <p>NOTE: We don't need to consider order-by columns here as the ordering is only allowed for aggregation functions
    *          or group-by expressions.
    */
-  public static Set<ExpressionContext> collectExpressionsToTransform(
-      AggregationFunction[] aggregationFunctions, @Nullable ExpressionContext[] groupByExpressions) {
+  public static Set<ExpressionContext> collectExpressionsToTransform(AggregationFunction[] aggregationFunctions,
+      @Nullable ExpressionContext[] groupByExpressions) {
     Set<ExpressionContext> expressions = new HashSet<>();
     for (AggregationFunction aggregationFunction : aggregationFunctions) {
       expressions.addAll(aggregationFunction.getInputExpressions());
     }
-
     if (groupByExpressions != null) {
       expressions.addAll(Arrays.asList(groupByExpressions));
     }
@@ -200,10 +199,9 @@ public class AggregationFunctionUtils {
     AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
     assert aggregationFunctions != null;
     Set<ExpressionContext> expressionsToTransform =
-        AggregationFunctionUtils.collectExpressionsToTransform(aggregationFunctions, groupByExpressions);
-
-    return new TransformPlanNode(indexSegment, queryContext, expressionsToTransform,
-        DocIdSetPlanNode.MAX_DOC_PER_CALL, filterOperator).run();
+        collectExpressionsToTransform(aggregationFunctions, groupByExpressions);
+    return new TransformPlanNode(indexSegment, queryContext, expressionsToTransform, DocIdSetPlanNode.MAX_DOC_PER_CALL,
+        filterOperator).run();
   }
 
   /**
@@ -211,7 +209,7 @@ public class AggregationFunctionUtils {
    * @param mainPredicateFilterOperator Filter operator corresponding to the main predicate
    * @param mainTransformOperator Transform operator corresponding to the main predicate
    */
-  public static List<Pair<AggregationFunction[], TransformOperator>> buildFilteredAggTranformPairs(
+  public static List<Pair<AggregationFunction[], TransformOperator>> buildFilteredAggTransformPairs(
       IndexSegment indexSegment, QueryContext queryContext, BaseFilterOperator mainPredicateFilterOperator,
       TransformOperator mainTransformOperator, @Nullable ExpressionContext[] groupByExpressions) {
     Map<FilterContext, Pair<List<AggregationFunction>, TransformOperator>> filterContextToAggFuncsMap = new HashMap<>();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.query.aggregation.groupby;
 
 import java.util.Collection;
 import java.util.Map;
-import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.data.table.IntermediateRecord;
@@ -79,8 +78,9 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
    * @param groupByExpressions Array of group-by expressions
    * @param transformOperator Transform operator
    */
-  public DefaultGroupByExecutor(QueryContext queryContext, AggregationFunction[] aggregationFunctions, ExpressionContext[] groupByExpressions,
-        TransformOperator transformOperator, GroupKeyGenerator groupKeyGenerator) {
+  public DefaultGroupByExecutor(QueryContext queryContext, AggregationFunction[] aggregationFunctions,
+      ExpressionContext[] groupByExpressions, TransformOperator transformOperator,
+      GroupKeyGenerator groupKeyGenerator) {
     _aggregationFunctions = aggregationFunctions;
     assert _aggregationFunctions != null;
     _nullHandlingEnabled = queryContext.isNullHandlingEnabled();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
@@ -110,8 +110,9 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
               new NoDictionaryMultiColumnGroupKeyGenerator(transformOperator, groupByExpressions, numGroupsLimit);
         }
       } else {
-        groupKeyGeneratorTemp = new DictionaryBasedGroupKeyGenerator(transformOperator, groupByExpressions, numGroupsLimit,
-            maxInitialResultHolderCapacity);
+        groupKeyGeneratorTemp =
+            new DictionaryBasedGroupKeyGenerator(transformOperator, groupByExpressions, numGroupsLimit,
+                maxInitialResultHolderCapacity);
       }
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
@@ -119,7 +119,6 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
     int maxNumResults = _groupKeyGenerator.getGlobalGroupKeyUpperBound();
     int initialCapacity = Math.min(maxNumResults, maxInitialResultHolderCapacity);
     int numAggregationFunctions = _aggregationFunctions.length;
-    // TODO(egalpin): study use of groupByResultHolders and their index relation to aggregationFunctions
     _groupByResultHolders = new GroupByResultHolder[numAggregationFunctions];
     for (int i = 0; i < numAggregationFunctions; i++) {
       _groupByResultHolders[i] = _aggregationFunctions[i].createGroupByResultHolder(initialCapacity, maxNumResults);
@@ -159,8 +158,6 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
     AggregationFunction aggregationFunction = _aggregationFunctions[functionIndex];
     Map<ExpressionContext, BlockValSet> blockValSetMap =
         AggregationFunctionUtils.getBlockValSetMap(aggregationFunction, transformBlock);
-    // TODO(egalpin): Each groupByResultHolder is a column, so there is one for each Agg function. If we can create the
-    //  array of result holders externally and share it between loop iterations, we'll be good here
     GroupByResultHolder groupByResultHolder = _groupByResultHolders[functionIndex];
     if (_hasMVGroupByExpression) {
       aggregationFunction.aggregateGroupByMV(length, _mvGroupKeys, groupByResultHolder, blockValSetMap);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupByExecutor.java
@@ -58,4 +58,8 @@ public interface GroupByExecutor {
    *
    */
   Collection<IntermediateRecord> trimGroupByResult(int trimSize, TableResizer tableResizer);
+
+  GroupKeyGenerator getGroupKeyGenerator();
+
+  GroupByResultHolder[] getGroupByResultHolders();
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -260,7 +260,7 @@ public class QueryContext {
   /**
    * Returns the filtered aggregation expressions for the query.
    */
-  public boolean isHasFilteredAggregations() {
+  public boolean hasFilteredAggregations() {
     return _hasFilteredAggregations;
   }
 
@@ -537,9 +537,9 @@ public class QueryContext {
         FilterContext filter = pair.getRight();
         if (filter != null) {
           // Filtered aggregation
-          if (_groupByExpressions != null) {
-            throw new IllegalStateException("GROUP BY with FILTER clauses is not supported");
-          }
+//          if (_groupByExpressions != null) {
+//            throw new IllegalStateException("GROUP BY with FILTER clauses is not supported");
+//          }
           queryContext._hasFilteredAggregations = true;
         }
         int functionIndex = filteredAggregationFunctions.size();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -536,10 +536,6 @@ public class QueryContext {
         FunctionContext aggregation = pair.getLeft();
         FilterContext filter = pair.getRight();
         if (filter != null) {
-          // Filtered aggregation
-//          if (_groupByExpressions != null) {
-//            throw new IllegalStateException("GROUP BY with FILTER clauses is not supported");
-//          }
           queryContext._hasFilteredAggregations = true;
         }
         int functionIndex = filteredAggregationFunctions.size();

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/GroupByTrimTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/GroupByTrimTest.java
@@ -29,11 +29,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.data.table.Table;
 import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.operator.combine.GroupByCombineOperator;
-import org.apache.pinot.core.operator.query.GroupByOperator;
 import org.apache.pinot.core.plan.GroupByPlanNode;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
@@ -50,12 +50,11 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
-
-import static org.testng.Assert.assertEquals;
 
 
 /**
@@ -120,7 +119,7 @@ public class GroupByTrimTest {
     queryContext.setMinServerGroupTrimSize(minServerGroupTrimSize);
 
     // Create a query operator
-    GroupByOperator groupByOperator = new GroupByPlanNode(_indexSegment, queryContext).run();
+    Operator<GroupByResultsBlock> groupByOperator = new GroupByPlanNode(_indexSegment, queryContext).run();
     GroupByCombineOperator combineOperator =
         new GroupByCombineOperator(Collections.singletonList(groupByOperator), queryContext, _executorService);
 
@@ -130,7 +129,7 @@ public class GroupByTrimTest {
     // Extract the execution result
     List<Pair<Double, Double>> extractedResult = extractTestResult(resultsBlock.getTable());
 
-    assertEquals(extractedResult, expectedResult);
+    Assert.assertEquals(extractedResult, expectedResult);
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
@@ -202,10 +202,10 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
     nonFilterQuery = "SELECT SUM(INT_COL) FROM MyTable WHERE BOOLEAN_COL=true AND STARTSWITH(STRING_COL, 'abc')";
     testQuery(filterQuery, nonFilterQuery);
 
-    filterQuery = "SELECT SUM(INT_COL) FILTER(WHERE BOOLEAN_COL AND STARTSWITH(REVERSE(STRING_COL), 'abc')) FROM "
-        + "MyTable";
-    nonFilterQuery = "SELECT SUM(INT_COL) FROM MyTable WHERE BOOLEAN_COL=true AND STARTSWITH(REVERSE(STRING_COL), "
-        + "'abc')";
+    filterQuery =
+        "SELECT SUM(INT_COL) FILTER(WHERE BOOLEAN_COL AND STARTSWITH(REVERSE(STRING_COL), 'abc')) FROM " + "MyTable";
+    nonFilterQuery =
+        "SELECT SUM(INT_COL) FROM MyTable WHERE BOOLEAN_COL=true AND STARTSWITH(REVERSE(STRING_COL), " + "'abc')";
     testQuery(filterQuery, nonFilterQuery);
   }
 
@@ -336,16 +336,14 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
   }
 
   @Test
-  public void testGroupBySupport() {
-    String filterQuery =
-        "SELECT SUM(INT_COL) FILTER(WHERE INT_COL > 25000) FROM MyTable GROUP BY BOOLEAN_COL";
-   String nonFilterQuery =
-        "SELECT SUM(INT_COL) FROM MyTable WHERE INT_COL > 25000 GROUP BY BOOLEAN_COL";
+  public void testGroupBy() {
+    String filterQuery = "SELECT SUM(INT_COL) FILTER(WHERE INT_COL > 25000) FROM MyTable GROUP BY BOOLEAN_COL";
+    String nonFilterQuery = "SELECT SUM(INT_COL) FROM MyTable WHERE INT_COL > 25000 GROUP BY BOOLEAN_COL";
     testQuery(filterQuery, nonFilterQuery);
   }
 
   @Test
-  public void testGroupBySupportCaseAlternative() {
+  public void testGroupByCaseAlternative() {
     String filterQuery =
         "SELECT SUM(INT_COL), SUM(INT_COL) FILTER(WHERE INT_COL > 25000) AS total_sum FROM MyTable GROUP BY "
             + "BOOLEAN_COL";
@@ -356,12 +354,11 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
   }
 
   @Test
-  public void testGroupBySupportSameFilter() {
+  public void testGroupBySameFilter() {
     String filterQuery =
         "SELECT AVG(INT_COL) FILTER(WHERE INT_COL > 25000), SUM(INT_COL) FILTER(WHERE INT_COL > 25000) FROM MyTable "
             + "GROUP BY BOOLEAN_COL";
-    String nonFilterQuery =
-        "SELECT AVG(INT_COL), SUM(INT_COL) FROM MyTable WHERE INT_COL > 25000 GROUP BY BOOLEAN_COL";
+    String nonFilterQuery = "SELECT AVG(INT_COL), SUM(INT_COL) FROM MyTable WHERE INT_COL > 25000 GROUP BY BOOLEAN_COL";
     testQuery(filterQuery, nonFilterQuery);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
@@ -347,7 +347,8 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
   @Test
   public void testGroupBySupportCaseAlternative() {
     String filterQuery =
-        "SELECT SUM(INT_COL), SUM(INT_COL) FILTER(WHERE INT_COL > 25000) AS total_sum FROM MyTable GROUP BY BOOLEAN_COL";
+        "SELECT SUM(INT_COL), SUM(INT_COL) FILTER(WHERE INT_COL > 25000) AS total_sum FROM MyTable GROUP BY "
+            + "BOOLEAN_COL";
     String nonFilterQuery =
         "SELECT SUM(INT_COL), SUM(CASE WHEN INT_COL > 25000 THEN INT_COL ELSE 0 END) AS total_sum FROM MyTable GROUP "
             + "BY BOOLEAN_COL";

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
@@ -335,10 +335,13 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
     testQuery(filterQuery, nonFilterQuery);
   }
 
-  @Test(expectedExceptions = IllegalStateException.class)
+  @Test
   public void testGroupBySupport() {
-    String filterQuery = "SELECT MIN(INT_COL) FILTER(WHERE NO_INDEX_COL > 2), MAX(INT_COL) FILTER(WHERE INT_COL > 2) "
-        + "FROM MyTable WHERE INT_COL < 1000 GROUP BY INT_COL";
-    getBrokerResponse(filterQuery);
+    String filterQuery =
+        "SELECT SUM(INT_COL), SUM(INT_COL) FILTER(WHERE INT_COL > 25000) AS total_sum FROM MyTable GROUP BY INT_COL";
+    String nonFilterQuery =
+        "SELECT SUM(INT_COL), SUM(CASE WHEN INT_COL > 25000 THEN INT_COL ELSE 0 END) AS total_sum FROM MyTable GROUP "
+            + "BY INT_COL";
+    testQuery(filterQuery, nonFilterQuery);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
@@ -338,10 +338,48 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
   @Test
   public void testGroupBySupport() {
     String filterQuery =
-        "SELECT SUM(INT_COL), SUM(INT_COL) FILTER(WHERE INT_COL > 25000) AS total_sum FROM MyTable GROUP BY INT_COL";
+        "SELECT SUM(INT_COL) FILTER(WHERE INT_COL > 25000) FROM MyTable GROUP BY BOOLEAN_COL";
+   String nonFilterQuery =
+        "SELECT SUM(INT_COL) FROM MyTable WHERE INT_COL > 25000 GROUP BY BOOLEAN_COL";
+    testQuery(filterQuery, nonFilterQuery);
+  }
+
+  @Test
+  public void testGroupBySupportCaseAlternative() {
+    String filterQuery =
+        "SELECT SUM(INT_COL), SUM(INT_COL) FILTER(WHERE INT_COL > 25000) AS total_sum FROM MyTable GROUP BY BOOLEAN_COL";
     String nonFilterQuery =
         "SELECT SUM(INT_COL), SUM(CASE WHEN INT_COL > 25000 THEN INT_COL ELSE 0 END) AS total_sum FROM MyTable GROUP "
-            + "BY INT_COL";
+            + "BY BOOLEAN_COL";
+    testQuery(filterQuery, nonFilterQuery);
+  }
+
+  @Test
+  public void testGroupBySupportSameFilter() {
+    String filterQuery =
+        "SELECT AVG(INT_COL) FILTER(WHERE INT_COL > 25000), SUM(INT_COL) FILTER(WHERE INT_COL > 25000) FROM MyTable "
+            + "GROUP BY BOOLEAN_COL";
+    String nonFilterQuery =
+        "SELECT AVG(INT_COL), SUM(INT_COL) FROM MyTable WHERE INT_COL > 25000 GROUP BY BOOLEAN_COL";
+    testQuery(filterQuery, nonFilterQuery);
+  }
+
+  @Test
+  public void testMultipleAggregationsOnSameFilterGroupBy() {
+    String filterQuery = "SELECT MIN(INT_COL) FILTER(WHERE NO_INDEX_COL > 29990), "
+        + "MAX(INT_COL) FILTER(WHERE INT_COL > 29990) FROM MyTable GROUP BY BOOLEAN_COL";
+    String nonFilterQuery = "SELECT MIN(INT_COL), MAX(INT_COL) FROM MyTable WHERE INT_COL > 29990 GROUP BY BOOLEAN_COL";
+    testQuery(filterQuery, nonFilterQuery);
+
+    filterQuery = "SELECT MIN(INT_COL) FILTER(WHERE NO_INDEX_COL > 29990) AS total_min, "
+        + "MAX(INT_COL) FILTER(WHERE INT_COL > 29990) AS total_max, "
+        + "SUM(INT_COL) FILTER(WHERE NO_INDEX_COL < 5000) AS total_sum, "
+        + "MAX(NO_INDEX_COL) FILTER(WHERE NO_INDEX_COL < 5000) AS total_max2 FROM MyTable GROUP BY BOOLEAN_COL";
+    nonFilterQuery = "SELECT MIN(CASE WHEN (NO_INDEX_COL > 29990) THEN INT_COL ELSE 99999 END) AS total_min, "
+        + "MAX(CASE WHEN (INT_COL > 29990) THEN INT_COL ELSE 0 END) AS total_max, "
+        + "SUM(CASE WHEN (NO_INDEX_COL < 5000) THEN INT_COL ELSE 0 END) AS total_sum, "
+        + "MAX(CASE WHEN (NO_INDEX_COL < 5000) THEN NO_INDEX_COL ELSE 0 END) AS total_max2 FROM MyTable GROUP BY "
+        + "BOOLEAN_COL";
     testQuery(filterQuery, nonFilterQuery);
   }
 }


### PR DESCRIPTION
Following @atris's awesome work[1] to support FILTER expressions[2][3], this PR aims to introduce support for FILTER expressions simultaneously with GROUP BY. The same swim-lane pattern established in the initial FILTER expression PR[1] is re-used/shared here by groupBy processing.

<img width="1280" alt="Screen Shot 2022-12-16 at 17 19 04" src="https://user-images.githubusercontent.com/7582748/208216345-e87a6331-3d0e-4cec-a4b2-a034a6552ec4.png">

Fixes #7519

[1] https://github.com/apache/pinot/pull/7916
[2] https://github.com/apache/pinot/issues/7519
[3] https://docs.google.com/document/d/1ZM-2c0jJkbeJ61m8sJF0qj19t5UYLhnTFvIAz-HCJmk