### PR TITLE
fix jmx_prometheus_javaagent config to extract cron scheduler metrics

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -88,14 +88,14 @@ rules:
   labels:
     table: "$1"
     taskType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.(.*?)\\.(\\w+).cronSchedulerTriggered\"><>(\\w+)"
-  name: "pinot_controller_cronSchedulerTriggered_$3"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.(.*?)\\.(\\w+).cronSchedulerJobTriggered\"><>(\\w+)"
+  name: "pinot_controller_cronSchedulerJobTriggered_$3"
   cache: true
   labels:
     table: "$1"
     taskType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.(.*?)\\.(\\w+).cronSchedulerSkipped\"><>(\\w+)"
-  name: "pinot_controller_cronSchedulerSkipped_$3"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.(.*?)\\.(\\w+).cronSchedulerJobSkipped\"><>(\\w+)"
+  name: "pinot_controller_cronSchedulerJobSkipped_$3"
   cache: true
   labels:
     table: "$1"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -83,8 +83,14 @@ rules:
   labels:
     table: "$1"
     taskType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.(.*?)\\.(\\w+).cronSchedulerTriggered\"><>(\\w+)"
-  name: "pinot_controller_cronSchedulerTriggered_$3"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.(.*?)\\.(\\w+).cronSchedulerJobTriggered\"><>(\\w+)"
+  name: "pinot_controller_cronSchedulerJobTriggered_$3"
+  cache: true
+  labels:
+    table: "$1"
+    taskType: "$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.(.*?)\\.(\\w+).cronSchedulerJobSkipped\"><>(\\w+)"
+  name: "pinot_controller_cronSchedulerJobSkipped_$3"
   cache: true
   labels:
     table: "$1"


### PR DESCRIPTION
Some metric names configured in jmx_prometheus_javaagent do not match jmx metric names. This PR fix the issue:
1. cronSchedulerTriggered -> cronSchedulerJobTriggered
2. cronSchedulerSkipped -> cronSchedulerJobSkipped