### PR TITLE
[multistage] [debuggability] OpChain and operator stats

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -142,7 +142,7 @@ public class QueryRunner {
             new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), System.currentTimeMillis());
         serverQueryResults.add(processServerQuery(request, _scheduler.getWorkerPool()));
       }
-      LOGGER.error(
+      LOGGER.debug(
           "RequestId:" + requestId + " StageId:" + distributedStagePlan.getStageId() + " Leaf stage v1 processing time:"
               + (System.currentTimeMillis() - leafStageStartMillis) + " ms");
       MailboxSendNode sendNode = (MailboxSendNode) distributedStagePlan.getStageRoot();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -88,24 +88,20 @@ public class QueryRunner {
    * Initializes the query executor.
    * <p>Should be called only once and before calling any other method.
    */
-  public void init(PinotConfiguration config, InstanceDataManager instanceDataManager,
-      HelixManager helixManager, ServerMetrics serverMetrics) {
+  public void init(PinotConfiguration config, InstanceDataManager instanceDataManager, HelixManager helixManager,
+      ServerMetrics serverMetrics) {
     String instanceName = config.getProperty(QueryConfig.KEY_OF_QUERY_RUNNER_HOSTNAME);
     _hostname = instanceName.startsWith(CommonConstants.Helix.PREFIX_OF_SERVER_INSTANCE) ? instanceName.substring(
         CommonConstants.Helix.SERVER_INSTANCE_PREFIX_LENGTH) : instanceName;
     _port = config.getProperty(QueryConfig.KEY_OF_QUERY_RUNNER_PORT, QueryConfig.DEFAULT_QUERY_RUNNER_PORT);
     _helixManager = helixManager;
     try {
-      long releaseMs = config.getProperty(
-          QueryConfig.KEY_OF_SCHEDULER_RELEASE_TIMEOUT_MS,
+      long releaseMs = config.getProperty(QueryConfig.KEY_OF_SCHEDULER_RELEASE_TIMEOUT_MS,
           QueryConfig.DEFAULT_SCHEDULER_RELEASE_TIMEOUT_MS);
 
-      _scheduler = new OpChainSchedulerService(
-          new RoundRobinScheduler(releaseMs),
-          Executors.newFixedThreadPool(
-              ResourceManager.DEFAULT_QUERY_WORKER_THREADS,
-              new NamedThreadFactory("query_worker_on_" + _port + "_port")),
-          releaseMs);
+      _scheduler = new OpChainSchedulerService(new RoundRobinScheduler(releaseMs),
+          Executors.newFixedThreadPool(ResourceManager.DEFAULT_QUERY_WORKER_THREADS,
+              new NamedThreadFactory("query_worker_on_" + _port + "_port")), releaseMs);
       _mailboxService = MultiplexingMailboxService.newInstance(_hostname, _port, config, _scheduler::onDataAvailable);
       _serverExecutor = new ServerQueryExecutorV1Impl();
       _serverExecutor.init(config.subset(PINOT_V1_SERVER_QUERY_CONFIG_PREFIX), instanceDataManager, serverMetrics);
@@ -136,8 +132,8 @@ public class QueryRunner {
       // and package it here for return. But we should really use a MailboxSendOperator directly put into the
       // server executor.
       long leafStageStartMillis = System.currentTimeMillis();
-      List<ServerPlanRequestContext> serverQueryRequests = constructServerQueryRequests(distributedStagePlan,
-          requestMetadataMap, _helixPropertyStore, _mailboxService);
+      List<ServerPlanRequestContext> serverQueryRequests =
+          constructServerQueryRequests(distributedStagePlan, requestMetadataMap, _helixPropertyStore, _mailboxService);
 
       // send the data table via mailbox in one-off fashion (e.g. no block-level split, one data table/partition key)
       List<InstanceResponseBlock> serverQueryResults = new ArrayList<>(serverQueryRequests.size());
@@ -146,26 +142,27 @@ public class QueryRunner {
             new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), System.currentTimeMillis());
         serverQueryResults.add(processServerQuery(request, _scheduler.getWorkerPool()));
       }
-      LOGGER.debug("RequestId:", requestId, " StageId:", distributedStagePlan.getStageId(),
-          "Leaf stage processing time:", System.currentTimeMillis() - leafStageStartMillis, " ms");
+      LOGGER.error(
+          "RequestId:" + requestId + " StageId:" + distributedStagePlan.getStageId() + " Leaf stage v1 processing time:"
+              + (System.currentTimeMillis() - leafStageStartMillis) + " ms");
       MailboxSendNode sendNode = (MailboxSendNode) distributedStagePlan.getStageRoot();
       StageMetadata receivingStageMetadata = distributedStagePlan.getMetadataMap().get(sendNode.getReceiverStageId());
-      MailboxSendOperator mailboxSendOperator =
-          new MailboxSendOperator(_mailboxService,
-              new LeafStageTransferableBlockOperator(serverQueryResults, sendNode.getDataSchema(), requestId,
-                  sendNode.getStageId()),
-              receivingStageMetadata.getServerInstances(), sendNode.getExchangeType(),
-              sendNode.getPartitionKeySelector(), _hostname, _port, serverQueryRequests.get(0).getRequestId(),
-              sendNode.getStageId());
+      MailboxSendOperator mailboxSendOperator = new MailboxSendOperator(_mailboxService,
+          new LeafStageTransferableBlockOperator(serverQueryResults, sendNode.getDataSchema(), requestId,
+              sendNode.getStageId()), receivingStageMetadata.getServerInstances(), sendNode.getExchangeType(),
+          sendNode.getPartitionKeySelector(), _hostname, _port, serverQueryRequests.get(0).getRequestId(),
+          sendNode.getStageId());
       int blockCounter = 0;
       while (!TransferableBlockUtils.isEndOfStream(mailboxSendOperator.nextBlock())) {
         LOGGER.debug("Acquired transferable block: {}", blockCounter++);
       }
+      mailboxSendOperator.toExplainString();
     } else {
       long timeoutMs = Long.parseLong(requestMetadataMap.get(QueryConfig.KEY_OF_BROKER_REQUEST_TIMEOUT_MS));
       StageNode stageRoot = distributedStagePlan.getStageRoot();
-      OpChain rootOperator = PhysicalPlanVisitor.build(stageRoot, new PlanRequestContext(_mailboxService, requestId,
-          stageRoot.getStageId(), timeoutMs, _hostname, _port, distributedStagePlan.getMetadataMap()));
+      OpChain rootOperator = PhysicalPlanVisitor.build(stageRoot,
+          new PlanRequestContext(_mailboxService, requestId, stageRoot.getStageId(), timeoutMs, _hostname, _port,
+              distributedStagePlan.getMetadataMap()));
       _scheduler.register(rootOperator);
     }
   }
@@ -177,8 +174,8 @@ public class QueryRunner {
     Preconditions.checkState(stageMetadata.getScannedTables().size() == 1,
         "Server request for V2 engine should only have 1 scan table per request.");
     String rawTableName = stageMetadata.getScannedTables().get(0);
-    Map<String, List<String>> tableToSegmentListMap = stageMetadata.getServerInstanceToSegmentsMap()
-        .get(distributedStagePlan.getServerInstance());
+    Map<String, List<String>> tableToSegmentListMap =
+        stageMetadata.getServerInstanceToSegmentsMap().get(distributedStagePlan.getServerInstance());
     List<ServerPlanRequestContext> requests = new ArrayList<>();
     for (Map.Entry<String, List<String>> tableEntry : tableToSegmentListMap.entrySet()) {
       String tableType = tableEntry.getKey();
@@ -190,15 +187,17 @@ public class QueryRunner {
             TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(rawTableName));
         Schema schema = ZKMetadataProvider.getTableSchema(helixPropertyStore,
             TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(rawTableName));
-        requests.add(ServerRequestPlanVisitor.build(mailboxService, distributedStagePlan, requestMetadataMap,
-            tableConfig, schema, stageMetadata.getTimeBoundaryInfo(), TableType.OFFLINE, tableEntry.getValue()));
+        requests.add(
+            ServerRequestPlanVisitor.build(mailboxService, distributedStagePlan, requestMetadataMap, tableConfig,
+                schema, stageMetadata.getTimeBoundaryInfo(), TableType.OFFLINE, tableEntry.getValue()));
       } else if (TableType.REALTIME.name().equals(tableType)) {
         TableConfig tableConfig = ZKMetadataProvider.getTableConfig(helixPropertyStore,
             TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(rawTableName));
         Schema schema = ZKMetadataProvider.getTableSchema(helixPropertyStore,
             TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(rawTableName));
-        requests.add(ServerRequestPlanVisitor.build(mailboxService, distributedStagePlan, requestMetadataMap,
-            tableConfig, schema, stageMetadata.getTimeBoundaryInfo(), TableType.REALTIME, tableEntry.getValue()));
+        requests.add(
+            ServerRequestPlanVisitor.build(mailboxService, distributedStagePlan, requestMetadataMap, tableConfig,
+                schema, stageMetadata.getTimeBoundaryInfo(), TableType.REALTIME, tableEntry.getValue()));
       } else {
         throw new IllegalArgumentException("Unsupported table type key: " + tableType);
       }
@@ -212,8 +211,8 @@ public class QueryRunner {
       return _serverExecutor.execute(serverQueryRequest, executorService);
     } catch (Exception e) {
       InstanceResponseBlock errorResponse = new InstanceResponseBlock();
-      errorResponse.getExceptions().put(QueryException.QUERY_EXECUTION_ERROR_CODE,
-          e.getMessage() + QueryException.getTruncatedStackTrace(e));
+      errorResponse.getExceptions()
+          .put(QueryException.QUERY_EXECUTION_ERROR_CODE, e.getMessage() + QueryException.getTruncatedStackTrace(e));
       return errorResponse;
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -135,6 +135,7 @@ public class QueryRunner {
       // TODO: make server query request return via mailbox, this is a hack to gather the non-streaming data table
       // and package it here for return. But we should really use a MailboxSendOperator directly put into the
       // server executor.
+      long leafStageStartMillis = System.currentTimeMillis();
       List<ServerPlanRequestContext> serverQueryRequests = constructServerQueryRequests(distributedStagePlan,
           requestMetadataMap, _helixPropertyStore, _mailboxService);
 
@@ -145,6 +146,8 @@ public class QueryRunner {
             new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), System.currentTimeMillis());
         serverQueryResults.add(processServerQuery(request, _scheduler.getWorkerPool()));
       }
+      LOGGER.debug("RequestId:", requestId, " StageId:", distributedStagePlan.getStageId(),
+          "Leaf stage processing time:", System.currentTimeMillis() - leafStageStartMillis, " ms");
       MailboxSendNode sendNode = (MailboxSendNode) distributedStagePlan.getStageRoot();
       StageMetadata receivingStageMetadata = distributedStagePlan.getMetadataMap().get(sendNode.getReceiverStageId());
       MailboxSendOperator mailboxSendOperator =

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -119,7 +119,7 @@ public class OpChainSchedulerService extends AbstractExecutionThreadService {
                         result.getDataBlock().getExceptions());
                   } else {
                     operatorChain.getRoot().toExplainString();
-                    LOGGER.error("({}): Completed {}", operatorChain, operatorChain.getStats());
+                    LOGGER.debug("({}): Completed {}", operatorChain, operatorChain.getStats());
                   }
                   operatorChain.close();
                 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -114,15 +114,18 @@ public class OpChainSchedulerService extends AbstractExecutionThreadService {
                   register(operatorChain, false);
                 } else {
                   if (result.isErrorBlock()) {
+                    operatorChain.getRoot().toExplainString();
                     LOGGER.error("({}): Completed erroneously {} {}", operatorChain, operatorChain.getStats(),
                         result.getDataBlock().getExceptions());
                   } else {
-                    LOGGER.debug("({}): Completed {}", operatorChain, operatorChain.getStats());
+                    operatorChain.getRoot().toExplainString();
+                    LOGGER.error("({}): Completed {}", operatorChain, operatorChain.getStats());
                   }
                   operatorChain.close();
                 }
               } catch (Exception e) {
                 operatorChain.close();
+                operatorChain.getRoot().toExplainString();
                 LOGGER.error("({}): Failed to execute operator chain! {}", operatorChain, operatorChain.getStats(), e);
               }
             }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -154,11 +154,6 @@ public class OpChainSchedulerService extends AbstractExecutionThreadService {
     LOGGER.debug("({}): Scheduler is now handling operator chain listening to mailboxes {}. "
             + "There are a total of {} chains awaiting execution.", operatorChain, operatorChain.getReceivingMailbox(),
         _scheduler.size());
-
-    // we want to track the time that it takes from registering
-    // an operator chain to when it completes, so make sure to
-    // start the timer here
-    operatorChain.getStats().startExecutionTimer();
   }
 
   public final void register(OpChain operatorChain, boolean isNew) {
@@ -167,8 +162,8 @@ public class OpChainSchedulerService extends AbstractExecutionThreadService {
       LOGGER.trace("({}): Registered operator chain (new: {}). Total: {}", operatorChain, isNew, _scheduler.size());
 
       _scheduler.register(operatorChain, isNew);
-      operatorChain.getStats().queued();
     } finally {
+      operatorChain.getStats().queued();
       _monitor.leave();
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -124,6 +124,9 @@ public class AggregateOperator extends MultiStageOperator {
   @Nullable
   @Override
   public String toExplainString() {
+    // TODO: move to close call;
+    _inputOperator.toExplainString();
+    LOGGER.error(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 
@@ -143,11 +146,9 @@ public class AggregateOperator extends MultiStageOperator {
         return produceAggregatedBlock();
       } else {
         // TODO: Move to close call.
-        LOGGER.debug("OperatorStats:" + _operatorStats);
         return TransferableBlockUtils.getEndOfStreamTransferableBlock();
       }
     } catch (Exception e) {
-      LOGGER.error("OperatorStats:" + _operatorStats);
       return TransferableBlockUtils.getErrorTransferableBlock(e);
     } finally {
       _operatorStats.endTimer();
@@ -167,7 +168,6 @@ public class AggregateOperator extends MultiStageOperator {
     }
     _hasReturnedAggregateBlock = true;
     if (rows.size() == 0) {
-      LOGGER.debug("OperatorStats:" + _operatorStats);
       return TransferableBlockUtils.getEndOfStreamTransferableBlock();
     } else {
       _operatorStats.recordOutput(1, rows.size());

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -35,11 +35,7 @@ import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-<<<<<<< HEAD
 import org.apache.pinot.segment.local.customobject.PinotFourthMoment;
-=======
-import org.apache.pinot.query.runtime.plan.PlanRequestContext;
->>>>>>> cead50bd07 (opchain and operator stats)
 import org.apache.pinot.spi.data.FieldSpec;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -91,9 +87,9 @@ public class AggregateOperator extends MultiStageOperator {
   }
 
   @VisibleForTesting
-  AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema,
-      List<RexExpression> aggCalls, List<RexExpression> groupSet, DataSchema inputSchema, Map<String,
-      Function<DataSchema.ColumnDataType, Merger>> mergers, long requestId, int stageId) {
+  AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema, List<RexExpression> aggCalls,
+      List<RexExpression> groupSet, DataSchema inputSchema, Map<String, Function<DataSchema.ColumnDataType, Merger>> mergers,
+      long requestId, int stageId) {
     _inputOperator = inputOperator;
     _groupSet = groupSet;
     _upstreamErrorBlock = null;
@@ -183,7 +179,9 @@ public class AggregateOperator extends MultiStageOperator {
    * @return whether or not the operator is ready to move on (EOS or ERROR)
    */
   private boolean consumeInputBlocks() {
+    _operatorStats.endTimer();
     TransferableBlock block = _inputOperator.nextBlock();
+    _operatorStats.startTimer();
     while (!block.isNoOpBlock()) {
       // setting upstream error block
       if (block.isErrorBlock()) {
@@ -203,7 +201,9 @@ public class AggregateOperator extends MultiStageOperator {
         }
       }
       _operatorStats.recordInput(1, container.size());
+      _operatorStats.endTimer();
       block = _inputOperator.nextBlock();
+      _operatorStats.startTimer();
     }
     return false;
   }
@@ -291,8 +291,7 @@ public class AggregateOperator extends MultiStageOperator {
   }
 
   private static class Accumulator {
-
-    private static final Map<String, Function<DataSchema.ColumnDataType, Merger>> MERGERS = ImmutableMap
+  private static final Map<String, Function<DataSchema.ColumnDataType, Merger>> MERGERS = ImmutableMap
         .<String, Function<DataSchema.ColumnDataType, Merger>>builder()
         .put("SUM", cdt -> AggregateOperator::mergeSum)
         .put("$SUM", cdt -> AggregateOperator::mergeSum)

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -88,16 +88,14 @@ public class AggregateOperator extends MultiStageOperator {
 
   @VisibleForTesting
   AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema, List<RexExpression> aggCalls,
-      List<RexExpression> groupSet, DataSchema inputSchema, Map<String, Function<DataSchema.ColumnDataType, Merger>> mergers,
-      long requestId, int stageId) {
+      List<RexExpression> groupSet, DataSchema inputSchema,
+      Map<String, Function<DataSchema.ColumnDataType, Merger>> mergers, long requestId, int stageId) {
     _inputOperator = inputOperator;
     _groupSet = groupSet;
     _upstreamErrorBlock = null;
 
     // we expect all agg calls to be aggregate function calls
-    _aggCalls = aggCalls.stream()
-        .map(RexExpression.FunctionCall.class::cast)
-        .collect(Collectors.toList());
+    _aggCalls = aggCalls.stream().map(RexExpression.FunctionCall.class::cast).collect(Collectors.toList());
 
     _accumulators = new Accumulator[_aggCalls.size()];
     for (int i = 0; i < _aggCalls.size(); i++) {
@@ -291,31 +289,25 @@ public class AggregateOperator extends MultiStageOperator {
   }
 
   private static class Accumulator {
-  private static final Map<String, Function<DataSchema.ColumnDataType, Merger>> MERGERS = ImmutableMap
-        .<String, Function<DataSchema.ColumnDataType, Merger>>builder()
-        .put("SUM", cdt -> AggregateOperator::mergeSum)
-        .put("$SUM", cdt -> AggregateOperator::mergeSum)
-        .put("$SUM0", cdt -> AggregateOperator::mergeSum)
-        .put("MIN", cdt -> AggregateOperator::mergeMin)
-        .put("$MIN", cdt -> AggregateOperator::mergeMin)
-        .put("$MIN0", cdt -> AggregateOperator::mergeMin)
-        .put("MAX", cdt -> AggregateOperator::mergeMax)
-        .put("$MAX", cdt -> AggregateOperator::mergeMax)
-        .put("$MAX0", cdt -> AggregateOperator::mergeMax)
-        .put("COUNT", cdt -> AggregateOperator::mergeCount)
-        .put("BOOL_AND", cdt -> AggregateOperator::mergeBoolAnd)
-        .put("$BOOL_AND", cdt -> AggregateOperator::mergeBoolAnd)
-        .put("$BOOL_AND0", cdt -> AggregateOperator::mergeBoolAnd)
-        .put("BOOL_OR", cdt -> AggregateOperator::mergeBoolOr)
-        .put("$BOOL_OR", cdt -> AggregateOperator::mergeBoolOr)
-        .put("$BOOL_OR0", cdt -> AggregateOperator::mergeBoolOr)
-        .put("FOURTHMOMENT", cdt -> cdt == DataSchema.ColumnDataType.OBJECT
-            ? new MergeFourthMomentObject() : new MergeFourthMomentNumeric())
-        .put("$FOURTHMOMENT", cdt -> cdt == DataSchema.ColumnDataType.OBJECT
-            ? new MergeFourthMomentObject() : new MergeFourthMomentNumeric())
-        .put("$FOURTHMOMENT0", cdt -> cdt == DataSchema.ColumnDataType.OBJECT
-            ? new MergeFourthMomentObject() : new MergeFourthMomentNumeric())
-        .build();
+    private static final Map<String, Function<DataSchema.ColumnDataType, Merger>> MERGERS =
+        ImmutableMap.<String, Function<DataSchema.ColumnDataType, Merger>>builder()
+            .put("SUM", cdt -> AggregateOperator::mergeSum).put("$SUM", cdt -> AggregateOperator::mergeSum)
+            .put("$SUM0", cdt -> AggregateOperator::mergeSum).put("MIN", cdt -> AggregateOperator::mergeMin)
+            .put("$MIN", cdt -> AggregateOperator::mergeMin).put("$MIN0", cdt -> AggregateOperator::mergeMin)
+            .put("MAX", cdt -> AggregateOperator::mergeMax).put("$MAX", cdt -> AggregateOperator::mergeMax)
+            .put("$MAX0", cdt -> AggregateOperator::mergeMax).put("COUNT", cdt -> AggregateOperator::mergeCount)
+            .put("BOOL_AND", cdt -> AggregateOperator::mergeBoolAnd)
+            .put("$BOOL_AND", cdt -> AggregateOperator::mergeBoolAnd)
+            .put("$BOOL_AND0", cdt -> AggregateOperator::mergeBoolAnd)
+            .put("BOOL_OR", cdt -> AggregateOperator::mergeBoolOr)
+            .put("$BOOL_OR", cdt -> AggregateOperator::mergeBoolOr)
+            .put("$BOOL_OR0", cdt -> AggregateOperator::mergeBoolOr).put("FOURTHMOMENT",
+                cdt -> cdt == DataSchema.ColumnDataType.OBJECT ? new MergeFourthMomentObject()
+                    : new MergeFourthMomentNumeric()).put("$FOURTHMOMENT",
+                cdt -> cdt == DataSchema.ColumnDataType.OBJECT ? new MergeFourthMomentObject()
+                    : new MergeFourthMomentNumeric()).put("$FOURTHMOMENT0",
+                cdt -> cdt == DataSchema.ColumnDataType.OBJECT ? new MergeFourthMomentObject()
+                    : new MergeFourthMomentNumeric()).build();
 
     final int _inputRef;
     final Object _literal;
@@ -357,8 +349,7 @@ public class AggregateOperator extends MultiStageOperator {
     private RexExpression toAggregationFunctionOperand(RexExpression.FunctionCall rexExpression) {
       List<RexExpression> functionOperands = rexExpression.getFunctionOperands();
       Preconditions.checkState(functionOperands.size() < 2, "aggregate functions cannot have more than one operand");
-      return functionOperands.size() > 0
-          ? functionOperands.get(0)
+      return functionOperands.size() > 0 ? functionOperands.get(0)
           : new RexExpression.Literal(FieldSpec.DataType.INT, 1);
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -126,7 +126,7 @@ public class AggregateOperator extends MultiStageOperator {
   public String toExplainString() {
     // TODO: move to close call;
     _inputOperator.toExplainString();
-    LOGGER.error(_operatorStats.toString());
+    LOGGER.debug(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -29,7 +29,6 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.utils.FunctionInvokeUtils;
-import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,31 +48,22 @@ import org.slf4j.LoggerFactory;
  */
 public class FilterOperator extends MultiStageOperator {
   private static final String EXPLAIN_NAME = "FILTER";
-<<<<<<< HEAD
   private final MultiStageOperator _upstreamOperator;
-=======
   private static final Logger LOGGER = LoggerFactory.getLogger(AggregateOperator.class);
-
-  private final Operator<TransferableBlock> _upstreamOperator;
->>>>>>> a5662b3d36 (opchain and operator stats)
   private final TransformOperand _filterOperand;
   private final DataSchema _dataSchema;
   private TransferableBlock _upstreamErrorBlock;
 
-<<<<<<< HEAD
-  public FilterOperator(MultiStageOperator upstreamOperator, DataSchema dataSchema, RexExpression filter) {
-=======
   // TODO: Move to OperatorContext class.
   private OperatorStats _operatorStats;
 
-  public FilterOperator(Operator<TransferableBlock> upstreamOperator, DataSchema dataSchema, RexExpression filter,
-      PlanRequestContext context) {
->>>>>>> a5662b3d36 (opchain and operator stats)
+  public FilterOperator(MultiStageOperator upstreamOperator, DataSchema dataSchema, RexExpression filter,
+      long requestId, int stageId) {
     _upstreamOperator = upstreamOperator;
     _dataSchema = dataSchema;
     _filterOperand = TransformOperand.toTransformOperand(filter, dataSchema);
     _upstreamErrorBlock = null;
-    _operatorStats = new OperatorStats(context.getRequestId(), context.getStageId(), EXPLAIN_NAME);
+    _operatorStats = new OperatorStats(requestId, stageId, toExplainString());
   }
 
   @Override
@@ -91,7 +81,10 @@ public class FilterOperator extends MultiStageOperator {
   protected TransferableBlock getNextBlock() {
     _operatorStats.startTimer();
     try {
-      return transform(_upstreamOperator.nextBlock());
+      _operatorStats.endTimer();
+      TransferableBlock block = _upstreamOperator.nextBlock();
+      _operatorStats.startTimer();
+      return transform(block);
     } catch (Exception e) {
       LOGGER.debug("OperatorStats:" + _operatorStats);
       return TransferableBlockUtils.getErrorTransferableBlock(e);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -75,7 +75,7 @@ public class FilterOperator extends MultiStageOperator {
   @Override
   public String toExplainString() {
     _upstreamOperator.toExplainString();
-    LOGGER.error(_operatorStats.toString());
+    LOGGER.debug(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -132,7 +132,7 @@ public class HashJoinOperator extends MultiStageOperator {
   public String toExplainString() {
     _leftTableOperator.toExplainString();
     _rightTableOperator.toExplainString();
-    LOGGER.error(_operatorStats.toString());
+    LOGGER.debug(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -118,7 +118,7 @@ public class HashJoinOperator extends MultiStageOperator {
       _matchedRightRows = null;
     }
     _upstreamErrorBlock = null;
-    _operatorStats = new OperatorStats(requestId, stageId, toExplainString());
+    _operatorStats = new OperatorStats(requestId, stageId, EXPLAIN_NAME);
   }
 
   // TODO: Separate left and right table operator.
@@ -130,6 +130,9 @@ public class HashJoinOperator extends MultiStageOperator {
   @Nullable
   @Override
   public String toExplainString() {
+    _leftTableOperator.toExplainString();
+    _rightTableOperator.toExplainString();
+    LOGGER.error(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 
@@ -138,7 +141,6 @@ public class HashJoinOperator extends MultiStageOperator {
     _operatorStats.startTimer();
     try {
       if (_isTerminated) {
-        LOGGER.debug("OperatorStats:" + _operatorStats);
         return TransferableBlockUtils.getEndOfStreamTransferableBlock();
       }
       if (!_isHashTableBuilt) {
@@ -146,7 +148,6 @@ public class HashJoinOperator extends MultiStageOperator {
         buildBroadcastHashTable();
       }
       if (_upstreamErrorBlock != null) {
-        LOGGER.error("OperatorStats:" + _operatorStats);
         return _upstreamErrorBlock;
       } else if (!_isHashTableBuilt) {
         return TransferableBlockUtils.getNoOpTransferableBlock();
@@ -157,7 +158,6 @@ public class HashJoinOperator extends MultiStageOperator {
       // JOIN each left block with the right block.
       return buildJoinedDataBlock(leftBlock);
     } catch (Exception e) {
-      LOGGER.error("OperatorStats:" + _operatorStats);
       return TransferableBlockUtils.getErrorTransferableBlock(e);
     } finally {
       _operatorStats.endTimer();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -40,6 +40,8 @@ import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -57,17 +59,23 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
  */
 public class LeafStageTransferableBlockOperator extends MultiStageOperator {
   private static final String EXPLAIN_NAME = "LEAF_STAGE_TRANSFER_OPERATOR";
+  private static final Logger LOGGER = LoggerFactory.getLogger(LeafStageTransferableBlockOperator.class);
 
   private final InstanceResponseBlock _errorBlock;
   private final List<InstanceResponseBlock> _baseResultBlock;
   private final DataSchema _desiredDataSchema;
   private int _currentIndex;
 
-  public LeafStageTransferableBlockOperator(List<InstanceResponseBlock> baseResultBlock, DataSchema dataSchema) {
+  // TODO: Move to OperatorContext class.
+  private OperatorStats _operatorStats;
+
+  public LeafStageTransferableBlockOperator(List<InstanceResponseBlock> baseResultBlock, DataSchema dataSchema,
+      long requestId, int stageId) {
     _baseResultBlock = baseResultBlock;
     _desiredDataSchema = dataSchema;
     _errorBlock = baseResultBlock.stream().filter(e -> !e.getExceptions().isEmpty()).findFirst().orElse(null);
     _currentIndex = 0;
+    _operatorStats = new OperatorStats(requestId, stageId, EXPLAIN_NAME);
   }
 
   @Override
@@ -83,24 +91,35 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
 
   @Override
   protected TransferableBlock getNextBlock() {
-    if (_currentIndex < 0) {
-      throw new RuntimeException("Leaf transfer terminated. next block should no longer be called.");
-    }
-    if (_errorBlock != null) {
-      _currentIndex = -1;
-      return new TransferableBlock(DataBlockUtils.getErrorDataBlock(_errorBlock.getExceptions()));
-    } else {
-      if (_currentIndex < _baseResultBlock.size()) {
-        InstanceResponseBlock responseBlock = _baseResultBlock.get(_currentIndex++);
-        if (responseBlock.getResultsBlock() != null && responseBlock.getResultsBlock().getNumRows() > 0) {
-          return composeTransferableBlock(responseBlock, _desiredDataSchema);
-        } else {
-          return new TransferableBlock(Collections.emptyList(), _desiredDataSchema, DataBlock.Type.ROW);
-        }
-      } else {
-        _currentIndex = -1;
-        return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock());
+    _operatorStats.startTimer();
+    try {
+      if (_currentIndex < 0) {
+        throw new RuntimeException("Leaf transfer terminated. next block should no longer be called.");
       }
+      if (_errorBlock != null) {
+        _currentIndex = -1;
+        LOGGER.error("OperatorStats:" + _operatorStats);
+        return new TransferableBlock(DataBlockUtils.getErrorDataBlock(_errorBlock.getExceptions()));
+      } else {
+        if (_currentIndex < _baseResultBlock.size()) {
+          InstanceResponseBlock responseBlock = _baseResultBlock.get(_currentIndex++);
+          if (responseBlock.getResultsBlock() != null && responseBlock.getResultsBlock().getNumRows() > 0) {
+            _operatorStats.recordInput(1, responseBlock.getResultsBlock().getNumRows());
+            _operatorStats.recordOutput(1, responseBlock.getResultsBlock().getNumRows());
+            return composeTransferableBlock(responseBlock, _desiredDataSchema);
+          } else {
+            _operatorStats.recordInput(1, responseBlock.getResultsBlock().getNumRows());
+            _operatorStats.recordOutput(1, responseBlock.getResultsBlock().getNumRows());
+            return new TransferableBlock(Collections.emptyList(), _desiredDataSchema, DataBlock.Type.ROW);
+          }
+        } else {
+          _currentIndex = -1;
+          LOGGER.debug("OperatorStats:" + _operatorStats);
+          return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock());
+        }
+      }
+    } finally {
+      _operatorStats.endTimer();
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -75,7 +75,7 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     _desiredDataSchema = dataSchema;
     _errorBlock = baseResultBlock.stream().filter(e -> !e.getExceptions().isEmpty()).findFirst().orElse(null);
     _currentIndex = 0;
-    _operatorStats = new OperatorStats(requestId, stageId, EXPLAIN_NAME);
+    _operatorStats = new OperatorStats(requestId, stageId, toExplainString());
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -86,7 +86,7 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
   @Nullable
   @Override
   public String toExplainString() {
-    LOGGER.error(_operatorStats.toString());
+    LOGGER.debug(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -75,7 +75,7 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     _desiredDataSchema = dataSchema;
     _errorBlock = baseResultBlock.stream().filter(e -> !e.getExceptions().isEmpty()).findFirst().orElse(null);
     _currentIndex = 0;
-    _operatorStats = new OperatorStats(requestId, stageId, toExplainString());
+    _operatorStats = new OperatorStats(requestId, stageId, EXPLAIN_NAME);
   }
 
   @Override
@@ -86,19 +86,19 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
   @Nullable
   @Override
   public String toExplainString() {
+    LOGGER.error(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 
   @Override
   protected TransferableBlock getNextBlock() {
-    _operatorStats.startTimer();
     try {
+      _operatorStats.startTimer();
       if (_currentIndex < 0) {
         throw new RuntimeException("Leaf transfer terminated. next block should no longer be called.");
       }
       if (_errorBlock != null) {
         _currentIndex = -1;
-        LOGGER.error("OperatorStats:" + _operatorStats);
         return new TransferableBlock(DataBlockUtils.getErrorDataBlock(_errorBlock.getExceptions()));
       } else {
         if (_currentIndex < _baseResultBlock.size()) {
@@ -114,7 +114,6 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
           }
         } else {
           _currentIndex = -1;
-          LOGGER.debug("OperatorStats:" + _operatorStats);
           return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock());
         }
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -44,7 +44,7 @@ public class LiteralValueOperator extends MultiStageOperator {
   public LiteralValueOperator(DataSchema dataSchema, List<List<RexExpression>> rexLiteralRows,
       long requestId, int stageId) {
     _dataSchema = dataSchema;
-    _operatorStats = new OperatorStats(requestId, stageId, toExplainString());
+    _operatorStats = new OperatorStats(requestId, stageId, EXPLAIN_NAME);
     _rexLiteralBlock = constructBlock(rexLiteralRows);
     _isLiteralBlockReturned = false;
   }
@@ -57,18 +57,18 @@ public class LiteralValueOperator extends MultiStageOperator {
   @Nullable
   @Override
   public String toExplainString() {
+    LOGGER.error(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 
   @Override
   protected TransferableBlock getNextBlock() {
-    _operatorStats.startTimer();
     try {
+      _operatorStats.startTimer();
       if (!_isLiteralBlockReturned) {
         _isLiteralBlockReturned = true;
         return _rexLiteralBlock;
       } else {
-        LOGGER.debug("OperatorStats:" + _operatorStats);
         return TransferableBlockUtils.getEndOfStreamTransferableBlock();
       }
     } finally {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -57,7 +57,7 @@ public class LiteralValueOperator extends MultiStageOperator {
   @Nullable
   @Override
   public String toExplainString() {
-    LOGGER.error(_operatorStats.toString());
+    LOGGER.debug(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -27,7 +27,6 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -43,9 +42,9 @@ public class LiteralValueOperator extends MultiStageOperator {
   private OperatorStats _operatorStats;
 
   public LiteralValueOperator(DataSchema dataSchema, List<List<RexExpression>> rexLiteralRows,
-      PlanRequestContext context) {
+      long requestId, int stageId) {
     _dataSchema = dataSchema;
-    _operatorStats = new OperatorStats(context.getRequestId(), context.getStageId(), EXPLAIN_NAME);
+    _operatorStats = new OperatorStats(requestId, stageId, toExplainString());
     _rexLiteralBlock = constructBlock(rexLiteralRows);
     _isLiteralBlockReturned = false;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -171,8 +171,8 @@ public class MailboxReceiveOperator extends MultiStageOperator {
             }
           }
         } catch (Exception e) {
-          // TODO: Handle this exception.
-          LOGGER.error(String.format("Error receiving data from mailbox %s", mailboxId), e);
+          return TransferableBlockUtils.getErrorTransferableBlock(
+              new RuntimeException(String.format("Error polling mailbox=%s", mailboxId), e));
         }
       }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -110,7 +110,7 @@ public class MailboxReceiveOperator extends MultiStageOperator {
     }
     _upstreamErrorBlock = null;
     _serverIdx = 0;
-    _operatorStats = new OperatorStats(jobId, stageId, EXPLAIN_NAME);
+    _operatorStats = new OperatorStats(jobId, stageId, toExplainString());
   }
 
   public List<MailboxIdentifier> getSendingMailbox() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -125,7 +125,7 @@ public class MailboxReceiveOperator extends MultiStageOperator {
   @Nullable
   @Override
   public String toExplainString() {
-    LOGGER.error(_operatorStats.toString());
+    LOGGER.debug(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -126,7 +126,9 @@ public class MailboxSendOperator extends MultiStageOperator {
     _operatorStats.startTimer();
     TransferableBlock transferableBlock;
     try {
+      _operatorStats.endTimer();
       transferableBlock = _dataTableBlockBaseOperator.nextBlock();
+      _operatorStats.startTimer();
       while (!transferableBlock.isNoOpBlock()) {
         _exchange.send(transferableBlock);
         _operatorStats.recordInput(1, transferableBlock.getNumRows());
@@ -136,8 +138,9 @@ public class MailboxSendOperator extends MultiStageOperator {
           LOGGER.debug("OperatorStats:" + _operatorStats);
           return transferableBlock;
         }
-
+        _operatorStats.endTimer();
         transferableBlock = _dataTableBlockBaseOperator.nextBlock();
+        _operatorStats.startTimer();
       }
     } catch (final Exception e) {
       // ideally, MailboxSendOperator doesn't ever throw an exception because

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -119,7 +119,7 @@ public class MailboxSendOperator extends MultiStageOperator {
   @Override
   public String toExplainString() {
     _dataTableBlockBaseOperator.toExplainString();
-    LOGGER.error(_operatorStats.toString());
+    LOGGER.debug(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -118,6 +118,8 @@ public class MailboxSendOperator extends MultiStageOperator {
   @Nullable
   @Override
   public String toExplainString() {
+    _dataTableBlockBaseOperator.toExplainString();
+    LOGGER.error(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 
@@ -135,7 +137,6 @@ public class MailboxSendOperator extends MultiStageOperator {
         // The # of output block is not accurate because we may do a split in exchange send.
         _operatorStats.recordOutput(1, transferableBlock.getNumRows());
         if (transferableBlock.isEndOfStreamBlock()) {
-          LOGGER.debug("OperatorStats:" + _operatorStats);
           return transferableBlock;
         }
         _operatorStats.endTimer();
@@ -151,10 +152,8 @@ public class MailboxSendOperator extends MultiStageOperator {
         _exchange.send(transferableBlock);
       } catch (Exception e2) {
         LOGGER.error("Exception while sending block to mailbox.", e2);
-        LOGGER.error("OperatorStats:" + _operatorStats);
       }
     } finally {
-      // This time is incorrect because mailbox send is async.
       _operatorStats.endTimer();
     }
     return transferableBlock;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
@@ -52,6 +52,7 @@ public class OpChain implements AutoCloseable {
     return _receivingMailbox;
   }
 
+  // TODO: Move OperatorStats here.
   public OpChainStats getStats() {
     return _stats;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainStats.java
@@ -34,13 +34,14 @@ public class OpChainStats {
 
   // use memoized supplier so that the timing doesn't start until the
   // first time we get the timer
-  private final Supplier<ThreadResourceUsageProvider> _exTimer
-      = Suppliers.memoize(ThreadResourceUsageProvider::new)::get;
+  private final Supplier<ThreadResourceUsageProvider> _exTimer =
+      Suppliers.memoize(ThreadResourceUsageProvider::new)::get;
 
   // this is used to make sure that toString() doesn't have side
   // effects (accidentally starting the timer)
   private volatile boolean _exTimerStarted = false;
 
+  private final Stopwatch _executeStopwatch = Stopwatch.createUnstarted();
   private final Stopwatch _queuedStopwatch = Stopwatch.createUnstarted();
   private final AtomicLong _queuedCount = new AtomicLong();
 
@@ -62,20 +63,23 @@ public class OpChainStats {
     if (!_queuedStopwatch.isRunning()) {
       _queuedStopwatch.start();
     }
+    if (_executeStopwatch.isRunning()) {
+      _executeStopwatch.stop();
+    }
   }
 
   public void startExecutionTimer() {
     _exTimerStarted = true;
     _exTimer.get();
+    if (!_executeStopwatch.isRunning()) {
+      _executeStopwatch.start();
+    }
   }
 
   @Override
   public String toString() {
-    return String.format("(%s) Queued Count: %s, Executing Time: %sms, Queued Time: %sms",
-        _id,
-        _queuedCount.get(),
-        _exTimerStarted ? TimeUnit.NANOSECONDS.toMillis(_exTimer.get().getThreadTimeNs()) : 0,
-        _queuedStopwatch.elapsed(TimeUnit.MILLISECONDS)
-    );
+    return String.format("(%s) Queued Count: %s, Executing Time: %sms, Queued Time: %sms", _id, _queuedCount.get(),
+        _exTimerStarted ? _executeStopwatch.elapsed(TimeUnit.MILLISECONDS) : 0,
+        _queuedStopwatch.elapsed(TimeUnit.MILLISECONDS));
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
@@ -45,11 +45,15 @@ public class OperatorStats {
   }
 
   public void startTimer() {
-    _executeStopwatch.start();
+    if(!_executeStopwatch.isRunning()){
+      _executeStopwatch.start();
+    }
   }
 
   public void endTimer() {
-    _executeStopwatch.stop();
+    if(_executeStopwatch.isRunning()) {
+      _executeStopwatch.stop();
+    }
   }
 
   public void recordInput(int numBlock, int numRows) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
@@ -45,13 +45,13 @@ public class OperatorStats {
   }
 
   public void startTimer() {
-    if(!_executeStopwatch.isRunning()){
+    if (!_executeStopwatch.isRunning()) {
       _executeStopwatch.start();
     }
   }
 
   public void endTimer() {
-    if(_executeStopwatch.isRunning()) {
+    if (_executeStopwatch.isRunning()) {
       _executeStopwatch.stop();
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
@@ -66,6 +66,7 @@ public class OperatorStats {
     _numOutputRows += numRows;
   }
 
+  // TODO: Return the string as a JSON string.
   @Override
   public String toString() {
     return String.format(

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
@@ -65,8 +65,9 @@ public class OperatorStats {
   @Override
   public String toString() {
     return String.format(
-        "(%s) OperatorStats[requestId: %s, stageId] ExecutionWalTime: %sms, InputRows: %s, InputBlock: %s, "
-            + "OutputRows: %s, OutputBlock: %s", _requestId, _stageId, _executeStopwatch.elapsed(TimeUnit.MILLISECONDS),
-        _numInputRows, _numInputBlock, _numOutputRows, _numOutputBlock);
+        "OperatorStats[type: %s, requestId: %s, stageId %s] ExecutionWalTime: %sms, InputRows: %s, InputBlock: "
+            + "%s, OutputRows: %s, OutputBlock: %s", _operatorType, _requestId, _stageId,
+        _executeStopwatch.elapsed(TimeUnit.MILLISECONDS), _numInputRows, _numInputBlock, _numOutputRows,
+        _numOutputBlock);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
@@ -65,7 +65,7 @@ public class OperatorStats {
   @Override
   public String toString() {
     return String.format(
-        "OperatorStats[type: %s, requestId: %s, stageId %s] ExecutionWalTime: %sms, InputRows: %s, InputBlock: "
+        "OperatorStats[type: %s, requestId: %s, stageId %s] ExecutionWallTime: %sms, InputRows: %s, InputBlock: "
             + "%s, OutputRows: %s, OutputBlock: %s", _operatorType, _requestId, _stageId,
         _executeStopwatch.elapsed(TimeUnit.MILLISECONDS), _numInputRows, _numInputBlock, _numOutputRows,
         _numOutputBlock);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
@@ -1,0 +1,72 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import com.google.common.base.Stopwatch;
+import java.util.concurrent.TimeUnit;
+
+
+public class OperatorStats {
+  private final Stopwatch _executeStopwatch = Stopwatch.createUnstarted();
+
+  // TODO: add a operatorId for better tracking purpose.
+  private final int _stageId;
+  private final long _requestId;
+
+  private final String _operatorType;
+
+  private int _numInputBlock = 0;
+  private int _numInputRows = 0;
+
+  private int _numOutputBlock = 0;
+
+  private int _numOutputRows = 0;
+
+  public OperatorStats(long requestId, int stageId, String operatorType) {
+    _stageId = stageId;
+    _requestId = requestId;
+    _operatorType = operatorType;
+  }
+
+  public void startTimer() {
+    _executeStopwatch.start();
+  }
+
+  public void endTimer() {
+    _executeStopwatch.stop();
+  }
+
+  public void recordInput(int numBlock, int numRows) {
+    _numInputBlock += numBlock;
+    _numInputRows += numRows;
+  }
+
+  public void recordOutput(int numBlock, int numRows) {
+    _numOutputBlock += numBlock;
+    _numOutputRows += numRows;
+  }
+
+  @Override
+  public String toString() {
+    return String.format(
+        "(%s) OperatorStats[requestId: %s, stageId] ExecutionWalTime: %sms, InputRows: %s, InputBlock: %s, "
+            + "OutputRows: %s, OutputBlock: %s", _requestId, _stageId, _executeStopwatch.elapsed(TimeUnit.MILLISECONDS),
+        _numInputRows, _numInputBlock, _numOutputRows, _numOutputBlock);
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -151,7 +151,7 @@ public class SortOperator extends MultiStageOperator {
         _operatorStats.endTimer();
         block = _upstreamOperator.nextBlock();
         _operatorStats.startTimer();
-        _operatorStats.recordInput(1, block.getNumRows());
+        _operatorStats.recordInput(1, container.size());
       }
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -85,6 +85,8 @@ public class SortOperator extends MultiStageOperator {
   @Nullable
   @Override
   public String toExplainString() {
+    _upstreamOperator.toExplainString();
+    LOGGER.error(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 
@@ -95,7 +97,6 @@ public class SortOperator extends MultiStageOperator {
       consumeInputBlocks();
       return produceSortedBlock();
     } catch (Exception e) {
-      LOGGER.error("OperatorStats:" + _operatorStats);
       return TransferableBlockUtils.getErrorTransferableBlock(e);
     } finally {
       _operatorStats.endTimer();
@@ -119,13 +120,11 @@ public class SortOperator extends MultiStageOperator {
       _operatorStats.recordOutput(1, rows.size());
       _isSortedBlockConstructed = true;
       if (rows.size() == 0) {
-        LOGGER.debug("OperatorStats:" + _operatorStats);
         return TransferableBlockUtils.getEndOfStreamTransferableBlock();
       } else {
         return new TransferableBlock(rows, _dataSchema, DataBlock.Type.ROW);
       }
     } else {
-      LOGGER.debug("OperatorStats:" + _operatorStats);
       return TransferableBlockUtils.getEndOfStreamTransferableBlock();
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -32,7 +32,6 @@ import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -55,15 +54,15 @@ public class SortOperator extends MultiStageOperator {
 
   public SortOperator(MultiStageOperator upstreamOperator, List<RexExpression> collationKeys,
       List<RelFieldCollation.Direction> collationDirections, int fetch, int offset, DataSchema dataSchema,
-      PlanRequestContext context) {
+      long requestId, int stageId) {
     this(upstreamOperator, collationKeys, collationDirections, fetch, offset, dataSchema,
-        SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY, context);
+        SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY, requestId, stageId);
   }
 
   @VisibleForTesting
   SortOperator(MultiStageOperator upstreamOperator, List<RexExpression> collationKeys,
       List<RelFieldCollation.Direction> collationDirections, int fetch, int offset, DataSchema dataSchema,
-      int maxHolderCapacity, PlanRequestContext context) {
+      int maxHolderCapacity, long requestId, int stageId) {
     _upstreamOperator = upstreamOperator;
     _fetch = fetch;
     _offset = offset;
@@ -75,7 +74,7 @@ public class SortOperator extends MultiStageOperator {
         : maxHolderCapacity;
     _rows = new PriorityQueue<>(_numRowsToKeep,
         new SortComparator(collationKeys, collationDirections, dataSchema, false));
-    _operatorStats = new OperatorStats(context.getRequestId(), context.getStageId(), EXPLAIN_NAME);
+    _operatorStats = new OperatorStats(requestId, stageId, EXPLAIN_NAME);
   }
 
   @Override
@@ -133,7 +132,9 @@ public class SortOperator extends MultiStageOperator {
 
   private void consumeInputBlocks() {
     if (!_isSortedBlockConstructed) {
+      _operatorStats.endTimer();
       TransferableBlock block = _upstreamOperator.nextBlock();
+      _operatorStats.startTimer();
       while (!block.isNoOpBlock()) {
         // setting upstream error block
         if (block.isErrorBlock()) {
@@ -148,8 +149,9 @@ public class SortOperator extends MultiStageOperator {
         for (Object[] row : container) {
           SelectionOperatorUtils.addToPriorityQueue(row, _rows, _numRowsToKeep);
         }
-
+        _operatorStats.endTimer();
         block = _upstreamOperator.nextBlock();
+        _operatorStats.startTimer();
         _operatorStats.recordInput(1, block.getNumRows());
       }
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -86,7 +86,7 @@ public class SortOperator extends MultiStageOperator {
   @Override
   public String toExplainString() {
     _upstreamOperator.toExplainString();
-    LOGGER.error(_operatorStats.toString());
+    LOGGER.debug(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -79,7 +79,7 @@ public class TransformOperator extends MultiStageOperator {
   @Override
   public String toExplainString() {
     _upstreamOperator.toExplainString();
-    LOGGER.error(_operatorStats.toString());
+    LOGGER.debug(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -47,13 +47,8 @@ import org.slf4j.LoggerFactory;
  */
 public class TransformOperator extends MultiStageOperator {
   private static final String EXPLAIN_NAME = "TRANSFORM";
-<<<<<<< HEAD
   private final MultiStageOperator _upstreamOperator;
-=======
   private static final Logger LOGGER = LoggerFactory.getLogger(TransformOperator.class);
-
-  private final Operator<TransferableBlock> _upstreamOperator;
->>>>>>> a5662b3d36 (opchain and operator stats)
   private final List<TransformOperand> _transformOperandsList;
   private final int _resultColumnSize;
   // TODO: Check type matching between resultSchema and the actual result.
@@ -61,13 +56,8 @@ public class TransformOperator extends MultiStageOperator {
   private TransferableBlock _upstreamErrorBlock;
   private OperatorStats _operatorStats;
 
-<<<<<<< HEAD
   public TransformOperator(MultiStageOperator upstreamOperator, DataSchema resultSchema,
-      List<RexExpression> transforms, DataSchema upstreamDataSchema) {
-=======
-  public TransformOperator(Operator<TransferableBlock> upstreamOperator, DataSchema resultSchema,
-      List<RexExpression> transforms, DataSchema upstreamDataSchema, PlanRequestContext context) {
->>>>>>> a5662b3d36 (opchain and operator stats)
+      List<RexExpression> transforms, DataSchema upstreamDataSchema, long requestId, int stageId) {
     Preconditions.checkState(!transforms.isEmpty(), "transform operand should not be empty.");
     Preconditions.checkState(resultSchema.size() == transforms.size(),
         "result schema size:" + resultSchema.size() + " doesn't match transform operand size:" + transforms.size());
@@ -78,7 +68,7 @@ public class TransformOperator extends MultiStageOperator {
       _transformOperandsList.add(TransformOperand.toTransformOperand(rexExpression, upstreamDataSchema));
     }
     _resultSchema = resultSchema;
-    _operatorStats = new OperatorStats(context.getRequestId(), context.getStageId(), EXPLAIN_NAME);
+    _operatorStats = new OperatorStats(requestId, stageId, EXPLAIN_NAME);
   }
 
   @Override
@@ -96,7 +86,10 @@ public class TransformOperator extends MultiStageOperator {
   protected TransferableBlock getNextBlock() {
     _operatorStats.startTimer();
     try {
-      return transform(_upstreamOperator.nextBlock());
+      _operatorStats.endTimer();
+      TransferableBlock block = _upstreamErrorBlock;
+      _operatorStats.startTimer();
+      return transform(block);
     } catch (Exception e) {
       LOGGER.error("OperatorStats:" + _operatorStats);
       return TransferableBlockUtils.getErrorTransferableBlock(e);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -110,7 +110,7 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<MultiStageOperator,
   public MultiStageOperator visitProject(ProjectNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
     return new TransformOperator(nextOperator, node.getDataSchema(), node.getProjects(),
-        node.getInputs().get(0).getDataSchema(), context._requestId, context._stageId);
+        node.getInputs().get(0).getDataSchema(), context.getRequestId(), context.getStageId());
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -84,13 +84,17 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<MultiStageOperator,
   public MultiStageOperator visitAggregate(AggregateNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
     return new AggregateOperator(nextOperator, node.getDataSchema(), node.getAggCalls(),
+<<<<<<< HEAD
         node.getGroupSet(), node.getInputs().get(0).getDataSchema());
+=======
+        node.getGroupSet(), context);
+>>>>>>> cead50bd07 (opchain and operator stats)
   }
 
   @Override
   public MultiStageOperator visitFilter(FilterNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
-    return new FilterOperator(nextOperator, node.getDataSchema(), node.getCondition());
+    return new FilterOperator(nextOperator, node.getDataSchema(), node.getCondition(), context);
   }
 
   @Override
@@ -101,21 +105,21 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<MultiStageOperator,
     MultiStageOperator leftOperator = left.visit(this, context);
     MultiStageOperator rightOperator = right.visit(this, context);
 
-    return new HashJoinOperator(leftOperator, rightOperator, left.getDataSchema(), node);
+    return new HashJoinOperator(leftOperator, rightOperator, left.getDataSchema(), node, context);
   }
 
   @Override
   public MultiStageOperator visitProject(ProjectNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
     return new TransformOperator(nextOperator, node.getDataSchema(), node.getProjects(),
-        node.getInputs().get(0).getDataSchema());
+        node.getInputs().get(0).getDataSchema(), context);
   }
 
   @Override
   public MultiStageOperator visitSort(SortNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
     return new SortOperator(nextOperator, node.getCollationKeys(), node.getCollationDirections(),
-        node.getFetch(), node.getOffset(), node.getDataSchema());
+        node.getFetch(), node.getOffset(), node.getDataSchema(), context);
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -84,17 +84,14 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<MultiStageOperator,
   public MultiStageOperator visitAggregate(AggregateNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
     return new AggregateOperator(nextOperator, node.getDataSchema(), node.getAggCalls(),
-<<<<<<< HEAD
-        node.getGroupSet(), node.getInputs().get(0).getDataSchema());
-=======
-        node.getGroupSet(), context);
->>>>>>> cead50bd07 (opchain and operator stats)
+        node.getGroupSet(), node.getInputs().get(0).getDataSchema(), context._requestId, context._stageId);
   }
 
   @Override
   public MultiStageOperator visitFilter(FilterNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
-    return new FilterOperator(nextOperator, node.getDataSchema(), node.getCondition(), context);
+    return new FilterOperator(nextOperator, node.getDataSchema(), node.getCondition(), context.getRequestId(),
+        context.getStageId());
   }
 
   @Override
@@ -105,21 +102,22 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<MultiStageOperator,
     MultiStageOperator leftOperator = left.visit(this, context);
     MultiStageOperator rightOperator = right.visit(this, context);
 
-    return new HashJoinOperator(leftOperator, rightOperator, left.getDataSchema(), node, context);
+    return new HashJoinOperator(leftOperator, rightOperator, left.getDataSchema(), node, context.getRequestId(),
+        context.getStageId());
   }
 
   @Override
   public MultiStageOperator visitProject(ProjectNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
     return new TransformOperator(nextOperator, node.getDataSchema(), node.getProjects(),
-        node.getInputs().get(0).getDataSchema(), context);
+        node.getInputs().get(0).getDataSchema(), context._requestId, context._stageId);
   }
 
   @Override
   public MultiStageOperator visitSort(SortNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
     return new SortOperator(nextOperator, node.getCollationKeys(), node.getCollationDirections(),
-        node.getFetch(), node.getOffset(), node.getDataSchema(), context);
+        node.getFetch(), node.getOffset(), node.getDataSchema(), context.getRequestId(), context.getStageId());
   }
 
   @Override
@@ -129,6 +127,7 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<MultiStageOperator,
 
   @Override
   public MultiStageOperator visitValue(ValueNode node, PlanRequestContext context) {
-    return new LiteralValueOperator(node.getDataSchema(), node.getLiteralRows());
+    return new LiteralValueOperator(node.getDataSchema(), node.getLiteralRows(), context.getRequestId(),
+        context.getStageId());
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryDispatcher.java
@@ -77,7 +77,7 @@ public class QueryDispatcher {
     long toResultTableStartTime = System.currentTimeMillis();
     ResultTable resultTable = toResultTable(resultDataBlocks, queryPlan.getQueryResultFields(),
         queryPlan.getQueryStageMap().get(0).getDataSchema());
-    LOGGER.error(
+    LOGGER.debug(
         "RequestId:" + requestId + " StageId: 0 Broker toResultTable processing time:" + (System.currentTimeMillis()
             - toResultTableStartTime) + " ms");
     return resultTable;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryDispatcher.java
@@ -46,12 +46,16 @@ import org.apache.pinot.query.runtime.operator.MailboxReceiveOperator;
 import org.apache.pinot.query.runtime.plan.DistributedStagePlan;
 import org.apache.pinot.query.runtime.plan.serde.QueryPlanSerDeUtils;
 import org.roaringbitmap.RoaringBitmap;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * {@code QueryDispatcher} dispatch a query to different workers.
  */
 public class QueryDispatcher {
+  private static final Logger LOGGER = LoggerFactory.getLogger(QueryDispatcher.class);
+
   private final Map<String, DispatchClient> _dispatchClientMap = new ConcurrentHashMap<>();
 
   public QueryDispatcher() {
@@ -69,8 +73,14 @@ public class QueryDispatcher {
         reduceNode.getSenderStageId(), reduceNode.getDataSchema(), mailboxService.getHostname(),
         mailboxService.getMailboxPort(), timeoutMs);
     List<DataBlock> resultDataBlocks = reduceMailboxReceive(mailboxReceiveOperator, timeoutMs);
-    return toResultTable(resultDataBlocks, queryPlan.getQueryResultFields(),
+    mailboxReceiveOperator.toExplainString();
+    long toResultTableStartTime = System.currentTimeMillis();
+    ResultTable resultTable = toResultTable(resultDataBlocks, queryPlan.getQueryResultFields(),
         queryPlan.getQueryStageMap().get(0).getDataSchema());
+    LOGGER.error(
+        "RequestId:" + requestId + " StageId: 0 Broker toResultTable processing time:" + (System.currentTimeMillis()
+            - toResultTableStartTime) + " ms");
+    return resultTable;
   }
 
   public int submit(long requestId, QueryPlan queryPlan, long timeoutMs)

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -48,6 +49,9 @@ public class AggregateOperatorTest {
 
   @Mock
   private MultiStageOperator _input;
+
+  @Mock
+  private PlanRequestContext _context;
 
   @BeforeMethod
   public void setUp() {
@@ -71,7 +75,7 @@ public class AggregateOperatorTest {
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema);
+    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, 1, 2);
 
     // When:
     TransferableBlock block1 = operator.nextBlock(); // build
@@ -87,12 +91,11 @@ public class AggregateOperatorTest {
     List<RexExpression> calls = ImmutableList.of(getSum(new RexExpression.InputRef(1)));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
-    Mockito.when(_input.nextBlock())
-        .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
+    Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema);
+    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, 1, 2);
 
     // When:
     TransferableBlock block = operator.nextBlock();
@@ -109,13 +112,12 @@ public class AggregateOperatorTest {
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
-    Mockito.when(_input.nextBlock())
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{1, 1}))
+    Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{1, 1}))
         .thenReturn(TransferableBlockUtils.getNoOpTransferableBlock())
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema);
+    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, 1, 2);
 
     // When:
     TransferableBlock block1 = operator.nextBlock(); // build when reading NoOp block
@@ -134,12 +136,11 @@ public class AggregateOperatorTest {
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
-    Mockito.when(_input.nextBlock())
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, 1}))
+    Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, 1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema);
+    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, 1, 2);
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -160,12 +161,11 @@ public class AggregateOperatorTest {
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
-    Mockito.when(_input.nextBlock())
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, 3}))
+    Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, 3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema);
+    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, 1, 2);
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -196,9 +196,8 @@ public class AggregateOperatorTest {
     Mockito.when(merger.merge(Mockito.any(), Mockito.any())).thenReturn(12d);
     Mockito.when(merger.initialize(Mockito.any())).thenReturn(1d);
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, ImmutableMap.of(
-        "SUM", cdt -> merger
-    ));
+    AggregateOperator operator =
+        new AggregateOperator(_input, outSchema, calls, group, inSchema, ImmutableMap.of("SUM", cdt -> merger), 1, 2);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock(); // (output result)
@@ -220,7 +219,7 @@ public class AggregateOperatorTest {
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
     AggregateOperator sum0GroupBy1 =
         new AggregateOperator(upstreamOperator, OperatorTestUtil.getDataSchema(OperatorTestUtil.OP_1),
-            Arrays.asList(agg), Arrays.asList(new RexExpression.InputRef(1)), inSchema);
+            Arrays.asList(agg), Arrays.asList(new RexExpression.InputRef(1)), inSchema, 1, 2);
     TransferableBlock result = sum0GroupBy1.getNextBlock();
     while (result.isNoOpBlock()) {
       result = sum0GroupBy1.getNextBlock();
@@ -232,20 +231,18 @@ public class AggregateOperatorTest {
     Assert.assertEquals(resultRows.get(1), expectedRows.get(1));
   }
 
-  @Test(
-      expectedExceptions = IllegalStateException.class,
-      expectedExceptionsMessageRegExp = ".*Unexpected value: AVERAGE.*")
+  @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*Unexpected value: "
+      + "AVERAGE.*")
   public void shouldThrowOnUnknownAggFunction() {
     // Given:
     List<RexExpression> calls = ImmutableList.of(
-        new RexExpression.FunctionCall(SqlKind.AVG, FieldSpec.DataType.INT, "AVERAGE", ImmutableList.of())
-    );
+        new RexExpression.FunctionCall(SqlKind.AVG, FieldSpec.DataType.INT, "AVERAGE", ImmutableList.of()));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
     DataSchema outSchema = new DataSchema(new String[]{"unknown"}, new ColumnDataType[]{DOUBLE});
     DataSchema inSchema = new DataSchema(new String[]{"unknown"}, new ColumnDataType[]{DOUBLE});
 
     // When:
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema);
+    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, 1, 2);
   }
 
   @Test
@@ -262,7 +259,7 @@ public class AggregateOperatorTest {
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema);
+    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, 1, 2);
 
     // When:
     TransferableBlock block = operator.nextBlock();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
@@ -28,7 +28,6 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -49,7 +48,6 @@ public class AggregateOperatorTest {
 
   @Mock
   private MultiStageOperator _input;
-
 
   @BeforeMethod
   public void setUp() {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
@@ -50,8 +50,6 @@ public class AggregateOperatorTest {
   @Mock
   private MultiStageOperator _input;
 
-  @Mock
-  private PlanRequestContext _context;
 
   @BeforeMethod
   public void setUp() {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/FilterOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/FilterOperatorTest.java
@@ -27,6 +27,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -41,6 +42,9 @@ public class FilterOperatorTest {
   private AutoCloseable _mocks;
   @Mock
   private MultiStageOperator _upstreamOperator;
+
+  @Mock
+  private PlanRequestContext _context;
 
   @BeforeMethod
   public void setUp() {
@@ -61,7 +65,7 @@ public class FilterOperatorTest {
     DataSchema inputSchema = new DataSchema(new String[]{"boolCol"}, new DataSchema.ColumnDataType[]{
         DataSchema.ColumnDataType.BOOLEAN
     });
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, _context);
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
     DataBlock error = errorBlock.getDataBlock();
@@ -76,7 +80,7 @@ public class FilterOperatorTest {
         DataSchema.ColumnDataType.INT
     });
     Mockito.when(_upstreamOperator.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, _context);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertTrue(dataBlock.isEndOfStreamBlock());
   }
@@ -89,7 +93,7 @@ public class FilterOperatorTest {
         DataSchema.ColumnDataType.INT
     });
     Mockito.when(_upstreamOperator.nextBlock()).thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, _context);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertTrue(dataBlock.isNoOpBlock());
   }
@@ -104,7 +108,7 @@ public class FilterOperatorTest {
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{0}, new Object[]{1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, _context);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -122,7 +126,7 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, _context);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -137,7 +141,7 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, _context);
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
     DataBlock data = errorBlock.getDataBlock();
@@ -152,7 +156,7 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, ref0);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, ref0, _context);
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
     DataBlock data = errorBlock.getDataBlock();
@@ -167,7 +171,7 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1, true}, new Object[]{2, false}));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, ref1);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, ref1, _context);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -187,7 +191,7 @@ public class FilterOperatorTest {
     RexExpression.FunctionCall andCall = new RexExpression.FunctionCall(SqlKind.AND, FieldSpec.DataType.BOOLEAN, "AND",
         ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
 
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, andCall);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, andCall, _context);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -207,7 +211,7 @@ public class FilterOperatorTest {
     RexExpression.FunctionCall orCall = new RexExpression.FunctionCall(SqlKind.OR, FieldSpec.DataType.BOOLEAN, "OR",
         ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
 
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, orCall);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, orCall, _context);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -229,7 +233,7 @@ public class FilterOperatorTest {
     RexExpression.FunctionCall notCall = new RexExpression.FunctionCall(SqlKind.NOT, FieldSpec.DataType.BOOLEAN, "NOT",
         ImmutableList.of(new RexExpression.InputRef(0)));
 
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, notCall);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, notCall, _context);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -248,7 +252,7 @@ public class FilterOperatorTest {
     RexExpression.FunctionCall greaterThan =
         new RexExpression.FunctionCall(SqlKind.GREATER_THAN, FieldSpec.DataType.BOOLEAN, "greaterThan",
             ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, greaterThan);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, greaterThan, _context);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -268,7 +272,7 @@ public class FilterOperatorTest {
         new RexExpression.FunctionCall(SqlKind.OTHER, FieldSpec.DataType.BOOLEAN, "startsWith",
             ImmutableList.of(new RexExpression.InputRef(0),
                 new RexExpression.Literal(FieldSpec.DataType.STRING, "star")));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, startsWith);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, startsWith, _context);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -289,6 +293,6 @@ public class FilterOperatorTest {
         new RexExpression.FunctionCall(SqlKind.OTHER, FieldSpec.DataType.BOOLEAN, "startsWithError",
             ImmutableList.of(new RexExpression.InputRef(0),
                 new RexExpression.Literal(FieldSpec.DataType.STRING, "star")));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, startsWith);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, startsWith, _context);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/FilterOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/FilterOperatorTest.java
@@ -27,7 +27,6 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -42,9 +41,6 @@ public class FilterOperatorTest {
   private AutoCloseable _mocks;
   @Mock
   private MultiStageOperator _upstreamOperator;
-
-  @Mock
-  private PlanRequestContext _context;
 
   @BeforeMethod
   public void setUp() {
@@ -65,7 +61,7 @@ public class FilterOperatorTest {
     DataSchema inputSchema = new DataSchema(new String[]{"boolCol"}, new DataSchema.ColumnDataType[]{
         DataSchema.ColumnDataType.BOOLEAN
     });
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, _context);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, 1, 2);
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
     DataBlock error = errorBlock.getDataBlock();
@@ -80,7 +76,7 @@ public class FilterOperatorTest {
         DataSchema.ColumnDataType.INT
     });
     Mockito.when(_upstreamOperator.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, _context);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, 1, 2);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertTrue(dataBlock.isEndOfStreamBlock());
   }
@@ -93,7 +89,7 @@ public class FilterOperatorTest {
         DataSchema.ColumnDataType.INT
     });
     Mockito.when(_upstreamOperator.nextBlock()).thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, _context);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, 1, 2);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertTrue(dataBlock.isNoOpBlock());
   }
@@ -108,7 +104,7 @@ public class FilterOperatorTest {
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{0}, new Object[]{1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, _context);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, 1, 2);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -126,7 +122,7 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, _context);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, 1, 2);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -141,7 +137,7 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, _context);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, 1, 2);
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
     DataBlock data = errorBlock.getDataBlock();
@@ -156,7 +152,7 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, ref0, _context);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, ref0, 1, 2);
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
     DataBlock data = errorBlock.getDataBlock();
@@ -171,7 +167,7 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1, true}, new Object[]{2, false}));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, ref1, _context);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, ref1, 1, 2);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -191,7 +187,7 @@ public class FilterOperatorTest {
     RexExpression.FunctionCall andCall = new RexExpression.FunctionCall(SqlKind.AND, FieldSpec.DataType.BOOLEAN, "AND",
         ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
 
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, andCall, _context);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, andCall, 1, 2);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -211,7 +207,7 @@ public class FilterOperatorTest {
     RexExpression.FunctionCall orCall = new RexExpression.FunctionCall(SqlKind.OR, FieldSpec.DataType.BOOLEAN, "OR",
         ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
 
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, orCall, _context);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, orCall, 1, 2);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -233,7 +229,7 @@ public class FilterOperatorTest {
     RexExpression.FunctionCall notCall = new RexExpression.FunctionCall(SqlKind.NOT, FieldSpec.DataType.BOOLEAN, "NOT",
         ImmutableList.of(new RexExpression.InputRef(0)));
 
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, notCall, _context);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, notCall, 1, 2);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -252,7 +248,7 @@ public class FilterOperatorTest {
     RexExpression.FunctionCall greaterThan =
         new RexExpression.FunctionCall(SqlKind.GREATER_THAN, FieldSpec.DataType.BOOLEAN, "greaterThan",
             ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, greaterThan, _context);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, greaterThan, 1, 2);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -272,7 +268,7 @@ public class FilterOperatorTest {
         new RexExpression.FunctionCall(SqlKind.OTHER, FieldSpec.DataType.BOOLEAN, "startsWith",
             ImmutableList.of(new RexExpression.InputRef(0),
                 new RexExpression.Literal(FieldSpec.DataType.STRING, "star")));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, startsWith, _context);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, startsWith, 1, 2);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -293,6 +289,6 @@ public class FilterOperatorTest {
         new RexExpression.FunctionCall(SqlKind.OTHER, FieldSpec.DataType.BOOLEAN, "startsWithError",
             ImmutableList.of(new RexExpression.InputRef(0),
                 new RexExpression.Literal(FieldSpec.DataType.STRING, "star")));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, startsWith, _context);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, startsWith, 1, 2);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.query.planner.partitioning.FieldSelectionKeySelector;
 import org.apache.pinot.query.planner.stage.JoinNode;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -50,6 +51,9 @@ public class HashJoinOperatorTest {
 
   @Mock
   private MultiStageOperator _rightOperator;
+
+  @Mock
+  private PlanRequestContext _context;
 
   @BeforeMethod
   public void setUp() {
@@ -90,7 +94,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
-    HashJoinOperator joinOnString = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator joinOnString = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
 
     TransferableBlock result = joinOnString.nextBlock();
     while (result.isNoOpBlock()) {
@@ -127,7 +131,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator joinOnInt = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator joinOnInt = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
     TransferableBlock result = joinOnInt.nextBlock();
     while (result.isNoOpBlock()) {
       result = joinOnInt.nextBlock();
@@ -161,7 +165,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node = new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(new ArrayList<>(), new ArrayList<>()),
         joinClauses);
-    HashJoinOperator joinOnInt = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator joinOnInt = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
     TransferableBlock result = joinOnInt.nextBlock();
     while (result.isNoOpBlock()) {
       result = joinOnInt.nextBlock();
@@ -202,7 +206,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.LEFT, getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -236,7 +240,7 @@ public class HashJoinOperatorTest {
     List<RexExpression> joinClauses = new ArrayList<>();
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -267,7 +271,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.LEFT, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -301,7 +305,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -339,7 +343,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node = new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(new ArrayList<>(), new ArrayList<>()),
         joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -377,7 +381,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node = new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(new ArrayList<>(), new ArrayList<>()),
         joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -411,7 +415,7 @@ public class HashJoinOperatorTest {
     });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.RIGHT, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator joinOnNum = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator joinOnNum = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
     TransferableBlock result = joinOnNum.nextBlock();
     while (result.isNoOpBlock()) {
       result = joinOnNum.nextBlock();
@@ -461,7 +465,7 @@ public class HashJoinOperatorTest {
     });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.SEMI, getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
   }
 
   @Test
@@ -485,7 +489,7 @@ public class HashJoinOperatorTest {
     });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.FULL, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -537,7 +541,7 @@ public class HashJoinOperatorTest {
     });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.ANTI, getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
   }
 
   @Test
@@ -562,7 +566,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -595,7 +599,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -631,7 +635,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
 
     TransferableBlock result = join.nextBlock(); // first no-op consumes first right data block.
     Assert.assertTrue(result.isNoOpBlock());

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -32,7 +32,6 @@ import org.apache.pinot.query.planner.partitioning.FieldSelectionKeySelector;
 import org.apache.pinot.query.planner.stage.JoinNode;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -51,9 +50,6 @@ public class HashJoinOperatorTest {
 
   @Mock
   private MultiStageOperator _rightOperator;
-
-  @Mock
-  private PlanRequestContext _context;
 
   @BeforeMethod
   public void setUp() {
@@ -94,7 +90,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
-    HashJoinOperator joinOnString = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator joinOnString = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
 
     TransferableBlock result = joinOnString.nextBlock();
     while (result.isNoOpBlock()) {
@@ -131,7 +127,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator joinOnInt = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator joinOnInt = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
     TransferableBlock result = joinOnInt.nextBlock();
     while (result.isNoOpBlock()) {
       result = joinOnInt.nextBlock();
@@ -165,7 +161,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node = new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(new ArrayList<>(), new ArrayList<>()),
         joinClauses);
-    HashJoinOperator joinOnInt = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator joinOnInt = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
     TransferableBlock result = joinOnInt.nextBlock();
     while (result.isNoOpBlock()) {
       result = joinOnInt.nextBlock();
@@ -206,7 +202,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.LEFT, getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -240,7 +236,7 @@ public class HashJoinOperatorTest {
     List<RexExpression> joinClauses = new ArrayList<>();
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -271,7 +267,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.LEFT, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -305,7 +301,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -343,7 +339,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node = new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(new ArrayList<>(), new ArrayList<>()),
         joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -381,7 +377,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node = new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(new ArrayList<>(), new ArrayList<>()),
         joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -415,7 +411,7 @@ public class HashJoinOperatorTest {
     });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.RIGHT, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator joinOnNum = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator joinOnNum = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
     TransferableBlock result = joinOnNum.nextBlock();
     while (result.isNoOpBlock()) {
       result = joinOnNum.nextBlock();
@@ -442,8 +438,7 @@ public class HashJoinOperatorTest {
     Assert.assertTrue(result.isSuccessfulEndOfStreamBlock());
   }
 
-  @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*SEMI is not "
-      + "supported.*")
+  @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*SEMI is not supported.*")
   public void shouldThrowOnSemiJoin() {
     DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
         DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
@@ -465,7 +460,7 @@ public class HashJoinOperatorTest {
     });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.SEMI, getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
   }
 
   @Test
@@ -489,7 +484,7 @@ public class HashJoinOperatorTest {
     });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.FULL, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -541,7 +536,7 @@ public class HashJoinOperatorTest {
     });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.ANTI, getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
   }
 
   @Test
@@ -566,7 +561,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -599,7 +594,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -635,7 +630,7 @@ public class HashJoinOperatorTest {
         });
     JoinNode node =
         new JoinNode(1, resultSchema, JoinRelType.INNER, getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, _context);
+    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2);
 
     TransferableBlock result = join.nextBlock(); // first no-op consumes first right data block.
     Assert.assertTrue(result.isNoOpBlock());

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperatorTest.java
@@ -52,7 +52,8 @@ public class LeafStageTransferableBlockOperatorTest {
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
         new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2})), queryContext));
-    LeafStageTransferableBlockOperator operator = new LeafStageTransferableBlockOperator(resultsBlockList, schema);
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -66,18 +67,19 @@ public class LeafStageTransferableBlockOperatorTest {
   @Test
   public void shouldHandleDesiredDataSchemaConversionCorrectly() {
     // Given:
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
-        "SELECT boolCol, tsCol, boolCol AS newNamedBoolCol FROM tbl");
+    QueryContext queryContext =
+        QueryContextConverterUtils.getQueryContext("SELECT boolCol, tsCol, boolCol AS newNamedBoolCol FROM tbl");
     DataSchema resultSchema = new DataSchema(new String[]{"boolCol", "tsCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.TIMESTAMP});
-    DataSchema desiredSchema = new DataSchema(new String[]{"boolCol", "tsCol", "newNamedBoolCol"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.TIMESTAMP,
-            DataSchema.ColumnDataType.BOOLEAN});
+    DataSchema desiredSchema =
+        new DataSchema(new String[]{"boolCol", "tsCol", "newNamedBoolCol"}, new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.TIMESTAMP, DataSchema.ColumnDataType.BOOLEAN
+        });
     List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
-        new SelectionResultsBlock(resultSchema, Arrays.asList(new Object[]{1, 1660000000000L},
-            new Object[]{0, 1600000000000L})), queryContext));
-    LeafStageTransferableBlockOperator operator = new LeafStageTransferableBlockOperator(resultsBlockList,
-        desiredSchema);
+        new SelectionResultsBlock(resultSchema,
+            Arrays.asList(new Object[]{1, 1660000000000L}, new Object[]{0, 1600000000000L})), queryContext));
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(resultsBlockList, desiredSchema, 1, 2);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -96,9 +98,10 @@ public class LeafStageTransferableBlockOperatorTest {
     DataSchema schema = new DataSchema(new String[]{"boolCol", "tsCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.TIMESTAMP});
     List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
-        new SelectionResultsBlock(schema, Arrays.asList(new Object[]{1, 1660000000000L},
-            new Object[]{0, 1600000000000L})), queryContext));
-    LeafStageTransferableBlockOperator operator = new LeafStageTransferableBlockOperator(resultsBlockList, schema);
+        new SelectionResultsBlock(schema,
+            Arrays.asList(new Object[]{1, 1660000000000L}, new Object[]{0, 1600000000000L})), queryContext));
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -115,13 +118,15 @@ public class LeafStageTransferableBlockOperatorTest {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT strCol, intCol FROM tbl");
     DataSchema schema = new DataSchema(new String[]{"strCol", "intCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
-    List<InstanceResponseBlock> resultsBlockList = Arrays.asList(
-        new InstanceResponseBlock(new SelectionResultsBlock(schema,
-            Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2})), queryContext),
-        new InstanceResponseBlock(new SelectionResultsBlock(schema,
-            Arrays.asList(new Object[]{"bar", 3}, new Object[]{"foo", 4})), queryContext),
+    List<InstanceResponseBlock> resultsBlockList = Arrays.asList(new InstanceResponseBlock(
+            new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2})),
+            queryContext),
+        new InstanceResponseBlock(
+            new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"bar", 3}, new Object[]{"foo", 4})),
+            queryContext),
         new InstanceResponseBlock(new SelectionResultsBlock(schema, Collections.emptyList()), queryContext));
-    LeafStageTransferableBlockOperator operator = new LeafStageTransferableBlockOperator(resultsBlockList, schema);
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2);
 
     // When:
     TransferableBlock resultBlock1 = operator.nextBlock();
@@ -145,12 +150,13 @@ public class LeafStageTransferableBlockOperatorTest {
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
     InstanceResponseBlock errorBlock = new InstanceResponseBlock();
     errorBlock.addException(QueryException.QUERY_EXECUTION_ERROR.getErrorCode(), "foobar");
-    List<InstanceResponseBlock> resultsBlockList = Arrays.asList(
-        new InstanceResponseBlock(new SelectionResultsBlock(schema,
-            Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2})), queryContext),
+    List<InstanceResponseBlock> resultsBlockList = Arrays.asList(new InstanceResponseBlock(
+            new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2})),
+            queryContext),
         errorBlock,
         new InstanceResponseBlock(new SelectionResultsBlock(schema, Collections.emptyList()), queryContext));
-    LeafStageTransferableBlockOperator operator = new LeafStageTransferableBlockOperator(resultsBlockList, schema);
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -162,16 +168,16 @@ public class LeafStageTransferableBlockOperatorTest {
   @Test
   public void shouldReorderWhenQueryContextAskForNotInOrderGroupByAsDistinct() {
     // Given:
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
-        "SELECT intCol, strCol FROM tbl GROUP BY strCol, intCol");
+    QueryContext queryContext =
+        QueryContextConverterUtils.getQueryContext("SELECT intCol, strCol FROM tbl GROUP BY strCol, intCol");
     // result schema doesn't match with DISTINCT columns using GROUP BY.
     DataSchema schema = new DataSchema(new String[]{"intCol", "strCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
-    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(
-        new InstanceResponseBlock(new DistinctResultsBlock(mock(DistinctAggregationFunction.class),
-            new DistinctTable(schema, Arrays.asList(
-                new Record(new Object[]{1, "foo"}), new Record(new Object[]{2, "bar"})))), queryContext));
-    LeafStageTransferableBlockOperator operator = new LeafStageTransferableBlockOperator(resultsBlockList, schema);
+    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
+        new DistinctResultsBlock(mock(DistinctAggregationFunction.class), new DistinctTable(schema,
+            Arrays.asList(new Record(new Object[]{1, "foo"}), new Record(new Object[]{2, "bar"})))), queryContext));
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -184,16 +190,15 @@ public class LeafStageTransferableBlockOperatorTest {
   @Test
   public void shouldParsedBlocksSuccessfullyWithDistinctQuery() {
     // Given:
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
-        "SELECT DISTINCT strCol, intCol FROM tbl");
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT DISTINCT strCol, intCol FROM tbl");
     // result schema doesn't match with DISTINCT columns using GROUP BY.
     DataSchema schema = new DataSchema(new String[]{"strCol", "intCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
-    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(
-        new InstanceResponseBlock(new DistinctResultsBlock(mock(DistinctAggregationFunction.class),
-            new DistinctTable(schema, Arrays.asList(
-                new Record(new Object[]{"foo", 1}), new Record(new Object[]{"bar", 2})))), queryContext));
-    LeafStageTransferableBlockOperator operator = new LeafStageTransferableBlockOperator(resultsBlockList, schema);
+    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
+        new DistinctResultsBlock(mock(DistinctAggregationFunction.class), new DistinctTable(schema,
+            Arrays.asList(new Record(new Object[]{"foo", 1}), new Record(new Object[]{"bar", 2})))), queryContext));
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -209,12 +214,15 @@ public class LeafStageTransferableBlockOperatorTest {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
         "SELECT intCol, count(*), sum(doubleCol), strCol FROM tbl GROUP BY strCol, intCol");
     // result schema doesn't match with columns ordering using GROUP BY, this should not occur.
-    DataSchema schema = new DataSchema(new String[]{"intCol", "count(*)", "sum(doubleCol)", "strCol"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.STRING});
+    DataSchema schema =
+        new DataSchema(new String[]{"intCol", "count(*)", "sum(doubleCol)", "strCol"}, new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG,
+            DataSchema.ColumnDataType.STRING
+        });
     List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(
         new InstanceResponseBlock(new GroupByResultsBlock(schema, Collections.emptyList()), queryContext));
-    LeafStageTransferableBlockOperator operator = new LeafStageTransferableBlockOperator(resultsBlockList, schema);
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -230,11 +238,14 @@ public class LeafStageTransferableBlockOperatorTest {
         + "sum(doubleCol) FROM tbl GROUP BY strCol, intCol HAVING sum(doubleCol) < 10 AND count(*) > 0");
     // result schema contains duplicate reference from agg and having. it will repeat itself.
     DataSchema schema = new DataSchema(new String[]{"strCol", "intCol", "count(*)", "sum(doubleCol)", "sum(doubleCol)"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG});
+        new DataSchema.ColumnDataType[]{
+            DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT,
+            DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG
+        });
     List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(
         new InstanceResponseBlock(new GroupByResultsBlock(schema, Collections.emptyList()), queryContext));
-    LeafStageTransferableBlockOperator operator = new LeafStageTransferableBlockOperator(resultsBlockList, schema);
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -246,15 +257,14 @@ public class LeafStageTransferableBlockOperatorTest {
   @Test
   public void shouldNotErrorOutWhenDealingWithAggregationResults() {
     // Given:
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
-        "SELECT count(*), sum(doubleCol) FROM tbl");
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT count(*), sum(doubleCol) FROM tbl");
     // result schema doesn't match with DISTINCT columns using GROUP BY.
     DataSchema schema = new DataSchema(new String[]{"count_star", "sum(doubleCol)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG});
-    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(
-        new InstanceResponseBlock(new AggregationResultsBlock(queryContext.getAggregationFunctions(),
-            Collections.emptyList()), queryContext));
-    LeafStageTransferableBlockOperator operator = new LeafStageTransferableBlockOperator(resultsBlockList, schema);
+    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
+        new AggregationResultsBlock(queryContext.getAggregationFunctions(), Collections.emptyList()), queryContext));
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -275,8 +285,8 @@ public class LeafStageTransferableBlockOperatorTest {
     // When:
     List<InstanceResponseBlock> responseBlockList = Collections.singletonList(
         new InstanceResponseBlock(new SelectionResultsBlock(resultSchema, Collections.emptyList()), queryContext));
-    LeafStageTransferableBlockOperator operator = new LeafStageTransferableBlockOperator(responseBlockList,
-        desiredSchema);
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(responseBlockList, desiredSchema, 1, 2);
     TransferableBlock resultBlock = operator.nextBlock();
 
     // Then:
@@ -287,19 +297,19 @@ public class LeafStageTransferableBlockOperatorTest {
   @Test
   public void shouldNotErrorOutWhenIncorrectDataSchemaProvidedWithEmptyRowsDistinct() {
     // Given:
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
-        "SELECT strCol, intCol FROM tbl GROUP BY strCol, intCol");
+    QueryContext queryContext =
+        QueryContextConverterUtils.getQueryContext("SELECT strCol, intCol FROM tbl GROUP BY strCol, intCol");
     DataSchema resultSchema = new DataSchema(new String[]{"strCol", "intCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
     DataSchema desiredSchema = new DataSchema(new String[]{"strCol", "intCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
 
     // When:
-    List<InstanceResponseBlock> responseBlockList = Collections.singletonList(
-        new InstanceResponseBlock(new DistinctResultsBlock(mock(DistinctAggregationFunction.class),
+    List<InstanceResponseBlock> responseBlockList = Collections.singletonList(new InstanceResponseBlock(
+        new DistinctResultsBlock(mock(DistinctAggregationFunction.class),
             new DistinctTable(resultSchema, Collections.emptyList())), queryContext));
-    LeafStageTransferableBlockOperator operator = new LeafStageTransferableBlockOperator(responseBlockList,
-        desiredSchema);
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(responseBlockList, desiredSchema, 1, 2);
     TransferableBlock resultBlock = operator.nextBlock();
 
     // Then:
@@ -310,18 +320,18 @@ public class LeafStageTransferableBlockOperatorTest {
   @Test
   public void shouldNotErrorOutWhenIncorrectDataSchemaProvidedWithEmptyRowsGroupBy() {
     // Given:
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
-        "SELECT strCol, SUM(intCol) FROM tbl GROUP BY strCol");
+    QueryContext queryContext =
+        QueryContextConverterUtils.getQueryContext("SELECT strCol, SUM(intCol) FROM tbl GROUP BY strCol");
     DataSchema resultSchema = new DataSchema(new String[]{"strCol", "SUM(intCol)"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
     DataSchema desiredSchema = new DataSchema(new String[]{"strCol", "SUM(intCol)"},
-      new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
 
     // When:
     List<InstanceResponseBlock> responseBlockList = Collections.singletonList(
         new InstanceResponseBlock(new GroupByResultsBlock(resultSchema, Collections.emptyList()), queryContext));
-    LeafStageTransferableBlockOperator operator = new LeafStageTransferableBlockOperator(responseBlockList,
-        desiredSchema);
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(responseBlockList, desiredSchema, 1, 2);
     TransferableBlock resultBlock = operator.nextBlock();
 
     // Then:

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LiteralValueOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LiteralValueOperatorTest.java
@@ -65,7 +65,7 @@ public class LiteralValueOperatorTest {
             new RexExpression.Literal(DataType.STRING, ""),
             new RexExpression.Literal(DataType.INT, 2))
     );
-    LiteralValueOperator operator = new LiteralValueOperator(schema, literals, _context);
+    LiteralValueOperator operator = new LiteralValueOperator(schema, literals, 1, 2);
 
     // When:
     TransferableBlock transferableBlock = operator.nextBlock();
@@ -81,7 +81,7 @@ public class LiteralValueOperatorTest {
     // Given:
     DataSchema schema = new DataSchema(new String[]{}, new ColumnDataType[]{});
     List<List<RexExpression>> literals = ImmutableList.of(ImmutableList.of());
-    LiteralValueOperator operator = new LiteralValueOperator(schema, literals, _context);
+    LiteralValueOperator operator = new LiteralValueOperator(schema, literals, 1, 2);
 
     // When:
     TransferableBlock transferableBlock = operator.nextBlock();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LiteralValueOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LiteralValueOperatorTest.java
@@ -24,12 +24,33 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 
 public class LiteralValueOperatorTest {
+
+  private AutoCloseable _mocks;
+
+  @Mock
+  private PlanRequestContext _context;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
 
   @Test
   public void shouldReturnLiteralBlock() {
@@ -44,7 +65,7 @@ public class LiteralValueOperatorTest {
             new RexExpression.Literal(DataType.STRING, ""),
             new RexExpression.Literal(DataType.INT, 2))
     );
-    LiteralValueOperator operator = new LiteralValueOperator(schema, literals);
+    LiteralValueOperator operator = new LiteralValueOperator(schema, literals, _context);
 
     // When:
     TransferableBlock transferableBlock = operator.nextBlock();
@@ -60,7 +81,7 @@ public class LiteralValueOperatorTest {
     // Given:
     DataSchema schema = new DataSchema(new String[]{}, new ColumnDataType[]{});
     List<List<RexExpression>> literals = ImmutableList.of(ImmutableList.of());
-    LiteralValueOperator operator = new LiteralValueOperator(schema, literals);
+    LiteralValueOperator operator = new LiteralValueOperator(schema, literals, _context);
 
     // When:
     TransferableBlock transferableBlock = operator.nextBlock();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -74,7 +74,7 @@ public class MailboxSendOperatorTest {
     // Given:
     MailboxSendOperator operator = new MailboxSendOperator(
         _mailboxService, _input, ImmutableList.of(_server), RelDistribution.Type.HASH_DISTRIBUTED, _selector,
-        server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory);
+        server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory, 1, 2);
     Mockito.when(_input.nextBlock())
         .thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
 
@@ -91,7 +91,7 @@ public class MailboxSendOperatorTest {
     // Given:
     MailboxSendOperator operator = new MailboxSendOperator(
         _mailboxService, _input, ImmutableList.of(_server), RelDistribution.Type.HASH_DISTRIBUTED, _selector,
-        server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory);
+        server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory, 1, 2);
     TransferableBlock errorBlock = TransferableBlockUtils.getErrorTransferableBlock(new Exception("foo!"));
     Mockito.when(_input.nextBlock())
         .thenReturn(errorBlock);
@@ -109,7 +109,7 @@ public class MailboxSendOperatorTest {
     // Given:
     MailboxSendOperator operator = new MailboxSendOperator(
         _mailboxService, _input, ImmutableList.of(_server), RelDistribution.Type.HASH_DISTRIBUTED, _selector,
-        server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory);
+        server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory, 1, 2);
     Mockito.when(_input.nextBlock())
         .thenThrow(new RuntimeException("foo!"));
     ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
@@ -128,7 +128,7 @@ public class MailboxSendOperatorTest {
     // Given:
     MailboxSendOperator operator = new MailboxSendOperator(
         _mailboxService, _input, ImmutableList.of(_server), RelDistribution.Type.HASH_DISTRIBUTED, _selector,
-        server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory);
+        server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory, 1, 2);
     TransferableBlock eosBlock = TransferableBlockUtils.getEndOfStreamTransferableBlock();
     Mockito.when(_input.nextBlock())
         .thenReturn(eosBlock);
@@ -146,7 +146,7 @@ public class MailboxSendOperatorTest {
     // Given:
     MailboxSendOperator operator = new MailboxSendOperator(
         _mailboxService, _input, ImmutableList.of(_server), RelDistribution.Type.HASH_DISTRIBUTED, _selector,
-        server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory);
+        server -> new StringMailboxIdentifier("123:from:1:to:2"), _exchangeFactory, 1, 2);
     TransferableBlock dataBlock = block(new DataSchema(new String[]{}, new DataSchema.ColumnDataType[]{}));
     Mockito.when(_input.nextBlock())
         .thenReturn(dataBlock)

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -47,6 +48,9 @@ public class SortOperatorTest {
   @Mock
   private MultiStageOperator _input;
 
+  @Mock
+  private PlanRequestContext _context;
+
   @BeforeMethod
   public void setUp() {
     _mocks = MockitoAnnotations.openMocks(this);
@@ -64,7 +68,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(TransferableBlockUtils.getErrorTransferableBlock(new Exception("foo!")));
@@ -82,7 +86,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
 
     Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
 
@@ -99,7 +103,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
 
     Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
@@ -116,7 +120,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}, new Object[]{1}))
@@ -139,7 +143,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(1);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"ignored", "sort"}, new DataSchema.ColumnDataType[]{INT, INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{1, 2}, new Object[]{2, 1}))
@@ -162,7 +166,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{STRING});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{"b"}, new Object[]{"a"}))
@@ -185,7 +189,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.DESCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}, new Object[]{1}))
@@ -208,7 +212,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 1, schema);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 1, schema, _context);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
@@ -231,7 +235,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 1, 1, schema);
+    SortOperator op = new SortOperator(_input, collation, directions, 1, 1, schema, _context);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
@@ -253,7 +257,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 2, 0, schema, 1);
+    SortOperator op = new SortOperator(_input, collation, directions, 2, 0, schema, 1, _context);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
@@ -275,7 +279,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, -1, 0, schema);
+    SortOperator op = new SortOperator(_input, collation, directions, -1, 0, schema, _context);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
@@ -296,7 +300,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}))
@@ -320,7 +324,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0, 1);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING, Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"first", "second"}, new DataSchema.ColumnDataType[]{INT, INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{1, 2}, new Object[]{1, 1}, new Object[]{1, 3}))
@@ -344,7 +348,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0, 1);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING, Direction.DESCENDING);
     DataSchema schema = new DataSchema(new String[]{"first", "second"}, new DataSchema.ColumnDataType[]{INT, INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{1, 2}, new Object[]{1, 1}, new Object[]{1, 3}))
@@ -368,7 +372,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}))

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
@@ -28,7 +28,6 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -47,9 +46,6 @@ public class SortOperatorTest {
 
   @Mock
   private MultiStageOperator _input;
-
-  @Mock
-  private PlanRequestContext _context;
 
   @BeforeMethod
   public void setUp() {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
@@ -68,7 +68,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(TransferableBlockUtils.getErrorTransferableBlock(new Exception("foo!")));
@@ -86,7 +86,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2);
 
     Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
 
@@ -103,7 +103,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2);
 
     Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
@@ -120,7 +120,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}, new Object[]{1}))
@@ -143,7 +143,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(1);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"ignored", "sort"}, new DataSchema.ColumnDataType[]{INT, INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{1, 2}, new Object[]{2, 1}))
@@ -166,7 +166,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{STRING});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{"b"}, new Object[]{"a"}))
@@ -189,7 +189,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.DESCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}, new Object[]{1}))
@@ -212,7 +212,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 1, schema, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 1, schema, 1, 2);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
@@ -235,7 +235,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 1, 1, schema, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, 1, 1, schema, 1, 2);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
@@ -257,7 +257,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 2, 0, schema, 1, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, 2, 0, schema, 1, 1, 2);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
@@ -279,7 +279,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, -1, 0, schema, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, -1, 0, schema, 1, 2);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
@@ -300,7 +300,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}))
@@ -324,7 +324,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0, 1);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING, Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"first", "second"}, new DataSchema.ColumnDataType[]{INT, INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{1, 2}, new Object[]{1, 1}, new Object[]{1, 3}))
@@ -348,7 +348,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0, 1);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING, Direction.DESCENDING);
     DataSchema schema = new DataSchema(new String[]{"first", "second"}, new DataSchema.ColumnDataType[]{INT, INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{1, 2}, new Object[]{1, 1}, new Object[]{1, 3}))
@@ -372,7 +372,7 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, _context);
+    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}))

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
@@ -28,7 +28,6 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -47,9 +46,6 @@ public class TransformOperatorTest {
 
   @Mock
   private MultiStageOperator _upstreamOp;
-
-  @Mock
-  private PlanRequestContext _context;
 
   @BeforeMethod
   public void setUp() {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
@@ -75,7 +75,7 @@ public class TransformOperatorTest {
     RexExpression.InputRef ref0 = new RexExpression.InputRef(0);
     RexExpression.InputRef ref1 = new RexExpression.InputRef(1);
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(ref0, ref1), upStreamSchema, _context);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(ref0, ref1), upStreamSchema, 1, 2);
     TransferableBlock result = op.nextBlock();
 
     Assert.assertTrue(!result.isErrorBlock());
@@ -99,8 +99,7 @@ public class TransformOperatorTest {
     RexExpression.Literal boolLiteral = new RexExpression.Literal(FieldSpec.DataType.BOOLEAN, true);
     RexExpression.Literal strLiteral = new RexExpression.Literal(FieldSpec.DataType.STRING, "str");
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema,
-            _context);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema, 1, 2);
     TransferableBlock result = op.nextBlock();
     // Literal operands should just output original literals.
     Assert.assertTrue(!result.isErrorBlock());
@@ -130,7 +129,7 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"plusR", "minusR"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema, _context);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema, 1, 2);
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(!result.isErrorBlock());
     List<Object[]> resultRows = result.getContainer();
@@ -158,7 +157,7 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"plusR", "minusR"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema, _context);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema, 1, 2);
 
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
@@ -178,8 +177,7 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"inCol", "strCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema,
-            _context);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema, 1, 2);
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
     DataBlock data = result.getDataBlock();
@@ -202,8 +200,7 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"boolCol", "strCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.STRING});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema,
-            _context);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema, 1, 2);
     TransferableBlock result = op.nextBlock();
     // First block has two rows
     Assert.assertFalse(result.isErrorBlock());
@@ -235,7 +232,7 @@ public class TransformOperatorTest {
         DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING
     });
     TransformOperator transform =
-        new TransformOperator(_upstreamOp, resultSchema, new ArrayList<>(), upStreamSchema, _context);
+        new TransformOperator(_upstreamOp, resultSchema, new ArrayList<>(), upStreamSchema, 1, 2);
   }
 
   @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*doesn't match "
@@ -248,6 +245,6 @@ public class TransformOperatorTest {
     });
     RexExpression.InputRef ref0 = new RexExpression.InputRef(0);
     TransformOperator transform =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(ref0), upStreamSchema, _context);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(ref0), upStreamSchema, 1, 2);
   }
 };

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -46,6 +47,9 @@ public class TransformOperatorTest {
 
   @Mock
   private MultiStageOperator _upstreamOp;
+
+  @Mock
+  private PlanRequestContext _context;
 
   @BeforeMethod
   public void setUp() {
@@ -71,7 +75,7 @@ public class TransformOperatorTest {
     RexExpression.InputRef ref0 = new RexExpression.InputRef(0);
     RexExpression.InputRef ref1 = new RexExpression.InputRef(1);
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(ref0, ref1), upStreamSchema);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(ref0, ref1), upStreamSchema, _context);
     TransferableBlock result = op.nextBlock();
 
     Assert.assertTrue(!result.isErrorBlock());
@@ -95,7 +99,8 @@ public class TransformOperatorTest {
     RexExpression.Literal boolLiteral = new RexExpression.Literal(FieldSpec.DataType.BOOLEAN, true);
     RexExpression.Literal strLiteral = new RexExpression.Literal(FieldSpec.DataType.STRING, "str");
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema,
+            _context);
     TransferableBlock result = op.nextBlock();
     // Literal operands should just output original literals.
     Assert.assertTrue(!result.isErrorBlock());
@@ -125,7 +130,7 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"plusR", "minusR"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema, _context);
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(!result.isErrorBlock());
     List<Object[]> resultRows = result.getContainer();
@@ -153,7 +158,7 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"plusR", "minusR"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema, _context);
 
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
@@ -173,7 +178,8 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"inCol", "strCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema,
+            _context);
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
     DataBlock data = result.getDataBlock();
@@ -196,7 +202,8 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"boolCol", "strCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.STRING});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema,
+            _context);
     TransferableBlock result = op.nextBlock();
     // First block has two rows
     Assert.assertFalse(result.isErrorBlock());
@@ -227,7 +234,8 @@ public class TransformOperatorTest {
     DataSchema upStreamSchema = new DataSchema(new String[]{"string1", "string2"}, new DataSchema.ColumnDataType[]{
         DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING
     });
-    TransformOperator transform = new TransformOperator(_upstreamOp, resultSchema, new ArrayList<>(), upStreamSchema);
+    TransformOperator transform =
+        new TransformOperator(_upstreamOp, resultSchema, new ArrayList<>(), upStreamSchema, _context);
   }
 
   @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*doesn't match "
@@ -240,6 +248,6 @@ public class TransformOperatorTest {
     });
     RexExpression.InputRef ref0 = new RexExpression.InputRef(0);
     TransformOperator transform =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(ref0), upStreamSchema);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(ref0), upStreamSchema, _context);
   }
 };

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
@@ -95,7 +95,8 @@ public class TransformOperatorTest {
     RexExpression.Literal boolLiteral = new RexExpression.Literal(FieldSpec.DataType.BOOLEAN, true);
     RexExpression.Literal strLiteral = new RexExpression.Literal(FieldSpec.DataType.STRING, "str");
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema, 1, 2);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema, 1,
+            2);
     TransferableBlock result = op.nextBlock();
     // Literal operands should just output original literals.
     Assert.assertTrue(!result.isErrorBlock());
@@ -173,7 +174,8 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"inCol", "strCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema, 1, 2);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema, 1,
+            2);
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
     DataBlock data = result.getDataBlock();
@@ -196,7 +198,8 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"boolCol", "strCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.STRING});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema, 1, 2);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema, 1,
+            2);
     TransferableBlock result = op.nextBlock();
     // First block has two rows
     Assert.assertFalse(result.isErrorBlock());


### PR DESCRIPTION
Log operator and opchain stats to help better debug perf issues. 

In non-error case, the log is printed out as log.debug. 

The stats include wall time and # of output and input rows and blocks.

Some of the operators don't output wall time such as MailboxSend op.

Currently, the stats are printed whenever we call operator toExplainString(). This should be moved to close() call chaining in the future.


Note it is log error in sample output for getting the sample easier. It will be log debug in production.
Sample output:
```
16:16:11.806 ERROR [QueryRunner] [grpc-default-executor-0] RequestId:2 StageId:3 Leaf stage v1 processing time:76 ms
16:16:11.806 ERROR [LeafStageTransferableBlockOperator] [grpc-default-executor-0] OperatorStats[type: LEAF_STAGE_TRANSFER_OPERATOR, requestId: 2, stageId 3] ExecutionWallTime: 0ms, InputRows: 2, InputBlock: 1, OutputRows: 2, OutputBlock: 1
16:16:11.806 ERROR [MailboxSendOperator] [grpc-default-executor-0] OperatorStats[type: MAILBOX_SEND, requestId: 2, stageId 3] ExecutionWallTime: 0ms, InputRows: 2, InputBlock: 2, OutputRows: 2, OutputBlock: 2
16:16:11.809 ERROR [MailboxReceiveOperator] [query_worker_on_8422_port-1-thread-22] OperatorStats[type: MAILBOX_RECEIVE, requestId: 2, stageId 3] ExecutionWallTime: 0ms, InputRows: 2, InputBlock: 1, OutputRows: 2, OutputBlock: 1
16:16:11.809 ERROR [AggregateOperator] [query_worker_on_8422_port-1-thread-22] OperatorStats[type: AGGREGATE_OPERATOR, requestId: 2, stageId 2] ExecutionWallTime: 0ms, InputRows: 2, InputBlock: 1, OutputRows: 2, OutputBlock: 1
16:16:11.809 ERROR [TransformOperator] [query_worker_on_8422_port-1-thread-22] OperatorStats[type: TRANSFORM, requestId: 2, stageId 2] ExecutionWallTime: 0ms, InputRows: 2, InputBlock: 1, OutputRows: 2, OutputBlock: 1
16:16:11.809 ERROR [AggregateOperator] [query_worker_on_8422_port-1-thread-22] OperatorStats[type: FILTER, requestId: 2, stageId 2] ExecutionWallTime: 0ms, InputRows: 2, InputBlock: 1, OutputRows: 2, OutputBlock: 1
16:16:11.809 ERROR [SortOperator] [query_worker_on_8422_port-1-thread-22] OperatorStats[type: SORT, requestId: 2, stageId 2] ExecutionWallTime: 1ms, InputRows: 0, InputBlock: 1, OutputRows: 2, OutputBlock: 1
16:16:11.809 ERROR [TransformOperator] [query_worker_on_8422_port-1-thread-22] OperatorStats[type: TRANSFORM, requestId: 2, stageId 2] ExecutionWallTime: 0ms, InputRows: 2, InputBlock: 1, OutputRows: 2, OutputBlock: 1
16:16:11.809 ERROR [MailboxSendOperator] [query_worker_on_8422_port-1-thread-22] OperatorStats[type: MAILBOX_SEND, requestId: 2, stageId 2] ExecutionWallTime: 0ms, InputRows: 2, InputBlock: 2, OutputRows: 2, OutputBlock: 2
16:16:11.809 ERROR [OpChainSchedulerService] [query_worker_on_8422_port-1-thread-22] (OpChain{2_2}): Completed (2_2) Queued Count: 2, Executing Time: 3ms, Queued Time: 63ms
16:16:11.811 ERROR [MailboxReceiveOperator] [query_worker_on_8422_port-1-thread-23] OperatorStats[type: MAILBOX_RECEIVE, requestId: 2, stageId 2] ExecutionWallTime: 0ms, InputRows: 2, InputBlock: 1, OutputRows: 2, OutputBlock: 1
16:16:11.811 ERROR [SortOperator] [query_worker_on_8422_port-1-thread-23] OperatorStats[type: SORT, requestId: 2, stageId 1] ExecutionWallTime: 0ms, InputRows: 0, InputBlock: 1, OutputRows: 2, OutputBlock: 1
16:16:11.811 ERROR [MailboxSendOperator] [query_worker_on_8422_port-1-thread-23] OperatorStats[type: MAILBOX_SEND, requestId: 2, stageId 1] ExecutionWallTime: 1ms, InputRows: 2, InputBlock: 2, OutputRows: 2, OutputBlock: 2
16:16:11.811 ERROR [OpChainSchedulerService] [query_worker_on_8422_port-1-thread-23] (OpChain{2_1}): Completed (2_1) Queued Count: 2, Executing Time: 2ms, Queued Time: 91ms
16:16:11.812 ERROR [MailboxReceiveOperator] [jersey-server-managed-async-executor-1] OperatorStats[type: MAILBOX_RECEIVE, requestId: 2, stageId 1] ExecutionWallTime: 80ms, InputRows: 2, InputBlock: 1, OutputRows: 2, OutputBlock: 1
16:16:11.812 ERROR [QueryDispatcher] [jersey-server-managed-async-executor-1] RequestId:2 StageId: 0 Broker toResultTable processing time:0 ms
```