### PR TITLE
[hotfix][multistage] use normal baseballStats

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
@@ -31,11 +31,18 @@ import org.apache.pinot.tools.admin.command.QuickstartRunner;
 
 public class MultistageEngineQuickStart extends Quickstart {
   private static final String[] MULTI_STAGE_TABLE_DIRECTORIES = new String[]{
+      "examples/batch/airlineStats",
+      "examples/batch/baseballStats",
+      "examples/batch/billing",
+      "examples/batch/dimBaseballTeams",
+      "examples/batch/githubEvents",
+      "examples/batch/githubComplexTypeEvents",
       "examples/batch/ssb/customer",
       "examples/batch/ssb/dates",
       "examples/batch/ssb/lineorder",
       "examples/batch/ssb/part",
       "examples/batch/ssb/supplier",
+      "examples/batch/starbucksStores",
   };
 
   @Override
@@ -81,9 +88,7 @@ public class MultistageEngineQuickStart extends Quickstart {
 
   @Override
   public String[] getDefaultBatchTableDirectories() {
-    List<String> tableDirs = new ArrayList<>(Arrays.asList(MULTI_STAGE_TABLE_DIRECTORIES));
-    tableDirs.addAll(Arrays.asList(DEFAULT_OFFLINE_TABLE_DIRECTORIES));
-    return tableDirs.toArray(new String[]{});
+    return MULTI_STAGE_TABLE_DIRECTORIES;
   }
 
   @Override


### PR DESCRIPTION
in multistage-quickstart example to not uses `examples/minions/batch/baseballStats`. instead use normal one `examples/batch/baseballStats`. This saves extra 30-60 second load time.

Since it is already covered in other examples. Making multistage quickstart to use the normal one to save loading time