### PR TITLE
Show correct query plan when prefetch is enabled

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/Operator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/Operator.java
@@ -51,6 +51,23 @@ public interface Operator<T extends Block> {
   default void prepareForExplainPlan(ExplainPlanRows explainPlanRows) {
   }
 
+  default void explainPlan(ExplainPlanRows explainPlanRows, int[] globalId, int parentId) {
+    prepareForExplainPlan(explainPlanRows);
+    String explainPlanString = toExplainString();
+    if (explainPlanString != null) {
+      ExplainPlanRowData explainPlanRowData = new ExplainPlanRowData(explainPlanString, globalId[0], parentId);
+      parentId = globalId[0]++;
+      explainPlanRows.appendExplainPlanRowData(explainPlanRowData);
+    }
+
+    List<? extends Operator> children = getChildOperators();
+    for (Operator child : children) {
+      if (child != null) {
+        child.explainPlan(explainPlanRows, globalId, parentId);
+      }
+    }
+  }
+
   /**
    * Returns the index segment associated with the operator.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/Operator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/Operator.java
@@ -48,6 +48,9 @@ public interface Operator<T extends Block> {
   @Nullable
   String toExplainString();
 
+  default void prepareForExplainPlan(ExplainPlanRows explainPlanRows) {
+  }
+
   /**
    * Returns the index segment associated with the operator.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
@@ -54,12 +54,16 @@ public class AcquireReleaseColumnsSegmentOperator extends BaseOperator<BaseResul
     _fetchContext = fetchContext;
   }
 
+  public void materializeChildOperator() {
+    _childOperator = (Operator<BaseResultsBlock>) _planNode.run();
+  }
+
   /**
    * Runs the planNode to get the childOperator, and then proceeds with execution.
    */
   @Override
   protected BaseResultsBlock getNextBlock() {
-    _childOperator = (Operator<BaseResultsBlock>) _planNode.run();
+    materializeChildOperator();
     return _childOperator.nextBlock();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.operator;
 
 import java.util.Collections;
 import java.util.List;
+import org.apache.pinot.core.common.ExplainPlanRows;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
 import org.apache.pinot.core.plan.PlanNode;
@@ -83,6 +84,12 @@ public class AcquireReleaseColumnsSegmentOperator extends BaseOperator<BaseResul
    */
   public void release() {
     _indexSegment.release(_fetchContext);
+  }
+
+  @Override
+  public void prepareForExplainPlan(ExplainPlanRows explainPlanRows) {
+    materializeChildOperator();
+    acquire();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
@@ -88,8 +88,8 @@ public class AcquireReleaseColumnsSegmentOperator extends BaseOperator<BaseResul
 
   @Override
   public void prepareForExplainPlan(ExplainPlanRows explainPlanRows) {
-    materializeChildOperator();
     acquire();
+    materializeChildOperator();
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
@@ -126,13 +126,13 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
     }
   }
 
-  protected void prefetchAll() {
+  public void prefetchAll() {
     for (int i = 0; i < _fetchContextSize; i++) {
       _indexSegments.get(i).prefetch(_fetchContexts.get(i));
     }
   }
 
-  protected void releaseAll() {
+  public void releaseAll() {
     for (int i = 0; i < _fetchContextSize; i++) {
       _indexSegments.get(i).release(_fetchContexts.get(i));
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/EmptyFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/EmptyFilterOperator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.operator.filter;
 
 import java.util.Collections;
 import java.util.List;
+import org.apache.pinot.core.common.ExplainPlanRows;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.EmptyFilterBlock;
 import org.apache.pinot.core.operator.blocks.FilterBlock;
@@ -70,5 +71,10 @@ public final class EmptyFilterOperator extends BaseFilterOperator {
   @Override
   public List<Operator> getChildOperators() {
     return Collections.emptyList();
+  }
+
+  @Override
+  public void prepareForExplainPlan(ExplainPlanRows explainPlanRows) {
+    explainPlanRows.setHasEmptyFilter(true);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.operator.filter;
 
 import java.util.Collections;
 import java.util.List;
+import org.apache.pinot.core.common.ExplainPlanRows;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.FilterBlock;
 import org.apache.pinot.core.operator.docidsets.MatchAllDocIdSet;
@@ -62,5 +63,10 @@ public class MatchAllFilterOperator extends BaseFilterOperator {
   @Override
   public String toExplainString() {
     return new StringBuilder(EXPLAIN_NAME).append("(docs:").append(_numDocs).append(')').toString();
+  }
+
+  @Override
+  public void prepareForExplainPlan(ExplainPlanRows explainPlanRows) {
+    explainPlanRows.setHasMatchAllFilter(true);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -47,6 +47,7 @@ import org.apache.pinot.core.common.ExplainPlanRows;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
+import org.apache.pinot.core.operator.AcquireReleaseColumnsSegmentOperator;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
@@ -476,6 +477,10 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       if (node instanceof MatchAllFilterOperator) {
         explainPlanRows.setHasMatchAllFilter(true);
       }
+    }
+
+    if (node instanceof AcquireReleaseColumnsSegmentOperator) {
+      ((AcquireReleaseColumnsSegmentOperator) node).materializeChildOperator();
     }
 
     List<Operator> children = node.getChildOperators();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -415,7 +415,9 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       int[] operatorId = {3};
       ExplainPlanRows explainPlanRows = new ExplainPlanRows();
       // Get the segment explain plan for a single segment
-      getSegmentExplainPlanRowData(child, explainPlanRows, operatorId, 2);
+      if (child != null) {
+        child.explainPlan(explainPlanRows, operatorId, 2);
+      }
       int numRows = explainPlanRows.getExplainPlanRowData().size();
       if (numRows > 0) {
         operatorDepthToRowDataMap.putIfAbsent(numRows, new ArrayList<>());
@@ -453,29 +455,6 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     }
 
     return operatorDepthToRowDataMap;
-  }
-
-  /**
-   * Get the list of Explain Plan rows for a single segment
-   */
-  private static void getSegmentExplainPlanRowData(Operator node, ExplainPlanRows explainPlanRows, int[] globalId,
-      int parentId) {
-    if (node == null) {
-      return;
-    }
-
-    node.prepareForExplainPlan(explainPlanRows);
-    String explainPlanString = node.toExplainString();
-    if (explainPlanString != null) {
-      ExplainPlanRowData explainPlanRowData = new ExplainPlanRowData(explainPlanString, globalId[0], parentId);
-      parentId = globalId[0]++;
-      explainPlanRows.appendExplainPlanRowData(explainPlanRowData);
-    }
-
-    List<Operator> children = node.getChildOperators();
-    for (Operator child : children) {
-      getSegmentExplainPlanRowData(child, explainPlanRows, globalId, parentId);
-    }
   }
 
   public static InstanceResponseBlock executeExplainQuery(Plan queryPlan, QueryContext queryContext) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -25,6 +25,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -143,6 +144,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
 
   private ServerMetrics _serverMetrics;
   private QueryExecutor _queryExecutor;
+  private QueryExecutor _queryExecutorWithPrefetchEnabled;
   private BrokerReduceService _brokerReduceService;
 
   @Override
@@ -319,13 +321,58 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     _queryExecutor = new ServerQueryExecutorV1Impl();
     _queryExecutor.init(new PinotConfiguration(queryExecutorConfig), instanceDataManager, _serverMetrics);
 
+    PinotConfiguration prefetchEnabledConf = new PinotConfiguration(queryExecutorConfig);
+    prefetchEnabledConf.setProperty(ServerQueryExecutorV1Impl.ENABLE_PREFETCH, "true");
+    _queryExecutorWithPrefetchEnabled = new ServerQueryExecutorV1Impl();
+    _queryExecutorWithPrefetchEnabled.init(prefetchEnabledConf, instanceDataManager, _serverMetrics);
+
     // Create the BrokerReduceService
     _brokerReduceService = new BrokerReduceService(new PinotConfiguration(
         Collections.singletonMap(CommonConstants.Broker.CONFIG_OF_MAX_REDUCE_THREADS_PER_QUERY, 2)));
   }
 
+  private ResultTable getPrefetchEnabledResulTable(ResultTable resultTable) {
+    // TODO does not work for cases where different segments have different plans (more than 1 PLAN_START rows)
+    List<Object[]> newRows = new ArrayList<>();
+    int acquireOpParentId = -1;
+
+    Iterator<Object[]> it = resultTable.getRows().iterator();
+    // After each PLAN_START, we need to add ACQUIRE_RELEASE_COLUMNS_SEGMENT (unles ALL_SEGMENTS_PRUNED_ON_SERVER),
+    // and all following op should have their ids incremented
+
+    while (it.hasNext()) {
+      Object[] row = it.next();
+      String op = row[0].toString();
+      newRows.add(row);
+      acquireOpParentId = Math.max(acquireOpParentId, (int) row[1]);
+      if (op.startsWith("PLAN_START")) {
+        newRows.add(new Object[]{"ACQUIRE_RELEASE_COLUMNS_SEGMENT", acquireOpParentId + 1, acquireOpParentId});
+        break;
+      }
+    }
+
+    while (it.hasNext()) {
+      Object[] row = it.next();
+      String op = row[0].toString();
+      newRows.add(new Object[]{row[0].toString(), ((int) row[1] + 1), ((int) row[2]) + 1});
+    }
+
+    return new ResultTable(resultTable.getDataSchema(), newRows);
+  }
+
   /** Checks the correctness of EXPLAIN PLAN output. */
   private void check(String query, ResultTable expected) {
+    check(query, expected, false);
+  }
+
+  private void check(String query, ResultTable expected, boolean checkPrefetchEnabled) {
+    checkWithQueryExecutor(query, expected, _queryExecutor);
+    if (checkPrefetchEnabled) {
+      checkWithQueryExecutor(query, getPrefetchEnabledResulTable(expected), _queryExecutorWithPrefetchEnabled);
+    }
+  }
+
+  private void checkWithQueryExecutor(String query, ResultTable expected, QueryExecutor queryExecutor) {
     BrokerRequest brokerRequest = CalciteSqlCompiler.compileToBrokerRequest(query);
 
     int segmentsForServer1 = _segmentNames.size() / 2;
@@ -343,10 +390,10 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     brokerRequest.getPinotQuery().getDataSource().setTableName(OFFLINE_TABLE_NAME);
     InstanceRequest instanceRequest1 = new InstanceRequest(0L, brokerRequest);
     instanceRequest1.setSearchSegments(indexSegmentsForServer1);
-    InstanceResponseBlock instanceResponse1 = _queryExecutor.execute(getQueryRequest(instanceRequest1), QUERY_RUNNERS);
+    InstanceResponseBlock instanceResponse1 = queryExecutor.execute(getQueryRequest(instanceRequest1), QUERY_RUNNERS);
     InstanceRequest instanceRequest2 = new InstanceRequest(0L, brokerRequest);
     instanceRequest2.setSearchSegments(indexSegmentsForServer2);
-    InstanceResponseBlock instanceResponse2 = _queryExecutor.execute(getQueryRequest(instanceRequest2), QUERY_RUNNERS);
+    InstanceResponseBlock instanceResponse2 = queryExecutor.execute(getQueryRequest(instanceRequest2), QUERY_RUNNERS);
 
     // Broker side
     // Use 2 Threads for 2 data-tables
@@ -401,7 +448,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     });
     result1.add(new Object[]{"DOC_ID_SET", 6, 5});
     result1.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
-    check(query1, new ResultTable(DATA_SCHEMA, result1));
+    check(query1, new ResultTable(DATA_SCHEMA, result1), true);
 
     String query2 = "EXPLAIN PLAN FOR SELECT 'mickey' FROM testTable";
     List<Object[]> result2 = new ArrayList<>();
@@ -414,7 +461,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result2.add(new Object[]{"PROJECT()", 5, 4});
     result2.add(new Object[]{"DOC_ID_SET", 6, 5});
     result2.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
-    check(query2, new ResultTable(DATA_SCHEMA, result2));
+    check(query2, new ResultTable(DATA_SCHEMA, result2), true);
 
     String query3 = "EXPLAIN PLAN FOR SELECT invertedIndexCol1, noIndexCol1 FROM testTable LIMIT 100";
     List<Object[]> result3 = new ArrayList<>();
@@ -427,7 +474,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result3.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
     result3.add(new Object[]{"DOC_ID_SET", 6, 5});
     result3.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
-    check(query3, new ResultTable(DATA_SCHEMA, result3));
+    check(query3, new ResultTable(DATA_SCHEMA, result3), true);
 
     String query4 = "EXPLAIN PLAN FOR SELECT DISTINCT invertedIndexCol1, noIndexCol1 FROM testTable LIMIT 100";
     List<Object[]> result4 = new ArrayList<>();
@@ -440,7 +487,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     result4.add(new Object[]{"PROJECT(invertedIndexCol1, noIndexCol1)", 5, 4});
     result4.add(new Object[]{"DOC_ID_SET", 6, 5});
     result4.add(new Object[]{"FILTER_MATCH_ENTIRE_SEGMENT(docs:3)", 7, 6});
-    check(query4, new ResultTable(DATA_SCHEMA, result4));
+    check(query4, new ResultTable(DATA_SCHEMA, result4), true);
   }
 
   @Test
@@ -2051,21 +2098,21 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 2 is pruned because 'mickey' is not within range (and all values in that segment are 'pluto')
     // Segments 3 and 4 don't contain 'mickey' but 'mickey' is within range so they return EmptyFilterOperator
     // Segment 1 contains 'mickey' so the FILTER_SORTED_INDEX plan is returned for it
-    String query1 = "SET explainPlanVerbose=true; EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE "
-        + "invertedIndexCol3 = 'mickey'";
-    List<Object[]> result1 = new ArrayList<>();
-    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
-    result1.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
-    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
-        ExplainPlanRows.PLAN_START_IDS});
-    result1.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
-    result1.add(new Object[]{"FILTER_EMPTY", 4, 3});
-    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
-        ExplainPlanRows.PLAN_START_IDS});
-    result1.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
-    result1.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3 "
-        + "= 'mickey')", 4, 3});
-    check(query1, new ResultTable(DATA_SCHEMA, result1));
+//    String query1 = "SET explainPlanVerbose=true; EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE "
+//        + "invertedIndexCol3 = 'mickey'";
+//    List<Object[]> result1 = new ArrayList<>();
+//    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+//    result1.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+//    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
+//        ExplainPlanRows.PLAN_START_IDS});
+//    result1.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+//    result1.add(new Object[]{"FILTER_EMPTY", 4, 3});
+//    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+//        ExplainPlanRows.PLAN_START_IDS});
+//    result1.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+//    result1.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3 "
+//        + "= 'mickey')", 4, 3});
+//    check(query1, new ResultTable(DATA_SCHEMA, result1));
 
     // Segment 2 is pruned because 'mickey' is not within range (and all values in that segment are 'pluto')
     // Segments 3 and 4 don't contain 'mickey' but 'mickey' is within range so they return EmptyFilterOperator
@@ -2075,7 +2122,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     List<Object[]> result2 = new ArrayList<>();
     result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result2.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
-    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+    result2.add(new Object[]{
+        "PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
         ExplainPlanRows.PLAN_START_IDS});
     result2.add(new Object[]{"AGGREGATE(aggregations:sum(noIndexCol2))", 3, 2});
     result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol2)", 4, 3});
@@ -2403,6 +2451,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
   public void tearDown() {
     _brokerReduceService.shutDown();
     _queryExecutor.shutDown();
+    _queryExecutorWithPrefetchEnabled.shutDown();
     for (IndexSegment segment : _indexSegments) {
       segment.destroy();
     }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -2098,21 +2098,21 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Segment 2 is pruned because 'mickey' is not within range (and all values in that segment are 'pluto')
     // Segments 3 and 4 don't contain 'mickey' but 'mickey' is within range so they return EmptyFilterOperator
     // Segment 1 contains 'mickey' so the FILTER_SORTED_INDEX plan is returned for it
-//    String query1 = "SET explainPlanVerbose=true; EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE "
-//        + "invertedIndexCol3 = 'mickey'";
-//    List<Object[]> result1 = new ArrayList<>();
-//    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
-//    result1.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
-//    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
-//        ExplainPlanRows.PLAN_START_IDS});
-//    result1.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
-//    result1.add(new Object[]{"FILTER_EMPTY", 4, 3});
-//    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
-//        ExplainPlanRows.PLAN_START_IDS});
-//    result1.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
-//    result1.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3 "
-//        + "= 'mickey')", 4, 3});
-//    check(query1, new ResultTable(DATA_SCHEMA, result1));
+    String query1 = "SET explainPlanVerbose=true; EXPLAIN PLAN FOR SELECT count(*) FROM testTable WHERE "
+        + "invertedIndexCol3 = 'mickey'";
+    List<Object[]> result1 = new ArrayList<>();
+    result1.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
+    result1.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:2)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result1.add(new Object[]{"FILTER_EMPTY", 4, 3});
+    result1.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+        ExplainPlanRows.PLAN_START_IDS});
+    result1.add(new Object[]{"FAST_FILTERED_COUNT", 3, 2});
+    result1.add(new Object[]{"FILTER_SORTED_INDEX(indexLookUp:sorted_index,operator:EQ,predicate:invertedIndexCol3 "
+        + "= 'mickey')", 4, 3});
+    check(query1, new ResultTable(DATA_SCHEMA, result1));
 
     // Segment 2 is pruned because 'mickey' is not within range (and all values in that segment are 'pluto')
     // Segments 3 and 4 don't contain 'mickey' but 'mickey' is within range so they return EmptyFilterOperator
@@ -2122,8 +2122,7 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     List<Object[]> result2 = new ArrayList<>();
     result2.add(new Object[]{"BROKER_REDUCE(limit:10)", 1, 0});
     result2.add(new Object[]{"COMBINE_AGGREGATE", 2, 1});
-    result2.add(new Object[]{
-        "PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
+    result2.add(new Object[]{"PLAN_START(numSegmentsForThisPlan:1)", ExplainPlanRows.PLAN_START_IDS,
         ExplainPlanRows.PLAN_START_IDS});
     result2.add(new Object[]{"AGGREGATE(aggregations:sum(noIndexCol2))", 3, 2});
     result2.add(new Object[]{"TRANSFORM_PASSTHROUGH(noIndexCol2)", 4, 3});


### PR DESCRIPTION
Due to AcquireReleaseColumnsSegmentOperator's childOperator not being materialized until needed, the query plan output in case where prefetch is enabled, is limited to just 
```
BROKER_REDUCE(limit:10)
COMBINE_SELECT
ACQUIRE_RELEASE_COLUMNS_SEGMENT
```

This PR fixes it.