### PR TITLE
propagate inverted status with BitmapDocIdIterator to avoid expensive flipping of bitmaps

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/AndDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/AndDocIdIterator.java
@@ -32,7 +32,7 @@ public final class AndDocIdIterator implements BlockDocIdIterator {
 
   private int _nextDocId = 0;
 
-  public AndDocIdIterator(BlockDocIdIterator[] docIdIterators) {
+  public AndDocIdIterator(BlockDocIdIterator... docIdIterators) {
     _docIdIterators = docIdIterators;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/BitmapBasedDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/BitmapBasedDocIdIterator.java
@@ -31,4 +31,11 @@ public interface BitmapBasedDocIdIterator extends BlockDocIdIterator {
    * Returns a bitmap of the matching document ids.
    */
   ImmutableRoaringBitmap getDocIds();
+
+  /**
+   * Returns true if the doc ids represent absence rather than presence and need to be handled specially
+   * */
+  default boolean isInverted() {
+    return false;
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/InvertedBitmapDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/InvertedBitmapDocIdIterator.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.dociditerators;
+
+import org.apache.pinot.segment.spi.Constants;
+import org.roaringbitmap.PeekableIntIterator;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+
+public class InvertedBitmapDocIdIterator implements BitmapBasedDocIdIterator {
+  private final ImmutableRoaringBitmap _docIds;
+  private final PeekableIntIterator _docIdIterator;
+  private final int _lastDoc;
+  private int _nextDocId;
+  private int _nextNonMatchingDocId;
+
+  public InvertedBitmapDocIdIterator(ImmutableRoaringBitmap docIds, int numDocs) {
+    _docIds = docIds;
+    _docIdIterator = docIds.getIntIterator();
+    _nextDocId = 0;
+
+    int currentDocIdFromChildIterator = _docIdIterator.next();
+    _nextNonMatchingDocId = currentDocIdFromChildIterator == Constants.EOF ? numDocs : currentDocIdFromChildIterator;
+    _lastDoc = numDocs - 1;
+  }
+
+  @Override
+  public int next() {
+    while (_nextDocId == _nextNonMatchingDocId && _docIdIterator.hasNext()) {
+      _nextDocId++;
+      int nextNonMatchingDocId = _docIdIterator.next();
+      _nextNonMatchingDocId = nextNonMatchingDocId == Constants.EOF ? _lastDoc : nextNonMatchingDocId;
+    }
+    if (_nextDocId >= _lastDoc) {
+      return Constants.EOF;
+    }
+    return _nextDocId++;
+  }
+
+  @Override
+  public int advance(int targetDocId) {
+    _nextDocId = targetDocId;
+    if (targetDocId > _nextNonMatchingDocId) {
+      _docIdIterator.advanceIfNeeded(targetDocId);
+      _nextNonMatchingDocId = _docIdIterator.hasNext() ? _docIdIterator.next() : _lastDoc;
+    }
+    return next();
+  }
+
+  @Override
+  public ImmutableRoaringBitmap getDocIds() {
+    return _docIds;
+  }
+
+  @Override
+  public boolean isInverted() {
+    return true;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
@@ -40,6 +40,14 @@ public interface ScanBasedDocIdIterator extends BlockDocIdIterator {
   MutableRoaringBitmap applyAnd(ImmutableRoaringBitmap docIds);
 
   /**
+   * Applies ANDNOT operation to the given bitmap of document ids, returns a bitmap of the matching document ids.
+   */
+  default MutableRoaringBitmap applyAndNot(ImmutableRoaringBitmap docIds, int numDocs) {
+    // FIXME we're scanning anyway, so flipping a bitmap doesn't seem quite so bad, but this can be improved
+    return applyAnd(ImmutableRoaringBitmap.flip(docIds, 0L, numDocs));
+  }
+
+  /**
    * Returns the number of entries (SV value contains one entry, MV value contains multiple entries) scanned during the
    * iteration. This method should be called after the iteration is done.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/BitmapDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/BitmapDocIdSet.java
@@ -18,15 +18,21 @@
  */
 package org.apache.pinot.core.operator.docidsets;
 
+import org.apache.pinot.core.operator.dociditerators.BitmapBasedDocIdIterator;
 import org.apache.pinot.core.operator.dociditerators.BitmapDocIdIterator;
+import org.apache.pinot.core.operator.dociditerators.InvertedBitmapDocIdIterator;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
 
 public class BitmapDocIdSet implements FilterBlockDocIdSet {
-  private final BitmapDocIdIterator _iterator;
+  private final BitmapBasedDocIdIterator _iterator;
 
   public BitmapDocIdSet(ImmutableRoaringBitmap docIds, int numDocs) {
-    _iterator = new BitmapDocIdIterator(docIds, numDocs);
+    this(docIds, numDocs, false);
+  }
+
+  public BitmapDocIdSet(ImmutableRoaringBitmap docIds, int numDocs, boolean inverted) {
+    _iterator = inverted ? new InvertedBitmapDocIdIterator(docIds, numDocs) : new BitmapDocIdIterator(docIds, numDocs);
   }
 
   public BitmapDocIdSet(BitmapDocIdIterator iterator) {
@@ -34,7 +40,7 @@ public class BitmapDocIdSet implements FilterBlockDocIdSet {
   }
 
   @Override
-  public BitmapDocIdIterator iterator() {
+  public BitmapBasedDocIdIterator iterator() {
     return _iterator;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/NotDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/NotDocIdSet.java
@@ -33,6 +33,7 @@ public class NotDocIdSet implements FilterBlockDocIdSet {
 
   @Override
   public BlockDocIdIterator iterator() {
+    // FIXME if the child set is an inverted bitmap, we could just invert it again
     return new NotDocIdIterator(_childDocIdSet.iterator(), _numDocs);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/OrDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/OrDocIdSet.java
@@ -88,7 +88,11 @@ public final class OrDocIdSet implements FilterBlockDocIdSet {
         }
       }
       for (BitmapBasedDocIdIterator bitmapBasedDocIdIterator : bitmapBasedDocIdIterators) {
-        docIds.or(bitmapBasedDocIdIterator.getDocIds());
+        if (bitmapBasedDocIdIterator.isInverted()) {
+          docIds.orNot(bitmapBasedDocIdIterator.getDocIds(), _numDocs);
+        } else {
+          docIds.or(bitmapBasedDocIdIterator.getDocIds());
+        }
       }
       BitmapDocIdIterator bitmapDocIdIterator = new BitmapDocIdIterator(docIds, _numDocs);
       int numRemainingDocIdIterators = remainingDocIdIterators.size();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java
@@ -36,13 +36,16 @@ public class AndFilterOperator extends BaseFilterOperator {
   private final List<BaseFilterOperator> _filterOperators;
   private final Map<String, String> _queryOptions;
 
-  public AndFilterOperator(List<BaseFilterOperator> filterOperators, Map<String, String> queryOptions) {
+  private final int _numDocs;
+
+  public AndFilterOperator(List<BaseFilterOperator> filterOperators, Map<String, String> queryOptions, int numDocs) {
     _filterOperators = filterOperators;
     _queryOptions = queryOptions;
+    _numDocs = numDocs;
   }
 
-  public AndFilterOperator(List<BaseFilterOperator> filterOperators) {
-    this(filterOperators, null);
+  public AndFilterOperator(List<BaseFilterOperator> filterOperators, int numDocs) {
+    this(filterOperators, null, numDocs);
   }
 
   @Override
@@ -52,7 +55,7 @@ public class AndFilterOperator extends BaseFilterOperator {
     for (BaseFilterOperator filterOperator : _filterOperators) {
       filterBlockDocIdSets.add(filterOperator.nextBlock().getBlockDocIdSet());
     }
-    return new FilterBlock(new AndDocIdSet(filterBlockDocIdSets, _queryOptions));
+    return new FilterBlock(new AndDocIdSet(filterBlockDocIdSets, _queryOptions, _numDocs));
   }
 
   @Override
@@ -76,7 +79,6 @@ public class AndFilterOperator extends BaseFilterOperator {
     }
     return BufferFastAggregation.andCardinality(bitmaps);
   }
-
 
   @Override
   public List<Operator> getChildOperators() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/CombinedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/CombinedFilterOperator.java
@@ -38,12 +38,14 @@ public class CombinedFilterOperator extends BaseFilterOperator {
   private final BaseFilterOperator _mainFilterOperator;
   private final BaseFilterOperator _subFilterOperator;
   private final Map<String, String> _queryOptions;
+  private final int _numDocs;
 
   public CombinedFilterOperator(BaseFilterOperator mainFilterOperator, BaseFilterOperator subFilterOperator,
-      Map<String, String> queryOptions) {
+      Map<String, String> queryOptions, int numDocs) {
     _mainFilterOperator = mainFilterOperator;
     _subFilterOperator = subFilterOperator;
     _queryOptions = queryOptions;
+    _numDocs = numDocs;
   }
 
   @Override
@@ -61,6 +63,7 @@ public class CombinedFilterOperator extends BaseFilterOperator {
     Tracing.activeRecording().setNumChildren(2);
     FilterBlockDocIdSet mainFilterDocIdSet = _mainFilterOperator.nextBlock().getNonScanFilterBLockDocIdSet();
     FilterBlockDocIdSet subFilterDocIdSet = _subFilterOperator.nextBlock().getBlockDocIdSet();
-    return new FilterBlock(new AndDocIdSet(Arrays.asList(mainFilterDocIdSet, subFilterDocIdSet), _queryOptions));
+    return new FilterBlock(
+        new AndDocIdSet(Arrays.asList(mainFilterDocIdSet, subFilterDocIdSet), _queryOptions, _numDocs));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
@@ -107,7 +107,7 @@ public class FilterOperatorUtils {
     } else {
       // Return the AND filter operator with re-ordered child filter operators
       FilterOperatorUtils.reorderAndFilterChildOperators(queryContext, childFilterOperators);
-      return new AndFilterOperator(childFilterOperators, queryContext.getQueryOptions());
+      return new AndFilterOperator(childFilterOperators, queryContext.getQueryOptions(), numDocs);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ScanBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ScanBasedFilterOperator.java
@@ -59,7 +59,6 @@ public class ScanBasedFilterOperator extends BaseFilterOperator {
     }
   }
 
-
   @Override
   public List<Operator> getChildOperators() {
     return Collections.emptyList();

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -90,7 +90,7 @@ public class AggregationPlanNode implements PlanNode {
 
     List<Pair<AggregationFunction[], TransformOperator>> aggToTransformOpList =
         AggregationFunctionUtils.buildFilteredAggTransformPairs(_indexSegment, _queryContext,
-            filterOperatorPair.getRight(), transformOperator, null);
+            filterOperatorPair.getRight(), transformOperator, null, numTotalDocs);
     return new FilteredAggregationOperator(_queryContext.getAggregationFunctions(), aggToTransformOpList, numTotalDocs);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
@@ -76,7 +76,7 @@ public class GroupByPlanNode implements PlanNode {
 
     List<Pair<AggregationFunction[], TransformOperator>> aggToTransformOpList =
         AggregationFunctionUtils.buildFilteredAggTransformPairs(_indexSegment, _queryContext,
-            filterOperatorPair.getRight(), transformOperator, groupByExpressions);
+            filterOperatorPair.getRight(), transformOperator, groupByExpressions, numTotalDocs);
     return new FilteredGroupByOperator(_queryContext.getAggregationFunctions(), aggToTransformOpList,
         _queryContext.getGroupByExpressions().toArray(new ExpressionContext[0]), numTotalDocs, _queryContext);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -211,7 +211,7 @@ public class AggregationFunctionUtils {
    */
   public static List<Pair<AggregationFunction[], TransformOperator>> buildFilteredAggTransformPairs(
       IndexSegment indexSegment, QueryContext queryContext, BaseFilterOperator mainPredicateFilterOperator,
-      TransformOperator mainTransformOperator, @Nullable ExpressionContext[] groupByExpressions) {
+      TransformOperator mainTransformOperator, @Nullable ExpressionContext[] groupByExpressions, int numDocs) {
     Map<FilterContext, Pair<List<AggregationFunction>, TransformOperator>> filterContextToAggFuncsMap = new HashMap<>();
     List<AggregationFunction> nonFilteredAggregationFunctions = new ArrayList<>();
     List<Pair<AggregationFunction, FilterContext>> aggregationFunctions =
@@ -232,7 +232,7 @@ public class AggregationFunctionUtils {
             buildFilterOperator(indexSegment, queryContext, currentFilterExpression);
         BaseFilterOperator wrappedFilterOperator =
             new CombinedFilterOperator(mainPredicateFilterOperator, filterPlanOpPair.getRight(),
-                queryContext.getQueryOptions());
+                queryContext.getQueryOptions(), numDocs);
         TransformOperator newTransformOperator =
             buildTransformOperatorForFilteredAggregates(indexSegment, queryContext, wrappedFilterOperator,
                 groupByExpressions);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/dociditerators/AndDocIdIteratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/dociditerators/AndDocIdIteratorTest.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.operator.dociditerators;
 
-import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.segment.spi.Constants;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.Test;
 
@@ -41,16 +41,60 @@ public class AndDocIdIteratorTest {
     bitmap2.add(docIds2);
     MutableRoaringBitmap bitmap3 = new MutableRoaringBitmap();
     bitmap3.add(docIds3);
-    AndDocIdIterator andDocIdIterator = new AndDocIdIterator(new BlockDocIdIterator[]{
-        new RangelessBitmapDocIdIterator(bitmap1), new RangelessBitmapDocIdIterator(bitmap2),
-        new RangelessBitmapDocIdIterator(bitmap3)
-    });
+    AndDocIdIterator andDocIdIterator =
+        new AndDocIdIterator(new RangelessBitmapDocIdIterator(bitmap1), new RangelessBitmapDocIdIterator(bitmap2),
+            new RangelessBitmapDocIdIterator(bitmap3));
 
     assertEquals(andDocIdIterator.next(), 2);
     assertEquals(andDocIdIterator.next(), 7);
     assertEquals(andDocIdIterator.advance(10), 13);
     assertEquals(andDocIdIterator.advance(16), 16);
     assertEquals(andDocIdIterator.next(), 20);
+    assertEquals(andDocIdIterator.next(), Constants.EOF);
+  }
+
+  @Test
+  public void testAndDocIdIteratorWithInvertedChildren() {
+    int numDocs = 20;
+    // not = [4, 6, 8, 11, 14, 17, 19]
+    int[] docIds1 = new int[]{0, 1, 2, 3, 5, 7, 10, 12, 13, 15, 16, 18, 20};
+    // not = [0, 3, 8, 10, 14, 17, 18]
+    int[] docIds2 = new int[]{1, 2, 4, 5, 6, 7, 9, 11, 12, 13, 15, 16, 19, 20};
+    // not = [1, 5, 6, 9, 12, 14, 17, 18]
+    int[] docIds3 = new int[]{0, 2, 3, 4, 7, 8, 10, 11, 13, 15, 16, 19, 20};
+    int[] expected = new int[]{14, 17};
+
+    ImmutableRoaringBitmap bitmap1 = ImmutableRoaringBitmap.bitmapOf(docIds1);
+    ImmutableRoaringBitmap bitmap2 = ImmutableRoaringBitmap.bitmapOf(docIds2);
+    ImmutableRoaringBitmap bitmap3 = ImmutableRoaringBitmap.bitmapOf(docIds3);
+    AndDocIdIterator andDocIdIterator = new AndDocIdIterator(new InvertedBitmapDocIdIterator(bitmap1, numDocs),
+        new InvertedBitmapDocIdIterator(bitmap2, numDocs), new InvertedBitmapDocIdIterator(bitmap3, numDocs));
+
+    for (int docId : expected) {
+      assertEquals(andDocIdIterator.next(), docId);
+    }
+    assertEquals(andDocIdIterator.next(), Constants.EOF);
+  }
+
+  @Test
+  public void testAndDocIdIteratorWithMixedChildren() {
+    int numDocs = 20;
+    int[] docIds1 = new int[]{0, 1, 2, 3, 5, 7, 10, 12, 13, 14, 15, 16, 17, 18, 20};
+    // not = [0, 3, 8, 10, 14, 17, 18]
+    int[] docIds2 = new int[]{1, 2, 4, 5, 6, 7, 9, 11, 12, 13, 15, 16, 19, 20};
+    // not = [1, 5, 6, 9, 12, 14, 17, 18]
+    int[] docIds3 = new int[]{0, 2, 3, 4, 7, 8, 10, 11, 13, 15, 16, 19, 20};
+    int[] expected = new int[]{14, 17, 18};
+
+    ImmutableRoaringBitmap bitmap1 = ImmutableRoaringBitmap.bitmapOf(docIds1);
+    ImmutableRoaringBitmap bitmap2 = ImmutableRoaringBitmap.bitmapOf(docIds2);
+    ImmutableRoaringBitmap bitmap3 = ImmutableRoaringBitmap.bitmapOf(docIds3);
+    AndDocIdIterator andDocIdIterator = new AndDocIdIterator(new BitmapDocIdIterator(bitmap1, numDocs),
+        new InvertedBitmapDocIdIterator(bitmap2, numDocs), new InvertedBitmapDocIdIterator(bitmap3, numDocs));
+
+    for (int docId : expected) {
+      assertEquals(andDocIdIterator.next(), docId);
+    }
     assertEquals(andDocIdIterator.next(), Constants.EOF);
   }
 }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
@@ -61,7 +61,8 @@ public class BenchmarkAndDocIdIterator {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public void benchAndFilterOperator(MyState myState, Blackhole bh) {
     for (int i = 0; i < 100; i++) {
-      bh.consume(new AndFilterOperator(myState._childOperators).nextBlock().getBlockDocIdSet().iterator());
+      bh.consume(new AndFilterOperator(myState._childOperators, NUM_DOCS).nextBlock()
+              .getBlockDocIdSet().iterator());
     }
   }
 
@@ -70,7 +71,8 @@ public class BenchmarkAndDocIdIterator {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public void benchAndFilterOperatorDegenerate(MyState myState, Blackhole bh) {
     for (int i = 0; i < 100; i++) {
-      bh.consume(new AndFilterOperator(myState._childOperatorsNoOrdering).nextBlock().getBlockDocIdSet().iterator());
+      bh.consume(new AndFilterOperator(myState._childOperatorsNoOrdering, NUM_DOCS).nextBlock()
+              .getBlockDocIdSet().iterator());
     }
   }
 


### PR DESCRIPTION
This supersedes #8546 which addressed a bottleneck clearly visible in queries with negations