### PR TITLE
add option to run SegmentRelocator sequentially and kinda fairly

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -201,6 +201,8 @@ public class ControllerConf extends PinotConfiguration {
         "controller.segmentRelocator.externalViewStabilizationTimeoutInMs";
     public static final String SEGMENT_RELOCATOR_EXTERNAL_VIEW_CHECK_INTERVAL_IN_MS =
         "controller.segmentRelocator.externalViewCheckIntervalInMs";
+    public static final String SEGMENT_RELOCATOR_REBALANCE_TABLES_SEQUENTIALLY =
+        "controller.segmentRelocator.rebalanceTablesSequentially";
 
     // The flag to indicate if controller periodic job will fix the missing LLC segment deep store copy.
     // Default value is false.
@@ -925,6 +927,10 @@ public class ControllerConf extends PinotConfiguration {
   public long getSegmentRelocatorExternalViewStabilizationTimeoutInMs() {
     return getProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS,
         RebalanceConfigConstants.DEFAULT_EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS);
+  }
+
+  public boolean isSegmentRelocatorRebalanceTablesSequentially() {
+    return getProperty(ControllerPeriodicTasksConf.SEGMENT_RELOCATOR_REBALANCE_TABLES_SEQUENTIALLY, false);
   }
 
   public long getPeriodicTaskInitialDelayInSeconds() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -109,7 +109,6 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
           }
         } catch (InterruptedException e) {
           LOGGER.warn("Got interrupted while rebalancing tables sequentially", e);
-          Thread.currentThread().interrupt();
         }
       });
     } else {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -141,6 +141,7 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
   @VisibleForTesting
   void rebalanceWaitingTable(Consumer<String> rebalancer)
       throws InterruptedException {
+    LOGGER.debug("Getting next waiting table to rebalance");
     String nextTable = _waitingQueue.take();
     try {
       rebalancer.accept(nextTable);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocatorTest.java
@@ -53,7 +53,10 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 
 public class SegmentRelocatorTest {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultiDirQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultiDirQuickstart.java
@@ -45,6 +45,7 @@ public class MultiDirQuickstart extends Quickstart {
     properties.put("controller.segmentRelocator.enableLocalTierMigration", "true");
     properties.put("controller.segmentRelocator.externalViewCheckIntervalInMs", "2000");
     properties.put("controller.segmentRelocator.externalViewStabilizationTimeoutInMs", "60000");
+    properties.put("controller.segmentRelocator.rebalanceTablesSequentially", "true");
     /*
      * One can also set `dataDir` as part of tierConfigs in TableConfig to overwrite the instance configs (or set as
      * cluster configs), but it's recommended to use instance (or cluster) configs for consistency across tables.


### PR DESCRIPTION
Previously, SegmentRelocator just keeps adding new rebalance tasks periodically, w/o knowing the previous ones may be still running and perhaps for the same table. This option adds a waiting queue for SegmentRelocator to run rebalance tasks sequentially and w/o redundancy.

Running tasks sequentially is mainly to avoid cpu overload on controllers. When table has a large ideal/external states, the waitForExternalViewToConverge() method can be very cpu costly, as it has to deserialize those large helix state. Besides, this method is called by TableRebalancer in a while-true loop to rebalance table incrementally, incurring the cost of deserialization repetitively. We found when running many SegmentRelocator tasks in parallel, the cpu util of controllers could go up to 100%, affecting other cluster activities like real-time ingestion. 

## Release notes ##
controller.segmentRelocator.rebalanceTablesSequentially - false by default