### PR TITLE
Make a system property to call system.exit() for LaunchDataIngestionJobCommand

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
@@ -160,6 +160,9 @@ public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand impl
   public static void main(String[] args) {
     PluginManager.get().init();
     int exitCode = new CommandLine(new LaunchDataIngestionJobCommand()).execute(args);
-    System.exit(exitCode);
+    if ((exitCode != 0)
+        && Boolean.parseBoolean(System.getProperties().getProperty("pinot.admin.system.exit"))) {
+      System.exit(exitCode);
+    }
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
@@ -161,7 +161,7 @@ public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand impl
     PluginManager.get().init();
     int exitCode = new CommandLine(new LaunchDataIngestionJobCommand()).execute(args);
     if ((exitCode != 0)
-        && Boolean.parseBoolean(System.getProperties().getProperty("pinot.admin.system.exit"))) {
+        || Boolean.parseBoolean(System.getProperties().getProperty("pinot.admin.system.exit"))) {
       System.exit(exitCode);
     }
   }


### PR DESCRIPTION
Use a system property to call system.exit() for LaunchDataIngestionJobCommand.

The reason is SparkJob may fail due to this system.exit() call.
