### PR TITLE
Fix the issue with ADLSGen2 connector when writing a file

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/main/java/org/apache/pinot/plugin/filesystem/ADLSGen2PinotFS.java
@@ -657,7 +657,7 @@ public class ADLSGen2PinotFS extends BasePinotFS {
         totalBytesRead += bytesRead;
       }
       // Call flush on ADLS Gen 2
-      fileClient.flush(totalBytesRead);
+      fileClient.flush(totalBytesRead, true);
 
       return true;
     } catch (DataLakeStorageException | NoSuchAlgorithmException e) {


### PR DESCRIPTION
412 error has been introduced after the client version bump. This is because the behavior change from the ADLSGen2 client. For more context, please check:
https://github.com/Azure/azure-sdk-for-java/issues/31248