### PR TITLE
Fix issue with S3 FS not working with segments with spaces in the name

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -378,6 +378,13 @@ public abstract class BaseTableDataManager implements TableDataManager {
         // doesn't load anything from an empty indexDir, but gets the info to complete the copyTo.
         try (SegmentDirectory segmentDirectory = initSegmentDirectory(segmentName, String.valueOf(zkMetadata.getCrc()),
             indexLoadingConfig)) {
+          if (segmentDirectory.isDirectoryMatchingWithLatestConfigs()) {
+            // The segment directory is already in sync with latest configs
+            ImmutableSegment segment = ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, schema);
+            addSegment(segment);
+            removeBackup(indexDir);
+            return;
+          }
           segmentDirectory.copyTo(indexDir);
         }
       }

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -204,9 +204,9 @@ public class S3PinotFS extends BasePinotFS {
     Preconditions.checkNotNull(uri, "uri is null");
     URI strippedUri = getBase(uri).relativize(uri);
     if (isPathTerminatedByDelimiter(strippedUri)) {
-      return sanitizePath(strippedUri.getPath());
+      return sanitizePath(strippedUri.toString());
     }
-    return sanitizePath(strippedUri.getPath() + DELIMITER);
+    return sanitizePath(strippedUri.toString() + DELIMITER);
   }
 
   private URI normalizeToDirectoryUri(URI uri)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
@@ -102,6 +102,11 @@ public class SegmentLocalFSDirectory extends SegmentDirectory {
   }
 
   @Override
+  public boolean isDirectoryMatchingWithLatestConfigs() {
+    return false;
+  }
+
+  @Override
   public URI getIndexDir() {
     return _indexDir.toURI();
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java
@@ -98,6 +98,8 @@ import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
  */
 public abstract class SegmentDirectory implements Closeable {
 
+  public abstract boolean isDirectoryMatchingWithLatestConfigs();
+
   public abstract URI getIndexDir();
 
   public abstract SegmentMetadataImpl getSegmentMetadata();


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds early‑exit reload when segment directory matches latest configs and fixes S3 prefix handling for segment names containing spaces\.

```mermaid
flowchart TD
  N0["BaseTableDataManager#46;reloadSegment #40;F1#41;"]:::stModified
  N1["initSegmentDirectory #40;F1#41;"]:::stModified
  N2["SegmentDirectory#46;isDirectoryMatchingWithLatestConfigs #40;F4#44; F3#41;"]:::stModified
  N3["ImmutableSegmentLoader#46;load #40;F1#41;"]:::stModified
  N4["addSegment #40;F1#41;"]:::stModified
  N5["removeBackup #40;F1#41;"]:::stModified
  N6["segmentDirectory#46;copyTo #40;F1#41;"]:::stModified
  N7["S3PinotFS#46;normalizeToDirectoryPrefix #40;F2#41;"]:::stModified
  N0 -->|"call"| N1
  N1 -->|"call on returned dir"| N2
  N2 -->|"true branch #40;if#41;"| N3
  N3 -->|"call"| N4
  N4 -->|"call"| N5
  N2 -->|"false branch #40;else#41;"| N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager\.java — [before](https://github.com/apache/pinot/blob/53e1dbcf63a94c16964288b360c3d354d329ced5/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java) · [after](https://github.com/apache/pinot/blob/a29c4b2b0e68edd9a157cdaa42d4f475ab10fefb/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java)
- F2: pinot\-plugins/pinot\-file\-system/pinot\-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS\.java — [before](https://github.com/apache/pinot/blob/53e1dbcf63a94c16964288b360c3d354d329ced5/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java) · [after](https://github.com/apache/pinot/blob/a29c4b2b0e68edd9a157cdaa42d4f475ab10fefb/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java)
- F3: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory\.java — [before](https://github.com/apache/pinot/blob/53e1dbcf63a94c16964288b360c3d354d329ced5/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java) · [after](https://github.com/apache/pinot/blob/a29c4b2b0e68edd9a157cdaa42d4f475ab10fefb/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java)
- F4: pinot\-segment\-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory\.java — [before](https://github.com/apache/pinot/blob/53e1dbcf63a94c16964288b360c3d354d329ced5/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java) · [after](https://github.com/apache/pinot/blob/a29c4b2b0e68edd9a157cdaa42d4f475ab10fefb/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectory.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjUzZTFkYmNmNjNhOTRjMTY5NjQyODhiMzYwYzNkMzU0ZDMyOWNlZDUiLCJjb250ZXh0X2hhc2giOiJjMzE4YjJhYTJhOGI1NmRmYjNlMTgyNjdmODdkMmU5MjMwYTAwMGY5Y2E2Y2MyM2U0ZGRkMDBkYjZkZWI4ZGY5IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NDU4NTExLCJoZWFkX3NoYSI6ImEyOWM0YjJiMGU2OGVkZDlhMTU3Y2RhYTQyZDRmNDc1YWIxMGZlZmIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJjNTBjZWYxMWE3OTA2NWFjYjYzODQzMzZmOWI3ZmI0NzUyNGNmOTUzIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 852d37cee7c53192291ef2cb2fe3faad67e5f187c8929177f669a28ecc3c0fda -->
<!-- pinot-pr-flow:end -->

S3PinotFS fails to process segments with spaces in their names. This is due to URI.getPath() returning decoded path while the `.prefix` function expects unescaped path.
