### PR TITLE
Add controller API for force commit status

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/controllerjob/ControllerJobType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/controllerjob/ControllerJobType.java
@@ -20,5 +20,6 @@ package org.apache.pinot.common.metadata.controllerjob;
 
 public enum ControllerJobType {
   RELOAD_SEGMENT,
-  RELOAD_ALL_SEGMENTS
+  RELOAD_ALL_SEGMENTS,
+  FORCE_COMMIT
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -20,6 +20,7 @@ package org.apache.pinot.controller.api.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableSet;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiKeyAuthDefinition;
 import io.swagger.annotations.ApiOperation;
@@ -175,7 +176,7 @@ public class PinotRealtimeTableResource {
         controllerJobZKMetadata.get(CommonConstants.ControllerJob.CONSUMING_SEGMENTS_FORCE_COMMITTED_LIST), Set.class);
     Set<String> onlineSegmentsForTable =
         _pinotHelixResourceManager.getSegmentsFromIdealStateMatchingState(tableNameWithType,
-            Set.of(CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE));
+            ImmutableSet.of(CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE));
 
     Set<String> segmentsYetToBeCommitted = new HashSet<>();
     consumingSegmentCommitted.forEach(segmentName -> {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -20,7 +20,6 @@ package org.apache.pinot.controller.api.resources;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.collect.ImmutableSet;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiKeyAuthDefinition;
 import io.swagger.annotations.ApiOperation;
@@ -175,8 +174,7 @@ public class PinotRealtimeTableResource {
     Set<String> consumingSegmentCommitted = JsonUtils.stringToObject(
         controllerJobZKMetadata.get(CommonConstants.ControllerJob.CONSUMING_SEGMENTS_FORCE_COMMITTED_LIST), Set.class);
     Set<String> onlineSegmentsForTable =
-        _pinotHelixResourceManager.getSegmentsFromIdealStateMatchingState(tableNameWithType,
-            ImmutableSet.of(CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE));
+        _pinotHelixResourceManager.getOnlineSegmentsFromIdealState(tableNameWithType, false);
 
     Set<String> segmentsYetToBeCommitted = new HashSet<>();
     consumingSegmentCommitted.forEach(segmentName -> {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -847,16 +847,19 @@ public class PinotTableRestletResource {
       notes = "Get list of controller jobs for this table")
   public Map<String, Map<String, String>> getControllerJobs(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
-      @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr
-  ) {
+      @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
+      @ApiParam(value = "Comma separated list of job types") @QueryParam("jobTypes") @Nullable String jobTypesString) {
     TableType tableTypeFromRequest = Constants.validateTableType(tableTypeStr);
     List<String> tableNamesWithType =
         ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableTypeFromRequest,
             LOGGER);
-
+    Set<String> jobTypesToFilter = null;
+    if (StringUtils.isNotEmpty(jobTypesString)) {
+      jobTypesToFilter = new HashSet<>(java.util.Arrays.asList(StringUtils.split(jobTypesString, ",")));
+    }
     Map<String, Map<String, String>> result = new HashMap<>();
     for (String tableNameWithType : tableNamesWithType) {
-      result.putAll(_pinotHelixResourceManager.getAllJobsForTable(tableNameWithType));
+      result.putAll(_pinotHelixResourceManager.getAllJobsForTable(tableNameWithType, jobTypesToFilter));
     }
 
     return result;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -855,7 +855,7 @@ public class PinotTableRestletResource {
             LOGGER);
     Set<String> jobTypesToFilter = null;
     if (StringUtils.isNotEmpty(jobTypesString)) {
-      jobTypesToFilter = new HashSet<>(java.util.Arrays.asList(StringUtils.split(jobTypesString, ",")));
+      jobTypesToFilter = new HashSet<>(java.util.Arrays.asList(StringUtils.split(jobTypesString, ',')));
     }
     Map<String, Map<String, String>> result = new HashMap<>();
     for (String tableNameWithType : tableNamesWithType) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3628,19 +3628,19 @@ public class PinotHelixResourceManager {
             tableNameWithType, segmentsToCheck));
   }
 
-  public Set<String> getOnlineSegmentsFromIdealState(String tableNameWithType, boolean includeConsuming) {
+  public Set<String> getSegmentsFromIdealStateMatchingState(String tableNameWithType,
+      @Nullable Set<String> filterStates) {
     IdealState tableIdealState = getTableIdealState(tableNameWithType);
     Preconditions.checkState((tableIdealState != null), "Table ideal state is null");
     Map<String, Map<String, String>> segmentAssignment = tableIdealState.getRecord().getMapFields();
-    Set<String> onlineSegments = new HashSet<>(HashUtil.getHashMapCapacity(segmentAssignment.size()));
+    Set<String> matchingSegments = new HashSet<>(HashUtil.getHashMapCapacity(segmentAssignment.size()));
     for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
-      Map<String, String> instanceStateMap = entry.getValue();
-      if (instanceStateMap.containsValue(SegmentStateModel.ONLINE) || (includeConsuming
-          && instanceStateMap.containsValue(SegmentStateModel.CONSUMING))) {
-        onlineSegments.add(entry.getKey());
+      String segmentName = entry.getKey();
+      if (filterStates == null || !Collections.disjoint(entry.getValue().values(), filterStates)) {
+        matchingSegments.add(segmentName);
       }
     }
-    return onlineSegments;
+    return matchingSegments;
   }
 
   public Set<String> getOnlineSegmentsFromExternalView(String tableNameWithType) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2064,13 +2064,15 @@ public class PinotHelixResourceManager {
    * @param tableNameWithType the table for which jobs are to be fetched
    * @return A Map of jobId to job properties
    */
-  public Map<String, Map<String, String>> getAllJobsForTable(String tableNameWithType) {
+  public Map<String, Map<String, String>> getAllJobsForTable(String tableNameWithType, Set<String> jobTypesToFilter) {
     String jobsResourcePath = ZKMetadataProvider.constructPropertyStorePathForControllerJob();
     try {
       ZNRecord tableJobsRecord = _propertyStore.get(jobsResourcePath, null, -1);
       Map<String, Map<String, String>> controllerJobs = tableJobsRecord.getMapFields();
       return controllerJobs.entrySet().stream().filter(
-              job -> job.getValue().get(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE).equals(tableNameWithType))
+              job -> job.getValue().get(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE).equals(tableNameWithType)
+                  && (jobTypesToFilter == null || jobTypesToFilter.contains(
+                      job.getValue().get(CommonConstants.ControllerJob.JOB_TYPE))))
           .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
     } catch (ZkNoNodeException e) {
       LOGGER.warn("Could not find controller job node for table : {}", tableNameWithType, e);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3628,16 +3628,16 @@ public class PinotHelixResourceManager {
             tableNameWithType, segmentsToCheck));
   }
 
-  public Set<String> getSegmentsFromIdealStateMatchingState(String tableNameWithType,
-      @Nullable Set<String> filterStates) {
+  public Set<String> getOnlineSegmentsFromIdealState(String tableNameWithType, boolean includeConsuming) {
     IdealState tableIdealState = getTableIdealState(tableNameWithType);
     Preconditions.checkState((tableIdealState != null), "Table ideal state is null");
     Map<String, Map<String, String>> segmentAssignment = tableIdealState.getRecord().getMapFields();
     Set<String> matchingSegments = new HashSet<>(HashUtil.getHashMapCapacity(segmentAssignment.size()));
     for (Map.Entry<String, Map<String, String>> entry : segmentAssignment.entrySet()) {
-      String segmentName = entry.getKey();
-      if (filterStates == null || !Collections.disjoint(entry.getValue().values(), filterStates)) {
-        matchingSegments.add(segmentName);
+      Map<String, String> instanceStateMap = entry.getValue();
+      if (instanceStateMap.containsValue(SegmentStateModel.ONLINE) || (includeConsuming
+          && instanceStateMap.containsValue(SegmentStateModel.CONSUMING))) {
+        matchingSegments.add(entry.getKey());
       }
     }
     return matchingSegments;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1453,10 +1453,11 @@ public class PinotLLCRealtimeSegmentManager {
   /**
    * Force commit the current segments in consuming state and restart consumption
    */
-  public void forceCommit(String tableNameWithType) {
+  public Set<String> forceCommit(String tableNameWithType) {
     IdealState idealState = getIdealState(tableNameWithType);
     Set<String> consumingSegments = findConsumingSegments(idealState);
     sendForceCommitMessageToServers(tableNameWithType, consumingSegments);
+    return consumingSegments;
   }
 
   /**

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -384,7 +384,7 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
       setShowReloadStatusModal(true);
       const [reloadStatusData, tableJobsData] = await Promise.all([
         PinotMethodUtils.reloadStatusOp(tableName, tableType),
-        PinotMethodUtils.fetchTableJobs(tableName),
+        PinotMethodUtils.fetchTableJobs(tableName, "RELOAD_SEGMENT,RELOAD_ALL_SEGMENTS"),
       ]);
 
       if(reloadStatusData.error || tableJobsData.error) {

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -203,8 +203,15 @@ export const reloadStatus = (tableName: string, tableType: string): Promise<Axio
 export const deleteSegment = (tableName: string, instanceName: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.delete(`/segments/${tableName}/${instanceName}`, {headers});
 
-export const getTableJobs = (tableName: string): Promise<AxiosResponse<TableSegmentJobs>> => 
-  baseApi.get(`/table/${tableName}/jobs`);
+export const getTableJobs = (tableName: string, jobTypes?: string): Promise<AxiosResponse<TableSegmentJobs>> => {
+  let queryParams = {};
+
+  if (jobTypes) {
+    queryParams["jobTypes"] = jobTypes
+  }
+
+  return baseApi.get(`/table/${tableName}/jobs`, { params: queryParams });
+}
 
 export const getSegmentReloadStatus = (jobId: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.get(`/segments/segmentReloadStatus/${jobId}`, {headers});

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -893,8 +893,8 @@ const deleteSegmentOp = (tableName, segmentName) => {
   });
 };
 
-const fetchTableJobs = async (tableName: string) => {
-  const response = await getTableJobs(tableName);
+const fetchTableJobs = async (tableName: string, jobTypes?: string) => {
+  const response = await getTableJobs(tableName, jobTypes);
   
   return response.data;
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/IngestionConfigHybridIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/IngestionConfigHybridIntegrationTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.ingestion.FilterConfig;
 import org.apache.pinot.spi.config.table.ingestion.IngestionConfig;
@@ -31,6 +32,8 @@ import org.apache.pinot.spi.config.table.ingestion.StreamIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.TransformConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
@@ -38,6 +41,7 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
 
 
 /**
@@ -215,6 +219,45 @@ public class IngestionConfigHybridIntegrationTest extends BaseClusterIntegration
     sqlQuery = "Select * from " + DEFAULT_TABLE_NAME + "_OFFLINE" + "  where AirlineID = 19393 or ArrDelayMinutes <= 5";
     response = postQuery(sqlQuery);
     Assert.assertEquals(response.get("resultTable").get("rows").size(), 0);
+  }
+
+  @Test
+  public void testForceCommit()
+      throws Exception {
+    Set<String> consumingSegments = _controllerStarter.getHelixResourceManager()
+        .getSegmentsFromIdealStateMatchingState(getTableName() + "_REALTIME",
+            Set.of(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING));
+    String jobId = forceCommit(getTableName());
+
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        if (isForceCommitJobCompleted(jobId)) {
+          assertTrue(_controllerStarter.getHelixResourceManager()
+              .getSegmentsFromIdealStateMatchingState(getTableName() + "_REALTIME",
+                  Set.of(CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE)).containsAll(consumingSegments));
+          return true;
+        }
+        return false;
+      } catch (Exception e) {
+        return false;
+      }
+    }, 60000L, "Error verifying force commit operation on table!");
+  }
+
+  public boolean isForceCommitJobCompleted(String forceCommitJobId)
+      throws Exception {
+    String jobStatusResponse = sendGetRequest(_controllerRequestURLBuilder.forForceCommitJobStatus(forceCommitJobId));
+    JsonNode jobStatus = JsonUtils.stringToJsonNode(jobStatusResponse);
+
+    assertEquals(jobStatus.get("jobId").asText(), forceCommitJobId);
+    assertEquals(jobStatus.get("jobType").asText(), "FORCE_COMMIT");
+    return jobStatus.get("numberOfSegmentsYetToBeCommitted").asInt(-1) == 0;
+  }
+
+  private String forceCommit(String tableName)
+      throws Exception {
+    String response = sendPostRequest(_controllerRequestURLBuilder.forTableForceCommit(tableName), null);
+    return JsonUtils.stringToJsonNode(response).get("forceCommitJobId").asText();
   }
 
   @AfterClass

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/IngestionConfigHybridIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/IngestionConfigHybridIntegrationTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.integration.tests;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableSet;
 import java.io.File;
 import java.util.Arrays;
 import java.util.Collections;
@@ -226,7 +227,7 @@ public class IngestionConfigHybridIntegrationTest extends BaseClusterIntegration
       throws Exception {
     Set<String> consumingSegments = _controllerStarter.getHelixResourceManager()
         .getSegmentsFromIdealStateMatchingState(getTableName() + "_REALTIME",
-            Set.of(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING));
+            ImmutableSet.of(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING));
     String jobId = forceCommit(getTableName());
 
     TestUtils.waitForCondition(aVoid -> {
@@ -234,7 +235,8 @@ public class IngestionConfigHybridIntegrationTest extends BaseClusterIntegration
         if (isForceCommitJobCompleted(jobId)) {
           assertTrue(_controllerStarter.getHelixResourceManager()
               .getSegmentsFromIdealStateMatchingState(getTableName() + "_REALTIME",
-                  Set.of(CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE)).containsAll(consumingSegments));
+                  ImmutableSet.of(CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE))
+              .containsAll(consumingSegments));
           return true;
         }
         return false;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -699,7 +699,7 @@ public class CommonConstants {
      */
     public static final String SEGMENT_RELOAD_JOB_SEGMENT_NAME = "segmentName";
     // Force commit job ZK props
-    public static final String CONSUMING_SEGMENTS_FORCE_COMMITTED_LIST = "segmentForceCommitted";
+    public static final String CONSUMING_SEGMENTS_FORCE_COMMITTED_LIST = "segmentsForceCommitted";
   }
 
   public static class Accounting {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -698,6 +698,8 @@ public class CommonConstants {
      * Segment reload job ZK props
      */
     public static final String SEGMENT_RELOAD_JOB_SEGMENT_NAME = "segmentName";
+    // Force commit job ZK props
+    public static final String CONSUMING_SEGMENTS_FORCE_COMMITTED_LIST = "segmentForceCommitted";
   }
 
   public static class Accounting {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -218,6 +218,14 @@ public class ControllerRequestURLBuilder {
     return stringBuilder.toString();
   }
 
+  public String forTableForceCommit(String tableName) {
+    return StringUtil.join("/", _baseUrl, "tables", tableName, "forceCommit");
+  }
+
+  public String forForceCommitJobStatus(String jobId) {
+    return StringUtil.join("/", _baseUrl, "tables", "forceCommitStatus", jobId);
+  }
+
   public String forTableReload(String tableName, TableType tableType, boolean forceDownload) {
     String query = String.format("reload?type=%s&forceDownload=%s", tableType.name(), forceDownload);
     return StringUtil.join("/", _baseUrl, "segments", tableName, query);


### PR DESCRIPTION
Force commit is an async operation with no way of knowing how many of the segments have succesfully been forcecommited after submitting the operation. This change adds an API to be able to check it's current progress