### PR TITLE
Fix local segment tar copy

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/SegmentPushUtils.java
@@ -24,6 +24,7 @@ import java.io.InputStream;
 import java.io.Serializable;
 import java.net.URI;
 import java.net.URISyntaxException;
+import java.net.URLDecoder;
 import java.nio.file.FileSystems;
 import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
@@ -384,7 +385,7 @@ public class SegmentPushUtils implements Serializable {
     try {
       if (fileSystem instanceof LocalPinotFS) {
         // For local file system, we don't need to copy the tar file.
-        tarFile = new File(tarFileURI);
+        tarFile = new File(URLDecoder.decode(tarFileURI.getRawPath(), "UTF-8"));
       } else {
         // For other file systems, we need to download the file to local file system
         fileSystem.copyToLocalFile(tarFileURI, tarFile);


### PR DESCRIPTION
This PR fixes an issue with `SegmentPushUtils` which was causing metadata copy to fail with 
```Caught exception while executing task: Task_FileIngestionTask_c529e4e5-266d-4fdb-b357-180bdc2ffad4_1672760123830_1
java.lang.IllegalArgumentException: URI is not absolute
	at java.io.File.<init>(File.java:418) ~[?:?]
	at org.apache.pinot.segment.local.utils.SegmentPushUtils.generateSegmentMetadataFile(SegmentPushUtils.java:387) ~[pinot-segment-local-0.13.0-SNAPSHOT.jar:0.13.0-SNAPSHOT-42ca28bc329865351ea5be33afe67dea6435833d]
	at org.apache.pinot.segment.local.utils.SegmentPushUtils.sendSegmentUriAndMetadata(SegmentPushUtils.java:287) ~[pinot-segment-local-0.13.0-SNAPSHOT.jar:0.13.0-SNAPSHOT-42ca28bc329865351ea5be33afe67dea6435833d]
	at org.apache.pinot.segment.local.utils.SegmentPushUtils.sendSegmentUriAndMetadata(SegmentPushUtils.java:137) ~[pinot-segment-local-0.13.0-SNAPSHOT.jar:0.13.0-SNAPSHOT-42ca28bc329865351ea5be33afe67dea6435833d]
```	
	
Directly using the segment file URI to create a File leads to failures. We need to use absolute path string