### PR TITLE
Allow liveness check using query parameter during server shutdown

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ShutDownFilter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ShutDownFilter.java
@@ -41,9 +41,12 @@ public class ShutDownFilter implements ContainerRequestFilter {
   @Override
   public void filter(ContainerRequestContext requestContext)
       throws IOException {
-    if (_shutDownInProgress.get() && !(requestContext.getMethod().equals("GET") && requestContext.getUriInfo().getPath()
-        .equals("health/liveness"))) {
-      throw new WebApplicationException("Server is shutting down", Response.Status.SERVICE_UNAVAILABLE);
+    // NOTE: Allow health check requests for liveness check
+    if (_shutDownInProgress.get() && !(requestContext.getUriInfo().getMatchedResources()
+        .get(0) instanceof HealthCheckResource)) {
+      String errMessage = "Server is shutting down";
+      throw new WebApplicationException(errMessage,
+          Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(errMessage).build());
     }
   }
 }

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/HealthCheckResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/HealthCheckResourceTest.java
@@ -41,29 +41,44 @@ public class HealthCheckResourceTest extends BaseResourceTest {
     when(mockFailureCallback.getServiceStatus()).thenReturn(ServiceStatus.Status.BAD);
 
     assertEquals(_webTarget.path(livenessPath).request().get(Response.class).getStatus(), 200);
-    assertEquals(_webTarget.path(healthPath).request().get(Response.class).getStatus(), 503);
-    assertEquals(_webTarget.path(readinessPath).request().get(Response.class).getStatus(), 503);
-
-    ServiceStatus.setServiceStatusCallback(_instanceId, mockSuccessCallback);
-    assertEquals(_webTarget.path(livenessPath).request().get(Response.class).getStatus(), 200);
-    assertEquals(_webTarget.path(healthPath).request().get(Response.class).getStatus(), 200);
-    assertEquals(_webTarget.path(readinessPath).request().get(Response.class).getStatus(), 200);
-
-    ServiceStatus.setServiceStatusCallback(_instanceId, mockFailureCallback);
-    assertEquals(_webTarget.path(livenessPath).request().get(Response.class).getStatus(), 200);
+    assertEquals(
+        _webTarget.path(healthPath).queryParam("checkType", "liveness").request().get(Response.class).getStatus(), 200);
     assertEquals(_webTarget.path(healthPath).request().get(Response.class).getStatus(), 503);
     assertEquals(_webTarget.path(readinessPath).request().get(Response.class).getStatus(), 503);
     assertEquals(
         _webTarget.path(healthPath).queryParam("checkType", "readiness").request().get(Response.class).getStatus(),
         503);
+
+    ServiceStatus.setServiceStatusCallback(_instanceId, mockSuccessCallback);
+    assertEquals(_webTarget.path(livenessPath).request().get(Response.class).getStatus(), 200);
     assertEquals(
         _webTarget.path(healthPath).queryParam("checkType", "liveness").request().get(Response.class).getStatus(), 200);
+    assertEquals(_webTarget.path(healthPath).request().get(Response.class).getStatus(), 200);
+    assertEquals(_webTarget.path(readinessPath).request().get(Response.class).getStatus(), 200);
+    assertEquals(
+        _webTarget.path(healthPath).queryParam("checkType", "readiness").request().get(Response.class).getStatus(),
+        200);
+
+    ServiceStatus.setServiceStatusCallback(_instanceId, mockFailureCallback);
+    assertEquals(_webTarget.path(livenessPath).request().get(Response.class).getStatus(), 200);
+    assertEquals(
+        _webTarget.path(healthPath).queryParam("checkType", "liveness").request().get(Response.class).getStatus(), 200);
+    assertEquals(_webTarget.path(healthPath).request().get(Response.class).getStatus(), 503);
+    assertEquals(_webTarget.path(readinessPath).request().get(Response.class).getStatus(), 503);
+    assertEquals(
+        _webTarget.path(healthPath).queryParam("checkType", "readiness").request().get(Response.class).getStatus(),
+        503);
 
     // Start shutting down the HTTP server, only liveness check should go through
     ServiceStatus.setServiceStatusCallback(_instanceId, mockSuccessCallback);
     _adminApiApplication.startShuttingDown();
     assertEquals(_webTarget.path(livenessPath).request().get(Response.class).getStatus(), 200);
+    assertEquals(
+        _webTarget.path(healthPath).queryParam("checkType", "liveness").request().get(Response.class).getStatus(), 200);
     assertEquals(_webTarget.path(healthPath).request().get(Response.class).getStatus(), 503);
     assertEquals(_webTarget.path(readinessPath).request().get(Response.class).getStatus(), 503);
+    assertEquals(
+        _webTarget.path(healthPath).queryParam("checkType", "readiness").request().get(Response.class).getStatus(),
+        503);
   }
 }


### PR DESCRIPTION
On top of #9915, also allow liveness check using query parameter to pass the shut down filter.