### PR TITLE
Change scripts to use npm ci and webpack --mode development by default

### DIFF
--- a/docker/images/pinot/Dockerfile
+++ b/docker/images/pinot/Dockerfile
@@ -25,7 +25,8 @@ ARG PINOT_BRANCH=master
 ARG KAFKA_VERSION=2.0
 ARG JDK_VERSION=11
 ARG PINOT_GIT_URL="https://github.com/apache/pinot.git"
-RUN echo "Trying to build Pinot from [ ${PINOT_GIT_URL} ] on branch [ ${PINOT_BRANCH} ] with Kafka version [ ${KAFKA_VERSION} ]"
+ARG CI=true
+RUN echo "Trying to build Pinot from [ ${PINOT_GIT_URL} ] on branch [ ${PINOT_BRANCH} ] with Kafka version [ ${KAFKA_VERSION} ] and CI [ ${CI} ]"
 ENV PINOT_HOME=/opt/pinot
 ENV PINOT_BUILD_DIR=/opt/pinot-build
 ENV MAVEN_HOME /usr/share/maven

--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -33,7 +33,7 @@
   <url>https://pinot.apache.org/</url>
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
-    <npm.script>build</npm.script>
+    <npm.script>build-ci</npm.script>
   </properties>
   <dependencies>
     <dependency>
@@ -235,13 +235,13 @@
             </configuration>
           </execution>
           <execution>
-            <id>npm install</id>
+            <id>npm ci</id>
             <goals>
               <goal>npm</goal>
             </goals>
             <phase>generate-resources</phase>
             <configuration>
-              <arguments>install</arguments>
+              <arguments>ci</arguments>
             </configuration>
           </execution>
           <execution>

--- a/pinot-controller/src/main/resources/package.json
+++ b/pinot-controller/src/main/resources/package.json
@@ -7,6 +7,7 @@
     "start": "npm-run-all --parallel lint dev",
     "build": "webpack --mode production",
     "build-dev": "webpack --mode development",
+    "build-ci": "if [ \"$CI\" = true ]; then npm run-script build; else npm run-script build-dev; fi",
     "build-analyze": "webpack --mode production --analyze",
     "lint": "eslint 'app/**/*.{js,ts,tsx,jsx}' --quiet --fix",
     "test": "echo \"Error: no test specified\" && exit 1"


### PR DESCRIPTION
`pinot-controller` contains a resource which is the controller frontend, which is built with npm. This PR tries to improve the developer relation with these code by:
1. Using `npm ci` instead of `npm install`.
2. Using `webpack --mode development` instead of `webpack --mode production` by default.

The first is a recommended way to build npm projects when package-lock.json is used. From https://docs.npmjs.com/cli/v9/commands/npm-ci:
> This command is similar to [npm install](https://docs.npmjs.com/cli/v9/commands/npm-install), except it's meant to be used in automated environments such as test platforms, continuous integration, and deployment -- or any situation where you want to make sure you're doing a clean install of your dependencies.

The differences with `npm install` can be seen in the link above, but the main idea is that `npm ci` will always use the dependencies in `package-lock.json` while `npm install` will try to verify if there is a newer library version (when open versions, aka ^ in npm, are used). By using `npm ci` we are going to have more repeatable builds. The idea is that whenever we actually want to upgrade dependencies we should do `npm install` (or the alternative that only updates the single dependency we care about) locally, which will modify the `package-lock.json` and the commit that file, which will make that any `npm ci` executed after that (in both dev envs and ci env) will use the new dependency.

The second change tries to accelerate the build in dev machines. Right now the `generate-resources` maven phase is bound to execute `npm run-script build`, which in fact executes `webpack --mode production`. There is another npm script called `build-dev` which runs `webpack --mode development`. The difference between these modes can be seen in the [offical documentation](https://webpack.js.org/configuration/mode/), but the idea is that development mode should be used in... well, development environments. It will not mangle the code, which means that it will be more verbose and easier to debug, but it will take less time to create the package.

What this PR does is to add and use a new npm script called `build-ci` which is defined as:
```
    "build-ci": "if [ \"$CI\" = true ]; then npm run-script build; else npm run-script build-dev; fi",
```

CI is a variable defined in most CIs, including GitHub Actions ([link](https://docs.github.com/en/actions/learn-github-actions/variables#default-environment-variables)). If this variable is defined and its value is true, then `npm run-script build` will be executed, which is the normal behavior right now. Otherwise `npm run-script build-dev` will be executed. Therefore in dev machines, where CI env variable will not be defined, we will build the bundle using the faster and easier to debug mode.

In the build log we can know whether it is using one mode or the other. For example:
```
[INFO] > if [ "$CI" = true ]; then npm run-script build; else npm run-script build-dev; fi
[INFO] 
[INFO] 
[INFO] > pinot-controller-ui@1.0.0 build /opt/proyectos/startree/pinot/pinot-controller/src/main/resources
[INFO] > webpack --mode production
```

This PR also changes the dockerfile when building Pinot in order to set the CI variable to true by default. This is needed to correctly build the image in both CI environments and in local ones, although we can opt out by setting the docker ARG to false
