### PR TITLE
Make BaseDefaultColumnHandler constructor safe for SegmentMetadata initialised with IS

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -129,7 +129,8 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
     _indexLoadingConfig = indexLoadingConfig;
     _schema = schema;
     _segmentWriter = segmentWriter;
-    _segmentProperties = SegmentMetadataUtils.getPropertiesConfiguration(segmentMetadata);
+    _segmentProperties = (_segmentMetadata.getIndexDir() == null) ? null
+        : SegmentMetadataUtils.getPropertiesConfiguration(_segmentMetadata);
   }
 
   @Override


### PR DESCRIPTION
For `needPrerocess` calls, we don't need metadata files. This changes makes it possible to initialise BaseDefaultColumnHandler with Inputstream based SegmentMetadata implementations.