### PR TITLE
Add an API to download validDocIdsSnapshots from peer servers

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/RoaringBitmapUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/RoaringBitmapUtils.java
@@ -20,6 +20,7 @@ package org.apache.pinot.common.utils;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import org.roaringbitmap.ImmutableBitmapDataProvider;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -27,7 +28,7 @@ public class RoaringBitmapUtils {
   private RoaringBitmapUtils() {
   }
 
-  public static byte[] serialize(RoaringBitmap bitmap) {
+  public static byte[] serialize(ImmutableBitmapDataProvider bitmap) {
     byte[] bytes = new byte[bitmap.serializedSizeInBytes()];
     ByteBuffer byteBuffer = ByteBuffer.wrap(bytes);
     bitmap.serialize(byteBuffer);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -150,7 +150,7 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     }
   }
 
-  private File getValidDocIdsSnapshotFile() {
+  public File getValidDocIdsSnapshotFile() {
     return new File(SegmentDirectoryPaths.findSegmentDirectory(_segmentMetadata.getIndexDir()),
         V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -150,7 +150,7 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     }
   }
 
-  public File getValidDocIdsSnapshotFile() {
+  private File getValidDocIdsSnapshotFile() {
     return new File(SegmentDirectoryPaths.findSegmentDirectory(_segmentMetadata.getIndexDir()),
         V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME);
   }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ServerResourceUtils.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ServerResourceUtils.java
@@ -19,9 +19,14 @@
 package org.apache.pinot.server.api.resources;
 
 import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.server.access.AccessControl;
+import org.apache.pinot.server.access.AccessControlFactory;
+import org.apache.pinot.server.access.HttpRequesterIdentity;
+import org.apache.pinot.server.access.RequesterIdentity;
 import org.apache.pinot.server.starter.ServerInstance;
 
 
@@ -53,5 +58,21 @@ public class ServerResourceUtils {
           Response.Status.INTERNAL_SERVER_ERROR);
     }
     return instanceDataManager;
+  }
+
+  public static void validateDataAccess(AccessControlFactory accessControlFactory, String tableNameWithType,
+      HttpHeaders httpHeaders) {
+    boolean hasDataAccess;
+    try {
+      AccessControl accessControl = accessControlFactory.create();
+      RequesterIdentity httpRequestIdentity = new HttpRequesterIdentity(httpHeaders);
+      hasDataAccess = accessControl.hasDataAccess(httpRequestIdentity, tableNameWithType);
+    } catch (Exception e) {
+      throw new WebApplicationException("Caught exception while validating access to table: " + tableNameWithType,
+          Response.Status.INTERNAL_SERVER_ERROR);
+    }
+    if (!hasDataAccess) {
+      throw new WebApplicationException("No data access to table: " + tableNameWithType, Response.Status.FORBIDDEN);
+    }
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -426,8 +426,7 @@ public class TablesResource {
       @ApiParam(value = "Name of the table with type REALTIME", required = true, example = "myTable_REALTIME")
       @PathParam("tableNameWithType") String tableNameWithType,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName,
-      @Context HttpHeaders httpHeaders)
-      throws Exception {
+      @Context HttpHeaders httpHeaders) {
     LOGGER.info("Received a request to download validDocIds for segment {} table {}", segmentName, tableNameWithType);
     // Validate data access
     ServerResourceUtils.validateDataAccess(_accessControlFactory, tableNameWithType, httpHeaders);
@@ -450,16 +449,15 @@ public class TablesResource {
       }
       MutableRoaringBitmap validDocIds =
           indexSegment.getValidDocIds() != null ? indexSegment.getValidDocIds().getMutableRoaringBitmap() : null;
-
       if (validDocIds == null) {
         throw new WebApplicationException(
             String.format("Missing validDocIds for table %s segment %s does not exist", tableNameWithType, segmentName),
             Response.Status.NOT_FOUND);
       }
 
-      byte[] validDocIdsSnapshot = RoaringBitmapUtils.serialize(validDocIds.toRoaringBitmap());
-      Response.ResponseBuilder builder = Response.ok(validDocIdsSnapshot);
-      builder.header(HttpHeaders.CONTENT_LENGTH, validDocIdsSnapshot.length);
+      byte[] validDocIdsBytes = RoaringBitmapUtils.serialize(validDocIds);
+      Response.ResponseBuilder builder = Response.ok(validDocIdsBytes);
+      builder.header(HttpHeaders.CONTENT_LENGTH, validDocIdsBytes.length);
       return builder.build();
     } finally {
       tableDataManager.releaseSegment(segmentDataManager);

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -28,8 +28,6 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
-import java.io.ByteArrayOutputStream;
-import java.io.DataOutputStream;
 import java.io.File;
 import java.io.UnsupportedEncodingException;
 import java.net.URI;
@@ -71,6 +69,7 @@ import org.apache.pinot.common.restlet.resources.TableSegmentValidationInfo;
 import org.apache.pinot.common.restlet.resources.TableSegments;
 import org.apache.pinot.common.restlet.resources.TablesList;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
@@ -458,14 +457,9 @@ public class TablesResource {
             Response.Status.NOT_FOUND);
       }
 
-      ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream();
-      try (DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream)) {
-        validDocIds.serialize(dataOutputStream);
-        byteArrayOutputStream.close();
-      }
-      byte[] validDocIdsSnapshot = byteArrayOutputStream.toByteArray();
+      byte[] validDocIdsSnapshot = RoaringBitmapUtils.serialize(validDocIds.toRoaringBitmap());
       Response.ResponseBuilder builder = Response.ok(validDocIdsSnapshot);
-      builder.header(HttpHeaders.CONTENT_LENGTH, byteArrayOutputStream.size());
+      builder.header(HttpHeaders.CONTENT_LENGTH, validDocIdsSnapshot.length);
       return builder.build();
     } finally {
       tableDataManager.releaseSegment(segmentDataManager);

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -418,14 +418,15 @@ public class TablesResource {
   @GET
   @Produces(MediaType.APPLICATION_OCTET_STREAM)
   @Path("/segments/{tableNameWithType}/{segmentName}/validDocIds")
-  @ApiOperation(value = "Download validDocIds for an REALTIME immutable segment", notes = "Download validDocIds for an immutable segment in bitmap format.")
+  @ApiOperation(value = "Download validDocIds for an REALTIME immutable segment", notes = "Download validDocIds for "
+      + "an immutable segment in bitmap format.")
   public Response downloadValidDocIds(
       @ApiParam(value = "Name of the table with type REALTIME", required = true, example = "myTable_REALTIME")
       @PathParam("tableNameWithType") String tableNameWithType,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName,
       @Context HttpHeaders httpHeaders)
       throws Exception {
-    LOGGER.info("Received a request to download validDocIds for segment {} for table {}", segmentName, tableNameWithType);
+    LOGGER.info("Received a request to download validDocIds for segment {} table {}", segmentName, tableNameWithType);
     // Validate data access
     ServerResourceUtils.validateDataAccess(_accessControlFactory, tableNameWithType, httpHeaders);
 

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -19,13 +19,11 @@
 package org.apache.pinot.server.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
 import javax.ws.rs.core.Response;
-import javax.ws.rs.core.StreamingOutput;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.restlet.resources.TableMetadataInfo;
 import org.apache.pinot.common.restlet.resources.TableSegments;
@@ -294,10 +292,7 @@ public class TablesResourceTest extends BaseResourceTest {
     // Download the snapshot in byte[] format.
     Response response = _webTarget.path(snapshotPath).request().get(Response.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
-    StreamingOutput stream = (StreamingOutput) response.getEntity();
-    ByteArrayOutputStream output = new ByteArrayOutputStream();
-    stream.write(output);
-    byte[] snapshot = output.toByteArray();
+    byte[] snapshot = response.readEntity(byte[].class);
 
     // Load the snapshot file.
     Assert.assertNotNull(snapshot);

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -234,12 +234,13 @@ public class TablesResourceTest extends BaseResourceTest {
         (ImmutableSegmentImpl) _realtimeIndexSegments.get(0));
 
     // Verify non-existent table and segment download return NOT_FOUND status.
-    Response response = _webTarget.path("/tables/UNKNOWN_REALTIME/segments/segmentname/validDocIds").request().get(Response.class);
+    Response response = _webTarget.path("/tables/UNKNOWN_REALTIME/segments/segmentname/validDocIds").request()
+        .get(Response.class);
     Assert.assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
 
-    response = _webTarget
-        .path("/tables/" + TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME) + "/segments/UNKNOWN_SEGMENT/validDocIds")
-        .request().get(Response.class);
+    response = _webTarget.path(
+        String.format("/tables/%s/segments/%s/validDocIds", TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME),
+            "UNKNOWN_SEGMENT")).request().get(Response.class);
     Assert.assertEquals(response.getStatus(), Response.Status.NOT_FOUND.getStatusCode());
   }
 


### PR DESCRIPTION
Part of a series of PRs for Pinot Upsert Optimizations.

Issue: https://github.com/apache/pinot/issues/9529
Tags: `feature` `release-notes`

Made the following change to Server TablesResource

- Added an API to download validDocIdsSnapshot from peer servers.

The change is proposed by [Upsert TTL feature design doc](https://docs.google.com/document/d/1AhkZPkf4St3hj96IXyNs6NOiItxm3LXw3NAgNbG3oRo/edit?pli=1#heading=h.z1lc2k9b0z02)