### PR TITLE
evaluate equals queries against range index when available

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
@@ -61,7 +61,7 @@ public class FilterOperatorUtils {
       if (dataSource.getDataSourceMetadata().isSorted() && dataSource.getDictionary() != null) {
         return new SortedIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
       }
-      if (dataSource.getRangeIndex() != null) {
+      if (RangeIndexBasedFilterOperator.canEvaluate(predicateEvaluator, dataSource)) {
         return new RangeIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
       }
       return new ScanBasedFilterOperator(predicateEvaluator, dataSource, numDocs, nullHandlingEnabled);
@@ -79,6 +79,9 @@ public class FilterOperatorUtils {
       }
       if (dataSource.getInvertedIndex() != null) {
         return new BitmapBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
+      }
+      if (RangeIndexBasedFilterOperator.canEvaluate(predicateEvaluator, dataSource)) {
+        return new RangeIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
       }
       return new ScanBasedFilterOperator(predicateEvaluator, dataSource, numDocs, nullHandlingEnabled);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/EqualsPredicateEvaluatorFactory.java
@@ -21,6 +21,10 @@ package org.apache.pinot.core.operator.filter.predicate;
 import java.math.BigDecimal;
 import java.util.Arrays;
 import org.apache.pinot.common.request.context.predicate.EqPredicate;
+import org.apache.pinot.core.operator.filter.predicate.traits.DoubleValue;
+import org.apache.pinot.core.operator.filter.predicate.traits.FloatValue;
+import org.apache.pinot.core.operator.filter.predicate.traits.IntValue;
+import org.apache.pinot.core.operator.filter.predicate.traits.LongValue;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BooleanUtils;
@@ -82,7 +86,8 @@ public class EqualsPredicateEvaluatorFactory {
     }
   }
 
-  private static final class DictionaryBasedEqPredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator {
+  private static final class DictionaryBasedEqPredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator
+      implements IntValue {
     final int _matchingDictId;
     final int[] _matchingDictIds;
 
@@ -128,9 +133,15 @@ public class EqualsPredicateEvaluatorFactory {
     public int[] getMatchingDictIds() {
       return _matchingDictIds;
     }
+
+    @Override
+    public int getInt() {
+      return _matchingDictId;
+    }
   }
 
-  private static final class IntRawValueBasedEqPredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  private static final class IntRawValueBasedEqPredicateEvaluator extends BaseRawValueBasedPredicateEvaluator
+      implements IntValue {
     final int _matchingValue;
 
     IntRawValueBasedEqPredicateEvaluator(EqPredicate eqPredicate, int matchingValue) {
@@ -165,9 +176,15 @@ public class EqualsPredicateEvaluatorFactory {
       }
       return matches;
     }
+
+    @Override
+    public int getInt() {
+      return _matchingValue;
+    }
   }
 
-  private static final class LongRawValueBasedEqPredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  private static final class LongRawValueBasedEqPredicateEvaluator extends BaseRawValueBasedPredicateEvaluator
+      implements LongValue {
     final long _matchingValue;
 
     LongRawValueBasedEqPredicateEvaluator(EqPredicate eqPredicate, long matchingValue) {
@@ -202,9 +219,15 @@ public class EqualsPredicateEvaluatorFactory {
       }
       return matches;
     }
+
+    @Override
+    public long getLong() {
+      return _matchingValue;
+    }
   }
 
-  private static final class FloatRawValueBasedEqPredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  private static final class FloatRawValueBasedEqPredicateEvaluator extends BaseRawValueBasedPredicateEvaluator
+      implements FloatValue {
     final float _matchingValue;
 
     FloatRawValueBasedEqPredicateEvaluator(EqPredicate eqPredicate, float matchingValue) {
@@ -239,9 +262,15 @@ public class EqualsPredicateEvaluatorFactory {
       }
       return matches;
     }
+
+    @Override
+    public float getFloat() {
+      return _matchingValue;
+    }
   }
 
-  private static final class DoubleRawValueBasedEqPredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  private static final class DoubleRawValueBasedEqPredicateEvaluator extends BaseRawValueBasedPredicateEvaluator
+      implements DoubleValue {
     final double _matchingValue;
 
     DoubleRawValueBasedEqPredicateEvaluator(EqPredicate eqPredicate, double matchingValue) {
@@ -275,6 +304,11 @@ public class EqualsPredicateEvaluatorFactory {
         }
       }
       return matches;
+    }
+
+    @Override
+    public double getDouble() {
+      return _matchingValue;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/RangePredicateEvaluatorFactory.java
@@ -22,6 +22,10 @@ import com.google.common.base.Preconditions;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import java.math.BigDecimal;
 import org.apache.pinot.common.request.context.predicate.RangePredicate;
+import org.apache.pinot.core.operator.filter.predicate.traits.DoubleRange;
+import org.apache.pinot.core.operator.filter.predicate.traits.FloatRange;
+import org.apache.pinot.core.operator.filter.predicate.traits.IntRange;
+import org.apache.pinot.core.operator.filter.predicate.traits.LongRange;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BooleanUtils;
@@ -112,7 +116,8 @@ public class RangePredicateEvaluatorFactory {
     }
   }
 
-  public static final class SortedDictionaryBasedRangePredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator {
+  public static final class SortedDictionaryBasedRangePredicateEvaluator extends BaseDictionaryBasedPredicateEvaluator
+      implements IntRange {
     final int _startDictId;
     // Exclusive
     final int _endDictId;
@@ -214,6 +219,16 @@ public class RangePredicateEvaluatorFactory {
     public int getNumMatchingItems() {
       return Math.max(_numMatchingDictIds, 0);
     }
+
+    @Override
+    public int getInclusiveLowerBound() {
+      return getStartDictId();
+    }
+
+    @Override
+    public int getInclusiveUpperBound() {
+      return getEndDictId() - 1;
+    }
   }
 
   private static final class UnsortedDictionaryBasedRangePredicateEvaluator
@@ -294,7 +309,8 @@ public class RangePredicateEvaluatorFactory {
     }
   }
 
-  public static final class IntRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  private static final class IntRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator
+      implements IntRange {
     final int _inclusiveLowerBound;
     final int _inclusiveUpperBound;
 
@@ -315,10 +331,12 @@ public class RangePredicateEvaluatorFactory {
       }
     }
 
+    @Override
     public int getInclusiveLowerBound() {
       return _inclusiveLowerBound;
     }
 
+    @Override
     public int getInclusiveUpperBound() {
       return _inclusiveUpperBound;
     }
@@ -347,7 +365,8 @@ public class RangePredicateEvaluatorFactory {
     }
   }
 
-  public static final class LongRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  private static final class LongRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator
+      implements LongRange {
     final long _inclusiveLowerBound;
     final long _inclusiveUpperBound;
 
@@ -368,10 +387,12 @@ public class RangePredicateEvaluatorFactory {
       }
     }
 
+    @Override
     public long getInclusiveLowerBound() {
       return _inclusiveLowerBound;
     }
 
+    @Override
     public long getInclusiveUpperBound() {
       return _inclusiveUpperBound;
     }
@@ -400,7 +421,8 @@ public class RangePredicateEvaluatorFactory {
     }
   }
 
-  public static final class FloatRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  private static final class FloatRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator
+      implements FloatRange {
     final float _inclusiveLowerBound;
     final float _inclusiveUpperBound;
 
@@ -421,10 +443,12 @@ public class RangePredicateEvaluatorFactory {
       }
     }
 
+    @Override
     public float getInclusiveLowerBound() {
       return _inclusiveLowerBound;
     }
 
+    @Override
     public float getInclusiveUpperBound() {
       return _inclusiveUpperBound;
     }
@@ -453,7 +477,8 @@ public class RangePredicateEvaluatorFactory {
     }
   }
 
-  public static final class DoubleRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator {
+  private static final class DoubleRawValueBasedRangePredicateEvaluator extends BaseRawValueBasedPredicateEvaluator
+      implements DoubleRange {
     final double _inclusiveLowerBound;
     final double _inclusiveUpperBound;
 
@@ -474,10 +499,12 @@ public class RangePredicateEvaluatorFactory {
       }
     }
 
+    @Override
     public double getInclusiveLowerBound() {
       return _inclusiveLowerBound;
     }
 
+    @Override
     public double getInclusiveUpperBound() {
       return _inclusiveUpperBound;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/DoubleRange.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/DoubleRange.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter.predicate.traits;
+
+public interface DoubleRange {
+  double getInclusiveLowerBound();
+
+  double getInclusiveUpperBound();
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/DoubleValue.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/DoubleValue.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter.predicate.traits;
+
+public interface DoubleValue {
+  double getDouble();
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/FloatRange.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/FloatRange.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter.predicate.traits;
+
+public interface FloatRange {
+  float getInclusiveLowerBound();
+
+  float getInclusiveUpperBound();
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/FloatValue.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/FloatValue.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter.predicate.traits;
+
+public interface FloatValue {
+  float getFloat();
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/IntRange.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/IntRange.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter.predicate.traits;
+
+public interface IntRange {
+  int getInclusiveLowerBound();
+
+  int getInclusiveUpperBound();
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/IntValue.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/IntValue.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter.predicate.traits;
+
+public interface IntValue {
+  int getInt();
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/LongRange.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/LongRange.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter.predicate.traits;
+
+public interface LongRange {
+  long getInclusiveLowerBound();
+
+  long getInclusiveUpperBound();
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/LongValue.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/predicate/traits/LongValue.java
@@ -1,0 +1,23 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.filter.predicate.traits;
+
+public interface LongValue {
+  long getLong();
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/RangeQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/RangeQueriesTest.java
@@ -145,6 +145,16 @@ public class RangeQueriesTest extends BaseQueriesTest {
         {buildSelectionQuery(RAW_LONG_COL, 250, 500, false), 250, 500, false},
         {buildSelectionQuery(RAW_FLOAT_COL, 250, 500, false), 250, 500, false},
         {buildSelectionQuery(RAW_DOUBLE_COL, 250, 500, false), 250, 500, false},
+        {buildSelectionQuery(DICTIONARIZED_INT_COL, 300), 300, 300, true},
+        {buildSelectionQuery(RAW_INT_COL, 300), 300, 300, true},
+        {buildSelectionQuery(RAW_LONG_COL, 300), 300, 300, true},
+        {buildSelectionQuery(RAW_FLOAT_COL, 300), 300, 300, true},
+        {buildSelectionQuery(RAW_DOUBLE_COL, 300), 300, 300, true},
+        {buildSelectionQuery(DICTIONARIZED_INT_COL, 301), 301, 301, true},
+        {buildSelectionQuery(RAW_INT_COL, 301), 301, 301, true},
+        {buildSelectionQuery(RAW_LONG_COL, 301), 301, 301, true},
+        {buildSelectionQuery(RAW_FLOAT_COL, 301), 301, 301, true},
+        {buildSelectionQuery(RAW_DOUBLE_COL, 301), 301, 301, true}
     };
   }
 
@@ -156,6 +166,11 @@ public class RangeQueriesTest extends BaseQueriesTest {
       return "select " + RAW_INT_COL + " from " + RAW_TABLE_NAME + " where " + filterCol + " > "
           + formatValue(filterCol, min) + " and " + filterCol + " < " + formatValue(filterCol, max);
     }
+  }
+
+  private static String buildSelectionQuery(String filterCol, Number value) {
+      return "select " + RAW_INT_COL + " from " + RAW_TABLE_NAME + " where " + filterCol + " = "
+              + formatValue(filterCol, value);
   }
 
   @DataProvider
@@ -171,6 +186,16 @@ public class RangeQueriesTest extends BaseQueriesTest {
         {buildCountQuery(RAW_LONG_COL, 250, 500, false), 2},
         {buildCountQuery(RAW_FLOAT_COL, 250, 500, false), 2},
         {buildCountQuery(RAW_DOUBLE_COL, 250, 500, false), 2},
+        {buildCountQuery(DICTIONARIZED_INT_COL, 300), 1},
+        {buildCountQuery(RAW_INT_COL, 300), 1},
+        {buildCountQuery(RAW_LONG_COL, 300), 1},
+        {buildCountQuery(RAW_FLOAT_COL, 300), 1},
+        {buildCountQuery(RAW_DOUBLE_COL, 300), 1},
+        {buildCountQuery(DICTIONARIZED_INT_COL, 301), 0},
+        {buildCountQuery(RAW_INT_COL, 301), 0},
+        {buildCountQuery(RAW_LONG_COL, 301), 0},
+        {buildCountQuery(RAW_FLOAT_COL, 301), 0},
+        {buildCountQuery(RAW_DOUBLE_COL, 301), 0}
     };
   }
 
@@ -182,6 +207,10 @@ public class RangeQueriesTest extends BaseQueriesTest {
       return "select count(*) from " + RAW_TABLE_NAME + " where " + filterCol + " > "
           + formatValue(filterCol, min) + " and " + filterCol + " < " + formatValue(filterCol, max);
     }
+  }
+
+  private static String buildCountQuery(String filterCol, Number value) {
+    return "select count(*) from " + RAW_TABLE_NAME + " where " + filterCol + " = " + formatValue(filterCol, value);
   }
 
   private static String buildFilter(String filterCol, Number min, Number max) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/BitSlicedIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/BitSlicedIndexCreatorTest.java
@@ -171,9 +171,12 @@ public class BitSlicedIndexCreatorTest {
       }
       testRange(reader, dataset, prev, prev + 1);
       testRange(reader, dataset, prev + 1, prev + 1);
+      testPoint(reader, dataset, prev + 1);
       testRange(reader, dataset, prev + 1, Integer.MAX_VALUE);
       testRange(reader, dataset, Integer.MAX_VALUE, Integer.MAX_VALUE);
       testRange(reader, dataset, Integer.MIN_VALUE, Integer.MAX_VALUE);
+      testPoint(reader, dataset, Integer.MIN_VALUE);
+      testPoint(reader, dataset, Integer.MAX_VALUE);
     } finally {
       FileUtils.forceDelete(rangeIndexFile);
     }
@@ -190,6 +193,12 @@ public class BitSlicedIndexCreatorTest {
       assertEquals(reader.getMatchingDocIds(max, min), reference);
       assertEquals(reader.getNumMatchingDocs(max, min), reference.getCardinality());
     }
+  }
+
+  private static void testPoint(BitSlicedRangeIndexReader reader, Dataset<int[]> dataset, int value) {
+    ImmutableRoaringBitmap reference = dataset.scan(value, value);
+    assertEquals(reader.getMatchingDocIds(value), reference);
+    assertEquals(reader.getNumMatchingDocs(value), reference.getCardinality());
   }
 
   private void testLong(Dataset<long[]> dataset)
@@ -216,9 +225,12 @@ public class BitSlicedIndexCreatorTest {
       }
       testRange(reader, dataset, prev, prev + 1);
       testRange(reader, dataset, prev + 1, prev + 1);
+      testPoint(reader, dataset, prev + 1);
       testRange(reader, dataset, prev + 1, Long.MAX_VALUE);
       testRange(reader, dataset, Long.MAX_VALUE, Long.MAX_VALUE);
       testRange(reader, dataset, Long.MIN_VALUE, Long.MAX_VALUE);
+      testPoint(reader, dataset, Long.MIN_VALUE);
+      testPoint(reader, dataset, Long.MAX_VALUE);
     } finally {
       FileUtils.forceDelete(rangeIndexFile);
     }
@@ -235,6 +247,12 @@ public class BitSlicedIndexCreatorTest {
       assertEquals(reader.getMatchingDocIds(max, min), reference);
       assertEquals(reader.getNumMatchingDocs(max, min), reference.getCardinality());
     }
+  }
+
+  private static void testPoint(BitSlicedRangeIndexReader reader, Dataset<long[]> dataset, long value) {
+    ImmutableRoaringBitmap reference = dataset.scan(value, value);
+    assertEquals(reader.getMatchingDocIds(value), reference);
+    assertEquals(reader.getNumMatchingDocs(value), reference.getCardinality());
   }
 
   private void testFloat(Dataset<float[]> dataset)
@@ -261,9 +279,12 @@ public class BitSlicedIndexCreatorTest {
       }
       testRange(reader, dataset, prev, prev + 1);
       testRange(reader, dataset, prev + 1, prev + 1);
+      testPoint(reader, dataset, prev + 1);
       testRange(reader, dataset, prev + 1, Float.POSITIVE_INFINITY);
       testRange(reader, dataset, Float.POSITIVE_INFINITY, Float.POSITIVE_INFINITY);
       testRange(reader, dataset, Float.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
+      testPoint(reader, dataset, Float.POSITIVE_INFINITY);
+      testPoint(reader, dataset, Float.NEGATIVE_INFINITY);
     } finally {
       FileUtils.forceDelete(rangeIndexFile);
     }
@@ -280,6 +301,12 @@ public class BitSlicedIndexCreatorTest {
       assertEquals(reader.getMatchingDocIds(max, min), reference);
       assertEquals(reader.getNumMatchingDocs(max, min), reference.getCardinality());
     }
+  }
+
+  private static void testPoint(BitSlicedRangeIndexReader reader, Dataset<float[]> dataset, float value) {
+    ImmutableRoaringBitmap reference = dataset.scan(value, value);
+    assertEquals(reader.getMatchingDocIds(value), reference);
+    assertEquals(reader.getNumMatchingDocs(value), reference.getCardinality());
   }
 
   private void testDouble(Dataset<double[]> dataset)
@@ -306,9 +333,12 @@ public class BitSlicedIndexCreatorTest {
       }
       testRange(reader, dataset, prev, prev + 1);
       testRange(reader, dataset, prev + 1, prev + 1);
+      testPoint(reader, dataset, prev + 1);
       testRange(reader, dataset, prev + 1, Double.POSITIVE_INFINITY);
       testRange(reader, dataset, Double.POSITIVE_INFINITY, Double.POSITIVE_INFINITY);
       testRange(reader, dataset, Double.NEGATIVE_INFINITY, Float.POSITIVE_INFINITY);
+      testPoint(reader, dataset, Double.POSITIVE_INFINITY);
+      testPoint(reader, dataset, Double.NEGATIVE_INFINITY);
     } finally {
       FileUtils.forceDelete(rangeIndexFile);
     }
@@ -325,6 +355,12 @@ public class BitSlicedIndexCreatorTest {
       assertEquals(reader.getMatchingDocIds(max, min), reference);
       assertEquals(reader.getNumMatchingDocs(max, min), reference.getCardinality());
     }
+  }
+
+  private static void testPoint(BitSlicedRangeIndexReader reader, Dataset<double[]> dataset, double value) {
+    ImmutableRoaringBitmap reference = dataset.scan(value, value);
+    assertEquals(reader.getMatchingDocIds(value), reference);
+    assertEquals(reader.getNumMatchingDocs(value), reference.getCardinality());
   }
 
   private static BitSlicedRangeIndexCreator newBitSlicedIndexCreator(ColumnMetadata metadata) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/RangeIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/RangeIndexReader.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.spi.index.reader;
 import java.io.Closeable;
 import javax.annotation.Nullable;
 
+
 /**
  * Interface for indexed range queries
  * @param <T>
@@ -73,6 +74,46 @@ public interface RangeIndexReader<T> extends Closeable {
   int getNumMatchingDocs(double min, double max);
 
   /**
+   * Returns the number of docs with an equal value.
+   * The count is exact unless {@see getPartiallyMatchingDocIds} returns a non-null value.
+   * @param value the value
+   * @return the matching doc ids.
+   */
+  default int getNumMatchingDocs(int value) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns the number of docs with an equal value.
+   * The count is exact unless {@see getPartiallyMatchingDocIds} returns a non-null value.
+   * @param value the value
+   * @return the matching doc ids.
+   */
+  default int getNumMatchingDocs(long value) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns the number of docs with an equal value.
+   * The count is exact unless {@see getPartiallyMatchingDocIds} returns a non-null value.
+   * @param value the value
+   * @return the matching doc ids.
+   */
+  default int getNumMatchingDocs(float value) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns the number of docs with an equal value.
+   * The count is exact unless {@see getPartiallyMatchingDocIds} returns a non-null value.
+   * @param value the value
+   * @return the matching doc ids.
+   */
+  default int getNumMatchingDocs(double value) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
    * Returns doc ids with a value between min and max, both inclusive.
    * Doc ids returned by this method must correspond to values which
    * satisfy the query.
@@ -117,16 +158,48 @@ public interface RangeIndexReader<T> extends Closeable {
   T getMatchingDocIds(double min, double max);
 
   /**
-   * Returns doc ids with a value between min and max, both inclusive.
-   * Doc ids returned by this method may correspond to values which
-   * satisfy the query, and require post filtering. If the implementation
-   * supports exact matches, this method will return null.
-   * @param min the inclusive lower bound.
-   * @param max the inclusive upper bound.
+   * Returns doc ids with an equal value.
+   * Doc ids returned by this method must correspond to values which
+   * satisfy the query.
+   * @param value the value
    * @return the matching doc ids.
    */
-  @Nullable
-  T getPartiallyMatchingDocIds(int min, int max);
+  default T getMatchingDocIds(int value) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns doc ids with an equal value.
+   * Doc ids returned by this method must correspond to values which
+   * satisfy the query.
+   * @param value the value
+   * @return the matching doc ids.
+   */
+  default T getMatchingDocIds(long value) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns doc ids with an equal value.
+   * Doc ids returned by this method must correspond to values which
+   * satisfy the query.
+   * @param value the value
+   * @return the matching doc ids.
+   */
+  default T getMatchingDocIds(float value) {
+    throw new UnsupportedOperationException();
+  }
+
+  /**
+   * Returns doc ids with an equal value.
+   * Doc ids returned by this method must correspond to values which
+   * satisfy the query.
+   * @param value the value
+   * @return the matching doc ids.
+   */
+  default T getMatchingDocIds(double value) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Returns doc ids with a value between min and max, both inclusive.
@@ -138,7 +211,9 @@ public interface RangeIndexReader<T> extends Closeable {
    * @return the matching doc ids.
    */
   @Nullable
-  T getPartiallyMatchingDocIds(long min, long max);
+  default T getPartiallyMatchingDocIds(int min, int max) {
+    return null;
+  }
 
   /**
    * Returns doc ids with a value between min and max, both inclusive.
@@ -150,7 +225,9 @@ public interface RangeIndexReader<T> extends Closeable {
    * @return the matching doc ids.
    */
   @Nullable
-  T getPartiallyMatchingDocIds(float min, float max);
+  default T getPartiallyMatchingDocIds(long min, long max) {
+    return null;
+  }
 
   /**
    * Returns doc ids with a value between min and max, both inclusive.
@@ -162,5 +239,21 @@ public interface RangeIndexReader<T> extends Closeable {
    * @return the matching doc ids.
    */
   @Nullable
-  T getPartiallyMatchingDocIds(double min, double max);
+  default T getPartiallyMatchingDocIds(float min, float max) {
+    return null;
+  }
+
+  /**
+   * Returns doc ids with a value between min and max, both inclusive.
+   * Doc ids returned by this method may correspond to values which
+   * satisfy the query, and require post filtering. If the implementation
+   * supports exact matches, this method will return null.
+   * @param min the inclusive lower bound.
+   * @param max the inclusive upper bound.
+   * @return the matching doc ids.
+   */
+  @Nullable
+  default T getPartiallyMatchingDocIds(double min, double max) {
+    return null;
+  }
 }


### PR DESCRIPTION
Allows equals queries on `INT`, `LONG`, `FLOAT`, `DOUBLE` raw columns, or columns on other data types with a sorted dictionary, to make use of a range index, which now has an efficient implementation of equals queries. This avoids scanning the column. 

This allows users to use a range index in preference to an inverted index when they:
* have very high cardinality and an inverted index is too wasteful
* don't want the spatial overhead of a dictionary and are willing to trade some cycles to save space
* occasionally run equals queries on a column mostly queried by range

This can also be used within Pinot to make the timestamp index capable of satisfying more queries.