### PR TITLE
[multistage] fixing IN subquery compilation issue

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -102,6 +102,8 @@ public class QueryEnvironment {
         .defaultSchema(_rootSchema.plus())
         .sqlToRelConverterConfig(SqlToRelConverter.config()
             .withHintStrategyTable(getHintStrategyTable())
+            // SUB-QUERY Threshold is useless as we are encoding all IN clause in-line anyway
+            .withInSubQueryThreshold(Integer.MAX_VALUE)
             .addRelBuilderConfigTransform(c -> c.withPushJoinCondition(true))
             .addRelBuilderConfigTransform(c -> c.withAggregateUnique(true)))
         .build();

--- a/pinot-query-runtime/src/test/resources/queries/TableExpressions.json
+++ b/pinot-query-runtime/src/test/resources/queries/TableExpressions.json
@@ -12,6 +12,9 @@
           ["bar", 2],
           ["alice", 42],
           ["bob", 196883]
+        ],
+        "partitionColumns": [
+          "strCol"
         ]
       }
     },
@@ -22,6 +25,10 @@
       { "sql": "SELECT * FROM {tbl} WHERE intCol > 5" },
       { "sql": "SELECT * FROM {tbl} WHERE strCol IN ('foo', 'bar')" },
       { "sql": "SELECT * FROM {tbl} WHERE intCol IN (196883, 42)" },
+      { "sql": "SELECT * FROM {tbl} WHERE strCol IN ('foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar')" },
+      { "sql": "SELECT * FROM {tbl} WHERE intCol IN (1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15, 16, 17, 20, 21, 22, 23, 24, 25, 26, 27, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)" },
+      { "sql": "SELECT * FROM {tbl} WHERE strCol NOT IN ('foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar', 'foo', 'bar')" },
+      { "sql": "SELECT * FROM {tbl} WHERE intCol NOT IN (1, 2, 3, 4, 5, 6, 7, 10, 11, 12, 13, 14, 15, 16, 17, 20, 21, 22, 23, 24, 25, 26, 27, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10)" },
       { "sql": "SELECT * FROM {tbl} WHERE intCol NOT IN (196883, 42) AND strCol IN ('alice')" },
       { "sql": "SELECT * FROM {tbl} WHERE strCol IN (SELECT strCol FROM {tbl} WHERE intCol > 100)" },
       { "sql": "SELECT * FROM {tbl} WHERE intCol < (SELECT SUM(intCol) FROM {tbl} AS b WHERE strCol BETWEEN 'bar' AND 'foo')" },


### PR DESCRIPTION
Calcite has default LogicalValue conversion rule to convert `IN (xxx)` into a static-table with semi-join logic. 
- when IN clause has more than 20 items, it causes trouble confuses Pinot's join-exchange rule. 
- this logic is not useful since we encode the IN clause entirely in expression.

removing it by setting the conversion threshold to int max