### PR TITLE
Enhance early termination for combine operators

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
@@ -69,7 +69,7 @@ public class AcquireReleaseColumnsSegmentOperator extends BaseOperator<BaseResul
   public void acquire() {
     // do not acquire if interrupted (similar to the check inside the nextBlock())
     if (Thread.interrupted()) {
-      throw new EarlyTerminationException();
+      throw new EarlyTerminationException("Interrupted while acquiring segment");
     }
     _indexSegment.acquire(_fetchContext);
   }
@@ -80,7 +80,6 @@ public class AcquireReleaseColumnsSegmentOperator extends BaseOperator<BaseResul
   public void release() {
     _indexSegment.release(_fetchContext);
   }
-
 
   @Override
   public String toExplainString() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/BaseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/BaseOperator.java
@@ -37,7 +37,7 @@ public abstract class BaseOperator<T extends Block> implements Operator<T> {
        itself will cancel all worker's futures. Therefore, the worker will interrupt even if we only kill the runner
        thread. */
     if (Tracing.ThreadAccountantOps.isInterrupted()) {
-      throw new EarlyTerminationException();
+      throw new EarlyTerminationException("Interrupted while processing next block");
     }
     try (InvocationScope ignored = Tracing.getTracer().createScope(getClass())) {
       return getNextBlock();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
@@ -119,7 +119,8 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
     } catch (EarlyTerminationException e) {
       Exception killedErrorMsg = Tracing.getThreadAccountant().getErrorStatus();
       return new ExceptionResultsBlock(new QueryCancelledException(
-          "Cancelled while combining results" + (killedErrorMsg == null ? StringUtils.EMPTY : " " + killedErrorMsg)));
+          "Cancelled while combining results" + (killedErrorMsg == null ? StringUtils.EMPTY : " " + killedErrorMsg),
+          e));
     } finally {
       releaseAll();
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
@@ -69,7 +69,7 @@ public abstract class BaseSingleBlockCombineOperator<T extends BaseResultsBlock>
       startProcess();
       mergedBlock = mergeResults();
     } catch (InterruptedException e) {
-      throw new EarlyTerminationException();
+      throw new EarlyTerminationException("Interrupted while merging results blocks", e);
     } catch (Exception e) {
       LOGGER.error("Caught exception while merging results blocks (query: {})", _queryContext, e);
       mergedBlock = new ExceptionResultsBlock(QueryException.getException(QueryException.INTERNAL_ERROR, e));

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
@@ -301,15 +301,6 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator
     return mergedBlock;
   }
 
-  @Override
-  protected void onProcessSegmentsException(Throwable t) {
-    _blockingQueue.offer(new ExceptionResultsBlock(t));
-  }
-
-  @Override
-  protected void onProcessSegmentsFinish() {
-  }
-
   protected void mergeResultsBlocks(SelectionResultsBlock mergedBlock, SelectionResultsBlock blockToMerge) {
     DataSchema mergedDataSchema = mergedBlock.getDataSchema();
     DataSchema dataSchemaToMerge = blockToMerge.getDataSchema();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/BaseStreamingCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/BaseStreamingCombineOperator.java
@@ -32,8 +32,10 @@ import org.apache.pinot.core.operator.blocks.results.ExceptionResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.MetadataResultsBlock;
 import org.apache.pinot.core.operator.combine.BaseCombineOperator;
 import org.apache.pinot.core.operator.combine.CombineOperatorUtils;
+import org.apache.pinot.core.operator.combine.merger.ResultsBlockMerger;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
+import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -50,37 +52,41 @@ public abstract class BaseStreamingCombineOperator<T extends BaseResultsBlock>
 
   // Use a BlockingQueue to store the intermediate results blocks
   protected final BlockingQueue<BaseResultsBlock> _blockingQueue = new LinkedBlockingQueue<>();
+  protected final ResultsBlockMerger<T> _resultsBlockMerger;
 
   protected int _numOperatorsFinished;
-  protected BaseResultsBlock _exceptionBlock;
+  protected boolean _querySatisfied;
 
-  public BaseStreamingCombineOperator(List<Operator> operators,
+  public BaseStreamingCombineOperator(ResultsBlockMerger<T> resultsBlockMerger, List<Operator> operators,
       QueryContext queryContext, ExecutorService executorService) {
     super(operators, queryContext, executorService);
+    _resultsBlockMerger = resultsBlockMerger;
   }
 
+  /**
+   * {@inheritDoc}
+   *
+   * When all the results blocks are returned, returns a final metadata block. Caller shouldn't call this method after
+   * it returns the metadata block or exception block.
+   */
   @Override
   protected BaseResultsBlock getNextBlock() {
     long endTimeMs = _queryContext.getEndTimeMs();
-    // TODO: Early terminate when query is satisfied
-    while (_exceptionBlock == null && _numOperatorsFinished < _numOperators) {
+    Object querySatisfiedTracker = createQuerySatisfiedTracker();
+    while (!_querySatisfied && _numOperatorsFinished < _numOperators) {
       try {
         BaseResultsBlock resultsBlock =
             _blockingQueue.poll(endTimeMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
-
         if (resultsBlock == null) {
           // Query times out, skip streaming the remaining results blocks
           LOGGER.error("Timed out while polling results block (query: {})", _queryContext);
-          _exceptionBlock = new ExceptionResultsBlock(
-              QueryException.getException(QueryException.EXECUTION_TIMEOUT_ERROR,
-                  new TimeoutException("Timed out while polling results block")));
-          return _exceptionBlock;
+          return new ExceptionResultsBlock(QueryException.getException(QueryException.EXECUTION_TIMEOUT_ERROR,
+              new TimeoutException("Timed out while polling results block")));
         }
         if (resultsBlock.getProcessingExceptions() != null) {
           // Caught exception while processing segment, skip streaming the remaining results blocks and directly return
           // the exception
-          _exceptionBlock = resultsBlock;
-          return _exceptionBlock;
+          return resultsBlock;
         }
         if (resultsBlock == LAST_RESULTS_BLOCK) {
           // Caught LAST_RESULTS_BLOCK from a specific task, indicated it has finished.
@@ -88,11 +94,13 @@ public abstract class BaseStreamingCombineOperator<T extends BaseResultsBlock>
           _numOperatorsFinished++;
           continue;
         }
+        _querySatisfied = isQuerySatisfied((T) resultsBlock, querySatisfiedTracker);
         return resultsBlock;
+      } catch (InterruptedException e) {
+        throw new EarlyTerminationException();
       } catch (Exception e) {
-        LOGGER.error("Caught exception while merging results blocks (query: {})", _queryContext, e);
-        _exceptionBlock = new ExceptionResultsBlock(QueryException.getException(QueryException.INTERNAL_ERROR, e));
-        return _exceptionBlock;
+        LOGGER.error("Caught exception while streaming results blocks (query: {})", _queryContext, e);
+        return new ExceptionResultsBlock(QueryException.getException(QueryException.INTERNAL_ERROR, e));
       }
     }
     // Setting the execution stats for the final return
@@ -106,28 +114,35 @@ public abstract class BaseStreamingCombineOperator<T extends BaseResultsBlock>
   @Override
   protected void processSegments() {
     int operatorId;
+    Object tracker = createQuerySatisfiedTracker();
     while ((operatorId = _nextOperatorId.getAndIncrement()) < _numOperators) {
       Operator<T> operator = _operators.get(operatorId);
-      // If the combine operator indicates it should finish all its operator tasks. Then skip acquiring the
-      // segments entirely.
-      if (!shouldFinishOperators()) {
-        try {
-          if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
-            ((AcquireReleaseColumnsSegmentOperator) operator).acquire();
+      try {
+        if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
+          ((AcquireReleaseColumnsSegmentOperator) operator).acquire();
+        }
+        if (isChildOperatorSingleBlock()) {
+          T resultsBlock = operator.nextBlock();
+          _blockingQueue.offer(resultsBlock);
+          // When query is satisfied, skip processing the remaining segments
+          if (isQuerySatisfied(resultsBlock, tracker)) {
+            _nextOperatorId.set(_numOperators);
+            return;
           }
+        } else {
           T resultsBlock;
           while ((resultsBlock = operator.nextBlock()) != null) {
-            if (isOperatorSatisfied(resultsBlock)) {
-              _blockingQueue.offer(resultsBlock);
-              break;
-            } else {
-              _blockingQueue.offer(resultsBlock);
+            _blockingQueue.offer(resultsBlock);
+            // When query is satisfied, skip processing the remaining segments
+            if (isQuerySatisfied(resultsBlock, tracker)) {
+              _nextOperatorId.set(_numOperators);
+              return;
             }
           }
-        } finally {
-          if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
-            ((AcquireReleaseColumnsSegmentOperator) operator).release();
-          }
+        }
+      } finally {
+        if (operator instanceof AcquireReleaseColumnsSegmentOperator) {
+          ((AcquireReleaseColumnsSegmentOperator) operator).release();
         }
       }
       // offer the LAST_RESULTS_BLOCK indicate finish of the current operator.
@@ -145,22 +160,24 @@ public abstract class BaseStreamingCombineOperator<T extends BaseResultsBlock>
   }
 
   /**
-   * Determine if a returned result block from operator sub-task has already satisfied the query requirement.
-   *
-   * @param resultsBlock the result block returned from operator run in sub-task
-   * @return true if no more getNextBlock() should be called this particular operator.
+   * Returns whether the child operator returns only a single block.
    */
-  protected boolean isOperatorSatisfied(T resultsBlock) {
-    return resultsBlock == null;
+  protected boolean isChildOperatorSingleBlock() {
+    return true;
   }
 
   /**
-   * Determine if the aggregated condition of the all the operator sub-tasks has satisfied the query requirement.
-   *
-   * @return true if we should not schedule any additional {@link Operator#nextBlock()}.
+   * Creates a tracker object to track if the query is satisfied.
    */
-  protected boolean shouldFinishOperators() {
-    return false;
+  protected Object createQuerySatisfiedTracker() {
+    return null;
+  }
+
+  /**
+   * Returns {@code true} if the query is already satisfied with the results block.
+   */
+  protected boolean isQuerySatisfied(T resultsBlock, Object tracker) {
+    return _resultsBlockMerger.isQuerySatisfied(resultsBlock);
   }
 
   public void start() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/BaseStreamingCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/BaseStreamingCombineOperator.java
@@ -97,7 +97,7 @@ public abstract class BaseStreamingCombineOperator<T extends BaseResultsBlock>
         _querySatisfied = isQuerySatisfied((T) resultsBlock, querySatisfiedTracker);
         return resultsBlock;
       } catch (InterruptedException e) {
-        throw new EarlyTerminationException();
+        throw new EarlyTerminationException("Interrupted while streaming results blocks", e);
       } catch (Exception e) {
         LOGGER.error("Caught exception while streaming results blocks (query: {})", _queryContext, e);
         return new ExceptionResultsBlock(QueryException.getException(QueryException.INTERNAL_ERROR, e));

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingAggregationCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingAggregationCombineOperator.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
+import org.apache.pinot.core.operator.combine.merger.AggregationResultsBlockMerger;
 import org.apache.pinot.core.query.request.context.QueryContext;
 
 
@@ -34,17 +35,11 @@ public class StreamingAggregationCombineOperator extends BaseStreamingCombineOpe
 
   public StreamingAggregationCombineOperator(List<Operator> operators, QueryContext queryContext,
       ExecutorService executorService) {
-    super(operators, queryContext, executorService);
+    super(new AggregationResultsBlockMerger(queryContext), operators, queryContext, executorService);
   }
 
   @Override
   public String toExplainString() {
     return EXPLAIN_NAME;
-  }
-
-  @Override
-  protected boolean isOperatorSatisfied(AggregationResultsBlock resultsBlock) {
-    // AggregateResultBlock is produced once per segment, thus operator is always satisfied after the first block
-    return true;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingDistinctCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingDistinctCombineOperator.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.results.DistinctResultsBlock;
+import org.apache.pinot.core.operator.combine.merger.DistinctResultsBlockMerger;
 import org.apache.pinot.core.query.request.context.QueryContext;
 
 
@@ -34,17 +35,11 @@ public class StreamingDistinctCombineOperator extends BaseStreamingCombineOperat
 
   public StreamingDistinctCombineOperator(List<Operator> operators, QueryContext queryContext,
       ExecutorService executorService) {
-    super(operators, queryContext, executorService);
+    super(new DistinctResultsBlockMerger(queryContext), operators, queryContext, executorService);
   }
 
   @Override
   public String toExplainString() {
     return EXPLAIN_NAME;
-  }
-
-  @Override
-  protected boolean isOperatorSatisfied(DistinctResultsBlock resultsBlock) {
-    // DistinctResultsBlock is produced once per segment, thus operator is always satisfied after the first block
-    return true;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java
@@ -120,7 +120,7 @@ public class StreamingGroupByCombineOperator extends BaseStreamingCombineOperato
       try {
         return getFinalResult();
       } catch (InterruptedException e) {
-        throw new EarlyTerminationException();
+        throw new EarlyTerminationException("Interrupted while merging results blocks", e);
       } catch (Exception e) {
         LOGGER.error("Caught exception while merging results blocks (query: {})", _queryContext, e);
         return new ExceptionResultsBlock(QueryException.getException(QueryException.INTERNAL_ERROR, e));

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java
@@ -28,7 +28,6 @@ import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
@@ -52,8 +51,6 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
 import org.apache.pinot.core.util.GroupByUtils;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
-import org.apache.pinot.spi.exception.QueryCancelledException;
-import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.LoopUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -87,7 +84,7 @@ public class StreamingGroupByCombineOperator extends BaseStreamingCombineOperato
 
   public StreamingGroupByCombineOperator(List<Operator> operators, QueryContext queryContext,
       ExecutorService executorService) {
-    super(operators, overrideMaxExecutionThreads(queryContext, operators.size()), executorService);
+    super(null, operators, overrideMaxExecutionThreads(queryContext, operators.size()), executorService);
 
     int minTrimSize = queryContext.getMinServerGroupTrimSize();
     if (minTrimSize > 0) {
@@ -119,25 +116,14 @@ public class StreamingGroupByCombineOperator extends BaseStreamingCombineOperato
 
   @Override
   protected BaseResultsBlock getNextBlock() {
-    while (_exceptionBlock == null && !_opCompleted) {
+    if (!_opCompleted) {
       try {
-        // This guarantees final result block is reduced
-        BaseResultsBlock resultsBlock = getFinalResult();
-        if (resultsBlock instanceof ExceptionResultsBlock) {
-          _exceptionBlock = resultsBlock;
-          return _exceptionBlock;
-        } else {
-          return resultsBlock;
-        }
-      } catch (InterruptedException | EarlyTerminationException e) {
-        Exception killedErrorMsg = Tracing.getThreadAccountant().getErrorStatus();
-        _exceptionBlock = new ExceptionResultsBlock(new QueryCancelledException(
-            "result block stream cancelled" + (killedErrorMsg == null ? StringUtils.EMPTY : " " + killedErrorMsg), e));
-        return _exceptionBlock;
+        return getFinalResult();
+      } catch (InterruptedException e) {
+        throw new EarlyTerminationException();
       } catch (Exception e) {
         LOGGER.error("Caught exception while merging results blocks (query: {})", _queryContext, e);
-        _exceptionBlock = new ExceptionResultsBlock(QueryException.getException(QueryException.INTERNAL_ERROR, e));
-        return _exceptionBlock;
+        return new ExceptionResultsBlock(QueryException.getException(QueryException.INTERNAL_ERROR, e));
       }
     }
     // Setting the execution stats for the final return
@@ -250,7 +236,7 @@ public class StreamingGroupByCombineOperator extends BaseStreamingCombineOperato
 
   // TODO: combine this with the single block group by combine operator
   private BaseResultsBlock getFinalResult()
-      throws Exception {
+      throws InterruptedException {
     long timeoutMs = _queryContext.getEndTimeMs() - System.currentTimeMillis();
     _opCompleted = _operatorLatch.await(timeoutMs, TimeUnit.MILLISECONDS);
     if (!_opCompleted) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingInstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingInstanceResponseOperator.java
@@ -74,8 +74,8 @@ public class StreamingInstanceResponseOperator extends InstanceResponseOperator 
     } catch (EarlyTerminationException e) {
       Exception killedErrorMsg = Tracing.getThreadAccountant().getErrorStatus();
       return new InstanceResponseBlock(new ExceptionResultsBlock(new QueryCancelledException(
-          "Cancelled while streaming results" + (killedErrorMsg == null ? StringUtils.EMPTY : " " + killedErrorMsg))),
-          _queryContext);
+          "Cancelled while streaming results" + (killedErrorMsg == null ? StringUtils.EMPTY : " " + killedErrorMsg),
+          e)), _queryContext);
     } catch (Exception e) {
       return new InstanceResponseBlock(new ExceptionResultsBlock(QueryException.DATA_TABLE_SERIALIZATION_ERROR, e),
           _queryContext);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingInstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingInstanceResponseOperator.java
@@ -23,6 +23,7 @@ import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.proto.Server;
@@ -36,6 +37,9 @@ import org.apache.pinot.core.operator.combine.BaseCombineOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.FetchContext;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.spi.exception.EarlyTerminationException;
+import org.apache.pinot.spi.exception.QueryCancelledException;
+import org.apache.pinot.spi.trace.Tracing;
 
 
 public class StreamingInstanceResponseOperator extends InstanceResponseOperator {
@@ -67,6 +71,11 @@ public class StreamingInstanceResponseOperator extends InstanceResponseOperator 
       }
       // Return a metadata-only block
       return new InstanceResponseBlock(resultsBlock, _queryContext);
+    } catch (EarlyTerminationException e) {
+      Exception killedErrorMsg = Tracing.getThreadAccountant().getErrorStatus();
+      return new InstanceResponseBlock(new ExceptionResultsBlock(new QueryCancelledException(
+          "Cancelled while streaming results" + (killedErrorMsg == null ? StringUtils.EMPTY : " " + killedErrorMsg))),
+          _queryContext);
     } catch (Exception e) {
       return new InstanceResponseBlock(new ExceptionResultsBlock(QueryException.DATA_TABLE_SERIALIZATION_ERROR, e),
           _queryContext);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOrderByCombineOperator.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
+import org.apache.pinot.core.operator.combine.merger.SelectionOrderByResultsBlockMerger;
 import org.apache.pinot.core.query.request.context.QueryContext;
 
 
@@ -34,16 +35,11 @@ public class StreamingSelectionOrderByCombineOperator extends BaseStreamingCombi
 
   public StreamingSelectionOrderByCombineOperator(List<Operator> operators, QueryContext queryContext,
       ExecutorService executorService) {
-    super(operators, queryContext, executorService);
+    super(new SelectionOrderByResultsBlockMerger(queryContext), operators, queryContext, executorService);
   }
 
   @Override
   public String toExplainString() {
     return EXPLAIN_NAME;
-  }
-
-  @Override
-  protected boolean isOperatorSatisfied(SelectionResultsBlock resultsBlock) {
-    return true;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/exception/EarlyTerminationException.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/exception/EarlyTerminationException.java
@@ -23,7 +23,16 @@ package org.apache.pinot.spi.exception;
  * terminated (interrupted).
  */
 public class EarlyTerminationException extends RuntimeException {
+
   public EarlyTerminationException() {
     super();
+  }
+
+  public EarlyTerminationException(String message) {
+    super(message);
+  }
+
+  public EarlyTerminationException(String message, Throwable cause) {
+    super(message, cause);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/LoopUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/LoopUtils.java
@@ -31,8 +31,8 @@ public class LoopUtils {
   // Check for thread interruption, every time after merging 8192 keys
   public static void checkMergePhaseInterruption(int mergedKeys) {
     if ((mergedKeys & MAX_ENTRIES_KEYS_MERGED_PER_INTERRUPTION_CHECK_MASK) == 0
-        && (Tracing.ThreadAccountantOps.isInterrupted())) {
-      throw new EarlyTerminationException();
+        && Tracing.ThreadAccountantOps.isInterrupted()) {
+      throw new EarlyTerminationException("Interrupted while merging records");
     }
   }
 }


### PR DESCRIPTION
- For single block combine operator, skip all remaining operators when query is satisfied
- For streaming combine operator, allow early termination when enough results are streamed back
- Handle `EarlyTerminationException` in the `InstanceResponseOperator` so that we won't miss the interrupt caught in `CombineOperator.nextBlock()`