### PR TITLE
[multistage] Trim Unused Fields Before Optimizer Runs

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -158,7 +158,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
           break;
       }
     } catch (Exception e) {
-      LOGGER.info("Caught exception while compiling SQL request {}: {}, {}", requestId, query, e.getMessage());
+      LOGGER.error(String.format("Caught exception while compiling SQL request %s: %s", requestId, query), e);
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.REQUEST_COMPILATION_EXCEPTIONS, 1);
       requestContext.setErrorCode(QueryException.SQL_PARSING_ERROR_CODE);
       return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR, e));

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -46,10 +46,12 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.fun.PinotOperatorTable;
 import org.apache.calcite.sql.util.PinotChainedSqlOperatorTable;
+import org.apache.calcite.sql2rel.RelFieldTrimmer;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
 import org.apache.calcite.sql2rel.StandardConvertletTable;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
+import org.apache.calcite.tools.RelBuilder;
 import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.query.context.PlannerContext;
 import org.apache.pinot.query.planner.PlannerUtils;
@@ -215,7 +217,9 @@ public class QueryEnvironment {
     // 4. optimize relNode
     // TODO: add support for traits, cost factory.
     try {
-      plannerContext.getRelOptPlanner().setRoot(relRoot.rel);
+      RelRoot trimmedRelRoot = relRoot.withRel(
+          new RelFieldTrimmer(plannerContext.getValidator(), RelBuilder.create(_config)).trim(relRoot.rel));
+      plannerContext.getRelOptPlanner().setRoot(trimmedRelRoot.rel);
       return plannerContext.getRelOptPlanner().findBestExp();
     } catch (Exception e) {
       throw new UnsupportedOperationException(


### PR DESCRIPTION
This seems to fix projection pushdown issues. PR is not really final since I am also reading more about this. There's a method to enable this via `SqlRelConverterConfig.config().withTrimUnusedFields(true)`, but the behavior of `SqlRelConverterConfig::convertQuery` doesn't really change and fields are not trimmed. I think it only trims the fields for prepared queries.

cc: @walterddr 