### PR TITLE
[multistage] adding async submission

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryServer.java
@@ -25,9 +25,12 @@ import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 import org.apache.pinot.common.proto.PinotQueryWorkerGrpc;
 import org.apache.pinot.common.proto.Worker;
+import org.apache.pinot.common.utils.NamedThreadFactory;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
 import org.apache.pinot.core.transport.grpc.GrpcQueryServer;
 import org.apache.pinot.query.runtime.QueryRunner;
@@ -45,13 +48,16 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
 
   private final Server _server;
   private final QueryRunner _queryRunner;
+  private final ExecutorService _executorService;
 
   public QueryServer(int port, QueryRunner queryRunner) {
     _server = ServerBuilder.forPort(port).addService(this).build();
     _queryRunner = queryRunner;
+    _executorService = Executors.newFixedThreadPool(ResourceManager.DEFAULT_QUERY_RUNNER_THREADS,
+        new NamedThreadFactory("query_server_on_" + port + "_port"));
 
-    LOGGER.info("Initialized QueryWorker on port: {} with numWorkerThreads: {}", port,
-        ResourceManager.DEFAULT_QUERY_WORKER_THREADS);
+    LOGGER.info("Initialized QueryServer on port: {} with numServerThreads: {}", port,
+        ResourceManager.DEFAULT_QUERY_RUNNER_THREADS);
   }
 
   public void start() {
@@ -89,25 +95,12 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
       return;
     }
 
-    // return dispatch successful.
-    // TODO: return meaningful value here.
+    // TODO: break this into parsing and execution, so that responseObserver can return upon compilation complete.
+    // compilation complete indicates dispatch successful.
+    _executorService.submit(() -> _queryRunner.processQuery(distributedStagePlan, requestMetadataMap));
+
     responseObserver.onNext(Worker.QueryResponse.newBuilder()
         .putMetadata(QueryConfig.KEY_OF_SERVER_RESPONSE_STATUS_OK, "").build());
     responseObserver.onCompleted();
-
-    // start a new GRPC ctx has all the values as the current context, but won't be cancelled
-    Context ctx = Context.current().fork();
-    // Set ctx as the current context within the Runnable can start asynchronous work here that will not
-    // be cancelled when submit returns
-    ctx.run(() -> {
-      // Process the query
-      try {
-        // TODO: break this into parsing and execution, so that responseObserver can return upon parsing complete.
-        _queryRunner.processQuery(distributedStagePlan, requestMetadataMap);
-      } catch (Exception e) {
-        LOGGER.error("Caught exception while processing request", e);
-        throw new RuntimeException(e);
-      }
-    });
   }
 }


### PR DESCRIPTION
Async query planning and return from dispatch directly once parsing finishes. 

- this PR attempts to address the async submission issue that are currently causing planMaker execution issue blocking the GRPC thread entirely. 

This one is related to https://github.com/apache/pinot/pull/10114 but i think the fundamental framework of approach is different (one uses FutureStub one uses BlockingStub with deadline). i am not sure which one is better but we need to decide on a general direction. 

The goal of this PR is for discussion and it is not ready to be merge. 

CC @ankitsultana @61yao @agavra 