### PR TITLE
Resolve NullPointerException when COUNT() is passed literal and nullHandling is enabled

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
@@ -49,8 +49,9 @@ public class CountAggregationFunction extends BaseSingleInputAggregationFunction
 
   public CountAggregationFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
     super(expression);
-    // Consider null values only when null handling is enabled and function is not COUNT(*)
-    _nullHandlingEnabled = nullHandlingEnabled && !expression.getIdentifier().equals("*");
+    // Consider null values only when null handling is enabled and function is not COUNT(*).
+    // Note that expressions where identifier is a literal like COUNT(1) are equivalent to COUNT(*).
+    _nullHandlingEnabled = nullHandlingEnabled && !expression.getIdentifier().equals("*") && !expression.getType().equals(ExpressionContext.Type.LITERAL);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
@@ -49,9 +49,12 @@ public class CountAggregationFunction extends BaseSingleInputAggregationFunction
 
   public CountAggregationFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
     super(expression);
-    // Consider null values only when null handling is enabled and function is not COUNT(*).
-    // Note that expressions where identifier is a literal like COUNT(1) are equivalent to COUNT(*).
-    _nullHandlingEnabled = nullHandlingEnabled && !expression.getIdentifier().equals("*") && !expression.getType().equals(ExpressionContext.Type.LITERAL);
+    // Consider null values only when null handling is enabled and function is not COUNT(*)
+    // Note COUNT on any literal gives same result as COUNT(*)
+    // So allow for identifiers that are not * and functions, disable for literals and *
+    _nullHandlingEnabled = nullHandlingEnabled
+            && ((expression.getType() == ExpressionContext.Type.IDENTIFIER && !expression.getIdentifier().equals("*"))
+            || (expression.getType() == ExpressionContext.Type.FUNCTION));
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -188,9 +188,11 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
   }
 
   @Test
-  public void testTotalCountUsingCountLiteral()
+  public void testTotalCountWithNullHandlingQueryOptionEnabled()
           throws Exception {
-    String query = "SELECT COUNT(1) FROM " + getTableName();
+    String query = "SELECT COUNT(*) FROM " + getTableName() + " option(enableNullHandling=true)";
+    testQuery(query);
+    query = "SELECT COUNT(1) FROM " + getTableName() + " option(enableNullHandling=true)";
     testQuery(query);
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -186,4 +186,11 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
     query = "SELECT description FROM " + getTableName() + " where description IS NOT DISTINCT FROM description";
     testQuery(query);
   }
+
+  @Test
+  public void testTotalCountUsingCountLiteral()
+          throws Exception {
+    String query = "SELECT COUNT(1) FROM " + getTableName();
+    testQuery(query);
+  }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -193,7 +193,7 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
   public void testTotalCountWithNullHandlingQueryOptionEnabled()
           throws Exception {
     DataTableBuilderFactory.setDataTableVersion(DataTableFactory.VERSION_4);
-    String pinotQuery = "SELECT COUNT(*) FROM " + getTableName() + "; SET ENABLENULLHANDLING = true";
+    String pinotQuery = "SELECT COUNT(*) FROM " + getTableName() + " option(enableNullHandling=true)";
     String h2Query = "SELECT COUNT(*) FROM " + getTableName();
     testQuery(pinotQuery, h2Query);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -22,6 +22,8 @@ import java.io.File;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.datatable.DataTableFactory;
+import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -190,9 +192,14 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
   @Test
   public void testTotalCountWithNullHandlingQueryOptionEnabled()
           throws Exception {
-    String query = "SELECT COUNT(*) FROM " + getTableName() + " option(enableNullHandling=true)";
-    testQuery(query);
-    query = "SELECT COUNT(1) FROM " + getTableName() + " option(enableNullHandling=true)";
-    testQuery(query);
+    DataTableBuilderFactory.setDataTableVersion(DataTableFactory.VERSION_4);
+    String pinotQuery = "SELECT COUNT(*) FROM " + getTableName() + "; SET ENABLENULLHANDLING = true";
+    String h2Query = "SELECT COUNT(*) FROM " + getTableName();
+    testQuery(pinotQuery, h2Query);
+
+    pinotQuery = "SELECT COUNT(1) FROM " + getTableName() + " option(enableNullHandling=true)";
+    h2Query = "SELECT COUNT(1) FROM " + getTableName();
+    testQuery(pinotQuery, h2Query);
+    DataTableBuilderFactory.setDataTableVersion(DataTableBuilderFactory.DEFAULT_VERSION);
   }
 }


### PR DESCRIPTION
- In CountAggregateFunction, NPE was thrown when COUNT() is passed a literal and nullHandling is enabled. expression.getIdentifier() returns null when expression is not an identifier.  
- Sample failing query: 
``` 
SELECT COUNT("int0") AS "value"
FROM "test"
HAVING (COUNT(1) > 0) option(enableNullHandling=true)
```
Same query can execute when option is not passed.
- Allow nullHandling when COUNT is passed an identifier or a function. Disable when literal or * as these give same result of returning # of rows.