### PR TITLE
[multistage] support aggregations that require intermediate representations

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/CustomObject.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/CustomObject.java
@@ -1,0 +1,43 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.common;
+
+import java.nio.ByteBuffer;
+
+
+public class CustomObject {
+  public static final int NULL_TYPE_VALUE = 100;
+
+  private final int _type;
+  private final ByteBuffer _buffer;
+
+  public CustomObject(int type, ByteBuffer buffer) {
+    _type = type;
+    _buffer = buffer;
+  }
+
+  public int getType() {
+    return _type;
+  }
+
+  public ByteBuffer getBuffer() {
+    return _buffer;
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/BaseDataBlock.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/BaseDataBlock.java
@@ -27,7 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.datatable.DataTableImplV3;
 import org.apache.pinot.common.datatable.DataTableUtils;
 import org.apache.pinot.common.response.ProcessingException;
@@ -348,16 +348,16 @@ public abstract class BaseDataBlock implements DataBlock {
 
   @Nullable
   @Override
-  public DataTable.CustomObject getCustomObject(int rowId, int colId) {
+  public CustomObject getCustomObject(int rowId, int colId) {
     int size = positionOffsetInVariableBufferAndGetLength(rowId, colId);
     int type = _variableSizeData.getInt();
     if (size == 0) {
-      assert type == DataTable.CustomObject.NULL_TYPE_VALUE;
+      assert type == CustomObject.NULL_TYPE_VALUE;
       return null;
     }
     ByteBuffer buffer = _variableSizeData.slice();
     buffer.limit(size);
-    return new DataTable.CustomObject(type, buffer);
+    return new CustomObject(type, buffer);
   }
 
   @Nullable

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/BaseDataBlock.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/BaseDataBlock.java
@@ -27,6 +27,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.datatable.DataTableImplV3;
 import org.apache.pinot.common.datatable.DataTableUtils;
 import org.apache.pinot.common.response.ProcessingException;
@@ -343,6 +344,20 @@ public abstract class BaseDataBlock implements DataBlock {
       strings[i] = _stringDictionary[_variableSizeData.getInt()];
     }
     return strings;
+  }
+
+  @Nullable
+  @Override
+  public DataTable.CustomObject getCustomObject(int rowId, int colId) {
+    int size = positionOffsetInVariableBufferAndGetLength(rowId, colId);
+    int type = _variableSizeData.getInt();
+    if (size == 0) {
+      assert type == DataTable.CustomObject.NULL_TYPE_VALUE;
+      return null;
+    }
+    ByteBuffer buffer = _variableSizeData.slice();
+    buffer.limit(size);
+    return new DataTable.CustomObject(type, buffer);
   }
 
   @Nullable

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlock.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlock.java
@@ -74,6 +74,8 @@ public interface DataBlock {
 
   String[] getStringArray(int rowId, int colId);
 
+  Object getCustomObject(int rowId, int colId);
+
   @Nullable
   RoaringBitmap getNullRowIds(int colId);
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlock.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlock.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.spi.utils.ByteArray;
@@ -74,7 +75,7 @@ public interface DataBlock {
 
   String[] getStringArray(int rowId, int colId);
 
-  Object getCustomObject(int rowId, int colId);
+  CustomObject getCustomObject(int rowId, int colId);
 
   @Nullable
   RoaringBitmap getNullRowIds(int colId);

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
@@ -25,6 +25,8 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.function.Function;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
@@ -87,14 +89,14 @@ public final class DataBlockUtils {
     }
   }
 
-  public static List<Object[]> extractRows(DataBlock dataBlock) {
+  public static List<Object[]> extractRows(DataBlock dataBlock, Function<CustomObject, Object> customObjectSerde) {
     DataSchema dataSchema = dataBlock.getDataSchema();
     DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
     RoaringBitmap[] nullBitmaps = extractNullBitmaps(dataBlock);
     int numRows = dataBlock.getNumberOfRows();
     List<Object[]> rows = new ArrayList<>(numRows);
     for (int rowId = 0; rowId < numRows; rowId++) {
-      rows.add(extractRowFromDataBlock(dataBlock, rowId, columnDataTypes, nullBitmaps));
+      rows.add(extractRowFromDataBlock(dataBlock, rowId, columnDataTypes, nullBitmaps, customObjectSerde));
     }
     return rows;
   }
@@ -189,8 +191,8 @@ public final class DataBlockUtils {
     return nullBitmaps;
   }
 
-  public static Object[] extractRowFromDataBlock(DataBlock dataBlock, int rowId, DataSchema.ColumnDataType[] dataTypes,
-      RoaringBitmap[] nullBitmaps) {
+  private static Object[] extractRowFromDataBlock(DataBlock dataBlock, int rowId, DataSchema.ColumnDataType[] dataTypes,
+      RoaringBitmap[] nullBitmaps, Function<CustomObject, Object> customObjectSerde) {
     int numColumns = nullBitmaps.length;
     Object[] row = new Object[numColumns];
     for (int colId = 0; colId < numColumns; colId++) {
@@ -251,7 +253,7 @@ public final class DataBlockUtils {
             row[colId] = DataSchema.ColumnDataType.TIMESTAMP_ARRAY.convert(dataBlock.getLongArray(rowId, colId));
             break;
           case OBJECT:
-            row[colId] = dataBlock.getCustomObject(rowId, colId);
+            row[colId] = customObjectSerde.apply(dataBlock.getCustomObject(rowId, colId));
             break;
           default:
             throw new IllegalStateException(

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
@@ -250,6 +250,9 @@ public final class DataBlockUtils {
           case TIMESTAMP_ARRAY:
             row[colId] = DataSchema.ColumnDataType.TIMESTAMP_ARRAY.convert(dataBlock.getLongArray(rowId, colId));
             break;
+          case OBJECT:
+            row[colId] = dataBlock.getCustomObject(rowId, colId);
+            break;
           default:
             throw new IllegalStateException(
                 String.format("Unsupported data type: %s for column: %s", dataTypes[colId], colId));

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/BaseDataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/BaseDataTable.java
@@ -26,6 +26,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.ByteArray;

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
@@ -21,10 +21,10 @@ package org.apache.pinot.common.datatable;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.spi.utils.ByteArray;
@@ -88,26 +88,6 @@ public interface DataTable {
   DataTable toMetadataOnlyDataTable();
 
   DataTable toDataOnlyDataTable();
-
-  class CustomObject {
-    public static final int NULL_TYPE_VALUE = 100;
-
-    private final int _type;
-    private final ByteBuffer _buffer;
-
-    public CustomObject(int type, ByteBuffer buffer) {
-      _type = type;
-      _buffer = buffer;
-    }
-
-    public int getType() {
-      return _type;
-    }
-
-    public ByteBuffer getBuffer() {
-      return _buffer;
-    }
-  }
 
   enum MetadataValueType {
     INT, LONG, STRING

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
@@ -29,6 +29,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.utils.DataSchema;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -422,6 +422,8 @@ public class DataSchema {
           return toTimestampArray(value);
         case BYTES_ARRAY:
           return (byte[][]) value;
+        case OBJECT:
+          return (Serializable) value;
         default:
           throw new IllegalStateException(String.format("Cannot convert: '%s' to type: %s", value, this));
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/ObjectSerDeUtils.java
@@ -59,7 +59,7 @@ import java.util.Map;
 import java.util.Set;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.theta.Sketch;
-import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.core.query.distinct.DistinctTable;
 import org.apache.pinot.core.query.utils.idset.IdSet;
 import org.apache.pinot.core.query.utils.idset.IdSets;
@@ -1244,7 +1244,7 @@ public class ObjectSerDeUtils {
     return SER_DES[objectTypeValue].serialize(value);
   }
 
-  public static <T> T deserialize(DataTable.CustomObject customObject) {
+  public static <T> T deserialize(CustomObject customObject) {
     return (T) SER_DES[customObject.getType()].deserialize(customObject.getBuffer());
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
@@ -28,11 +28,11 @@ import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import java.util.List;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.datablock.ColumnarDataBlock;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.RowDataBlock;
-import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -524,7 +524,7 @@ public class DataBlockBuilder {
     byteBuffer.putInt(builder._variableSizeDataByteArrayOutputStream.size());
     if (value == null) {
       byteBuffer.putInt(0);
-      builder._variableSizeDataOutputStream.writeInt(DataTable.CustomObject.NULL_TYPE_VALUE);
+      builder._variableSizeDataOutputStream.writeInt(CustomObject.NULL_TYPE_VALUE);
     } else {
       int objectTypeValue = ObjectSerDeUtils.ObjectType.getObjectType(value).getValue();
       byte[] bytes = ObjectSerDeUtils.serialize(value, objectTypeValue);

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/BaseDataTableBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datatable/BaseDataTableBuilder.java
@@ -24,7 +24,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.datatable.DataTableUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -103,7 +103,7 @@ public abstract class BaseDataTableBuilder implements DataTableBuilder {
     _currentRowDataByteBuffer.putInt(_variableSizeDataByteArrayOutputStream.size());
     if (value == null) {
       _currentRowDataByteBuffer.putInt(0);
-      _variableSizeDataOutputStream.writeInt(DataTable.CustomObject.NULL_TYPE_VALUE);
+      _variableSizeDataOutputStream.writeInt(CustomObject.NULL_TYPE_VALUE);
     } else {
       int objectTypeValue = ObjectSerDeUtils.ObjectType.getObjectType(value).getValue();
       byte[] bytes = ObjectSerDeUtils.serialize(value, objectTypeValue);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -293,6 +293,8 @@ public class AggregationFunctionFactory {
             return new FourthMomentAggregationFunction(firstArgument, FourthMomentAggregationFunction.Type.SKEWNESS);
           case KURTOSIS:
             return new FourthMomentAggregationFunction(firstArgument, FourthMomentAggregationFunction.Type.KURTOSIS);
+          case FOURTHMOMENT:
+            return new FourthMomentAggregationFunction(firstArgument, FourthMomentAggregationFunction.Type.MOMENT);
           default:
             throw new IllegalArgumentException();
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FilterContext;
@@ -142,7 +143,7 @@ public class AggregationFunctionUtils {
       case DOUBLE:
         return dataTable.getDouble(rowId, colId);
       case OBJECT:
-        DataTable.CustomObject customObject = dataTable.getCustomObject(rowId, colId);
+        CustomObject customObject = dataTable.getCustomObject(rowId, colId);
         return customObject != null ? ObjectSerDeUtils.deserialize(customObject) : null;
       default:
         throw new IllegalStateException("Illegal column data type in intermediate result: " + columnDataType);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FourthMomentAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FourthMomentAggregationFunction.java
@@ -36,7 +36,7 @@ public class FourthMomentAggregationFunction extends BaseSingleInputAggregationF
   private final Type _type;
 
   enum Type {
-    KURTOSIS, SKEWNESS
+    KURTOSIS, SKEWNESS, MOMENT
   }
 
   public FourthMomentAggregationFunction(ExpressionContext expression, Type type) {
@@ -51,6 +51,8 @@ public class FourthMomentAggregationFunction extends BaseSingleInputAggregationF
         return AggregationFunctionType.KURTOSIS;
       case SKEWNESS:
         return AggregationFunctionType.SKEWNESS;
+      case MOMENT:
+        return AggregationFunctionType.FOURTHMOMENT;
       default:
         throw new IllegalArgumentException("Unexpected type " + _type);
     }
@@ -159,6 +161,9 @@ public class FourthMomentAggregationFunction extends BaseSingleInputAggregationF
         return m4.kurtosis();
       case SKEWNESS:
         return m4.skew();
+      case MOMENT:
+        // this should never happen, as we're not extracting
+        // final result when using this method
       default:
         throw new IllegalStateException("Unexpected value: " + _type);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FourthMomentAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FourthMomentAggregationFunction.java
@@ -164,6 +164,7 @@ public class FourthMomentAggregationFunction extends BaseSingleInputAggregationF
       case MOMENT:
         // this should never happen, as we're not extracting
         // final result when using this method
+        throw new UnsupportedOperationException("Fourth moment cannot be used as aggregation function directly");
       default:
         throw new IllegalStateException("Unexpected value: " + _type);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
@@ -24,6 +24,7 @@ import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
@@ -77,7 +78,7 @@ public class DistinctDataTableReducer implements DataTableReducer {
       int numColumns = dataSchema.size();
       if (numColumns == 1 && dataSchema.getColumnDataType(0) == ColumnDataType.OBJECT) {
         // DistinctTable is still being returned as a single object
-        DataTable.CustomObject customObject = dataTable.getCustomObject(0, 0);
+        CustomObject customObject = dataTable.getCustomObject(0, 0);
         assert customObject != null;
         DistinctTable distinctTable = ObjectSerDeUtils.deserialize(customObject);
         if (!distinctTable.isEmpty()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -30,6 +30,7 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.BrokerGauge;
@@ -318,7 +319,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
                       break;
                     case OBJECT:
                       // TODO: Move ser/de into AggregationFunction interface
-                      DataTable.CustomObject customObject = dataTable.getCustomObject(rowId, colId);
+                      CustomObject customObject = dataTable.getCustomObject(rowId, colId);
                       if (customObject != null) {
                         values[colId] = ObjectSerDeUtils.deserialize(customObject);
                       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/function/InternalReduceFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/function/InternalReduceFunctions.java
@@ -17,7 +17,7 @@
  * under the License.
  */
 
-package org.apache.pinot.segment.local.function;
+package org.apache.pinot.core.query.reduce.function;
 
 import org.apache.pinot.segment.local.customobject.PinotFourthMoment;
 import org.apache.pinot.spi.annotations.ScalarFunction;

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableSerDeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableSerDeTest.java
@@ -31,6 +31,7 @@ import java.util.Map;
 import java.util.Random;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.datatable.DataTable.MetadataKey;
 import org.apache.pinot.common.datatable.DataTableFactory;
@@ -734,7 +735,7 @@ public class DataTableSerDeTest {
                 ERROR_MESSAGE);
             break;
           case OBJECT:
-            DataTable.CustomObject customObject = newDataTable.getCustomObject(rowId, colId);
+            CustomObject customObject = newDataTable.getCustomObject(rowId, colId);
             if (isNull) {
               Assert.assertNull(customObject, ERROR_MESSAGE);
             } else {

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
@@ -82,6 +82,7 @@ public class PinotQueryRuleSets {
           CoreRules.AGGREGATE_UNION_AGGREGATE,
 
           // reduce aggregate functions like AVG, STDDEV_POP etc.
+          PinotReduceAggregateFunctionsRule.INSTANCE,
           CoreRules.AGGREGATE_REDUCE_FUNCTIONS,
 
           // remove unnecessary sort rule

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotReduceAggregateFunctionsRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotReduceAggregateFunctionsRule.java
@@ -31,7 +31,6 @@ import org.apache.calcite.plan.RelOptRuleCall;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.type.RelDataType;
-import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.fun.PinotFourthMomentAggregateFunction;
@@ -176,10 +175,6 @@ public class PinotReduceAggregateFunctionsRule extends RelOptRule {
     RexNode fmRef = rexBuilder.addAggCall(fourthMomentCall, nGroups, newCalls,
         aggCallMapping, oldAggRel.getInput()::fieldIsNullable);
 
-    final RelDataTypeFactory typeFactory = oldAggRel.getCluster().getTypeFactory();
-    final RelDataType resultType = typeFactory.createTypeWithNullability(
-        oldCall.getType(), fmRef.getType().isNullable());
-    rexBuilder.ensureType(resultType, fmRef, true);
     final RexNode skewRef = rexBuilder.makeCall(
         isKurtosis ? PinotOperatorTable.KURTOSIS_REDUCE : PinotOperatorTable.SKEWNESS_REDUCE,
         fmRef);

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotReduceAggregateFunctionsRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotReduceAggregateFunctionsRule.java
@@ -50,8 +50,8 @@ import org.apache.calcite.util.CompositeList;
  * that the aggregation computation can merge partial results from different
  * intermediate nodes before reducing it into the final result.
  *
- * Also see {@link AggregateReduceFunctionsRule}, as this implementation
- * closely follows that.
+ * <p>This implementation follows closely with Calcite's
+ * {@link AggregateReduceFunctionsRule}.
  */
 public class PinotReduceAggregateFunctionsRule extends RelOptRule {
 

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotReduceAggregateFunctionsRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotReduceAggregateFunctionsRule.java
@@ -1,0 +1,206 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.calcite.rel.rules;
+
+import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeFactory;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.fun.PinotFourthMomentAggregateFunction;
+import org.apache.calcite.sql.fun.PinotKurtosisAggregateFunction;
+import org.apache.calcite.sql.fun.PinotOperatorTable;
+import org.apache.calcite.sql.fun.PinotSkewnessAggregateFunction;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.CompositeList;
+
+
+/**
+ * This rule rewrites aggregate functions when necessary for Pinot's
+ * multistage engine. For example, SKEWNESS must be rewritten into two
+ * parts: a multi-stage FOURTH_MOMENT calculation and then a scalar function
+ * that reduces the moment into the skewness at the end. This is to ensure
+ * that the aggregation computation can merge partial results from different
+ * intermediate nodes before reducing it into the final result.
+ *
+ * Also see {@link AggregateReduceFunctionsRule}, as this implementation
+ * closely follows that.
+ */
+public class PinotReduceAggregateFunctionsRule extends RelOptRule {
+
+  public static final PinotReduceAggregateFunctionsRule INSTANCE =
+      new PinotReduceAggregateFunctionsRule(PinotRuleUtils.PINOT_REL_FACTORY);
+
+  private static final Set<String> FUNCTIONS = ImmutableSet.of(
+      PinotSkewnessAggregateFunction.SKEWNESS,
+      PinotKurtosisAggregateFunction.KURTOSIS
+  );
+
+  protected PinotReduceAggregateFunctionsRule(RelBuilderFactory factory) {
+    super(operand(Aggregate.class, any()), factory, null);
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    if (call.rels.length < 1) {
+      return false;
+    }
+
+    if (call.rel(0) instanceof Aggregate) {
+      Aggregate agg = call.rel(0);
+      for (AggregateCall aggCall : agg.getAggCallList()) {
+        if (canReduce(aggCall)) {
+          return true;
+        }
+      }
+    }
+
+    return false;
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    Aggregate oldAggRel = call.rel(0);
+    reduceAggs(call, oldAggRel);
+  }
+
+  private void reduceAggs(RelOptRuleCall ruleCall, Aggregate oldAggRel) {
+    RexBuilder rexBuilder = oldAggRel.getCluster().getRexBuilder();
+
+    List<AggregateCall> oldCalls = oldAggRel.getAggCallList();
+    final int groupCount = oldAggRel.getGroupCount();
+
+    final List<AggregateCall> newCalls = new ArrayList<>();
+    final Map<AggregateCall, RexNode> aggCallMapping = new HashMap<>();
+
+    final List<RexNode> projList = new ArrayList<>();
+
+    // pass through group key
+    for (int i = 0; i < groupCount; i++) {
+      projList.add(rexBuilder.makeInputRef(oldAggRel, i));
+    }
+
+    // List of input expressions. If a particular aggregate needs more, it
+    // will add an expression to the end, and we will create an extra project
+    final RelBuilder relBuilder = ruleCall.builder();
+    relBuilder.push(oldAggRel.getInput());
+    final List<RexNode> inputExprs = new ArrayList<>(relBuilder.fields());
+
+    // create new aggregate function calls and rest of project list together
+    for (AggregateCall oldCall : oldCalls) {
+      projList.add(
+          reduceAgg(oldAggRel, oldCall, newCalls, aggCallMapping, inputExprs));
+    }
+
+    final int extraArgCount = inputExprs.size() - relBuilder.peek().getRowType().getFieldCount();
+    if (extraArgCount > 0) {
+      relBuilder.project(inputExprs,
+          CompositeList.of(
+              relBuilder.peek().getRowType().getFieldNames(),
+              Collections.nCopies(extraArgCount, null)));
+    }
+    newAggregateRel(relBuilder, oldAggRel, newCalls);
+    newCalcRel(relBuilder, oldAggRel.getRowType(), projList);
+    ruleCall.transformTo(relBuilder.build());
+  }
+
+  private RexNode reduceAgg(Aggregate oldAggRel, AggregateCall oldCall, List<AggregateCall> newCalls,
+      Map<AggregateCall, RexNode> aggCallMapping, List<RexNode> inputExprs) {
+    if (canReduce(oldCall)) {
+      switch (oldCall.getAggregation().getName()) {
+        case PinotSkewnessAggregateFunction.SKEWNESS:
+          return reduceFourthMoment(oldAggRel, oldCall, newCalls, aggCallMapping, false);
+        case PinotKurtosisAggregateFunction.KURTOSIS:
+          return reduceFourthMoment(oldAggRel, oldCall, newCalls, aggCallMapping, true);
+        default:
+          throw new IllegalStateException("Unexpected aggregation name " + oldCall.getAggregation().getName());
+      }
+    } else {
+      // anything else:  preserve original call
+      RexBuilder rexBuilder = oldAggRel.getCluster().getRexBuilder();
+      final int nGroups = oldAggRel.getGroupCount();
+      return rexBuilder.addAggCall(oldCall,
+          nGroups,
+          newCalls,
+          aggCallMapping,
+          oldAggRel.getInput()::fieldIsNullable);
+    }
+  }
+
+  private RexNode reduceFourthMoment(Aggregate oldAggRel, AggregateCall oldCall, List<AggregateCall> newCalls,
+      Map<AggregateCall, RexNode> aggCallMapping, boolean isKurtosis) {
+    final int nGroups = oldAggRel.getGroupCount();
+    final RexBuilder rexBuilder = oldAggRel.getCluster().getRexBuilder();
+    final AggregateCall fourthMomentCall =
+        AggregateCall.create(PinotFourthMomentAggregateFunction.INSTANCE,
+            oldCall.isDistinct(),
+            oldCall.isApproximate(),
+            oldCall.ignoreNulls(),
+            oldCall.getArgList(),
+            oldCall.filterArg,
+            oldCall.distinctKeys,
+            oldCall.collation,
+            oldAggRel.getGroupCount(),
+            oldAggRel.getInput(),
+            null,
+            null);
+
+    RexNode fmRef = rexBuilder.addAggCall(fourthMomentCall, nGroups, newCalls,
+        aggCallMapping, oldAggRel.getInput()::fieldIsNullable);
+
+    final RelDataTypeFactory typeFactory = oldAggRel.getCluster().getTypeFactory();
+    final RelDataType resultType = typeFactory.createTypeWithNullability(
+        oldCall.getType(), fmRef.getType().isNullable());
+    rexBuilder.ensureType(resultType, fmRef, true);
+    final RexNode skewRef = rexBuilder.makeCall(
+        isKurtosis ? PinotOperatorTable.KURTOSIS_REDUCE : PinotOperatorTable.SKEWNESS_REDUCE,
+        fmRef);
+    return rexBuilder.makeCast(oldCall.getType(), skewRef);
+  }
+
+  private boolean canReduce(AggregateCall call) {
+    return FUNCTIONS.contains(call.getAggregation().getName());
+  }
+
+  protected void newAggregateRel(RelBuilder relBuilder,
+      Aggregate oldAggregate,
+      List<AggregateCall> newCalls) {
+    relBuilder.aggregate(
+        relBuilder.groupKey(oldAggregate.getGroupSet(), oldAggregate.getGroupSets()),
+        newCalls);
+  }
+
+  protected void newCalcRel(RelBuilder relBuilder,
+      RelDataType rowType,
+      List<RexNode> exprs) {
+    relBuilder.project(exprs, rowType.getFieldNames());
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotBoolAndAggregateFunction.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotBoolAndAggregateFunction.java
@@ -29,7 +29,9 @@ import org.apache.calcite.util.Optionality;
 
 public class PinotBoolAndAggregateFunction extends SqlAggFunction {
 
-  public PinotBoolAndAggregateFunction() {
+  public static final PinotBoolAndAggregateFunction INSTANCE = new PinotBoolAndAggregateFunction();
+
+  private PinotBoolAndAggregateFunction() {
     super("BOOL_AND", null, SqlKind.OTHER_FUNCTION, ReturnTypes.BOOLEAN,
         null, OperandTypes.BOOLEAN, SqlFunctionCategory.USER_DEFINED_FUNCTION,
         false, false, Optionality.FORBIDDEN);

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotBoolOrAggregateFunction.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotBoolOrAggregateFunction.java
@@ -29,7 +29,9 @@ import org.apache.calcite.util.Optionality;
 
 public class PinotBoolOrAggregateFunction extends SqlAggFunction {
 
-  public PinotBoolOrAggregateFunction() {
+  public static final PinotBoolOrAggregateFunction INSTANCE = new PinotBoolOrAggregateFunction();
+
+  private PinotBoolOrAggregateFunction() {
     super("BOOL_OR", null, SqlKind.OTHER_FUNCTION, ReturnTypes.BOOLEAN,
         null, OperandTypes.BOOLEAN, SqlFunctionCategory.USER_DEFINED_FUNCTION,
         false, false, Optionality.FORBIDDEN);

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotFourthMomentAggregateFunction.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotFourthMomentAggregateFunction.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.Optionality;
+
+
+public class PinotFourthMomentAggregateFunction extends SqlAggFunction {
+
+  public static final PinotFourthMomentAggregateFunction INSTANCE = new PinotFourthMomentAggregateFunction();
+
+  public PinotFourthMomentAggregateFunction() {
+    super("FOURTHMOMENT", null, SqlKind.OTHER_FUNCTION, ReturnTypes.explicit(SqlTypeName.OTHER),
+        null, OperandTypes.NUMERIC, SqlFunctionCategory.USER_DEFINED_FUNCTION,
+        false, false, Optionality.FORBIDDEN);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotKurtosisAggregateFunction.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotKurtosisAggregateFunction.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.util.Optionality;
+
+
+public class PinotKurtosisAggregateFunction extends SqlAggFunction {
+
+  public static final String KURTOSIS = "KURTOSIS";
+  public static final PinotKurtosisAggregateFunction INSTANCE = new PinotKurtosisAggregateFunction();
+
+  public PinotKurtosisAggregateFunction() {
+    super(KURTOSIS, null, SqlKind.OTHER_FUNCTION, ReturnTypes.DOUBLE,
+        null, OperandTypes.NUMERIC, SqlFunctionCategory.USER_DEFINED_FUNCTION,
+        false, false, Optionality.FORBIDDEN);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
@@ -55,8 +55,8 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
   public static final SqlFunction KURTOSIS_REDUCE = new SqlFunction("KURTOSIS_REDUCE", SqlKind.OTHER_FUNCTION,
       ReturnTypes.DOUBLE, null, OperandTypes.BINARY, SqlFunctionCategory.USER_DEFINED_FUNCTION);
 
-  public static final SqlAggFunction BOOL_AND = new PinotBoolAndAggregateFunction();
-  public static final SqlAggFunction BOOL_OR = new PinotBoolOrAggregateFunction();
+  public static final SqlAggFunction BOOL_AND = PinotBoolAndAggregateFunction.INSTANCE;
+  public static final SqlAggFunction BOOL_OR = PinotBoolOrAggregateFunction.INSTANCE;
   public static final SqlAggFunction SKEWNESS = PinotSkewnessAggregateFunction.INSTANCE;
   public static final SqlAggFunction KURTOSIS = PinotKurtosisAggregateFunction.INSTANCE;
 

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
@@ -23,7 +23,11 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.validate.SqlNameMatchers;
 import org.apache.calcite.util.Util;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
@@ -46,8 +50,15 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
   private static @MonotonicNonNull PinotOperatorTable _instance;
 
   public static final SqlFunction COALESCE = new PinotSqlCoalesceFunction();
+  public static final SqlFunction SKEWNESS_REDUCE = new SqlFunction("SKEWNESS_REDUCE", SqlKind.OTHER_FUNCTION,
+      ReturnTypes.DOUBLE, null, OperandTypes.BINARY, SqlFunctionCategory.USER_DEFINED_FUNCTION);
+  public static final SqlFunction KURTOSIS_REDUCE = new SqlFunction("KURTOSIS_REDUCE", SqlKind.OTHER_FUNCTION,
+      ReturnTypes.DOUBLE, null, OperandTypes.BINARY, SqlFunctionCategory.USER_DEFINED_FUNCTION);
+
   public static final SqlAggFunction BOOL_AND = new PinotBoolAndAggregateFunction();
   public static final SqlAggFunction BOOL_OR = new PinotBoolOrAggregateFunction();
+  public static final SqlAggFunction SKEWNESS = PinotSkewnessAggregateFunction.INSTANCE;
+  public static final SqlAggFunction KURTOSIS = PinotKurtosisAggregateFunction.INSTANCE;
 
   // TODO: clean up lazy init by using Suppliers.memorized(this::computeInstance) and make getter wrapped around
   // supplier instance. this should replace all lazy init static objects in the codebase

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotSkewnessAggregateFunction.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotSkewnessAggregateFunction.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.util.Optionality;
+
+
+public class PinotSkewnessAggregateFunction extends SqlAggFunction {
+
+  public static final String SKEWNESS = "SKEWNESS";
+  public static final PinotSkewnessAggregateFunction INSTANCE = new PinotSkewnessAggregateFunction();
+
+  public PinotSkewnessAggregateFunction() {
+    super(SKEWNESS, null, SqlKind.OTHER_FUNCTION, ReturnTypes.DOUBLE,
+        null, OperandTypes.NUMERIC, SqlFunctionCategory.USER_DEFINED_FUNCTION,
+        false, false, Optionality.FORBIDDEN);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
@@ -165,6 +165,8 @@ public final class RelToStageConverter {
       case CHAR:
       case VARCHAR:
         return DataSchema.ColumnDataType.STRING;
+      case OTHER:
+        return DataSchema.ColumnDataType.OBJECT;
       case BINARY:
       case VARBINARY:
         return DataSchema.ColumnDataType.BYTES;
@@ -174,7 +176,11 @@ public final class RelToStageConverter {
   }
 
   public static FieldSpec.DataType convertToFieldSpecDataType(RelDataType relDataType) {
-    return convertToColumnDataType(relDataType).toDataType();
+    DataSchema.ColumnDataType columnDataType = convertToColumnDataType(relDataType);
+    if (columnDataType == DataSchema.ColumnDataType.OBJECT) {
+      return FieldSpec.DataType.BYTES;
+    }
+    return columnDataType.toDataType();
   }
 
   public static PinotDataType convertToPinotDataType(RelDataType relDataType) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlock.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/blocks/TransferableBlock.java
@@ -31,6 +31,7 @@ import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.BlockDocIdValueSet;
 import org.apache.pinot.core.common.BlockMetadata;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.common.datablock.DataBlockBuilder;
 
 
@@ -87,7 +88,7 @@ public class TransferableBlock implements Block {
     if (_container == null) {
       switch (_type) {
         case ROW:
-          _container = DataBlockUtils.extractRows(_dataBlock);
+          _container = DataBlockUtils.extractRows(_dataBlock, ObjectSerDeUtils::deserialize);
           break;
         case COLUMNAR:
         case METADATA:

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -29,8 +29,8 @@ import java.util.Map;
 import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.datablock.DataBlock;
-import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.common.Operator;
@@ -214,7 +214,7 @@ public class AggregateOperator extends MultiStageOperator {
   }
 
   private static PinotFourthMoment mergePinotFourthMoment(Object left, Object right) {
-    ((PinotFourthMoment) left).combine(ObjectSerDeUtils.deserialize((DataTable.CustomObject) right));
+    ((PinotFourthMoment) left).combine(ObjectSerDeUtils.deserialize((CustomObject) right));
     return (PinotFourthMoment) left;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -30,11 +30,15 @@ import java.util.function.BiFunction;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datablock.DataBlock;
+import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.segment.local.customobject.PinotFourthMoment;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
@@ -209,6 +213,11 @@ public class AggregateOperator extends MultiStageOperator {
     return ((Boolean) left) || ((Boolean) right);
   }
 
+  private static PinotFourthMoment mergePinotFourthMoment(Object left, Object right) {
+    ((PinotFourthMoment) left).combine(ObjectSerDeUtils.deserialize((DataTable.CustomObject) right));
+    return (PinotFourthMoment) left;
+  }
+
   private static Key extraRowKey(Object[] row, List<RexExpression> groupSet) {
     Object[] keyElements = new Object[groupSet.size()];
     for (int i = 0; i < groupSet.size(); i++) {
@@ -240,6 +249,9 @@ public class AggregateOperator extends MultiStageOperator {
         .put("BOOL_OR", AggregateOperator::mergeBoolOr)
         .put("$BOOL_OR", AggregateOperator::mergeBoolOr)
         .put("$BOOL_OR0", AggregateOperator::mergeBoolOr)
+        .put("FOURTHMOMENT", AggregateOperator::mergePinotFourthMoment)
+        .put("$FOURTHMOMENT", AggregateOperator::mergePinotFourthMoment)
+        .put("$FOURTHMOMENT0", AggregateOperator::mergePinotFourthMoment)
         .build();
 
     final int _inputRef;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -26,14 +26,11 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.function.BiFunction;
+import java.util.function.Function;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.core.common.ObjectSerDeUtils;
-import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
@@ -77,13 +74,14 @@ public class AggregateOperator extends MultiStageOperator {
   // groupSet has to be a list of InputRef and cannot be null
   // TODO: Add these two checks when we confirm we can handle error in upstream ctor call.
   public AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema,
-      List<RexExpression> aggCalls, List<RexExpression> groupSet) {
-    this(inputOperator, dataSchema, aggCalls, groupSet, AggregateOperator.Accumulator.MERGERS);
+      List<RexExpression> aggCalls, List<RexExpression> groupSet, DataSchema inputSchema) {
+    this(inputOperator, dataSchema, aggCalls, groupSet, inputSchema, AggregateOperator.Accumulator.MERGERS);
   }
 
   @VisibleForTesting
   AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema,
-      List<RexExpression> aggCalls, List<RexExpression> groupSet, Map<String, Merger> mergers) {
+      List<RexExpression> aggCalls, List<RexExpression> groupSet, DataSchema inputSchema, Map<String,
+      Function<DataSchema.ColumnDataType, Merger>> mergers) {
     _inputOperator = inputOperator;
     _groupSet = groupSet;
     _upstreamErrorBlock = null;
@@ -100,7 +98,7 @@ public class AggregateOperator extends MultiStageOperator {
       if (!mergers.containsKey(functionName)) {
         throw new IllegalStateException("Unexpected value: " + functionName);
       }
-      _accumulators[i] = new Accumulator(agg, mergers.get(functionName));
+      _accumulators[i] = new Accumulator(agg, mergers, functionName, inputSchema);
     }
 
     _groupByKeyHolder = new HashMap<>();
@@ -188,6 +186,14 @@ public class AggregateOperator extends MultiStageOperator {
     return false;
   }
 
+  private static Key extraRowKey(Object[] row, List<RexExpression> groupSet) {
+    Object[] keyElements = new Object[groupSet.size()];
+    for (int i = 0; i < groupSet.size(); i++) {
+      keyElements[i] = row[((RexExpression.InputRef) groupSet.get(i)).getIndex()];
+    }
+    return new Key(keyElements);
+  }
+
   private static Object mergeSum(Object left, Object right) {
     return ((Number) left).doubleValue() + ((Number) right).doubleValue();
   }
@@ -213,45 +219,81 @@ public class AggregateOperator extends MultiStageOperator {
     return ((Boolean) left) || ((Boolean) right);
   }
 
-  private static PinotFourthMoment mergePinotFourthMoment(Object left, Object right) {
-    ((PinotFourthMoment) left).combine(ObjectSerDeUtils.deserialize((CustomObject) right));
-    return (PinotFourthMoment) left;
-  }
+  // NOTE: the below two classes are needed depending on where the
+  // fourth moment is being executed - if the leaf stage gets a
+  // fourth moment pushed down to it, it will return a PinotFourthMoment
+  // as the result of the aggregation. If it is not possible (e.g. the
+  // input to the aggregate requires the result of a JOIN - such as
+  // FOURTHMOMENT(t1.a + t2.a)) then the input to the aggregate in the
+  // intermediate stage is a numeric.
 
-  private static Key extraRowKey(Object[] row, List<RexExpression> groupSet) {
-    Object[] keyElements = new Object[groupSet.size()];
-    for (int i = 0; i < groupSet.size(); i++) {
-      keyElements[i] = row[((RexExpression.InputRef) groupSet.get(i)).getIndex()];
+  private static class MergeFourthMomentNumeric implements Merger {
+
+    @Override
+    public Object merge(Object left, Object right) {
+      ((PinotFourthMoment) left).increment(((Number) right).doubleValue());
+      return left;
     }
-    return new Key(keyElements);
+
+    @Override
+    public Object initialize(Object other) {
+      PinotFourthMoment moment = new PinotFourthMoment();
+      moment.increment(((Number) other).doubleValue());
+      return moment;
+    }
   }
 
-  interface Merger extends BiFunction<Object, Object, Object> {
+  private static class MergeFourthMomentObject implements Merger {
+
+    @Override
+    public Object merge(Object left, Object right) {
+      PinotFourthMoment agg = (PinotFourthMoment) left;
+      agg.combine((PinotFourthMoment) right);
+      return agg;
+    }
+  }
+
+  interface Merger {
+    /**
+     * Initializes the merger based on the first input
+     */
+    default Object initialize(Object other) {
+      return other;
+    }
+
+    /**
+     * Merges the existing aggregate (the result of {@link #initialize(Object)}) with
+     * the new value coming in (which may be an aggregate in and of itself).
+     */
+    Object merge(Object agg, Object value);
   }
 
   private static class Accumulator {
 
-    private static final Map<String, Merger> MERGERS = ImmutableMap
-        .<String, Merger>builder()
-        .put("SUM", AggregateOperator::mergeSum)
-        .put("$SUM", AggregateOperator::mergeSum)
-        .put("$SUM0", AggregateOperator::mergeSum)
-        .put("MIN", AggregateOperator::mergeMin)
-        .put("$MIN", AggregateOperator::mergeMin)
-        .put("$MIN0", AggregateOperator::mergeMin)
-        .put("MAX", AggregateOperator::mergeMax)
-        .put("$MAX", AggregateOperator::mergeMax)
-        .put("$MAX0", AggregateOperator::mergeMax)
-        .put("COUNT", AggregateOperator::mergeCount)
-        .put("BOOL_AND", AggregateOperator::mergeBoolAnd)
-        .put("$BOOL_AND", AggregateOperator::mergeBoolAnd)
-        .put("$BOOL_AND0", AggregateOperator::mergeBoolAnd)
-        .put("BOOL_OR", AggregateOperator::mergeBoolOr)
-        .put("$BOOL_OR", AggregateOperator::mergeBoolOr)
-        .put("$BOOL_OR0", AggregateOperator::mergeBoolOr)
-        .put("FOURTHMOMENT", AggregateOperator::mergePinotFourthMoment)
-        .put("$FOURTHMOMENT", AggregateOperator::mergePinotFourthMoment)
-        .put("$FOURTHMOMENT0", AggregateOperator::mergePinotFourthMoment)
+    private static final Map<String, Function<DataSchema.ColumnDataType, Merger>> MERGERS = ImmutableMap
+        .<String, Function<DataSchema.ColumnDataType, Merger>>builder()
+        .put("SUM", cdt -> AggregateOperator::mergeSum)
+        .put("$SUM", cdt -> AggregateOperator::mergeSum)
+        .put("$SUM0", cdt -> AggregateOperator::mergeSum)
+        .put("MIN", cdt -> AggregateOperator::mergeMin)
+        .put("$MIN", cdt -> AggregateOperator::mergeMin)
+        .put("$MIN0", cdt -> AggregateOperator::mergeMin)
+        .put("MAX", cdt -> AggregateOperator::mergeMax)
+        .put("$MAX", cdt -> AggregateOperator::mergeMax)
+        .put("$MAX0", cdt -> AggregateOperator::mergeMax)
+        .put("COUNT", cdt -> AggregateOperator::mergeCount)
+        .put("BOOL_AND", cdt -> AggregateOperator::mergeBoolAnd)
+        .put("$BOOL_AND", cdt -> AggregateOperator::mergeBoolAnd)
+        .put("$BOOL_AND0", cdt -> AggregateOperator::mergeBoolAnd)
+        .put("BOOL_OR", cdt -> AggregateOperator::mergeBoolOr)
+        .put("$BOOL_OR", cdt -> AggregateOperator::mergeBoolOr)
+        .put("$BOOL_OR0", cdt -> AggregateOperator::mergeBoolOr)
+        .put("FOURTHMOMENT", cdt -> cdt == DataSchema.ColumnDataType.OBJECT
+            ? new MergeFourthMomentObject() : new MergeFourthMomentNumeric())
+        .put("$FOURTHMOMENT", cdt -> cdt == DataSchema.ColumnDataType.OBJECT
+            ? new MergeFourthMomentObject() : new MergeFourthMomentNumeric())
+        .put("$FOURTHMOMENT0", cdt -> cdt == DataSchema.ColumnDataType.OBJECT
+            ? new MergeFourthMomentObject() : new MergeFourthMomentNumeric())
         .build();
 
     final int _inputRef;
@@ -259,17 +301,21 @@ public class AggregateOperator extends MultiStageOperator {
     final Map<Key, Object> _results = new HashMap<>();
     final Merger _merger;
 
-    Accumulator(RexExpression.FunctionCall aggCall, Merger merger) {
-      _merger = merger;
+    Accumulator(RexExpression.FunctionCall aggCall, Map<String, Function<DataSchema.ColumnDataType, Merger>> merger,
+        String functionName, DataSchema inputSchema) {
       // agg function operand should either be a InputRef or a Literal
+      DataSchema.ColumnDataType dataType;
       RexExpression rexExpression = toAggregationFunctionOperand(aggCall);
       if (rexExpression instanceof RexExpression.InputRef) {
         _inputRef = ((RexExpression.InputRef) rexExpression).getIndex();
         _literal = null;
+        dataType = inputSchema.getColumnDataType(_inputRef);
       } else {
         _inputRef = -1;
         _literal = ((RexExpression.Literal) rexExpression).getValue();
+        dataType = DataSchema.ColumnDataType.fromDataType(rexExpression.getDataType(), false);
       }
+      _merger = merger.get(functionName).apply(dataType);
     }
 
     void accumulate(Key key, Object[] row) {
@@ -280,9 +326,9 @@ public class AggregateOperator extends MultiStageOperator {
       Object value = _inputRef == -1 ? _literal : row[_inputRef];
 
       if (currentRes == null) {
-        keys.put(key, value);
+        keys.put(key, _merger.initialize(value));
       } else {
-        Object mergedResult = _merger.apply(currentRes, value);
+        Object mergedResult = _merger.merge(currentRes, value);
         _results.put(key, mergedResult);
       }
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -282,7 +282,11 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     for (int colId = 0; colId < row.length; colId++) {
       Object value = row[colId];
       if (value != null) {
-        resultRow[colId] = dataSchema.getColumnDataType(colId).convert(value);
+        if (dataSchema.getColumnDataType(colId) == DataSchema.ColumnDataType.OBJECT) {
+          resultRow[colId] = value;
+        } else {
+          resultRow[colId] = dataSchema.getColumnDataType(colId).convert(value);
+        }
       }
     }
     return resultRow;
@@ -293,7 +297,11 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     for (int colId = 0; colId < columnIndices.length; colId++) {
       Object value = row[columnIndices[colId]];
       if (value != null) {
-        resultRow[colId] = dataSchema.getColumnDataType(colId).convert(value);
+        if (dataSchema.getColumnDataType(colId) == DataSchema.ColumnDataType.OBJECT) {
+          resultRow[colId] = value;
+        } else {
+          resultRow[colId] = dataSchema.getColumnDataType(colId).convert(value);
+        }
       }
     }
     return resultRow;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -297,11 +297,7 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     for (int colId = 0; colId < columnIndices.length; colId++) {
       Object value = row[columnIndices[colId]];
       if (value != null) {
-        if (dataSchema.getColumnDataType(colId) == DataSchema.ColumnDataType.OBJECT) {
-          resultRow[colId] = value;
-        } else {
-          resultRow[colId] = dataSchema.getColumnDataType(colId).convert(value);
-        }
+        resultRow[colId] = dataSchema.getColumnDataType(colId).convert(value);
       }
     }
     return resultRow;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -84,7 +84,7 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<MultiStageOperator,
   public MultiStageOperator visitAggregate(AggregateNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
     return new AggregateOperator(nextOperator, node.getDataSchema(), node.getAggCalls(),
-        node.getGroupSet());
+        node.getGroupSet(), node.getInputs().get(0).getDataSchema());
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryDispatcher.java
@@ -34,6 +34,7 @@ import org.apache.pinot.common.proto.PinotQueryWorkerGrpc;
 import org.apache.pinot.common.proto.Worker;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.planner.QueryPlan;
@@ -147,7 +148,7 @@ public class QueryDispatcher {
         for (int colId = 0; colId < numColumns; colId++) {
           nullBitmaps[colId] = dataBlock.getNullRowIds(colId);
         }
-        List<Object[]> rawRows = DataBlockUtils.extractRows(dataBlock);
+        List<Object[]> rawRows = DataBlockUtils.extractRows(dataBlock, ObjectSerDeUtils::deserialize);
         int rowId = 0;
         for (Object[] rawRow : rawRows) {
           Object[] row = new Object[numColumns];

--- a/pinot-query-runtime/src/test/resources/queries/Skew.json
+++ b/pinot-query-runtime/src/test/resources/queries/Skew.json
@@ -60,7 +60,6 @@
     },
     "queries": [
       {
-        "ignored": true,
         "description": "skew for int column",
         "sql": "SELECT groupingCol, SKEWNESS(val), KURTOSIS(val) FROM {tbl} GROUP BY groupingCol",
         "outputs": [

--- a/pinot-query-runtime/src/test/resources/queries/Skew.json
+++ b/pinot-query-runtime/src/test/resources/queries/Skew.json
@@ -1,0 +1,31 @@
+{
+  "skew": {
+    "tables": {
+      "tbl": {
+        "schema": [
+          {"name": "key", "type": "STRING"},
+          {"name": "val", "type": "INT"}
+        ],
+        "inputs": [
+          ["a", 1],
+          ["a", 2],
+          ["a", 3],
+          ["a", 4],
+          ["a", 4],
+          ["a", 4],
+          ["a", 7],
+          ["a", 9]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "description": "skew for int column",
+        "sql": "SELECT SKEWNESS(val), KURTOSIS(val) FROM {tbl} GROUP BY key",
+        "outputs": [
+          [0.8647536091225356, 0.3561662049861511]
+        ]
+      }
+    ]
+  }
+}

--- a/pinot-query-runtime/src/test/resources/queries/Skew.json
+++ b/pinot-query-runtime/src/test/resources/queries/Skew.json
@@ -3,27 +3,40 @@
     "tables": {
       "tbl": {
         "schema": [
-          {"name": "key", "type": "STRING"},
+          {"name": "groupingCol", "type": "STRING"},
+          {"name": "partition", "type": "STRING"},
           {"name": "val", "type": "INT"}
         ],
         "inputs": [
-          ["a", 1],
-          ["a", 2],
-          ["a", 3],
-          ["a", 4],
-          ["a", 4],
-          ["a", 4],
-          ["a", 7],
-          ["a", 9]
+          ["a", "key1", 1],
+          ["a", "key2", 2],
+          ["a", "key3", 3],
+          ["a", "key1", 4],
+          ["a", "key2", 4],
+          ["a", "key3", 4],
+          ["a", "key1", 7],
+          ["a", "key2", 9],
+          ["b", "key3", 1],
+          ["b", "key1", 2],
+          ["b", "key2", 3],
+          ["b", "key3", 4],
+          ["b", "key1", 4],
+          ["b", "key2", 4],
+          ["b", "key3", 7],
+          ["b", "key1", 9]
+        ],
+        "partitionColumns": [
+          "partition"
         ]
       }
     },
     "queries": [
       {
         "description": "skew for int column",
-        "sql": "SELECT SKEWNESS(val), KURTOSIS(val) FROM {tbl} GROUP BY key",
+        "sql": "SELECT groupingCol, SKEWNESS(val), KURTOSIS(val) FROM {tbl} GROUP BY groupingCol",
         "outputs": [
-          [0.8647536091225356, 0.3561662049861511]
+          ["a", 0.8647536091225356, 0.3561662049861511],
+          ["b", 0.8647536091225356, 0.3561662049861511]
         ]
       }
     ]

--- a/pinot-query-runtime/src/test/resources/queries/Skew.json
+++ b/pinot-query-runtime/src/test/resources/queries/Skew.json
@@ -68,6 +68,13 @@
         ]
       },
       {
+        "description": "no group by clause",
+        "sql": "SELECT SKEWNESS(val), KURTOSIS(val) FROM {tbl} WHERE groupingCol='a'",
+        "outputs": [
+          [0.8647536091225356, 0.3561662049861511]
+        ]
+      },
+      {
         "sql": "SELECT t1.groupingCol, SKEWNESS(t1.val + t2.val), KURTOSIS(t1.val + t2.val) FROM {tbl} AS t1 LEFT JOIN {tbl2} AS t2 USING (partitionCol) GROUP BY t1.groupingCol",
         "outputs": [
           ["a", 0.5412443772804422, -0.001438580062540293],

--- a/pinot-query-runtime/src/test/resources/queries/Skew.json
+++ b/pinot-query-runtime/src/test/resources/queries/Skew.json
@@ -4,7 +4,7 @@
       "tbl": {
         "schema": [
           {"name": "groupingCol", "type": "STRING"},
-          {"name": "partition", "type": "STRING"},
+          {"name": "partitionCol", "type": "STRING"},
           {"name": "val", "type": "INT"}
         ],
         "inputs": [
@@ -26,17 +26,53 @@
           ["b", "key1", 9]
         ],
         "partitionColumns": [
-          "partition"
+          "partitionCol"
+        ]
+      },
+      "tbl2": {
+        "schema": [
+          {"name": "groupingCol", "type": "STRING"},
+          {"name": "partitionCol", "type": "STRING"},
+          {"name": "val", "type": "INT"}
+        ],
+        "inputs": [
+          ["a", "key1", 1],
+          ["a", "key2", 2],
+          ["a", "key3", 3],
+          ["a", "key1", 4],
+          ["a", "key2", 4],
+          ["a", "key3", 4],
+          ["a", "key1", 7],
+          ["a", "key2", 9],
+          ["b", "key3", 1],
+          ["b", "key1", 2],
+          ["b", "key2", 3],
+          ["b", "key3", 4],
+          ["b", "key1", 4],
+          ["b", "key2", 4],
+          ["b", "key3", 7],
+          ["b", "key1", 9]
+        ],
+        "partitionColumns": [
+          "partitionCol"
         ]
       }
     },
     "queries": [
       {
+        "ignored": true,
         "description": "skew for int column",
         "sql": "SELECT groupingCol, SKEWNESS(val), KURTOSIS(val) FROM {tbl} GROUP BY groupingCol",
         "outputs": [
           ["a", 0.8647536091225356, 0.3561662049861511],
           ["b", 0.8647536091225356, 0.3561662049861511]
+        ]
+      },
+      {
+        "sql": "SELECT t1.groupingCol, SKEWNESS(t1.val + t2.val), KURTOSIS(t1.val + t2.val) FROM {tbl} AS t1 LEFT JOIN {tbl2} AS t2 USING (partitionCol) GROUP BY t1.groupingCol",
+        "outputs": [
+          ["a", 0.5412443772804422, -0.001438580062540293],
+          ["b", 0.5412443772804422, -0.001438580062540293]
         ]
       }
     ]

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InternalReduceFunctions.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InternalReduceFunctions.java
@@ -26,7 +26,7 @@ import org.apache.pinot.spi.annotations.ScalarFunction;
 /**
  * This class contains functions that are necessary for the multistage engine
  * aggregations that need to be reduced after the initial aggregation to get
- *
+ * the final result.
  */
 public class InternalReduceFunctions {
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InternalReduceFunctions.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InternalReduceFunctions.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.segment.local.function;
+
+import org.apache.pinot.segment.local.customobject.PinotFourthMoment;
+import org.apache.pinot.spi.annotations.ScalarFunction;
+
+
+/**
+ * This class contains functions that are necessary for the multistage engine
+ * aggregations that need to be reduced after the initial aggregation to get
+ *
+ */
+public class InternalReduceFunctions {
+
+  private InternalReduceFunctions() {
+  }
+
+  @ScalarFunction
+  public static double skewnessReduce(PinotFourthMoment fourthMoment) {
+    return fourthMoment.skew();
+  }
+
+  @ScalarFunction
+  public static double kurtosisReduce(PinotFourthMoment fourthMoment) {
+    return fourthMoment.kurtosis();
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -67,6 +67,7 @@ public enum AggregationFunctionType {
   STDDEVSAMP("stdDevSamp"),
   SKEWNESS("skewness"),
   KURTOSIS("kurtosis"),
+  FOURTHMOMENT("fourthmoment"),
 
   // Geo aggregation functions
   STUNION("STUnion"),


### PR DESCRIPTION
This PR adds support for `SKEWNESS` and `KURTOSIS` in the multistage engine. To do this, I needed to add support for intermediate aggregations - specifically, `SKEWNESS` and `KURTOSIS` have "results" that are not composable. To get around this, I split them into two methods: an aggregate and a reduce. The aggregate collects a `PinotFourthMoment`, which is serializable, and sends it along. When the aggregate completes, this object is reduced to the correct result using an internal reduce method. All this happens in a calcite rewrite rule that is now set up for future methods that need to do the same thing.