### PR TITLE
Bug with time based segment relocator on real-time segments

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/tier/TimeBasedTierSegmentSelector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/tier/TimeBasedTierSegmentSelector.java
@@ -57,6 +57,12 @@ public class TimeBasedTierSegmentSelector implements TierSegmentSelector {
         .checkNotNull(segmentZKMetadata, "Could not find zk metadata for segment: {} of table: {}", segmentName,
             tableNameWithType);
 
+    // don't try to move consuming segments
+    if (!segmentZKMetadata.getStatus().isCompleted()) {
+      return false;
+    }
+
+
     // get segment end time to decide if segment gets selected
     long endTimeMs = segmentZKMetadata.getEndTimeMs();
     Preconditions

--- a/pinot-common/src/test/java/org/apache/pinot/common/tier/TierSegmentSelectorTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/tier/TierSegmentSelectorTest.java
@@ -115,6 +115,30 @@ public class TierSegmentSelectorTest {
   }
 
   @Test
+  public void testRealTimeConsumingSegmentShouldNotBeRelocated() {
+
+    long now = System.currentTimeMillis();
+
+    String segmentName = "myTable__4__1__" + now;
+    String tableNameWithType = "myTable_REALTIME";
+    SegmentZKMetadata realtimeSegmentZKMetadata = new SegmentZKMetadata(segmentName);
+    realtimeSegmentZKMetadata.setStatus(CommonConstants.Segment.Realtime.Status.IN_PROGRESS);
+
+    ZNRecord segmentZKMetadataZNRecord = realtimeSegmentZKMetadata.toZNRecord();
+
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(propertyStore
+            .get(eq(ZKMetadataProvider.constructPropertyStorePathForSegment(tableNameWithType, segmentName)), any(),
+                    anyInt())).thenReturn(segmentZKMetadataZNRecord);
+
+    HelixManager helixManager = mock(HelixManager.class);
+    when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
+
+    TimeBasedTierSegmentSelector segmentSelector = new TimeBasedTierSegmentSelector(helixManager, "7d");
+    Assert.assertFalse(segmentSelector.selectSegment(tableNameWithType, segmentName));
+  }
+
+  @Test
   public void testFixedSegmentSelector() {
 
     // offline segment


### PR DESCRIPTION
In 0.12 the segment relocator tries to move consuming segments, resulting in the following error:

```
pinot-controller-multidir-blog  | 2023/02/13 09:48:27.735 ERROR [SegmentRelocator] [async-task-thread-75] Caught exception/error while rebalancing table: events_REALTIME
pinot-controller-multidir-blog  | java.lang.IllegalStateException: Invalid endTimeMs: -1 for segment: events__0__31__20230213T0943Z of table: events_REALTIME
pinot-controller-multidir-blog  | 	at org.apache.pinot.shaded.com.google.common.base.Preconditions.checkState(Preconditions.java:738) ~[pinot-all-0.12.0-jar-with-dependencies.jar:0.12.0-118f5e065cb258c171d97a586183759fbc61e2bf]
pinot-controller-multidir-blog  | 	at org.apache.pinot.common.tier.TimeBasedTierSegmentSelector.selectSegment(TimeBasedTierSegmentSelector.java:63) ~[pinot-all-0.12.0-jar-with-dependencies.jar:0.12.0-118f5e065cb258c171d97a586183759fbc61e2bf]
pinot-controller-multidir-blog  | 	at org.apache.pinot.controller.helix.core.relocation.SegmentRelocator.updateSegmentTargetTier(SegmentRelocator.java:212) ~[pinot-all-0.12.0-jar-with-dependencies.jar:0.12.0-118f5e065cb258c171d97a586183759fbc61e2bf]
pinot-controller-multidir-blog  | 	at org.apache.pinot.controller.helix.core.relocation.SegmentRelocator.updateTargetTier(SegmentRelocator.java:173) ~[pinot-all-0.12.0-jar-with-dependencies.jar:0.12.0-118f5e065cb258c171d97a586183759fbc61e2bf]
pinot-controller-multidir-blog  | 	at org.apache.pinot.controller.helix.core.relocation.SegmentRelocator.lambda$processTable$0(SegmentRelocator.java:134) ~[pinot-all-0.12.0-jar-with-dependencies.jar:0.12.0-118f5e065cb258c171d97a586183759fbc61e2bf]
pinot-controller-multidir-blog  | 	at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
pinot-controller-multidir-blog  | 	at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
pinot-controller-multidir-blog  | 	at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
pinot-controller-multidir-blog  | 	at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
pinot-controller-multidir-blog  | 	at java.lang.Thread.run(Thread.java:829) [?:?]
```

And also aborting the segment relocator job.

This PR fixes that bug.