### PR TITLE
fix(ui): show query result along with error message if both exist

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -554,6 +554,13 @@ const QueryPage = () => {
                   )
                 }
         
+                {/* Sql result errors */}
+                {resultError && (
+                  <Alert severity="error" className={classes.sqlError}>
+                    {resultError}
+                  </Alert>
+                )}
+        
                 <Grid item xs style={{ backgroundColor: 'white' }}>
                   {resultData.columns.length ? (
                     <>
@@ -632,13 +639,6 @@ const QueryPage = () => {
                     </>
                   ) : null}
                 </Grid>
-
-                {/* Sql result errors */}
-                {resultError && (
-                  <Alert severity="error" className={classes.sqlError}>
-                    {resultError}
-                  </Alert>
-                )}
               </>
             )}
           </Grid>

--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -553,92 +553,91 @@ const QueryPage = () => {
                                    </Alert>
                   )
                 }
+        
+                <Grid item xs style={{ backgroundColor: 'white' }}>
+                  {resultData.columns.length ? (
+                    <>
+                      <Grid container className={classes.actionBtns}>
+                        <Button
+                          variant="contained"
+                          color="primary"
+                          size="small"
+                          className={classes.btn}
+                          onClick={() => downloadData('xls')}
+                        >
+                          Excel
+                        </Button>
+                        <Button
+                          variant="contained"
+                          color="primary"
+                          size="small"
+                          className={classes.btn}
+                          onClick={() => downloadData('csv')}
+                        >
+                          CSV
+                        </Button>
+                        <Button
+                          variant="contained"
+                          color="primary"
+                          size="small"
+                          className={classes.btn}
+                          onClick={() => copyToClipboard()}
+                        >
+                          Copy
+                        </Button>
+                        {copyMsg ? (
+                          <Alert
+                            icon={<FileCopyIcon fontSize="inherit" />}
+                            severity="info"
+                          >
+                            Copied {resultData.records.length} rows to
+                            Clipboard
+                          </Alert>
+                        ) : null}
 
-                {resultError ? (
+                        <FormControlLabel
+                          control={
+                            <Switch
+                              checked={checked.showResultJSON}
+                              onChange={handleChange}
+                              name="showResultJSON"
+                              color="primary"
+                            />
+                          }
+                          label="Show JSON format"
+                          className={classes.runNowBtn}
+                        />
+                      </Grid>
+                      {!checked.showResultJSON ? (
+                        <CustomizedTables
+                          title="Query Result"
+                          data={resultData}
+                          isSticky={true}
+                          showSearchBox={true}
+                          inAccordionFormat={true}
+                        />
+                      ) : resultData.columns.length ? (
+                        <SimpleAccordion
+                          headerTitle="Query Result (JSON Format)"
+                          showSearchBox={false}
+                        >
+                          <CodeMirror
+                            options={jsonoptions}
+                            value={outputResult}
+                            className={classes.queryOutput}
+                            autoCursor={false}
+                          />
+                        </SimpleAccordion>
+                      ) : null}
+                    </>
+                  ) : null}
+                </Grid>
+
+                {/* Sql result errors */}
+                {resultError && (
                   <Alert severity="error" className={classes.sqlError}>
                     {resultError}
                   </Alert>
-                ) : (
-                  <>
-                    <Grid item xs style={{ backgroundColor: 'white' }}>
-                      {resultData.columns.length ? (
-                        <>
-                          <Grid container className={classes.actionBtns}>
-                            <Button
-                              variant="contained"
-                              color="primary"
-                              size="small"
-                              className={classes.btn}
-                              onClick={() => downloadData('xls')}
-                            >
-                              Excel
-                            </Button>
-                            <Button
-                              variant="contained"
-                              color="primary"
-                              size="small"
-                              className={classes.btn}
-                              onClick={() => downloadData('csv')}
-                            >
-                              CSV
-                            </Button>
-                            <Button
-                              variant="contained"
-                              color="primary"
-                              size="small"
-                              className={classes.btn}
-                              onClick={() => copyToClipboard()}
-                            >
-                              Copy
-                            </Button>
-                            {copyMsg ? (
-                              <Alert
-                                icon={<FileCopyIcon fontSize="inherit" />}
-                                severity="info"
-                              >
-                                Copied {resultData.records.length} rows to
-                                Clipboard
-                              </Alert>
-                            ) : null}
-
-                            <FormControlLabel
-                              control={
-                                <Switch
-                                  checked={checked.showResultJSON}
-                                  onChange={handleChange}
-                                  name="showResultJSON"
-                                  color="primary"
-                                />
-                              }
-                              label="Show JSON format"
-                              className={classes.runNowBtn}
-                            />
-                          </Grid>
-                          {!checked.showResultJSON ? (
-                            <CustomizedTables
-                              title="Query Result"
-                              data={resultData}
-                              isSticky={true}
-                              showSearchBox={true}
-                              inAccordionFormat={true}
-                            />
-                          ) : resultData.columns.length ? (
-                            <SimpleAccordion
-                              headerTitle="Query Result (JSON Format)"
-                              showSearchBox={false}
-                            >
-                              <CodeMirror
-                                options={jsonoptions}
-                                value={outputResult}
-                                className={classes.queryOutput}
-                                autoCursor={false}
-                              />
-                            </SimpleAccordion>
-                          ) : null}
-                        </>
-                      ) : null}
-                    </Grid>
-                  </>
                 )}
               </>
             )}

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -274,7 +274,11 @@ const getQueryResults = (params) => {
       errorStr = queryResponse;
     } 
     if (queryResponse && queryResponse.exceptions && queryResponse.exceptions.length) {
-      errorStr = JSON.stringify(queryResponse.exceptions, null, 2);
+      try{
+        errorStr = JSON.stringify(queryResponse.exceptions, null, 2);
+      } catch {
+        errorStr = "";
+      }
     } 
     if (queryResponse.resultTable?.dataSchema?.columnNames?.length) {
       columnList = queryResponse.resultTable.dataSchema.columnNames;

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -264,15 +264,7 @@ const getAsObject = (str: SQLResult) => {
 // Expected Output: {columns: [], records: []}
 const getQueryResults = (params) => {
   return getQueryResult(params).then(({ data }) => {
-  
-
     let queryResponse = getAsObject(data);
-    queryResponse.exceptions = [
-      {
-        "errorCode": 305,
-        "message": "null:\n1 segments unavailable: [airlineStats_OFFLINE_16072_16072_0]"
-      }
-    ]
 
     let errorStr = '';
     let dataArray = [];

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -264,7 +264,15 @@ const getAsObject = (str: SQLResult) => {
 // Expected Output: {columns: [], records: []}
 const getQueryResults = (params) => {
   return getQueryResult(params).then(({ data }) => {
+  
+
     let queryResponse = getAsObject(data);
+    queryResponse.exceptions = [
+      {
+        "errorCode": 305,
+        "message": "null:\n1 segments unavailable: [airlineStats_OFFLINE_16072_16072_0]"
+      }
+    ]
 
     let errorStr = '';
     let dataArray = [];
@@ -272,15 +280,13 @@ const getQueryResults = (params) => {
     // if sql api throws error, handle here
     if(typeof queryResponse === 'string'){
       errorStr = queryResponse;
-    } else if (queryResponse && queryResponse.exceptions && queryResponse.exceptions.length) {
+    } 
+    if (queryResponse && queryResponse.exceptions && queryResponse.exceptions.length) {
       errorStr = JSON.stringify(queryResponse.exceptions, null, 2);
-    } else
-    {
-      if (queryResponse.resultTable?.dataSchema?.columnNames?.length)
-      {
-        columnList = queryResponse.resultTable.dataSchema.columnNames;
-        dataArray = queryResponse.resultTable.rows;
-      }
+    } 
+    if (queryResponse.resultTable?.dataSchema?.columnNames?.length) {
+      columnList = queryResponse.resultTable.dataSchema.columnNames;
+      dataArray = queryResponse.resultTable.rows;
     }
 
     const columnStats = ['timeUsedMs',


### PR DESCRIPTION
### Issue
- when running a sql query, if the api result contains both `exceptions` as well as `resultTable` then ideally UI should show both
- instead UI is showing only exceptions 
- Eg- when API response contains both result and exception then UI only shows error alert 
```bash
curl -H "Content-Type: application/json" -X POST \
        -d '{"sql":"select count(*)  from airlineStats "}' \
         http://localhost:8000/query/sql
```
```json
{
  "resultTable": {
    "dataSchema": {
      "columnNames": [
        "count(*)"
      ],
      "columnDataTypes": [
        "LONG"
      ]
    },
    "rows": [
      [
        9343
      ]
    ]
  },
  "exceptions": [
    {
      "errorCode": 305,
      "message": "null:\n1 segments unavailable: [airlineStats_OFFLINE_16072_16072_0]"
    }
  ],
  "numServersQueried": 1,
  "numServersResponded": 1,
  "numSegmentsQueried": 30,
  "numSegmentsProcessed": 30,
  "numSegmentsMatched": 30,
  "numConsumingSegmentsQueried": 0,
  "numConsumingSegmentsProcessed": 0,
  "numConsumingSegmentsMatched": 0,
  "numDocsScanned": 9343,
  "numEntriesScannedInFilter": 0,
  "numEntriesScannedPostFilter": 0,
  "numGroupsLimitReached": false,
  "totalDocs": 9343,
  "timeUsedMs": 7,
  "offlineThreadCpuTimeNs": 0,
  "realtimeThreadCpuTimeNs": 0,
  "offlineSystemActivitiesCpuTimeNs": 0,
  "realtimeSystemActivitiesCpuTimeNs": 0,
  "offlineResponseSerializationCpuTimeNs": 0,
  "realtimeResponseSerializationCpuTimeNs": 0,
  "offlineTotalCpuTimeNs": 0,
  "realtimeTotalCpuTimeNs": 0,
  "segmentStatistics": [],
  "traceInfo": {},
  "numRowsResultSet": 1,
  "minConsumingFreshnessTimeMs": 0,
  "numSegmentsPrunedByBroker": 0,
  "numSegmentsPrunedByServer": 0,
  "numSegmentsPrunedInvalid": 0,
  "numSegmentsPrunedByLimit": 0,
  "numSegmentsPrunedByValue": 0,
  "explainPlanNumEmptyFilterSegments": 0,
  "explainPlanNumMatchAllFilterSegments": 0
}
```

![image](https://user-images.githubusercontent.com/41536903/211031688-e18f518e-eed3-4134-befd-0ff9cedb6fe9.png)


### Solution

show both query result as well as error message if both exist

<img width="1728" alt="image" src="https://user-images.githubusercontent.com/41536903/211166409-662bd894-e69c-4f4a-86c7-96ecd82d0249.png">
