### PR TITLE
Add name case for ScalarFunction annotation for casewhen

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ObjectFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ObjectFunctions.java
@@ -94,33 +94,41 @@ public class ObjectFunctions {
     return null;
   }
 
+  @Nullable
   @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
-  public static Object caseWhen(boolean c1, Object o1, Object oe) {
+  public static Object caseWhen(boolean c1, @Nullable Object o1, @Nullable Object oe) {
     return caseWhenVar(c1, o1, oe);
   }
 
+  @Nullable
   @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
-  public static Object caseWhen(boolean c1, Object o1, boolean c2, Object o2, Object oe) {
+  public static Object caseWhen(boolean c1, @Nullable Object o1, boolean c2, @Nullable Object o2, @Nullable Object oe) {
     return caseWhenVar(c1, o1, c2, o2, oe);
   }
 
+  @Nullable
   @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
-  public static Object caseWhen(boolean c1, Object o1, boolean c2, Object o2, boolean c3, Object o3, Object oe) {
+  public static Object caseWhen(boolean c1, @Nullable Object o1, boolean c2, @Nullable Object o2, boolean c3,
+                                @Nullable Object o3, @Nullable Object oe) {
     return caseWhenVar(c1, o1, c2, o2, c3, o3, oe);
   }
 
+  @Nullable
   @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
-  public static Object caseWhen(boolean c1, Object o1, boolean c2, Object o2, boolean c3, Object o3, boolean c4,
-      Object o4, Object oe) {
+  public static Object caseWhen(boolean c1, @Nullable Object o1, boolean c2, @Nullable Object o2, boolean c3,
+                                @Nullable Object o3, boolean c4, @Nullable Object o4, @Nullable Object oe) {
     return caseWhenVar(c1, o1, c2, o2, c3, o3, c4, o4, oe);
   }
 
+  @Nullable
   @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
-  public static Object caseWhen(boolean c1, Object o1, boolean c2, Object o2, boolean c3, Object o3, boolean c4,
-      Object o4, boolean c5, Object o5, Object oe) {
+  public static Object caseWhen(boolean c1, @Nullable Object o1, boolean c2, @Nullable Object o2, boolean c3,
+                                @Nullable Object o3, boolean c4, @Nullable Object o4, boolean c5, @Nullable Object o5,
+                                @Nullable Object oe) {
     return caseWhenVar(c1, o1, c2, o2, c3, o3, c4, o4, c5, o5, oe);
   }
 
+  @Nullable
   private static Object caseWhenVar(Object... objs) {
     for (int i = 0; i < objs.length - 1; i += 2) {
       if (BooleanUtils.toBoolean(objs[i])) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ObjectFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ObjectFunctions.java
@@ -94,28 +94,28 @@ public class ObjectFunctions {
     return null;
   }
 
-  @ScalarFunction
+  @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
   public static Object caseWhen(boolean c1, Object o1, Object oe) {
     return caseWhenVar(c1, o1, oe);
   }
 
-  @ScalarFunction
+  @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
   public static Object caseWhen(boolean c1, Object o1, boolean c2, Object o2, Object oe) {
     return caseWhenVar(c1, o1, c2, o2, oe);
   }
 
-  @ScalarFunction
+  @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
   public static Object caseWhen(boolean c1, Object o1, boolean c2, Object o2, boolean c3, Object o3, Object oe) {
     return caseWhenVar(c1, o1, c2, o2, c3, o3, oe);
   }
 
-  @ScalarFunction
+  @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
   public static Object caseWhen(boolean c1, Object o1, boolean c2, Object o2, boolean c3, Object o3, boolean c4,
       Object o4, Object oe) {
     return caseWhenVar(c1, o1, c2, o2, c3, o3, c4, o4, oe);
   }
 
-  @ScalarFunction
+  @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
   public static Object caseWhen(boolean c1, Object o1, boolean c2, Object o2, boolean c3, Object o3, boolean c4,
       Object o4, boolean c5, Object o5, Object oe) {
     return caseWhenVar(c1, o1, c2, o2, c3, o3, c4, o4, c5, o5, oe);

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
@@ -42,9 +42,9 @@ public class FunctionDefinitionRegistryTest {
   );
   private static final List<String> IGNORED_FUNCTION_NAMES = ImmutableList.of(
       // functions we are not supporting post transform anyway
-      "valuein", "mapvalue", "inidset", "lookup", "groovy", "scalar", "geotoh3", "case", "not_in", "timeconvert",
+      "valuein", "mapvalue", "inidset", "lookup", "groovy", "scalar", "geotoh3", "not_in", "timeconvert",
       // functions not needed for register b/c they are in std sql table or they will not be composed directly.
-      "in", "and", "or", "not", "range", "extract"
+      "in", "and", "or", "range", "extract"
   );
 
   @Test


### PR DESCRIPTION
- Added name `case` for the `caseWhen` Scalar Function implementations under `ObjectFunctions.java` 
- Also updated these to take nullable parameters and return nullable object with @Nullable annotations 
- Previously, a query like `SELECT CASEWHEN(2 > 0, 'yes', 'no)` could be executed only in broker (returning single row with a literal) while similar query `SELECT CASE WHEN 2 > 0 THEN 'YES' ELSE 'NO' END` resulted in server query (returning multiple rows of same literal) because CASE was not in function map.
- Update unit test to also check `case` and `not` are present in function registry since they are.
