### PR TITLE
Adding partition pruner in QueryContext

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/QueryOptionsUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/QueryOptionsUtilsTest.java
@@ -20,7 +20,9 @@
 package org.apache.pinot.common.utils.config;
 
 import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
 import java.util.Map;
+import java.util.Set;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -42,5 +44,14 @@ public class QueryOptionsUtilsTest {
     // Then:
     Assert.assertEquals(resolved.get(CommonConstants.Broker.Request.QueryOptionKey.ENABLE_NULL_HANDLING), "true");
     Assert.assertEquals(resolved.get(CommonConstants.Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE), "false");
+  }
+
+  @Test
+  public void testGetColumnPartitionMap() {
+    Map<String, Set<Integer>> columnPartitionMap =
+        QueryOptionsUtils.getColumnPartitionMap(ImmutableMap.of("columnPartitionMap", "k1:1/k1:2/k1:3/k2:4/k2:5/k2:6"));
+
+    Assert.assertEquals(columnPartitionMap.get("k1"), ImmutableSet.of(1, 2, 3));
+    Assert.assertEquals(columnPartitionMap.get("k2"), ImmutableSet.of(4, 5, 6));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/PartitionsSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/PartitionsSegmentPruner.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.pruner;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.spi.env.PinotConfiguration;
+
+
+/**
+ * The {@code PartitionSegmentPruner} is the segment pruner that prunes segments based on the partition info from the
+ * QueryContext.
+ */
+public class PartitionsSegmentPruner implements SegmentPruner {
+
+  @Override
+  public void init(PinotConfiguration config) {
+  }
+
+  @Override
+  public boolean isApplicableTo(QueryContext query) {
+    return query.getColumnPartitionMap() != null && !query.getColumnPartitionMap().isEmpty();
+  }
+
+  @Override
+  public List<IndexSegment> prune(List<IndexSegment> segments, QueryContext query) {
+    if (segments.isEmpty() || !isApplicableTo(query)) {
+      return segments;
+    }
+    Map<String, Set<Integer>> queryColumnPartitionMap = query.getColumnPartitionMap();
+    int numSegments = segments.size();
+    List<IndexSegment> selectedSegments = new ArrayList<>(numSegments);
+    for (IndexSegment segment : segments) {
+      SegmentMetadata segmentMetadata = segment.getSegmentMetadata();
+      boolean selected = false;
+      for (String column : queryColumnPartitionMap.keySet()) {
+        ColumnMetadata columnMetadataFor = segmentMetadata.getColumnMetadataFor(column);
+        if (columnMetadataFor == null) {
+          continue;
+        }
+        Set<Integer> segmentPartitions = columnMetadataFor.getPartitions();
+        if (segmentPartitions != null && !segmentPartitions.isEmpty()) {
+          for (int queryPartition : queryColumnPartitionMap.get(column)) {
+            if (segmentPartitions.contains(queryPartition)) {
+              selected = true;
+              break;
+            }
+          }
+          if (selected) {
+            break;
+          }
+        }
+      }
+      if (selected) {
+        selectedSegments.add(segment);
+      }
+    }
+    return selectedSegments;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPrunerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPrunerProvider.java
@@ -37,10 +37,12 @@ public class SegmentPrunerProvider {
 
   public static final String COLUMN_VALUE_SEGMENT_PRUNER_NAME = "columnvaluesegmentpruner";
   public static final String SELECTION_QUERY_SEGMENT_PRUNER_NAME = "selectionquerysegmentpruner";
+  public static final String PARTITIONS_SEGMENT_PRUNER_NAME = "partitionssegmentpruner";
 
   static {
     PRUNER_MAP.put(COLUMN_VALUE_SEGMENT_PRUNER_NAME, ColumnValueSegmentPruner.class);
     PRUNER_MAP.put(SELECTION_QUERY_SEGMENT_PRUNER_NAME, SelectionQuerySegmentPruner.class);
+    PRUNER_MAP.put(PARTITIONS_SEGMENT_PRUNER_NAME, PartitionsSegmentPruner.class);
   }
 
   @Nullable

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPrunerService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPrunerService.java
@@ -61,6 +61,9 @@ public class SegmentPrunerService {
           case SegmentPrunerProvider.COLUMN_VALUE_SEGMENT_PRUNER_NAME:
             _prunerStatsUpdaters.put(pruner, SegmentPrunerStatistics::setValuePruned);
             break;
+          case SegmentPrunerProvider.PARTITIONS_SEGMENT_PRUNER_NAME:
+            _prunerStatsUpdaters.put(pruner, SegmentPrunerStatistics::setPartitionPruned);
+            break;
           default:
             _prunerStatsUpdaters.put(pruner, (stats, value) -> { });
             break;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPrunerStatistics.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SegmentPrunerStatistics.java
@@ -26,6 +26,8 @@ public class SegmentPrunerStatistics {
 
   private int _limitPruned;
 
+  private int _partitionPruned;
+
   public int getInvalidSegments() {
     return _invalidSegments;
   }
@@ -48,5 +50,13 @@ public class SegmentPrunerStatistics {
 
   public void setLimitPruned(int limitPruned) {
     _limitPruned = limitPruned;
+  }
+
+  public int getPartitionPruned() {
+    return _partitionPruned;
+  }
+
+  public void setPartitionPruned(int partitionPruned) {
+    _partitionPruned = partitionPruned;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java
@@ -122,6 +122,8 @@ public class QueryContext {
   private boolean _nullHandlingEnabled;
   // Whether server returns the final result
   private boolean _serverReturnFinalResult;
+  // Explicitly specify the column partitions to query
+  private Map<String, Set<Integer>> _columnPartitionMap;
 
   private QueryContext(@Nullable String tableName, @Nullable QueryContext subquery,
       List<ExpressionContext> selectExpressions, List<String> aliasList, @Nullable FilterContext filter,
@@ -393,6 +395,14 @@ public class QueryContext {
     _serverReturnFinalResult = serverReturnFinalResult;
   }
 
+  public Map<String, Set<Integer>> getColumnPartitionMap() {
+    return _columnPartitionMap;
+  }
+
+  public void setColumnPartitionMap(Map<String, Set<Integer>> columnPartitionMap) {
+    _columnPartitionMap = columnPartitionMap;
+  }
+
   /**
    * Gets or computes a value of type {@code V} associated with a key of type {@code K} so that it can be shared
    * within the scope of a query.
@@ -511,6 +521,7 @@ public class QueryContext {
               _havingFilter, _orderByExpressions, _limit, _offset, _queryOptions, _expressionOverrideHints, _explain);
       queryContext.setNullHandlingEnabled(QueryOptionsUtils.isNullHandlingEnabled(_queryOptions));
       queryContext.setServerReturnFinalResult(QueryOptionsUtils.isServerReturnFinalResult(_queryOptions));
+      queryContext.setColumnPartitionMap(QueryOptionsUtils.getColumnPartitionMap(_queryOptions));
 
       // Pre-calculate the aggregation functions and columns for the query
       generateAggregationFunctions(queryContext);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/PartitionsSegmentPrunerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/pruner/PartitionsSegmentPrunerTest.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.pruner;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.testng.annotations.Test;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertSame;
+
+
+public class PartitionsSegmentPrunerTest {
+  private final PartitionsSegmentPruner _partitionPruner = new PartitionsSegmentPruner();
+
+  @Test
+  public void testPruner() {
+    List<IndexSegment> indexSegments =
+        Arrays.asList(
+            getIndexSegment(ImmutableMap.of("key1", ImmutableSet.of(1), "key2", ImmutableSet.of(1))),
+            getIndexSegment(ImmutableMap.of("key1", ImmutableSet.of(2), "key2", ImmutableSet.of(2))),
+            getIndexSegment(ImmutableMap.of("key1", ImmutableSet.of(3), "key2", ImmutableSet.of(3))));
+
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable");
+    List<IndexSegment> result = _partitionPruner.prune(indexSegments, queryContext);
+    assertEquals(result.size(), 3);
+
+    queryContext =
+        QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable OPTION (columnPartitionMap=key1:1)");
+    result = _partitionPruner.prune(indexSegments, queryContext);
+    assertEquals(result.size(), 1);
+    assertSame(result.get(0), indexSegments.get(0));
+
+    queryContext =
+        QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable OPTION (columnPartitionMap=key1:1/key1:2)");
+    result = _partitionPruner.prune(indexSegments, queryContext);
+    assertEquals(result.size(), 2);
+    assertSame(result.get(0), indexSegments.get(0));
+    assertSame(result.get(1), indexSegments.get(1));
+
+    queryContext =
+        QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable OPTION (columnPartitionMap=key1:1/key2:2)");
+    result = _partitionPruner.prune(indexSegments, queryContext);
+    assertEquals(result.size(), 2);
+    assertSame(result.get(0), indexSegments.get(0));
+    assertSame(result.get(1), indexSegments.get(1));
+
+    queryContext =
+        QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable OPTION (columnPartitionMap=key1:1/key2:1)");
+    result = _partitionPruner.prune(indexSegments, queryContext);
+    assertEquals(result.size(), 1);
+    assertSame(result.get(0), indexSegments.get(0));
+  }
+
+  private IndexSegment getIndexSegment(Map<String, Set<Integer>> columnPartitionMap) {
+    IndexSegment indexSegment = mock(IndexSegment.class);
+    when(indexSegment.getColumnNames()).thenReturn(ImmutableSet.copyOf(columnPartitionMap.keySet()));
+    SegmentMetadata segmentMetadata = mock(SegmentMetadata.class);
+    when(indexSegment.getSegmentMetadata()).thenReturn(segmentMetadata);
+    for (Map.Entry<String, Set<Integer>> entry : columnPartitionMap.entrySet()) {
+      ColumnMetadata columnMetadata = mock(ColumnMetadata.class);
+      when(columnMetadata.getPartitions()).thenReturn(entry.getValue());
+      when(segmentMetadata.getColumnMetadataFor(entry.getKey())).thenReturn(columnMetadata);
+    }
+    return indexSegment;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -307,6 +307,7 @@ public class CommonConstants {
         public static final String MAX_INITIAL_RESULT_HOLDER_CAPACITY = "maxInitialResultHolderCapacity";
         public static final String GROUP_TRIM_THRESHOLD = "groupTrimThreshold";
         public static final String STAGE_PARALLELISM = "stageParallelism";
+        public static final String COLUMN_PARTITION_MAP = "columnPartitionMap";
 
         // TODO: Remove these keys (only apply to PQL) after releasing 0.11.0
         @Deprecated


### PR DESCRIPTION
This is the support for querying a specific column partition.

Note that the segment is selected when any of the column partition from query matches the segment column metadata.

Sample query:
```
SELECT * FROM testTable OPTION (columnPartitionMap=key1:1/key2:1)
```