### PR TITLE
fix explain plan render, which is going to be multiple line in v2

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -281,7 +281,7 @@ export default function CustomizedTables({
   accordionToggleObject,
   tooltipData
 }: Props) {
-  // Separate the initial and final data into two separte state variables.
+  // Separate the initial and final data into two separated state variables.
   // This way we can filter and sort the data without affecting the original data.
   // If the component receives new data, we can simply set the new data to the initial data,
   // and the filters and sorts will be applied to the new data.
@@ -393,6 +393,9 @@ export default function CustomizedTables({
           variant="outlined"
         />
       );
+    }
+    if (str.search('\n') !== -1) {
+      return (<pre>{str.toString()}</pre>);
     }
     return (<span>{str.toString()}</span>);
   };


### PR DESCRIPTION
before:
![Screen Shot 2023-01-31 at 9 56 38 AM](https://user-images.githubusercontent.com/3581352/215895152-f83a3023-1a80-4f4c-9174-255a02bf0976.png)
after:
![Screen Shot 2023-01-31 at 2 10 07 PM](https://user-images.githubusercontent.com/3581352/215895149-cb86b4cb-8aca-4405-a52e-131b850a8cc5.png)