### PR TITLE
report minion task queue metrics at table level

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -119,6 +119,18 @@ rules:
     table: "$1"
     tableType: "$2"
     taskType: "$3"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.(numMinionSubtasksRunning|numMinionSubtasksWaiting|numMinionSubtasksError|percentMinionSubtasksInQueue|percentMinionSubtasksInError).(\\w+)_(\\w+).(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_$1_$5"
+  cache: true
+  labels:
+    table: "$2"
+    tableType: "$3"
+    taskType: "$4"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.(numMinionTasksInProgress|numMinionSubtasksRunning|numMinionSubtasksWaiting|numMinionSubtasksError|percentMinionSubtasksInQueue|percentMinionSubtasksInError).(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_$1_$3"
+  cache: true
+  labels:
+    taskType: "$2"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.timeMsSinceLastSuccessfulMinionTaskGeneration.(\\w+)_(\\w+)\\.(\\w+)\"><>(\\w+)"
   name: "pinot_controller_timeMsSinceLastSuccessfulMinionTaskGeneration_$4"
   cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -108,6 +108,18 @@ rules:
     table: "$1"
     tableType: "$2"
     taskType: "$3"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.(numMinionSubtasksRunning|numMinionSubtasksWaiting|numMinionSubtasksError|percentMinionSubtasksInQueue|percentMinionSubtasksInError).(\\w+)_(\\w+).(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_$1_$5"
+  cache: true
+  labels:
+    table: "$2"
+    tableType: "$3"
+    taskType: "$4"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.(numMinionTasksInProgress|numMinionSubtasksRunning|numMinionSubtasksWaiting|numMinionSubtasksError|percentMinionSubtasksInQueue|percentMinionSubtasksInError).(\\w+)\"><>(\\w+)"
+  name: "pinot_controller_$1_$3"
+  cache: true
+  labels:
+    taskType: "$2"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.timeMsSinceLastSuccessfulMinionTaskGeneration.(\\w+)_(\\w+)\\.(\\w+)\"><>(\\w+)"
   name: "pinot_controller_timeMsSinceLastSuccessfulMinionTaskGeneration_$4"
   cache: true

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMetrics.java
@@ -61,6 +61,7 @@ public class BrokerMetrics extends AbstractMetrics<BrokerQueryPhase, BrokerMeter
     return BrokerMeter.values();
   }
 
+  @Override
   protected BrokerGauge[] getGauges() {
     return BrokerGauge.values();
   }

--- a/pinot-common/src/test/java/org/apache/pinot/common/metrics/AbstractMetricsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/metrics/AbstractMetricsTest.java
@@ -42,11 +42,11 @@ public class AbstractMetricsTest {
     ControllerMetrics controllerMetrics = new ControllerMetrics(new YammerMetricsRegistry());
     String metricName = "test";
     // add gauge
-    controllerMetrics.addOrUpdateGauge(metricName, () -> 1L);
+    controllerMetrics.setOrUpdateGauge(metricName, () -> 1L);
     checkGauge(controllerMetrics, metricName, 1);
 
     // update gauge
-    controllerMetrics.addOrUpdateGauge(metricName, () -> 2L);
+    controllerMetrics.setOrUpdateGauge(metricName, () -> 2L);
     checkGauge(controllerMetrics, metricName, 2);
 
     // remove gauge

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -58,6 +58,7 @@ import org.apache.pinot.controller.api.exception.NoTaskScheduledException;
 import org.apache.pinot.controller.api.exception.UnknownTaskTypeException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.CompletionServiceHelper;
+import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
@@ -80,6 +81,7 @@ public class PinotHelixTaskResourceManager {
 
   private static final String TASK_QUEUE_PREFIX = "TaskQueue" + TASK_NAME_SEPARATOR;
   private static final String TASK_PREFIX = "Task" + TASK_NAME_SEPARATOR;
+  private static final String UNKNOWN_TABLE_NAME = "unknown";
 
   private final TaskDriver _taskDriver;
   private final PinotHelixResourceManager _helixResourceManager;
@@ -345,7 +347,7 @@ public class PinotHelixTaskResourceManager {
 
   /**
    * This method returns a count of sub-tasks in various states, given the top-level task name.
-   * @param parentTaskName (e.g. "Task_TestTask_1624403781879")
+   * @param parentTaskName in the form "Task_<taskType>_<uuid>_<timestamp>"
    * @return TaskCount object
    */
   public synchronized TaskCount getTaskCount(String parentTaskName) {
@@ -364,7 +366,46 @@ public class PinotHelixTaskResourceManager {
   }
 
   /**
-   * Returns a set of Task names (in the form "Task_TestTask_1624403781879") that are in progress or not started yet.
+   * This method returns a map of table name to count of sub-tasks in various states, given the top-level task name.
+   * @param parentTaskName in the form "Task_<taskType>_<uuid>_<timestamp>"
+   * @return a map of table name to {@link TaskCount}
+   */
+  public synchronized Map<String, TaskCount> getTableTaskCount(String parentTaskName) {
+    Map<String, TaskPartitionState> subtaskStates = getSubtaskStates(parentTaskName);
+    if (subtaskStates.isEmpty()) {
+      return Collections.emptyMap();
+    }
+
+    JobConfig jobConfig = _taskDriver.getJobConfig(getHelixJobName(parentTaskName));
+    // in theory, this should not happen because we have already checked JobContext
+    if (jobConfig == null) {
+      return Collections.emptyMap();
+    }
+
+    Map<String, TaskCount> tableTaskCountMap = new HashMap<>();
+    subtaskStates.forEach((taskId, taskState) -> {
+      TaskConfig taskConfig = jobConfig.getTaskConfig(taskId);
+      String tableNameWithType;
+      // in theory, this should not happen because jobContext has this taskId
+      if (taskConfig == null) {
+        tableNameWithType = UNKNOWN_TABLE_NAME;
+      } else {
+        tableNameWithType = taskConfig.getConfigMap().getOrDefault(MinionConstants.TABLE_NAME_KEY, UNKNOWN_TABLE_NAME);
+      }
+      tableTaskCountMap.compute(tableNameWithType, (name, taskCount) -> {
+        if (taskCount == null) {
+          taskCount = new TaskCount();
+        }
+        taskCount.addTaskState(taskState);
+        return taskCount;
+      });
+    });
+    return tableTaskCountMap;
+  }
+
+  /**
+   * Returns a set of Task names (in the form "Task_<taskType>_<uuid>_<timestamp>") that are in progress or not started
+   * yet.
    *
    * @param taskType
    * @return Set of task names
@@ -594,16 +635,12 @@ public class PinotHelixTaskResourceManager {
 
       // Iterate through all task configs associated with this task name
       for (PinotTaskConfig taskConfig : getSubtaskConfigs(taskName)) {
-        Map<String, String> pinotConfigs = taskConfig.getConfigs();
-
         // Filter task configs that matches this table name
-        if (pinotConfigs != null) {
-          String tableNameConfig = pinotConfigs.get(TABLE_NAME);
-          if (tableNameConfig != null && tableNameConfig.equals(tableNameWithType)) {
-            // Found a match ! Track state for this particular task in the final result map
-            filteredTaskStateMap.put(taskName, taskStateMap.get(taskName));
-            break;
-          }
+        String tableNameConfig = taskConfig.getTableName();
+        if (tableNameConfig != null && tableNameConfig.equals(tableNameWithType)) {
+          // Found a match ! Track state for this particular task in the final result map
+          filteredTaskStateMap.put(taskName, taskStateMap.get(taskName));
+          break;
         }
       }
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -547,13 +547,11 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
             taskGeneratorMostRecentRunInfo -> taskGeneratorMostRecentRunInfo.addSuccessRunTs(successRunTimestamp));
         // before the first task schedule, the follow two gauge metrics will be empty
         // TODO: find a better way to report task generation information
-        _controllerMetrics.addOrUpdateGauge(
-            ControllerGauge.TIME_MS_SINCE_LAST_SUCCESSFUL_MINION_TASK_GENERATION.getGaugeName() + "."
-                + tableConfig.getTableName() + "." + taskGenerator.getTaskType(),
+        _controllerMetrics.setOrUpdateTableGauge(tableConfig.getTableName(), taskGenerator.getTaskType(),
+            ControllerGauge.TIME_MS_SINCE_LAST_SUCCESSFUL_MINION_TASK_GENERATION,
             () -> System.currentTimeMillis() - successRunTimestamp);
-        _controllerMetrics.addOrUpdateGauge(
-            ControllerGauge.LAST_MINION_TASK_GENERATION_ENCOUNTERS_ERROR.getGaugeName() + "."
-                + tableConfig.getTableName() + "." + taskGenerator.getTaskType(), () -> 0L);
+        _controllerMetrics.setOrUpdateTableGauge(tableConfig.getTableName(), taskGenerator.getTaskType(),
+            ControllerGauge.LAST_MINION_TASK_GENERATION_ENCOUNTERS_ERROR, 0L);
       }
     } catch (Exception e) {
       StringWriter errors = new StringWriter();
@@ -567,9 +565,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
                 successRunTimestamp, errors.toString()));
         // before the first task schedule, the follow gauge metric will be empty
         // TODO: find a better way to report task generation information
-        _controllerMetrics.addOrUpdateGauge(
-            ControllerGauge.LAST_MINION_TASK_GENERATION_ENCOUNTERS_ERROR.getGaugeName() + "."
-                + tableConfig.getTableName() + "." + taskGenerator.getTaskType(), () -> 1L);
+        _controllerMetrics.setOrUpdateTableGauge(tableConfig.getTableName(), taskGenerator.getTaskType(),
+            ControllerGauge.LAST_MINION_TASK_GENERATION_ENCOUNTERS_ERROR, 1L);
       }
       throw e;
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitter.java
@@ -138,7 +138,6 @@ public class TaskMetricsEmitter extends BasePeriodicTask {
               ControllerGauge.PERCENT_MINION_SUBTASKS_IN_ERROR, tablePercent);
         });
 
-
         if (_preReportedTables.containsKey(taskType)) {
           Set<String> tableNameWithTypeSet = _preReportedTables.get(taskType);
           tableNameWithTypeSet.removeAll(tableAccumulatedCount.keySet());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitter.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.controller.helix.core.minion;
 
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
@@ -49,6 +51,9 @@ public class TaskMetricsEmitter extends BasePeriodicTask {
   private final ControllerMetrics _controllerMetrics;
   private final LeadControllerManager _leadControllerManager;
 
+  private final Set<String> _preReportedTaskTypes;
+  private final Map<String, Set<String>> _preReportedTables;
+
   public TaskMetricsEmitter(PinotHelixResourceManager pinotHelixResourceManager,
       PinotHelixTaskResourceManager helixTaskResourceManager, LeadControllerManager leadControllerManager,
       ControllerConf controllerConf, ControllerMetrics controllerMetrics) {
@@ -58,6 +63,8 @@ public class TaskMetricsEmitter extends BasePeriodicTask {
     _helixTaskResourceManager = helixTaskResourceManager;
     _controllerMetrics = controllerMetrics;
     _leadControllerManager = leadControllerManager;
+    _preReportedTaskTypes = new HashSet<>();
+    _preReportedTables = new HashMap<>();
   }
 
   @Override
@@ -71,41 +78,104 @@ public class TaskMetricsEmitter extends BasePeriodicTask {
         _helixTaskResourceManager.getTaskMetadataLastUpdateTimeMs();
     taskMetadataLastUpdateTime.forEach((tableNameWithType, taskTypeLastUpdateTime) ->
         taskTypeLastUpdateTime.forEach((taskType, lastUpdateTimeMs) ->
-            _controllerMetrics.addOrUpdateGauge(
-                ControllerGauge.TIME_MS_SINCE_LAST_MINION_TASK_METADATA_UPDATE.getGaugeName() + "."
-                    + tableNameWithType + "." + taskType, () -> System.currentTimeMillis() - lastUpdateTimeMs)));
+            _controllerMetrics.setOrUpdateTableGauge(tableNameWithType, taskType,
+                ControllerGauge.TIME_MS_SINCE_LAST_MINION_TASK_METADATA_UPDATE,
+                () -> System.currentTimeMillis() - lastUpdateTimeMs)));
 
     // The call to get task types can take time if there are a lot of tasks.
     // Potential optimization is to call it every (say) 30m if we detect a barrage of
     // zk requests.
     Set<String> taskTypes = _helixTaskResourceManager.getTaskTypes();
     for (String taskType : taskTypes) {
-      TaskCount accumulated = new TaskCount();
+      TaskCount taskTypeAccumulatedCount = new TaskCount();
+      Map<String, TaskCount> tableAccumulatedCount = new HashMap<>();
       try {
         Set<String> tasksInProgress = _helixTaskResourceManager.getTasksInProgress(taskType);
         final int numRunningTasks = tasksInProgress.size();
         for (String task : tasksInProgress) {
-          TaskCount taskCount = _helixTaskResourceManager.getTaskCount(task);
-          accumulated.accumulate(taskCount);
+          Map<String, TaskCount> tableTaskCount = _helixTaskResourceManager.getTableTaskCount(task);
+          tableTaskCount.forEach((tableNameWithType, taskCount) -> {
+            taskTypeAccumulatedCount.accumulate(taskCount);
+            tableAccumulatedCount.compute(tableNameWithType, (name, count) -> {
+              if (count == null) {
+                count = new TaskCount();
+              }
+              count.accumulate(taskCount);
+              return count;
+            });
+          });
         }
         // Emit metrics for taskType.
         _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.NUM_MINION_TASKS_IN_PROGRESS, taskType,
             numRunningTasks);
         _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.NUM_MINION_SUBTASKS_RUNNING, taskType,
-            accumulated.getRunning());
+            taskTypeAccumulatedCount.getRunning());
         _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.NUM_MINION_SUBTASKS_WAITING, taskType,
-            accumulated.getWaiting());
+            taskTypeAccumulatedCount.getWaiting());
         _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.NUM_MINION_SUBTASKS_ERROR, taskType,
-            accumulated.getError());
-        int total = accumulated.getTotal();
-        int percent = total != 0 ? (accumulated.getWaiting() + accumulated.getRunning()) * 100 / total : 0;
+            taskTypeAccumulatedCount.getError());
+        int total = taskTypeAccumulatedCount.getTotal();
+        int percent = total != 0
+            ? (taskTypeAccumulatedCount.getWaiting() + taskTypeAccumulatedCount.getRunning()) * 100 / total : 0;
         _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.PERCENT_MINION_SUBTASKS_IN_QUEUE, taskType, percent);
-        percent = total != 0 ? accumulated.getError() * 100 / total : 0;
+        percent = total != 0 ? taskTypeAccumulatedCount.getError() * 100 / total : 0;
         _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.PERCENT_MINION_SUBTASKS_IN_ERROR, taskType, percent);
+
+        // Emit metrics for table taskType
+        tableAccumulatedCount.forEach((tableNameWithType, taskCount) -> {
+          _controllerMetrics.setOrUpdateTableGauge(tableNameWithType, taskType,
+              ControllerGauge.NUM_MINION_SUBTASKS_RUNNING, () -> (long) taskCount.getRunning());
+          _controllerMetrics.setOrUpdateTableGauge(tableNameWithType, taskType,
+              ControllerGauge.NUM_MINION_SUBTASKS_WAITING, taskCount.getWaiting());
+          _controllerMetrics.setOrUpdateTableGauge(tableNameWithType, taskType,
+              ControllerGauge.NUM_MINION_SUBTASKS_ERROR, taskCount.getError());
+          int tableTotal = taskCount.getTotal();
+          int tablePercent = tableTotal != 0 ? (taskCount.getWaiting() + taskCount.getRunning()) * 100 / tableTotal : 0;
+          _controllerMetrics.setOrUpdateTableGauge(tableNameWithType, taskType,
+              ControllerGauge.PERCENT_MINION_SUBTASKS_IN_QUEUE, tablePercent);
+          tablePercent = tableTotal != 0 ? taskCount.getError() * 100 / tableTotal : 0;
+          _controllerMetrics.setOrUpdateTableGauge(tableNameWithType, taskType,
+              ControllerGauge.PERCENT_MINION_SUBTASKS_IN_ERROR, tablePercent);
+        });
+
+
+        if (_preReportedTables.containsKey(taskType)) {
+          Set<String> tableNameWithTypeSet = _preReportedTables.get(taskType);
+          tableNameWithTypeSet.removeAll(tableAccumulatedCount.keySet());
+          removeTableTaskTypeMetrics(tableNameWithTypeSet, taskType);
+        }
+        if (!tableAccumulatedCount.isEmpty()) {
+          // need to make a copy of the set because we may want to chagne the set later
+          Set<String> tableNameWithTypeSet = new HashSet<>(tableAccumulatedCount.keySet());
+          _preReportedTables.put(taskType, tableNameWithTypeSet);
+        } else {
+          _preReportedTables.remove(taskType);
+        }
       } catch (Exception e) {
         LOGGER.error("Caught exception while getting metrics for task type {}", taskType, e);
       }
     }
+
+    // clean up metrics for task types that have already been removed
+    _preReportedTaskTypes.removeAll(taskTypes);
+    for (String taskType : _preReportedTaskTypes) {
+      // remove task type level gauges
+      _controllerMetrics.removeGlobalGauge(taskType, ControllerGauge.NUM_MINION_TASKS_IN_PROGRESS);
+      _controllerMetrics.removeGlobalGauge(taskType, ControllerGauge.NUM_MINION_SUBTASKS_RUNNING);
+      _controllerMetrics.removeGlobalGauge(taskType, ControllerGauge.NUM_MINION_SUBTASKS_WAITING);
+      _controllerMetrics.removeGlobalGauge(taskType, ControllerGauge.NUM_MINION_SUBTASKS_ERROR);
+      _controllerMetrics.removeGlobalGauge(taskType, ControllerGauge.PERCENT_MINION_SUBTASKS_IN_QUEUE);
+      _controllerMetrics.removeGlobalGauge(taskType, ControllerGauge.PERCENT_MINION_SUBTASKS_IN_ERROR);
+      // remove table task type level gauges
+      if (_preReportedTables.containsKey(taskType)) {
+        removeTableTaskTypeMetrics(_preReportedTables.get(taskType), taskType);
+        _preReportedTables.remove(taskType);
+      }
+    }
+
+    // update previously reported task types
+    _preReportedTaskTypes.clear();
+    _preReportedTaskTypes.addAll(taskTypes);
 
     // Emit metric to count the number of online minion instances.
     List<String> onlineInstances = _pinotHelixResourceManager.getOnlineInstanceList();
@@ -116,5 +186,17 @@ public class TaskMetricsEmitter extends BasePeriodicTask {
       }
     }
     _controllerMetrics.setValueOfGlobalGauge(ControllerGauge.ONLINE_MINION_INSTANCES, onlineMinionInstanceCount);
+  }
+
+  private void removeTableTaskTypeMetrics(Set<String> tableNameWithTypeSet, String taskType) {
+    tableNameWithTypeSet.forEach(tableNameWithType -> {
+      _controllerMetrics.removeTableGauge(tableNameWithType, taskType, ControllerGauge.NUM_MINION_SUBTASKS_RUNNING);
+      _controllerMetrics.removeTableGauge(tableNameWithType, taskType, ControllerGauge.NUM_MINION_SUBTASKS_WAITING);
+      _controllerMetrics.removeTableGauge(tableNameWithType, taskType, ControllerGauge.NUM_MINION_SUBTASKS_ERROR);
+      _controllerMetrics.removeTableGauge(tableNameWithType, taskType,
+          ControllerGauge.PERCENT_MINION_SUBTASKS_IN_QUEUE);
+      _controllerMetrics.removeTableGauge(tableNameWithType, taskType,
+          ControllerGauge.PERCENT_MINION_SUBTASKS_IN_ERROR);
+    });
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManagerTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.controller.helix.core.minion;
 
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -210,7 +212,7 @@ public class PinotHelixTaskResourceManagerTest {
 
     JobContext jobContext = mock(JobContext.class);
     when(taskDriver.getJobContext(helixJobName)).thenReturn(jobContext);
-    when(jobContext.getPartitionSet()).thenReturn(Set.of(0, 1));
+    when(jobContext.getPartitionSet()).thenReturn(ImmutableSet.of(0, 1));
     when(jobContext.getTaskIdForPartition(0)).thenReturn("taskId0");
     when(jobContext.getTaskIdForPartition(1)).thenReturn("taskId1");
     when(jobContext.getPartitionState(0)).thenReturn(TaskPartitionState.RUNNING);
@@ -220,7 +222,7 @@ public class PinotHelixTaskResourceManagerTest {
     when(taskDriver.getJobConfig(helixJobName)).thenReturn(jobConfig);
     when(jobConfig.getTaskConfig("taskId0")).thenReturn(new TaskConfig("", new HashMap<>()));
     when(jobConfig.getTaskConfig("taskId1")).thenReturn(new TaskConfig("",
-        new HashMap<>(Map.of("tableName", "table1_OFFLINE"))));
+        new HashMap<>(ImmutableMap.of("tableName", "table1_OFFLINE"))));
 
     PinotHelixTaskResourceManager mgr =
         new PinotHelixTaskResourceManager(mock(PinotHelixResourceManager.class), taskDriver);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManagerTest.java
@@ -24,9 +24,12 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.helix.task.JobConfig;
 import org.apache.helix.task.JobContext;
+import org.apache.helix.task.TaskConfig;
 import org.apache.helix.task.TaskDriver;
 import org.apache.helix.task.TaskPartitionState;
+import org.apache.helix.task.WorkflowContext;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.CompletionServiceHelper;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -192,5 +195,51 @@ public class PinotHelixTaskResourceManagerTest {
     assertEquals(taskProgress, "No worker has run this subtask");
     taskProgress = (String) progress.get(subtaskNames[2]);
     assertEquals(taskProgress, "No worker has run this subtask");
+  }
+
+  @Test
+  public void testGetTableTaskCount() {
+    String taskType = "TestTask";
+    String taskName = "Task_TestTask_12345";
+    String helixJobQueueName = PinotHelixTaskResourceManager.getHelixJobQueueName(taskType);
+    String helixJobName = helixJobQueueName + "_" + taskName;
+
+    TaskDriver taskDriver = mock(TaskDriver.class);
+    WorkflowContext workflowContext = mock(WorkflowContext.class);
+    when(taskDriver.getWorkflowContext(helixJobQueueName)).thenReturn(workflowContext);
+
+    JobContext jobContext = mock(JobContext.class);
+    when(taskDriver.getJobContext(helixJobName)).thenReturn(jobContext);
+    when(jobContext.getPartitionSet()).thenReturn(Set.of(0, 1));
+    when(jobContext.getTaskIdForPartition(0)).thenReturn("taskId0");
+    when(jobContext.getTaskIdForPartition(1)).thenReturn("taskId1");
+    when(jobContext.getPartitionState(0)).thenReturn(TaskPartitionState.RUNNING);
+    when(jobContext.getPartitionState(1)).thenReturn(TaskPartitionState.COMPLETED);
+
+    JobConfig jobConfig = mock(JobConfig.class);
+    when(taskDriver.getJobConfig(helixJobName)).thenReturn(jobConfig);
+    when(jobConfig.getTaskConfig("taskId0")).thenReturn(new TaskConfig("", new HashMap<>()));
+    when(jobConfig.getTaskConfig("taskId1")).thenReturn(new TaskConfig("",
+        new HashMap<>(Map.of("tableName", "table1_OFFLINE"))));
+
+    PinotHelixTaskResourceManager mgr =
+        new PinotHelixTaskResourceManager(mock(PinotHelixResourceManager.class), taskDriver);
+    Map<String, PinotHelixTaskResourceManager.TaskCount> tableTaskCount = mgr.getTableTaskCount(taskName);
+    assertEquals(tableTaskCount.size(), 2);
+
+    PinotHelixTaskResourceManager.TaskCount taskCount = tableTaskCount.get("table1_OFFLINE");
+    assertEquals(taskCount.getTotal(), 1);
+    assertEquals(taskCount.getCompleted(), 1);
+    assertEquals(taskCount.getRunning(), 0);
+    assertEquals(taskCount.getWaiting(), 0);
+    assertEquals(taskCount.getError(), 0);
+    assertEquals(taskCount.getUnknown(), 0);
+    taskCount = tableTaskCount.get("unknown");
+    assertEquals(taskCount.getTotal(), 1);
+    assertEquals(taskCount.getCompleted(), 0);
+    assertEquals(taskCount.getRunning(), 1);
+    assertEquals(taskCount.getWaiting(), 0);
+    assertEquals(taskCount.getError(), 0);
+    assertEquals(taskCount.getUnknown(), 0);
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitterTest.java
@@ -1,0 +1,304 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.minion;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.task.TaskPartitionState;
+import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.LeadControllerManager;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.plugin.metrics.yammer.YammerMetricName;
+import org.apache.pinot.plugin.metrics.yammer.YammerMetricsRegistry;
+import org.apache.pinot.plugin.metrics.yammer.YammerSettableGauge;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.metrics.PinotMetricUtils;
+import org.apache.pinot.spi.metrics.PinotMetricsRegistry;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.utils.CommonConstants.CONFIG_OF_METRICS_FACTORY_CLASS_NAME;
+
+
+public class TaskMetricsEmitterTest {
+  private TaskMetricsEmitter _taskMetricsEmitter;
+  private ControllerMetrics _controllerMetrics;
+  private PinotHelixTaskResourceManager _pinotHelixTaskResourceManager;
+
+  @BeforeMethod
+  public void setUp() {
+    // initialize PinotMetrics
+    PinotConfiguration pinotConfiguration = new PinotConfiguration();
+    pinotConfiguration.setProperty(CONFIG_OF_METRICS_FACTORY_CLASS_NAME,
+        "org.apache.pinot.plugin.metrics.yammer.YammerMetricsFactory");
+    PinotMetricUtils.init(pinotConfiguration);
+
+    _controllerMetrics = new ControllerMetrics(new YammerMetricsRegistry());
+    _pinotHelixTaskResourceManager = Mockito.mock(PinotHelixTaskResourceManager.class);
+    PinotHelixResourceManager pinotHelixResourceManager = Mockito.mock(PinotHelixResourceManager.class);
+    LeadControllerManager leadControllerManager = Mockito.mock(LeadControllerManager.class);
+
+    Mockito.when(_pinotHelixTaskResourceManager.getTaskMetadataLastUpdateTimeMs()).thenReturn(Map.of());
+    Mockito.when(leadControllerManager.isLeaderForTable("TaskMetricsEmitter")).thenReturn(true);
+    Mockito.when(pinotHelixResourceManager.getOnlineInstanceList()).thenReturn(List.of());
+
+    _taskMetricsEmitter = new TaskMetricsEmitter(pinotHelixResourceManager,
+        _pinotHelixTaskResourceManager, leadControllerManager, new ControllerConf(), _controllerMetrics);
+  }
+
+  @Test
+  public void noTaskTypeMetrics() {
+    PinotMetricsRegistry metricsRegistry = _controllerMetrics.getMetricsRegistry();
+    Mockito.when(_pinotHelixTaskResourceManager.getTaskTypes()).thenReturn(Set.of());
+    _taskMetricsEmitter.runTask(null);
+    Assert.assertEquals(metricsRegistry.allMetrics().size(), 1);
+    Assert.assertTrue(metricsRegistry.allMetrics().containsKey(
+        new YammerMetricName(ControllerMetrics.class, "pinot.controller.onlineMinionInstances")));
+  }
+
+  @Test
+  public void taskType1ButNoInProgressTask() {
+    PinotMetricsRegistry metricsRegistry = _controllerMetrics.getMetricsRegistry();
+    String taskType = "taskType1";
+    Mockito.when(_pinotHelixTaskResourceManager.getTaskTypes()).thenReturn(Set.of(taskType));
+    Mockito.when(_pinotHelixTaskResourceManager.getTasksInProgress(taskType)).thenReturn(Set.of());
+    _taskMetricsEmitter.runTask(null);
+
+    Assert.assertEquals(metricsRegistry.allMetrics().size(), 7);
+    Assert.assertTrue(metricsRegistry.allMetrics().containsKey(
+        new YammerMetricName(ControllerMetrics.class, "pinot.controller.onlineMinionInstances")));
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionTasksInProgress.taskType1"))
+        .getMetric()).value(), 0L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionSubtasksRunning.taskType1"))
+        .getMetric()).value(), 0L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionSubtasksWaiting.taskType1"))
+        .getMetric()).value(), 0L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionSubtasksError.taskType1"))
+        .getMetric()).value(), 0L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class, "pinot.controller.percentMinionSubtasksInQueue.taskType1"))
+        .getMetric()).value(), 0L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class, "pinot.controller.percentMinionSubtasksInError.taskType1"))
+        .getMetric()).value(), 0L);
+  }
+
+  @Test
+  public void oneSingleTaskTypeWithTwoTables() {
+    String taskType = "taskType1";
+    Mockito.when(_pinotHelixTaskResourceManager.getTaskTypes()).thenReturn(Set.of(taskType));
+    String task11 = "task11";
+    String task12 = "task12";
+    Mockito.when(_pinotHelixTaskResourceManager.getTasksInProgress(taskType)).thenReturn(Set.of(task11, task12));
+
+    String table1 = "table1_OFFLINE";
+    String table2 = "table2_OFFLINE";
+    PinotHelixTaskResourceManager.TaskCount taskCount1 = new PinotHelixTaskResourceManager.TaskCount();
+    taskCount1.addTaskState(TaskPartitionState.COMPLETED);
+    PinotHelixTaskResourceManager.TaskCount taskCount2 = new PinotHelixTaskResourceManager.TaskCount();
+    taskCount2.addTaskState(TaskPartitionState.RUNNING);
+    Mockito.when(_pinotHelixTaskResourceManager.getTableTaskCount(task11)).thenReturn(
+        Map.of(table1, taskCount1, table2, taskCount2));
+    taskCount1 = new PinotHelixTaskResourceManager.TaskCount();
+    taskCount1.addTaskState(null);
+    taskCount2 = new PinotHelixTaskResourceManager.TaskCount();
+    taskCount2.addTaskState(TaskPartitionState.TASK_ERROR);
+    Mockito.when(_pinotHelixTaskResourceManager.getTableTaskCount(task12)).thenReturn(
+        Map.of(table1, taskCount1, table2, taskCount2));
+
+    runAndAssertForTaskType1WithTwoTables();
+  }
+
+  @Test
+  public void taskType1WithTwoTablesEmitMetricTwice() {
+    oneSingleTaskTypeWithTwoTables();
+    // the second run does not change anything
+    runAndAssertForTaskType1WithTwoTables();
+  }
+
+  private void runAndAssertForTaskType1WithTwoTables() {
+    PinotMetricsRegistry metricsRegistry = _controllerMetrics.getMetricsRegistry();
+    _taskMetricsEmitter.runTask(null);
+    Assert.assertEquals(metricsRegistry.allMetrics().size(), 17);
+
+    Assert.assertTrue(metricsRegistry.allMetrics().containsKey(
+        new YammerMetricName(ControllerMetrics.class, "pinot.controller.onlineMinionInstances")));
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionTasksInProgress.taskType1"))
+        .getMetric()).value(), 2L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionSubtasksRunning.taskType1"))
+        .getMetric()).value(), 1L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionSubtasksWaiting.taskType1"))
+        .getMetric()).value(), 1L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionSubtasksError.taskType1"))
+        .getMetric()).value(), 1L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class, "pinot.controller.percentMinionSubtasksInQueue.taskType1"))
+        .getMetric()).value(), 50L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class, "pinot.controller.percentMinionSubtasksInError.taskType1"))
+        .getMetric()).value(), 25L);
+
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                "pinot.controller.numMinionSubtasksRunning.table1_OFFLINE.taskType1"))
+        .getMetric()).value(), 0L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                "pinot.controller.numMinionSubtasksWaiting.table1_OFFLINE.taskType1"))
+        .getMetric()).value(), 1L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                "pinot.controller.numMinionSubtasksError.table1_OFFLINE.taskType1"))
+        .getMetric()).value(), 0L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                "pinot.controller.percentMinionSubtasksInQueue.table1_OFFLINE.taskType1"))
+        .getMetric()).value(), 50L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                "pinot.controller.percentMinionSubtasksInError.table1_OFFLINE.taskType1"))
+        .getMetric()).value(), 0L);
+
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                "pinot.controller.numMinionSubtasksRunning.table2_OFFLINE.taskType1"))
+        .getMetric()).value(), 1L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                "pinot.controller.numMinionSubtasksWaiting.table2_OFFLINE.taskType1"))
+        .getMetric()).value(), 0L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                "pinot.controller.numMinionSubtasksError.table2_OFFLINE.taskType1"))
+        .getMetric()).value(), 1L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                "pinot.controller.percentMinionSubtasksInQueue.table2_OFFLINE.taskType1"))
+        .getMetric()).value(), 50L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                "pinot.controller.percentMinionSubtasksInError.table2_OFFLINE.taskType1"))
+        .getMetric()).value(), 50L);
+  }
+
+  @Test
+  public void taskType2WithOneTable() {
+    oneTaskTypeWithOneTable("taskType2", "task21", "task22", "table3_OFFLINE");
+  }
+
+  private void oneTaskTypeWithOneTable(String taskType, String taskName1, String taskName2, String tableName) {
+    Mockito.when(_pinotHelixTaskResourceManager.getTaskTypes()).thenReturn(Set.of(taskType));
+    Mockito.when(_pinotHelixTaskResourceManager.getTasksInProgress(taskType)).thenReturn(Set.of(taskName1, taskName2));
+
+    PinotHelixTaskResourceManager.TaskCount taskCount = new PinotHelixTaskResourceManager.TaskCount();
+    taskCount.addTaskState(TaskPartitionState.COMPLETED);
+    Mockito.when(_pinotHelixTaskResourceManager.getTableTaskCount(taskName1)).thenReturn(Map.of(tableName, taskCount));
+    taskCount = new PinotHelixTaskResourceManager.TaskCount();
+    taskCount.addTaskState(null);
+    Mockito.when(_pinotHelixTaskResourceManager.getTableTaskCount(taskName2)).thenReturn(Map.of(tableName, taskCount));
+
+    PinotMetricsRegistry metricsRegistry = _controllerMetrics.getMetricsRegistry();
+    _taskMetricsEmitter.runTask(null);
+    Assert.assertEquals(metricsRegistry.allMetrics().size(), 12);
+
+    Assert.assertTrue(metricsRegistry.allMetrics().containsKey(
+        new YammerMetricName(ControllerMetrics.class, "pinot.controller.onlineMinionInstances")));
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                String.format("pinot.controller.numMinionTasksInProgress.%s", taskType)))
+        .getMetric()).value(), 2L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                String.format("pinot.controller.numMinionSubtasksRunning.%s", taskType)))
+        .getMetric()).value(), 0L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                String.format("pinot.controller.numMinionSubtasksWaiting.%s", taskType)))
+        .getMetric()).value(), 1L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                String.format("pinot.controller.numMinionSubtasksError.%s", taskType)))
+        .getMetric()).value(), 0L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                String.format("pinot.controller.percentMinionSubtasksInQueue.%s", taskType)))
+        .getMetric()).value(), 50L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                String.format("pinot.controller.percentMinionSubtasksInError.%s", taskType)))
+        .getMetric()).value(), 0L);
+
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                String.format("pinot.controller.numMinionSubtasksRunning.%s.%s", tableName, taskType)))
+        .getMetric()).value(), 0L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                String.format("pinot.controller.numMinionSubtasksWaiting.%s.%s", tableName, taskType)))
+        .getMetric()).value(), 1L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                String.format("pinot.controller.numMinionSubtasksError.%s.%s", tableName, taskType)))
+        .getMetric()).value(), 0L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                String.format("pinot.controller.percentMinionSubtasksInQueue.%s.%s", tableName, taskType)))
+        .getMetric()).value(), 50L);
+    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+            new YammerMetricName(ControllerMetrics.class,
+                String.format("pinot.controller.percentMinionSubtasksInError.%s.%s", tableName, taskType)))
+        .getMetric()).value(), 0L);
+  }
+
+  @Test
+  public void removeOneTableFromMinionTasks() {
+    oneSingleTaskTypeWithTwoTables();
+    oneTaskTypeWithOneTable("taskType1", "task11", "task12", "table1_OFFLINE");
+  }
+
+  @Test
+  public void addOneTableToMinionTasks() {
+    oneTaskTypeWithOneTable("taskType1", "task11", "task12", "table1_OFFLINE");
+    oneSingleTaskTypeWithTwoTables();
+  }
+
+  @Test
+  public void removeTheTaskTypeFromMinionTasks() {
+    oneSingleTaskTypeWithTwoTables();
+    noTaskTypeMetrics();
+  }
+
+  @Test
+  public void removeOldTaskTypeAddNewTaskType() {
+    oneSingleTaskTypeWithTwoTables();
+    taskType2WithOneTable();
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/TaskMetricsEmitterTest.java
@@ -18,9 +18,9 @@
  */
 package org.apache.pinot.controller.helix.core.minion;
 
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import org.apache.helix.task.TaskPartitionState;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.controller.ControllerConf;
@@ -58,9 +58,9 @@ public class TaskMetricsEmitterTest {
     PinotHelixResourceManager pinotHelixResourceManager = Mockito.mock(PinotHelixResourceManager.class);
     LeadControllerManager leadControllerManager = Mockito.mock(LeadControllerManager.class);
 
-    Mockito.when(_pinotHelixTaskResourceManager.getTaskMetadataLastUpdateTimeMs()).thenReturn(Map.of());
+    Mockito.when(_pinotHelixTaskResourceManager.getTaskMetadataLastUpdateTimeMs()).thenReturn(ImmutableMap.of());
     Mockito.when(leadControllerManager.isLeaderForTable("TaskMetricsEmitter")).thenReturn(true);
-    Mockito.when(pinotHelixResourceManager.getOnlineInstanceList()).thenReturn(List.of());
+    Mockito.when(pinotHelixResourceManager.getOnlineInstanceList()).thenReturn(ImmutableList.of());
 
     _taskMetricsEmitter = new TaskMetricsEmitter(pinotHelixResourceManager,
         _pinotHelixTaskResourceManager, leadControllerManager, new ControllerConf(), _controllerMetrics);
@@ -69,7 +69,7 @@ public class TaskMetricsEmitterTest {
   @Test
   public void noTaskTypeMetrics() {
     PinotMetricsRegistry metricsRegistry = _controllerMetrics.getMetricsRegistry();
-    Mockito.when(_pinotHelixTaskResourceManager.getTaskTypes()).thenReturn(Set.of());
+    Mockito.when(_pinotHelixTaskResourceManager.getTaskTypes()).thenReturn(ImmutableSet.of());
     _taskMetricsEmitter.runTask(null);
     Assert.assertEquals(metricsRegistry.allMetrics().size(), 1);
     Assert.assertTrue(metricsRegistry.allMetrics().containsKey(
@@ -80,29 +80,29 @@ public class TaskMetricsEmitterTest {
   public void taskType1ButNoInProgressTask() {
     PinotMetricsRegistry metricsRegistry = _controllerMetrics.getMetricsRegistry();
     String taskType = "taskType1";
-    Mockito.when(_pinotHelixTaskResourceManager.getTaskTypes()).thenReturn(Set.of(taskType));
-    Mockito.when(_pinotHelixTaskResourceManager.getTasksInProgress(taskType)).thenReturn(Set.of());
+    Mockito.when(_pinotHelixTaskResourceManager.getTaskTypes()).thenReturn(ImmutableSet.of(taskType));
+    Mockito.when(_pinotHelixTaskResourceManager.getTasksInProgress(taskType)).thenReturn(ImmutableSet.of());
     _taskMetricsEmitter.runTask(null);
 
     Assert.assertEquals(metricsRegistry.allMetrics().size(), 7);
     Assert.assertTrue(metricsRegistry.allMetrics().containsKey(
         new YammerMetricName(ControllerMetrics.class, "pinot.controller.onlineMinionInstances")));
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionTasksInProgress.taskType1"))
         .getMetric()).value(), 0L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionSubtasksRunning.taskType1"))
         .getMetric()).value(), 0L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionSubtasksWaiting.taskType1"))
         .getMetric()).value(), 0L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionSubtasksError.taskType1"))
         .getMetric()).value(), 0L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class, "pinot.controller.percentMinionSubtasksInQueue.taskType1"))
         .getMetric()).value(), 0L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class, "pinot.controller.percentMinionSubtasksInError.taskType1"))
         .getMetric()).value(), 0L);
   }
@@ -110,10 +110,11 @@ public class TaskMetricsEmitterTest {
   @Test
   public void oneSingleTaskTypeWithTwoTables() {
     String taskType = "taskType1";
-    Mockito.when(_pinotHelixTaskResourceManager.getTaskTypes()).thenReturn(Set.of(taskType));
+    Mockito.when(_pinotHelixTaskResourceManager.getTaskTypes()).thenReturn(ImmutableSet.of(taskType));
     String task11 = "task11";
     String task12 = "task12";
-    Mockito.when(_pinotHelixTaskResourceManager.getTasksInProgress(taskType)).thenReturn(Set.of(task11, task12));
+    Mockito.when(_pinotHelixTaskResourceManager.getTasksInProgress(taskType))
+        .thenReturn(ImmutableSet.of(task11, task12));
 
     String table1 = "table1_OFFLINE";
     String table2 = "table2_OFFLINE";
@@ -122,13 +123,13 @@ public class TaskMetricsEmitterTest {
     PinotHelixTaskResourceManager.TaskCount taskCount2 = new PinotHelixTaskResourceManager.TaskCount();
     taskCount2.addTaskState(TaskPartitionState.RUNNING);
     Mockito.when(_pinotHelixTaskResourceManager.getTableTaskCount(task11)).thenReturn(
-        Map.of(table1, taskCount1, table2, taskCount2));
+        ImmutableMap.of(table1, taskCount1, table2, taskCount2));
     taskCount1 = new PinotHelixTaskResourceManager.TaskCount();
     taskCount1.addTaskState(null);
     taskCount2 = new PinotHelixTaskResourceManager.TaskCount();
     taskCount2.addTaskState(TaskPartitionState.TASK_ERROR);
     Mockito.when(_pinotHelixTaskResourceManager.getTableTaskCount(task12)).thenReturn(
-        Map.of(table1, taskCount1, table2, taskCount2));
+        ImmutableMap.of(table1, taskCount1, table2, taskCount2));
 
     runAndAssertForTaskType1WithTwoTables();
   }
@@ -147,63 +148,63 @@ public class TaskMetricsEmitterTest {
 
     Assert.assertTrue(metricsRegistry.allMetrics().containsKey(
         new YammerMetricName(ControllerMetrics.class, "pinot.controller.onlineMinionInstances")));
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionTasksInProgress.taskType1"))
         .getMetric()).value(), 2L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionSubtasksRunning.taskType1"))
         .getMetric()).value(), 1L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionSubtasksWaiting.taskType1"))
         .getMetric()).value(), 1L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class, "pinot.controller.numMinionSubtasksError.taskType1"))
         .getMetric()).value(), 1L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class, "pinot.controller.percentMinionSubtasksInQueue.taskType1"))
         .getMetric()).value(), 50L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class, "pinot.controller.percentMinionSubtasksInError.taskType1"))
         .getMetric()).value(), 25L);
 
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 "pinot.controller.numMinionSubtasksRunning.table1_OFFLINE.taskType1"))
         .getMetric()).value(), 0L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 "pinot.controller.numMinionSubtasksWaiting.table1_OFFLINE.taskType1"))
         .getMetric()).value(), 1L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 "pinot.controller.numMinionSubtasksError.table1_OFFLINE.taskType1"))
         .getMetric()).value(), 0L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 "pinot.controller.percentMinionSubtasksInQueue.table1_OFFLINE.taskType1"))
         .getMetric()).value(), 50L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 "pinot.controller.percentMinionSubtasksInError.table1_OFFLINE.taskType1"))
         .getMetric()).value(), 0L);
 
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 "pinot.controller.numMinionSubtasksRunning.table2_OFFLINE.taskType1"))
         .getMetric()).value(), 1L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 "pinot.controller.numMinionSubtasksWaiting.table2_OFFLINE.taskType1"))
         .getMetric()).value(), 0L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 "pinot.controller.numMinionSubtasksError.table2_OFFLINE.taskType1"))
         .getMetric()).value(), 1L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 "pinot.controller.percentMinionSubtasksInQueue.table2_OFFLINE.taskType1"))
         .getMetric()).value(), 50L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 "pinot.controller.percentMinionSubtasksInError.table2_OFFLINE.taskType1"))
         .getMetric()).value(), 50L);
@@ -215,15 +216,18 @@ public class TaskMetricsEmitterTest {
   }
 
   private void oneTaskTypeWithOneTable(String taskType, String taskName1, String taskName2, String tableName) {
-    Mockito.when(_pinotHelixTaskResourceManager.getTaskTypes()).thenReturn(Set.of(taskType));
-    Mockito.when(_pinotHelixTaskResourceManager.getTasksInProgress(taskType)).thenReturn(Set.of(taskName1, taskName2));
+    Mockito.when(_pinotHelixTaskResourceManager.getTaskTypes()).thenReturn(ImmutableSet.of(taskType));
+    Mockito.when(_pinotHelixTaskResourceManager.getTasksInProgress(taskType))
+        .thenReturn(ImmutableSet.of(taskName1, taskName2));
 
     PinotHelixTaskResourceManager.TaskCount taskCount = new PinotHelixTaskResourceManager.TaskCount();
     taskCount.addTaskState(TaskPartitionState.COMPLETED);
-    Mockito.when(_pinotHelixTaskResourceManager.getTableTaskCount(taskName1)).thenReturn(Map.of(tableName, taskCount));
+    Mockito.when(_pinotHelixTaskResourceManager.getTableTaskCount(taskName1))
+        .thenReturn(ImmutableMap.of(tableName, taskCount));
     taskCount = new PinotHelixTaskResourceManager.TaskCount();
     taskCount.addTaskState(null);
-    Mockito.when(_pinotHelixTaskResourceManager.getTableTaskCount(taskName2)).thenReturn(Map.of(tableName, taskCount));
+    Mockito.when(_pinotHelixTaskResourceManager.getTableTaskCount(taskName2))
+        .thenReturn(ImmutableMap.of(tableName, taskCount));
 
     PinotMetricsRegistry metricsRegistry = _controllerMetrics.getMetricsRegistry();
     _taskMetricsEmitter.runTask(null);
@@ -231,48 +235,48 @@ public class TaskMetricsEmitterTest {
 
     Assert.assertTrue(metricsRegistry.allMetrics().containsKey(
         new YammerMetricName(ControllerMetrics.class, "pinot.controller.onlineMinionInstances")));
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 String.format("pinot.controller.numMinionTasksInProgress.%s", taskType)))
         .getMetric()).value(), 2L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 String.format("pinot.controller.numMinionSubtasksRunning.%s", taskType)))
         .getMetric()).value(), 0L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 String.format("pinot.controller.numMinionSubtasksWaiting.%s", taskType)))
         .getMetric()).value(), 1L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 String.format("pinot.controller.numMinionSubtasksError.%s", taskType)))
         .getMetric()).value(), 0L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 String.format("pinot.controller.percentMinionSubtasksInQueue.%s", taskType)))
         .getMetric()).value(), 50L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 String.format("pinot.controller.percentMinionSubtasksInError.%s", taskType)))
         .getMetric()).value(), 0L);
 
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 String.format("pinot.controller.numMinionSubtasksRunning.%s.%s", tableName, taskType)))
         .getMetric()).value(), 0L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 String.format("pinot.controller.numMinionSubtasksWaiting.%s.%s", tableName, taskType)))
         .getMetric()).value(), 1L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 String.format("pinot.controller.numMinionSubtasksError.%s.%s", tableName, taskType)))
         .getMetric()).value(), 0L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 String.format("pinot.controller.percentMinionSubtasksInQueue.%s.%s", tableName, taskType)))
         .getMetric()).value(), 50L);
-    Assert.assertEquals(((YammerSettableGauge) metricsRegistry.allMetrics().get(
+    Assert.assertEquals(((YammerSettableGauge<?>) metricsRegistry.allMetrics().get(
             new YammerMetricName(ControllerMetrics.class,
                 String.format("pinot.controller.percentMinionSubtasksInError.%s.%s", tableName, taskType)))
         .getMetric()).value(), 0L);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeToOfflineSegmentsMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeToOfflineSegmentsMinionClusterIntegrationTest.java
@@ -263,8 +263,6 @@ public class RealtimeToOfflineSegmentsMinionClusterIntegrationTest extends BaseC
     }
 
     testHardcodedQueries();
-
-    Thread.sleep(1000_000);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeToOfflineSegmentsMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/RealtimeToOfflineSegmentsMinionClusterIntegrationTest.java
@@ -263,6 +263,8 @@ public class RealtimeToOfflineSegmentsMinionClusterIntegrationTest extends BaseC
     }
 
     testHardcodedQueries();
+
+    Thread.sleep(1000_000);
   }
 
   @Test


### PR DESCRIPTION
This PR makes two changes
1. report minion task queue metrics at table level to help triage minion related problems
2. refactor metric class a bit to make it better