### PR TITLE
[Flaky test] Fix ForwardIndexHandlerTest

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandlerTest.java
@@ -386,7 +386,7 @@ public class ForwardIndexHandlerTest {
 
       // Populate data for the MV columns with forward index disabled to have unique entries per row.
       // Avoid creating empty arrays.
-      int numMVElements = random.nextInt(maxNumberOfMVEntries - 1) + 1;
+      int numMVElements = random.nextInt(maxNumberOfMVEntries) + 1;
       for (int j = 0; j < numMVElements; j++) {
         String str = "n" + i + j;
         tempMVIntRowsForwardIndexDisabled[i][j] = j;


### PR DESCRIPTION
Fix the exception when `maxNumberOfMVEntries` is 1 (generated randomly)