### PR TITLE
emit numberTasks metrics from minion

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/minion.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/minion.yml
@@ -10,7 +10,7 @@ rules:
   labels:
     table: "$1"
     tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"MinionMetrics\", name=\"pinot.minion.(.*?)_(OFFLINE|REALTIME).(\\w+).(taskExecution|taskQueueing|numberTasksExecuted|numberTasksCompleted|numberTasksCancelled|numberTasksFailed|numberTasksFatalFailed)\"><>(\\w+)"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"MinionMetrics\", name=\"pinot.minion.(.*?)_(OFFLINE|REALTIME).(\\w+).(taskExecution|taskQueueing|numberTasks|numberTasksExecuted|numberTasksCompleted|numberTasksCancelled|numberTasksFailed|numberTasksFatalFailed)\"><>(\\w+)"
   name: "pinot_minion_$4_$5"
   cache: true
   labels:

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -467,7 +467,7 @@ rules:
   labels:
     table: "$1"
     tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"MinionMetrics\", name=\"pinot.minion.(.*?)_(OFFLINE|REALTIME).(\\w+).(taskExecution|taskQueueing|numberTasksExecuted|numberTasksCompleted|numberTasksCancelled|numberTasksFailed|numberTasksFatalFailed)\"><>(\\w+)"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"MinionMetrics\", name=\"pinot.minion.(.*?)_(OFFLINE|REALTIME).(\\w+).(taskExecution|taskQueueing|numberTasks|numberTasksExecuted|numberTasksCompleted|numberTasksCancelled|numberTasksFailed|numberTasksFatalFailed)\"><>(\\w+)"
   name: "pinot_minion_$4_$5"
   cache: true
   labels:

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/MinionMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/MinionMeter.java
@@ -24,7 +24,7 @@ import org.apache.pinot.common.Utils;
 public enum MinionMeter implements AbstractMetrics.Meter {
   HEALTH_CHECK_GOOD_CALLS("healthChecks", true),
   HEALTH_CHECK_BAD_CALLS("healthChecks", true),
-
+  NUMBER_TASKS("tasks", false),
   NUMBER_TASKS_EXECUTED("tasks", false),
   NUMBER_TASKS_COMPLETED("tasks", false),
   NUMBER_TASKS_CANCELLED("tasks", false),

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
@@ -94,22 +94,26 @@ public class TaskFactoryRegistry {
                 PinotTaskConfig pinotTaskConfig = PinotTaskConfig.fromHelixTaskConfig(_taskConfig);
                 tableName = pinotTaskConfig.getTableName();
                 _minionMetrics.addValueToGlobalGauge(MinionGauge.NUMBER_OF_TASKS, 1L);
+                _minionMetrics.addMeteredValue(taskType, MinionMeter.NUMBER_TASKS, 1L);
                 if (tableName != null) {
                   _minionMetrics
                       .addTimedTableValue(tableName, taskType, MinionTimer.TASK_QUEUEING,
                           jobDequeueTimeMs - jobInQueueTimeMs, TimeUnit.MILLISECONDS);
                   _minionMetrics.addValueToTableGauge(tableName, MinionGauge.NUMBER_OF_TASKS, 1L);
+                  _minionMetrics.addMeteredTableValue(tableName, taskType, MinionMeter.NUMBER_TASKS, 1L);
                 }
                 MinionEventObservers.getInstance().addMinionEventObserver(_taskConfig.getId(), _eventObserver);
                 return runInternal(pinotTaskConfig);
               } finally {
                 MinionEventObservers.getInstance().removeMinionEventObserver(_taskConfig.getId());
                 _minionMetrics.addValueToGlobalGauge(MinionGauge.NUMBER_OF_TASKS, -1L);
+                _minionMetrics.addMeteredValue(taskType, MinionMeter.NUMBER_TASKS, -1L);
                 long executionTimeMs = System.currentTimeMillis() - jobDequeueTimeMs;
                 _minionMetrics
                     .addTimedValue(taskType, MinionTimer.TASK_EXECUTION, executionTimeMs, TimeUnit.MILLISECONDS);
                 if (tableName != null) {
                   _minionMetrics.addValueToTableGauge(tableName, MinionGauge.NUMBER_OF_TASKS, -1L);
+                  _minionMetrics.addMeteredTableValue(tableName, taskType, MinionMeter.NUMBER_TASKS, -1L);
                   _minionMetrics
                       .addTimedTableValue(tableName, taskType, MinionTimer.TASK_EXECUTION,
                           executionTimeMs, TimeUnit.MILLISECONDS);


### PR DESCRIPTION
emit numberTasks metrics from minion, at `task type` level and `table task type` level.

Following shows the emitted metrics (Prometheus metrics)

```
curl -s http://localhost:8080 | grep numberTasks_Count
# HELP pinot_minion_numberTasks_Count Attribute exposed for management "org.apache.pinot.common.metrics":name="pinot.minion.RealtimeToOfflineSegmentsTask.numberTasks",type="MinionMetrics",attribute=Count
# TYPE pinot_minion_numberTasks_Count untyped
pinot_minion_numberTasks_Count{id="RealtimeToOfflineSegmentsTask",} 0.0
pinot_minion_numberTasks_Count{table="mytable",tableType="REALTIME",taskType="RealtimeToOfflineSegmentsTask",} 0.0
```