### PR TITLE
Push bytes comparison down into ValueReader

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/FixedByteValueReaderWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/FixedByteValueReaderWriter.java
@@ -122,6 +122,12 @@ public final class FixedByteValueReaderWriter implements ValueReader {
     return ValueReaderComparisons.compareUtf8Bytes(_dataBuffer, startOffset, numBytesPerValue, true, bytes);
   }
 
+  @Override
+  public int compareBytes(int index, int numBytesPerValue, byte[] bytes) {
+    long startOffset = (long) index * numBytesPerValue;
+    return ValueReaderComparisons.compareBytes(_dataBuffer, startOffset, numBytesPerValue, bytes);
+  }
+
   public void writeInt(int index, int value) {
     _dataBuffer.putInt((long) index * Integer.BYTES, value);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/ValueReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/ValueReader.java
@@ -65,4 +65,9 @@ public interface ValueReader extends Closeable {
    * Returns the comparison result of the UTF-8 decoded values.
    */
   int compareUtf8Bytes(int index, int numBytesPerValue, byte[] bytes);
+
+  /**
+   * Returns the comparison result of the bytes values.
+   */
+  int compareBytes(int index, int numBytesPerValue, byte[] bytes);
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/ValueReaderComparisons.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/ValueReaderComparisons.java
@@ -54,6 +54,17 @@ public class ValueReaderComparisons {
     return -1;
   }
 
+  static int compareBytes(PinotDataBuffer dataBuffer, long startOffset, int length, byte[] bytes) {
+    // can use MethodHandles.byteArrayViewVarHandle here after dropping JDK8
+    ByteBuffer buffer = ByteBuffer.wrap(bytes);
+    int mismatchPosition = mismatch(dataBuffer, startOffset, length, buffer);
+    if (mismatchPosition == -1) {
+      return length - bytes.length;
+    }
+    // can use Byte.compareUnsigned here after dropping JDK8
+    return (dataBuffer.getByte(startOffset + mismatchPosition) & 0xFF) - (bytes[mismatchPosition] & 0xFF);
+  }
+
   static int compareUtf8Bytes(PinotDataBuffer dataBuffer, long startOffset, int length, boolean padded, byte[] bytes) {
     // can use MethodHandles.byteArrayViewVarHandle here after dropping JDK8
     ByteBuffer buffer = ByteBuffer.wrap(bytes);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/VarLengthValueReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/VarLengthValueReader.java
@@ -129,6 +129,15 @@ public class VarLengthValueReader implements ValueReader {
   }
 
   @Override
+  public int compareBytes(int index, int numBytesPerValue, byte[] bytes) {
+    int offsetPosition = _dataSectionStartOffSet + Integer.BYTES * index;
+    int startOffset = _dataBuffer.getInt(offsetPosition);
+    int endOffset = _dataBuffer.getInt(offsetPosition + Integer.BYTES);
+    int length = endOffset - startOffset;
+    return ValueReaderComparisons.compareBytes(_dataBuffer, startOffset, length, bytes);
+  }
+
+  @Override
   public void close() {
     // NOTE: DO NOT close the PinotDataBuffer here because it is tracked by the caller and might be reused later. The
     // caller is responsible of closing the PinotDataBuffer.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BaseImmutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BaseImmutableDictionary.java
@@ -27,7 +27,6 @@ import org.apache.pinot.segment.local.io.util.ValueReader;
 import org.apache.pinot.segment.local.io.util.VarLengthValueReader;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
-import org.apache.pinot.spi.utils.ByteArray;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 
@@ -212,7 +211,6 @@ public abstract class BaseImmutableDictionary implements Dictionary {
     byte[] utf8 = value.getBytes(UTF_8);
     while (low <= high) {
       int mid = (low + high) >>> 1;
-      // method requires zero padding byte, not safe to call in nonzero padding byte branch below
       int compareResult = _valueReader.compareUtf8Bytes(mid, _numBytesPerValue, utf8);
       if (compareResult < 0) {
         low = mid + 1;
@@ -228,11 +226,9 @@ public abstract class BaseImmutableDictionary implements Dictionary {
   protected int binarySearch(byte[] value) {
     int low = 0;
     int high = _length - 1;
-
     while (low <= high) {
       int mid = (low + high) >>> 1;
-      byte[] midValue = _valueReader.getBytes(mid, _numBytesPerValue);
-      int compareResult = ByteArray.compare(midValue, value);
+      int compareResult = _valueReader.compareBytes(mid, _numBytesPerValue, value);
       if (compareResult < 0) {
         low = mid + 1;
       } else if (compareResult > 0) {


### PR DESCRIPTION
Extends the idea in #10044 to accelerate the bytes comparison without reading the whole bytes value out.
We already have enough test coverage with `ImmutableDictionaryTest`, so not adding additional test.