### PR TITLE
[multistage] Add Worker SPI to Make Worker Assignment Configurable

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/worker/DefaultWorkerAssignmentStrategy.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/worker/DefaultWorkerAssignmentStrategy.java
@@ -1,0 +1,105 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.logical.worker;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.core.routing.RoutingTable;
+import org.apache.pinot.core.routing.TimeBoundaryInfo;
+import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.pinot.query.planner.PlannerUtils;
+import org.apache.pinot.query.planner.QueryPlan;
+import org.apache.pinot.query.planner.StageMetadata;
+import org.apache.pinot.query.routing.WorkerManager;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+
+
+/**
+ * The default worker assignment strategy. This assigns workers using the following:
+ * 1. For the root-stage, we assign the broker as the only worker.
+ * 2. For intermediate stages, we assign all available servers as workers. We haven't implemented tenant isolation yet
+ *    so all available servers across all tenants are picked for the intermediate stage, even if the tables in the query
+ *    belong to a single tenant.
+ * 3. Workers for the leaf-stage are determined by the segment/server selection made by RoutingManager.
+ */
+public class DefaultWorkerAssignmentStrategy implements WorkerAssignmentStrategy {
+  private final WorkerManager _workerManager;
+
+  DefaultWorkerAssignmentStrategy(WorkerManager workerManager) {
+    _workerManager = workerManager;
+  }
+
+  public void assignWorkers(QueryPlan queryPlan, long requestId) {
+    // assign workers to each stage.
+    for (Map.Entry<Integer, StageMetadata> e : queryPlan.getStageMetadataMap().entrySet()) {
+      assignWorkerToStage(e.getKey(), e.getValue(), requestId);
+    }
+  }
+
+  private void assignWorkerToStage(int stageId, StageMetadata stageMetadata, long requestId) {
+    List<String> scannedTables = stageMetadata.getScannedTables();
+    if (scannedTables.size() == 1) {
+      // table scan stage, need to attach server as well as segment info for each physical table type.
+      String logicalTableName = scannedTables.get(0);
+      Map<String, RoutingTable> routingTableMap = _workerManager.getRoutingTable(logicalTableName, requestId);
+      if (routingTableMap.size() == 0) {
+        throw new IllegalArgumentException("Unable to find routing entries for table: " + logicalTableName);
+      }
+      // acquire time boundary info if it is a hybrid table.
+      if (routingTableMap.size() > 1) {
+        TimeBoundaryInfo timeBoundaryInfo = _workerManager.getRoutingManager().getTimeBoundaryInfo(TableNameBuilder
+            .forType(TableType.OFFLINE).tableNameWithType(TableNameBuilder.extractRawTableName(logicalTableName)));
+        if (timeBoundaryInfo != null) {
+          stageMetadata.setTimeBoundaryInfo(timeBoundaryInfo);
+        } else {
+          // remove offline table routing if no time boundary info is acquired.
+          routingTableMap.remove(TableType.OFFLINE.name());
+        }
+      }
+
+      // extract all the instances associated to each table type
+      Map<ServerInstance, Map<String, List<String>>> serverInstanceToSegmentsMap = new HashMap<>();
+      for (Map.Entry<String, RoutingTable> routingEntry : routingTableMap.entrySet()) {
+        String tableType = routingEntry.getKey();
+        RoutingTable routingTable = routingEntry.getValue();
+        // for each server instance, attach all table types and their associated segment list.
+        for (Map.Entry<ServerInstance, List<String>> serverEntry
+            : routingTable.getServerInstanceToSegmentsMap().entrySet()) {
+          serverInstanceToSegmentsMap.putIfAbsent(serverEntry.getKey(), new HashMap<>());
+          Map<String, List<String>> tableTypeToSegmentListMap = serverInstanceToSegmentsMap.get(serverEntry.getKey());
+          Preconditions.checkState(tableTypeToSegmentListMap.put(tableType, serverEntry.getValue()) == null,
+              "Entry for server {} and table type: {} already exist!", serverEntry.getKey(), tableType);
+        }
+      }
+      stageMetadata.setServerInstances(new ArrayList<>(serverInstanceToSegmentsMap.keySet()));
+      stageMetadata.setServerInstanceToSegmentsMap(serverInstanceToSegmentsMap);
+    } else if (PlannerUtils.isRootStage(stageId)) {
+      // ROOT stage doesn't have a QueryServer as it is strictly only reducing results.
+      // here we simply assign the worker instance with identical server/mailbox port number.
+      stageMetadata.setServerInstances(Lists.newArrayList(_workerManager.getCurrentWorker()));
+    } else {
+      stageMetadata.setServerInstances(_workerManager.getMultiStageWorkers());
+    }
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/worker/WorkerAssignmentStrategy.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/worker/WorkerAssignmentStrategy.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.logical.worker;
+
+import org.apache.pinot.query.planner.QueryPlan;
+import org.apache.pinot.spi.annotations.InterfaceStability;
+
+
+/**
+ * WorkerAssignmentStrategy selects the servers to be used for each stage of the query.
+ */
+@InterfaceStability.Evolving
+public interface WorkerAssignmentStrategy {
+  void assignWorkers(QueryPlan queryPlan, long requestId);
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/worker/WorkerAssignmentStrategyFactory.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/worker/WorkerAssignmentStrategyFactory.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.planner.logical.worker;
+
+import java.util.Map;
+import org.apache.pinot.query.routing.WorkerManager;
+
+
+public class WorkerAssignmentStrategyFactory {
+  private WorkerAssignmentStrategyFactory() {
+  }
+
+  public static WorkerAssignmentStrategy create(Map<String, String> queryOptions, WorkerManager workerManager) {
+    // TODO: Use queryOptions to pick a worker assignment strategy. This is not done right now since we only have 1
+    //       strategy at the moment.
+    return new DefaultWorkerAssignmentStrategy(workerManager);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.query.routing;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
@@ -27,10 +25,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.RoutingTable;
-import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
-import org.apache.pinot.query.planner.PlannerUtils;
-import org.apache.pinot.query.planner.StageMetadata;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -38,10 +33,7 @@ import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 
 
 /**
- * The {@code WorkerManager} manages stage to worker assignment.
- *
- * <p>It contains the logic to assign worker to a particular stages. If it is a leaf stage the logic fallback to
- * how Pinot server assigned server and server-segment mapping.
+ * A re-usable abstraction for worker assignment strategy.
  *
  * TODO: Currently it is implemented by wrapping routing manager from Pinot Broker. however we can abstract out
  * the worker manager later when we split out the query-spi layer.
@@ -58,64 +50,16 @@ public class WorkerManager {
     _routingManager = routingManager;
   }
 
-  public void assignWorkerToStage(int stageId, StageMetadata stageMetadata, long requestId) {
-    List<String> scannedTables = stageMetadata.getScannedTables();
-    if (scannedTables.size() == 1) {
-      // table scan stage, need to attach server as well as segment info for each physical table type.
-      String logicalTableName = scannedTables.get(0);
-      Map<String, RoutingTable> routingTableMap = getRoutingTable(logicalTableName, requestId);
-      if (routingTableMap.size() == 0) {
-        throw new IllegalArgumentException("Unable to find routing entries for table: " + logicalTableName);
-      }
-      // acquire time boundary info if it is a hybrid table.
-      if (routingTableMap.size() > 1) {
-        TimeBoundaryInfo timeBoundaryInfo = _routingManager.getTimeBoundaryInfo(TableNameBuilder
-            .forType(TableType.OFFLINE).tableNameWithType(TableNameBuilder.extractRawTableName(logicalTableName)));
-        if (timeBoundaryInfo != null) {
-          stageMetadata.setTimeBoundaryInfo(timeBoundaryInfo);
-        } else {
-          // remove offline table routing if no time boundary info is acquired.
-          routingTableMap.remove(TableType.OFFLINE.name());
-        }
-      }
-
-      // extract all the instances associated to each table type
-      Map<ServerInstance, Map<String, List<String>>> serverInstanceToSegmentsMap = new HashMap<>();
-      for (Map.Entry<String, RoutingTable> routingEntry : routingTableMap.entrySet()) {
-        String tableType = routingEntry.getKey();
-        RoutingTable routingTable = routingEntry.getValue();
-        // for each server instance, attach all table types and their associated segment list.
-        for (Map.Entry<ServerInstance, List<String>> serverEntry
-            : routingTable.getServerInstanceToSegmentsMap().entrySet()) {
-          serverInstanceToSegmentsMap.putIfAbsent(serverEntry.getKey(), new HashMap<>());
-          Map<String, List<String>> tableTypeToSegmentListMap = serverInstanceToSegmentsMap.get(serverEntry.getKey());
-          Preconditions.checkState(tableTypeToSegmentListMap.put(tableType, serverEntry.getValue()) == null,
-              "Entry for server {} and table type: {} already exist!", serverEntry.getKey(), tableType);
-        }
-      }
-      stageMetadata.setServerInstances(new ArrayList<>(serverInstanceToSegmentsMap.keySet()));
-      stageMetadata.setServerInstanceToSegmentsMap(serverInstanceToSegmentsMap);
-    } else if (PlannerUtils.isRootStage(stageId)) {
-      // ROOT stage doesn't have a QueryServer as it is strictly only reducing results.
-      // here we simply assign the worker instance with identical server/mailbox port number.
-      stageMetadata.setServerInstances(Lists.newArrayList(new WorkerInstance(_hostName, _port, _port, _port, _port)));
-    } else {
-      stageMetadata.setServerInstances(filterServers(_routingManager.getEnabledServerInstanceMap().values()));
-    }
+  public List<ServerInstance> getMultiStageWorkers() {
+    return filterServers(_routingManager.getEnabledServerInstanceMap().values());
   }
 
-  private static List<ServerInstance> filterServers(Collection<ServerInstance> servers) {
-    List<ServerInstance> serverInstances = new ArrayList<>();
-    for (ServerInstance server : servers) {
-      String hostname = server.getHostname();
-      if (server.getQueryServicePort() > 0 && server.getQueryMailboxPort() > 0
-          && !hostname.startsWith(CommonConstants.Helix.PREFIX_OF_BROKER_INSTANCE)
-          && !hostname.startsWith(CommonConstants.Helix.PREFIX_OF_CONTROLLER_INSTANCE)
-          && !hostname.startsWith(CommonConstants.Helix.PREFIX_OF_MINION_INSTANCE)) {
-        serverInstances.add(server);
-      }
-    }
-    return serverInstances;
+  public RoutingManager getRoutingManager() {
+    return _routingManager;
+  }
+
+  public ServerInstance getCurrentWorker() {
+    return new WorkerInstance(_hostName, _port, _port, _port, _port);
   }
 
   /**
@@ -124,7 +68,7 @@ public class WorkerManager {
    * @param logicalTableName it can either be a hybrid table name or a physical table name with table type.
    * @return keyed-map from table type(s) to routing table(s).
    */
-  private Map<String, RoutingTable> getRoutingTable(String logicalTableName, long requestId) {
+  public Map<String, RoutingTable> getRoutingTable(String logicalTableName, long requestId) {
     String rawTableName = TableNameBuilder.extractRawTableName(logicalTableName);
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(logicalTableName);
     Map<String, RoutingTable> routingTableMap = new HashMap<>();
@@ -152,5 +96,19 @@ public class WorkerManager {
         TableNameBuilder.extractRawTableName(tableName));
     return _routingManager.getRoutingTable(
         CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM " + tableNameWithType), requestId);
+  }
+
+  private static List<ServerInstance> filterServers(Collection<ServerInstance> servers) {
+    List<ServerInstance> serverInstances = new ArrayList<>();
+    for (ServerInstance server : servers) {
+      String hostname = server.getHostname();
+      if (server.getQueryServicePort() > 0 && server.getQueryMailboxPort() > 0
+          && !hostname.startsWith(CommonConstants.Helix.PREFIX_OF_BROKER_INSTANCE)
+          && !hostname.startsWith(CommonConstants.Helix.PREFIX_OF_CONTROLLER_INSTANCE)
+          && !hostname.startsWith(CommonConstants.Helix.PREFIX_OF_MINION_INSTANCE)) {
+        serverInstances.add(server);
+      }
+    }
+    return serverInstances;
   }
 }


### PR DESCRIPTION
This adds a simple Worker SPI to make the worker assignment configurable per-query.

The worker assignment strategy may be picked by using queryOptions. This PR only adds the default implementation. We'll soon be adding a worker assignment strategy for colocated joins.

The interface is marked as Evolving since we'll be working heavily on worker assignment over the next month or so.

**Test-Plan:** Existing UTs have quite a lot of coverage. I also tested this by running the quickstart on local.