### PR TITLE
logging error if tableConfig is null while retrieving all tables for a tenant

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTenantRestletResource.java
@@ -246,6 +246,10 @@ public class PinotTenantRestletResource {
 
     for (String table : _pinotHelixResourceManager.getAllTables()) {
       TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(table);
+      if (tableConfig == null) {
+        LOGGER.error("Unable to retrieve table config for table: {}", table);
+        continue;
+      }
       String tableConfigTenant = tableConfig.getTenantConfig().getServer();
       if (tenantName.equals(tableConfigTenant)) {
         tables.add(table);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTenantRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTenantRestletResourceTest.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.controller.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.spi.config.table.TableType;
@@ -67,6 +69,17 @@ public class PinotTenantRestletResourceTest {
     }
 
     assertTrue(found);
+
+    // reset the ZK node to simulate corruption
+    ZkHelixPropertyStore<ZNRecord> propertyStore = TEST_INSTANCE.getPropertyStore();
+    String zkPath = "/CONFIGS/TABLE/" + TABLE_NAME;
+    ZNRecord znRecord = propertyStore.get(zkPath, null, 0);
+    propertyStore.set(zkPath, new ZNRecord(znRecord.getId()), 1);
+
+    // Now there should be no tables
+    tableList = JsonUtils.stringToJsonNode(ControllerTest.sendGetRequest(listTablesUrl));
+    tables = tableList.get("tables");
+    assertEquals(tables.size(), 0);
   }
 
   @AfterClass


### PR DESCRIPTION
In cases such as deleting a large table, the table config may become invalid, therefore causing a NullPointerException to be raised when listing all the tables for a tenant. Also, if a single table becomes invalid the Controller UI home page and tenants page fail to load. This fix adds a null check to allow the API to return without the invalid table.

![Screen Shot 2023-01-08 at 5 26 34 PM](https://user-images.githubusercontent.com/1396928/211229163-564aa954-94f5-4d86-af8d-e00b0e838175.png)

![Screen Shot 2023-01-08 at 5 25 37 PM](https://user-images.githubusercontent.com/1396928/211229165-422f0188-ecf0-44d5-8184-984b94cc5220.png)

![Screen Shot 2023-01-08 at 5 25 19 PM](https://user-images.githubusercontent.com/1396928/211229171-8e43a54c-b692-4e03-a80d-1901998fefdb.png)