### PR TITLE
Simplify UTF-8 comparison on null character

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/ValueReaderComparisons.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/ValueReaderComparisons.java
@@ -24,7 +24,6 @@ import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 
 
 public class ValueReaderComparisons {
-
   private ValueReaderComparisons() {
   }
 
@@ -61,16 +60,8 @@ public class ValueReaderComparisons {
     int mismatchPosition = mismatch(dataBuffer, startOffset, length, buffer);
     if (mismatchPosition == -1) {
       if (padded && bytes.length < length) {
-        // need to figure out whether the unpadded string is longer than the parameter or not
-        if (bytes.length == 0) {
-          // just need nonzero first byte
-          return dataBuffer.getByte(startOffset) == 0 ? 0 : 1;
-        } else if (bytes[bytes.length - 1] == 0) {
-          return -1;
-        } else {
-          // check if the stored string continues beyond the length of the parameter
-          return dataBuffer.getByte(startOffset + bytes.length) == 0 ? 0 : 1;
-        }
+        // check if the stored string continues beyond the length of the parameter
+        return dataBuffer.getByte(startOffset + bytes.length) == 0 ? 0 : 1;
       } else {
         // then we know the length precisely or know that the parameter is at least as long as we can store
         return length - bytes.length;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readerwriter/ValueReaderComparisonTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readerwriter/ValueReaderComparisonTest.java
@@ -43,6 +43,7 @@ import static org.testng.Assert.assertTrue;
 
 
 public class ValueReaderComparisonTest {
+
   @DataProvider
   public static Object[] text() {
     return Stream.of(Pair.of(ByteOrder.BIG_ENDIAN, true), Pair.of(ByteOrder.LITTLE_ENDIAN, true),
@@ -109,7 +110,6 @@ public class ValueReaderComparisonTest {
     void testCommonPrefixParameterLonger(ValueReader reader, int numBytesPerValue, String... strings) {
       for (int i = 0; i < strings.length; i++) {
         assertUtf8Comparison(reader, i, numBytesPerValue, strings[i] + "a", -1);
-        assertUtf8Comparison(reader, i, numBytesPerValue, strings[i] + "\0", -1);
         assertUtf8Comparison(reader, i, numBytesPerValue, strings[i] + fromHex("efbfbdd8"), -1);
         assertUtf8Comparison(reader, i, numBytesPerValue, strings[i] + "\uD841\uDF0E", -1);
       }
@@ -156,22 +156,27 @@ public class ValueReaderComparisonTest {
     void testConsistent(ValueReader reader, int numBytesPerValue, int numValuesToCompare) {
       for (int i = 0; i < numValuesToCompare; i++) {
         byte[] bytes = new byte[ThreadLocalRandom.current().nextInt(numBytesPerValue * 2)];
-        assertConsistentUtf8Comparison(reader, i, numBytesPerValue, new String(bytes, StandardCharsets.UTF_8));
-        for (int j = 0; j < 128; j++) {
+
+        for (int j = 1; j < 128; j++) {
           Arrays.fill(bytes, (byte) j);
           assertConsistentUtf8Comparison(reader, i, numBytesPerValue, new String(bytes, StandardCharsets.UTF_8));
         }
+
         byte[] utf8 = "ß".getBytes(StandardCharsets.UTF_8);
         for (int j = 0; j + 1 < bytes.length; j += 2) {
           bytes[j] = utf8[0];
           bytes[j + 1] = utf8[1];
         }
+        assertConsistentUtf8Comparison(reader, i, numBytesPerValue, new String(bytes, StandardCharsets.UTF_8));
+
         utf8 = "道".getBytes(StandardCharsets.UTF_8);
         for (int j = 0; j + 2 < bytes.length; j += 3) {
           bytes[j] = utf8[0];
           bytes[j + 1] = utf8[1];
           bytes[j + 2] = utf8[2];
         }
+        assertConsistentUtf8Comparison(reader, i, numBytesPerValue, new String(bytes, StandardCharsets.UTF_8));
+
         utf8 = "\uD841\uDF0E".getBytes(StandardCharsets.UTF_8);
         for (int j = 0; j + 3 < bytes.length; j += 4) {
           bytes[j] = utf8[0];
@@ -180,6 +185,7 @@ public class ValueReaderComparisonTest {
           bytes[j + 3] = utf8[3];
         }
         assertConsistentUtf8Comparison(reader, i, numBytesPerValue, new String(bytes, StandardCharsets.UTF_8));
+
         ThreadLocalRandom.current().nextBytes(bytes);
         for (int j = 0; j < bytes.length; j++) {
           if (bytes[j] == 0) {
@@ -187,6 +193,7 @@ public class ValueReaderComparisonTest {
           }
         }
         assertConsistentUtf8Comparison(reader, i, numBytesPerValue, new String(bytes, StandardCharsets.UTF_8));
+
         assertConsistentUtf8Comparison(reader, i, numBytesPerValue, fromHex("efbfbdd8"));
         assertConsistentUtf8Comparison(reader, i, numBytesPerValue, fromHex("7fbfbdd8"));
         assertConsistentUtf8Comparison(reader, i, numBytesPerValue, fromHex("7f818181"));


### PR DESCRIPTION
Null character (byte zero) is not allowed in string values ingested into Pinot (all the string values ingested will be sanitized and all the characters after the first null character will be truncated), so we don't really need to guarantee the ordering when the input string value from the query has null character in the end because the original value is anyway modified. This can simplify the comparison logic and reduce overhead when string dictionary has paddings.

E.g. if the value in the dictionary is "abc\0\0\0" after padding, the original input value could be "abc", "abc\0", "abc\0\0", "abc\0\0\0" or even "abc\0\0\0\0", "abc\0abc".
After the change, the comparison result is:
- = "abc"
- = "abc\0"
- = "abc\0\0"
- = "abc\0\0\0"
- < "abc\0\0\0\0"
- < "abc\0a"