### PR TITLE
Add an option to reduce random access by caching fields of visited nodes when doing BFS over StarTree index

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -109,12 +109,8 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SKIP_UPSERT));
   }
 
-  public static boolean isScanStarTreeNodes(Map<String, String> queryOptions) {
-    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SCAN_STAR_TREE_NODES));
-  }
-
-  public static boolean isScanStarTreeNodesOnHeap(Map<String, String> queryOptions) {
-    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SCAN_STAR_TREE_NODES_ON_HEAP));
+  public static boolean isReduceRandomAccess(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.REDUCE_RANDOM_ACCESS));
   }
 
   public static boolean isSkipStarTree(Map<String, String> queryOptions) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -113,6 +113,10 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SCAN_STAR_TREE_NODES));
   }
 
+  public static boolean isScanStarTreeNodesOnHeap(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SCAN_STAR_TREE_NODES_ON_HEAP));
+  }
+
   public static boolean isSkipStarTree(Map<String, String> queryOptions) {
     return "false".equalsIgnoreCase(queryOptions.get(QueryOptionKey.USE_STAR_TREE));
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/operator/StarTreeFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/operator/StarTreeFilterOperator.java
@@ -43,6 +43,7 @@ import org.apache.pinot.core.operator.filter.FilterOperatorUtils;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.CompositePredicateEvaluator;
+import org.apache.pinot.segment.local.startree.CachedStarTreeNode;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.startree.StarTree;
 import org.apache.pinot.segment.spi.index.startree.StarTreeNode;
@@ -209,6 +210,9 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
     StarTree starTree = _starTreeV2.getStarTree();
     List<String> dimensionNames = starTree.getDimensionNames();
     StarTreeNode starTreeRootNode = starTree.getRoot();
+    if (QueryOptionsUtils.isScanStarTreeNodesOnHeap(_queryContext.getQueryOptions())) {
+      starTreeRootNode = new CachedStarTreeNode(starTreeRootNode);
+    }
 
     // Use BFS to traverse the star tree
     Queue<StarTreeNode> queue = new ArrayDeque<>();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/CachedStarTreeNode.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/CachedStarTreeNode.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.startree;
+
+import java.util.Iterator;
+import org.apache.pinot.segment.spi.index.startree.StarTreeNode;
+
+
+/**
+ * Getting all fields in current StarTree node immediately and cache them, instead of jumping back and forth inside the
+ * data buffer to read fields from parent and children nodes while doing BFS over the StarTree index tree, making the
+ * buffer reads a lot more sequential.
+ */
+public class CachedStarTreeNode implements StarTreeNode {
+  private final StarTreeNode _delegate;
+  private final int _dimensionId;
+  private final int _dimensionValue;
+  private final int _startDocId;
+  private final int _endDocId;
+  private final int _aggregatedDocId;
+  private final int _numChildren;
+
+  public CachedStarTreeNode(StarTreeNode starTreeNode) {
+    _delegate = starTreeNode;
+    _dimensionId = _delegate.getDimensionId();
+    _dimensionValue = _delegate.getDimensionValue();
+    _startDocId = _delegate.getStartDocId();
+    _endDocId = _delegate.getEndDocId();
+    _aggregatedDocId = _delegate.getAggregatedDocId();
+    _numChildren = _delegate.getNumChildren();
+  }
+
+  @Override
+  public int getDimensionId() {
+    return _dimensionId;
+  }
+
+  @Override
+  public int getDimensionValue() {
+    return _dimensionValue;
+  }
+
+  @Override
+  public int getChildDimensionId() {
+    return _delegate.getChildDimensionId();
+  }
+
+  @Override
+  public int getStartDocId() {
+    return _startDocId;
+  }
+
+  @Override
+  public int getEndDocId() {
+    return _endDocId;
+  }
+
+  @Override
+  public int getAggregatedDocId() {
+    return _aggregatedDocId;
+  }
+
+  @Override
+  public int getNumChildren() {
+    return _numChildren;
+  }
+
+  @Override
+  public boolean isLeaf() {
+    return _delegate.isLeaf();
+  }
+
+  @Override
+  public StarTreeNode getChildForDimensionValue(int dimensionValue) {
+    return new CachedStarTreeNode(_delegate.getChildForDimensionValue(dimensionValue));
+  }
+
+  @Override
+  public Iterator<? extends StarTreeNode> getChildrenIterator() {
+    Iterator<? extends StarTreeNode> delegateIterator = _delegate.getChildrenIterator();
+    return new Iterator<>() {
+      @Override
+      public boolean hasNext() {
+        return delegateIterator.hasNext();
+      }
+
+      @Override
+      public CachedStarTreeNode next() {
+        return new CachedStarTreeNode(delegateIterator.next());
+      }
+
+      @Override
+      public void remove() {
+        delegateIterator.remove();
+      }
+    };
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/CachedStarTreeNode.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/CachedStarTreeNode.java
@@ -88,7 +88,8 @@ public class CachedStarTreeNode implements StarTreeNode {
 
   @Override
   public StarTreeNode getChildForDimensionValue(int dimensionValue) {
-    return new CachedStarTreeNode(_delegate.getChildForDimensionValue(dimensionValue));
+    StarTreeNode child = _delegate.getChildForDimensionValue(dimensionValue);
+    return child == null ? null : new CachedStarTreeNode(child);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/OffHeapStarTreeNode.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/OffHeapStarTreeNode.java
@@ -39,11 +39,13 @@ public class OffHeapStarTreeNode implements StarTreeNode {
   private final PinotDataBuffer _dataBuffer;
   private final int _nodeId;
   private final int _firstChildId;
+  private final int _lastChildId;
 
   public OffHeapStarTreeNode(PinotDataBuffer dataBuffer, int nodeId) {
     _dataBuffer = dataBuffer;
     _nodeId = nodeId;
     _firstChildId = getInt(FIRST_CHILD_ID_OFFSET);
+    _lastChildId = getInt(LAST_CHILD_ID_OFFSET);
   }
 
   private int getInt(int fieldOffset) {
@@ -136,9 +138,8 @@ public class OffHeapStarTreeNode implements StarTreeNode {
 
   @Override
   public Iterator<OffHeapStarTreeNode> getChildrenIterator() {
-    return new Iterator<OffHeapStarTreeNode>() {
+    return new Iterator<>() {
       private int _currentChildId = _firstChildId;
-      private final int _lastChildId = getInt(LAST_CHILD_ID_OFFSET);
 
       @Override
       public boolean hasNext() {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/CachedStarTreeNodeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/startree/v2/builder/CachedStarTreeNodeTest.java
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.startree.v2.builder;
+
+import java.util.Iterator;
+import org.apache.pinot.segment.local.startree.CachedStarTreeNode;
+import org.apache.pinot.segment.spi.index.startree.StarTreeNode;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class CachedStarTreeNodeTest {
+  @Test
+  public void testGetFields() {
+    StarTreeNode childNode = createStarTreeNode(1, 2, -1, 3, 4, 5, 0, true, null);
+    StarTreeNode parentNode = createStarTreeNode(2, 20, 1, 1, 2, 6, 1, false, childNode);
+
+    // Parent node
+    StarTreeNode cached = new CachedStarTreeNode(parentNode);
+    Assert.assertEquals(cached.getDimensionId(), 2);
+    Assert.assertEquals(cached.getDimensionValue(), 20);
+    Assert.assertEquals(cached.getChildDimensionId(), 1);
+    Assert.assertEquals(cached.getStartDocId(), 1);
+    Assert.assertEquals(cached.getEndDocId(), 2);
+    Assert.assertEquals(cached.getAggregatedDocId(), 6);
+    Assert.assertEquals(cached.getNumChildren(), 1);
+    Assert.assertFalse(cached.isLeaf());
+
+    // Leaf node
+    cached = cached.getChildrenIterator().next();
+    Assert.assertTrue(cached instanceof CachedStarTreeNode);
+    Assert.assertEquals(cached.getDimensionId(), 1);
+    Assert.assertEquals(cached.getDimensionValue(), 2);
+    Assert.assertEquals(cached.getChildDimensionId(), -1);
+    Assert.assertEquals(cached.getStartDocId(), 3);
+    Assert.assertEquals(cached.getEndDocId(), 4);
+    Assert.assertEquals(cached.getAggregatedDocId(), 5);
+    Assert.assertEquals(cached.getNumChildren(), 0);
+    Assert.assertTrue(cached.isLeaf());
+  }
+
+  private StarTreeNode createStarTreeNode(int dimId, int dimValue, int childDimId, int startDocId, int endDocId,
+      int aggDocId, int numChildren, boolean isLeaf, StarTreeNode childNode) {
+    return new StarTreeNode() {
+      @Override
+      public int getDimensionId() {
+        return dimId;
+      }
+
+      @Override
+      public int getDimensionValue() {
+        return dimValue;
+      }
+
+      @Override
+      public int getChildDimensionId() {
+        return childDimId;
+      }
+
+      @Override
+      public int getStartDocId() {
+        return startDocId;
+      }
+
+      @Override
+      public int getEndDocId() {
+        return endDocId;
+      }
+
+      @Override
+      public int getAggregatedDocId() {
+        return aggDocId;
+      }
+
+      @Override
+      public int getNumChildren() {
+        return numChildren;
+      }
+
+      @Override
+      public boolean isLeaf() {
+        return isLeaf;
+      }
+
+      @Override
+      public StarTreeNode getChildForDimensionValue(int dimensionValue) {
+        return null;
+      }
+
+      @Override
+      public Iterator<? extends StarTreeNode> getChildrenIterator() {
+        return new Iterator<>() {
+          @Override
+          public boolean hasNext() {
+            return true;
+          }
+
+          @Override
+          public StarTreeNode next() {
+            return childNode;
+          }
+        };
+      }
+    };
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -279,8 +279,7 @@ public class CommonConstants {
         public static final String TIMEOUT_MS = "timeoutMs";
         public static final String SKIP_UPSERT = "skipUpsert";
         public static final String USE_STAR_TREE = "useStarTree";
-        public static final String SCAN_STAR_TREE_NODES = "scanStarTreeNodes";
-        public static final String SCAN_STAR_TREE_NODES_ON_HEAP = "scanStarTreeNodesOnHeap";
+        public static final String REDUCE_RANDOM_ACCESS = "reduceRandomAccess";
         public static final String ROUTING_OPTIONS = "routingOptions";
         public static final String USE_SCAN_REORDER_OPTIMIZATION = "useScanReorderOpt";
         public static final String MAX_EXECUTION_THREADS = "maxExecutionThreads";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -280,6 +280,7 @@ public class CommonConstants {
         public static final String SKIP_UPSERT = "skipUpsert";
         public static final String USE_STAR_TREE = "useStarTree";
         public static final String SCAN_STAR_TREE_NODES = "scanStarTreeNodes";
+        public static final String SCAN_STAR_TREE_NODES_ON_HEAP = "scanStarTreeNodesOnHeap";
         public static final String ROUTING_OPTIONS = "routingOptions";
         public static final String USE_SCAN_REORDER_OPTIMIZATION = "useScanReorderOpt";
         public static final String MAX_EXECUTION_THREADS = "maxExecutionThreads";


### PR DESCRIPTION
Add a query option `reduceRandomAccess`. For now it's mainly to reduce random access when traversing StarTree index, by caching node's fields to avoid probing the underlying index buffer back and forth when moving from many parent nodes to many children nodes, thus making reads over the index buffer sequential during BFS. By default, it's off so things work as before.