### PR TITLE
[dependencies bugfix] Update to next bug-fix release of clp

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -270,7 +270,7 @@ com.uber:h3:4.0.0
 com.yahoo.datasketches:memory:0.8.3
 com.yahoo.datasketches:sketches-core:0.8.3
 com.yammer.metrics:metrics-core:2.2.0
-com.yscope.clp:clp-ffi:0.2
+com.yscope.clp:clp-ffi:0.2.1
 com.zaxxer:HikariCP-java7:2.4.13
 commons-cli:commons-cli:1.2
 commons-codec:commons-codec:1.15

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
@@ -41,7 +41,7 @@
     <dependency>
       <groupId>com.yscope.clp</groupId>
       <artifactId>clp-ffi</artifactId>
-      <version>0.2</version>
+      <version>0.2.1</version>
     </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
The CLP library used by the pinot-clp-log plugin had a thread-safety issue in 0.2 that has now been fixed in 0.2.1, so this updates to that release.

# Testing performed
<!-- What tests and validation you performed on the change -->
* Created a Kafka topic with multiple partitions
* Created a corresponding Pinot table and schema with a field configured to be encoded with CLP
* Ingested data into the Kafka topic and ensured that it was successfully ingested into Pinot

