### PR TITLE
Java serialization for BrokerResponse

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.response;
 
+import java.io.Serializable;
 import java.util.List;
 import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.response.broker.ResultTable;
@@ -26,7 +27,7 @@ import org.apache.pinot.common.response.broker.ResultTable;
 /**
  * Interface for broker response.
  */
-public interface BrokerResponse {
+public interface BrokerResponse extends Serializable {
 
   /**
    * Set exceptions caught during request handling, into the broker response.

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/QueryProcessingException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/QueryProcessingException.java
@@ -19,12 +19,13 @@
 package org.apache.pinot.common.response.broker;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import java.io.Serializable;
 
 
 /**
  * This class represents an exception using a message and an error code.
  */
-public class QueryProcessingException {
+public class QueryProcessingException implements Serializable {
   private int _errorCode;
   private String _message;
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/ResultTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/ResultTable.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.response.broker;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
+import java.io.Serializable;
 import java.util.List;
 import org.apache.pinot.common.utils.DataSchema;
 
@@ -29,7 +30,7 @@ import org.apache.pinot.common.utils.DataSchema;
  * A tabular structure for representing result rows
  */
 @JsonPropertyOrder({"dataSchema", "rows"})
-public class ResultTable {
+public class ResultTable implements Serializable {
   private final DataSchema _dataSchema;
   private final List<Object[]> _rows;
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -46,7 +46,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * The <code>DataSchema</code> class describes the schema of {@link DataTable}.
  */
 @JsonPropertyOrder({"columnNames", "columnDataTypes"})
-public class DataSchema {
+public class DataSchema implements Serializable {
   private final String[] _columnNames;
   private final ColumnDataType[] _columnDataTypes;
   private ColumnDataType[] _storedColumnDataTypes;


### PR DESCRIPTION
This PR extends BrokerResponse to be Java Serializable as part of our pagination effort: https://github.com/apache/pinot/issues/5246
@jackjlli @siddharthteotia 