### PR TITLE
User friendly error message when only one column is passed to covariance function.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CovarianceAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CovarianceAggregationFunction.java
@@ -32,6 +32,7 @@ import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder
 import org.apache.pinot.core.query.aggregation.utils.StatisticalAggregationFunctionUtils;
 import org.apache.pinot.segment.local.customobject.CovarianceTuple;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
 
 
 /**
@@ -55,6 +56,9 @@ public class CovarianceAggregationFunction implements AggregationFunction<Covari
   protected final boolean _isSample;
 
   public CovarianceAggregationFunction(List<ExpressionContext> arguments, boolean isSample) {
+    if (arguments.size() != 2) {
+      throw new BadQueryRequestException("Atleast two expressions need to be provided to calculate covariance");
+    }
     _expression1 = arguments.get(0);
     _expression2 = arguments.get(1);
     _isSample = isSample;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CovarianceAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CovarianceAggregationFunction.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.core.query.aggregation.function;
 
+import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -32,8 +33,6 @@ import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder
 import org.apache.pinot.core.query.aggregation.utils.StatisticalAggregationFunctionUtils;
 import org.apache.pinot.segment.local.customobject.CovarianceTuple;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
-import org.apache.pinot.spi.exception.BadQueryRequestException;
-
 
 /**
  * Aggregation function which returns the population covariance of 2 expressions.
@@ -56,9 +55,10 @@ public class CovarianceAggregationFunction implements AggregationFunction<Covari
   protected final boolean _isSample;
 
   public CovarianceAggregationFunction(List<ExpressionContext> arguments, boolean isSample) {
-    if (arguments.size() != 2) {
-      throw new BadQueryRequestException("Atleast two expressions need to be provided to calculate covariance");
-    }
+    int numArguments = arguments.size();
+    Preconditions.checkArgument(numArguments == 2,
+            "Covariance expects 2 arguments, got: %s", numArguments);
+
     _expression1 = arguments.get(0);
     _expression2 = arguments.get(1);
     _isSample = isSample;


### PR DESCRIPTION
User friendly error message when only one column is passed to covariance function.
`covarpop`("1 column")` covarSamp`("1 column"), the error message currently shown is out of index, changing that to a user friendly message.

