### PR TITLE
make it more configurable to wait for external view to converge with ideal states

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.RebalanceConfigConstants;
 import org.apache.pinot.spi.utils.TimeUtils;
 
 import static org.apache.pinot.spi.utils.CommonConstants.Controller.CONFIG_OF_CONTROLLER_METRICS_PREFIX;
@@ -196,6 +197,10 @@ public class ControllerConf extends PinotConfiguration {
         "controller.segmentRelocator.initialDelayInSeconds";
     public static final String SEGMENT_RELOCATOR_ENABLE_LOCAL_TIER_MIGRATION =
         "controller.segmentRelocator.enableLocalTierMigration";
+    public static final String SEGMENT_RELOCATOR_EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS =
+        "controller.segmentRelocator.externalViewStabilizationTimeoutInMs";
+    public static final String SEGMENT_RELOCATOR_EXTERNAL_VIEW_CHECK_INTERVAL_IN_MS =
+        "controller.segmentRelocator.externalViewCheckIntervalInMs";
 
     // The flag to indicate if controller periodic job will fix the missing LLC segment deep store copy.
     // Default value is false.
@@ -910,6 +915,16 @@ public class ControllerConf extends PinotConfiguration {
 
   public boolean enableSegmentRelocatorLocalTierMigration() {
     return getProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_ENABLE_LOCAL_TIER_MIGRATION, false);
+  }
+
+  public long getSegmentRelocatorExternalViewCheckIntervalInMs() {
+    return getProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_EXTERNAL_VIEW_CHECK_INTERVAL_IN_MS,
+        RebalanceConfigConstants.DEFAULT_EXTERNAL_VIEW_CHECK_INTERVAL_IN_MS);
+  }
+
+  public long getSegmentRelocatorExternalViewStabilizationTimeoutInMs() {
+    return getProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS,
+        RebalanceConfigConstants.DEFAULT_EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS);
   }
 
   public long getPeriodicTaskInitialDelayInSeconds() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -641,7 +641,11 @@ public class PinotTableRestletResource {
           + "number of replicas allowed to be unavailable if value is negative") @DefaultValue("1")
   @QueryParam("minAvailableReplicas") int minAvailableReplicas, @ApiParam(
       value = "Whether to use best-efforts to rebalance (not fail the rebalance when the no-downtime contract cannot "
-          + "be achieved)") @DefaultValue("false") @QueryParam("bestEfforts") boolean bestEfforts) {
+          + "be achieved)") @DefaultValue("false") @QueryParam("bestEfforts") boolean bestEfforts, @ApiParam(
+      value = "How often to check if external view converges with ideal states") @DefaultValue("1000")
+  @QueryParam("externalViewCheckIntervalInMs") long externalViewCheckIntervalInMs,
+      @ApiParam(value = "How long to wait till external view converges with ideal states") @DefaultValue("3600000")
+      @QueryParam("externalViewStabilizationTimeoutInMs") long externalViewStabilizationTimeoutInMs) {
 
     String tableNameWithType = constructTableNameWithType(tableName, tableTypeStr);
 
@@ -653,6 +657,10 @@ public class PinotTableRestletResource {
     rebalanceConfig.addProperty(RebalanceConfigConstants.DOWNTIME, downtime);
     rebalanceConfig.addProperty(RebalanceConfigConstants.MIN_REPLICAS_TO_KEEP_UP_FOR_NO_DOWNTIME, minAvailableReplicas);
     rebalanceConfig.addProperty(RebalanceConfigConstants.BEST_EFFORTS, bestEfforts);
+    rebalanceConfig.addProperty(RebalanceConfigConstants.EXTERNAL_VIEW_CHECK_INTERVAL_IN_MS,
+        externalViewCheckIntervalInMs);
+    rebalanceConfig.addProperty(RebalanceConfigConstants.EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS,
+        externalViewStabilizationTimeoutInMs);
 
     try {
       if (dryRun || downtime) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -72,6 +72,8 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
   private final HttpConnectionManager _connectionManager;
   private final boolean _enableLocalTierMigration;
   private final int _timeoutMs;
+  private final long _externalViewCheckIntervalInMs;
+  private final long _externalViewStabilizationTimeoutInMs;
 
   public SegmentRelocator(PinotHelixResourceManager pinotHelixResourceManager,
       LeadControllerManager leadControllerManager, ControllerConf config, ControllerMetrics controllerMetrics,
@@ -83,6 +85,8 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
     _connectionManager = connectionManager;
     _enableLocalTierMigration = config.enableSegmentRelocatorLocalTierMigration();
     _timeoutMs = config.getServerAdminRequestTimeoutSeconds() * 1000;
+    _externalViewCheckIntervalInMs = config.getSegmentRelocatorExternalViewCheckIntervalInMs();
+    _externalViewStabilizationTimeoutInMs = config.getSegmentRelocatorExternalViewStabilizationTimeoutInMs();
   }
 
   @Override
@@ -118,6 +122,10 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
     // Allow at most one replica unavailable during relocation
     Configuration rebalanceConfig = new BaseConfiguration();
     rebalanceConfig.addProperty(RebalanceConfigConstants.MIN_REPLICAS_TO_KEEP_UP_FOR_NO_DOWNTIME, -1);
+    rebalanceConfig.addProperty(RebalanceConfigConstants.EXTERNAL_VIEW_CHECK_INTERVAL_IN_MS,
+        _externalViewCheckIntervalInMs);
+    rebalanceConfig.addProperty(RebalanceConfigConstants.EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS,
+        _externalViewStabilizationTimeoutInMs);
     // Run rebalance asynchronously
     _executorService.submit(() -> {
       try {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/RebalanceConfigConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/RebalanceConfigConstants.java
@@ -57,4 +57,12 @@ public class RebalanceConfigConstants {
   // - ExternalView has not converged within the maximum wait time -> continue to the next stage
   public static final String BEST_EFFORTS = "bestEfforts";
   public static final boolean DEFAULT_BEST_EFFORTS = false;
+
+  // The check on external view can be very costly when the table has very large ideal and external states, i.e. when
+  // having a huge number of segments. These two configs help reduce the cpu load on controllers, e.g. by doing the
+  // check less frequently and bail out sooner to rebalance at best effort if configured so.
+  public static final String EXTERNAL_VIEW_CHECK_INTERVAL_IN_MS = "externalViewCheckIntervalInMs";
+  public static final long DEFAULT_EXTERNAL_VIEW_CHECK_INTERVAL_IN_MS = 1_000L; // 1 second
+  public static final String EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS = "externalViewStabilizationTimeoutInMs";
+  public static final long DEFAULT_EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS = 60 * 60_000L; // 1 hour
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultiDirQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultiDirQuickstart.java
@@ -43,6 +43,8 @@ public class MultiDirQuickstart extends Quickstart {
     properties.put("controller.segment.relocator.frequencyPeriod", "60s");
     properties.put("controller.segmentRelocator.initialDelayInSeconds", "10");
     properties.put("controller.segmentRelocator.enableLocalTierMigration", "true");
+    properties.put("controller.segmentRelocator.externalViewCheckIntervalInMs", "2000");
+    properties.put("controller.segmentRelocator.externalViewStabilizationTimeoutInMs", "60000");
     /*
      * One can also set `dataDir` as part of tierConfigs in TableConfig to overwrite the instance configs (or set as
      * cluster configs), but it's recommended to use instance (or cluster) configs for consistency across tables.

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
@@ -36,7 +36,7 @@ public class PinotTableRebalancer extends PinotZKChanger {
 
   public PinotTableRebalancer(String zkAddress, String clusterName, boolean dryRun, boolean reassignInstances,
       boolean includeConsuming, boolean bootstrap, boolean downtime, int minReplicasToKeepUpForNoDowntime,
-      boolean bestEffort) {
+      boolean bestEffort, long externalViewCheckIntervalInMs, long externalViewStabilizationTimeoutInMs) {
     super(zkAddress, clusterName);
     _rebalanceConfig.addProperty(RebalanceConfigConstants.DRY_RUN, dryRun);
     _rebalanceConfig.addProperty(RebalanceConfigConstants.REASSIGN_INSTANCES, reassignInstances);
@@ -46,6 +46,10 @@ public class PinotTableRebalancer extends PinotZKChanger {
     _rebalanceConfig.addProperty(RebalanceConfigConstants.MIN_REPLICAS_TO_KEEP_UP_FOR_NO_DOWNTIME,
         minReplicasToKeepUpForNoDowntime);
     _rebalanceConfig.addProperty(RebalanceConfigConstants.BEST_EFFORTS, bestEffort);
+    _rebalanceConfig.addProperty(RebalanceConfigConstants.EXTERNAL_VIEW_CHECK_INTERVAL_IN_MS,
+        externalViewCheckIntervalInMs);
+    _rebalanceConfig.addProperty(RebalanceConfigConstants.EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS,
+        externalViewStabilizationTimeoutInMs);
   }
 
   public RebalanceResult rebalance(String tableNameWithType) {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/RebalanceTableCommand.java
@@ -20,6 +20,7 @@ package org.apache.pinot.tools.admin.command;
 
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceResult;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.RebalanceConfigConstants;
 import org.apache.pinot.tools.Command;
 import org.apache.pinot.tools.PinotTableRebalancer;
 import org.slf4j.Logger;
@@ -77,6 +78,15 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
           + " cannot be achieved, false by default)")
   private boolean _bestEfforts = false;
 
+  @CommandLine.Option(names = {"-externalViewCheckIntervalInMs"},
+      description = "How often to check if external view converges with ideal view")
+  private long _externalViewCheckIntervalInMs = RebalanceConfigConstants.DEFAULT_EXTERNAL_VIEW_CHECK_INTERVAL_IN_MS;
+
+  @CommandLine.Option(names = {"-externalViewStabilizationTimeoutInMs"},
+      description = "How long to wait till external view converges with ideal view")
+  private long _externalViewStabilizationTimeoutInMs =
+      RebalanceConfigConstants.DEFAULT_EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS;
+
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, help = true, description = "Print this message")
   private boolean _help = false;
 
@@ -94,7 +104,8 @@ public class RebalanceTableCommand extends AbstractBaseAdminCommand implements C
       throws Exception {
     PinotTableRebalancer tableRebalancer =
         new PinotTableRebalancer(_zkAddress, _clusterName, _dryRun, _reassignInstances, _includeConsuming, _bootstrap,
-            _downtime, _minAvailableReplicas, _bestEfforts);
+            _downtime, _minAvailableReplicas, _bestEfforts, _externalViewCheckIntervalInMs,
+            _externalViewStabilizationTimeoutInMs);
     RebalanceResult rebalanceResult = tableRebalancer.rebalance(_tableNameWithType);
     LOGGER
         .info("Got rebalance result: {} for table: {}", JsonUtils.objectToString(rebalanceResult), _tableNameWithType);


### PR DESCRIPTION
added two configs to make it more configurable on how often to check if and how long to wait if external view converges with ideal states

## Release notes ##
added two configs for segmentRelocator to fine tune the periodic table rebalance task
controller.segmentRelocator.externalViewStabilizationTimeoutMs - 1hr by default
controller.segmentRelocator.externalViewCheckIntervalMs - 1s by default

externalViewStabilizationTimeoutMs and externalViewCheckIntervalMs can also be set when triggering rebalance via rest API or cmd line