### PR TITLE
Fixes one case of counting null instances impacting avg agg accuracy

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgAggregationFunction.java
@@ -100,13 +100,15 @@ public class AvgAggregationFunction extends BaseSingleInputAggregationFunction<A
       double[] doubleValues = blockValSet.getDoubleValuesSV();
       if (nullBitmap.getCardinality() < length) {
         double sum = 0.0;
+        long count = 0L;
         // TODO: need to update the for-loop terminating condition to: i < length & i < doubleValues.length?
         for (int i = 0; i < length; i++) {
           if (!nullBitmap.contains(i)) {
             sum += doubleValues[i];
+            count++;
           }
         }
-        setAggregationResult(aggregationResultHolder, sum, length);
+        setAggregationResult(aggregationResultHolder, sum, count);
       }
       // Note: when all input values re null (nullBitmap.getCardinality() == values.length), avg is null. As a result,
       // we don't call setAggregationResult.

--- a/pinot-core/src/test/java/org/apache/pinot/queries/NullEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NullEnabledQueriesTest.java
@@ -495,7 +495,9 @@ public class NullEnabledQueriesTest extends BaseQueriesTest {
       assertTrue(Math.abs((Double) rows.get(0)[1] - min) < 1e-1);
       double max = baseValue.doubleValue() + 998;
       assertTrue(Math.abs((Double) rows.get(0)[2] - max) < 1e-1);
-      double avg = _sum / (double) _records.size();
+      // Nulls are added for all records where index % 2 is false, so half of the records are null.
+      double numNonNullRecords = nullValuesExist ? (_records.size() / 2.0) : _records.size();
+      double avg = _sum / numNonNullRecords;
       assertTrue(Math.abs((Double) rows.get(0)[3] - avg) < 1e-1);
       assertTrue(Math.abs((Double) rows.get(0)[4] - (4 * _sum)) < 1e-1);
     }


### PR DESCRIPTION
Based on what I can see in AvgAggregationFunction.java it looks as though null handling is implemented, but it seems that avg is still including nulls in the count (where avg is implemented as sum/count).  Needs tests but opening for fast feedback.

  I confirmed this using filtering, and test data where there are only 2 rows like this:


| myCol |
|-------|
| 1     |
| null  |



No filtering:
`SELECT avg(myCol) from myTable`
results in `0.5`


With filtering:
`SELECT avg(myCol) from myTableWHERE myCol is not null`
results in `1`



Slack ref: https://apache-pinot.slack.com/archives/CDRCA57FC/p1673551935766969