### PR TITLE
close startree index properly

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -247,7 +247,14 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     if (_partitionDedupMetadataManager != null) {
       _partitionDedupMetadataManager.removeSegment(this);
     }
-
+    // StarTreeIndexContainer refers to other column index containers, so close it firstly.
+    if (_starTreeIndexContainer != null) {
+      try {
+        _starTreeIndexContainer.close();
+      } catch (IOException e) {
+        LOGGER.error("Failed to close star-tree. Continuing with error.", e);
+      }
+    }
     for (Map.Entry<String, ColumnIndexContainer> entry : _indexContainerMap.entrySet()) {
       try {
         entry.getValue().close();
@@ -259,13 +266,6 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
       _segmentDirectory.close();
     } catch (Exception e) {
       LOGGER.error("Failed to close segment directory: {}. Continuing with error.", _segmentDirectory, e);
-    }
-    if (_starTreeIndexContainer != null) {
-      try {
-        _starTreeIndexContainer.close();
-      } catch (IOException e) {
-        LOGGER.error("Failed to close star-tree. Continuing with error.", e);
-      }
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexContainer.java
@@ -47,6 +47,10 @@ public class StarTreeIndexContainer implements Closeable {
   @Override
   public void close()
       throws IOException {
-    // The startree index buffer is owned by segment reader now.
+    // The startree index data buffer is owned by segment reader, but still need to close those startree instances as
+    // they have created their own fwd value readers.
+    for (StarTreeV2 starTree : _starTrees) {
+      starTree.close();
+    }
   }
 }


### PR DESCRIPTION
close startree index properly to avoid potential resource leakage, which is not happening today as all resource is released upon SegmentDirectory.close. But hook up the close() calls properly in case StarTree instances will have its own resource later on.