### PR TITLE
allow editing pools in instance details ui

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/InstanceDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/InstanceDetails.tsx
@@ -118,7 +118,8 @@ const InstanceDetails = ({ match }: RouteComponentProps<Props>) => {
       host: instanceHost,
       port: instanceDetails.port,
       type: instanceType,
-      tags: instanceDetails.tags
+      tags: instanceDetails.tags,
+      pools: instanceDetails.pools,
     };
     setState({enabled: instanceDetails.enabled});
     setInstanceDetails(JSON.stringify(instancePutObj, null, 2));


### PR DESCRIPTION
This is a simple ui feature + bugfix. Today there's two issues:
1) there's no way from the UI to easily create or update pools from the instance details config page
2) if you are using pools, and you accidentally use the `Edit Config` modal, you will delete your pools because they get reset to null (this should probably be fixed in the java API)

This just puts the pools field in the `instancePutObj` var so it's always included in the edit UI.
<img width="432" alt="image" src="https://user-images.githubusercontent.com/4760722/213609437-d6244e72-b045-48a4-b3f7-1bca568b5cdd.png">

I tested a few scenarios here:
- going from null -> a correctly formatted pool map works
  - there's no validation that the pool name is one of the tags which I think is necessary, but the current API isn't doing that validation
- adding pools works
- removing pools works
- setting it back to null also works
- trying to use a non-map value like a string breaks with a 400 error which is likely good enough for now