### PR TITLE
[spark-connector] Memory optimization for GRPC data fetcher

### DIFF
--- a/pinot-connectors/pinot-spark-connector/src/main/scala/org/apache/pinot/connector/spark/datasource/PinotInputPartitionReader.scala
+++ b/pinot-connectors/pinot-spark-connector/src/main/scala/org/apache/pinot/connector/spark/datasource/PinotInputPartitionReader.scala
@@ -23,17 +23,20 @@ import org.apache.spark.sql.catalyst.InternalRow
 import org.apache.spark.sql.sources.v2.reader.InputPartitionReader
 import org.apache.spark.sql.types.StructType
 
+import java.io.Closeable
+
 /**
  * Actual data reader on spark worker side.
- * Represents a spark partition, and is receive data from specified pinot server-segment list.
+ * Represents a spark partition, and receives data from specified pinot server-segment list.
  */
 class PinotInputPartitionReader(
-    schema: StructType,
-    partitionId: Int,
-    pinotSplit: PinotSplit,
-    dataSourceOptions: PinotDataSourceReadOptions)
+                                 schema: StructType,
+                                 partitionId: Int,
+                                 pinotSplit: PinotSplit,
+                                 dataSourceOptions: PinotDataSourceReadOptions)
   extends InputPartitionReader[InternalRow] {
-  private val responseIterator: Iterator[InternalRow] = fetchDataAndConvertToInternalRows()
+
+  private val (responseIterator: Iterator[InternalRow], source: Closeable) = getIteratorAndSource()
   private[this] var currentRow: InternalRow = _
 
   override def next(): Boolean = {
@@ -48,18 +51,22 @@ class PinotInputPartitionReader(
     currentRow
   }
 
-  override def close(): Unit = {}
+  override def close(): Unit = {
+    source.close()
+  }
 
-  private def fetchDataAndConvertToInternalRows(): Iterator[InternalRow] = {
-    if (dataSourceOptions.useGrpcServer)
-      PinotGrpcServerDataFetcher(pinotSplit)
+  private def getIteratorAndSource(): (Iterator[InternalRow], Closeable) = {
+    if (dataSourceOptions.useGrpcServer) {
+      val dataFetcher = PinotGrpcServerDataFetcher(pinotSplit)
+      val iterable = dataFetcher.fetchData()
+        .flatMap(PinotUtils.pinotDataTableToInternalRows(_, schema))
+      (iterable, dataFetcher)
+    } else {
+      (PinotServerDataFetcher(partitionId, pinotSplit, dataSourceOptions)
         .fetchData()
         .flatMap(PinotUtils.pinotDataTableToInternalRows(_, schema))
-        .toIterator
-    else
-      PinotServerDataFetcher(partitionId, pinotSplit, dataSourceOptions)
-        .fetchData()
-        .flatMap(PinotUtils.pinotDataTableToInternalRows(_, schema))
-        .toIterator
+        .toIterator,
+        () => {})
+    }
   }
 }

--- a/pinot-connectors/pinot-spark-connector/src/main/scala/org/apache/pinot/connector/spark/datasource/PinotInputPartitionReader.scala
+++ b/pinot-connectors/pinot-spark-connector/src/main/scala/org/apache/pinot/connector/spark/datasource/PinotInputPartitionReader.scala
@@ -30,10 +30,10 @@ import java.io.Closeable
  * Represents a spark partition, and receives data from specified pinot server-segment list.
  */
 class PinotInputPartitionReader(
-                                 schema: StructType,
-                                 partitionId: Int,
-                                 pinotSplit: PinotSplit,
-                                 dataSourceOptions: PinotDataSourceReadOptions)
+    schema: StructType,
+    partitionId: Int,
+    pinotSplit: PinotSplit,
+    dataSourceOptions: PinotDataSourceReadOptions)
   extends InputPartitionReader[InternalRow] {
 
   private val (responseIterator: Iterator[InternalRow], source: Closeable) = getIteratorAndSource()


### PR DESCRIPTION
Updated the `PinotGrpcServerDataFetcher` to return an `Iterator[DataTable]` instead of `List[DataTable]` which reduces memory usage on Spark reader side.

**Testing**
This is a purely performance related improvement and there are no functional changes, so I'm not adding specific unit tests. Integration tests under `ExampleSparkPinotConnectorTest` are passing as expected.

Our perf tests indicated significant improvements in GC behavior on Spark executors, especially for very large scans (>1M rows). Here is a comparison for "Task time (GC time)" from sample runs.



| From this |  | To this |
|----------|----|------|
| ![Screenshot 2023-01-31 at 3 24 35 PM](https://user-images.githubusercontent.com/212284/215906895-7ae3b92d-f848-4df1-9459-8754b30e793f.png) | -> | ![Screenshot 2023-01-31 at 3 24 02 PM](https://user-images.githubusercontent.com/212284/215906929-81f8ddbd-4435-4f2d-9624-94140752229f.png) |

`performance`