### PR TITLE
solve logger resource injection issue using a dummy log file server

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerLogger.java
@@ -40,8 +40,9 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.apache.pinot.common.utils.LoggerFileServer;
 import org.apache.pinot.common.utils.LoggerUtils;
+import org.apache.pinot.common.utils.log.DummyLogFileServer;
+import org.apache.pinot.common.utils.log.LogFileServer;
 
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
 
@@ -56,7 +57,7 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 public class PinotBrokerLogger {
 
   @Inject
-  private LoggerFileServer _loggerFileServer;
+  private LogFileServer _logFileServer;
 
   @GET
   @Path("/loggers")
@@ -94,10 +95,10 @@ public class PinotBrokerLogger {
   @ApiOperation(value = "Get all local log files")
   public Set<String> getLocalLogFiles() {
     try {
-      if (_loggerFileServer == null) {
+      if (_logFileServer == null || _logFileServer instanceof DummyLogFileServer) {
         throw new WebApplicationException("Root log directory doesn't exist", Response.Status.INTERNAL_SERVER_ERROR);
       }
-      return _loggerFileServer.getAllPaths();
+      return _logFileServer.getAllLogFilePaths();
     } catch (IOException e) {
       throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
     }
@@ -109,10 +110,10 @@ public class PinotBrokerLogger {
   @ApiOperation(value = "Download a log file")
   public Response downloadLogFile(
       @ApiParam(value = "Log file path", required = true) @QueryParam("filePath") String filePath) {
-    if (_loggerFileServer == null) {
+    if (_logFileServer == null || _logFileServer instanceof DummyLogFileServer) {
       throw new WebApplicationException("Root log directory is not configured",
           Response.Status.INTERNAL_SERVER_ERROR);
     }
-    return _loggerFileServer.downloadLogFile(filePath);
+    return _logFileServer.downloadLogFile(filePath);
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -32,7 +32,9 @@ import org.apache.commons.httpclient.MultiThreadedHttpConnectionManager;
 import org.apache.pinot.broker.requesthandler.BrokerRequestHandler;
 import org.apache.pinot.broker.routing.BrokerRoutingManager;
 import org.apache.pinot.common.metrics.BrokerMetrics;
-import org.apache.pinot.common.utils.LoggerFileServer;
+import org.apache.pinot.common.utils.log.DummyLogFileServer;
+import org.apache.pinot.common.utils.log.LocalLogFileServer;
+import org.apache.pinot.common.utils.log.LogFileServer;
 import org.apache.pinot.core.api.ServiceAutoDiscoveryFeature;
 import org.apache.pinot.core.query.executor.sql.SqlQueryExecutor;
 import org.apache.pinot.core.transport.ListenerConfig;
@@ -91,7 +93,9 @@ public class BrokerAdminApiApplication extends ResourceConfig {
         bind(brokerMetrics).to(BrokerMetrics.class);
         String loggerRootDir = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_LOGGER_ROOT_DIR);
         if (loggerRootDir != null) {
-          bind(new LoggerFileServer(loggerRootDir)).to(LoggerFileServer.class);
+          bind(new LocalLogFileServer(loggerRootDir)).to(LogFileServer.class);
+        } else {
+          bind(new DummyLogFileServer()).to(LogFileServer.class);
         }
         bind(brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_ID)).named(BROKER_INSTANCE_ID);
         bind(serverRoutingStatsManager).to(ServerRoutingStatsManager.class);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/log/DummyLogFileServer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/log/DummyLogFileServer.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.log;
+
+import java.io.IOException;
+import java.util.Set;
+import javax.ws.rs.core.Response;
+
+
+/**
+ * A dummy log file server.
+ */
+public class DummyLogFileServer implements LogFileServer {
+  @Override
+  public Set<String> getAllLogFilePaths()
+      throws IOException {
+    throw new RuntimeException("DummyLogFileServer does not support this operation");
+  }
+
+  @Override
+  public Response downloadLogFile(String filePath) {
+    throw new RuntimeException("DummyLogFileServer does not support this operation");
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/log/LocalLogFileServer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/log/LocalLogFileServer.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.utils;
+package org.apache.pinot.common.utils.log;
 
 import com.google.common.base.Preconditions;
 import java.io.File;
@@ -31,35 +31,36 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.StreamingOutput;
 
-
 /**
- * Logger file server.
+ * A real log file server.
  */
-public class LoggerFileServer {
-  private final File _loggerRootDir;
-  private final Path _loggerRootDirPath;
+public class LocalLogFileServer implements LogFileServer {
+  private final File _logRootDir;
+  private final Path _logRootDirPath;
 
-  public LoggerFileServer(String loggerRootDir) {
-    Preconditions.checkNotNull(loggerRootDir, "Logger root directory is null");
-    _loggerRootDir = new File(loggerRootDir);
-    Preconditions.checkState(_loggerRootDir.exists(), "Logger directory doesn't exists");
-    _loggerRootDirPath = Paths.get(_loggerRootDir.getAbsolutePath());
+  public LocalLogFileServer(String logRootDir) {
+    Preconditions.checkNotNull(logRootDir, "Log root directory is null");
+    _logRootDir = new File(logRootDir);
+    Preconditions.checkState(_logRootDir.exists(), "Log directory doesn't exists");
+    _logRootDirPath = Paths.get(_logRootDir.getAbsolutePath());
   }
 
-  public Set<String> getAllPaths()
+  @Override
+  public Set<String> getAllLogFilePaths()
       throws IOException {
     Set<String> allFiles = new TreeSet<>();
-    Files.walk(_loggerRootDirPath).filter(Files::isRegularFile).forEach(
-        f -> allFiles.add(f.toAbsolutePath().toString().replace(_loggerRootDirPath.toAbsolutePath() + "/", "")));
+    Files.walk(_logRootDirPath).filter(Files::isRegularFile).forEach(
+        f -> allFiles.add(f.toAbsolutePath().toString().replace(_logRootDirPath.toAbsolutePath() + "/", "")));
     return allFiles;
   }
 
+  @Override
   public Response downloadLogFile(String filePath) {
     try {
-      if (!getAllPaths().contains(filePath)) {
+      if (!getAllLogFilePaths().contains(filePath)) {
         throw new WebApplicationException("Invalid file path: " + filePath, Response.Status.FORBIDDEN);
       }
-      File logFile = new File(_loggerRootDir, filePath);
+      File logFile = new File(_logRootDir, filePath);
       if (!logFile.exists()) {
         throw new WebApplicationException("File: " + filePath + " doesn't exists", Response.Status.NOT_FOUND);
       }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/log/LogFileServer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/log/LogFileServer.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.log;
+
+import java.io.IOException;
+import java.util.Set;
+import javax.ws.rs.core.Response;
+
+/**
+ * Log file server interface
+ */
+public interface LogFileServer {
+  /**
+   * Returns all log file paths relative to logger root dir
+   * @return a set of all log file paths relative to logger root dir
+   * @throws IOException if there is problem reading all file paths
+   */
+  Set<String> getAllLogFilePaths() throws IOException;
+
+  /**
+   * Downloads a log file from the given file path (relative to logger root dir)
+   * @param filePath file path relative to logger root dir
+   * @return the log file content
+   */
+  Response downloadLogFile(String filePath);
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/log/LocalLogFileServerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/log/LocalLogFileServerTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.utils;
+package org.apache.pinot.common.utils.log;
 
 import java.io.File;
 import java.io.IOException;
@@ -31,7 +31,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 
 
-public class LoggerFileServerTest {
+public class LocalLogFileServerTest {
 
   @Test
   public void testLoggerFileServer()
@@ -39,12 +39,12 @@ public class LoggerFileServerTest {
     File logRootDir = new File(FileUtils.getTempDirectory(), "testGetAllLoggers-" + System.currentTimeMillis());
     try {
       logRootDir.mkdirs();
-      LoggerFileServer loggerFileServer = new LoggerFileServer(logRootDir.getAbsolutePath());
+      LogFileServer logFileServer = new LocalLogFileServer(logRootDir.getAbsolutePath());
 
       // Empty root log directory
-      assertEquals(loggerFileServer.getAllPaths().size(), 0);
+      assertEquals(logFileServer.getAllLogFilePaths().size(), 0);
       try {
-        loggerFileServer.downloadLogFile("log1");
+        logFileServer.downloadLogFile("log1");
         Assert.fail("Shouldn't reach here");
       } catch (WebApplicationException e1) {
         assertEquals(e1.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
@@ -52,10 +52,10 @@ public class LoggerFileServerTest {
 
       // 1 file: [ log1 ] in root log directory
       FileUtils.writeStringToFile(new File(logRootDir, "log1"), "mylog1", Charset.defaultCharset());
-      assertEquals(loggerFileServer.getAllPaths().size(), 1);
-      assertNotNull(loggerFileServer.downloadLogFile("log1"));
+      assertEquals(logFileServer.getAllLogFilePaths().size(), 1);
+      assertNotNull(logFileServer.downloadLogFile("log1"));
       try {
-        loggerFileServer.downloadLogFile("log2");
+        logFileServer.downloadLogFile("log2");
         Assert.fail("Shouldn't reach here");
       } catch (WebApplicationException e1) {
         assertEquals(e1.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());
@@ -63,11 +63,11 @@ public class LoggerFileServerTest {
 
       // 2 files: [ log1, log2 ] in root log directory
       FileUtils.writeStringToFile(new File(logRootDir, "log2"), "mylog2", Charset.defaultCharset());
-      assertEquals(loggerFileServer.getAllPaths().size(), 2);
-      assertNotNull(loggerFileServer.downloadLogFile("log1"));
-      assertNotNull(loggerFileServer.downloadLogFile("log2"));
+      assertEquals(logFileServer.getAllLogFilePaths().size(), 2);
+      assertNotNull(logFileServer.downloadLogFile("log1"));
+      assertNotNull(logFileServer.downloadLogFile("log2"));
       try {
-        loggerFileServer.downloadLogFile("log3");
+        logFileServer.downloadLogFile("log3");
         Assert.fail("Shouldn't reach here");
       } catch (WebApplicationException e1) {
         assertEquals(e1.getResponse().getStatus(), Response.Status.FORBIDDEN.getStatusCode());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -60,13 +60,15 @@ import org.apache.pinot.common.metrics.ValidationMetrics;
 import org.apache.pinot.common.minion.InMemoryTaskManagerStatusCache;
 import org.apache.pinot.common.minion.TaskGeneratorMostRecentRunInfo;
 import org.apache.pinot.common.minion.TaskManagerStatusCache;
-import org.apache.pinot.common.utils.LoggerFileServer;
 import org.apache.pinot.common.utils.ServiceStartableUtils;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.common.utils.TlsUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.common.utils.helix.LeadControllerUtils;
+import org.apache.pinot.common.utils.log.DummyLogFileServer;
+import org.apache.pinot.common.utils.log.LocalLogFileServer;
+import org.apache.pinot.common.utils.log.LogFileServer;
 import org.apache.pinot.common.version.PinotVersion;
 import org.apache.pinot.controller.api.ControllerAdminApiApplication;
 import org.apache.pinot.controller.api.access.AccessControlFactory;
@@ -483,7 +485,9 @@ public abstract class BaseControllerStarter implements ServiceStartable {
         bind(_pinotLLCRealtimeSegmentManager).to(PinotLLCRealtimeSegmentManager.class);
         String loggerRootDir = _config.getProperty(CommonConstants.Controller.CONFIG_OF_LOGGER_ROOT_DIR);
         if (loggerRootDir != null) {
-          bind(new LoggerFileServer(loggerRootDir)).to(LoggerFileServer.class);
+          bind(new LocalLogFileServer(loggerRootDir)).to(LogFileServer.class);
+        } else {
+          bind(new DummyLogFileServer()).to(LogFileServer.class);
         }
       }
     });

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerLogger.java
@@ -53,10 +53,11 @@ import org.apache.http.HttpVersion;
 import org.apache.http.client.methods.CloseableHttpResponse;
 import org.apache.http.client.methods.RequestBuilder;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
-import org.apache.pinot.common.utils.LoggerFileServer;
 import org.apache.pinot.common.utils.LoggerUtils;
 import org.apache.pinot.common.utils.SimpleHttpResponse;
 import org.apache.pinot.common.utils.config.InstanceUtils;
+import org.apache.pinot.common.utils.log.DummyLogFileServer;
+import org.apache.pinot.common.utils.log.LogFileServer;
 import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.api.access.Authenticate;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -76,7 +77,7 @@ public class PinotControllerLogger {
   private final FileUploadDownloadClient _fileUploadDownloadClient = new FileUploadDownloadClient();
 
   @Inject
-  private LoggerFileServer _loggerFileServer;
+  private LogFileServer _logFileServer;
 
   @Inject
   PinotHelixResourceManager _pinotHelixResourceManager;
@@ -117,10 +118,10 @@ public class PinotControllerLogger {
   @ApiOperation(value = "Get all local log files")
   public Set<String> getLocalLogFiles() {
     try {
-      if (_loggerFileServer == null) {
+      if (_logFileServer == null || _logFileServer instanceof DummyLogFileServer) {
         throw new WebApplicationException("Root log directory doesn't exist", Response.Status.INTERNAL_SERVER_ERROR);
       }
-      return _loggerFileServer.getAllPaths();
+      return _logFileServer.getAllLogFilePaths();
     } catch (IOException e) {
       throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
     }
@@ -133,11 +134,11 @@ public class PinotControllerLogger {
   @ApiOperation(value = "Download a log file")
   public Response downloadLogFile(
       @ApiParam(value = "Log file path", required = true) @QueryParam("filePath") String filePath) {
-    if (_loggerFileServer == null) {
+    if (_logFileServer == null || _logFileServer instanceof DummyLogFileServer) {
       throw new WebApplicationException("Root log directory is not configured",
           Response.Status.INTERNAL_SERVER_ERROR);
     }
-    return _loggerFileServer.downloadLogFile(filePath);
+    return _logFileServer.downloadLogFile(filePath);
   }
 
   @GET
@@ -145,7 +146,7 @@ public class PinotControllerLogger {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Collect log files from all the instances")
   public Map<String, Set<String>> getLogFilesFromAllInstances() {
-    if (_loggerFileServer == null) {
+    if (_logFileServer == null || _logFileServer instanceof DummyLogFileServer) {
       throw new WebApplicationException("Root directory doesn't exist", Response.Status.INTERNAL_SERVER_ERROR);
     }
     Map<String, Set<String>> instancesToLogFilesMap = new HashMap<>();

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
@@ -23,7 +23,9 @@ import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.List;
-import org.apache.pinot.common.utils.LoggerFileServer;
+import org.apache.pinot.common.utils.log.DummyLogFileServer;
+import org.apache.pinot.common.utils.log.LocalLogFileServer;
+import org.apache.pinot.common.utils.log.LogFileServer;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -62,7 +64,9 @@ public class MinionAdminApiApplication extends ResourceConfig {
         bind(instanceId).named(MINION_INSTANCE_ID);
         String loggerRootDir = minionConf.getProperty(CommonConstants.Minion.CONFIG_OF_LOGGER_ROOT_DIR);
         if (loggerRootDir != null) {
-          bind(new LoggerFileServer(loggerRootDir)).to(LoggerFileServer.class);
+          bind(new LocalLogFileServer(loggerRootDir)).to(LogFileServer.class);
+        } else {
+          bind(new DummyLogFileServer()).to(LogFileServer.class);
         }
       }
     });

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotMinionLogger.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotMinionLogger.java
@@ -40,8 +40,9 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.apache.pinot.common.utils.LoggerFileServer;
 import org.apache.pinot.common.utils.LoggerUtils;
+import org.apache.pinot.common.utils.log.DummyLogFileServer;
+import org.apache.pinot.common.utils.log.LogFileServer;
 
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
 
@@ -56,7 +57,7 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 public class PinotMinionLogger {
 
   @Inject
-  private LoggerFileServer _loggerFileServer;
+  private LogFileServer _logFileServer;
 
   @GET
   @Path("/loggers")
@@ -94,10 +95,10 @@ public class PinotMinionLogger {
   @ApiOperation(value = "Get all local log files")
   public Set<String> getLocalLogFiles() {
     try {
-      if (_loggerFileServer == null) {
+      if (_logFileServer == null || _logFileServer instanceof DummyLogFileServer) {
         throw new WebApplicationException("Root log directory doesn't exist", Response.Status.INTERNAL_SERVER_ERROR);
       }
-      return _loggerFileServer.getAllPaths();
+      return _logFileServer.getAllLogFilePaths();
     } catch (IOException e) {
       throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
     }
@@ -109,10 +110,10 @@ public class PinotMinionLogger {
   @ApiOperation(value = "Download a log file")
   public Response downloadLogFile(
       @ApiParam(value = "Log file path", required = true) @QueryParam("filePath") String filePath) {
-    if (_loggerFileServer == null) {
+    if (_logFileServer == null || _logFileServer instanceof DummyLogFileServer) {
       throw new WebApplicationException("Root log directory is not configured",
           Response.Status.INTERNAL_SERVER_ERROR);
     }
-    return _loggerFileServer.downloadLogFile(filePath);
+    return _logFileServer.downloadLogFile(filePath);
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
@@ -30,7 +30,9 @@ import javax.ws.rs.container.ContainerRequestContext;
 import javax.ws.rs.container.ContainerResponseContext;
 import javax.ws.rs.container.ContainerResponseFilter;
 import org.apache.pinot.common.metrics.ServerMetrics;
-import org.apache.pinot.common.utils.LoggerFileServer;
+import org.apache.pinot.common.utils.log.DummyLogFileServer;
+import org.apache.pinot.common.utils.log.LocalLogFileServer;
+import org.apache.pinot.common.utils.log.LogFileServer;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.server.access.AccessControlFactory;
@@ -73,7 +75,9 @@ public class AdminApiApplication extends ResourceConfig {
         bind(serverConf.getProperty(CommonConstants.Server.CONFIG_OF_INSTANCE_ID)).named(SERVER_INSTANCE_ID);
         String loggerRootDir = serverConf.getProperty(CommonConstants.Server.CONFIG_OF_LOGGER_ROOT_DIR);
         if (loggerRootDir != null) {
-          bind(new LoggerFileServer(loggerRootDir)).to(LoggerFileServer.class);
+          bind(new LocalLogFileServer(loggerRootDir)).to(LogFileServer.class);
+        } else {
+          bind(new DummyLogFileServer()).to(LogFileServer.class);
         }
       }
     });

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/PinotServerLogger.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/PinotServerLogger.java
@@ -40,8 +40,9 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.apache.pinot.common.utils.LoggerFileServer;
 import org.apache.pinot.common.utils.LoggerUtils;
+import org.apache.pinot.common.utils.log.DummyLogFileServer;
+import org.apache.pinot.common.utils.log.LogFileServer;
 
 import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_KEY;
 
@@ -56,7 +57,7 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
 public class PinotServerLogger {
 
   @Inject
-  private LoggerFileServer _loggerFileServer;
+  private LogFileServer _logFileServer;
 
   @GET
   @Path("/loggers")
@@ -94,10 +95,10 @@ public class PinotServerLogger {
   @ApiOperation(value = "Get all local log files")
   public Set<String> getLocalLogFiles() {
     try {
-      if (_loggerFileServer == null) {
+      if (_logFileServer == null || _logFileServer instanceof DummyLogFileServer) {
         throw new WebApplicationException("Root log directory doesn't exist", Response.Status.INTERNAL_SERVER_ERROR);
       }
-      return _loggerFileServer.getAllPaths();
+      return _logFileServer.getAllLogFilePaths();
     } catch (IOException e) {
       throw new WebApplicationException(e, Response.Status.INTERNAL_SERVER_ERROR);
     }
@@ -109,10 +110,10 @@ public class PinotServerLogger {
   @ApiOperation(value = "Download a log file")
   public Response downloadLogFile(
       @ApiParam(value = "Log file path", required = true) @QueryParam("filePath") String filePath) {
-    if (_loggerFileServer == null) {
+    if (_logFileServer == null || _logFileServer instanceof DummyLogFileServer) {
       throw new WebApplicationException("Root log directory is not configured",
           Response.Status.INTERNAL_SERVER_ERROR);
     }
-    return _loggerFileServer.downloadLogFile(filePath);
+    return _logFileServer.downloadLogFile(filePath);
   }
 }


### PR DESCRIPTION
When loggerRootDir is not provided, fix get loggers & set loggers issue (injection failure) by providing a dummy log file server 