### PR TITLE
[multistage][hotfix] fix limit pushdown only keep 10_000 rows

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -38,9 +38,9 @@ import org.slf4j.LoggerFactory;
 
 public class SortOperator extends MultiStageOperator {
   private static final String EXPLAIN_NAME = "SORT";
-  private final MultiStageOperator _upstreamOperator;
   private static final Logger LOGGER = LoggerFactory.getLogger(SortOperator.class);
 
+  private final MultiStageOperator _upstreamOperator;
   private final int _fetch;
   private final int _offset;
   private final DataSchema _dataSchema;
@@ -62,16 +62,14 @@ public class SortOperator extends MultiStageOperator {
   @VisibleForTesting
   SortOperator(MultiStageOperator upstreamOperator, List<RexExpression> collationKeys,
       List<RelFieldCollation.Direction> collationDirections, int fetch, int offset, DataSchema dataSchema,
-      int maxHolderCapacity, long requestId, int stageId) {
+      int defaultHolderCapacity, long requestId, int stageId) {
     _upstreamOperator = upstreamOperator;
     _fetch = fetch;
     _offset = Math.max(offset, 0);
     _dataSchema = dataSchema;
     _upstreamErrorBlock = null;
     _isSortedBlockConstructed = false;
-    _numRowsToKeep = _fetch > 0
-        ? Math.min(maxHolderCapacity, _fetch + (Math.max(_offset, 0)))
-        : maxHolderCapacity;
+    _numRowsToKeep = _fetch > 0 ? _fetch + _offset : defaultHolderCapacity;
     _rows = new PriorityQueue<>(_numRowsToKeep,
         new SortComparator(collationKeys, collationDirections, dataSchema, false));
     _operatorStats = new OperatorStats(requestId, stageId, EXPLAIN_NAME);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
@@ -248,12 +248,12 @@ public class SortOperatorTest {
   }
 
   @Test
-  public void shouldRespectMaxLimit() {
+  public void shouldRespectDefaultLimit() {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 2, 0, schema, 1, 1, 2);
+    SortOperator op = new SortOperator(_input, collation, directions, 0, 0, schema, 1, 1, 2);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))


### PR DESCRIPTION
previously sort is hard-coded to have limit 10_000. we should not limit on this. this will cause `SELECT * FROM tbl LIMIT 100000` to only return 10_000 rows.