### PR TITLE
Fixed file paths for *.tar.gz metadata files in cloud storage

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentPushUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/SegmentPushUtilsTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.local.utils;
 
 import java.io.IOException;
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.nio.file.Files;
 import java.util.Map;
 import org.apache.pinot.spi.ingestion.batch.spec.PushJobSpec;
@@ -29,6 +30,8 @@ import static org.testng.Assert.*;
 
 
 public class SegmentPushUtilsTest {
+ private static final String DEFAULT_SEGMENT_NAME = "mySegmentName";
+ private static final String DEFAULT_TAR_GZ_SEGMENT_FILE_NAME = "mySegmentName.tar.gz";
 
   @Test
   public void testGetSegmentUriToTarPathMap() throws IOException {
@@ -60,5 +63,43 @@ public class SegmentPushUtilsTest {
     assertEquals(result.size(), 2);
     assertEquals(result.get(segmentFiles[1]), segmentFiles[1]);
     assertEquals(result.get(segmentFiles[3]), segmentFiles[3]);
+  }
+
+  @Test
+  public void testBuildMetadataTarGzFilePathRemoteStorage()
+      throws URISyntaxException {
+    String tarFilePathInS3 = "s3://root/prefix/" + DEFAULT_TAR_GZ_SEGMENT_FILE_NAME;
+    URI metadataTarGzFilePath1 = SegmentPushUtils.buildMetadataTarGzFilePath(tarFilePathInS3, DEFAULT_SEGMENT_NAME);
+    String expMetadataTarGzFilePath1 = "s3://root/prefix/mySegmentName.metadata.tar.gz";
+    assertEquals(metadataTarGzFilePath1.toString(), expMetadataTarGzFilePath1);
+
+    String tarFilePathInGCS = "gs://root/prefix/child/" + DEFAULT_TAR_GZ_SEGMENT_FILE_NAME;
+    URI metadataTarGzFilePath2 = SegmentPushUtils.buildMetadataTarGzFilePath(tarFilePathInGCS, DEFAULT_SEGMENT_NAME);
+    String expMetadataTarGzFilePath2 = "gs://root/prefix/child/mySegmentName.metadata.tar.gz";
+    assertEquals(metadataTarGzFilePath2.toString(), expMetadataTarGzFilePath2);
+
+    String tarFilePathInLocal = "file://root/prefix/" + DEFAULT_TAR_GZ_SEGMENT_FILE_NAME;
+    URI metadataTarGzFilePath3 = SegmentPushUtils.buildMetadataTarGzFilePath(tarFilePathInLocal, DEFAULT_SEGMENT_NAME);
+    String expMetadataTarGzFilePath3 = "file://root/prefix/mySegmentName.metadata.tar.gz";
+    assertEquals(metadataTarGzFilePath3.toString(), expMetadataTarGzFilePath3);
+
+    String tarFilePathInRemote = "https://root/prefix/" + DEFAULT_TAR_GZ_SEGMENT_FILE_NAME; // e.g., Azure
+    URI metadataTarGzFilePath4 = SegmentPushUtils.buildMetadataTarGzFilePath(tarFilePathInRemote, DEFAULT_SEGMENT_NAME);
+    String expMetadataTarGzFilePath4 = "https://root/prefix/mySegmentName.metadata.tar.gz";
+    assertEquals(metadataTarGzFilePath4.toString(), expMetadataTarGzFilePath4);
+
+    String tarFilePathInHDFS = "hdfs://path/" + DEFAULT_TAR_GZ_SEGMENT_FILE_NAME;
+    URI metadataTarGzFilePath5 = SegmentPushUtils.buildMetadataTarGzFilePath(tarFilePathInHDFS, DEFAULT_SEGMENT_NAME);
+    String expMetadataTarGzFilePath5 = "hdfs://path/mySegmentName.metadata.tar.gz";
+    assertEquals(metadataTarGzFilePath5.toString(), expMetadataTarGzFilePath5);
+  }
+
+  @Test
+  public void testBuildMetadataTarGzFilePathLocalStorage()
+      throws URISyntaxException {
+    String localTarFilePath = "/var/folder/" + DEFAULT_TAR_GZ_SEGMENT_FILE_NAME;
+    URI metadataTarGzFilePath = SegmentPushUtils.buildMetadataTarGzFilePath(localTarFilePath, DEFAULT_SEGMENT_NAME);
+    String expMetadataTarGzFilePath = "/var/folder/mySegmentName.metadata.tar.gz";
+    assertEquals(metadataTarGzFilePath.toString(), expMetadataTarGzFilePath);
   }
 }


### PR DESCRIPTION
Changes are to fix the following exception
```
java.io.IOException: java.net.URISyntaxException: Expected scheme-specific part at index 3: s3:
```
originating post a call to the method `fileSystem.exists(metadataTarGzFilePath)`. The scheme part of the path got corrupted post a call to the method `new File(tarFilePath)`. For example, `new File("s3://bucket")` results in the path getting captured as `s3:/bucket` as opposed to `s3://bucket`.

The exception itself could be re-produced by calling the method `new URI(uri.getScheme(), uri.getHost(), null, null)` where URI was constructed from string `s3:/bucket/object.tar.gz`.


For additional context on segment metadata file creation (relevant recent change), refer to this [PR](https://github.com/apache/pinot/pull/10034).
