### PR TITLE
Quickstart should honor overrides from command line

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -66,7 +66,7 @@ public class Quickstart extends QuickStartBase {
 
     QuickstartRunner runner =
         new QuickstartRunner(quickstartTableRequests, 1, 1, getNumQuickstartRunnerServers(), 1, quickstartRunnerDir,
-            true, getAuthProvider(), getConfigOverrides(), null, true);
+            true, getAuthProvider(), getConfigOverrides(), _zkExternalAddress, true);
 
     printStatus(Color.CYAN, "***** Starting Zookeeper, controller, broker, server and minion *****");
     runner.startAll();


### PR DESCRIPTION
Quickstart allows overriding `zkAddress`. However, it is not being passed correctly from the command class to the underlying `Quickstart` class. This PR fixes it, thus, allowing command like: 

```
./bin/pinot-admin.sh -type batch -zkAddress localhost:2181
```

Label: `bugfix`