### PR TITLE
Add SASL_SSL support for stream github event command

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StreamGitHubEventsCommand.java
@@ -38,16 +38,27 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
   @CommandLine.Option(names = {"-personalAccessToken"}, required = true, description = "GitHub personal access token.")
   private String _personalAccessToken;
 
-  @CommandLine.Option(names = {"-sourceType"}, defaultValue = "Kafka",
-      description = "Stream DataSource to use for ingesting data. Supported values - Kafka,Kinesis")
+  @CommandLine.Option(names = {"-sourceType"}, defaultValue = "Kafka", description = "Stream DataSource to use for "
+      + "ingesting data. Supported values - Kafka,Kinesis")
   private String _sourceType;
 
-  @CommandLine.Option(names = {"-kafkaBrokerList"},
-      description = "Kafka broker list of the kafka cluster to produce events.")
+  @CommandLine.Option(names = {"-kafkaBrokerList"}, description = "Kafka broker list of the kafka cluster to produce "
+      + "events.")
   private String _kafkaBrokerList = KafkaStarterUtils.DEFAULT_KAFKA_BROKER;
 
-  @CommandLine.Option(names = {"-kinesisEndpoint"},
-      description = "Endpoint of localstack or any other Kinesis cluster when not using AWS.")
+  @CommandLine.Option(names = {"-kafkaSecurityProtocol"}, description = "Kafka security protocol "
+      + "(PLAINTEXT/SASL_SSL/etc")
+  private String _kafkaSecurityProtocol;
+
+  // Only needed when configured as SASL_SSL
+  @CommandLine.Option(names = {"-kafkaUserName"}, description = "Kafka Username")
+  private String _kafkaSaslUserName;
+
+  @CommandLine.Option(names = {"-kafkaPassword"}, description = "Kafka Password")
+  private String _kafkaSaslPassword;
+
+  @CommandLine.Option(names = {"-kinesisEndpoint"}, description = "Endpoint of localstack or any other Kinesis "
+      + "cluster when not using AWS.")
   private String _kinesisEndpoint = null;
 
   @CommandLine.Option(names = {"-awsRegion"}, description = "AWS Region in which Kinesis is located")
@@ -59,12 +70,12 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
   @CommandLine.Option(names = {"-awsSecretKey"}, description = "SecretKey for AWS Account")
   private String _secretKey;
 
-  @CommandLine.Option(names = {"-topic"}, required = true,
-      description = "Name of kafka-topic/kinesis-stream to publish events.")
+  @CommandLine.Option(names = {"-topic"}, required = true, description = "Name of kafka-topic/kinesis-stream to "
+      + "publish events.")
   private String _topic;
 
-  @CommandLine.Option(names = {"-eventType"},
-      description = "Type of GitHub event. Supported types - pullRequestMergedEvent")
+  @CommandLine.Option(names = {"-eventType"}, description = "Type of GitHub event. Supported types - "
+      + "pullRequestMergedEvent")
   private String _eventType = PULL_REQUEST_MERGED_EVENT_TYPE;
 
   @CommandLine.Option(names = {"-schemaFile"}, description = "Path to schema file. "
@@ -133,7 +144,9 @@ public class StreamGitHubEventsCommand extends AbstractBaseAdminCommand implemen
           break;
         case KAFKA:
         default:
-          streamDataProducer = PullRequestMergedEventsStream.getKafkaStreamDataProducer(_kafkaBrokerList);
+          streamDataProducer =
+              PullRequestMergedEventsStream.getKafkaStreamDataProducer(_kafkaBrokerList, _kafkaSecurityProtocol,
+                  _kafkaSaslUserName, _kafkaSaslPassword);
           break;
       }
       PullRequestMergedEventsStream pullRequestMergedEventsStream =


### PR DESCRIPTION
- Adding the sasl_ssl support for stream github event command
- This allows to configure to publish events to the kafka topics with sasl_ssl/plaintext.