### PR TITLE
improve startReplaceSegments error message

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3250,15 +3250,14 @@ public class PinotHelixResourceManager {
     Set<String> unavailableSegmentsInFrom = Sets.difference(new HashSet<>(segmentsFrom), segmentsForTable);
     Preconditions.checkArgument(unavailableSegmentsInFrom.isEmpty(), String.format(
         "'%s' from 'segmentsFrom' are unavailable in the table. (tableName = '%s', segmentsFrom = '%s', "
-            + "segmentsTo = '%s', segmentsFromTable = '%s')", unavailableSegmentsInFrom, tableNameWithType,
-        segmentsFrom, segmentsTo, segmentsForTable));
+            + "segmentsTo = '%s')", unavailableSegmentsInFrom, tableNameWithType, segmentsFrom, segmentsTo));
 
     // Check that all the segments from 'segmentTo' does not exist in the table.
     Set<String> availableSegmentsInTo = Sets.intersection(new HashSet<>(segmentsTo), segmentsForTable);
     Preconditions.checkArgument(availableSegmentsInTo.isEmpty(), String.format(
         "'%s' from 'segmentsTo' should not be available in the table at this point. (tableName = '%s', "
-            + "segmentsFrom = '%s', segmentsTo = '%s', segmentsFromTable = '%s')", availableSegmentsInTo,
-        tableNameWithType, segmentsFrom, segmentsTo, segmentsForTable));
+            + "segmentsFrom = '%s', segmentsTo = '%s')", availableSegmentsInTo, tableNameWithType, segmentsFrom,
+        segmentsTo));
 
     try {
       DEFAULT_RETRY_POLICY.attempt(() -> {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -26,6 +26,7 @@ import com.google.common.cache.CacheLoader;
 import com.google.common.cache.LoadingCache;
 import com.google.common.collect.BiMap;
 import com.google.common.collect.HashBiMap;
+import com.google.common.collect.Sets;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
@@ -3246,16 +3247,18 @@ public class PinotHelixResourceManager {
 
     // Check that all the segments from 'segmentsFrom' exist in the table
     Set<String> segmentsForTable = new HashSet<>(getSegmentsFor(tableNameWithType, true));
-    Preconditions.checkArgument(segmentsForTable.containsAll(segmentsFrom), String.format(
-        "Not all segments from 'segmentsFrom' are available in the table. (tableName = '%s', segmentsFrom = '%s', "
-            + "segmentsTo = '%s', segmentsFromTable = '%s')", tableNameWithType, segmentsFrom, segmentsTo,
-        segmentsForTable));
+    Set<String> unavailableSegmentsInFrom = Sets.difference(new HashSet<>(segmentsFrom), segmentsForTable);
+    Preconditions.checkArgument(unavailableSegmentsInFrom.isEmpty(), String.format(
+        "'%s' from 'segmentsFrom' are unavailable in the table. (tableName = '%s', segmentsFrom = '%s', "
+            + "segmentsTo = '%s', segmentsFromTable = '%s')", unavailableSegmentsInFrom, tableNameWithType,
+        segmentsFrom, segmentsTo, segmentsForTable));
 
     // Check that all the segments from 'segmentTo' does not exist in the table.
-    Preconditions.checkArgument(Collections.disjoint(segmentsForTable, segmentsTo), String.format(
-        "Any segments from 'segmentsTo' should not be available in the table at this point. (tableName = '%s', "
-            + "segmentsFrom = '%s', segmentsTo = '%s', segmentsFromTable = '%s')", tableNameWithType, segmentsFrom,
-        segmentsTo, segmentsForTable));
+    Set<String> availableSegmentsInTo = Sets.intersection(new HashSet<>(segmentsTo), segmentsForTable);
+    Preconditions.checkArgument(availableSegmentsInTo.isEmpty(), String.format(
+        "'%s' from 'segmentsTo' should not be available in the table at this point. (tableName = '%s', "
+            + "segmentsFrom = '%s', segmentsTo = '%s', segmentsFromTable = '%s')", availableSegmentsInTo,
+        tableNameWithType, segmentsFrom, segmentsTo, segmentsForTable));
 
     try {
       DEFAULT_RETRY_POLICY.attempt(() -> {


### PR DESCRIPTION
improve startReplaceSegments error message so that it's easy to locate problematic segment names.