### PR TITLE
[multistage] support count distinct in intermediate stage

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/function/InternalReduceFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/function/InternalReduceFunctions.java
@@ -19,6 +19,7 @@
 
 package org.apache.pinot.core.query.reduce.function;
 
+import java.util.Set;
 import org.apache.pinot.segment.local.customobject.PinotFourthMoment;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 
@@ -41,5 +42,10 @@ public class InternalReduceFunctions {
   @ScalarFunction
   public static double kurtosisReduce(PinotFourthMoment fourthMoment) {
     return fourthMoment.kurtosis();
+  }
+
+  @ScalarFunction
+  public static int countDistinctReduce(Set<?> values) {
+    return values.size();
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotDistinctCountAggregateFunction.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotDistinctCountAggregateFunction.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.calcite.sql.fun;
+
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.OperandTypes;
+import org.apache.calcite.sql.type.ReturnTypes;
+import org.apache.calcite.sql.type.SqlTypeName;
+import org.apache.calcite.util.Optionality;
+
+
+public class PinotDistinctCountAggregateFunction extends SqlAggFunction {
+
+  public static final PinotDistinctCountAggregateFunction INSTANCE = new PinotDistinctCountAggregateFunction();
+
+  public PinotDistinctCountAggregateFunction() {
+    super("DISTINCTCOUNT", null, SqlKind.OTHER_FUNCTION, ReturnTypes.explicit(SqlTypeName.OTHER),
+        null, OperandTypes.ANY, SqlFunctionCategory.USER_DEFINED_FUNCTION,
+        false, false, Optionality.FORBIDDEN);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
@@ -54,6 +54,9 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
       ReturnTypes.DOUBLE, null, OperandTypes.BINARY, SqlFunctionCategory.USER_DEFINED_FUNCTION);
   public static final SqlFunction KURTOSIS_REDUCE = new SqlFunction("KURTOSIS_REDUCE", SqlKind.OTHER_FUNCTION,
       ReturnTypes.DOUBLE, null, OperandTypes.BINARY, SqlFunctionCategory.USER_DEFINED_FUNCTION);
+  public static final SqlFunction COUNT_DISTINCT_REDUCE = new SqlFunction("COUNT_DISTINCT_REDUCE",
+      SqlKind.OTHER_FUNCTION, ReturnTypes.INTEGER, null, OperandTypes.BINARY,
+      SqlFunctionCategory.USER_DEFINED_FUNCTION);
 
   public static final SqlAggFunction BOOL_AND = PinotBoolAndAggregateFunction.INSTANCE;
   public static final SqlAggFunction BOOL_OR = PinotBoolOrAggregateFunction.INSTANCE;

--- a/pinot-query-runtime/src/test/resources/queries/CountDistinct.json
+++ b/pinot-query-runtime/src/test/resources/queries/CountDistinct.json
@@ -1,0 +1,48 @@
+{
+  "countDistinct": {
+    "tables": {
+      "tbl1": {
+        "schema": [
+          {"name": "groupingCol", "type": "STRING"},
+          {"name": "val", "type": "STRING"}
+        ],
+        "inputs": [
+          ["a", "foo"],
+          ["a", "foo"],
+          ["a", "bar"],
+          ["a", "bar"],
+          ["b", "foo"],
+          ["b", "foo"],
+          ["b", "foo"],
+          ["b", "baz"],
+          ["b", "baz"],
+          ["b", "baz"]
+        ]
+      },
+      "tbl2": {
+        "schema": [
+          {"name": "groupingCol", "type": "STRING"},
+          {"name": "val", "type": "STRING"}
+        ],
+        "inputs": [
+          ["a", "foo"],
+          ["a", "foo"],
+          ["a", "bar"],
+          ["a", "bingo"],
+          ["b", "foo"],
+          ["b", "foo"],
+          ["b", "foo"],
+          ["b", "baz"],
+          ["b", "baz"],
+          ["b", "ringo"]
+        ]
+      }
+    },
+    "queries": [
+      {"sql": "SELECT COUNT(DISTINCT val) FROM {tbl1}"},
+      {"sql": "SELECT groupingCol, COUNT(DISTINCT val) FROM {tbl1} GROUP BY groupingCol"},
+      {"sql": "SELECT l.groupingCol, COUNT(DISTINCT l.val), COUNT(DISTINCT r.val) FROM {tbl1} l JOIN {tbl2} r ON l.groupingCol = r.groupingCol GROUP BY l.groupingCol"},
+      {"sql": "SELECT l.groupingCol, COUNT(DISTINCT CONCAT(l.val, r.val)) FROM {tbl1} l JOIN {tbl2} r ON l.groupingCol = r.groupingCol GROUP BY l.groupingCol"}
+    ]
+  }
+}


### PR DESCRIPTION
This PR introduces support for `COUNT(DISTINCT <foo>)` in the multistage engine. Before this PR, the `COUNT(DISTINCT X)` was turned into just `COUNT(X)` because the `distinct` field was ignored in the `RexExpression#toRexExpression(AggregateCall aggCall)` method. After this PR, we split it into a v1 `DISTINCTCOUNT` and then a SUM at the end