### PR TITLE
[multistage][bugfix] Fix not-in clause not execute properly

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -344,7 +344,11 @@ public class DataSchema {
      */
     public boolean isSuperTypeOf(ColumnDataType subTypeCandidate) {
       if (this.isNumber() && subTypeCandidate.isNumber() && this != BIG_DECIMAL && subTypeCandidate != BIG_DECIMAL) {
+        // NUMBER subtype check using type hoisting rules defined in NUMERIC_TYPE_ORDERING
         return NUMERIC_TYPE_ORDERING.max(this, subTypeCandidate) == this;
+      } else if (subTypeCandidate == BOOLEAN) {
+        // BOOLEAN type is sub-type of any number type, checking whether it is equal to 1.
+        return this.isNumber();
       } else {
         return this == subTypeCandidate;
       }
@@ -394,7 +398,7 @@ public class DataSchema {
         case BIG_DECIMAL:
           return (BigDecimal) value;
         case BOOLEAN:
-          return (Integer) value == 1;
+          return ((Number) value).intValue() == 1;
         case TIMESTAMP:
           return new Timestamp((long) value);
         case STRING:
@@ -456,7 +460,7 @@ public class DataSchema {
         case BIG_DECIMAL:
           return (BigDecimal) value;
         case BOOLEAN:
-          return (Integer) value == 1;
+          return ((Number) value).intValue() == 1;
         case TIMESTAMP:
           return new Timestamp((long) value).toString();
         case STRING:

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -348,7 +348,7 @@ public class DataSchema {
         return NUMERIC_TYPE_ORDERING.max(this, subTypeCandidate) == this;
       } else if (subTypeCandidate == BOOLEAN) {
         // BOOLEAN type is sub-type of any number type, checking whether it is equal to 1.
-        return this.isNumber();
+        return this == subTypeCandidate || (this.isNumber() && this != BIG_DECIMAL);
       } else {
         return this == subTypeCandidate;
       }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
@@ -113,6 +113,12 @@ public class DataSchemaTest {
         Assert.assertFalse(numberTypeToTest.get(idx).isSuperTypeOf(numberTypeToTest.get(subTypeIdx)));
       }
     }
+
+    // Boolean can be converted by any number type, but not the other way around
+    for (int idx = 0; idx < numberTypeToTest.size(); idx++) {
+      Assert.assertTrue(numberTypeToTest.get(idx).isSuperTypeOf(BOOLEAN));
+      Assert.assertFalse(BOOLEAN.isSuperTypeOf(numberTypeToTest.get(idx)));
+    }
   }
 
   @Test

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FilterOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/FilterOperand.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.spi.utils.BooleanUtils;
 
 
 public abstract class FilterOperand extends TransformOperand {
@@ -44,7 +45,7 @@ public abstract class FilterOperand extends TransformOperand {
     @Override
     public Boolean apply(Object[] row) {
       for (TransformOperand child : _childOperands) {
-        if (!(Boolean) child.apply(row)) {
+        if (!BooleanUtils.toBoolean(child.apply(row))) {
           return false;
         }
       }
@@ -65,7 +66,7 @@ public abstract class FilterOperand extends TransformOperand {
     @Override
     public Boolean apply(Object[] row) {
       for (TransformOperand child : _childOperands) {
-        if ((Boolean) child.apply(row)) {
+        if (BooleanUtils.toBoolean(child.apply(row))) {
           return true;
         }
       }
@@ -82,7 +83,20 @@ public abstract class FilterOperand extends TransformOperand {
 
     @Override
     public Boolean apply(Object[] row) {
-      return !(Boolean) _childOperand.apply(row);
+      return !BooleanUtils.toBoolean(_childOperand.apply(row));
+    }
+  }
+
+  public static class True extends FilterOperand {
+    TransformOperand _childOperand;
+
+    public True(RexExpression childExpr, DataSchema inputDataSchema) {
+      _childOperand = toTransformOperand(childExpr, inputDataSchema);
+    }
+
+    @Override
+    public Boolean apply(Object[] row) {
+      return BooleanUtils.toBoolean(_childOperand.apply(row));
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/TransformOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/TransformOperand.java
@@ -55,9 +55,15 @@ public abstract class TransformOperand {
       case "OR":
         Preconditions.checkState(operandSize >= 2, "OR takes >=2 argument, passed in argument size:" + operandSize);
         return new FilterOperand.Or(functionOperands, inputDataSchema);
+      case "ISNOTTRUE":
       case "NOT":
-        Preconditions.checkState(operandSize == 1, "NOT takes one argument, passed in argument size:" + operandSize);
+        Preconditions.checkState(operandSize == 1,
+            "NOT / IS_NOT_TRUE takes one argument, passed in argument size:" + operandSize);
         return new FilterOperand.Not(functionOperands.get(0), inputDataSchema);
+      case "ISTRUE":
+        Preconditions.checkState(operandSize == 1,
+            "BOOL / IS_TRUE takes one argument, passed in argument size:" + operandSize);
+        return new FilterOperand.True(functionOperands.get(0), inputDataSchema);
       case "equals":
         return new FilterOperand.Predicate(functionOperands, inputDataSchema) {
           @Override

--- a/pinot-query-runtime/src/test/resources/queries/TableExpressions.json
+++ b/pinot-query-runtime/src/test/resources/queries/TableExpressions.json
@@ -16,6 +16,9 @@
       }
     },
     "queries": [
+      { "sql": "SELECT * FROM {tbl} WHERE strCol IN (SELECT strCol FROM {tbl} WHERE intCol < 100)" },
+      { "sql": "SELECT * FROM {tbl} WHERE strCol NOT IN (SELECT strCol FROM {tbl} WHERE intCol > 100)" },
+      { "sql": "SELECT * FROM {tbl} WHERE strCol NOT IN (SELECT strCol FROM {tbl} WHERE intCol < 100)" },
       { "sql": "SELECT * FROM {tbl} WHERE intCol > 5" },
       { "sql": "SELECT * FROM {tbl} WHERE strCol IN ('foo', 'bar')" },
       { "sql": "SELECT * FROM {tbl} WHERE intCol IN (196883, 42)" },
@@ -86,6 +89,7 @@
       }
     },
     "queries": [
+      { "sql": "SELECT * FROM {tbl1} WHERE strCol NOT IN (SELECT strCol1 FROM {tbl2} WHERE intCol > 100)" },
       { "sql": "SELECT strCol FROM {tbl1} GROUP BY strCol" },
       { "sql": "SELECT strCol FROM {tbl1} GROUP BY strCol, intCol" },
       { "sql": "SELECT strCol, intCol FROM {tbl1} GROUP BY strCol, intCol" },

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BooleanUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BooleanUtils.java
@@ -34,7 +34,9 @@ public class BooleanUtils {
   }
 
   public static boolean toBoolean(Object booleanObject) {
-    if (booleanObject instanceof String) {
+    if (booleanObject == null) {
+      return false;
+    } else if (booleanObject instanceof String) {
       return BooleanUtils.toBoolean((String) booleanObject);
     } else if (booleanObject instanceof Number) {
       return ((Number) booleanObject).intValue() != 0;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BooleanUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BooleanUtils.java
@@ -39,7 +39,7 @@ public class BooleanUtils {
     } else if (booleanObject instanceof String) {
       return BooleanUtils.toBoolean((String) booleanObject);
     } else if (booleanObject instanceof Number) {
-      return ((Number) booleanObject).intValue() != 0;
+      return ((Number) booleanObject).intValue() == 1;
     } else if (booleanObject instanceof Boolean) {
       return (boolean) booleanObject;
     } else {


### PR DESCRIPTION
Summary
===
- this is a follow up on https://github.com/apache/pinot/pull/9886
- this fixes #9867

Changelist
===
1. FilterOperand now support ISTRUE and ISNOTTRUE, which can be generated by Calcite
2. FilterOperand now use BooleanUtils.toBoolean to convert to boolean (not ideal in performance but surely for correctness)
3. Changed conversion rule for Boolean type in DataSchema b/c MIN(boolCol) and MAX(boolCol) returns a DOUBLE instead of an INT