### PR TITLE
fix: add AES256 server side encryption support for S3PinotFS

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
@@ -20,7 +20,9 @@ package org.apache.pinot.plugin.filesystem;
 
 import com.google.common.base.Joiner;
 import com.google.common.base.Preconditions;
+import java.util.Optional;
 import java.util.UUID;
+import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
 
@@ -41,6 +43,8 @@ public class S3Config {
   public static final String SERVER_SIDE_ENCRYPTION_CONFIG_KEY = "serverSideEncryption";
   public static final String SSE_KMS_KEY_ID_CONFIG_KEY = "ssekmsKeyId";
   public static final String SSE_KMS_ENCRYPTION_CONTEXT_CONFIG_KEY = "ssekmsEncryptionContext";
+  public static final String SSE_CUSTOMER_ENCRYPTION_KEY_CONFIG_KEY = "sseCustomerKey";
+  public static final String SSE_CUSTOMER_ENCRYPTION_KEY_MD5_CONFIG_KEY = "sseCustomerKeyMD5";
 
   // IAM Role related configurations
   public static final String IAM_ROLE_BASED_ACCESS_ENABLED = "iamRoleBasedAccessEnabled";
@@ -62,6 +66,8 @@ public class S3Config {
   private final String _serverSideEncryption;
   private String _ssekmsKeyId;
   private String _ssekmsEncryptionContext;
+  private String _sseCustomerKey;
+  private String _sseCustomerKeyMD5;
 
   private boolean _iamRoleBasedAccess;
   private String _roleArn;
@@ -80,6 +86,9 @@ public class S3Config {
     _serverSideEncryption = pinotConfig.getProperty(SERVER_SIDE_ENCRYPTION_CONFIG_KEY);
     _ssekmsKeyId = pinotConfig.getProperty(SSE_KMS_KEY_ID_CONFIG_KEY);
     _ssekmsEncryptionContext = pinotConfig.getProperty(SSE_KMS_ENCRYPTION_CONTEXT_CONFIG_KEY);
+    _sseCustomerKey = pinotConfig.getProperty(SSE_CUSTOMER_ENCRYPTION_KEY_CONFIG_KEY);
+    _sseCustomerKeyMD5 = Optional.ofNullable(pinotConfig.getProperty(SSE_CUSTOMER_ENCRYPTION_KEY_MD5_CONFIG_KEY))
+        .orElseGet(() -> DigestUtils.md5Hex(_sseCustomerKey));
 
     _iamRoleBasedAccess = Boolean.parseBoolean(
         pinotConfig.getProperty(IAM_ROLE_BASED_ACCESS_ENABLED, DEFAULT_IAM_ROLE_BASED_ACCESS_ENABLED));
@@ -127,6 +136,14 @@ public class S3Config {
 
   public String getSsekmsEncryptionContext() {
     return _ssekmsEncryptionContext;
+  }
+
+  public String getSseCustomerKey() {
+    return _sseCustomerKey;
+  }
+
+  public String getSseCustomerKeyMD5() {
+    return _sseCustomerKeyMD5;
   }
 
   public boolean isIamRoleBasedAccess() {

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -87,6 +87,9 @@ public class S3PinotFS extends BasePinotFS {
   private ServerSideEncryption _serverSideEncryption = null;
   private String _ssekmsKeyId;
   private String _ssekmsEncryptionContext;
+  private String _sseCustomerKey;
+  private String _sseCustomerKeyMD5;
+  private String _sseCustomerAlgorithm;
 
   @Override
   public void init(PinotConfiguration config) {
@@ -179,7 +182,10 @@ public class S3PinotFS extends BasePinotFS {
           _ssekmsEncryptionContext = s3Config.getSsekmsEncryptionContext();
           break;
         case AES256:
-          // Todo: Support AES256.
+          _sseCustomerAlgorithm = serverSideEncryption;
+          _sseCustomerKey = s3Config.getSseCustomerKey();
+          _sseCustomerKeyMD5 = s3Config.getSseCustomerKeyMD5();
+          break;
         default:
           throw new UnsupportedOperationException("Unsupported server side encryption: " + _serverSideEncryption);
       }
@@ -623,6 +629,12 @@ public class S3PinotFS extends BasePinotFS {
       if (_ssekmsEncryptionContext != null) {
         putReqBuilder.ssekmsEncryptionContext(_ssekmsEncryptionContext);
       }
+      if (_sseCustomerKey != null) {
+        putReqBuilder
+            .sseCustomerAlgorithm(_sseCustomerAlgorithm)
+            .sseCustomerKey(_sseCustomerKey)
+            .sseCustomerKeyMD5(_sseCustomerKeyMD5);
+      }
     }
     return putReqBuilder.build();
   }
@@ -641,6 +653,12 @@ public class S3PinotFS extends BasePinotFS {
       copyReqBuilder.serverSideEncryption(_serverSideEncryption).ssekmsKeyId(_ssekmsKeyId);
       if (_ssekmsEncryptionContext != null) {
         copyReqBuilder.ssekmsEncryptionContext(_ssekmsEncryptionContext);
+      }
+      if (_sseCustomerKey != null) {
+        copyReqBuilder
+            .sseCustomerAlgorithm(_sseCustomerAlgorithm)
+            .sseCustomerKey(_sseCustomerKey)
+            .sseCustomerKeyMD5(_sseCustomerKeyMD5);
       }
     }
     return copyReqBuilder.build();


### PR DESCRIPTION
Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
