### PR TITLE
Allow segment upload to deepstore only when server segment store uri is configured

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
@@ -79,8 +79,7 @@ public class TableDataManagerProvider {
       case REALTIME:
         Map<String, String> streamConfigMap = IngestionConfigUtils.getStreamConfigMap(
             tableDataManagerConfig.getTableConfig());
-        if (Boolean.parseBoolean(streamConfigMap.getOrDefault(StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE,
-            "false"))
+        if (Boolean.parseBoolean(streamConfigMap.get(StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE))
             && StringUtils.isEmpty(tableDataManagerConfig.getInstanceDataManagerConfig().getSegmentStoreUri())) {
           throw new IllegalStateException(String.format("Table has enabled %s config. But the server has not "
               + "configured the segmentstore uri. Configure the server config %s",

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
@@ -79,7 +79,8 @@ public class TableDataManagerProvider {
       case REALTIME:
         Map<String, String> streamConfigMap = IngestionConfigUtils.getStreamConfigMap(
             tableDataManagerConfig.getTableConfig());
-        if (Boolean.parseBoolean(streamConfigMap.getOrDefault(StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE, "false"))
+        if (Boolean.parseBoolean(streamConfigMap.getOrDefault(StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE,
+            "false"))
             && StringUtils.isEmpty(tableDataManagerConfig.getInstanceDataManagerConfig().getSegmentStoreUri())) {
           throw new IllegalStateException(String.format("Table has enabled %s config. But the server has not "
               + "configured the segmentstore uri. Configure the server config %s",

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.data.manager.offline;
 
 import com.google.common.cache.LoadingCache;
+import java.util.Map;
 import java.util.concurrent.Semaphore;
 import java.util.function.Supplier;
 import org.apache.commons.lang3.StringUtils;
@@ -35,6 +36,7 @@ import org.apache.pinot.segment.local.data.manager.TableDataManagerParams;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.IngestionConfigUtils;
 
 
 /**
@@ -75,10 +77,9 @@ public class TableDataManagerProvider {
         }
         break;
       case REALTIME:
-        if (tableDataManagerConfig.getTableConfig().getIndexingConfig() != null
-            && tableDataManagerConfig.getTableConfig().getIndexingConfig().getStreamConfigs() != null
-            && Boolean.parseBoolean(tableDataManagerConfig.getTableConfig().getIndexingConfig()
-            .getStreamConfigs().get(StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE))
+        Map<String, String> streamConfigMap = IngestionConfigUtils.getStreamConfigMap(
+            tableDataManagerConfig.getTableConfig());
+        if (Boolean.parseBoolean(streamConfigMap.get(StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE))
             && StringUtils.isEmpty(tableDataManagerConfig.getInstanceDataManagerConfig().getSegmentStoreUri())) {
           throw new IllegalStateException(String.format("Table has enabled %s config. But the server has not "
               + "configured the segmentstore uri. Configure the server config %s",

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
@@ -79,7 +79,7 @@ public class TableDataManagerProvider {
       case REALTIME:
         Map<String, String> streamConfigMap = IngestionConfigUtils.getStreamConfigMap(
             tableDataManagerConfig.getTableConfig());
-        if (Boolean.parseBoolean(streamConfigMap.get(StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE))
+        if (Boolean.parseBoolean(streamConfigMap.getOrDefault(StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE, "false"))
             && StringUtils.isEmpty(tableDataManagerConfig.getInstanceDataManagerConfig().getSegmentStoreUri())) {
           throw new IllegalStateException(String.format("Table has enabled %s config. But the server has not "
               + "configured the segmentstore uri. Configure the server config %s",

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1000,6 +1000,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     SegmentCompletionProtocol.Response commitResponse = commit(controllerVipUrl, isSplitCommit);
 
     if (!commitResponse.getStatus().equals(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS)) {
+      _segmentLogger.warn("Controller response was {} and not {}", commitResponse.getStatus(),
+          SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
       return false;
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/PinotFSSegmentUploader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/PinotFSSegmentUploader.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.data.manager.realtime;
 
+import com.google.common.base.Preconditions;
 import java.io.File;
 import java.net.URI;
 import java.util.UUID;
@@ -54,6 +55,8 @@ public class PinotFSSegmentUploader implements SegmentUploader {
 
   public URI uploadSegment(File segmentFile, LLCSegmentName segmentName) {
     if (_segmentStoreUriStr == null || _segmentStoreUriStr.isEmpty()) {
+      LOGGER.error("Missing segment store uri. Failed to upload segment file {} for {}.", segmentFile.getName(),
+          segmentName.getSegmentName());
       return null;
     }
     Callable<URI> uploadTask = () -> {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/PinotFSSegmentUploader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/PinotFSSegmentUploader.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.data.manager.realtime;
 
-import com.google.common.base.Preconditions;
 import java.io.File;
 import java.net.URI;
 import java.util.UUID;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
@@ -72,8 +72,10 @@ public class SegmentCommitterFactory {
     String peerSegmentDownloadScheme = _tableConfig.getValidationConfig().getPeerSegmentDownloadScheme();
     String segmentStoreUri = _indexLoadingConfig.getSegmentStoreURI();
 
-    if (!Strings.isNullOrEmpty(segmentStoreUri) // We seem to allow the server instance to come up without a valid segment store uri. Hence, this check is needed.
-        && (uploadToFs || peerSegmentDownloadScheme != null)) { // TODO: non-null check exists for backwards compatibility. remove peerDownloadScheme non-null check once users have migrated
+    // We seem to allow the server instance to come up without a valid segment store uri. Hence, this check is needed.
+    if (!Strings.isNullOrEmpty(segmentStoreUri)
+        && (uploadToFs || peerSegmentDownloadScheme != null)) {
+      // TODO: non-null check exists for backwards compatibility. remove check once users have migrated
       segmentUploader = new PinotFSSegmentUploader(segmentStoreUri,
           PinotFSSegmentUploader.DEFAULT_SEGMENT_UPLOAD_TIMEOUT_MILLIS);
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
@@ -74,7 +74,7 @@ public class SegmentCommitterFactory {
 
     // We seem to allow the server instance to come up without a valid segment store uri. Hence, this check is needed.
 
-    if (peerSegmentDownloadScheme != null || (StringUtils.isEmpty(segmentStoreUri) && uploadToFs)) {
+    if (peerSegmentDownloadScheme != null || (!StringUtils.isEmpty(segmentStoreUri) && uploadToFs)) {
       // TODO: peer scheme non-null check exists for backwards compatibility. remove check once users have migrated
       segmentUploader = new PinotFSSegmentUploader(segmentStoreUri,
           PinotFSSegmentUploader.DEFAULT_SEGMENT_UPLOAD_TIMEOUT_MILLIS);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.data.manager.realtime;
 
+import com.google.common.base.Strings;
 import java.net.URISyntaxException;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
@@ -69,9 +70,11 @@ public class SegmentCommitterFactory {
 
     boolean uploadToFs = _streamConfig.isServerUploadToDeepStore();
     String peerSegmentDownloadScheme = _tableConfig.getValidationConfig().getPeerSegmentDownloadScheme();
-    // TODO: exists for backwards compatibility. remove peerDownloadScheme non-null check once users have migrated
-    if (uploadToFs || peerSegmentDownloadScheme != null) {
-      segmentUploader = new PinotFSSegmentUploader(_indexLoadingConfig.getSegmentStoreURI(),
+    String segmentStoreUri = _indexLoadingConfig.getSegmentStoreURI();
+
+    if (!Strings.isNullOrEmpty(segmentStoreUri) // We seem to allow the server instance to come up without a valid segment store uri. Hence, this check is needed.
+        && (uploadToFs || peerSegmentDownloadScheme != null)) { // TODO: non-null check exists for backwards compatibility. remove peerDownloadScheme non-null check once users have migrated
+      segmentUploader = new PinotFSSegmentUploader(segmentStoreUri,
           PinotFSSegmentUploader.DEFAULT_SEGMENT_UPLOAD_TIMEOUT_MILLIS);
     } else {
       segmentUploader = new Server2ControllerSegmentUploader(_logger,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.data.manager.realtime;
 
 import java.net.URISyntaxException;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
@@ -72,9 +71,7 @@ public class SegmentCommitterFactory {
     String peerSegmentDownloadScheme = _tableConfig.getValidationConfig().getPeerSegmentDownloadScheme();
     String segmentStoreUri = _indexLoadingConfig.getSegmentStoreURI();
 
-    // We seem to allow the server instance to come up without a valid segment store uri. Hence, this check is needed.
-
-    if (peerSegmentDownloadScheme != null || (!StringUtils.isEmpty(segmentStoreUri) && uploadToFs)) {
+    if (uploadToFs || peerSegmentDownloadScheme != null) {
       // TODO: peer scheme non-null check exists for backwards compatibility. remove check once users have migrated
       segmentUploader = new PinotFSSegmentUploader(segmentStoreUri,
           PinotFSSegmentUploader.DEFAULT_SEGMENT_UPLOAD_TIMEOUT_MILLIS);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pinot.core.data.manager.realtime;
 
-import com.google.common.base.Strings;
 import java.net.URISyntaxException;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
@@ -73,7 +73,7 @@ public class SegmentCommitterFactory {
     String segmentStoreUri = _indexLoadingConfig.getSegmentStoreURI();
 
     // We seem to allow the server instance to come up without a valid segment store uri. Hence, this check is needed.
-    if (!Strings.isNullOrEmpty(segmentStoreUri)
+    if (!StringUtils.isEmpty(segmentStoreUri)
         && (uploadToFs || peerSegmentDownloadScheme != null)) {
       // TODO: non-null check exists for backwards compatibility. remove check once users have migrated
       segmentUploader = new PinotFSSegmentUploader(segmentStoreUri,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
@@ -73,9 +73,9 @@ public class SegmentCommitterFactory {
     String segmentStoreUri = _indexLoadingConfig.getSegmentStoreURI();
 
     // We seem to allow the server instance to come up without a valid segment store uri. Hence, this check is needed.
-    if (!StringUtils.isEmpty(segmentStoreUri)
-        && (uploadToFs || peerSegmentDownloadScheme != null)) {
-      // TODO: non-null check exists for backwards compatibility. remove check once users have migrated
+
+    if (peerSegmentDownloadScheme != null || (StringUtils.isEmpty(segmentStoreUri) && uploadToFs)) {
+      // TODO: peer scheme non-null check exists for backwards compatibility. remove check once users have migrated
       segmentUploader = new PinotFSSegmentUploader(segmentStoreUri,
           PinotFSSegmentUploader.DEFAULT_SEGMENT_UPLOAD_TIMEOUT_MILLIS);
     } else {

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -841,6 +841,7 @@ public class LLRealtimeSegmentDataManagerTest {
     when(tableDataManagerConfig.getTableName()).thenReturn(REALTIME_TABLE_NAME);
     when(tableDataManagerConfig.getTableType()).thenReturn(TableType.REALTIME);
     when(tableDataManagerConfig.getDataDir()).thenReturn(FileUtils.getTempDirectoryPath());
+    when(tableDataManagerConfig.getTableConfig()).thenReturn(tableConfig);
     InstanceDataManagerConfig instanceDataManagerConfig = mock(InstanceDataManagerConfig.class);
     when(instanceDataManagerConfig.getMaxParallelSegmentBuilds()).thenReturn(4);
     when(instanceDataManagerConfig.getStreamSegmentDownloadUntarRateLimit()).thenReturn(-1L);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactoryTest.java
@@ -99,9 +99,11 @@ public class SegmentCommitterFactoryTest {
     Map<String, String> streamConfigMap = new HashMap<>(getMinimumStreamConfigMap());
     streamConfigMap.put(StreamConfigProperties.SERVER_UPLOAD_TO_DEEPSTORE, "true");
     TableConfig config = createRealtimeTableConfig("testDeepStoreConfig", streamConfigMap).build();
+    IndexLoadingConfig indexLoadingConfig = Mockito.mock(IndexLoadingConfig.class);
+    Mockito.when(indexLoadingConfig.getSegmentStoreURI()).thenReturn("file:///path/to/segment/store.txt");
 
     SegmentCommitterFactory factory = new SegmentCommitterFactory(Mockito.mock(Logger.class), protocolHandler, config,
-        Mockito.mock(IndexLoadingConfig.class), Mockito.mock(ServerMetrics.class));
+        indexLoadingConfig, Mockito.mock(ServerMetrics.class));
     SegmentCommitter committer = factory.createSegmentCommitter(true, requestParams, controllerVipUrl);
     Assert.assertNotNull(committer);
     Assert.assertTrue(committer instanceof SplitSegmentCommitter);
@@ -115,7 +117,7 @@ public class SegmentCommitterFactoryTest {
         .build();
 
     factory = new SegmentCommitterFactory(Mockito.mock(Logger.class), protocolHandler, config1,
-        Mockito.mock(IndexLoadingConfig.class), Mockito.mock(ServerMetrics.class));
+        indexLoadingConfig, Mockito.mock(ServerMetrics.class));
     committer = factory.createSegmentCommitter(true, requestParams, controllerVipUrl);
     Assert.assertNotNull(committer);
     Assert.assertTrue(committer instanceof SplitSegmentCommitter);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -39,7 +39,6 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.HelixManager;
 import org.apache.helix.model.ExternalView;
@@ -112,10 +111,6 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     _instanceId = _instanceDataManagerConfig.getInstanceId();
     _helixManager = helixManager;
     _serverMetrics = serverMetrics;
-    if (StringUtils.isEmpty(_instanceDataManagerConfig.getSegmentStoreUri())) {
-      LOGGER.warn("Segment store uri not configured on this instance. PinotFSSegmentUploader will fail to upload "
-          + "segments to segment store.");
-    }
     _segmentUploader = new PinotFSSegmentUploader(_instanceDataManagerConfig.getSegmentStoreUri(),
         PinotFSSegmentUploader.DEFAULT_SEGMENT_UPLOAD_TIMEOUT_MILLIS);
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.server.starter.helix;
 
 import com.google.common.base.Preconditions;
+import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -111,6 +112,10 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     _instanceId = _instanceDataManagerConfig.getInstanceId();
     _helixManager = helixManager;
     _serverMetrics = serverMetrics;
+    if (Strings.isNullOrEmpty(_instanceDataManagerConfig.getSegmentStoreUri())) {
+      LOGGER.warn("Segment store uri not configured on this instance. PinotFSSegmentUploader will fail to upload "
+          + "segments to segment store.");
+    }
     _segmentUploader = new PinotFSSegmentUploader(_instanceDataManagerConfig.getSegmentStoreUri(),
         PinotFSSegmentUploader.DEFAULT_SEGMENT_UPLOAD_TIMEOUT_MILLIS);
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.server.starter.helix;
 
 import com.google.common.base.Preconditions;
-import com.google.common.base.Strings;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
@@ -40,6 +39,7 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.HelixManager;
 import org.apache.helix.model.ExternalView;
@@ -112,7 +112,7 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     _instanceId = _instanceDataManagerConfig.getInstanceId();
     _helixManager = helixManager;
     _serverMetrics = serverMetrics;
-    if (Strings.isNullOrEmpty(_instanceDataManagerConfig.getSegmentStoreUri())) {
+    if (StringUtils.isEmpty(_instanceDataManagerConfig.getSegmentStoreUri())) {
       LOGGER.warn("Segment store uri not configured on this instance. PinotFSSegmentUploader will fail to upload "
           + "segments to segment store.");
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -73,6 +73,7 @@ public class StartControllerCommand extends AbstractBaseAdminCommand implements 
   // This can be set via the set method, or via config file input.
   private boolean _tenantIsolation = true;
 
+  @CommandLine.Option(names = {"-configOverride"}, required = false, split = ",")
   private Map<String, Object> _configOverrides = new HashMap<>();
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
@@ -86,6 +86,7 @@ public class StartServerCommand extends AbstractBaseAdminCommand implements Comm
   // TODO support forbids = {"-serverHost", "-serverPort", "-dataDir", "-segmentDir"}
   private String _configFileName;
 
+  @CommandLine.Option(names = {"-configOverride"}, required = false, split = ",")
   private Map<String, Object> _configOverrides = new HashMap<>();
 
   @Override


### PR DESCRIPTION
* When testing server upload to deepstore, we noticed that segment store uri config is not mandatory for the server instance. The upload from server to deep store was failing due to this missing configuration. Moreover, the server logs did not contain any information about why the commit failed and the partition would just hang on the server. 
This PR:
* Improves on the error logging 
* If segment store uri is missing when `serverUploadToDeepstore` is enabled, pinot will throw an exception and will not create the table data manager.
* Added some quick fixes to the `StartController` and `StartServer` commands to accept config overrides via command line


Labels: `bugfix`

