### PR TITLE
[multistage] make QueryServer async process query

### DIFF
--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
@@ -20,18 +20,14 @@ package org.apache.pinot.query;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeoutException;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.metrics.ServerMetrics;
-import org.apache.pinot.common.utils.NamedThreadFactory;
 import org.apache.pinot.common.utils.SchemaUtils;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.query.runtime.QueryRunner;
-import org.apache.pinot.query.runtime.executor.OpChainSchedulerService;
-import org.apache.pinot.query.runtime.executor.RoundRobinScheduler;
 import org.apache.pinot.query.runtime.plan.DistributedStagePlan;
 import org.apache.pinot.query.service.QueryConfig;
 import org.apache.pinot.query.testutils.MockInstanceDataManagerFactory;
@@ -61,11 +57,9 @@ import static org.mockito.Mockito.when;
  * multi-stage query communication.
  */
 public class QueryServerEnclosure {
-  private static final int DEFAULT_EXECUTOR_THREAD_NUM = 5;
   private static final String TABLE_CONFIGS_PREFIX = "/CONFIGS/TABLE/";
   private static final String SCHEMAS_PREFIX = "/SCHEMAS/";
 
-  private final OpChainSchedulerService _scheduler;
   private final int _queryRunnerPort;
   private final Map<String, Object> _runnerConfig = new HashMap<>();
   private final InstanceDataManager _instanceDataManager;
@@ -83,10 +77,6 @@ public class QueryServerEnclosure {
           String.format("Server_%s", QueryConfig.DEFAULT_QUERY_RUNNER_HOSTNAME));
       _runnerConfig.put(QueryConfig.KEY_OF_SCHEDULER_RELEASE_TIMEOUT_MS, 100);
       _queryRunner = new QueryRunner();
-      _scheduler = new OpChainSchedulerService(new RoundRobinScheduler(),
-          Executors.newFixedThreadPool(
-              DEFAULT_EXECUTOR_THREAD_NUM,
-              new NamedThreadFactory("test_query_server_enclosure_on_" + _queryRunnerPort + "_port")));
     } catch (Exception e) {
       throw new RuntimeException("Test Failed!", e);
     }
@@ -125,13 +115,11 @@ public class QueryServerEnclosure {
     _queryRunner = new QueryRunner();
     _queryRunner.init(configuration, _instanceDataManager, _helixManager, mockServiceMetrics());
     _queryRunner.start();
-    _scheduler.startAsync().awaitRunning();
   }
 
   public void shutDown() {
     try {
       _queryRunner.shutDown();
-      _scheduler.stopAsync().awaitTerminated();
     } catch (TimeoutException e) {
       throw new RuntimeException(e);
     }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/QueryDispatcherTest.java
@@ -23,6 +23,10 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.apache.pinot.common.utils.NamedThreadFactory;
+import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
 import org.apache.pinot.query.QueryEnvironment;
 import org.apache.pinot.query.QueryEnvironmentTestBase;
 import org.apache.pinot.query.QueryTestSet;
@@ -40,6 +44,9 @@ import org.testng.annotations.Test;
 public class QueryDispatcherTest extends QueryTestSet {
   private static final Random RANDOM_REQUEST_ID_GEN = new Random();
   private static final int QUERY_SERVER_COUNT = 2;
+  private static final ExecutorService EXECUTOR_SERVICE = Executors.newFixedThreadPool(
+      ResourceManager.DEFAULT_QUERY_WORKER_THREADS, new NamedThreadFactory("QueryDispatcherTestExecutorService"));
+
   private final Map<Integer, QueryServer> _queryServerMap = new HashMap<>();
   private final Map<Integer, QueryRunner> _queryRunnerMap = new HashMap<>();
 
@@ -51,7 +58,8 @@ public class QueryDispatcherTest extends QueryTestSet {
 
     for (int i = 0; i < QUERY_SERVER_COUNT; i++) {
       int availablePort = QueryTestUtils.getAvailablePort();
-      QueryRunner queryRunner = Mockito.mock(QueryRunner.class);
+      QueryRunner queryRunner = Mockito.mock(QueryRunner.class);;
+      Mockito.when(queryRunner.getExecutorService()).thenReturn(EXECUTOR_SERVICE);
       QueryServer queryServer = new QueryServer(availablePort, queryRunner);
       queryServer.start();
       _queryServerMap.put(availablePort, queryServer);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/QueryServerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/QueryServerTest.java
@@ -26,8 +26,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import org.apache.pinot.common.proto.PinotQueryWorkerGrpc;
 import org.apache.pinot.common.proto.Worker;
+import org.apache.pinot.common.utils.NamedThreadFactory;
+import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.query.QueryEnvironment;
 import org.apache.pinot.query.QueryEnvironmentTestBase;
@@ -54,6 +58,8 @@ public class QueryServerTest extends QueryTestSet {
   private static final int QUERY_SERVER_COUNT = 2;
   private static final String KEY_OF_SERVER_INSTANCE_HOST = "pinot.query.runner.server.hostname";
   private static final String KEY_OF_SERVER_INSTANCE_PORT = "pinot.query.runner.server.port";
+  private static final ExecutorService EXECUTOR_SERVICE = Executors.newFixedThreadPool(
+      ResourceManager.DEFAULT_QUERY_WORKER_THREADS, new NamedThreadFactory("QueryServerTestExecutorService"));
 
   private final Map<Integer, QueryServer> _queryServerMap = new HashMap<>();
   private final Map<Integer, ServerInstance> _queryServerInstanceMap = new HashMap<>();
@@ -68,6 +74,7 @@ public class QueryServerTest extends QueryTestSet {
     for (int i = 0; i < QUERY_SERVER_COUNT; i++) {
       int availablePort = QueryTestUtils.getAvailablePort();
       QueryRunner queryRunner = Mockito.mock(QueryRunner.class);
+      Mockito.when(queryRunner.getExecutorService()).thenReturn(EXECUTOR_SERVICE);
       QueryServer queryServer = new QueryServer(availablePort, queryRunner);
       queryServer.start();
       _queryServerMap.put(availablePort, queryServer);


### PR DESCRIPTION
currently all processing of multistage query occupies the default-grpc-thread until opChain is scheduled or ServerExecutorV1Impl launches query request. this potentially decreases the throughput of QueryServer. 

- Making it async by submitting the query compilation to also run on the same threadpool as the opChain
- This behavior is more align with how current V1 engine works as both the planMaker/combine operator and the segment plans are run on the same threadpool

relates to #10117. 