### PR TITLE
[refactor] move min/max combine out

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
@@ -72,7 +72,7 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator extends BaseCombine
   private final List<MinMaxValueContext> _minMaxValueContexts;
   private final AtomicReference<Comparable> _globalBoundaryValue = new AtomicReference<>();
 
-  MinMaxValueBasedSelectionOrderByCombineOperator(List<Operator> operators, QueryContext queryContext,
+  public MinMaxValueBasedSelectionOrderByCombineOperator(List<Operator> operators, QueryContext queryContext,
       ExecutorService executorService) {
     super(operators, queryContext, executorService);
     _endOperatorId = new AtomicInteger(_numOperators);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOrderByCombineOperator.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.PriorityQueue;
 import java.util.concurrent.ExecutorService;
 import org.apache.pinot.common.exception.QueryException;
-import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
@@ -31,7 +30,6 @@ import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
-import org.apache.pinot.spi.exception.QueryCancelledException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,25 +64,12 @@ public class SelectionOrderByCombineOperator extends BaseCombineOperator<Selecti
    * {@inheritDoc}
    *
    * <p> Execute query on one or more segments in a single thread, and store multiple intermediate result blocks
-   * into BlockingQueue. Try to use
-   * {@link org.apache.pinot.core.operator.combine.MinMaxValueBasedSelectionOrderByCombineOperator} first, which
-   * will skip processing some segments based on the column min/max value. Otherwise fall back to the default combine
-   * (process all segments).
+   * into BlockingQueue.
    */
   @Override
   protected BaseResultsBlock getNextBlock() {
     List<OrderByExpressionContext> orderByExpressions = _queryContext.getOrderByExpressions();
     assert orderByExpressions != null;
-    if (orderByExpressions.get(0).getExpression().getType() == ExpressionContext.Type.IDENTIFIER) {
-      try {
-        return new MinMaxValueBasedSelectionOrderByCombineOperator(_operators, _queryContext,
-            _executorService).getNextBlock();
-      } catch (QueryCancelledException e) {
-        throw e;
-      } catch (Exception e) {
-        LOGGER.warn("Caught exception while using min/max value based combine, using the default combine", e);
-      }
-    }
     return super.getNextBlock();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/SelectionOrderByCombineOperator.java
@@ -23,10 +23,8 @@ import java.util.List;
 import java.util.PriorityQueue;
 import java.util.concurrent.ExecutorService;
 import org.apache.pinot.common.exception.QueryException;
-import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Operator;
-import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
@@ -58,19 +56,6 @@ public class SelectionOrderByCombineOperator extends BaseCombineOperator<Selecti
   @Override
   public String toExplainString() {
     return EXPLAIN_NAME;
-  }
-
-  /**
-   * {@inheritDoc}
-   *
-   * <p> Execute query on one or more segments in a single thread, and store multiple intermediate result blocks
-   * into BlockingQueue.
-   */
-  @Override
-  protected BaseResultsBlock getNextBlock() {
-    List<OrderByExpressionContext> orderByExpressions = _queryContext.getOrderByExpressions();
-    assert orderByExpressions != null;
-    return super.getNextBlock();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -48,8 +48,6 @@ import org.apache.pinot.spi.exception.QueryCancelledException;
 import org.apache.pinot.spi.trace.InvocationRecording;
 import org.apache.pinot.spi.trace.InvocationScope;
 import org.apache.pinot.spi.trace.Tracing;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -57,7 +55,6 @@ import org.slf4j.LoggerFactory;
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class CombinePlanNode implements PlanNode {
-  private static final Logger LOGGER = LoggerFactory.getLogger(CombinePlanNode.class);
   // Try to schedule 10 plans for each thread, or evenly distribute plans to all MAX_NUM_THREADS_PER_QUERY threads
   private static final int TARGET_NUM_PLANS_PER_THREAD = 10;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextUtils.java
@@ -59,6 +59,12 @@ public class QueryContextUtils {
         || !(aggregationFunctions[0] instanceof DistinctAggregationFunction));
   }
 
+  public static boolean isMinMaxBasedSelectionOrderBy(QueryContext query) {
+    List<OrderByExpressionContext> orderByExpressions = query.getOrderByExpressions();
+    return orderByExpressions != null
+        && orderByExpressions.get(0).getExpression().getType() == ExpressionContext.Type.IDENTIFIER;
+  }
+
   /**
    * Returns {@code true} if the given query is a distinct query, {@code false} otherwise.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextUtils.java
@@ -59,12 +59,6 @@ public class QueryContextUtils {
         || !(aggregationFunctions[0] instanceof DistinctAggregationFunction));
   }
 
-  public static boolean isMinMaxBasedSelectionOrderBy(QueryContext query) {
-    List<OrderByExpressionContext> orderByExpressions = query.getOrderByExpressions();
-    return orderByExpressions != null
-        && orderByExpressions.get(0).getExpression().getType() == ExpressionContext.Type.IDENTIFIER;
-  }
-
   /**
    * Returns {@code true} if the given query is a distinct query, {@code false} otherwise.
    */

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineSlowOperatorsTest.java
@@ -146,8 +146,8 @@ public class CombineSlowOperatorsTest {
     });
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable ORDER BY column");
     queryContext.setEndTimeMs(System.currentTimeMillis() + 10000);
-    SelectionOrderByCombineOperator combineOperator =
-        new SelectionOrderByCombineOperator(operators, queryContext, _executorService);
+    MinMaxValueBasedSelectionOrderByCombineOperator combineOperator =
+        new MinMaxValueBasedSelectionOrderByCombineOperator(operators, queryContext, _executorService);
     testCancelCombineOperator(combineOperator, ready, "Cancelled while merging results blocks");
   }
 


### PR DESCRIPTION
we can know whether we are able to use min/max combine operator in advance. no need to nest it within selection order by combine operator