### PR TITLE
fix table sorting while filter is applied

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -333,7 +333,8 @@ export default function CustomizedTables({
         }
         return false;
       });
-      setFinalData(filteredRescords);
+      let filteredData = {...initialData, records: filteredRescords};
+      setFinalData(Utils.tableFormat(filteredData));
     }
   }, [initialData, setFinalData]);
 
@@ -341,6 +342,9 @@ export default function CustomizedTables({
     clearTimeout(timeoutId.current);
     timeoutId.current = setTimeout(() => {
       filterSearchResults(search.toLowerCase());
+      // Table.tsx currently doesn't support sorting after filtering. So for now, we just
+      // remove the visual indicator of the sorted column until users sort again.
+      setColumnClicked('')
     }, 200);
 
     return () => {

--- a/pinot-controller/src/main/resources/app/utils/Utils.tsx
+++ b/pinot-controller/src/main/resources/app/utils/Utils.tsx
@@ -22,7 +22,7 @@ import React from 'react';
 import ReactDiffViewer, {DiffMethod} from 'react-diff-viewer';
 import { map, isEqual, findIndex, findLast } from 'lodash';
 import app_state from '../app_state';
-import { DISPLAY_SEGMENT_STATUS, SEGMENT_STATUS } from 'Models';
+import {DISPLAY_SEGMENT_STATUS, SEGMENT_STATUS, TableData} from 'Models';
 
 const sortArray = function (sortingArr, keyName, ascendingFlag) {
   if (ascendingFlag) {
@@ -47,13 +47,13 @@ const sortArray = function (sortingArr, keyName, ascendingFlag) {
   });
 };
 
-const tableFormat = (data) => {
+const tableFormat = (data: TableData): Array<{ [key: string]: any }> => {
   const rows = data.records;
   const header = data.columns;
 
-  const results = [];
+  const results: Array<{ [key: string]: any }> = [];
   rows.forEach((singleRow) => {
-    const obj = {};
+    const obj: { [key: string]: any } = {};
     singleRow.forEach((val: any, index: number) => {
       obj[header[index]+app_state.columnNameSeparator+index] = val;
     });


### PR DESCRIPTION
This is a `ui` `bugfix`. Not sure how this was working before as the data type was completely off. But now when you filter a table, the correct data type is stored, and you can keep sorting.

If you filter while sorted, the data would become unsorted. This is fixable, but I think this whole component needs some refactoring and testing by a real frontend person. So for now, i'm just removing the little arrow indicating sorting if you filter while sorted.