### PR TITLE
allow to access raw properties more flexibly

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentMetadata.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2Metadata;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
@@ -122,5 +123,9 @@ public interface SegmentMetadata {
 
   default boolean isMutableSegment() {
     return false;
+  }
+
+  default PropertiesConfiguration getPropertiesConfiguration() {
+    return null;
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/utils/SegmentMetadataUtils.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/utils/SegmentMetadataUtils.java
@@ -38,6 +38,10 @@ public class SegmentMetadataUtils {
   }
 
   public static PropertiesConfiguration getPropertiesConfiguration(SegmentMetadata segmentMetadata) {
+    PropertiesConfiguration segmentMetadataPropConfig = segmentMetadata.getPropertiesConfiguration();
+    if (segmentMetadataPropConfig != null) {
+      return segmentMetadataPropConfig;
+    }
     File indexDir = segmentMetadata.getIndexDir();
     Preconditions.checkState(indexDir != null, "Cannot get PropertiesConfiguration from in-memory segment: %s",
         segmentMetadata.getName());


### PR DESCRIPTION
Follow up on the [clean up](https://github.com/apache/pinot/pull/9952) to make it flexible to access the raw PropertiesConfiguration owned by the SegmentMetadata object, as controlled by the provided Supplier<PropertiesConfiguration>. 