### PR TITLE
Handle in-memory segment metadata for index checking

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
@@ -42,16 +42,18 @@ import static org.apache.pinot.spi.data.FieldSpec.DataType;
 
 public class ColumnMinMaxValueGenerator {
   private final SegmentMetadata _segmentMetadata;
-  private final PropertiesConfiguration _segmentProperties;
   private final SegmentDirectory.Writer _segmentWriter;
   private final ColumnMinMaxValueGeneratorMode _columnMinMaxValueGeneratorMode;
+
+  // NOTE: _segmentProperties shouldn't be used when checking whether min/max value need to be generated because at that
+  //       time _segmentMetadata might not be loaded from a local file
+  private PropertiesConfiguration _segmentProperties;
 
   private boolean _minMaxValueAdded;
 
   public ColumnMinMaxValueGenerator(SegmentMetadata segmentMetadata, SegmentDirectory.Writer segmentWriter,
       ColumnMinMaxValueGeneratorMode columnMinMaxValueGeneratorMode) {
     _segmentMetadata = segmentMetadata;
-    _segmentProperties = SegmentMetadataUtils.getPropertiesConfiguration(segmentMetadata);
     _segmentWriter = segmentWriter;
     _columnMinMaxValueGeneratorMode = columnMinMaxValueGeneratorMode;
   }
@@ -68,6 +70,7 @@ public class ColumnMinMaxValueGenerator {
   public void addColumnMinMaxValue()
       throws Exception {
     Preconditions.checkState(_columnMinMaxValueGeneratorMode != ColumnMinMaxValueGeneratorMode.NONE);
+    _segmentProperties = SegmentMetadataUtils.getPropertiesConfiguration(_segmentMetadata);
     for (String column : getColumnsToAddMinMaxValue()) {
       addColumnMinMaxValueForColumn(column);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -120,7 +120,9 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
   protected final Schema _schema;
   protected final SegmentDirectory.Writer _segmentWriter;
 
-  private final PropertiesConfiguration _segmentProperties;
+  // NOTE: _segmentProperties shouldn't be used when checking whether default column need to be created because at that
+  //       time _segmentMetadata might not be loaded from a local file
+  private PropertiesConfiguration _segmentProperties;
 
   protected BaseDefaultColumnHandler(File indexDir, SegmentMetadata segmentMetadata,
       IndexLoadingConfig indexLoadingConfig, Schema schema, SegmentDirectory.Writer segmentWriter) {
@@ -129,7 +131,6 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
     _indexLoadingConfig = indexLoadingConfig;
     _schema = schema;
     _segmentWriter = segmentWriter;
-    _segmentProperties = SegmentMetadataUtils.getPropertiesConfiguration(segmentMetadata);
   }
 
   @Override
@@ -151,6 +152,7 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
     }
 
     // Update each default column based on the default column action.
+    _segmentProperties = SegmentMetadataUtils.getPropertiesConfiguration(_segmentMetadata);
     Iterator<Map.Entry<String, DefaultColumnAction>> entryIterator = defaultColumnActionMap.entrySet().iterator();
     while (entryIterator.hasNext()) {
       Map.Entry<String, DefaultColumnAction> entry = entryIterator.next();


### PR DESCRIPTION
When checking if pre-processing is needed during segment load, the segment metadata might not be loaded from the local file, and segment properties might not be available. This PR fixes the logic by not using the segment properties when checking if pre-processing is needed.