### PR TITLE
Add pinot Prefix to Server Thread Pool Config

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/util/ListenerConfigUtilTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/util/ListenerConfigUtilTest.java
@@ -67,8 +67,8 @@ public class ListenerConfigUtilTest {
         listenerConfigs.get(0).getThreadPoolConfig().getMaxPoolSize());
 
     // Set server thread pool configs and assert that they are set
-    controllerConf.setProperty("controller.http.server.thread.pool.corePoolSize", 7);
-    controllerConf.setProperty("controller.http.server.thread.pool.maxPoolSize", 9);
+    controllerConf.setProperty("pinot.controller.http.server.thread.pool.corePoolSize", 7);
+    controllerConf.setProperty("pinot.controller.http.server.thread.pool.maxPoolSize", 9);
 
     listenerConfigs = ListenerConfigUtil.buildControllerConfigs(controllerConf);
     Assert.assertEquals(listenerConfigs.size(), 1);

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
@@ -98,7 +98,8 @@ public final class ListenerConfigUtil {
     String portString = controllerConf.getProperty("controller.port");
     if (portString != null) {
       listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, Integer.parseInt(portString),
-          CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(controllerConf, "controller")));
+          CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(controllerConf,
+          "pinot.controller")));
     }
 
     TlsConfig tlsDefaults = TlsUtils.extractTlsConfig(controllerConf, "controller.tls");
@@ -115,7 +116,7 @@ public final class ListenerConfigUtil {
     String queryPortString = brokerConf.getProperty(CommonConstants.Helix.KEY_OF_BROKER_QUERY_PORT);
     if (queryPortString != null) {
       listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, Integer.parseInt(queryPortString),
-          CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(brokerConf, "broker")));
+          CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(brokerConf, "pinot.broker")));
     }
 
     TlsConfig tlsDefaults = TlsUtils.extractTlsConfig(brokerConf, CommonConstants.Broker.BROKER_TLS_PREFIX);
@@ -126,7 +127,7 @@ public final class ListenerConfigUtil {
     if (listeners.isEmpty()) {
       listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST,
           CommonConstants.Helix.DEFAULT_BROKER_QUERY_PORT, CommonConstants.HTTP_PROTOCOL, new TlsConfig(),
-          buildServerThreadPoolConfig(brokerConf, "broker")));
+          buildServerThreadPoolConfig(brokerConf, "pinot.broker")));
     }
 
     return listeners;
@@ -139,7 +140,7 @@ public final class ListenerConfigUtil {
     if (adminApiPortString != null) {
       listeners.add(
           new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, Integer.parseInt(adminApiPortString),
-              CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(serverConf, "server")));
+              CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(serverConf, "pinot.server")));
     }
 
     TlsConfig tlsDefaults = TlsUtils.extractTlsConfig(serverConf, CommonConstants.Server.SERVER_TLS_PREFIX);
@@ -150,7 +151,7 @@ public final class ListenerConfigUtil {
     if (listeners.isEmpty()) {
       listeners.add(
           new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, CommonConstants.Server.DEFAULT_ADMIN_API_PORT,
-              CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(serverConf, "server")));
+              CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(serverConf, "pinot.server")));
     }
 
     return listeners;
@@ -162,7 +163,7 @@ public final class ListenerConfigUtil {
     String portString = minionConf.getProperty(CommonConstants.Helix.KEY_OF_MINION_PORT);
     if (portString != null) {
       listeners.add(new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, Integer.parseInt(portString),
-          CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(minionConf, "minion")));
+          CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(minionConf, "pinot.minion")));
     }
 
     TlsConfig tlsDefaults = TlsUtils.extractTlsConfig(minionConf, CommonConstants.Minion.MINION_TLS_PREFIX);
@@ -172,7 +173,7 @@ public final class ListenerConfigUtil {
     if (listeners.isEmpty()) {
       listeners.add(
           new ListenerConfig(CommonConstants.HTTP_PROTOCOL, DEFAULT_HOST, CommonConstants.Minion.DEFAULT_HELIX_PORT,
-              CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(minionConf, "minion")));
+              CommonConstants.HTTP_PROTOCOL, new TlsConfig(), buildServerThreadPoolConfig(minionConf, "pinot.minion")));
     }
 
     return listeners;


### PR DESCRIPTION
In this [PR](https://github.com/apache/pinot/pull/10001) the configs looked like so:

```
controller.http.server.thread.pool.corePoolSize: 10
controller.http.server.thread.pool.maxPoolSize: 10
broker.http.server.thread.pool.corePoolSize: 10
...
```

This PR changes them to:

```
pinot.controller.http.server.thread.pool.corePoolSize: 10
pinot.controller.http.server.thread.pool.maxPoolSize: 10
pinot.broker.http.server.thread.pool.corePoolSize: 10
...
```

At present soem configs have the pinot. prefix and some don't. Going forward we can try to ensure all configs have a pinot prefix to keep things consistent.

**Test-Plan:** Tested on local for controller and broker by starting them with custom configs that set the pool size to 7, and then taking a thread-dump.

Example:
```
$ export JAVA_OPTS="-Xms4G -Xmx4G -XX:+UseG1GC -XX:MaxGCPauseMillis=200 -Xloggc:gc-pinot-broker.log"
./bin/pinot-admin.sh StartBroker \
    -zkAddress localhost:2191 -brokerConf conf/pinot-broker.conf
...
$ jstack 22682 | grep grizzly-http | wc -l
       7
```

cc: @Jackie-Jiang 