### PR TITLE
[multistage] consolidate operator stats

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -54,16 +54,13 @@ public class FilterOperator extends MultiStageOperator {
   private final DataSchema _dataSchema;
   private TransferableBlock _upstreamErrorBlock;
 
-  // TODO: Move to OperatorContext class.
-  private OperatorStats _operatorStats;
-
   public FilterOperator(MultiStageOperator upstreamOperator, DataSchema dataSchema, RexExpression filter,
       long requestId, int stageId) {
+    super(requestId, stageId);
     _upstreamOperator = upstreamOperator;
     _dataSchema = dataSchema;
     _filterOperand = TransformOperand.toTransformOperand(filter, dataSchema);
     _upstreamErrorBlock = null;
-    _operatorStats = new OperatorStats(requestId, stageId, EXPLAIN_NAME);
   }
 
   @Override
@@ -74,23 +71,16 @@ public class FilterOperator extends MultiStageOperator {
   @Nullable
   @Override
   public String toExplainString() {
-    _upstreamOperator.toExplainString();
-    LOGGER.debug(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 
   @Override
   protected TransferableBlock getNextBlock() {
-    _operatorStats.startTimer();
     try {
-      _operatorStats.endTimer();
       TransferableBlock block = _upstreamOperator.nextBlock();
-      _operatorStats.startTimer();
       return transform(block);
     } catch (Exception e) {
       return TransferableBlockUtils.getErrorTransferableBlock(e);
-    } finally {
-      _operatorStats.endTimer();
     }
   }
 
@@ -113,8 +103,6 @@ public class FilterOperator extends MultiStageOperator {
         resultRows.add(row);
       }
     }
-    _operatorStats.recordInput(1, container.size());
-    _operatorStats.recordOutput(1, resultRows.size());
     return new TransferableBlock(resultRows, _dataSchema, DataBlock.Type.ROW);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -39,12 +39,10 @@ public class LiteralValueOperator extends MultiStageOperator {
   private final TransferableBlock _rexLiteralBlock;
   private boolean _isLiteralBlockReturned;
 
-  private OperatorStats _operatorStats;
-
   public LiteralValueOperator(DataSchema dataSchema, List<List<RexExpression>> rexLiteralRows,
       long requestId, int stageId) {
+    super(requestId, stageId);
     _dataSchema = dataSchema;
-    _operatorStats = new OperatorStats(requestId, stageId, EXPLAIN_NAME);
     _rexLiteralBlock = constructBlock(rexLiteralRows);
     _isLiteralBlockReturned = false;
   }
@@ -57,22 +55,16 @@ public class LiteralValueOperator extends MultiStageOperator {
   @Nullable
   @Override
   public String toExplainString() {
-    LOGGER.debug(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 
   @Override
   protected TransferableBlock getNextBlock() {
-    try {
-      _operatorStats.startTimer();
-      if (!_isLiteralBlockReturned) {
-        _isLiteralBlockReturned = true;
-        return _rexLiteralBlock;
-      } else {
-        return TransferableBlockUtils.getEndOfStreamTransferableBlock();
-      }
-    } finally {
-      _operatorStats.endTimer();
+    if (!_isLiteralBlockReturned) {
+      _isLiteralBlockReturned = true;
+      return _rexLiteralBlock;
+    } else {
+      return TransferableBlockUtils.getEndOfStreamTransferableBlock();
     }
   }
 
@@ -85,8 +77,6 @@ public class LiteralValueOperator extends MultiStageOperator {
       }
       blockContent.add(row);
     }
-    _operatorStats.recordInput(1, blockContent.size());
-    _operatorStats.recordOutput(1, blockContent.size());
     return new TransferableBlock(blockContent, _dataSchema, DataBlock.Type.ROW);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -66,7 +66,6 @@ public class MailboxReceiveOperator extends MultiStageOperator {
   private final long _deadlineTimestampNano;
   private int _serverIdx;
   private TransferableBlock _upstreamErrorBlock;
-  private OperatorStats _operatorStats;
 
   private static MailboxIdentifier toMailboxId(VirtualServer sender, long jobId, long stageId,
       VirtualServerAddress receiver) {
@@ -80,6 +79,7 @@ public class MailboxReceiveOperator extends MultiStageOperator {
   public MailboxReceiveOperator(MailboxService<TransferableBlock> mailboxService,
       List<VirtualServer> sendingStageInstances, RelDistribution.Type exchangeType, VirtualServerAddress receiver,
       long jobId, int stageId, Long timeoutMs) {
+    super(jobId, stageId);
     _mailboxService = mailboxService;
     Preconditions.checkState(SUPPORTED_EXCHANGE_TYPES.contains(exchangeType),
         "Exchange/Distribution type: " + exchangeType + " is not supported!");
@@ -113,7 +113,6 @@ public class MailboxReceiveOperator extends MultiStageOperator {
     }
     _upstreamErrorBlock = null;
     _serverIdx = 0;
-    _operatorStats = new OperatorStats(jobId, stageId, EXPLAIN_NAME);
   }
 
   public List<MailboxIdentifier> getSendingMailbox() {
@@ -128,68 +127,60 @@ public class MailboxReceiveOperator extends MultiStageOperator {
   @Nullable
   @Override
   public String toExplainString() {
-    LOGGER.debug(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 
   @Override
   protected TransferableBlock getNextBlock() {
-    try {
-      _operatorStats.startTimer();
-      if (_upstreamErrorBlock != null) {
-        return _upstreamErrorBlock;
-      } else if (System.nanoTime() >= _deadlineTimestampNano) {
-        return TransferableBlockUtils.getErrorTransferableBlock(QueryException.EXECUTION_TIMEOUT_ERROR);
-      }
+    if (_upstreamErrorBlock != null) {
+      return _upstreamErrorBlock;
+    } else if (System.nanoTime() >= _deadlineTimestampNano) {
+      return TransferableBlockUtils.getErrorTransferableBlock(QueryException.EXECUTION_TIMEOUT_ERROR);
+    }
 
-      int startingIdx = _serverIdx;
-      int openMailboxCount = 0;
-      int eosMailboxCount = 0;
+    int startingIdx = _serverIdx;
+    int openMailboxCount = 0;
+    int eosMailboxCount = 0;
 
-      // For all non-singleton distribution, we poll from every instance to check mailbox content.
-      // TODO: Fix wasted CPU cycles on waiting for servers that are not supposed to give content.
-      for (int i = 0; i < _sendingMailbox.size(); i++) {
-        // this implements a round-robin mailbox iterator, so we don't starve any mailboxes
-        _serverIdx = (startingIdx + i) % _sendingMailbox.size();
-        MailboxIdentifier mailboxId = _sendingMailbox.get(_serverIdx);
-        try {
-          ReceivingMailbox<TransferableBlock> mailbox = _mailboxService.getReceivingMailbox(mailboxId);
-          if (!mailbox.isClosed()) {
-            openMailboxCount++;
-            TransferableBlock block = mailbox.receive();
-            // Get null block when pulling times out from mailbox.
-            if (block != null) {
-              if (block.isErrorBlock()) {
-                _upstreamErrorBlock =
-                    TransferableBlockUtils.getErrorTransferableBlock(block.getDataBlock().getExceptions());
-                return _upstreamErrorBlock;
-              }
-              if (!block.isEndOfStreamBlock()) {
-                _operatorStats.recordInput(1, block.getNumRows());
-                _operatorStats.recordOutput(1, block.getNumRows());
-                return block;
-              } else {
-                eosMailboxCount++;
-              }
+    // For all non-singleton distribution, we poll from every instance to check mailbox content.
+    // TODO: Fix wasted CPU cycles on waiting for servers that are not supposed to give content.
+    for (int i = 0; i < _sendingMailbox.size(); i++) {
+      // this implements a round-robin mailbox iterator, so we don't starve any mailboxes
+      _serverIdx = (startingIdx + i) % _sendingMailbox.size();
+      MailboxIdentifier mailboxId = _sendingMailbox.get(_serverIdx);
+      try {
+        ReceivingMailbox<TransferableBlock> mailbox = _mailboxService.getReceivingMailbox(mailboxId);
+        if (!mailbox.isClosed()) {
+          openMailboxCount++;
+          TransferableBlock block = mailbox.receive();
+          // Get null block when pulling times out from mailbox.
+          if (block != null) {
+            if (block.isErrorBlock()) {
+              _upstreamErrorBlock =
+                  TransferableBlockUtils.getErrorTransferableBlock(block.getDataBlock().getExceptions());
+              return _upstreamErrorBlock;
+            }
+            if (!block.isEndOfStreamBlock()) {
+              return block;
+            } else {
+              eosMailboxCount++;
             }
           }
-        } catch (Exception e) {
-          return TransferableBlockUtils.getErrorTransferableBlock(
-              new RuntimeException(String.format("Error polling mailbox=%s", mailboxId), e));
         }
+      } catch (Exception e) {
+        return TransferableBlockUtils.getErrorTransferableBlock(
+            new RuntimeException(String.format("Error polling mailbox=%s", mailboxId), e));
       }
-
-      // there are two conditions in which we should return EOS: (1) there were
-      // no mailboxes to open (this shouldn't happen because the second condition
-      // should be hit first, but is defensive) (2) every mailbox that was opened
-      // returned an EOS block. in every other scenario, there are mailboxes that
-      // are not yet exhausted and we should wait for more data to be available
-      TransferableBlock block =
-          openMailboxCount > 0 && openMailboxCount > eosMailboxCount ? TransferableBlockUtils.getNoOpTransferableBlock()
-              : TransferableBlockUtils.getEndOfStreamTransferableBlock();
-      return block;
-    } finally {
-      _operatorStats.endTimer();
     }
+
+    // there are two conditions in which we should return EOS: (1) there were
+    // no mailboxes to open (this shouldn't happen because the second condition
+    // should be hit first, but is defensive) (2) every mailbox that was opened
+    // returned an EOS block. in every other scenario, there are mailboxes that
+    // are not yet exhausted and we should wait for more data to be available
+    TransferableBlock block =
+        openMailboxCount > 0 && openMailboxCount > eosMailboxCount ? TransferableBlockUtils.getNoOpTransferableBlock()
+            : TransferableBlockUtils.getEndOfStreamTransferableBlock();
+    return block;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -81,6 +81,7 @@ public class MailboxSendOperator extends MultiStageOperator {
       MultiStageOperator dataTableBlockBaseOperator, List<VirtualServer> receivingStageInstances,
       RelDistribution.Type exchangeType, KeySelector<Object[], Object[]> keySelector,
       MailboxIdGenerator mailboxIdGenerator, BlockExchangeFactory blockExchangeFactory, long jobId, int stageId) {
+    super(jobId, stageId);
     _dataTableBlockBaseOperator = dataTableBlockBaseOperator;
 
     List<MailboxIdentifier> receivingMailboxes;
@@ -124,8 +125,6 @@ public class MailboxSendOperator extends MultiStageOperator {
   @Nullable
   @Override
   public String toExplainString() {
-    _dataTableBlockBaseOperator.toExplainString();
-    LOGGER.debug(_operatorStats.toString());
     return EXPLAIN_NAME;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -45,7 +45,7 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
     try (InvocationScope ignored = Tracing.getTracer().createScope(getClass())) {
       _operatorStats.startTimer();
       TransferableBlock nextBlock = getNextBlock();
-      _operatorStats.recordOutput(1, nextBlock.getNumRows());
+      _operatorStats.recordRow(1, nextBlock.getNumRows());
       _operatorStats.endTimer();
       // TODO: move this to centralized reporting in broker
       if (nextBlock.isEndOfStreamBlock()) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -19,13 +19,43 @@
 package org.apache.pinot.query.runtime.operator;
 
 import java.util.List;
-import org.apache.pinot.core.operator.BaseOperator;
+import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.spi.exception.EarlyTerminationException;
+import org.apache.pinot.spi.trace.InvocationScope;
+import org.apache.pinot.spi.trace.Tracing;
 import org.slf4j.LoggerFactory;
 
 
-public abstract class MultiStageOperator extends BaseOperator<TransferableBlock> implements AutoCloseable {
+public abstract class MultiStageOperator implements Operator<TransferableBlock>, AutoCloseable {
   private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(MultiStageOperator.class);
+
+  // TODO: Move to OperatorContext class.
+  private OperatorStats _operatorStats;
+
+  public MultiStageOperator(long requestId, int stageId) {
+    _operatorStats = new OperatorStats(requestId, stageId, toExplainString());
+  }
+
+  @Override
+  public final TransferableBlock nextBlock() {
+    if (Tracing.ThreadAccountantOps.isInterrupted()) {
+      throw new EarlyTerminationException("Interrupted while processing next block");
+    }
+    try (InvocationScope ignored = Tracing.getTracer().createScope(getClass())) {
+      _operatorStats.startTimer();
+      TransferableBlock nextBlock = getNextBlock();
+      _operatorStats.recordOutput(1, nextBlock.getNumRows());
+      _operatorStats.endTimer();
+      if (nextBlock.isEndOfStreamBlock()) {
+        LOGGER.info("Recorded operator stats: " + _operatorStats);
+      }
+      return nextBlock;
+    }
+  }
+
+  // Make it protected because we should always call nextBlock()
+  protected abstract TransferableBlock getNextBlock();
 
   @Override
   public List<MultiStageOperator> getChildOperators() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -31,14 +31,14 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
   private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(MultiStageOperator.class);
 
   // TODO: Move to OperatorContext class.
-  private OperatorStats _operatorStats;
+  private final OperatorStats _operatorStats;
 
   public MultiStageOperator(long requestId, int stageId) {
     _operatorStats = new OperatorStats(requestId, stageId, toExplainString());
   }
 
   @Override
-  public final TransferableBlock nextBlock() {
+  public TransferableBlock nextBlock() {
     if (Tracing.ThreadAccountantOps.isInterrupted()) {
       throw new EarlyTerminationException("Interrupted while processing next block");
     }
@@ -47,6 +47,7 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
       TransferableBlock nextBlock = getNextBlock();
       _operatorStats.recordOutput(1, nextBlock.getNumRows());
       _operatorStats.endTimer();
+      // TODO: move this to centralized reporting in broker
       if (nextBlock.isEndOfStreamBlock()) {
         LOGGER.info("Recorded operator stats: " + _operatorStats);
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
@@ -31,12 +31,8 @@ public class OperatorStats {
 
   private final String _operatorType;
 
-  private int _numInputBlock = 0;
-  private int _numInputRows = 0;
-
-  private int _numOutputBlock = 0;
-
-  private int _numOutputRows = 0;
+  private int _numBlock = 0;
+  private int _numRows = 0;
 
   public OperatorStats(long requestId, int stageId, String operatorType) {
     _stageId = stageId;
@@ -56,23 +52,16 @@ public class OperatorStats {
     }
   }
 
-  public void recordInput(int numBlock, int numRows) {
-    _numInputBlock += numBlock;
-    _numInputRows += numRows;
-  }
-
-  public void recordOutput(int numBlock, int numRows) {
-    _numOutputBlock += numBlock;
-    _numOutputRows += numRows;
+  public void recordRow(int numBlock, int numRows) {
+    _numBlock += numBlock;
+    _numRows += numRows;
   }
 
   // TODO: Return the string as a JSON string.
   @Override
   public String toString() {
     return String.format(
-        "OperatorStats[type: %s, requestId: %s, stageId %s] ExecutionWallTime: %sms, InputRows: %s, InputBlock: "
-            + "%s, OutputRows: %s, OutputBlock: %s", _operatorType, _requestId, _stageId,
-        _executeStopwatch.elapsed(TimeUnit.MILLISECONDS), _numInputRows, _numInputBlock, _numOutputRows,
-        _numOutputBlock);
+        "OperatorStats[requestId: %s, stageId %s, type: %s] ExecutionWallTime: %sms, No. Rows: %s, No. Block: %s",
+        _requestId, _stageId, _operatorType, _executeStopwatch.elapsed(TimeUnit.MILLISECONDS), _numRows, _numBlock);
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
@@ -36,6 +36,13 @@ public class MultistageEngineQuickStart extends Quickstart {
       "examples/batch/ssb/lineorder",
       "examples/batch/ssb/part",
       "examples/batch/ssb/supplier",
+      "examples/batch/airlineStats",
+      "examples/batch/baseballStats",
+      "examples/batch/dimBaseballTeams",
+      "examples/batch/starbucksStores",
+      "examples/batch/githubEvents",
+      "examples/batch/githubComplexTypeEvents",
+      "examples/batch/billing",
   };
 
   @Override
@@ -81,9 +88,7 @@ public class MultistageEngineQuickStart extends Quickstart {
 
   @Override
   public String[] getDefaultBatchTableDirectories() {
-    List<String> tableDirs = new ArrayList<>(Arrays.asList(MULTI_STAGE_TABLE_DIRECTORIES));
-    tableDirs.addAll(Arrays.asList(DEFAULT_OFFLINE_TABLE_DIRECTORIES));
-    return tableDirs.toArray(new String[]{});
+    return MULTI_STAGE_TABLE_DIRECTORIES;
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
@@ -36,13 +36,6 @@ public class MultistageEngineQuickStart extends Quickstart {
       "examples/batch/ssb/lineorder",
       "examples/batch/ssb/part",
       "examples/batch/ssb/supplier",
-      "examples/batch/airlineStats",
-      "examples/batch/baseballStats",
-      "examples/batch/dimBaseballTeams",
-      "examples/batch/starbucksStores",
-      "examples/batch/githubEvents",
-      "examples/batch/githubComplexTypeEvents",
-      "examples/batch/billing",
   };
 
   @Override
@@ -88,7 +81,9 @@ public class MultistageEngineQuickStart extends Quickstart {
 
   @Override
   public String[] getDefaultBatchTableDirectories() {
-    return MULTI_STAGE_TABLE_DIRECTORIES;
+    List<String> tableDirs = new ArrayList<>(Arrays.asList(MULTI_STAGE_TABLE_DIRECTORIES));
+    tableDirs.addAll(Arrays.asList(DEFAULT_OFFLINE_TABLE_DIRECTORIES));
+    return tableDirs.toArray(new String[]{});
   }
 
   @Override


### PR DESCRIPTION
Summary
===
consolidate all stats logging to multistage operator 

- all logging is done in `MultistageOperator` base class
    - wrapped in a new nextBlock() method.
    - logged once per operator per server instance.
- removed input/output row, input row is just the output row of the upstream operators
- removed the inserted start/stop in actual operator impl, so time will include the targetted operator and its upstreams
- made it much easier to sort and find individual request/stage stats as they are lump together.


Example
===
Example below on a 3 server cluster (all 3 server logs are consolidated)
- Example 1
<details>
  <summary>sql1</summary>

```
SELECT AirlineID, count(*) 
FROM airlineStats 
WHERE Dest IN (
  SELECT Origin FROM airlineStats WHERE WeatherDelay > 10
)
GROUP BY AirlineID
ORDER BY COUNT(*) DESC
LIMIT 1000
```

</details>
<details>
  <summary>log1</summary>

```
43220 2023/02/06 14:48:19.311 INFO [ControllerResponseFilter] [grizzly-http-server-17] Handled request from 0:0:0:0:0:0:0:1 POST http://localhost:9000/sql, content-type application/json; charset=UTF-8 status code 200 OK
43221 2023/02/06 14:48:20.384 INFO [PinotQueryResource] [grizzly-http-server-20] url string passed is : http://192.168.1.23:8000/query/sql
43222 2023/02/06 14:48:20.430 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-30] Recorded operator stats: OperatorStats[requestId: 6, stageId 4, type: LEAF_STAGE_TRANSFER_OPERATOR] ExecutionWallTime: 0ms, No. Rows: 3187, No. Block: 2
43223 2023/02/06 14:48:20.430 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-30] Recorded operator stats: OperatorStats[requestId: 6, stageId 4, type: MAILBOX_SEND] ExecutionWallTime: 1ms, No. Rows: 0, No. Block: 1
43224 2023/02/06 14:48:20.433 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-29] Recorded operator stats: OperatorStats[requestId: 6, stageId 4, type: LEAF_STAGE_TRANSFER_OPERATOR] ExecutionWallTime: 0ms, No. Rows: 3350, No. Block: 2
43225 2023/02/06 14:48:20.433 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-29] Recorded operator stats: OperatorStats[requestId: 6, stageId 4, type: MAILBOX_SEND] ExecutionWallTime: 1ms, No. Rows: 0, No. Block: 1
43226 2023/02/06 14:48:20.436 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-18] Recorded operator stats: OperatorStats[requestId: 6, stageId 4, type: LEAF_STAGE_TRANSFER_OPERATOR] ExecutionWallTime: 0ms, No. Rows: 3209, No. Block: 2
43227 2023/02/06 14:48:20.436 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-18] Recorded operator stats: OperatorStats[requestId: 6, stageId 4, type: MAILBOX_SEND] ExecutionWallTime: 1ms, No. Rows: 0, No. Block: 1
43228 2023/02/06 14:48:20.444 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-7] Recorded operator stats: OperatorStats[requestId: 6, stageId 6, type: LEAF_STAGE_TRANSFER_OPERATOR] ExecutionWallTime: 0ms, No. Rows: 25, No. Block: 2
43229 2023/02/06 14:48:20.444 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-7] Recorded operator stats: OperatorStats[requestId: 6, stageId 6, type: MAILBOX_SEND] ExecutionWallTime: 1ms, No. Rows: 0, No. Block: 1
43230 2023/02/06 14:48:20.447 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-8] Recorded operator stats: OperatorStats[requestId: 6, stageId 6, type: LEAF_STAGE_TRANSFER_OPERATOR] ExecutionWallTime: 0ms, No. Rows: 20, No. Block: 2
43231 2023/02/06 14:48:20.448 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-8] Recorded operator stats: OperatorStats[requestId: 6, stageId 6, type: MAILBOX_SEND] ExecutionWallTime: 1ms, No. Rows: 0, No. Block: 1
43232 2023/02/06 14:48:20.450 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-32] Recorded operator stats: OperatorStats[requestId: 6, stageId 6, type: LEAF_STAGE_TRANSFER_OPERATOR] ExecutionWallTime: 0ms, No. Rows: 24, No. Block: 2
43233 2023/02/06 14:48:20.450 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-32] Recorded operator stats: OperatorStats[requestId: 6, stageId 6, type: MAILBOX_SEND] ExecutionWallTime: 0ms, No. Rows: 0, No. Block: 1
43234 2023/02/06 14:48:20.450 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-10] Recorded operator stats: OperatorStats[requestId: 6, stageId 6, type: MAILBOX_RECEIVE] ExecutionWallTime: 9ms, No. Rows: 22, No. Block: 9
43235 2023/02/06 14:48:20.451 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-10] Recorded operator stats: OperatorStats[requestId: 6, stageId 5, type: AGGREGATE_OPERATOR] ExecutionWallTime: 9ms, No. Rows: 16, No. Block: 7
43236 2023/02/06 14:48:20.451 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-26] Recorded operator stats: OperatorStats[requestId: 6, stageId 6, type: MAILBOX_RECEIVE] ExecutionWallTime: 15ms, No. Rows: 25, No. Block: 7
43237 2023/02/06 14:48:20.451 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-24] Recorded operator stats: OperatorStats[requestId: 6, stageId 6, type: MAILBOX_RECEIVE] ExecutionWallTime: 13ms, No. Rows: 22, No. Block: 7
43238 2023/02/06 14:48:20.451 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-26] Recorded operator stats: OperatorStats[requestId: 6, stageId 5, type: AGGREGATE_OPERATOR] ExecutionWallTime: 16ms, No. Rows: 16, No. Block: 5
43239 2023/02/06 14:48:20.451 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-24] Recorded operator stats: OperatorStats[requestId: 6, stageId 5, type: AGGREGATE_OPERATOR] ExecutionWallTime: 13ms, No. Rows: 17, No. Block: 5
43240 2023/02/06 14:48:20.451 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-10] Recorded operator stats: OperatorStats[requestId: 6, stageId 5, type: MAILBOX_SEND] ExecutionWallTime: 9ms, No. Rows: 0, No. Block: 6
43241 2023/02/06 14:48:20.451 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-24] Recorded operator stats: OperatorStats[requestId: 6, stageId 5, type: MAILBOX_SEND] ExecutionWallTime: 14ms, No. Rows: 0, No. Block: 4
43242 2023/02/06 14:48:20.451 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-26] Recorded operator stats: OperatorStats[requestId: 6, stageId 5, type: MAILBOX_SEND] ExecutionWallTime: 16ms, No. Rows: 0, No. Block: 4
43243 2023/02/06 14:48:20.452 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-14] Recorded operator stats: OperatorStats[requestId: 6, stageId 5, type: MAILBOX_RECEIVE] ExecutionWallTime: 31ms, No. Rows: 16, No. Block: 3
43244 2023/02/06 14:48:20.452 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-23] Recorded operator stats: OperatorStats[requestId: 6, stageId 5, type: MAILBOX_RECEIVE] ExecutionWallTime: 29ms, No. Rows: 17, No. Block: 3
43245 2023/02/06 14:48:20.452 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-9] Recorded operator stats: OperatorStats[requestId: 6, stageId 5, type: MAILBOX_RECEIVE] ExecutionWallTime: 27ms, No. Rows: 16, No. Block: 3
43246 2023/02/06 14:48:20.454 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-14] Recorded operator stats: OperatorStats[requestId: 6, stageId 4, type: MAILBOX_RECEIVE] ExecutionWallTime: 0ms, No. Rows: 3541, No. Block: 4
43247 2023/02/06 14:48:20.454 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-14] Recorded operator stats: OperatorStats[requestId: 6, stageId 3, type: HASH_JOIN] ExecutionWallTime: 32ms, No. Rows: 2375, No. Block: 5
43248 2023/02/06 14:48:20.454 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-9] Recorded operator stats: OperatorStats[requestId: 6, stageId 4, type: MAILBOX_RECEIVE] ExecutionWallTime: 0ms, No. Rows: 2937, No. Block: 4
43249 2023/02/06 14:48:20.454 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-9] Recorded operator stats: OperatorStats[requestId: 6, stageId 3, type: HASH_JOIN] ExecutionWallTime: 28ms, No. Rows: 1525, No. Block: 5
43250 2023/02/06 14:48:20.454 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-14] Recorded operator stats: OperatorStats[requestId: 6, stageId 3, type: AGGREGATE_OPERATOR] ExecutionWallTime: 33ms, No. Rows: 14, No. Block: 3
43251 2023/02/06 14:48:20.455 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-14] Recorded operator stats: OperatorStats[requestId: 6, stageId 3, type: MAILBOX_SEND] ExecutionWallTime: 34ms, No. Rows: 0, No. Block: 2
43252 2023/02/06 14:48:20.455 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-23] Recorded operator stats: OperatorStats[requestId: 6, stageId 4, type: MAILBOX_RECEIVE] ExecutionWallTime: 0ms, No. Rows: 3268, No. Block: 4
43253 2023/02/06 14:48:20.455 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-23] Recorded operator stats: OperatorStats[requestId: 6, stageId 3, type: HASH_JOIN] ExecutionWallTime: 31ms, No. Rows: 2412, No. Block: 5
43254 2023/02/06 14:48:20.455 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-9] Recorded operator stats: OperatorStats[requestId: 6, stageId 3, type: AGGREGATE_OPERATOR] ExecutionWallTime: 29ms, No. Rows: 14, No. Block: 3
43255 2023/02/06 14:48:20.455 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-23] Recorded operator stats: OperatorStats[requestId: 6, stageId 3, type: AGGREGATE_OPERATOR] ExecutionWallTime: 32ms, No. Rows: 14, No. Block: 3
43256 2023/02/06 14:48:20.455 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-9] Recorded operator stats: OperatorStats[requestId: 6, stageId 3, type: MAILBOX_SEND] ExecutionWallTime: 30ms, No. Rows: 0, No. Block: 2
43257 2023/02/06 14:48:20.455 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-23] Recorded operator stats: OperatorStats[requestId: 6, stageId 3, type: MAILBOX_SEND] ExecutionWallTime: 32ms, No. Rows: 0, No. Block: 2
43258 2023/02/06 14:48:20.456 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-13] Recorded operator stats: OperatorStats[requestId: 6, stageId 3, type: MAILBOX_RECEIVE] ExecutionWallTime: 43ms, No. Rows: 18, No. Block: 6
43259 2023/02/06 14:48:20.456 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-13] Recorded operator stats: OperatorStats[requestId: 6, stageId 2, type: AGGREGATE_OPERATOR] ExecutionWallTime: 43ms, No. Rows: 6, No. Block: 4
43260 2023/02/06 14:48:20.456 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-13] Recorded operator stats: OperatorStats[requestId: 6, stageId 2, type: SORT] ExecutionWallTime: 43ms, No. Rows: 6, No. Block: 4
43261 2023/02/06 14:48:20.456 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-13] Recorded operator stats: OperatorStats[requestId: 6, stageId 2, type: MAILBOX_SEND] ExecutionWallTime: 43ms, No. Rows: 0, No. Block: 3
43262 2023/02/06 14:48:20.456 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-20] Recorded operator stats: OperatorStats[requestId: 6, stageId 3, type: MAILBOX_RECEIVE] ExecutionWallTime: 37ms, No. Rows: 9, No. Block: 7
43263 2023/02/06 14:48:20.456 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-20] Recorded operator stats: OperatorStats[requestId: 6, stageId 2, type: AGGREGATE_OPERATOR] ExecutionWallTime: 37ms, No. Rows: 3, No. Block: 5
43264 2023/02/06 14:48:20.456 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-22] Recorded operator stats: OperatorStats[requestId: 6, stageId 3, type: MAILBOX_RECEIVE] ExecutionWallTime: 40ms, No. Rows: 15, No. Block: 7
43265 2023/02/06 14:48:20.456 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-22] Recorded operator stats: OperatorStats[requestId: 6, stageId 2, type: AGGREGATE_OPERATOR] ExecutionWallTime: 40ms, No. Rows: 5, No. Block: 5
43266 2023/02/06 14:48:20.456 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-20] Recorded operator stats: OperatorStats[requestId: 6, stageId 2, type: SORT] ExecutionWallTime: 37ms, No. Rows: 3, No. Block: 5
43267 2023/02/06 14:48:20.456 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-22] Recorded operator stats: OperatorStats[requestId: 6, stageId 2, type: SORT] ExecutionWallTime: 40ms, No. Rows: 5, No. Block: 5
43268 2023/02/06 14:48:20.456 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-20] Recorded operator stats: OperatorStats[requestId: 6, stageId 2, type: MAILBOX_SEND] ExecutionWallTime: 38ms, No. Rows: 0, No. Block: 4
43269 2023/02/06 14:48:20.456 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-22] Recorded operator stats: OperatorStats[requestId: 6, stageId 2, type: MAILBOX_SEND] ExecutionWallTime: 40ms, No. Rows: 0, No. Block: 4
43270 2023/02/06 14:48:20.457 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-25] Recorded operator stats: OperatorStats[requestId: 6, stageId 2, type: MAILBOX_RECEIVE] ExecutionWallTime: 46ms, No. Rows: 14, No. Block: 6
43271 2023/02/06 14:48:20.457 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-25] Recorded operator stats: OperatorStats[requestId: 6, stageId 1, type: SORT] ExecutionWallTime: 46ms, No. Rows: 14, No. Block: 4
43272 2023/02/06 14:48:20.457 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-25] Recorded operator stats: OperatorStats[requestId: 6, stageId 1, type: MAILBOX_SEND] ExecutionWallTime: 46ms, No. Rows: 0, No. Block: 3
43273 2023/02/06 14:48:20.457 INFO [MultiStageOperator] [jersey-server-managed-async-executor-5] Recorded operator stats: OperatorStats[requestId: 6, stageId 1, type: MAILBOX_RECEIVE] ExecutionWallTime: 9ms, No. Rows: 14, No. Block: 69
```

</details>

- Example 2
<details>
  <summary>sql2</summary>

```
SELECT src.AirlineID, dst.Carrier
FROM airlineStats src JOIN airlineStats dst ON src.Dest = dst.Origin
```

</details>
<details>
  <summary>log2</summary>

```
43413 2023/02/06 14:50:08.285 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-23] Recorded operator stats: OperatorStats[requestId: 8, stageId 2, type: LEAF_STAGE_TRANSFER_OPERATOR] ExecutionWallTime: 0ms, No. Rows: 3187, No. Block: 2
43414 2023/02/06 14:50:08.286 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-23] Recorded operator stats: OperatorStats[requestId: 8, stageId 2, type: MAILBOX_SEND] ExecutionWallTime: 2ms, No. Rows: 0, No. Block: 1
43415 2023/02/06 14:50:08.290 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-5] Recorded operator stats: OperatorStats[requestId: 8, stageId 2, type: LEAF_STAGE_TRANSFER_OPERATOR] ExecutionWallTime: 0ms, No. Rows: 3350, No. Block: 2
43416 2023/02/06 14:50:08.290 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-5] Recorded operator stats: OperatorStats[requestId: 8, stageId 2, type: MAILBOX_SEND] ExecutionWallTime: 3ms, No. Rows: 0, No. Block: 1
43417 2023/02/06 14:50:08.294 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-28] Recorded operator stats: OperatorStats[requestId: 8, stageId 2, type: LEAF_STAGE_TRANSFER_OPERATOR] ExecutionWallTime: 0ms, No. Rows: 3209, No. Block: 2
43418 2023/02/06 14:50:08.294 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-28] Recorded operator stats: OperatorStats[requestId: 8, stageId 2, type: MAILBOX_SEND] ExecutionWallTime: 2ms, No. Rows: 0, No. Block: 1
43419 2023/02/06 14:50:08.298 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-21] Recorded operator stats: OperatorStats[requestId: 8, stageId 3, type: LEAF_STAGE_TRANSFER_OPERATOR] ExecutionWallTime: 0ms, No. Rows: 3187, No. Block: 2
43420 2023/02/06 14:50:08.298 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-21] Recorded operator stats: OperatorStats[requestId: 8, stageId 3, type: MAILBOX_SEND] ExecutionWallTime: 1ms, No. Rows: 0, No. Block: 1
43421 2023/02/06 14:50:08.301 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-12] Recorded operator stats: OperatorStats[requestId: 8, stageId 3, type: LEAF_STAGE_TRANSFER_OPERATOR] ExecutionWallTime: 0ms, No. Rows: 3350, No. Block: 2
43422 2023/02/06 14:50:08.301 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-12] Recorded operator stats: OperatorStats[requestId: 8, stageId 3, type: MAILBOX_SEND] ExecutionWallTime: 1ms, No. Rows: 0, No. Block: 1
43423 2023/02/06 14:50:08.311 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-4] Recorded operator stats: OperatorStats[requestId: 8, stageId 3, type: LEAF_STAGE_TRANSFER_OPERATOR] ExecutionWallTime: 0ms, No. Rows: 3209, No. Block: 2
43424 2023/02/06 14:50:08.311 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-4] Recorded operator stats: OperatorStats[requestId: 8, stageId 3, type: MAILBOX_SEND] ExecutionWallTime: 9ms, No. Rows: 0, No. Block: 1
43425 2023/02/06 14:50:08.311 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-10] Recorded operator stats: OperatorStats[requestId: 8, stageId 3, type: MAILBOX_RECEIVE] ExecutionWallTime: 23ms, No. Rows: 3008, No. Block: 7
43426 2023/02/06 14:50:08.312 INFO [MultiStageOperator] [query_worker_on_8442_port-1-thread-11] Recorded operator stats: OperatorStats[requestId: 8, stageId 3, type: MAILBOX_RECEIVE] ExecutionWallTime: 29ms, No. Rows: 3549, No. Block: 5
43427 2023/02/06 14:50:08.312 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-30] Recorded operator stats: OperatorStats[requestId: 8, stageId 3, type: MAILBOX_RECEIVE] ExecutionWallTime: 34ms, No. Rows: 3189, No. Block: 5
43428 2023/02/06 14:50:08.709 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-10] Recorded operator stats: OperatorStats[requestId: 8, stageId 2, type: MAILBOX_RECEIVE] ExecutionWallTime: 0ms, No. Rows: 2937, No. Block: 4
43429 2023/02/06 14:50:08.709 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-10] Recorded operator stats: OperatorStats[requestId: 8, stageId 1, type: HASH_JOIN] ExecutionWallTime: 144ms, No. Rows: 370623, No. Block: 7
43430 2023/02/06 14:50:08.709 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-10] Recorded operator stats: OperatorStats[requestId: 8, stageId 1, type: TRANSFORM] ExecutionWallTime: 350ms, No. Rows: 370623, No. Block: 7
43431 2023/02/06 14:50:08.709 INFO [MultiStageOperator] [query_worker_on_8444_port-5-thread-10] Recorded operator stats: OperatorStats[requestId: 8, stageId 1, type: MAILBOX_SEND] ExecutionWallTime: 422ms, No. Rows: 0, No. Block: 4
43432 2023/02/06 14:50:08.830 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-30] Recorded operator stats: OperatorStats[requestId: 8, stageId 2, type: MAILBOX_RECEIVE] ExecutionWallTime: 0ms, No. Rows: 3268, No. Block: 4
43433 2023/02/06 14:50:08.830 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-30] Recorded operator stats: OperatorStats[requestId: 8, stageId 1, type: HASH_JOIN] ExecutionWallTime: 166ms, No. Rows: 642933, No. Block: 5
43434 2023/02/06 14:50:08.830 INFO [MultiStageOperator] [query_worker_on_8443_port-3-thread-30] Recorded operator stats: OperatorStats[requestId: 8, stageId 1, type: TRANSFORM] ExecutionWallTime: 372ms, No. Rows: 642933, No. Block: 5
```

</details>

Follow up
===
1. split time between upstream and current operator
    - we don't have input and output and no split between operators so everything is a chained
2. do reporting all at the broker level and consolidate
    - right now it logs everywhere in server not easy to track
3. do default opChain level reporting instead of operator level
    - operator level reporting should be only enabled via Trace