### PR TITLE
add API to get progress of subtasks with given state

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -33,6 +33,7 @@ import io.swagger.annotations.SwaggerDefinition;
 import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -465,11 +466,12 @@ public class PinotTaskRestletResource {
   public String getSubtaskWithGivenStateProgress(@Context HttpHeaders httpHeaders,
       @ApiParam(value = "Subtask state (UNKNOWN,IN_PROGRESS,SUCCEEDED,CANCELLED,ERROR)", required = true)
       @PathParam("subTaskState") String subTaskState,
-      @ApiParam(value = "Minion work IDs separated by comma") @QueryParam("minionWorkerIds") @Nullable
+      @ApiParam(value = "Minion worker IDs separated by comma") @QueryParam("minionWorkerIds") @Nullable
           String minionWorkerIds) {
     Set<String> selectedMinionWorkers = new HashSet<>();
     if (StringUtils.isNotEmpty(minionWorkerIds)) {
-      Collections.addAll(selectedMinionWorkers, StringUtils.split(minionWorkerIds, ','));
+      selectedMinionWorkers.addAll(
+          Arrays.stream(StringUtils.split(minionWorkerIds, ',')).map(String::trim).collect(Collectors.toList()));
     }
     // Relying on original schema that was used to query the controller
     String scheme = _uriInfo.getRequestUri().getScheme();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -457,7 +457,7 @@ public class PinotTaskRestletResource {
   }
 
   @GET
-  @Path("/tasks/subtask/state/{subTaskState}/progress")
+  @Path("/tasks/subtask/workers/progress")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation("Get progress of all subtasks with specified state tracked by minion worker in memory")
   @ApiResponses(value = {
@@ -465,7 +465,7 @@ public class PinotTaskRestletResource {
   })
   public String getSubtaskWithGivenStateProgress(@Context HttpHeaders httpHeaders,
       @ApiParam(value = "Subtask state (UNKNOWN,IN_PROGRESS,SUCCEEDED,CANCELLED,ERROR)", required = true)
-      @PathParam("subTaskState") String subTaskState,
+      @QueryParam("subTaskState") String subTaskState,
       @ApiParam(value = "Minion worker IDs separated by comma") @QueryParam("minionWorkerIds") @Nullable
           String minionWorkerIds) {
     Set<String> selectedMinionWorkers = new HashSet<>();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -463,7 +463,7 @@ public class PinotTaskRestletResource {
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")
   })
-  public String getSubtaskWithGivenStateProgress(@Context HttpHeaders httpHeaders,
+  public String getSubtaskOnWorkerProgress(@Context HttpHeaders httpHeaders,
       @ApiParam(value = "Subtask state (UNKNOWN,IN_PROGRESS,SUCCEEDED,CANCELLED,ERROR)", required = true)
       @QueryParam("subTaskState") String subTaskState,
       @ApiParam(value = "Minion worker IDs separated by comma") @QueryParam("minionWorkerIds") @Nullable
@@ -489,7 +489,7 @@ public class PinotTaskRestletResource {
     int timeoutMs = _controllerConf.getMinionAdminRequestTimeoutSeconds() * 1000;
     try {
       Map<String, Object> minionWorkerIdSubtaskProgressMap =
-          _pinotHelixTaskResourceManager.getSubtaskWithGivenStateProgress(subTaskState, _executor, _connectionManager,
+          _pinotHelixTaskResourceManager.getSubtaskOnWorkerProgress(subTaskState, _executor, _connectionManager,
               selectedMinionWorkerEndpoints, requestHeaders, timeoutMs);
       return JsonUtils.objectToString(minionWorkerIdSubtaskProgressMap);
     } catch (Exception e) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -463,7 +463,8 @@ public class PinotTaskRestletResource {
       @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")
   })
   public String getSubtaskWithGivenStateProgress(@Context HttpHeaders httpHeaders,
-      @ApiParam(value = "Subtask state", required = true) @PathParam("subTaskState") String subTaskState,
+      @ApiParam(value = "Subtask state (UNKNOWN,IN_PROGRESS,SUCCEEDED,CANCELLED,ERROR)", required = true)
+      @PathParam("subTaskState") String subTaskState,
       @ApiParam(value = "Minion work IDs separated by comma") @QueryParam("minionWorkerIds") @Nullable
           String minionWorkerIds) {
     Set<String> selectedMinionWorkers = new HashSet<>();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -25,6 +25,8 @@ import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiKeyAuthDefinition;
 import io.swagger.annotations.ApiOperation;
 import io.swagger.annotations.ApiParam;
+import io.swagger.annotations.ApiResponse;
+import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
@@ -33,6 +35,7 @@ import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -58,6 +61,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriInfo;
 import org.apache.commons.httpclient.HttpConnectionManager;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.task.TaskPartitionState;
@@ -419,7 +423,7 @@ public class PinotTaskRestletResource {
   @GET
   @Path("/tasks/subtask/{taskName}/progress")
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation("Get progress of specified sub tasks for the given task tracked by worker in memory")
+  @ApiOperation("Get progress of specified sub tasks for the given task tracked by minion worker in memory")
   public String getSubtaskProgress(@Context HttpHeaders httpHeaders,
       @ApiParam(value = "Task name", required = true) @PathParam("taskName") String taskName,
       @ApiParam(value = "Sub task names separated by comma") @QueryParam("subtaskNames") @Nullable
@@ -448,6 +452,47 @@ public class PinotTaskRestletResource {
       throw new ControllerApplicationException(LOGGER, String
           .format("Failed to get worker side progress for task: %s due to error: %s", taskName,
               ExceptionUtils.getStackTrace(e)), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  @GET
+  @Path("/tasks/subtask/state/{subTaskState}/progress")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation("Get progress of all subtasks with specified state tracked by minion worker in memory")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")
+  })
+  public String getSubtaskWithGivenStateProgress(@Context HttpHeaders httpHeaders,
+      @ApiParam(value = "Subtask state", required = true) @PathParam("subTaskState") String subTaskState,
+      @ApiParam(value = "Minion work IDs separated by comma") @QueryParam("minionWorkerIds") @Nullable
+          String minionWorkerIds) {
+    Set<String> selectedMinionWorkers = new HashSet<>();
+    if (StringUtils.isNotEmpty(minionWorkerIds)) {
+      Collections.addAll(selectedMinionWorkers, StringUtils.split(minionWorkerIds, ','));
+    }
+    // Relying on original schema that was used to query the controller
+    String scheme = _uriInfo.getRequestUri().getScheme();
+    List<InstanceConfig> allMinionWorkerInstanceConfigs = _pinotHelixResourceManager.getAllMinionInstanceConfigs();
+    Map<String, String> selectedMinionWorkerEndpoints = new HashMap<>();
+    for (InstanceConfig worker : allMinionWorkerInstanceConfigs) {
+      if (selectedMinionWorkers.isEmpty() || selectedMinionWorkers.contains(worker.getId())) {
+        selectedMinionWorkerEndpoints.put(worker.getId(),
+            String.format("%s://%s:%d", scheme, worker.getHostName(), Integer.parseInt(worker.getPort())));
+      }
+    }
+    Map<String, String> requestHeaders = new HashMap<>();
+    httpHeaders.getRequestHeaders().keySet().forEach(header ->
+        requestHeaders.put(header, httpHeaders.getHeaderString(header)));
+    int timeoutMs = _controllerConf.getMinionAdminRequestTimeoutSeconds() * 1000;
+    try {
+      Map<String, Object> minionWorkerIdSubtaskProgressMap =
+          _pinotHelixTaskResourceManager.getSubtaskWithGivenStateProgress(subTaskState, _executor, _connectionManager,
+              selectedMinionWorkerEndpoints, requestHeaders, timeoutMs);
+      return JsonUtils.objectToString(minionWorkerIdSubtaskProgressMap);
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER,
+          String.format("Failed to get minion worker side progress for subtasks with state %s due to error: %s",
+              subTaskState, ExceptionUtils.getStackTrace(e)), Response.Status.INTERNAL_SERVER_ERROR, e);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -633,7 +633,8 @@ public class PinotHelixTaskResourceManager {
    */
   public synchronized Map<String, Object> getSubtaskWithGivenStateProgress(String subtaskState,
       Executor executor, HttpConnectionManager connMgr, Map<String, String> selectedMinionWorkerEndpoints,
-      Map<String, String> requestHeaders, int timeoutMs) {
+      Map<String, String> requestHeaders, int timeoutMs)
+      throws JsonProcessingException {
     return getSubtaskWithGivenStateProgress(subtaskState,
         new CompletionServiceHelper(executor, connMgr, HashBiMap.create(0)), selectedMinionWorkerEndpoints,
         requestHeaders, timeoutMs);
@@ -642,7 +643,8 @@ public class PinotHelixTaskResourceManager {
   @VisibleForTesting
   Map<String, Object> getSubtaskWithGivenStateProgress(String subtaskState,
       CompletionServiceHelper completionServiceHelper, Map<String, String> selectedMinionWorkerEndpoints,
-      Map<String, String> requestHeaders, int timeoutMs) {
+      Map<String, String> requestHeaders, int timeoutMs)
+      throws JsonProcessingException {
     Map<String, Object> minionWorkerIdSubtaskProgressMap = new HashMap<>();
     if (selectedMinionWorkerEndpoints.isEmpty()) {
       return minionWorkerIdSubtaskProgressMap;
@@ -660,7 +662,8 @@ public class PinotHelixTaskResourceManager {
       String worker = entry.getKey();
       String resp = entry.getValue();
       LOGGER.debug("Got resp: {} from worker: {}", resp, worker);
-      minionWorkerIdSubtaskProgressMap.put(minionWorkerUrlToWorkerIdMap.get(worker), resp);
+      minionWorkerIdSubtaskProgressMap
+          .put(minionWorkerUrlToWorkerIdMap.get(worker), JsonUtils.stringToObject(resp, Map.class));
     }
     if (serviceResponse._failedResponseCount > 0) {
       // Instead of aborting, subtasks without worker side progress return the task status tracked by Helix.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManager.java
@@ -631,17 +631,17 @@ public class PinotHelixTaskResourceManager {
    * @param timeoutMs timeout (in millisecond) for requests sent to minion workers
    * @return a map of minion worker id to subtask progress
    */
-  public synchronized Map<String, Object> getSubtaskWithGivenStateProgress(String subtaskState,
+  public synchronized Map<String, Object> getSubtaskOnWorkerProgress(String subtaskState,
       Executor executor, HttpConnectionManager connMgr, Map<String, String> selectedMinionWorkerEndpoints,
       Map<String, String> requestHeaders, int timeoutMs)
       throws JsonProcessingException {
-    return getSubtaskWithGivenStateProgress(subtaskState,
+    return getSubtaskOnWorkerProgress(subtaskState,
         new CompletionServiceHelper(executor, connMgr, HashBiMap.create(0)), selectedMinionWorkerEndpoints,
         requestHeaders, timeoutMs);
   }
 
   @VisibleForTesting
-  Map<String, Object> getSubtaskWithGivenStateProgress(String subtaskState,
+  Map<String, Object> getSubtaskOnWorkerProgress(String subtaskState,
       CompletionServiceHelper completionServiceHelper, Map<String, String> selectedMinionWorkerEndpoints,
       Map<String, String> requestHeaders, int timeoutMs)
       throws JsonProcessingException {
@@ -651,7 +651,7 @@ public class PinotHelixTaskResourceManager {
     }
     Map<String, String> minionWorkerUrlToWorkerIdMap = selectedMinionWorkerEndpoints.entrySet().stream()
         .collect(Collectors.toMap(
-            entry -> String.format("%s/tasks/subtask/state/%s/progress", entry.getValue(), subtaskState),
+            entry -> String.format("%s/tasks/subtask/state/progress?subTaskState=%s", entry.getValue(), subtaskState),
             Map.Entry::getKey));
     List<String> workerUrls = new ArrayList<>(minionWorkerUrlToWorkerIdMap.keySet());
     LOGGER.debug("Getting task progress with workerUrls: {}", workerUrls);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResourceTest.java
@@ -107,11 +107,11 @@ public class PinotTaskRestletResourceTest {
     HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
     when(httpHeaders.getRequestHeaders()).thenReturn(new MultivaluedHashMap<>());
     ArgumentCaptor<Map<String, String>> minionWorkerEndpointsCaptor = ArgumentCaptor.forClass(Map.class);
-    when(_pinotHelixTaskResourceManager.getSubtaskWithGivenStateProgress(anyString(), any(), any(),
+    when(_pinotHelixTaskResourceManager.getSubtaskOnWorkerProgress(anyString(), any(), any(),
         minionWorkerEndpointsCaptor.capture(), anyMap(), anyInt()))
         .thenReturn(Collections.emptyMap());
     String progress =
-        _pinotTaskRestletResource.getSubtaskWithGivenStateProgress(httpHeaders, "IN_PROGRESS", minionWorkerIds);
+        _pinotTaskRestletResource.getSubtaskOnWorkerProgress(httpHeaders, "IN_PROGRESS", minionWorkerIds);
     assertEquals(progress, "{}");
     return minionWorkerEndpointsCaptor.getValue();
   }
@@ -131,9 +131,9 @@ public class PinotTaskRestletResourceTest {
     HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
     when(httpHeaders.getRequestHeaders()).thenReturn(new MultivaluedHashMap<>());
     when(_pinotHelixTaskResourceManager
-        .getSubtaskWithGivenStateProgress(anyString(), any(), any(), anyMap(), anyMap(), anyInt()))
+        .getSubtaskOnWorkerProgress(anyString(), any(), any(), anyMap(), anyMap(), anyInt()))
         .thenThrow(new RuntimeException());
     assertThrows(ControllerApplicationException.class,
-        () -> _pinotTaskRestletResource.getSubtaskWithGivenStateProgress(httpHeaders, "IN_PROGRESS", null));
+        () -> _pinotTaskRestletResource.getSubtaskOnWorkerProgress(httpHeaders, "IN_PROGRESS", null));
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResourceTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.api.resources;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.net.URI;
@@ -70,7 +71,8 @@ public class PinotTaskRestletResourceTest {
   }
 
   @Test
-  public void testGetSubtaskWithGivenStateProgressWhenMinionWorkerIdsAreNotSpecified() {
+  public void testGetSubtaskWithGivenStateProgressWhenMinionWorkerIdsAreNotSpecified()
+      throws JsonProcessingException {
     Map<String, String> minionWorkerEndpoints
         = invokeGetSubtaskWithGivenStateProgressAndReturnCapturedMinionWorkerEndpoints(null);
     assertEquals(minionWorkerEndpoints,
@@ -78,7 +80,8 @@ public class PinotTaskRestletResourceTest {
   }
 
   @Test
-  public void testGetSubtaskWithGivenStateProgressWhenAllMinionWorkerIdsAreSpecified() {
+  public void testGetSubtaskWithGivenStateProgressWhenAllMinionWorkerIdsAreSpecified()
+      throws JsonProcessingException {
     Map<String, String> minionWorkerEndpoints
         = invokeGetSubtaskWithGivenStateProgressAndReturnCapturedMinionWorkerEndpoints("minion1,minion2");
     assertEquals(minionWorkerEndpoints,
@@ -86,7 +89,8 @@ public class PinotTaskRestletResourceTest {
   }
 
   @Test
-  public void testGetSubtaskWithGivenStateProgressWhenOneMinionWorkerIdIsSpecified() {
+  public void testGetSubtaskWithGivenStateProgressWhenOneMinionWorkerIdIsSpecified()
+      throws JsonProcessingException {
     Map<String, String> minionWorkerEndpoints
         = invokeGetSubtaskWithGivenStateProgressAndReturnCapturedMinionWorkerEndpoints("minion1");
     assertEquals(minionWorkerEndpoints,
@@ -94,7 +98,8 @@ public class PinotTaskRestletResourceTest {
   }
 
   private Map<String, String> invokeGetSubtaskWithGivenStateProgressAndReturnCapturedMinionWorkerEndpoints(
-      String minionWorkerIds) {
+      String minionWorkerIds)
+      throws JsonProcessingException {
     InstanceConfig minion1 = createInstanceConfig("minion1", "minion1", "9514");
     InstanceConfig minion2 = createInstanceConfig("minion2", "minion2", "9514");
     when(_pinotHelixResourceManager.getAllMinionInstanceConfigs()).thenReturn(ImmutableList.of(minion1, minion2));
@@ -119,7 +124,8 @@ public class PinotTaskRestletResourceTest {
 
 
   @Test
-  public void testGetSubtaskWithGivenStateProgressWithException() {
+  public void testGetSubtaskWithGivenStateProgressWithException()
+      throws JsonProcessingException {
     when(_pinotHelixResourceManager.getAllMinionInstanceConfigs()).thenReturn(Collections.emptyList());
     HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
     when(httpHeaders.getRequestHeaders()).thenReturn(new MultivaluedHashMap<>());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResourceTest.java
@@ -1,0 +1,132 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Collections;
+import java.util.Map;
+import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.MultivaluedHashMap;
+import javax.ws.rs.core.UriInfo;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.api.exception.ControllerApplicationException;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+
+public class PinotTaskRestletResourceTest {
+  @Mock
+  PinotHelixResourceManager _pinotHelixResourceManager;
+  @Mock
+  PinotHelixTaskResourceManager _pinotHelixTaskResourceManager;
+  @Mock
+  ControllerConf _controllerConf;
+  @Mock
+  UriInfo _uriInfo;
+
+  @InjectMocks
+  PinotTaskRestletResource _pinotTaskRestletResource;
+
+  @BeforeMethod
+  public void init()
+      throws URISyntaxException {
+    MockitoAnnotations.openMocks(this);
+    when(_uriInfo.getRequestUri()).thenReturn(new URI("http://localhost:9000"));
+  }
+
+  @Test
+  public void testGetSubtaskWithGivenStateProgressWhenMinionWorkerIdsAreNotSpecified() {
+    Map<String, String> minionWorkerEndpoints
+        = invokeGetSubtaskWithGivenStateProgressAndReturnCapturedMinionWorkerEndpoints(null);
+    assertEquals(minionWorkerEndpoints,
+        ImmutableMap.of("minion1", "http://minion1:9514", "minion2", "http://minion2:9514"));
+  }
+
+  @Test
+  public void testGetSubtaskWithGivenStateProgressWhenAllMinionWorkerIdsAreSpecified() {
+    Map<String, String> minionWorkerEndpoints
+        = invokeGetSubtaskWithGivenStateProgressAndReturnCapturedMinionWorkerEndpoints("minion1,minion2");
+    assertEquals(minionWorkerEndpoints,
+        ImmutableMap.of("minion1", "http://minion1:9514", "minion2", "http://minion2:9514"));
+  }
+
+  @Test
+  public void testGetSubtaskWithGivenStateProgressWhenOneMinionWorkerIdIsSpecified() {
+    Map<String, String> minionWorkerEndpoints
+        = invokeGetSubtaskWithGivenStateProgressAndReturnCapturedMinionWorkerEndpoints("minion1");
+    assertEquals(minionWorkerEndpoints,
+        ImmutableMap.of("minion1", "http://minion1:9514"));
+  }
+
+  private Map<String, String> invokeGetSubtaskWithGivenStateProgressAndReturnCapturedMinionWorkerEndpoints(
+      String minionWorkerIds) {
+    InstanceConfig minion1 = createInstanceConfig("minion1", "minion1", "9514");
+    InstanceConfig minion2 = createInstanceConfig("minion2", "minion2", "9514");
+    when(_pinotHelixResourceManager.getAllMinionInstanceConfigs()).thenReturn(ImmutableList.of(minion1, minion2));
+    HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+    when(httpHeaders.getRequestHeaders()).thenReturn(new MultivaluedHashMap<>());
+    ArgumentCaptor<Map<String, String>> minionWorkerEndpointsCaptor = ArgumentCaptor.forClass(Map.class);
+    when(_pinotHelixTaskResourceManager.getSubtaskWithGivenStateProgress(anyString(), any(), any(),
+        minionWorkerEndpointsCaptor.capture(), anyMap(), anyInt()))
+        .thenReturn(Collections.emptyMap());
+    String progress =
+        _pinotTaskRestletResource.getSubtaskWithGivenStateProgress(httpHeaders, "IN_PROGRESS", minionWorkerIds);
+    assertEquals(progress, "{}");
+    return minionWorkerEndpointsCaptor.getValue();
+  }
+
+  private InstanceConfig createInstanceConfig(String instanceId, String hostName, String port) {
+    InstanceConfig instanceConfig = new InstanceConfig(instanceId);
+    instanceConfig.setHostName(hostName);
+    instanceConfig.setPort(port);
+    return instanceConfig;
+  }
+
+
+  @Test
+  public void testGetSubtaskWithGivenStateProgressWithException() {
+    when(_pinotHelixResourceManager.getAllMinionInstanceConfigs()).thenReturn(Collections.emptyList());
+    HttpHeaders httpHeaders = Mockito.mock(HttpHeaders.class);
+    when(httpHeaders.getRequestHeaders()).thenReturn(new MultivaluedHashMap<>());
+    when(_pinotHelixTaskResourceManager
+        .getSubtaskWithGivenStateProgress(anyString(), any(), any(), anyMap(), anyMap(), anyInt()))
+        .thenThrow(new RuntimeException());
+    assertThrows(ControllerApplicationException.class,
+        () -> _pinotTaskRestletResource.getSubtaskWithGivenStateProgress(httpHeaders, "IN_PROGRESS", null));
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResourceTest.java
@@ -82,8 +82,9 @@ public class PinotTaskRestletResourceTest {
   @Test
   public void testGetSubtaskWithGivenStateProgressWhenAllMinionWorkerIdsAreSpecified()
       throws JsonProcessingException {
+    // use minion worker ids with spaces ensure they will be trimmed.
     Map<String, String> minionWorkerEndpoints
-        = invokeGetSubtaskWithGivenStateProgressAndReturnCapturedMinionWorkerEndpoints("minion1,minion2");
+        = invokeGetSubtaskWithGivenStateProgressAndReturnCapturedMinionWorkerEndpoints(" minion1 , minion2 ");
     assertEquals(minionWorkerEndpoints,
         ImmutableMap.of("minion1", "http://minion1:9514", "minion2", "http://minion2:9514"));
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManagerTest.java
@@ -215,7 +215,7 @@ public class PinotHelixTaskResourceManagerTest {
     // No worker to run subtasks.
     Map<String, String> selectedMinionWorkerEndpoints = new HashMap<>();
     Map<String, Object> progress =
-        mgr.getSubtaskWithGivenStateProgress("IN_PROGRESS", httpHelper,
+        mgr.getSubtaskOnWorkerProgress("IN_PROGRESS", httpHelper,
             selectedMinionWorkerEndpoints, Collections.emptyMap(), 1000);
     assertTrue(progress.isEmpty());
     verify(httpHelper, Mockito.never()).doMultiGetRequest(any(), any(), anyBoolean(), any(), anyInt());
@@ -241,7 +241,8 @@ public class PinotHelixTaskResourceManagerTest {
       subtaskIds[2 * i + 1] = taskIdPrefix + "_" + (2 * i + 1);
       // Notice that for testing purpose, we map subtask names to empty strings. In reality, subtask names will be
       // mapped to jsonized org.apache.pinot.minion.event.MinionEventObserver
-      httpResp._httpResponses.put(String.format("%s/tasks/subtask/state/IN_PROGRESS/progress", workerEndpoint),
+      httpResp._httpResponses.put(
+          String.format("%s/tasks/subtask/state/progress?subTaskState=IN_PROGRESS", workerEndpoint),
           JsonUtils.objectToString(ImmutableMap.of(subtaskIds[2 * i], "", subtaskIds[2 * i + 1], "")));
     }
     httpResp._failedResponseCount = 1;
@@ -253,11 +254,12 @@ public class PinotHelixTaskResourceManagerTest {
         new PinotHelixTaskResourceManager(mock(PinotHelixResourceManager.class), mock(TaskDriver.class));
 
     Map<String, Object> progress =
-        mgr.getSubtaskWithGivenStateProgress("IN_PROGRESS", httpHelper, selectedMinionWorkerEndpoints,
+        mgr.getSubtaskOnWorkerProgress("IN_PROGRESS", httpHelper, selectedMinionWorkerEndpoints,
             Collections.emptyMap(), 1000);
     List<String> value = workerEndpointCaptor.getValue();
     Set<String> expectedWorkerUrls = selectedMinionWorkerEndpoints.values().stream()
-        .map(workerEndpoint -> String.format("%s/tasks/subtask/state/IN_PROGRESS/progress", workerEndpoint))
+        .map(workerEndpoint
+            -> String.format("%s/tasks/subtask/state/progress?subTaskState=IN_PROGRESS", workerEndpoint))
         .collect(Collectors.toSet());
     assertEquals(new HashSet<>(value), expectedWorkerUrls);
     assertEquals(progress.size(), 3);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManagerTest.java
@@ -18,13 +18,17 @@
  */
 package org.apache.pinot.controller.helix.core.minion;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.task.JobConfig;
 import org.apache.helix.task.JobContext;
@@ -35,6 +39,8 @@ import org.apache.helix.task.WorkflowContext;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.util.CompletionServiceHelper;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -42,6 +48,7 @@ import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -197,6 +204,70 @@ public class PinotHelixTaskResourceManagerTest {
     assertEquals(taskProgress, "No worker has run this subtask");
     taskProgress = (String) progress.get(subtaskNames[2]);
     assertEquals(taskProgress, "No worker has run this subtask");
+  }
+
+  @Test
+  public void testGetSubtaskWithGivenStateProgressNoWorker() {
+    CompletionServiceHelper httpHelper = mock(CompletionServiceHelper.class);
+    PinotHelixTaskResourceManager mgr =
+        new PinotHelixTaskResourceManager(mock(PinotHelixResourceManager.class), mock(TaskDriver.class));
+    // No worker to run subtasks.
+    Map<String, String> selectedMinionWorkerEndpoints = new HashMap<>();
+    Map<String, Object> progress =
+        mgr.getSubtaskWithGivenStateProgress("IN_PROGRESS", httpHelper,
+            selectedMinionWorkerEndpoints, Collections.emptyMap(), 1000);
+    assertTrue(progress.isEmpty());
+    verify(httpHelper, Mockito.never()).doMultiGetRequest(any(), any(), anyBoolean(), any(), anyInt());
+  }
+
+  @Test
+  public void testGetSubtaskWithGivenStateProgress()
+      throws IOException {
+    CompletionServiceHelper httpHelper = mock(CompletionServiceHelper.class);
+    CompletionServiceHelper.CompletionServiceResponse httpResp =
+        new CompletionServiceHelper.CompletionServiceResponse();
+    String taskIdPrefix = "Task_SegmentGenerationAndPushTask_someone";
+    String workerIdPrefix = "worker";
+    String[] subtaskIds = new String[6];
+    String[] workerIds = new String[3];
+    Map<String, String> selectedMinionWorkerEndpoints = new HashMap<>();
+    for (int i = 0; i < 3; i++) {
+      workerIds[i] = workerIdPrefix + i;
+      String workerEndpoint = "http://" + workerIds[i] + ":9000";
+      selectedMinionWorkerEndpoints.put(workerIds[i], workerEndpoint);
+
+      subtaskIds[2 * i] = taskIdPrefix + "_" + (2 * i);
+      subtaskIds[2 * i + 1] = taskIdPrefix + "_" + (2 * i + 1);
+      // Notice that for testing purpose, we map subtask names to empty strings. In reality, subtask names will be
+      // mapped to jsonized org.apache.pinot.minion.event.MinionEventObserver
+      httpResp._httpResponses.put(workerEndpoint,
+          JsonUtils.objectToString(ImmutableMap.of(subtaskIds[2 * i], "", subtaskIds[2 * i + 1], "")));
+    }
+    httpResp._failedResponseCount = 1;
+    ArgumentCaptor<List<String>> workerEndpointCaptor = ArgumentCaptor.forClass(List.class);
+    when(httpHelper.doMultiGetRequest(workerEndpointCaptor.capture(), any(), anyBoolean(), any(), anyInt()))
+        .thenReturn(httpResp);
+
+    PinotHelixTaskResourceManager mgr =
+        new PinotHelixTaskResourceManager(mock(PinotHelixResourceManager.class), mock(TaskDriver.class));
+
+    Map<String, Object> progress =
+        mgr.getSubtaskWithGivenStateProgress("IN_PROGRESS", httpHelper, selectedMinionWorkerEndpoints,
+            Collections.emptyMap(), 1000);
+    List<String> value = workerEndpointCaptor.getValue();
+    Set<String> expectedWorkerUrls = selectedMinionWorkerEndpoints.values().stream()
+        .map(workerEndpoint -> String.format("%s/tasks/subtask/state/IN_PROGRESS/progress", workerEndpoint))
+        .collect(Collectors.toSet());
+    assertEquals(new HashSet<>(value), expectedWorkerUrls);
+    assertEquals(progress.size(), 3);
+    for (int i = 0; i < 3; i++) {
+      Object responseFromMinionWorker = progress.get(workerIds[i]);
+      JsonNode jsonNode = JsonUtils.stringToJsonNode((String) responseFromMinionWorker);
+      Map<String, Object> subtaskProgressMap = JsonUtils.jsonNodeToMap(jsonNode);
+      assertEquals(subtaskProgressMap.size(), 2);
+      assertTrue(subtaskProgressMap.containsKey(subtaskIds[2 * i]));
+      assertTrue(subtaskProgressMap.containsKey(subtaskIds[2 * i + 1]));
+    }
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManagerTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.helix.core.minion;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -206,7 +207,8 @@ public class PinotHelixTaskResourceManagerTest {
   }
 
   @Test
-  public void testGetSubtaskWithGivenStateProgressNoWorker() {
+  public void testGetSubtaskWithGivenStateProgressNoWorker()
+      throws JsonProcessingException {
     CompletionServiceHelper httpHelper = mock(CompletionServiceHelper.class);
     PinotHelixTaskResourceManager mgr =
         new PinotHelixTaskResourceManager(mock(PinotHelixResourceManager.class), mock(TaskDriver.class));
@@ -261,7 +263,7 @@ public class PinotHelixTaskResourceManagerTest {
     assertEquals(progress.size(), 3);
     for (int i = 0; i < 3; i++) {
       Object responseFromMinionWorker = progress.get(workerIds[i]);
-      Map<String, Object> subtaskProgressMap = JsonUtils.stringToObject((String) responseFromMinionWorker, Map.class);
+      Map<String, Object> subtaskProgressMap = (Map<String, Object>) responseFromMinionWorker;
       assertEquals(subtaskProgressMap.size(), 2);
       assertTrue(subtaskProgressMap.containsKey(subtaskIds[2 * i]));
       assertTrue(subtaskProgressMap.containsKey(subtaskIds[2 * i + 1]));

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotHelixTaskResourceManagerTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.controller.helix.core.minion;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
 import java.io.IOException;
@@ -240,7 +239,7 @@ public class PinotHelixTaskResourceManagerTest {
       subtaskIds[2 * i + 1] = taskIdPrefix + "_" + (2 * i + 1);
       // Notice that for testing purpose, we map subtask names to empty strings. In reality, subtask names will be
       // mapped to jsonized org.apache.pinot.minion.event.MinionEventObserver
-      httpResp._httpResponses.put(workerEndpoint,
+      httpResp._httpResponses.put(String.format("%s/tasks/subtask/state/IN_PROGRESS/progress", workerEndpoint),
           JsonUtils.objectToString(ImmutableMap.of(subtaskIds[2 * i], "", subtaskIds[2 * i + 1], "")));
     }
     httpResp._failedResponseCount = 1;
@@ -262,8 +261,7 @@ public class PinotHelixTaskResourceManagerTest {
     assertEquals(progress.size(), 3);
     for (int i = 0; i < 3; i++) {
       Object responseFromMinionWorker = progress.get(workerIds[i]);
-      JsonNode jsonNode = JsonUtils.stringToJsonNode((String) responseFromMinionWorker);
-      Map<String, Object> subtaskProgressMap = JsonUtils.jsonNodeToMap(jsonNode);
+      Map<String, Object> subtaskProgressMap = JsonUtils.stringToObject((String) responseFromMinionWorker, Map.class);
       assertEquals(subtaskProgressMap.size(), 2);
       assertTrue(subtaskProgressMap.containsKey(subtaskIds[2 * i]));
       assertTrue(subtaskProgressMap.containsKey(subtaskIds[2 * i + 1]));

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResource.java
@@ -27,18 +27,21 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
 import javax.ws.rs.Produces;
 import javax.ws.rs.QueryParam;
 import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.minion.event.MinionEventObserver;
 import org.apache.pinot.minion.event.MinionEventObservers;
 import org.apache.pinot.minion.event.MinionTaskState;
@@ -88,31 +91,54 @@ public class PinotTaskProgressResource {
   }
 
   @GET
-  @Path("/tasks/subtask/state/{subTaskState}/progress")
+  @Path("/tasks/subtask/state/progress")
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation("Get finer grained task progress tracked in memory for subtasks with the given state")
+  @ApiOperation("Get finer grained task progress tracked in memory for given subtasks or given state")
   @ApiResponses(value = {
       @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")
   })
-  public String getSubtaskWithGivenStateProgress(
-      @ApiParam(value = "Subtask state", required = true) @PathParam("subTaskState") String subTaskState) {
+  public String getSubtaskProgress(
+      @ApiParam(value = "Sub task names separated by comma") @QueryParam("subtaskNames") @Nullable String subtaskNames,
+      @ApiParam(value = "Subtask state", required = true) @QueryParam("subTaskState") @Nullable String subTaskState) {
     try {
-      MinionTaskState minionTaskState = MinionTaskState.IN_PROGRESS;
-      try {
-        minionTaskState = MinionTaskState.valueOf(subTaskState.toUpperCase());
-      } catch (IllegalArgumentException e) {
-        LOGGER.warn("{} is not a valid subtask state, defaulting to IN_PROGRESS", subTaskState);
-        subTaskState = MinionTaskState.IN_PROGRESS.toString();
+      Map<String, MinionEventObserver> progress = new HashMap<>();
+      if (StringUtils.isEmpty(subtaskNames) && StringUtils.isEmpty(subTaskState)) {
+        LOGGER.debug("Getting progress of all subtasks");
+        progress.putAll(MinionEventObservers.getInstance().getMinionEventObservers());
+      } else if (!StringUtils.isEmpty(subtaskNames) && !StringUtils.isEmpty(subTaskState)) {
+        throw new Exception("Subtask names and state should not be specified at the same time");
+      } else if (!StringUtils.isEmpty(subTaskState)) {
+        MinionTaskState minionTaskState = MinionTaskState.IN_PROGRESS;
+        try {
+          minionTaskState = MinionTaskState.valueOf(subTaskState.toUpperCase());
+        } catch (IllegalArgumentException e) {
+          LOGGER.warn("{} is not a valid subtask state, defaulting to IN_PROGRESS", subTaskState);
+          subTaskState = MinionTaskState.IN_PROGRESS.toString();
+        }
+        LOGGER.debug("Getting progress for subtasks with state {}", subTaskState);
+        progress.putAll(MinionEventObservers.getInstance().getMinionEventObserverWithGivenState(minionTaskState));
+      } else {
+        // !StringUtils.isEmpty(subtaskNames) is true
+        LOGGER.debug("Getting progress for subtasks: {}", subtaskNames);
+        List<String> subTaskNames =
+            Arrays.stream(StringUtils.split(subtaskNames, CommonConstants.Minion.TASK_LIST_SEPARATOR))
+                .map(String::trim)
+                .collect(Collectors.toList());
+        for (String subtaskName : subTaskNames) {
+          MinionEventObserver observer = MinionEventObservers.getInstance().getMinionEventObserver(subtaskName);
+          if (observer != null) {
+            progress.put(subtaskName, observer);
+          }
+        }
       }
-      LOGGER.debug("Getting progress for subtasks with state {}", subTaskState);
-      Map<String, MinionEventObserver> progress
-          = MinionEventObservers.getInstance().getMinionEventObserverWithGivenState(minionTaskState);
       LOGGER.debug("Got subtasks progress: {}", progress);
       return JsonUtils.objectToString(progress);
     } catch (Exception e) {
       throw new WebApplicationException(Response.status(Response.Status.INTERNAL_SERVER_ERROR).entity(
-              String.format("Failed to get task progress for subtasks with state: %s due to error: %s",
-                  subTaskState, e.getMessage()))
+              String.format("Failed to get task progress for subtasks %s with state %s due to error: %s",
+                  StringUtils.isEmpty(subtaskNames) ? "NOT_SPECIFIED" : subtaskNames,
+                  StringUtils.isEmpty(subTaskState) ? "NOT_SPECIFIED" : subTaskState,
+                  e.getMessage()))
           .build());
     }
   }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObserver.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObserver.java
@@ -70,4 +70,20 @@ public interface MinionEventObserver {
    * @param exception Exception encountered during execution
    */
   void notifyTaskError(PinotTaskConfig pinotTaskConfig, Exception exception);
+
+  /**
+   * Gets the minion task state
+   * @return a {@link MinionTaskState}
+   */
+  default MinionTaskState getTaskState() {
+    return MinionTaskState.UNKNOWN;
+  }
+
+  /**
+   * Gets the minion task start timestamp
+   * @return the minion task start timestamp
+   */
+  default long getStartTs() {
+    return -1;
+  }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObservers.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObservers.java
@@ -26,6 +26,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Condition;
 import java.util.concurrent.locks.ReentrantLock;
+import java.util.stream.Collectors;
 import org.apache.pinot.minion.MinionConf;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.slf4j.Logger;
@@ -109,6 +110,17 @@ public class MinionEventObservers {
 
   public MinionEventObserver getMinionEventObserver(String taskId) {
     return _taskEventObservers.get(taskId);
+  }
+
+  /**
+   * Gets all {@link MinionEventObserver}s with the given {@link MinionTaskState}
+   * @param taskState the {@link MinionTaskState} to match
+   * @return a map of subtask ID to {@link MinionEventObserver}
+   */
+  public Map<String, MinionEventObserver> getMinionEventObserverWithGivenState(MinionTaskState taskState) {
+    return _taskEventObservers.entrySet().stream()
+        .filter(e -> e.getValue().getTaskState() == taskState)
+        .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue));
   }
 
   public void addMinionEventObserver(String taskId, MinionEventObserver eventObserver) {

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObservers.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionEventObservers.java
@@ -113,6 +113,14 @@ public class MinionEventObservers {
   }
 
   /**
+   * Gets all {@link MinionEventObserver}s
+   * @return a map of subtask ID to {@link MinionEventObserver}
+   */
+  public Map<String, MinionEventObserver> getMinionEventObservers() {
+    return _taskEventObservers;
+  }
+
+  /**
    * Gets all {@link MinionEventObserver}s with the given {@link MinionTaskState}
    * @param taskState the {@link MinionTaskState} to match
    * @return a map of subtask ID to {@link MinionEventObserver}

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionTaskState.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/event/MinionTaskState.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion.event;
+
+/**
+ * MinionTaskState represent a minion task state
+ */
+public enum MinionTaskState {
+  /**
+   * No state is reported / unknown
+   */
+  UNKNOWN,
+  /**
+   * The minion task is in progress
+   */
+  IN_PROGRESS,
+  /**
+   * The minion task succeeded
+   */
+  SUCCEEDED,
+  /**
+   * The minion task is cancelled
+   */
+  CANCELLED,
+  /**
+   * The minion task encounters error
+   */
+  ERROR
+}

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResourceTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResourceTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.minion.api.resources;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
 import java.util.Map;
 import org.apache.pinot.minion.event.MinionEventObserver;
@@ -59,8 +58,7 @@ public class PinotTaskProgressResourceTest {
 
     String subtaskWithSucceededState =
         pinotTaskProgressResource.getSubtaskWithGivenStateProgress(MinionTaskState.SUCCEEDED.toString());
-    JsonNode jsonNode = JsonUtils.stringToJsonNode(subtaskWithSucceededState);
-    Map<String, Object> subtaskProgressMap = JsonUtils.jsonNodeToMap(jsonNode);
+    Map<String, Object> subtaskProgressMap = JsonUtils.stringToObject(subtaskWithSucceededState, Map.class);
     assertEquals(subtaskProgressMap.size(), 1);
 
     String subtaskWithUnknownState =
@@ -78,15 +76,13 @@ public class PinotTaskProgressResourceTest {
 
   private void assertInProgressSubtasks(String subtaskWithInProgressState)
       throws IOException {
-    JsonNode jsonNode = JsonUtils.stringToJsonNode(subtaskWithInProgressState);
-    Map<String, Object> subtaskProgressMap = JsonUtils.jsonNodeToMap(jsonNode);
+    Map<String, Object> subtaskProgressMap = JsonUtils.stringToObject(subtaskWithInProgressState, Map.class);
     assertEquals(subtaskProgressMap.size(), 2);
   }
 
   private void assertNoSubtaskWithTheGivenState(String subtaskWithTheGivenState)
       throws IOException {
-    JsonNode jsonNode = JsonUtils.stringToJsonNode(subtaskWithTheGivenState);
-    Map<String, Object> subtaskProgressMap = JsonUtils.jsonNodeToMap(jsonNode);
+    Map<String, Object> subtaskProgressMap = JsonUtils.stringToObject(subtaskWithTheGivenState, Map.class);
     assertEquals(subtaskProgressMap.size(), 0);
   }
 }

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResourceTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/api/resources/PinotTaskProgressResourceTest.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.minion.api.resources;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.Map;
+import org.apache.pinot.minion.event.MinionEventObserver;
+import org.apache.pinot.minion.event.MinionEventObservers;
+import org.apache.pinot.minion.event.MinionProgressObserver;
+import org.apache.pinot.minion.event.MinionTaskState;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class PinotTaskProgressResourceTest {
+
+  @Test
+  public void testGetSubtaskWithGivenStateProgress()
+      throws IOException {
+    MinionEventObserver observer1 = new MinionProgressObserver();
+    observer1.notifyTaskStart(null);
+    MinionEventObservers.getInstance().addMinionEventObserver("t01", observer1);
+
+    MinionEventObserver observer2 = new MinionProgressObserver();
+    observer2.notifyProgress(null, "");
+    MinionEventObservers.getInstance().addMinionEventObserver("t02", observer2);
+
+    MinionEventObserver observer3 = new MinionProgressObserver();
+    observer3.notifyTaskSuccess(null, "");
+    MinionEventObservers.getInstance().addMinionEventObserver("t03", observer3);
+
+    PinotTaskProgressResource pinotTaskProgressResource = new PinotTaskProgressResource();
+    String subtaskWithInProgressState =
+        pinotTaskProgressResource.getSubtaskWithGivenStateProgress(MinionTaskState.IN_PROGRESS.toString());
+    assertInProgressSubtasks(subtaskWithInProgressState);
+
+    String subtaskWithUndefinedState =
+        pinotTaskProgressResource.getSubtaskWithGivenStateProgress("Undefined");
+    assertInProgressSubtasks(subtaskWithUndefinedState);
+
+    String subtaskWithSucceededState =
+        pinotTaskProgressResource.getSubtaskWithGivenStateProgress(MinionTaskState.SUCCEEDED.toString());
+    JsonNode jsonNode = JsonUtils.stringToJsonNode(subtaskWithSucceededState);
+    Map<String, Object> subtaskProgressMap = JsonUtils.jsonNodeToMap(jsonNode);
+    assertEquals(subtaskProgressMap.size(), 1);
+
+    String subtaskWithUnknownState =
+        pinotTaskProgressResource.getSubtaskWithGivenStateProgress(MinionTaskState.UNKNOWN.toString());
+    assertNoSubtaskWithTheGivenState(subtaskWithUnknownState);
+
+    String subtaskWithCancelledState =
+        pinotTaskProgressResource.getSubtaskWithGivenStateProgress(MinionTaskState.UNKNOWN.toString());
+    assertNoSubtaskWithTheGivenState(subtaskWithCancelledState);
+
+    String subtaskWithErrorState =
+        pinotTaskProgressResource.getSubtaskWithGivenStateProgress(MinionTaskState.UNKNOWN.toString());
+    assertNoSubtaskWithTheGivenState(subtaskWithErrorState);
+  }
+
+  private void assertInProgressSubtasks(String subtaskWithInProgressState)
+      throws IOException {
+    JsonNode jsonNode = JsonUtils.stringToJsonNode(subtaskWithInProgressState);
+    Map<String, Object> subtaskProgressMap = JsonUtils.jsonNodeToMap(jsonNode);
+    assertEquals(subtaskProgressMap.size(), 2);
+  }
+
+  private void assertNoSubtaskWithTheGivenState(String subtaskWithTheGivenState)
+      throws IOException {
+    JsonNode jsonNode = JsonUtils.stringToJsonNode(subtaskWithTheGivenState);
+    Map<String, Object> subtaskProgressMap = JsonUtils.jsonNodeToMap(jsonNode);
+    assertEquals(subtaskProgressMap.size(), 0);
+  }
+}

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionProgressObserverTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/event/MinionProgressObserverTest.java
@@ -49,4 +49,31 @@ public class MinionProgressObserverTest {
     entry = progress.get(2);
     assertTrue(entry.getStatus().contains("bad bug"), entry.getStatus());
   }
+
+  @Test
+  public void testGetStartTs() {
+    MinionProgressObserver observer = new MinionProgressObserver(3);
+    long ts1 = System.currentTimeMillis();
+    observer.notifyTaskStart(null);
+    long ts = observer.getStartTs();
+    long ts2 = System.currentTimeMillis();
+    assertTrue(ts1 <= ts);
+    assertTrue(ts2 >= ts);
+  }
+
+  @Test
+  public void testUpdateAndGetTaskState() {
+    MinionProgressObserver observer = new MinionProgressObserver(3);
+    assertEquals(observer.getTaskState(), MinionTaskState.UNKNOWN);
+    observer.notifyTaskStart(null);
+    assertEquals(observer.getTaskState(), MinionTaskState.IN_PROGRESS);
+    observer.notifyProgress(null, "");
+    assertEquals(observer.getTaskState(), MinionTaskState.IN_PROGRESS);
+    observer.notifyTaskSuccess(null, "");
+    assertEquals(observer.getTaskState(), MinionTaskState.SUCCEEDED);
+    observer.notifyTaskCancelled(null);
+    assertEquals(observer.getTaskState(), MinionTaskState.CANCELLED);
+    observer.notifyTaskError(null, new Exception());
+    assertEquals(observer.getTaskState(), MinionTaskState.ERROR);
+  }
 }


### PR DESCRIPTION
With this API, we can get
1. Progress of subtasks with given state of specified minion worker IDs, or
2. Progress of subtasks with given state of all minion workers if no minion worker ID is specified

This API is helpful for minion debugging.

The following is an example of the API and its response

![Screenshot 2023-01-24 at 5 01 09 PM](https://user-images.githubusercontent.com/9796617/214456379-afd5169c-8759-4340-af0a-d7b5d5131093.png)


