### PR TITLE
[multistage] add singleton instance stage

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
@@ -65,7 +65,7 @@ public class PinotJoinExchangeNodeInsertRule extends RelOptRule {
 
     if (joinInfo.leftKeys.isEmpty()) {
       // when there's no JOIN key, use broadcast.
-      leftExchange = LogicalExchange.create(leftInput, RelDistributions.SINGLETON);
+      leftExchange = LogicalExchange.create(leftInput, RelDistributions.RANDOM_DISTRIBUTED);
       rightExchange = LogicalExchange.create(rightInput, RelDistributions.BROADCAST_DISTRIBUTED);
     } else {
       // when join key exists, use hash distribution.

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
@@ -59,10 +59,6 @@ public class PinotQueryRuleSets {
           CoreRules.PROJECT_MERGE,
           // remove identity project
           CoreRules.PROJECT_REMOVE,
-          // add an extra exchange for sort
-          PinotSortExchangeNodeInsertRule.INSTANCE,
-          // copy exchanges down
-          PinotSortExchangeCopyRule.SORT_EXCHANGE_COPY,
           // reorder sort and projection
           CoreRules.SORT_PROJECT_TRANSPOSE,
 
@@ -95,6 +91,13 @@ public class PinotQueryRuleSets {
 
           // Pinot specific rules
           PinotFilterExpandSearchRule.INSTANCE,
+
+          // Pinot exchange rules
+          // add an extra exchange for sort
+          PinotSortExchangeNodeInsertRule.INSTANCE,
+          // copy exchanges down, this must be done after SortExchangeNodeInsertRule
+          PinotSortExchangeCopyRule.SORT_EXCHANGE_COPY,
+
           PinotJoinExchangeNodeInsertRule.INSTANCE,
           PinotAggregateExchangeNodeInsertRule.INSTANCE
       );

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotSortExchangeCopyRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotSortExchangeCopyRule.java
@@ -30,6 +30,7 @@ import org.apache.calcite.rel.logical.LogicalSortExchange;
 import org.apache.calcite.rel.metadata.RelMdUtil;
 import org.apache.calcite.rel.metadata.RelMetadataQuery;
 import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.pinot.query.planner.logical.RexExpressionUtils;
@@ -42,6 +43,9 @@ public class PinotSortExchangeCopyRule extends RelRule<RelRule.Config> {
   public static final PinotSortExchangeCopyRule SORT_EXCHANGE_COPY =
       PinotSortExchangeCopyRule.Config.DEFAULT.toRule();
   private static final TypeFactory TYPE_FACTORY = new TypeFactory(new TypeSystem());
+  private static final RexBuilder REX_BUILDER = new RexBuilder(TYPE_FACTORY);
+  private static final RexLiteral REX_ZERO = REX_BUILDER.makeLiteral(0,
+      TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER));
 
   /**
    * Creates a PinotSortExchangeCopyRule.
@@ -80,14 +84,14 @@ public class PinotSortExchangeCopyRule extends RelRule<RelRule.Config> {
     } else if (sort.offset == null) {
       fetch = sort.fetch;
     } else {
-      RexBuilder rexBuilder = new RexBuilder(TYPE_FACTORY);
       int total = RexExpressionUtils.getValueAsInt(sort.fetch) + RexExpressionUtils.getValueAsInt(sort.offset);
-      fetch = rexBuilder.makeLiteral(total, TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER));
+      fetch = REX_BUILDER.makeLiteral(total, TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER));
     }
 
     final RelNode newExchangeInput = sort.copy(sort.getTraitSet(), exchange.getInput(), collation, null, fetch);
     final RelNode exchangeCopy = exchange.copy(exchange.getTraitSet(), newExchangeInput, exchange.getDistribution());
-    final RelNode sortCopy = sort.copy(sort.getTraitSet(), exchangeCopy, collation, sort.offset, sort.fetch);
+    final RelNode sortCopy = sort.copy(sort.getTraitSet(), exchangeCopy, collation,
+        sort.offset == null ? REX_ZERO : sort.offset, sort.fetch);
 
     call.transformTo(sortCopy);
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/PlannerUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/PlannerUtils.java
@@ -40,6 +40,10 @@ public class PlannerUtils {
     return stageId == 0;
   }
 
+  public static boolean isFinalStage(int stageId) {
+    return stageId == 1;
+  }
+
   public static String explainPlan(RelNode relRoot, SqlExplainFormat format, SqlExplainLevel explainLevel) {
     return RelOptUtil.dumpPlan("Execution Plan", relRoot, format, explainLevel);
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/StageMetadata.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/StageMetadata.java
@@ -25,6 +25,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.pinot.query.planner.hints.PinotRelationalHints;
 import org.apache.pinot.query.planner.stage.AggregateNode;
 import org.apache.pinot.query.planner.stage.SortNode;
 import org.apache.pinot.query.planner.stage.StageNode;
@@ -72,10 +73,14 @@ public class StageMetadata implements Serializable {
       _scannedTables.add(((TableScanNode) stageNode).getTableName());
     }
     if (stageNode instanceof AggregateNode) {
-      _requiresSingletonInstance = ((AggregateNode) stageNode).getGroupSet().size() == 0;
+      AggregateNode aggNode = (AggregateNode) stageNode;
+      _requiresSingletonInstance = _requiresSingletonInstance || (aggNode.getGroupSet().size() == 0
+          && aggNode.getRelHints().contains(PinotRelationalHints.AGG_INTERMEDIATE_STAGE));
     }
     if (stageNode instanceof SortNode) {
-      _requiresSingletonInstance = ((SortNode) stageNode).getCollationKeys().size() > 0;
+      SortNode sortNode = (SortNode) stageNode;
+      _requiresSingletonInstance = _requiresSingletonInstance || (sortNode.getCollationKeys().size() > 0
+          && sortNode.getOffset() != -1);
     }
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/StageMetadata.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/StageMetadata.java
@@ -25,6 +25,8 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.pinot.query.planner.stage.AggregateNode;
+import org.apache.pinot.query.planner.stage.SortNode;
 import org.apache.pinot.query.planner.stage.StageNode;
 import org.apache.pinot.query.planner.stage.TableScanNode;
 import org.apache.pinot.query.routing.VirtualServer;
@@ -54,17 +56,26 @@ public class StageMetadata implements Serializable {
   // time boundary info
   private TimeBoundaryInfo _timeBoundaryInfo;
 
+  // whether a stage requires singleton instance to execute, e.g. stage contains global reduce (sort/agg) operator.
+  private boolean _requiresSingletonInstance;
 
   public StageMetadata() {
     _scannedTables = new ArrayList<>();
     _serverInstances = new ArrayList<>();
     _serverInstanceToSegmentsMap = new HashMap<>();
     _timeBoundaryInfo = null;
+    _requiresSingletonInstance = false;
   }
 
   public void attach(StageNode stageNode) {
     if (stageNode instanceof TableScanNode) {
       _scannedTables.add(((TableScanNode) stageNode).getTableName());
+    }
+    if (stageNode instanceof AggregateNode) {
+      _requiresSingletonInstance = ((AggregateNode) stageNode).getGroupSet().size() == 0;
+    }
+    if (stageNode instanceof SortNode) {
+      _requiresSingletonInstance = ((SortNode) stageNode).getCollationKeys().size() > 0;
     }
   }
 
@@ -95,6 +106,10 @@ public class StageMetadata implements Serializable {
 
   public TimeBoundaryInfo getTimeBoundaryInfo() {
     return _timeBoundaryInfo;
+  }
+
+  public boolean isRequiresSingletonInstance() {
+    return _requiresSingletonInstance;
   }
 
   public void setTimeBoundaryInfo(TimeBoundaryInfo timeBoundaryInfo) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/hints/PinotRelationalHints.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/hints/PinotRelationalHints.java
@@ -25,8 +25,6 @@ import org.apache.calcite.rel.hint.RelHint;
  * Provide certain relational hint to query planner for better optimization.
  */
 public class PinotRelationalHints {
-  public static final RelHint USE_HASH_DISTRIBUTE = RelHint.builder("USE_HASH_DISTRIBUTE").build();
-  public static final RelHint USE_BROADCAST_DISTRIBUTE = RelHint.builder("USE_BROADCAST_DISTRIBUTE").build();
   public static final RelHint AGG_INTERMEDIATE_STAGE = RelHint.builder("AGG_INTERMEDIATE_STAGE").build();
   public static final RelHint AGG_LEAF_STAGE = RelHint.builder("AGG_LEAF_STAGE").build();
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToStageConverter.java
@@ -97,7 +97,7 @@ public final class RelToStageConverter {
 
   private static StageNode convertLogicalAggregate(LogicalAggregate node, int currentStageId) {
     return new AggregateNode(currentStageId, toDataSchema(node.getRowType()), node.getAggCallList(),
-        node.getGroupSet());
+        node.getGroupSet(), node.getHints());
   }
 
   private static StageNode convertLogicalProject(LogicalProject node, int currentStageId) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
@@ -91,7 +91,7 @@ public class RexExpressionUtils {
 
   public static Integer getValueAsInt(RexNode in) {
     if (in == null) {
-      return 0;
+      return -1;
     }
 
     Preconditions.checkArgument(in instanceof RexLiteral, "expected literal, got " + in);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/AggregateNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/AggregateNode.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
@@ -29,6 +30,8 @@ import org.apache.pinot.query.planner.serde.ProtoProperties;
 
 
 public class AggregateNode extends AbstractStageNode {
+
+  private List<RelHint> _relHints;
   @ProtoProperties
   private List<RexExpression> _aggCalls;
   @ProtoProperties
@@ -38,13 +41,15 @@ public class AggregateNode extends AbstractStageNode {
     super(stageId);
   }
 
-  public AggregateNode(int stageId, DataSchema dataSchema, List<AggregateCall> aggCalls, ImmutableBitSet groupSet) {
+  public AggregateNode(int stageId, DataSchema dataSchema, List<AggregateCall> aggCalls, ImmutableBitSet groupSet,
+      List<RelHint> relHints) {
     super(stageId, dataSchema);
     _aggCalls = aggCalls.stream().map(RexExpression::toRexExpression).collect(Collectors.toList());
     _groupSet = new ArrayList<>(groupSet.cardinality());
     for (Integer integer : groupSet) {
       _groupSet.add(new RexExpression.InputRef(integer));
     }
+    _relHints = relHints;
   }
 
   public List<RexExpression> getAggCalls() {
@@ -53,6 +58,10 @@ public class AggregateNode extends AbstractStageNode {
 
   public List<RexExpression> getGroupSet() {
     return _groupSet;
+  }
+
+  public List<RelHint> getRelHints() {
+    return _relHints;
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -65,7 +65,7 @@ public class SortOperator extends MultiStageOperator {
       int maxHolderCapacity, long requestId, int stageId) {
     _upstreamOperator = upstreamOperator;
     _fetch = fetch;
-    _offset = offset;
+    _offset = Math.max(offset, 0);
     _dataSchema = dataSchema;
     _upstreamErrorBlock = null;
     _isSortedBlockConstructed = false;

--- a/pinot-query-runtime/src/test/resources/queries/Parallelism.json
+++ b/pinot-query-runtime/src/test/resources/queries/Parallelism.json
@@ -37,11 +37,7 @@
       {"sql": "SET stageParallelism=2; SELECT {l}.key, {l}.lval, {r}.rval FROM {l} JOIN {r} ON {l}.key = {r}.key"},
       {"sql": "SET stageParallelism=2; SELECT {l}.key, SUM({l}.lval + {r}.rval) FROM {l} JOIN {r} ON {l}.key = {r}.key GROUP BY {l}.key"},
       {"sql": "SET stageParallelism=2; SELECT * FROM {l} WHERE lval NOT IN (SELECT rval FROM {r} WHERE rval > 2)"},
-      {
-        "description": "current stage parallelism doesn't work with broadcast join",
-        "sql": "SET stageParallelism=2; SELECT * FROM {l}, {r}",
-        "expectedException": ".*Cannot issue query with stageParallelism > 1 for queries that use SINGLETON exchange.*"
-      }
+      {"sql": "SET stageParallelism=2; SELECT * FROM {l}, {r}"}
     ]
   }
 }


### PR DESCRIPTION
some of the operators in v2 engine are actually singleton instance stages such as 
- global agg ` SELECT COUNT(*) FROM tbl` or 
- global sort `SELECT col FROM tbl ORDER BY col`

there's no reason to run them on multiple instances which we currently do. the current implementation works b/c
- all but one instances is actually processing data
- all remaining instances will process pass-through end-of-stream blocks and thus contribute nothing to the final results.

This PR allows these operator to run on a random singleton server
