### PR TITLE
push utf8 comparison down into ValueReader

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/FixedByteValueReaderWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/FixedByteValueReaderWriter.java
@@ -122,6 +122,12 @@ public final class FixedByteValueReaderWriter implements ValueReader {
     return value;
   }
 
+  @Override
+  public int compareUtf8Bytes(int index, int numBytesPerValue, byte[] bytes) {
+    long startOffset = (long) index * numBytesPerValue;
+    return ValueReaderComparisons.compareUtf8Bytes(_dataBuffer, startOffset, numBytesPerValue, true, bytes);
+  }
+
   public void writeInt(int index, int value) {
     _dataBuffer.putInt((long) index * Integer.BYTES, value);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/ValueReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/ValueReader.java
@@ -65,4 +65,9 @@ public interface ValueReader extends Closeable {
    * NOTE: Do not reuse buffer for BYTES because the return value can have variable length.
    */
   byte[] getBytes(int index, int numBytesPerValue);
+
+  /**
+   * Assumes a zero padding byte, caller responsible for checking before use.
+   */
+  int compareUtf8Bytes(int index, int numBytesPerValue, byte[] bytes);
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/ValueReaderComparisons.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/ValueReaderComparisons.java
@@ -1,0 +1,155 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.util;
+
+import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+
+
+public class ValueReaderComparisons {
+
+  private ValueReaderComparisons() {
+  }
+
+  private static int mismatch(PinotDataBuffer dataBuffer, long startOffset, int length, ByteBuffer buffer) {
+    boolean littleEndian = dataBuffer.order() == ByteOrder.LITTLE_ENDIAN;
+    if (littleEndian) {
+      buffer.order(ByteOrder.LITTLE_ENDIAN);
+    }
+    int limit = Math.min(length, buffer.limit());
+    int loopBound = limit & ~0x7;
+    int i = 0;
+    for (; i < loopBound; i += 8) {
+      long ours = dataBuffer.getLong(startOffset + i);
+      long theirs = buffer.getLong(i);
+      if (ours != theirs) {
+        long difference = ours ^ theirs;
+        return i + ((littleEndian ? Long.numberOfTrailingZeros(difference) : Long.numberOfLeadingZeros(difference))
+            >>> 3);
+      }
+    }
+    for (; i < limit; i++) {
+      byte ours = dataBuffer.getByte(startOffset + i);
+      byte theirs = buffer.get(i);
+      if (ours != theirs) {
+        return i;
+      }
+    }
+    return -1;
+  }
+
+  static int compareUtf8Bytes(PinotDataBuffer dataBuffer, long startOffset, int length, boolean padded, byte[] bytes) {
+    // can use MethodHandles.byteArrayViewVarHandle here after dropping JDK8
+    ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    int mismatchPosition = mismatch(dataBuffer, startOffset, length, buffer);
+    if (mismatchPosition == -1) {
+      if (padded && bytes.length < length) {
+        // need to figure out whether the unpadded string is longer than the parameter or not
+        if (bytes.length == 0) {
+          // just need nonzero first byte
+          return dataBuffer.getByte(startOffset) == 0 ? 0 : 1;
+        } else if (bytes[bytes.length - 1] == 0) {
+          return -1;
+        } else {
+          // check if the stored string continues beyond the length of the parameter
+          return dataBuffer.getByte(startOffset + bytes.length) == 0 ? 0 : 1;
+        }
+      } else {
+        // then we know the length precisely or know that the parameter is at least as long as we can store
+        return length - bytes.length;
+      }
+    }
+    // we know the position of the mismatch but need to do utf8 decoding before comparison
+    // to respect collation rules
+    return compareUtf8(dataBuffer, startOffset, buffer, mismatchPosition);
+  }
+
+  private static int compareUtf8(PinotDataBuffer ourBuffer, long ourStartOffset, ByteBuffer theirBuffer,
+      int mismatchPosition) {
+    char ours1 = '\ufffd';
+    char ours2 = '\ufffd';
+    char theirs1 = '\ufffd';
+    char theirs2 = '\ufffd';
+
+    // 1. seek backwards from mismatch position to find start of each utf8 sequence
+    //    assuming we have valid UTF-8 and knowing that the content before mismatchPosition is
+    //    identical, we will go back the same distance in each buffer
+    while (mismatchPosition > 0 && isUtf8Continuation(theirBuffer.get(mismatchPosition))) {
+      mismatchPosition--;
+    }
+    // 2. decode to get the 1 or 2 characters containing where the mismatch lies
+    {
+      long position = ourStartOffset + mismatchPosition;
+      byte first = ourBuffer.getByte(position);
+      int control = first & 0xF0;
+      if (first >= 0) {
+        ours1 = (char) (first & 0xFF);
+      } else if (control < 0xE0) {
+        ours1 = decode(first, ourBuffer.getByte(position + 1));
+      } else if (control == 0xE0) {
+        ours1 = decode(first, ourBuffer.getByte(position + 1), ourBuffer.getByte(position + 2));
+      } else {
+        int codepoint = decode(first, ourBuffer.getByte(position + 1), ourBuffer.getByte(position + 2),
+            ourBuffer.getByte(position + 3));
+        if (Character.isValidCodePoint(codepoint)) {
+          ours1 = Character.highSurrogate(codepoint);
+          ours2 = Character.lowSurrogate(codepoint);
+        }
+      }
+    }
+    {
+      byte first = theirBuffer.get(mismatchPosition);
+      int control = first & 0xF0;
+      if (first >= 0) {
+        theirs1 = (char) (first & 0xFF);
+      } else if (control < 0xE0) {
+        theirs1 = decode(first, theirBuffer.get(mismatchPosition + 1));
+      } else if (control == 0xE0) {
+        theirs1 = decode(first, theirBuffer.get(mismatchPosition + 1), theirBuffer.get(mismatchPosition + 2));
+      } else {
+        int codepoint = decode(first, theirBuffer.get(mismatchPosition + 1), theirBuffer.get(mismatchPosition + 2),
+            theirBuffer.get(mismatchPosition + 3));
+        if (Character.isValidCodePoint(codepoint)) {
+          theirs1 = Character.highSurrogate(codepoint);
+          theirs2 = Character.lowSurrogate(codepoint);
+        }
+      }
+    }
+    // 3. compare the first characters to differ
+    return ours1 == theirs1 ? Character.compare(ours2, theirs2) : Character.compare(ours1, theirs1);
+  }
+
+  private static char decode(int b1, int b2) {
+    return (char) (((b1 << 6) ^ b2) ^ (((byte) 0xC0 << 6) ^ ((byte) 0x80)));
+  }
+
+  private static char decode(int b1, int b2, int b3) {
+    return (char) ((b1 << 12) ^ (b2 << 6) ^ (b3 ^ (((byte) 0xE0 << 12) ^ ((byte) 0x80 << 6) ^ ((byte) 0x80))));
+  }
+
+  private static int decode(int b1, int b2, int b3, int b4) {
+    return ((b1 << 18) ^ (b2 << 12) ^ (b3 << 6) ^ (b4 ^ (((byte) 0xF0 << 18) ^ ((byte) 0x80 << 12) ^ ((byte) 0x80 << 6)
+        ^ ((byte) 0x80))));
+  }
+
+  private static boolean isUtf8Continuation(byte value) {
+    return (value & 0xC0) == 0x80;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/VarLengthValueReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/VarLengthValueReader.java
@@ -120,6 +120,15 @@ public class VarLengthValueReader implements ValueReader {
   }
 
   @Override
+  public int compareUtf8Bytes(int index, int numBytesPerValue, byte[] bytes) {
+    int offsetPosition = _dataSectionStartOffSet + Integer.BYTES * index;
+    int startOffset = _dataBuffer.getInt(offsetPosition);
+    int endOffset = _dataBuffer.getInt(offsetPosition + Integer.BYTES);
+    int length = endOffset - startOffset;
+    return ValueReaderComparisons.compareUtf8Bytes(_dataBuffer, startOffset, length, false, bytes);
+  }
+
+  @Override
   public void close() {
     // NOTE: DO NOT close the PinotDataBuffer here because it is tracked by the caller and might be reused later. The
     // caller is responsible of closing the PinotDataBuffer.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BaseImmutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BaseImmutableDictionary.java
@@ -219,14 +219,14 @@ public abstract class BaseImmutableDictionary implements Dictionary {
    * TODO: Clean up the segments with legacy non-zero padding byte, and remove the support for non-zero padding byte
    */
   protected int binarySearch(String value) {
-    byte[] buffer = getBuffer();
     int low = 0;
     int high = _length - 1;
     if (_paddingByte == 0) {
+      byte[] utf8 = value.getBytes(UTF_8);
       while (low <= high) {
         int mid = (low + high) >>> 1;
-        String midValue = _valueReader.getUnpaddedString(mid, _numBytesPerValue, _paddingByte, buffer);
-        int compareResult = midValue.compareTo(value);
+        // method requires zero padding byte, not safe to call in nonzero padding byte branch below
+        int compareResult = _valueReader.compareUtf8Bytes(mid, _numBytesPerValue, utf8);
         if (compareResult < 0) {
           low = mid + 1;
         } else if (compareResult > 0) {
@@ -236,6 +236,7 @@ public abstract class BaseImmutableDictionary implements Dictionary {
         }
       }
     } else {
+      byte[] buffer = getBuffer();
       String paddedValue = padString(value);
       while (low <= high) {
         int mid = (low + high) >>> 1;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readerwriter/ValueReaderComparisonTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readerwriter/ValueReaderComparisonTest.java
@@ -1,0 +1,364 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.readerwriter;
+
+import java.io.IOException;
+import java.nio.ByteOrder;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+import java.util.UUID;
+import java.util.concurrent.ThreadLocalRandom;
+import java.util.stream.IntStream;
+import java.util.stream.Stream;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.segment.local.io.util.FixedByteValueReaderWriter;
+import org.apache.pinot.segment.local.io.util.ValueReader;
+import org.apache.pinot.segment.local.io.util.VarLengthValueReader;
+import org.apache.pinot.segment.local.io.util.VarLengthValueWriter;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class ValueReaderComparisonTest {
+  @DataProvider
+  public static Object[] text() {
+    return Stream.of(Pair.of(ByteOrder.BIG_ENDIAN, true), Pair.of(ByteOrder.LITTLE_ENDIAN, true),
+        // there is no little endian support for var length at the time of writing
+        Pair.of(ByteOrder.BIG_ENDIAN, false)).flatMap(
+        pair -> Stream.of(new AsciiTestCase(pair.getLeft(), pair.getRight()),
+            new Utf8TestCase(pair.getLeft(), pair.getRight()),
+            new RandomBytesTextTestCase(pair.getLeft(), pair.getRight()),
+            new OrderedInvalidUtf8TestCase(pair.getLeft(), pair.getRight()))).toArray(Object[]::new);
+  }
+
+  static abstract class TestCase {
+
+    private final ByteOrder _byteOrder;
+    private final boolean _fixed;
+
+    public TestCase(ByteOrder byteOrder, boolean fixed) {
+      _byteOrder = byteOrder;
+      _fixed = fixed;
+    }
+
+    ByteOrder getByteOrder() {
+      return _byteOrder;
+    }
+
+    boolean isFixed() {
+      return _fixed;
+    }
+
+    @Override
+    public String toString() {
+      return getClass().getSimpleName() + " " + _byteOrder + (_fixed ? " fixed width" : " variable width");
+    }
+  }
+
+  static abstract class TextTestCase extends TestCase {
+
+    public TextTestCase(ByteOrder byteOrder, boolean fixed) {
+      super(byteOrder, fixed);
+    }
+
+    abstract String[] generateStrings();
+
+    void testEqual(ValueReader reader, int numBytesPerValue, String... strings) {
+      for (int i = 0; i < strings.length; i++) {
+        assertUtf8Comparison(reader, i, numBytesPerValue, strings[i], 0);
+      }
+    }
+
+    void testEmpty(ValueReader reader, int numBytesPerValue, String... strings) {
+      for (int i = 0; i < strings.length; i++) {
+        assertUtf8Comparison(reader, i, numBytesPerValue, "", strings[i].isEmpty() ? 0 : 1);
+      }
+    }
+
+    void testCommonPrefixStoredLonger(ValueReader reader, int numBytesPerValue, String... strings) {
+      for (int i = 0; i < strings.length; i++) {
+        if (!strings[i].isEmpty()) {
+          assertUtf8Comparison(reader, i, numBytesPerValue, strings[i].substring(0, strings[i].length() - 1), 1);
+        }
+      }
+    }
+
+    void testCommonPrefixParameterLonger(ValueReader reader, int numBytesPerValue, String... strings) {
+      for (int i = 0; i < strings.length; i++) {
+        assertUtf8Comparison(reader, i, numBytesPerValue, strings[i] + "a", -1);
+        assertUtf8Comparison(reader, i, numBytesPerValue, strings[i] + "\0", -1);
+        assertUtf8Comparison(reader, i, numBytesPerValue, strings[i] + fromHex("efbfbdd8"), -1);
+        assertUtf8Comparison(reader, i, numBytesPerValue, strings[i] + "\uD841\uDF0E", -1);
+      }
+    }
+
+    void testCommonPrefixParameterOverflowing(ValueReader reader, int numBytesPerValue, String... strings) {
+      StringBuilder sb = new StringBuilder();
+      for (int i = 0; i < numBytesPerValue; i++) {
+        sb.append("a");
+      }
+      String overflow = sb.toString();
+      for (int i = 0; i < strings.length; i++) {
+        assertUtf8Comparison(reader, i, numBytesPerValue, strings[i] + overflow, -1);
+      }
+    }
+
+    void testInferiorPrefixes(ValueReader reader, int numBytesPerValue, String... strings) {
+      for (int i = 0; i < strings.length; i++) {
+        char[] chars = strings[i].toCharArray();
+        for (int j = 0; j < strings[i].length(); j++) {
+          chars[j]--;
+          assertUtf8Comparison(reader, i, numBytesPerValue, new String(chars), 1);
+          chars[j]++; // fix the string for the next iteration
+        }
+      }
+    }
+
+    void testSuperiorPrefixes(ValueReader reader, int numBytesPerValue, String... strings) {
+      for (int i = 0; i < strings.length; i++) {
+        char[] chars = strings[i].toCharArray();
+        for (int j = 0; j < strings[i].length(); j++) {
+          // this test's ordering assumption is not valid for surrogates
+          if (!Character.isLowSurrogate(chars[j])) {
+            chars[j]++;
+            String string = new String(chars);
+            int signum = strings[i].compareTo(string);
+            assertUtf8Comparison(reader, i, numBytesPerValue, string, Integer.compare(signum, 0));
+            chars[j]--; // fix the string for the next iteration
+          }
+        }
+      }
+    }
+
+    void testConsistent(ValueReader reader, int numBytesPerValue, int numValuesToCompare) {
+      for (int i = 0; i < numValuesToCompare; i++) {
+        byte[] bytes = new byte[ThreadLocalRandom.current().nextInt(numBytesPerValue * 2)];
+        assertConsistentUtf8Comparison(reader, i, numBytesPerValue, new String(bytes, StandardCharsets.UTF_8));
+        for (int j = 0; j < 128; j++) {
+          Arrays.fill(bytes, (byte) j);
+          assertConsistentUtf8Comparison(reader, i, numBytesPerValue, new String(bytes, StandardCharsets.UTF_8));
+        }
+        byte[] utf8 = "ß".getBytes(StandardCharsets.UTF_8);
+        for (int j = 0; j + 1 < bytes.length; j += 2) {
+          bytes[j] = utf8[0];
+          bytes[j + 1] = utf8[1];
+        }
+        utf8 = "道".getBytes(StandardCharsets.UTF_8);
+        for (int j = 0; j + 2 < bytes.length; j += 3) {
+          bytes[j] = utf8[0];
+          bytes[j + 1] = utf8[1];
+          bytes[j + 2] = utf8[2];
+        }
+        utf8 = "\uD841\uDF0E".getBytes(StandardCharsets.UTF_8);
+        for (int j = 0; j + 3 < bytes.length; j += 4) {
+          bytes[j] = utf8[0];
+          bytes[j + 1] = utf8[1];
+          bytes[j + 2] = utf8[2];
+          bytes[j + 3] = utf8[3];
+        }
+        assertConsistentUtf8Comparison(reader, i, numBytesPerValue, new String(bytes, StandardCharsets.UTF_8));
+        ThreadLocalRandom.current().nextBytes(bytes);
+        for (int j = 0; j < bytes.length; j++) {
+          if (bytes[j] == 0) {
+            bytes[j] = '0';
+          }
+        }
+        assertConsistentUtf8Comparison(reader, i, numBytesPerValue, new String(bytes, StandardCharsets.UTF_8));
+        assertConsistentUtf8Comparison(reader, i, numBytesPerValue, fromHex("efbfbdd8"));
+        assertConsistentUtf8Comparison(reader, i, numBytesPerValue, fromHex("7fbfbdd8"));
+        assertConsistentUtf8Comparison(reader, i, numBytesPerValue, fromHex("7f818181"));
+        assertConsistentUtf8Comparison(reader, i, numBytesPerValue, fromHex("7ff2bd9fbf"));
+        assertConsistentUtf8Comparison(reader, i, numBytesPerValue, fromHex("7f3fee8080"));
+      }
+    }
+  }
+
+  static class AsciiTestCase extends TextTestCase {
+
+    public AsciiTestCase(ByteOrder byteOrder, boolean fixed) {
+      super(byteOrder, fixed);
+    }
+
+    @Override
+    public String[] generateStrings() {
+      char[] symbols = "abcdefghijklmnopqrstuvwxyz0123456789".toCharArray();
+      // generate [a, ab, abc, ...]
+      return IntStream.range(0, 33).mapToObj(size -> new String(Arrays.copyOf(symbols, size))).toArray(String[]::new);
+    }
+  }
+
+  static class Utf8TestCase extends TextTestCase {
+    public Utf8TestCase(ByteOrder byteOrder, boolean fixed) {
+      super(byteOrder, fixed);
+    }
+
+    @Override
+    public String[] generateStrings() {
+      String[] symbols = new String[]{"a", "ß", "道", "\uD841\uDF0E", "é", "e\u0301"};
+      return IntStream.range(1, 100).mapToObj(size -> {
+        StringBuilder sb = new StringBuilder();
+        int offset = size % symbols.length;
+        for (int i = 0; i < size; i++) {
+          sb.append(symbols[(i + offset) % symbols.length]);
+        }
+        return sb.toString();
+      }).toArray(String[]::new);
+    }
+  }
+
+  static class RandomBytesTextTestCase extends TextTestCase {
+    public RandomBytesTextTestCase(ByteOrder byteOrder, boolean fixed) {
+      super(byteOrder, fixed);
+    }
+
+    @Override
+    String[] generateStrings() {
+      return IntStream.range(1, 128).mapToObj(size -> {
+        byte[] bytes = new byte[size];
+        ThreadLocalRandom.current().nextBytes(bytes);
+        // String sanitization truncates to first zero, so remove zeros here
+        for (int i = 0; i < size; i++) {
+          if (bytes[i] == 0) {
+            bytes[i] = '0';
+          }
+        }
+        return new String(bytes, StandardCharsets.UTF_8);
+      }).toArray(String[]::new);
+    }
+  }
+
+  static class OrderedInvalidUtf8TestCase extends TextTestCase {
+
+    public OrderedInvalidUtf8TestCase(ByteOrder byteOrder, boolean fixed) {
+      super(byteOrder, fixed);
+    }
+
+    @Override
+    String[] generateStrings() {
+      String[] strings = new String[7];
+      strings[0] = fromHex("edbfbdd8bb");
+      strings[1] = fromHex("eebfbdd8bb");
+      strings[2] = fromHex("efbfbdd8bb");
+      strings[3] = fromHex("f0bfbdd8bb");
+      strings[4] = fromHex("f0a09c8e");
+      strings[5] = fromHex("7ff2bd9fbf");
+      strings[6] = fromHex("7f3fee8080");
+      return strings;
+    }
+  }
+
+  @Test(dataProvider = "text")
+  public void testUtf8Comparison(TextTestCase testCase)
+      throws IOException {
+    String[] strings = testCase.generateStrings();
+    int maxUtf8Length = Integer.MIN_VALUE;
+    for (String string : strings) {
+      maxUtf8Length = Math.max(string.getBytes(StandardCharsets.UTF_8).length, maxUtf8Length);
+    }
+    // round up to next power of 2
+    int numBytesPerValue =
+        (maxUtf8Length & -maxUtf8Length) == 0 ? maxUtf8Length : 1 << (32 - Integer.numberOfLeadingZeros(maxUtf8Length));
+    Pair<ValueReader, PinotDataBuffer> readerAndBuffer =
+        prepare(testCase.isFixed(), numBytesPerValue, testCase.getByteOrder(), strings);
+    ValueReader reader = readerAndBuffer.getKey();
+    try {
+      testCase.testEqual(reader, numBytesPerValue, strings);
+      testCase.testEmpty(reader, numBytesPerValue, strings);
+      testCase.testCommonPrefixStoredLonger(reader, numBytesPerValue, strings);
+      testCase.testCommonPrefixParameterLonger(reader, numBytesPerValue, strings);
+      testCase.testCommonPrefixParameterOverflowing(reader, numBytesPerValue, strings);
+      testCase.testInferiorPrefixes(reader, numBytesPerValue, strings);
+      testCase.testSuperiorPrefixes(reader, numBytesPerValue, strings);
+      testCase.testConsistent(reader, numBytesPerValue, strings.length);
+    } finally {
+      readerAndBuffer.getValue().close();
+    }
+  }
+
+  private static void assertUtf8Comparison(ValueReader readerWriter, int index, int numBytesPerValue, String string,
+      int signum) {
+    byte[] value = string.getBytes(StandardCharsets.UTF_8);
+    String stored = readerWriter.getUnpaddedString(index, numBytesPerValue, (byte) 0, new byte[numBytesPerValue]);
+    String error = stored + " " + string;
+    int comparisonViaMaterialization = stored.compareTo(string);
+    assertEquals(signum, Integer.compare(comparisonViaMaterialization, 0), error);
+    int utf8Comparison = readerWriter.compareUtf8Bytes(index, numBytesPerValue, value);
+    assertEquals(signum, Integer.compare(utf8Comparison, 0), error);
+  }
+
+  private static void assertConsistentUtf8Comparison(ValueReader readerWriter, int index, int numBytesPerValue,
+      String string) {
+    byte[] value = string.getBytes(StandardCharsets.UTF_8);
+    int utf8Comparison = readerWriter.compareUtf8Bytes(index, numBytesPerValue, value);
+    String stored = readerWriter.getUnpaddedString(index, numBytesPerValue, (byte) 0, new byte[numBytesPerValue]);
+    int comparisonViaMaterialization = stored.compareTo(string);
+    assertTrue(
+        (utf8Comparison == comparisonViaMaterialization) || (utf8Comparison < 0 && comparisonViaMaterialization < 0)
+            || (utf8Comparison > 0 && comparisonViaMaterialization > 0),
+        "stored=" + BytesUtils.toHexString(stored.getBytes(StandardCharsets.UTF_8)) + ", parameter="
+            + BytesUtils.toHexString(value));
+  }
+
+  private static Pair<ValueReader, PinotDataBuffer> prepare(boolean fixed, int numBytesPerValue, ByteOrder byteOrder,
+      String... storedValues)
+      throws IOException {
+    byte[][] bytes = new byte[storedValues.length][];
+    for (int i = 0; i < storedValues.length; i++) {
+      bytes[i] = storedValues[i].getBytes(StandardCharsets.UTF_8);
+    }
+    return prepare(fixed, numBytesPerValue, byteOrder, bytes);
+  }
+
+  private static Pair<ValueReader, PinotDataBuffer> prepare(boolean fixed, int numBytesPerValue, ByteOrder byteOrder,
+      byte[]... storedValues)
+      throws IOException {
+    if (fixed) {
+      PinotDataBuffer buffer =
+          PinotDataBuffer.allocateDirect(1000L + (long) storedValues.length * numBytesPerValue, byteOrder,
+              "ValueReaderComparisonTest");
+      FixedByteValueReaderWriter readerWriter = new FixedByteValueReaderWriter(buffer);
+      for (int i = 0; i < storedValues.length; i++) {
+        readerWriter.writeBytes(i, numBytesPerValue, storedValues[i]);
+      }
+      return Pair.of(readerWriter, buffer);
+    } else {
+      assert byteOrder == ByteOrder.BIG_ENDIAN : "little endian unsupported by VarLengthValueWriter";
+      Path file = Files.createTempFile(ValueReaderComparisonTest.class.getName() + "-" + UUID.randomUUID(), ".tmp");
+      VarLengthValueWriter writer = new VarLengthValueWriter(file.toFile(), storedValues.length);
+      for (byte[] storedValue : storedValues) {
+        writer.add(storedValue);
+      }
+      writer.close();
+      PinotDataBuffer buffer =
+          PinotDataBuffer.mapFile(file.toFile(), true, 0, Files.size(file), byteOrder, "ValueReaderComparisonTest");
+      return Pair.of(new VarLengthValueReader(buffer), buffer);
+    }
+  }
+
+  private static String fromHex(String hex) {
+    return new String(BytesUtils.toBytes(hex), StandardCharsets.UTF_8);
+  }
+}


### PR DESCRIPTION
This pushes the unsigned comparison operation down into the `ValueReader` so that a string doesn't need to be materialised to do the comparison. For `FixedByteValueReaderWriter`, which has showed up as a CPU bottleneck in pretty much every profile of Pinot query evaluation I have looked at, the work done to find where the string ends within the fixed width bucket before copying the string can be skipped. 