### PR TITLE
Create metadata only tarball for metadata push job

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtils.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationJobUtils.java
@@ -18,14 +18,31 @@
  */
 package org.apache.pinot.plugin.ingestion.batch.common;
 
+import java.io.File;
 import java.io.Serializable;
+import java.net.URI;
+import java.nio.file.FileVisitResult;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.SimpleFileVisitor;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.utils.TarGzCompressionUtils;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.spi.filesystem.PinotFS;
+import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.spec.SegmentNameGeneratorSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 @SuppressWarnings("serial")
 public class SegmentGenerationJobUtils implements Serializable {
   private SegmentGenerationJobUtils() {
   }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentGenerationJobUtils.class);
 
   /**
    * Always use local directory sequence id unless explicitly config: "use.global.directory.sequence.id".
@@ -45,5 +62,34 @@ public class SegmentGenerationJobUtils implements Serializable {
       }
     }
     return Boolean.parseBoolean(useGlobalDirectorySequenceId);
+  }
+
+  public static void createSegmentMetadataTarGz(File localSegmentDir, File localMetadataTarFile)
+      throws Exception {
+    List<File> metadataFiles = new ArrayList<>();
+    Files.walkFileTree(localSegmentDir.toPath(), new SimpleFileVisitor<Path>() {
+      @Override
+      public FileVisitResult visitFile(Path file, java.nio.file.attribute.BasicFileAttributes attrs) {
+        if (file.getFileName().toString().equals(V1Constants.MetadataKeys.METADATA_FILE_NAME)
+            || file.getFileName().toString().equals(V1Constants.SEGMENT_CREATION_META)) {
+          metadataFiles.add(file.toFile());
+        }
+        return FileVisitResult.CONTINUE;
+      }
+    });
+    LOGGER.info("Tarring metadata files from: [{}] to: {}", metadataFiles, localMetadataTarFile);
+    TarGzCompressionUtils.createTarGzFile(metadataFiles.toArray(new File[0]), localMetadataTarFile);
+  }
+
+  public static void moveLocalTarFileToRemote(File localMetadataTarFile, URI outputMetadataTarURI, boolean overwrite)
+      throws Exception {
+    LOGGER.info("Trying to move metadata tar file from: [{}] to [{}]", localMetadataTarFile, outputMetadataTarURI);
+    PinotFS outputPinotFS = PinotFSFactory.create(outputMetadataTarURI.getScheme());
+    if (!overwrite && outputPinotFS.exists(outputMetadataTarURI)) {
+      LOGGER.warn("Not overwrite existing output metadata tar file: {}", outputPinotFS.exists(outputMetadataTarURI));
+    } else {
+      outputPinotFS.copyFromLocalFile(localMetadataTarFile, outputMetadataTarURI);
+    }
+    FileUtils.deleteQuietly(localMetadataTarFile);
   }
 }

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-2.4/src/main/java/org/apache/pinot/plugin/ingestion/batch/spark/SparkSegmentGenerationJobRunner.java
@@ -275,6 +275,7 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
           taskSpec.setSequenceId(idx);
           taskSpec.setSegmentNameGeneratorSpec(_spec.getSegmentNameGeneratorSpec());
           taskSpec.setFailOnEmptySegment(_spec.isFailOnEmptySegment());
+          taskSpec.setCreateMetadataTarGz(_spec.isCreateMetadataTarGz());
           taskSpec.setCustomProperty(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());
 
           SegmentGenerationTaskRunner taskRunner = new SegmentGenerationTaskRunner(taskSpec);
@@ -290,20 +291,29 @@ public class SparkSegmentGenerationJobRunner implements IngestionJobRunner, Seri
           long compressedSegmentSize = FileUtils.sizeOf(localSegmentTarFile);
           LOGGER.info("Size for segment: {}, uncompressed: {}, compressed: {}", segmentName,
               DataSizeUtils.fromBytes(uncompressedSegmentSize), DataSizeUtils.fromBytes(compressedSegmentSize));
-          //move segment to output PinotFS
-          URI outputSegmentTarURI =
-              SegmentGenerationUtils.getRelativeOutputPath(finalInputDirURI, inputFileURI, finalOutputDirURI)
-                  .resolve(segmentTarFileName);
-          LOGGER.info("Trying to move segment tar file from: [{}] to [{}]", localSegmentTarFile, outputSegmentTarURI);
-          if (!_spec.isOverwriteOutput() && PinotFSFactory.create(outputSegmentTarURI.getScheme())
-              .exists(outputSegmentTarURI)) {
-            LOGGER.warn("Not overwrite existing output segment tar file: {}",
-                finalOutputDirFS.exists(outputSegmentTarURI));
-          } else {
-            finalOutputDirFS.copyFromLocalFile(localSegmentTarFile, outputSegmentTarURI);
+          // Move segment to output PinotFS
+          URI relativeOutputPath =
+              SegmentGenerationUtils.getRelativeOutputPath(finalInputDirURI, inputFileURI, finalOutputDirURI);
+          URI outputSegmentTarURI = relativeOutputPath.resolve(segmentTarFileName);
+          SegmentGenerationJobUtils.moveLocalTarFileToRemote(localSegmentTarFile, outputSegmentTarURI,
+              _spec.isOverwriteOutput());
+
+          // Create and upload segment metadata tar file
+          String metadataTarFileName = URLEncoder.encode(segmentName + Constants.METADATA_TAR_GZ_FILE_EXT, "UTF-8");
+          URI outputMetadataTarURI = relativeOutputPath.resolve(metadataTarFileName);
+
+          if (finalOutputDirFS.exists(outputMetadataTarURI) && (_spec.isOverwriteOutput()
+              || !_spec.isCreateMetadataTarGz())) {
+            LOGGER.info("Deleting existing metadata tar gz file: {}", outputMetadataTarURI);
+            finalOutputDirFS.delete(outputMetadataTarURI, true);
+          }
+          if (taskSpec.isCreateMetadataTarGz()) {
+            File localMetadataTarFile = new File(localOutputTempDir, metadataTarFileName);
+            SegmentGenerationJobUtils.createSegmentMetadataTarGz(localSegmentDir, localMetadataTarFile);
+            SegmentGenerationJobUtils.moveLocalTarFileToRemote(localMetadataTarFile, outputMetadataTarURI,
+                _spec.isOverwriteOutput());
           }
           FileUtils.deleteQuietly(localSegmentDir);
-          FileUtils.deleteQuietly(localSegmentTarFile);
           FileUtils.deleteQuietly(localInputDataFile);
         }
       });

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/main/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunner.java
@@ -244,6 +244,7 @@ public class SegmentGenerationJobRunner implements IngestionJobRunner {
     taskSpec.setInputFilePath(localInputDataFile.getAbsolutePath());
     taskSpec.setSequenceId(seqId);
     taskSpec.setFailOnEmptySegment(_spec.isFailOnEmptySegment());
+    taskSpec.setCreateMetadataTarGz(_spec.isCreateMetadataTarGz());
     taskSpec.setCustomProperty(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());
 
     // If there's already been a failure, log and skip this file. Do this check right before the

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/Constants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/Constants.java
@@ -26,4 +26,5 @@ public class Constants {
    * By default Pinot segments are compressed in 'tar.gz' format then pushed to controller.
    */
   public static final String TAR_GZ_FILE_EXT = ".tar.gz";
+  public static final String METADATA_TAR_GZ_FILE_EXT = ".metadata.tar.gz";
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/PushJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/PushJobSpec.java
@@ -61,6 +61,20 @@ public class PushJobSpec implements Serializable {
    */
   private String _pushFileNamePattern;
 
+  /**
+   * Prefer using segment metadata tar gz file to push segment if exists.
+   */
+  private boolean _preferMetadataTarGz = true;
+
+  public boolean isPreferMetadataTarGz() {
+    return _preferMetadataTarGz;
+  }
+
+  public PushJobSpec setPreferMetadataTarGz(boolean preferMetadataTarGz) {
+    _preferMetadataTarGz = preferMetadataTarGz;
+    return this;
+  }
+
   public String getPushFileNamePattern() {
     return _pushFileNamePattern;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationJobSpec.java
@@ -139,6 +139,11 @@ public class SegmentGenerationJobSpec implements Serializable {
    */
   private String _authToken;
 
+  /**
+   * Create a separated metadata only tar gz file to reduce the data transfer of segment metadata push job.
+   */
+  private boolean _createMetadataTarGz;
+
   public ExecutionFrameworkSpec getExecutionFrameworkSpec() {
     return _executionFrameworkSpec;
   }
@@ -309,6 +314,14 @@ public class SegmentGenerationJobSpec implements Serializable {
 
   public void setAuthToken(String authToken) {
     _authToken = authToken;
+  }
+
+  public boolean isCreateMetadataTarGz() {
+    return _createMetadataTarGz;
+  }
+
+  public void setCreateMetadataTarGz(boolean createMetadataTarGz) {
+    _createMetadataTarGz = createMetadataTarGz;
   }
 
   public String toJSONString(boolean removeSensitiveKeys) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationTaskSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/spec/SegmentGenerationTaskSpec.java
@@ -70,6 +70,8 @@ public class SegmentGenerationTaskSpec implements Serializable {
 
   private boolean _failOnEmptySegment = false;
 
+  private boolean _createMetadataTarGz = false;
+
   /**
    * Custom properties set into segment metadata
    */
@@ -137,6 +139,14 @@ public class SegmentGenerationTaskSpec implements Serializable {
 
   public void setFailOnEmptySegment(boolean failOnEmptySegment) {
     _failOnEmptySegment = failOnEmptySegment;
+  }
+
+  public boolean isCreateMetadataTarGz() {
+    return _createMetadataTarGz;
+  }
+
+  public void setCreateMetadataTarGz(boolean createMetadataTarGz) {
+    _createMetadataTarGz = createMetadataTarGz;
   }
 
   public void setCustomProperty(String key, String value) {


### PR DESCRIPTION
Problem:
Segment metadata push job always download segment tarball from remote, untar metadata files then tar them into a new tar.gz file then upload. This wastes a lot of download bandwidth and time for push job to get the metadata.

This PR introduce a new field: `createMetadataTarGz` to allow create another tar gz file with only `metadata.properties` and `creation.meta` along with the segment tar file.

The push job will look at the remote directories and choose to push `metadata.tar.gz` file if exists.
This can also be disabled by setting `preferMetadataTarGz` to `false` in `pushJobSpec`.

Release notes:
Simplify segment metadata push job by pre-creating segment metadata tar gz file. This can be enabled by setting `createMetadataTarGz` to `true` in `ingestionJobSpec`.
