### PR TITLE
Add PinotHelixResourceManager to MetadataEventNotifier

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -459,7 +459,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     }
 
     final MetadataEventNotifierFactory metadataEventNotifierFactory =
-        MetadataEventNotifierFactory.loadFactory(_config.subset(METADATA_EVENT_NOTIFIER_PREFIX));
+        MetadataEventNotifierFactory.loadFactory(_config.subset(METADATA_EVENT_NOTIFIER_PREFIX), _helixResourceManager);
 
     LOGGER.info("Controller download url base: {}", _config.generateVipUrl());
     LOGGER.info("Injecting configuration and resource managers to the API context");
@@ -495,7 +495,8 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     LOGGER.info("Starting controller admin application on: {}", ListenerConfigUtil.toString(_listenerConfigs));
     _adminApp.start(_listenerConfigs);
 
-    _controllerMetrics.addCallbackGauge("dataDir.exists", () -> new File(_config.getDataDir()).exists() ? 1L : 0L);
+    _controllerMetrics.addCallbackGauge("dataDir.exists",
+        () -> new File(_config.getDataDir()).exists() ? 1L : 0L);
     _controllerMetrics.addCallbackGauge("dataDir.fileOpLatencyMs", () -> {
       File dataDir = new File(_config.getDataDir());
       if (dataDir.exists()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/events/DefaultMetadataEventNotifierFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/events/DefaultMetadataEventNotifierFactory.java
@@ -18,15 +18,17 @@
  */
 package org.apache.pinot.controller.api.events;
 
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 public class DefaultMetadataEventNotifierFactory extends MetadataEventNotifierFactory {
 
-  public MetadataEventNotifier create() {
-    return new DefaultMetadataEventNotifier();
+  @Override
+  public void init(PinotConfiguration configuration, PinotHelixResourceManager pinotHelixResourceManager) {
   }
 
-  public void init(PinotConfiguration configuration) {
+  public MetadataEventNotifier create() {
+    return new DefaultMetadataEventNotifier();
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/events/DefaultMetadataEventNotifierFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/events/DefaultMetadataEventNotifierFactory.java
@@ -28,6 +28,7 @@ public class DefaultMetadataEventNotifierFactory extends MetadataEventNotifierFa
   public void init(PinotConfiguration configuration, PinotHelixResourceManager pinotHelixResourceManager) {
   }
 
+  @Override
   public MetadataEventNotifier create() {
     return new DefaultMetadataEventNotifier();
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/events/MetadataEventNotifierFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/events/MetadataEventNotifierFactory.java
@@ -27,6 +27,7 @@ import org.slf4j.LoggerFactory;
 public abstract class MetadataEventNotifierFactory {
   public static final Logger LOGGER = LoggerFactory.getLogger(MetadataEventNotifierFactory.class);
   public static final String METADATA_EVENT_CLASS_CONFIG = "factory.class";
+
   public abstract void init(PinotConfiguration configuration, PinotHelixResourceManager pinotHelixResourceManager);
 
   public abstract MetadataEventNotifier create();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/events/MetadataEventNotifierFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/events/MetadataEventNotifierFactory.java
@@ -27,10 +27,7 @@ import org.slf4j.LoggerFactory;
 public abstract class MetadataEventNotifierFactory {
   public static final Logger LOGGER = LoggerFactory.getLogger(MetadataEventNotifierFactory.class);
   public static final String METADATA_EVENT_CLASS_CONFIG = "factory.class";
-
-  protected static PinotHelixResourceManager _pinotHelixResourceManager;
-
-  public abstract void init(PinotConfiguration configuration);
+  public abstract void init(PinotConfiguration configuration, PinotHelixResourceManager pinotHelixResourceManager);
 
   public abstract MetadataEventNotifier create();
 
@@ -40,12 +37,11 @@ public abstract class MetadataEventNotifierFactory {
 
     String metadataEventNotifierClassName =
         configuration.getProperty(METADATA_EVENT_CLASS_CONFIG, DefaultMetadataEventNotifierFactory.class.getName());
-    _pinotHelixResourceManager = helixResourceManager;
     try {
       LOGGER.info("Instantiating metadata event notifier factory class {}", metadataEventNotifierClassName);
       metadataEventNotifierFactory =
           (MetadataEventNotifierFactory) Class.forName(metadataEventNotifierClassName).newInstance();
-      metadataEventNotifierFactory.init(configuration);
+      metadataEventNotifierFactory.init(configuration, helixResourceManager);
       return metadataEventNotifierFactory;
     } catch (Exception e) {
       throw new RuntimeException(e);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/events/MetadataEventNotifierFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/events/MetadataEventNotifierFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.api.events;
 
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,16 +28,19 @@ public abstract class MetadataEventNotifierFactory {
   public static final Logger LOGGER = LoggerFactory.getLogger(MetadataEventNotifierFactory.class);
   public static final String METADATA_EVENT_CLASS_CONFIG = "factory.class";
 
+  protected static PinotHelixResourceManager _pinotHelixResourceManager;
+
   public abstract void init(PinotConfiguration configuration);
 
   public abstract MetadataEventNotifier create();
 
-  public static MetadataEventNotifierFactory loadFactory(PinotConfiguration configuration) {
+  public static MetadataEventNotifierFactory loadFactory(PinotConfiguration configuration, PinotHelixResourceManager
+      helixResourceManager) {
     MetadataEventNotifierFactory metadataEventNotifierFactory;
 
     String metadataEventNotifierClassName =
         configuration.getProperty(METADATA_EVENT_CLASS_CONFIG, DefaultMetadataEventNotifierFactory.class.getName());
-
+    _pinotHelixResourceManager = helixResourceManager;
     try {
       LOGGER.info("Instantiating metadata event notifier factory class {}", metadataEventNotifierClassName);
       metadataEventNotifierFactory =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -181,7 +181,8 @@ public class PinotLLCRealtimeSegmentManager {
     _controllerConf = controllerConf;
     _controllerMetrics = controllerMetrics;
     _metadataEventNotifierFactory =
-        MetadataEventNotifierFactory.loadFactory(controllerConf.subset(METADATA_EVENT_NOTIFIER_PREFIX));
+        MetadataEventNotifierFactory.loadFactory(controllerConf.subset(METADATA_EVENT_NOTIFIER_PREFIX),
+            helixResourceManager);
     _numIdealStateUpdateLocks = controllerConf.getRealtimeSegmentMetadataCommitNumLocks();
     _idealStateUpdateLocks = new Lock[_numIdealStateUpdateLocks];
     for (int i = 0; i < _numIdealStateUpdateLocks; i++) {


### PR DESCRIPTION
The implementations of MetadataEventNotifier requires the PinotHelixResourceManager in order to get the pinot table configs. With the table properties specific to realtime vs offline, different types of metadata events are emitted. `bugfix`
