### PR TITLE
[minion] check segment existency and fail early

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/FileUploadDownloadClientWithoutServerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/FileUploadDownloadClientWithoutServerTest.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class FileUploadDownloadClientWithoutServerTest {
+  @Test
+  public void testExtractBaseURI()
+      throws URISyntaxException {
+    Assert.assertEquals(FileUploadDownloadClient.extractBaseURI(new URI("http://example.com:8000/a/b?c=d")),
+        new URI("http://example.com:8000"));
+  }
+
+  @Test
+  public void testGetURI()
+      throws URISyntaxException {
+    Assert.assertEquals(FileUploadDownloadClient.getURI("http", "example.com", 8000),
+        new URI("http://example.com:8000"));
+  }
+}

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -163,7 +163,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
     String inputSegmentNames = configs.get(MinionConstants.SEGMENT_NAME_KEY);
     String uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
     AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(configs.get(MinionConstants.AUTH_TOKEN));
-    Set<String> nonExistentSegmentNames = SegmentConversionUtils.nonExistentSegments(tableNameWithType,
+    Set<String> nonExistentSegmentNames = SegmentConversionUtils.extractNonExistentSegments(tableNameWithType,
         FileUploadDownloadClient.extractBaseURI(new URI(uploadURL)),
         Arrays.asList(inputSegmentNames.split(MinionConstants.SEGMENT_NAME_SEPARATOR)), authProvider);
     if (!CollectionUtils.isEmpty(nonExistentSegmentNames)) {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -27,8 +27,10 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.stream.Collectors;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
@@ -154,25 +156,33 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
   @Override
   public List<SegmentConversionResult> executeTask(PinotTaskConfig pinotTaskConfig)
       throws Exception {
-    preProcess(pinotTaskConfig);
-    _pinotTaskConfig = pinotTaskConfig;
-    _eventObserver = MinionEventObservers.getInstance().getMinionEventObserver(pinotTaskConfig.getTaskId());
-    String taskType = pinotTaskConfig.getTaskType();
+    // check whether all segments to process exist in the table, if not, terminate early to avoid wasting computing
+    // resources
     Map<String, String> configs = pinotTaskConfig.getConfigs();
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
     String inputSegmentNames = configs.get(MinionConstants.SEGMENT_NAME_KEY);
-    String downloadURLString = configs.get(MinionConstants.DOWNLOAD_URL_KEY);
-    String[] downloadURLs = downloadURLString.split(MinionConstants.URL_SEPARATOR);
     String uploadURL = configs.get(MinionConstants.UPLOAD_URL_KEY);
     AuthProvider authProvider = AuthProviderUtils.makeAuthProvider(configs.get(MinionConstants.AUTH_TOKEN));
+    Set<String> nonExistentSegmentNames = SegmentConversionUtils.nonExistentSegments(tableNameWithType,
+        FileUploadDownloadClient.extractBaseURI(new URI(uploadURL)),
+        Arrays.asList(inputSegmentNames.split(MinionConstants.SEGMENT_NAME_SEPARATOR)), authProvider);
+    if (!CollectionUtils.isEmpty(nonExistentSegmentNames)) {
+      throw new RuntimeException(String.format("Segments to process: %s do not exist in table: %s",
+          nonExistentSegmentNames, tableNameWithType));
+    }
 
+    preProcess(pinotTaskConfig);
+
+    _pinotTaskConfig = pinotTaskConfig;
+    _eventObserver = MinionEventObservers.getInstance().getMinionEventObserver(pinotTaskConfig.getTaskId());
+    String taskType = pinotTaskConfig.getTaskType();
+    String downloadURLString = configs.get(MinionConstants.DOWNLOAD_URL_KEY);
+    String[] downloadURLs = downloadURLString.split(MinionConstants.URL_SEPARATOR);
     LOGGER.info("Start executing {} on table: {}, input segments: {} with downloadURLs: {}, uploadURL: {}", taskType,
         tableNameWithType, inputSegmentNames, downloadURLString, uploadURL);
-
     File tempDataDir = new File(new File(MINION_CONTEXT.getDataDir(), taskType), "tmp-" + UUID.randomUUID());
     Preconditions.checkState(tempDataDir.mkdirs());
     String crypterName = getTableConfig(tableNameWithType).getValidationConfig().getCrypterClassName();
-
     try {
       List<File> inputSegmentDirs = new ArrayList<>();
       for (int i = 0; i < downloadURLs.length; i++) {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/SegmentConversionUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/SegmentConversionUtils.java
@@ -66,15 +66,15 @@ public class SegmentConversionUtils {
   }
 
   /**
-   * Checks whether the given list of segments all exist or not
+   * Extract non-existent segments from the given list of segments
    * @param tableNameWithType a table name with type
    * @param controllerBaseURI the controller base URI
    * @param segmentNames a list of segments to check
    * @param authProvider a {@link AuthProvider}
-   * @return
+   * @return a set of non-existent segment names
    * @throws Exception when there are exceptions checking whether the given list of segments all exist or not
    */
-  public static Set<String> nonExistentSegments(String tableNameWithType, URI controllerBaseURI,
+  public static Set<String> extractNonExistentSegments(String tableNameWithType, URI controllerBaseURI,
       List<String> segmentNames, @Nullable AuthProvider authProvider)
       throws Exception {
     Preconditions.checkArgument(!CollectionUtils.isEmpty(segmentNames),

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/SegmentConversionUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/SegmentConversionUtilsTest.java
@@ -68,32 +68,9 @@ public class SegmentConversionUtilsTest {
   public void testNonExistentSegments()
       throws Exception {
     Assert.assertEquals(
-        SegmentConversionUtils.extractNonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
-        FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
-            ImmutableList.of(TEST_TABLE_SEGMENT_1, TEST_TABLE_SEGMENT_3), null),
-        ImmutableSet.of(TEST_TABLE_SEGMENT_3));
-    Assert.assertEquals(
-        SegmentConversionUtils.extractNonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
-            FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
-            ImmutableList.of(TEST_TABLE_SEGMENT_3), null),
-        ImmutableSet.of(TEST_TABLE_SEGMENT_3));
-    Assert.assertTrue(
-        SegmentConversionUtils.extractNonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
-            FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
-            ImmutableList.of(TEST_TABLE_SEGMENT_1), null).isEmpty());
-    Assert.assertTrue(
-        SegmentConversionUtils.extractNonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
-            FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
-            ImmutableList.of(TEST_TABLE_SEGMENT_1, TEST_TABLE_SEGMENT_2), null).isEmpty());
-  }
-
-  @Test
-  public void testNonExistentSegmentsThrowsWhenTheSegmentNameListIsEmpty()
-      throws Exception {
-    Assert.assertThrows(IllegalArgumentException.class, () ->
-        SegmentConversionUtils.extractNonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
-        FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
-            ImmutableList.of(), null));
+        SegmentConversionUtils.getSegmentNamesForTable(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
+        FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT), null),
+        ImmutableSet.of(TEST_TABLE_SEGMENT_1, TEST_TABLE_SEGMENT_2));
   }
 
   @AfterClass

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/SegmentConversionUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/SegmentConversionUtilsTest.java
@@ -18,13 +18,13 @@
  */
 package org.apache.pinot.plugin.minion.tasks;
 
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import com.sun.net.httpserver.HttpServer;
 import java.io.OutputStream;
 import java.net.InetSocketAddress;
-import java.util.List;
-import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import org.apache.http.HttpStatus;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -53,7 +53,8 @@ public class SegmentConversionUtilsTest {
     _testServer = HttpServer.create(new InetSocketAddress(TEST_PORT), 0);
     _testServer.createContext("/segments/myTable", exchange -> {
       String response = JsonUtils.objectToString(
-          List.of(Map.of(TEST_TABLE_TYPE, List.of(TEST_TABLE_SEGMENT_1, TEST_TABLE_SEGMENT_2))));
+          ImmutableList.of(
+              ImmutableMap.of(TEST_TABLE_TYPE, ImmutableList.of(TEST_TABLE_SEGMENT_1, TEST_TABLE_SEGMENT_2))));
       exchange.sendResponseHeaders(HttpStatus.SC_OK, response.length());
       OutputStream os = exchange.getResponseBody();
       os.write(response.getBytes());
@@ -67,32 +68,32 @@ public class SegmentConversionUtilsTest {
   public void testNonExistentSegments()
       throws Exception {
     Assert.assertEquals(
-        SegmentConversionUtils.nonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
+        SegmentConversionUtils.extractNonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
         FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
-        List.of(TEST_TABLE_SEGMENT_1, TEST_TABLE_SEGMENT_3), null),
-        Set.of(TEST_TABLE_SEGMENT_3));
+            ImmutableList.of(TEST_TABLE_SEGMENT_1, TEST_TABLE_SEGMENT_3), null),
+        ImmutableSet.of(TEST_TABLE_SEGMENT_3));
     Assert.assertEquals(
-        SegmentConversionUtils.nonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
+        SegmentConversionUtils.extractNonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
             FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
-            List.of(TEST_TABLE_SEGMENT_3), null),
-        Set.of(TEST_TABLE_SEGMENT_3));
+            ImmutableList.of(TEST_TABLE_SEGMENT_3), null),
+        ImmutableSet.of(TEST_TABLE_SEGMENT_3));
     Assert.assertTrue(
-        SegmentConversionUtils.nonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
+        SegmentConversionUtils.extractNonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
             FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
-            List.of(TEST_TABLE_SEGMENT_1), null).isEmpty());
+            ImmutableList.of(TEST_TABLE_SEGMENT_1), null).isEmpty());
     Assert.assertTrue(
-        SegmentConversionUtils.nonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
+        SegmentConversionUtils.extractNonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
             FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
-            List.of(TEST_TABLE_SEGMENT_1, TEST_TABLE_SEGMENT_2), null).isEmpty());
+            ImmutableList.of(TEST_TABLE_SEGMENT_1, TEST_TABLE_SEGMENT_2), null).isEmpty());
   }
 
   @Test
   public void testNonExistentSegmentsThrowsWhenTheSegmentNameListIsEmpty()
       throws Exception {
     Assert.assertThrows(IllegalArgumentException.class, () ->
-        SegmentConversionUtils.nonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
+        SegmentConversionUtils.extractNonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
         FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
-        List.of(), null));
+            ImmutableList.of(), null));
   }
 
   @AfterClass

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/SegmentConversionUtilsTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/SegmentConversionUtilsTest.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.minion.tasks;
+
+import com.sun.net.httpserver.HttpServer;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import org.apache.http.HttpStatus;
+import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class SegmentConversionUtilsTest {
+  private static final String TEST_TABLE_WITHOUT_TYPE = "myTable";
+  private static final String TEST_TABLE_TYPE = "REALTIME";
+
+  private static final String TEST_TABLE_SEGMENT_1 = "myTable_REALTIME_segment_1";
+
+  private static final String TEST_TABLE_SEGMENT_2 = "myTable_REALTIME_segment_2";
+  private static final String TEST_TABLE_SEGMENT_3 = "myTable_REALTIME_segment_3";
+  private static final String TEST_SCHEME = "http";
+  private static final String TEST_HOST = "localhost";
+  private static final int TEST_PORT = new Random().nextInt(10000) + 10000;
+  private HttpServer _testServer;
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    _testServer = HttpServer.create(new InetSocketAddress(TEST_PORT), 0);
+    _testServer.createContext("/segments/myTable", exchange -> {
+      String response = JsonUtils.objectToString(
+          List.of(Map.of(TEST_TABLE_TYPE, List.of(TEST_TABLE_SEGMENT_1, TEST_TABLE_SEGMENT_2))));
+      exchange.sendResponseHeaders(HttpStatus.SC_OK, response.length());
+      OutputStream os = exchange.getResponseBody();
+      os.write(response.getBytes());
+      os.close();
+    });
+    _testServer.setExecutor(null); // creates a default executor
+    _testServer.start();
+  }
+
+  @Test
+  public void testNonExistentSegments()
+      throws Exception {
+    Assert.assertEquals(
+        SegmentConversionUtils.nonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
+        FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
+        List.of(TEST_TABLE_SEGMENT_1, TEST_TABLE_SEGMENT_3), null),
+        Set.of(TEST_TABLE_SEGMENT_3));
+    Assert.assertEquals(
+        SegmentConversionUtils.nonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
+            FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
+            List.of(TEST_TABLE_SEGMENT_3), null),
+        Set.of(TEST_TABLE_SEGMENT_3));
+    Assert.assertTrue(
+        SegmentConversionUtils.nonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
+            FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
+            List.of(TEST_TABLE_SEGMENT_1), null).isEmpty());
+    Assert.assertTrue(
+        SegmentConversionUtils.nonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
+            FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
+            List.of(TEST_TABLE_SEGMENT_1, TEST_TABLE_SEGMENT_2), null).isEmpty());
+  }
+
+  @Test
+  public void testNonExistentSegmentsThrowsWhenTheSegmentNameListIsEmpty()
+      throws Exception {
+    Assert.assertThrows(IllegalArgumentException.class, () ->
+        SegmentConversionUtils.nonExistentSegments(TEST_TABLE_WITHOUT_TYPE + "_" + TEST_TABLE_TYPE,
+        FileUploadDownloadClient.getURI(TEST_SCHEME, TEST_HOST, TEST_PORT),
+        List.of(), null));
+  }
+
+  @AfterClass
+  public void shutDown() {
+    _testServer.stop(0);
+  }
+}


### PR DESCRIPTION
In `BaseMultipleSegmentsConversionExecutor`, we check existency of input segments before running the minion task, so that computing resources and time can be saved.