### PR TITLE
fix(ui): update table status to inline with new segment status

### DIFF
--- a/pinot-controller/src/main/resources/app/components/SegmentStatusRenderer.tsx
+++ b/pinot-controller/src/main/resources/app/components/SegmentStatusRenderer.tsx
@@ -99,7 +99,7 @@ export const SegmentStatusRenderer = ({
 
         break;
       }
-      case DISPLAY_SEGMENT_STATUS.PARTIAL: {
+      case DISPLAY_SEGMENT_STATUS.UPDATING: {
         setStatusColor(StatusColor.Warning);
         setStatusTooltipTitle("External view is OFFLINE or missing for one or more servers of this segment");
 

--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -367,7 +367,7 @@ export default function CustomizedTables({
         />
       );
     }
-    if (str.toLowerCase() === 'consuming' || str.toLocaleLowerCase() === "partial") {
+    if (str.toLowerCase() === 'consuming' || str.toLocaleLowerCase() === "partial" || str.toLocaleLowerCase() === "updating" ) {
       return (
         <StyledChip
           label={str}

--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -349,7 +349,7 @@ export default function CustomizedTables({
   }, [search, timeoutId, filterSearchResults]);
 
   const styleCell = (str: string) => {
-    if (str === 'Good' || str.toLowerCase() === 'online' || str.toLowerCase() === 'alive' || str.toLowerCase() === 'true') {
+    if (str.toLowerCase() === 'good' || str.toLowerCase() === 'online' || str.toLowerCase() === 'alive' || str.toLowerCase() === 'true') {
       return (
         <StyledChip
           label={str}
@@ -358,7 +358,7 @@ export default function CustomizedTables({
         />
       );
     }
-    if (str === 'Bad' || str.toLowerCase() === 'offline' || str.toLowerCase() === 'dead' || str.toLowerCase() === 'false') {
+    if (str.toLocaleLowerCase() === 'bad' || str.toLowerCase() === 'offline' || str.toLowerCase() === 'dead' || str.toLowerCase() === 'false') {
       return (
         <StyledChip
           label={str}
@@ -367,7 +367,7 @@ export default function CustomizedTables({
         />
       );
     }
-    if (str.toLowerCase() === 'consuming') {
+    if (str.toLowerCase() === 'consuming' || str.toLocaleLowerCase() === "partial") {
       return (
         <StyledChip
           label={str}

--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -235,6 +235,6 @@ declare module 'Models' {
   export const enum DISPLAY_SEGMENT_STATUS {
     BAD = "BAD",
     GOOD = "GOOD",
-    PARTIAL = "PARTIAL",
+    UPDATING = "UPDATING",
   }
 }

--- a/pinot-controller/src/main/resources/app/utils/Utils.tsx
+++ b/pinot-controller/src/main/resources/app/utils/Utils.tsx
@@ -63,55 +63,39 @@ const tableFormat = (data) => {
 };
 
 const getSegmentStatus = (idealStateObj, externalViewObj) => {
-  const idealSegmentKeys = Object.keys(idealStateObj);
-  const idealSegmentCount = idealSegmentKeys.length;
+  const tableStatus = getDisplayTableStatus(idealStateObj, externalViewObj);
+  const statusMismatchDiffComponent = (
+    <ReactDiffViewer
+      oldValue={JSON.stringify(idealStateObj, null, 2)}
+      newValue={JSON.stringify(externalViewObj, null, 2)}
+      splitView={true}
+      showDiffOnly={true}
+      leftTitle={"Ideal State"}
+      rightTitle={"External View"}
+      compareMethod={DiffMethod.WORDS}
+    />
+  );
 
-  const externalSegmentKeys = Object.keys(externalViewObj);
-  const externalSegmentCount = externalSegmentKeys.length;
-
-  if (idealSegmentCount !== externalSegmentCount) {
-    let segmentStatusComponent = (
-        <ReactDiffViewer
-            oldValue={JSON.stringify(idealStateObj, null, 2)}
-            newValue={JSON.stringify(externalViewObj, null, 2)}
-            splitView={true}
-            showDiffOnly={true}
-            leftTitle={"Ideal State"}
-            rightTitle={"External View"}
-            compareMethod={DiffMethod.WORDS}
-        />
-    )
-    return {
-      value: 'Bad',
-      tooltip: `Ideal Segment Count: ${idealSegmentCount} does not match external Segment Count: ${externalSegmentCount}`,
-      component: segmentStatusComponent,
-    };
+  if(tableStatus === DISPLAY_SEGMENT_STATUS.BAD) {
+    return ({
+      value: tableStatus,
+      tooltip: "One or more segments in this table are in bad state. Click the status to view more details.",
+      component: statusMismatchDiffComponent,
+    })
   }
 
-  let segmentStatus = {value: 'Good', tooltip: null, component: null};
-  idealSegmentKeys.map((segmentKey) => {
-    if (segmentStatus.value === 'Good') {
-      if (!isEqual(idealStateObj[segmentKey], externalViewObj[segmentKey])) {
-        let segmentStatusComponent = (
-            <ReactDiffViewer
-                oldValue={JSON.stringify(idealStateObj, null, 2)}
-                newValue={JSON.stringify(externalViewObj, null, 2)}
-                splitView={true}
-                showDiffOnly={true}
-                leftTitle={"Ideal State"}
-                rightTitle={"External View"}
-                compareMethod={DiffMethod.WORDS}
-            />
-        )
-        segmentStatus = {
-          value: 'Bad',
-          tooltip: "Ideal Status does not match external status",
-          component: segmentStatusComponent
-        };
-      }
-    }
+  if(tableStatus === DISPLAY_SEGMENT_STATUS.PARTIAL) {
+    return ({
+      value: tableStatus,
+      tooltip: "One or more segments in this table are in updating state. Click the status to view more details.",
+      component: statusMismatchDiffComponent,
+    })
+  }
+
+  return ({
+    value: tableStatus,
+    tooltip: "All segments in this table are in good state.",
   });
-  return segmentStatus;
 };
 
 const findNestedObj = (entireObj, keyToFind, valToFind) => {
@@ -346,6 +330,21 @@ const splitStringByLastUnderscore = (str: string) => {
   return [beforeUnderscore, afterUnderscore];
 }
 
+export const getDisplayTableStatus = (idealStateObj, externalViewObj): DISPLAY_SEGMENT_STATUS => {
+  const segmentStatusArr = [];
+  Object.keys(idealStateObj).forEach((key) => {
+    segmentStatusArr.push(getDisplaySegmentStatus(idealStateObj[key], externalViewObj[key]))
+  })
+
+  if(segmentStatusArr.includes(DISPLAY_SEGMENT_STATUS.BAD)) {
+    return DISPLAY_SEGMENT_STATUS.BAD;
+  }
+  if(segmentStatusArr.includes(DISPLAY_SEGMENT_STATUS.PARTIAL)) {
+    return DISPLAY_SEGMENT_STATUS.PARTIAL;
+  }
+  return DISPLAY_SEGMENT_STATUS.GOOD;
+}
+
 export const getDisplaySegmentStatus = (idealState, externalView): DISPLAY_SEGMENT_STATUS => {
   const externalViewStatesArray = Object.values(externalView || {});
 
@@ -355,7 +354,7 @@ export const getDisplaySegmentStatus = (idealState, externalView): DISPLAY_SEGME
   }
 
   // if EV status is CONSUMING or ONLINE then segment is in Good state
-  if(externalViewStatesArray.every((status) => status === SEGMENT_STATUS.CONSUMING || status === SEGMENT_STATUS.ONLINE)) {
+  if(externalViewStatesArray.every((status) => status === SEGMENT_STATUS.CONSUMING || status === SEGMENT_STATUS.ONLINE) && isEqual(idealState, externalView)) {
     return DISPLAY_SEGMENT_STATUS.GOOD;
   }
 

--- a/pinot-controller/src/main/resources/app/utils/Utils.tsx
+++ b/pinot-controller/src/main/resources/app/utils/Utils.tsx
@@ -84,7 +84,7 @@ const getSegmentStatus = (idealStateObj, externalViewObj) => {
     })
   }
 
-  if(tableStatus === DISPLAY_SEGMENT_STATUS.PARTIAL) {
+  if(tableStatus === DISPLAY_SEGMENT_STATUS.UPDATING) {
     return ({
       value: tableStatus,
       tooltip: "One or more segments in this table are in updating state. Click the status to view more details.",
@@ -339,8 +339,8 @@ export const getDisplayTableStatus = (idealStateObj, externalViewObj): DISPLAY_S
   if(segmentStatusArr.includes(DISPLAY_SEGMENT_STATUS.BAD)) {
     return DISPLAY_SEGMENT_STATUS.BAD;
   }
-  if(segmentStatusArr.includes(DISPLAY_SEGMENT_STATUS.PARTIAL)) {
-    return DISPLAY_SEGMENT_STATUS.PARTIAL;
+  if(segmentStatusArr.includes(DISPLAY_SEGMENT_STATUS.UPDATING)) {
+    return DISPLAY_SEGMENT_STATUS.UPDATING;
   }
   return DISPLAY_SEGMENT_STATUS.GOOD;
 }
@@ -366,11 +366,11 @@ export const getDisplaySegmentStatus = (idealState, externalView): DISPLAY_SEGME
   // If EV is empty or EV state is OFFLINE and does not matches IS then segment is in Partial state.
   // PARTIAL state can also be interpreted as we're waiting for segments to converge
   if(externalViewStatesArray.length === 0 || externalViewStatesArray.includes(SEGMENT_STATUS.OFFLINE) && !isEqual(idealState, externalView)) {
-    return DISPLAY_SEGMENT_STATUS.PARTIAL;
+    return DISPLAY_SEGMENT_STATUS.UPDATING;
   }
 
   // does not match any condition -> assume PARTIAL state as we are waiting for segments to converge 
-  return DISPLAY_SEGMENT_STATUS.PARTIAL;
+  return DISPLAY_SEGMENT_STATUS.UPDATING;
 }
 
 export default {


### PR DESCRIPTION
## What does this PR do?
- update table status to inline with new segment status
- change `Partial` segment & table status name to `Updating`

## Issue 
- Table status was incorrect and did not reflect segment status which was recently updated (#9699)
- Table status only have two status Good (IS matches EV) and Bad (IS != EV)
- The correct definition of table status should be calculated from updated segment status 
- Regarding segment status name change we got feedback that `Partial` name is confusing so changing that to `Updating` makes more sense.

## Solution
-  Based on updated segment status definitions below is how the table shows combined status of all the segments.
- when any segment status = Bad then table status = Bad
- when any segment status = Partial then table status = Partial
- IS = EV then table status = Good

https://user-images.githubusercontent.com/41536903/211564733-15956766-416d-4927-87b1-c53674a1d8c5.mp4

- segment status name change
<img width="721" alt="image" src="https://user-images.githubusercontent.com/41536903/211825775-89230f33-abd1-4925-b365-9e496c7579ca.png">

