### PR TITLE
Avoid upsert metadata access after the manager is closed

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -107,6 +107,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
   // Cache used for identifying segments which could not be acquired since they were recently deleted.
   protected Cache<String, String> _recentlyDeletedSegments;
 
+  protected volatile boolean _shutDown;
+
   @Override
   public void init(TableDataManagerConfig tableDataManagerConfig, String instanceId,
       ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager,
@@ -182,11 +184,17 @@ public abstract class BaseTableDataManager implements TableDataManager {
   @Override
   public void shutDown() {
     _logger.info("Shutting down table data manager for table: {}", _tableNameWithType);
+    _shutDown = true;
     doShutdown();
     _logger.info("Shut down table data manager for table: {}", _tableNameWithType);
   }
 
   protected abstract void doShutdown();
+
+  @Override
+  public boolean isShutDown() {
+    return _shutDown;
+  }
 
   /**
    * {@inheritDoc}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -873,6 +873,11 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
   protected SegmentBuildDescriptor buildSegmentInternal(boolean forCommit) {
     closeStreamConsumers();
+    // Do not allow building segment when table data manager is already shut down
+    if (_realtimeTableDataManager.isShutDown()) {
+      _segmentLogger.warn("Table data manager is already shut down");
+      return null;
+    }
     try {
       final long startTimeMillis = now();
       if (_segBuildSemaphore != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -246,14 +246,20 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   @Override
   protected void doShutdown() {
     if (_tableUpsertMetadataManager != null) {
+      // Stop the upsert metadata manager first to prevent removing metadata when destroying segments
+      _tableUpsertMetadataManager.stop();
+      for (SegmentDataManager segmentDataManager : _segmentDataManagerMap.values()) {
+        segmentDataManager.destroy();
+      }
       try {
         _tableUpsertMetadataManager.close();
       } catch (IOException e) {
         _logger.warn("Cannot close upsert metadata manager properly for table: {}", _tableNameWithType, e);
       }
-    }
-    for (SegmentDataManager segmentDataManager : _segmentDataManagerMap.values()) {
-      segmentDataManager.destroy();
+    } else {
+      for (SegmentDataManager segmentDataManager : _segmentDataManagerMap.values()) {
+        segmentDataManager.destroy();
+      }
     }
     if (_leaseExtender != null) {
       _leaseExtender.shutDown();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -62,6 +62,8 @@ public interface TableDataManager {
    */
   void shutDown();
 
+  boolean isShutDown();
+
   /**
    * Adds a loaded immutable segment into the table.
    */

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -182,7 +182,7 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
   }
 
   @Override
-  public void addRecord(MutableSegment segment, RecordInfo recordInfo) {
+  protected void doAddRecord(MutableSegment segment, RecordInfo recordInfo) {
     ThreadSafeMutableRoaringBitmap validDocIds = Objects.requireNonNull(segment.getValidDocIds());
     _primaryKeyToRecordLocationMap.compute(HashUtils.hashPrimaryKey(recordInfo.getPrimaryKey(), _hashFunction),
         (primaryKey, currentRecordLocation) -> {
@@ -217,12 +217,8 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
   }
 
   @Override
-  public GenericRow updateRecord(GenericRow record, RecordInfo recordInfo) {
-    // Directly return the record when partial-upsert is not enabled
-    if (_partialUpsertHandler == null) {
-      return record;
-    }
-
+  protected GenericRow doUpdateRecord(GenericRow record, RecordInfo recordInfo) {
+    assert _partialUpsertHandler != null;
     AtomicReference<GenericRow> previousRecordReference = new AtomicReference<>();
     RecordLocation currentRecordLocation = _primaryKeyToRecordLocationMap.computeIfPresent(
         HashUtils.hashPrimaryKey(recordInfo.getPrimaryKey(), _hashFunction), (pk, recordLocation) -> {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -40,11 +40,17 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   }
 
   @Override
+  public void stop() {
+    for (ConcurrentMapPartitionUpsertMetadataManager metadataManager : _partitionMetadataManagerMap.values()) {
+      metadataManager.stop();
+    }
+  }
+
+  @Override
   public void close()
       throws IOException {
-    for (ConcurrentMapPartitionUpsertMetadataManager partitionUpsertMetadataManager
-        : _partitionMetadataManagerMap.values()) {
-      partitionUpsertMetadataManager.close();
+    for (ConcurrentMapPartitionUpsertMetadataManager metadataManager : _partitionMetadataManagerMap.values()) {
+      metadataManager.close();
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -83,4 +83,9 @@ public interface PartitionUpsertMetadataManager extends Closeable {
    * Returns the merged record when partial-upsert is enabled.
    */
   GenericRow updateRecord(GenericRow record, RecordInfo recordInfo);
+
+  /**
+   * Stops the metadata manager. After invoking this method, no access to the metadata will be accepted.
+   */
+  void stop();
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -38,4 +38,9 @@ public interface TableUpsertMetadataManager extends Closeable {
   PartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId);
 
   UpsertConfig.Mode getUpsertMode();
+
+  /**
+   * Stops the metadata manager. After invoking this method, no access to the metadata will be accepted.
+   */
+  void stop();
 }


### PR DESCRIPTION
Currently we may still access the upsert metadata when the metadata manager is already closed. This can cause exception or even server crash if we release the metadata when closing the metadata manager.
This PR fixes the issue by:
1. Introducing `stop()` which reject future metadata access operations
2. Track the pending metadata access operations, and `close()` the metadata manager only when all the pending operations are finished

## Incompatible
This PR changes the upsert metadata manager interfaces and abstract method signatures