### PR TITLE
Add a tracker for end-to-end consumption delay of events.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -46,8 +46,9 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   DEDUP_PRIMARY_KEYS_COUNT("dedupPrimaryKeysCount", false),
   CONSUMPTION_QUOTA_UTILIZATION("ratio", false),
   JVM_HEAP_USED_BYTES("bytes", true),
-  // Ingestion delay metric
-  REALTIME_INGESTION_DELAY_MS("milliseconds", false);
+  // Ingestion delay metrics
+  REALTIME_INGESTION_DELAY_MS("milliseconds", false),
+  END_TO_END_REALTIME_INGESTION_DELAY_MS("milliseconds", false);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -82,8 +82,8 @@ public class IngestionDelayTracker {
       _ingestionTimeMs = ingestionTimesMs;
       _firstStreamIngestionTimeMs = firstStreamIngestionTimeMs;
     }
-    public final long _ingestionTimeMs;
-    public final long _firstStreamIngestionTimeMs;
+    private final long _ingestionTimeMs;
+    private final long _firstStreamIngestionTimeMs;
   }
   // Sleep interval for timer thread that triggers read of ideal state
   private static final int TIMER_THREAD_TICK_INTERVAL_MS = 300000; // 5 minutes +/- precision in timeouts

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -76,6 +76,15 @@ import org.slf4j.LoggerFactory;
 
 public class IngestionDelayTracker {
 
+  // Class to wrap supported timestamps collected for an ingested event
+  private static class IngestionTimestamps {
+    IngestionTimestamps(long ingestionTimesMs, long creationTimeMs) {
+      _ingestionTimeMs = ingestionTimesMs;
+      _creationTimeMs = creationTimeMs;
+    }
+    public final long _ingestionTimeMs;
+    public final long _creationTimeMs;
+  }
   // Sleep interval for timer thread that triggers read of ideal state
   private static final int TIMER_THREAD_TICK_INTERVAL_MS = 300000; // 5 minutes +/- precision in timeouts
   // Once a partition is marked for verification, we wait 10 minutes to pull its ideal state.
@@ -85,7 +94,7 @@ public class IngestionDelayTracker {
   private static final Logger _logger = LoggerFactory.getLogger(IngestionDelayTracker.class.getSimpleName());
 
   // HashMap used to store ingestion time measures for all partitions active for the current table.
-  private final Map<Integer, Long> _partitionToIngestionTimeMsMap = new ConcurrentHashMap<>();
+  private final Map<Integer, IngestionTimestamps> _partitionToIngestionTimestampsMap = new ConcurrentHashMap<>();
   // We mark partitions that go from CONSUMING to ONLINE in _partitionsMarkedForVerification: if they do not
   // go back to CONSUMING in some period of time, we verify whether they are still hosted in this server by reading
   // ideal state. This is done with the goal of minimizing reading ideal state for efficiency reasons.
@@ -141,10 +150,7 @@ public class IngestionDelayTracker {
    *
    * @param ingestionTimeMs original ingestion time in milliseconds.
    */
-  private long getIngestionDelayMs(Long ingestionTimeMs) {
-    if (ingestionTimeMs == null) {
-      return 0; // return 0 when not initialized
-    }
+  private long getIngestionDelayMs(long ingestionTimeMs) {
     // Compute aged delay for current partition
     long agedIngestionDelayMs = _clock.millis() - ingestionTimeMs;
     // Correct to zero for any time shifts due to NTP or time reset.
@@ -159,7 +165,7 @@ public class IngestionDelayTracker {
    * @param partitionGroupId partition ID which we should stop tracking.
    */
   private void removePartitionId(int partitionGroupId) {
-    _partitionToIngestionTimeMsMap.remove(partitionGroupId);
+    _partitionToIngestionTimestampsMap.remove(partitionGroupId);
     // If we are removing a partition we should stop reading its ideal state.
     _partitionsMarkedForVerification.remove(partitionGroupId);
     _serverMetrics.removePartitionGauge(_metricName, partitionGroupId, ServerGauge.REALTIME_INGESTION_DELAY_MS);
@@ -196,21 +202,28 @@ public class IngestionDelayTracker {
    * Called by LLRealTimeSegmentDataManagers to post ingestion time updates to this tracker class.
    *
    * @param ingestionTimeMs ingestion time being recorded.
+   * @param creationTimeMs event creation time.
    * @param partitionGroupId partition ID for which this ingestion time is being recorded.
    */
-  public void updateIngestionDelay(long ingestionTimeMs, int partitionGroupId) {
+  public void updateIngestionDelay(long ingestionTimeMs, long creationTimeMs, int partitionGroupId) {
     // Store new measure and wipe old one for this partition
-    // TODO: see if we can install gauges after the server is ready.
     if (!_isServerReadyToServeQueries.get()) {
       // Do not update the ingestion delay metrics during server startup period
       return;
     }
-    Long previousMeasure = _partitionToIngestionTimeMsMap.put(partitionGroupId,
-        ingestionTimeMs);
+    IngestionTimestamps previousMeasure = _partitionToIngestionTimestampsMap.put(partitionGroupId,
+        new IngestionTimestamps(ingestionTimeMs, creationTimeMs));
     if (previousMeasure == null) {
       // First time we start tracking a partition we should start tracking it via metric
       _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionGroupId,
           ServerGauge.REALTIME_INGESTION_DELAY_MS, () -> getPartitionIngestionDelayMs(partitionGroupId));
+      if (creationTimeMs != Long.MIN_VALUE) {
+        // Only publish this metric when creation time is supported by the underlying stream
+        // When this timestamp is not supported it always returns the value Long.MIN_VALUE
+        _serverMetrics.setOrUpdatePartitionGauge(_metricName, partitionGroupId,
+            ServerGauge.END_TO_END_REALTIME_INGESTION_DELAY_MS,
+            () -> getPartitionEndToEndIngestionDelayMs(partitionGroupId));
+      }
     }
     // If we are consuming we do not need to track this partition for removal.
     _partitionsMarkedForVerification.remove(partitionGroupId);
@@ -283,8 +296,27 @@ public class IngestionDelayTracker {
    */
   public long getPartitionIngestionDelayMs(int partitionGroupId) {
     // Not protected as this will only be invoked when metric is installed which happens after server ready
-    Long currentMeasure = _partitionToIngestionTimeMsMap.get(partitionGroupId);
-    return getIngestionDelayMs(currentMeasure);
+    IngestionTimestamps currentMeasure = _partitionToIngestionTimestampsMap.get(partitionGroupId);
+    if (currentMeasure == null) {
+      return 0;
+    }
+    return getIngestionDelayMs(currentMeasure._ingestionTimeMs);
+  }
+
+  /*
+   * Method to get end to end ingestion delay for a given partition.
+   *
+   * @param partitionGroupId partition for which we are retrieving the delay
+   *
+   * @return End to end ingestion delay in milliseconds for the given partition ID.
+   */
+  public long getPartitionEndToEndIngestionDelayMs(int partitionGroupId) {
+    // Not protected as this will only be invoked when metric is installed which happens after server ready
+    IngestionTimestamps currentMeasure = _partitionToIngestionTimestampsMap.get(partitionGroupId);
+    if (currentMeasure == null) {
+      return 0;
+    }
+    return getIngestionDelayMs(currentMeasure._creationTimeMs);
   }
 
   /*
@@ -299,7 +331,7 @@ public class IngestionDelayTracker {
       return;
     }
     // Remove partitions so their related metrics get uninstalled.
-    for (Map.Entry<Integer, Long> entry : _partitionToIngestionTimeMsMap.entrySet()) {
+    for (Map.Entry<Integer, IngestionTimestamps> entry : _partitionToIngestionTimestampsMap.entrySet()) {
       removePartitionId(entry.getKey());
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -300,7 +300,7 @@ public class IngestionDelayTracker {
   public long getPartitionIngestionDelayMs(int partitionGroupId) {
     // Not protected as this will only be invoked when metric is installed which happens after server ready
     IngestionTimestamps currentMeasure = _partitionToIngestionTimestampsMap.get(partitionGroupId);
-    if (currentMeasure == null) {
+    if (currentMeasure == null) { // Guard just in case we read the metric without initializing it
       return 0;
     }
     return getIngestionDelayMs(currentMeasure._ingestionTimeMs);
@@ -316,7 +316,7 @@ public class IngestionDelayTracker {
   public long getPartitionEndToEndIngestionDelayMs(int partitionGroupId) {
     // Not protected as this will only be invoked when metric is installed which happens after server ready
     IngestionTimestamps currentMeasure = _partitionToIngestionTimestampsMap.get(partitionGroupId);
-    if (currentMeasure == null) {
+    if (currentMeasure == null) { // Guard just in case we read the metric without initializing it
       return 0;
     }
     return getIngestionDelayMs(currentMeasure._firstStreamIngestionTimeMs);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -615,7 +615,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       }
     } else if (!prematureExit) {
       // Record Pinot ingestion delay as zero since we are up-to-date and no new events
-      _realtimeTableDataManager.updateIngestionDelay(System.currentTimeMillis(), _partitionGroupId);
+      _realtimeTableDataManager.updateIngestionDelay(System.currentTimeMillis(), System.currentTimeMillis(),
+          _partitionGroupId);
       if (_segmentLogger.isDebugEnabled()) {
         _segmentLogger.debug("empty batch received - sleeping for {}ms", idlePipeSleepTimeMillis);
       }
@@ -1571,6 +1572,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     if ((indexedMessageCount > 0) && (_lastRowMetadata != null)) {
       // Record Ingestion delay for this partition
       _realtimeTableDataManager.updateIngestionDelay(_lastRowMetadata.getRecordIngestionTimeMs(),
+          _lastRowMetadata.getRecordCreationTimeMs(),
           _partitionGroupId);
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -615,8 +615,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       }
     } else if (!prematureExit) {
       // Record Pinot ingestion delay as zero since we are up-to-date and no new events
-      _realtimeTableDataManager.updateIngestionDelay(System.currentTimeMillis(), System.currentTimeMillis(),
-          _partitionGroupId);
+      long currentTimeMs = System.currentTimeMillis();
+      _realtimeTableDataManager.updateIngestionDelay(currentTimeMs, currentTimeMs, _partitionGroupId);
       if (_segmentLogger.isDebugEnabled()) {
         _segmentLogger.debug("empty batch received - sleeping for {}ms", idlePipeSleepTimeMillis);
       }
@@ -1572,7 +1572,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     if ((indexedMessageCount > 0) && (_lastRowMetadata != null)) {
       // Record Ingestion delay for this partition
       _realtimeTableDataManager.updateIngestionDelay(_lastRowMetadata.getRecordIngestionTimeMs(),
-          _lastRowMetadata.getRecordCreationTimeMs(),
+          _lastRowMetadata.getFirstStreamRecordIngestionTimeMs(),
           _partitionGroupId);
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -240,8 +240,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    * @param ingestionTimeMs Ingestion delay being reported.
    * @param partitionGroupId Partition ID for which delay is being updated.
    */
-  public void updateIngestionDelay(long ingestionTimeMs, int partitionGroupId) {
-    _ingestionDelayTracker.updateIngestionDelay(ingestionTimeMs, partitionGroupId);
+  public void updateIngestionDelay(long ingestionTimeMs, long creationTimeMs, int partitionGroupId) {
+    _ingestionDelayTracker.updateIngestionDelay(ingestionTimeMs, creationTimeMs, partitionGroupId);
   }
 
   /*

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -240,8 +240,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    * @param ingestionTimeMs Ingestion delay being reported.
    * @param partitionGroupId Partition ID for which delay is being updated.
    */
-  public void updateIngestionDelay(long ingestionTimeMs, long creationTimeMs, int partitionGroupId) {
-    _ingestionDelayTracker.updateIngestionDelay(ingestionTimeMs, creationTimeMs, partitionGroupId);
+  public void updateIngestionDelay(long ingestionTimeMs, long firstStreamIngestionTimeMs, int partitionGroupId) {
+    _ingestionDelayTracker.updateIngestionDelay(ingestionTimeMs, firstStreamIngestionTimeMs, partitionGroupId);
   }
 
   /*

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/RowMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/RowMetadata.java
@@ -39,8 +39,8 @@ public interface RowMetadata {
 
   /**
    * Returns the timestamp associated with the record. This typically refers to the time it was ingested into the
-   * upstream source. In some cases, it may be the time at which the record was created, aka event time (eg. in kafka,
-   * a topic may be configured to use record `CreateTime` instead of `LogAppendTime`).
+   * (last) upstream source. In some cases, it may be the time at which the record was created, aka event time
+   * (eg. in kafka, a topic may be configured to use record `CreateTime` instead of `LogAppendTime`).
    *
    * Expected to be used for stream-based sources.
    *
@@ -50,15 +50,18 @@ public interface RowMetadata {
   long getRecordIngestionTimeMs();
 
   /**
-   * Returns the creation timestamp associated with the record. In cases where the upstream ingestion pipeline is
-   * simple this timestamp matches the result of getRecordIngestionTimeMs();
+   * When supported by the underlying stream, this method returns the timestamp in milliseconds associated with
+   * the ingestion of the record in the first stream.
    *
-   * Expected to be used for stream-based sources.
+   * Complex ingestion pipelines may be composed of multiple streams:
+   * (EventCreation) -> {First Stream} -> ... -> {Last Stream}
    *
-   * @return timestamp (epoch in milliseconds) when the row was initially created and ingested upstream for the first
-   *         time Long.MIN_VALUE if not available
+   * @return timestamp (epoch in milliseconds) when the row was initially ingested upstream for the first
+   *         time Long.MIN_VALUE if not supported by the underlying stream.
    */
-  long getRecordCreationTimeMs();
+  default long getFirstStreamRecordIngestionTimeMs() {
+    return Long.MIN_VALUE;
+  }
 
   /**
    * Returns the stream message headers

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/RowMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/RowMetadata.java
@@ -50,6 +50,17 @@ public interface RowMetadata {
   long getRecordIngestionTimeMs();
 
   /**
+   * Returns the creation timestamp associated with the record. In cases where the upstream ingestion pipeline is
+   * simple this timestamp matches the result of getRecordIngestionTimeMs();
+   *
+   * Expected to be used for stream-based sources.
+   *
+   * @return timestamp (epoch in milliseconds) when the row was initially created and ingested upstream for the first
+   *         time Long.MIN_VALUE if not available
+   */
+  long getRecordCreationTimeMs();
+
+  /**
    * Returns the stream message headers
    *
    * @return A {@link GenericRow} that encapsulates the headers in the ingested row

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
@@ -30,13 +30,18 @@ import org.apache.pinot.spi.data.readers.GenericRow;
  */
 public class StreamMessageMetadata implements RowMetadata {
   private final long _recordIngestionTimeMs;
+  private final long _recordCreationTimeMs;
   private final GenericRow _headers;
   private final Map<String, String> _metadata;
 
   public StreamMessageMetadata(long recordIngestionTimeMs, @Nullable GenericRow headers) {
-    this(recordIngestionTimeMs, headers, Collections.emptyMap());
+    this(recordIngestionTimeMs, Long.MIN_VALUE, headers, Collections.emptyMap());
   }
 
+  public StreamMessageMetadata(long recordIngestionTimeMs, @Nullable GenericRow headers,
+      Map<String, String> metadata) {
+    this(recordIngestionTimeMs, Long.MIN_VALUE, headers, metadata);
+  }
   /**
    * Construct the stream based message/row message metadata
    *
@@ -44,9 +49,10 @@ public class StreamMessageMetadata implements RowMetadata {
    *                         use Long.MIN_VALUE if not applicable
    * @param metadata
    */
-  public StreamMessageMetadata(long recordIngestionTimeMs, @Nullable GenericRow headers,
+  public StreamMessageMetadata(long recordIngestionTimeMs, long recordCreationTimeMs, @Nullable GenericRow headers,
       Map<String, String> metadata) {
     _recordIngestionTimeMs = recordIngestionTimeMs;
+    _recordCreationTimeMs = recordCreationTimeMs;
     _headers = headers;
     _metadata = metadata;
   }
@@ -54,6 +60,11 @@ public class StreamMessageMetadata implements RowMetadata {
   @Override
   public long getRecordIngestionTimeMs() {
     return _recordIngestionTimeMs;
+  }
+
+  @Override
+  public long getRecordCreationTimeMs() {
+    return _recordCreationTimeMs;
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMessageMetadata.java
@@ -30,7 +30,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
  */
 public class StreamMessageMetadata implements RowMetadata {
   private final long _recordIngestionTimeMs;
-  private final long _recordCreationTimeMs;
+  private final long _firstStreamRecordIngestionTimeMs;
   private final GenericRow _headers;
   private final Map<String, String> _metadata;
 
@@ -45,14 +45,16 @@ public class StreamMessageMetadata implements RowMetadata {
   /**
    * Construct the stream based message/row message metadata
    *
-   * @param recordIngestionTimeMs  the time that the message was ingested by the stream provider
+   * @param recordIngestionTimeMs  the time that the message was ingested by the stream provider.
    *                         use Long.MIN_VALUE if not applicable
+   * @param firstStreamRecordIngestionTimeMs the time that the message was ingested by the first stream provider
+   *                         in the ingestion pipeline. use Long.MIN_VALUE if not applicable
    * @param metadata
    */
-  public StreamMessageMetadata(long recordIngestionTimeMs, long recordCreationTimeMs, @Nullable GenericRow headers,
-      Map<String, String> metadata) {
+  public StreamMessageMetadata(long recordIngestionTimeMs, long firstStreamRecordIngestionTimeMs,
+      @Nullable GenericRow headers, Map<String, String> metadata) {
     _recordIngestionTimeMs = recordIngestionTimeMs;
-    _recordCreationTimeMs = recordCreationTimeMs;
+    _firstStreamRecordIngestionTimeMs = firstStreamRecordIngestionTimeMs;
     _headers = headers;
     _metadata = metadata;
   }
@@ -63,8 +65,8 @@ public class StreamMessageMetadata implements RowMetadata {
   }
 
   @Override
-  public long getRecordCreationTimeMs() {
-    return _recordCreationTimeMs;
+  public long getFirstStreamRecordIngestionTimeMs() {
+    return _firstStreamRecordIngestionTimeMs;
   }
 
   @Override


### PR DESCRIPTION
## Description
In the previous PR #9994, we introduced ingestion delay tracker that reports the delay between the time an event is published to the stream and the time pinot table is consuming from.

This PR extends that idea for the cases where the events consumed in Pinot table have gone through multiple streams. For example, let's say there's a stream processor that reads from stream A. Then it does some transformation and produces the transformed events to stream B. And the pinot table consumes from topic B. It's beneficial if we know the end-to-end delay between the time when an event is published to stream A and the time the transformed event in stream B is ingested to the Pinot table.

## Testing Done
1. IngestionDelayTrackerTest (all tests pass including new shutdown unit test)

2. Test live system with stream that does not support creation time stamp, verify we only export the realtimeIngestionDelayMs metric.
![NoEndToEndMetric](https://user-images.githubusercontent.com/109560870/213594250-e7332c22-f107-442d-89e1-e56b2de9bc3b.png)
![OnlyIngestionDelay](https://user-images.githubusercontent.com/109560870/213594268-e5227a7d-b9c7-41a4-b677-f79c87e2be61.png)


3. Test live system with stream that does support creation time, verify both metrics are exported.
 
![endToEndMetric](https://user-images.githubusercontent.com/109560870/213594304-c32cd381-5aeb-4783-a6f0-3cef3df8bc15.png)
![IngestionDelayPlus](https://user-images.githubusercontent.com/109560870/213594319-05485599-cd01-4bbd-bcd0-a896cd086bc7.png)

