### PR TITLE
[multistage] add support for stage parallelism

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Map;
 import java.util.Properties;
 import org.apache.calcite.config.CalciteConnectionConfigImpl;
 import org.apache.calcite.config.CalciteConnectionProperty;
@@ -135,7 +136,7 @@ public class QueryEnvironment {
     try (PlannerContext plannerContext = new PlannerContext(_config, _catalogReader, _typeFactory, _hepProgram)) {
       plannerContext.setOptions(sqlNodeAndOptions.getOptions());
       RelRoot relRoot = compileQuery(sqlNodeAndOptions.getSqlNode(), plannerContext);
-      return toDispatchablePlan(relRoot, plannerContext, requestId);
+      return toDispatchablePlan(relRoot, plannerContext, requestId, sqlNodeAndOptions.getOptions());
     } catch (CalciteContextException e) {
       throw new RuntimeException("Error composing query plan for '" + sqlQuery
           + "': " + e.getMessage() + "'", e);
@@ -225,10 +226,11 @@ public class QueryEnvironment {
     }
   }
 
-  private QueryPlan toDispatchablePlan(RelRoot relRoot, PlannerContext plannerContext, long requestId) {
+  private QueryPlan toDispatchablePlan(RelRoot relRoot, PlannerContext plannerContext, long requestId,
+      Map<String, String> options) {
     // 5. construct a dispatchable query plan.
     StagePlanner queryStagePlanner = new StagePlanner(plannerContext, _workerManager, requestId, _tableCache);
-    return queryStagePlanner.makePlan(relRoot);
+    return queryStagePlanner.makePlan(relRoot, options);
   }
 
   // --------------------------------------------------------------------------

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -21,7 +21,6 @@ package org.apache.pinot.query;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Map;
 import java.util.Properties;
 import org.apache.calcite.config.CalciteConnectionConfigImpl;
 import org.apache.calcite.config.CalciteConnectionProperty;
@@ -136,7 +135,7 @@ public class QueryEnvironment {
     try (PlannerContext plannerContext = new PlannerContext(_config, _catalogReader, _typeFactory, _hepProgram)) {
       plannerContext.setOptions(sqlNodeAndOptions.getOptions());
       RelRoot relRoot = compileQuery(sqlNodeAndOptions.getSqlNode(), plannerContext);
-      return toDispatchablePlan(relRoot, plannerContext, requestId, sqlNodeAndOptions.getOptions());
+      return toDispatchablePlan(relRoot, plannerContext, requestId);
     } catch (CalciteContextException e) {
       throw new RuntimeException("Error composing query plan for '" + sqlQuery
           + "': " + e.getMessage() + "'", e);
@@ -226,11 +225,10 @@ public class QueryEnvironment {
     }
   }
 
-  private QueryPlan toDispatchablePlan(RelRoot relRoot, PlannerContext plannerContext, long requestId,
-      Map<String, String> options) {
+  private QueryPlan toDispatchablePlan(RelRoot relRoot, PlannerContext plannerContext, long requestId) {
     // 5. construct a dispatchable query plan.
     StagePlanner queryStagePlanner = new StagePlanner(plannerContext, _workerManager, requestId, _tableCache);
-    return queryStagePlanner.makePlan(relRoot, options);
+    return queryStagePlanner.makePlan(relRoot);
   }
 
   // --------------------------------------------------------------------------

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/StagePlanner.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/StagePlanner.java
@@ -61,9 +61,10 @@ public class StagePlanner {
    * Construct the dispatchable plan from relational logical plan.
    *
    * @param relRoot relational plan root.
+   * @param options configured per-query options that affect planning
    * @return dispatchable plan.
    */
-  public QueryPlan makePlan(RelRoot relRoot) {
+  public QueryPlan makePlan(RelRoot relRoot, Map<String, String> options) {
     RelNode relRootNode = relRoot.rel;
     // Stage ID starts with 1, 0 will be reserved for ROOT stage.
     _stageIdCounter = 1;
@@ -85,7 +86,7 @@ public class StagePlanner {
 
     // assign workers to each stage.
     for (Map.Entry<Integer, StageMetadata> e : queryPlan.getStageMetadataMap().entrySet()) {
-      _workerManager.assignWorkerToStage(e.getKey(), e.getValue(), _requestId);
+      _workerManager.assignWorkerToStage(e.getKey(), e.getValue(), _requestId, options);
     }
 
     // Run physical optimizations

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/StagePlanner.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/StagePlanner.java
@@ -61,10 +61,9 @@ public class StagePlanner {
    * Construct the dispatchable plan from relational logical plan.
    *
    * @param relRoot relational plan root.
-   * @param options configured per-query options that affect planning
    * @return dispatchable plan.
    */
-  public QueryPlan makePlan(RelRoot relRoot, Map<String, String> options) {
+  public QueryPlan makePlan(RelRoot relRoot) {
     RelNode relRootNode = relRoot.rel;
     // Stage ID starts with 1, 0 will be reserved for ROOT stage.
     _stageIdCounter = 1;
@@ -86,7 +85,7 @@ public class StagePlanner {
 
     // assign workers to each stage.
     for (Map.Entry<Integer, StageMetadata> e : queryPlan.getStageMetadataMap().entrySet()) {
-      _workerManager.assignWorkerToStage(e.getKey(), e.getValue(), _requestId, options);
+      _workerManager.assignWorkerToStage(e.getKey(), e.getValue(), _requestId, _plannerContext.getOptions());
     }
 
     // Run physical optimizations

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -90,6 +90,11 @@ public class MailboxSendOperator extends MultiStageOperator {
       for (VirtualServer serverInstance : receivingStageInstances) {
         if (serverInstance.getHostname().equals(mailboxService.getHostname())
             && serverInstance.getQueryMailboxPort() == mailboxService.getMailboxPort()) {
+          if (singletonInstance != null && singletonInstance.getServer().equals(serverInstance.getServer())) {
+            throw new IllegalArgumentException("Cannot issue query with stageParallelism > 1 for queries that "
+                + "use SINGLETON exchange. This is an internal limitation that is being worked on - reissue "
+                + "your query again without stageParallelism.");
+          }
           Preconditions.checkState(singletonInstance == null, "multiple instance found for singleton exchange type!");
           singletonInstance = serverInstance;
         }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
@@ -112,6 +112,11 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
 
   protected List<Object[]> queryH2(String sql)
       throws Exception {
+    int firstSemi = sql.indexOf(';');
+    if (firstSemi > 0 && firstSemi != sql.length() - 1) {
+      // trim off any SET statements for H2
+      sql = sql.substring(firstSemi + 1);
+    }
     Statement h2statement = _h2Connection.createStatement(ResultSet.TYPE_FORWARD_ONLY, ResultSet.CONCUR_READ_ONLY);
     h2statement.execute(sql);
     ResultSet h2ResultSet = h2statement.getResultSet();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/serde/QueryPlanSerDeUtilsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/serde/QueryPlanSerDeUtilsTest.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.query.runtime.plan.serde;
+
+import org.apache.pinot.query.routing.VirtualServer;
+import org.mockito.Mockito;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class QueryPlanSerDeUtilsTest {
+
+  @Test
+  public void shouldSerializeServer() {
+    // Given:
+    VirtualServer server = Mockito.mock(VirtualServer.class);
+    Mockito.when(server.getVirtualId()).thenReturn(1);
+    Mockito.when(server.getHostname()).thenReturn("Server_192.987.1.123");
+    Mockito.when(server.getPort()).thenReturn(80);
+    Mockito.when(server.getGrpcPort()).thenReturn(10);
+    Mockito.when(server.getQueryServicePort()).thenReturn(20);
+    Mockito.when(server.getQueryMailboxPort()).thenReturn(30);
+
+    // When:
+    String serialized = QueryPlanSerDeUtils.instanceToString(server);
+
+    // Then:
+    Assert.assertEquals(serialized, "1@Server_192.987.1.123:80(10:20:30)");
+  }
+
+  @Test
+  public void shouldDeserializeServerString() {
+    // Given:
+    String serverString = "1@Server_192.987.1.123:80(10:20:30)";
+
+    // When:
+    VirtualServer server = QueryPlanSerDeUtils.stringToInstance(serverString);
+
+    // Then:
+    Assert.assertEquals(server.getVirtualId(), 1);
+    Assert.assertEquals(server.getHostname(), "Server_192.987.1.123");
+    Assert.assertEquals(server.getPort(), 80);
+    Assert.assertEquals(server.getGrpcPort(), 10);
+    Assert.assertEquals(server.getQueryServicePort(), 20);
+    Assert.assertEquals(server.getQueryMailboxPort(), 30);
+  }
+}

--- a/pinot-query-runtime/src/test/resources/queries/Parallelism.json
+++ b/pinot-query-runtime/src/test/resources/queries/Parallelism.json
@@ -1,0 +1,47 @@
+{
+  "test_parallelism": {
+    "tables": {
+      "l": {
+        "schema": [
+          {"name": "key", "type": "STRING"},
+          {"name": "lval", "type": "INT"}
+        ],
+        "inputs": [
+          ["foo", 1],
+          ["foo", 3],
+          ["foo", 5],
+          ["bar", 2],
+          ["bar", 4],
+          ["bar", 6]
+        ]
+      },
+      "r": {
+        "schema": [
+          {"name": "key", "type": "STRING"},
+          {"name": "rval", "type": "INT"}
+        ],
+        "inputs": [
+          ["foo", 1],
+          ["foo", 3],
+          ["foo", 7],
+          ["bar", 2],
+          ["bar", 4],
+          ["bar", 8]
+        ]
+      }
+    },
+    "queries": [
+      {"sql": "SET stageParallelism=2; SELECT * FROM {l} WHERE lval > 3"},
+      {"sql": "SET stageParallelism=2; SELECT * FROM {l} WHERE lval > 3 ORDER BY lval LIMIT 1"},
+      {"sql": "SET stageParallelism=2; SELECT key, SUM(lval) FROM {l} GROUP BY key"},
+      {"sql": "SET stageParallelism=2; SELECT {l}.key, {l}.lval, {r}.rval FROM {l} JOIN {r} ON {l}.key = {r}.key"},
+      {"sql": "SET stageParallelism=2; SELECT {l}.key, SUM({l}.lval + {r}.rval) FROM {l} JOIN {r} ON {l}.key = {r}.key GROUP BY {l}.key"},
+      {"sql": "SET stageParallelism=2; SELECT * FROM {l} WHERE lval NOT IN (SELECT rval FROM {r} WHERE rval > 2)"},
+      {
+        "description": "current stage parallelism doesn't work with broadcast join",
+        "sql": "SET stageParallelism=2; SELECT * FROM {l}, {r}",
+        "expectedException": ".*Cannot issue query with stageParallelism > 1 for queries that use SINGLETON exchange.*"
+      }
+    ]
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -299,6 +299,7 @@ public class CommonConstants {
         public static final String NUM_GROUPS_LIMIT = "numGroupsLimit";
         public static final String MAX_INITIAL_RESULT_HOLDER_CAPACITY = "maxInitialResultHolderCapacity";
         public static final String GROUP_TRIM_THRESHOLD = "groupTrimThreshold";
+        public static final String STAGE_PARALLELISM = "stageParallelism";
 
         // TODO: Remove these keys (only apply to PQL) after releasing 0.11.0
         @Deprecated


### PR DESCRIPTION
This PR introduces the per-query configuration of `stageParallelism` to allow running intermediate nodes in parallel. For example: `SET stageParallelism=2; SELECT ...` will run intermediate stages with 2x more threads than there are intermediate servers. 

The main change is in `WorkerManager`, where the configuration is utilized.