### PR TITLE
handle null more defensively when loading startree index

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -200,7 +200,7 @@ public class ImmutableSegmentLoader {
 
     // Load star-tree index if it exists
     StarTreeIndexContainer starTreeIndexContainer = null;
-    if (segmentMetadata.getStarTreeV2MetadataList() != null) {
+    if (segmentMetadata.getStarTreeV2MetadataList() != null && segmentReader.getStarTreeIndex() != null) {
       starTreeIndexContainer = new StarTreeIndexContainer(segmentReader, segmentMetadata, indexContainerMap);
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexContainer.java
@@ -26,7 +26,6 @@ import java.util.Map;
 import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
-import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 
 
@@ -39,11 +38,10 @@ public class StarTreeIndexContainer implements Closeable {
   public StarTreeIndexContainer(SegmentDirectory.Reader segmentReader, SegmentMetadataImpl segmentMetadata,
       Map<String, ColumnIndexContainer> indexContainerMap)
       throws IOException {
-    try (InputStream indexMap = segmentReader.getStarTreeIndexMap()) {
-      PinotDataBuffer indexData = segmentReader.getStarTreeIndex();
-      _starTrees = (indexData != null && indexMap != null) ? StarTreeLoaderUtils.loadStarTreeV2(indexData,
-          StarTreeIndexMapUtils.loadFromInputStream(indexMap, segmentMetadata.getStarTreeV2MetadataList().size()),
-          segmentMetadata, indexContainerMap) : null;
+    try (InputStream inputStream = segmentReader.getStarTreeIndexMap()) {
+      _starTrees = StarTreeLoaderUtils.loadStarTreeV2(segmentReader.getStarTreeIndex(),
+          StarTreeIndexMapUtils.loadFromInputStream(inputStream, segmentMetadata.getStarTreeV2MetadataList().size()),
+          segmentMetadata, indexContainerMap);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexContainer.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import org.apache.pinot.segment.spi.index.column.ColumnIndexContainer;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 
 
@@ -38,10 +39,11 @@ public class StarTreeIndexContainer implements Closeable {
   public StarTreeIndexContainer(SegmentDirectory.Reader segmentReader, SegmentMetadataImpl segmentMetadata,
       Map<String, ColumnIndexContainer> indexContainerMap)
       throws IOException {
-    try (InputStream inputStream = segmentReader.getStarTreeIndexMap()) {
-      _starTrees = StarTreeLoaderUtils.loadStarTreeV2(segmentReader.getStarTreeIndex(),
-          StarTreeIndexMapUtils.loadFromInputStream(inputStream, segmentMetadata.getStarTreeV2MetadataList().size()),
-          segmentMetadata, indexContainerMap);
+    try (InputStream indexMap = segmentReader.getStarTreeIndexMap()) {
+      PinotDataBuffer indexData = segmentReader.getStarTreeIndex();
+      _starTrees = (indexData != null && indexMap != null) ? StarTreeLoaderUtils.loadStarTreeV2(indexData,
+          StarTreeIndexMapUtils.loadFromInputStream(indexMap, segmentMetadata.getStarTreeV2MetadataList().size()),
+          segmentMetadata, indexContainerMap) : null;
     }
   }
 


### PR DESCRIPTION
this also gives custom segment directory loaders a way to skip startree index by returning null for the index data