### PR TITLE
upgrade to RoaringBitmap 0.9.38

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -452,8 +452,8 @@ org.jetbrains:annotations:13.0
 org.lz4:lz4-java:1.8.0
 org.objenesis:objenesis:2.1
 org.quartz-scheduler:quartz:2.3.2
-org.roaringbitmap:RoaringBitmap:0.9.35
-org.roaringbitmap:shims:0.9.35
+org.roaringbitmap:RoaringBitmap:0.9.38
+org.roaringbitmap:shims:0.9.38
 org.scala-lang.modules:scala-collection-compat_2.12:2.3.0
 org.scala-lang.modules:scala-java8-compat_2.12:0.9.1
 org.scala-lang.modules:scala-xml_2.12:1.3.0

--- a/pom.xml
+++ b/pom.xml
@@ -442,7 +442,7 @@
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>
-        <version>0.9.35</version>
+        <version>0.9.38</version>
       </dependency>
       <dependency>
         <groupId>com.101tec</groupId>


### PR DESCRIPTION
Contains a bug fix for the timestamp index, see release notes https://github.com/RoaringBitmap/RoaringBitmap/releases/tag/0.9.38