### PR TITLE
limit helix task result info message size to 1000

### DIFF
--- a/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
@@ -58,7 +58,7 @@ import org.slf4j.MDC;
  */
 public class TaskFactoryRegistry {
   private static final Logger LOGGER = LoggerFactory.getLogger(TaskFactoryRegistry.class);
-  private static final int MAX_TASK_RESULT_INFO_LEN = 100;
+  private static final int MAX_TASK_RESULT_INFO_LEN = 1000;
 
   private final Map<String, TaskFactory> _taskFactoryRegistry = new HashMap<>();
 
@@ -197,7 +197,7 @@ public class TaskFactoryRegistry {
   }
 
   private static String extractAndTrimRootCauseMessage(Throwable th) {
-    String rootCauseMessage = ExceptionUtils.getRootCauseMessage(th);
+    String rootCauseMessage = ExceptionUtils.getStackTrace(th);
     if (rootCauseMessage != null && rootCauseMessage.length() > MAX_TASK_RESULT_INFO_LEN) {
       return rootCauseMessage.substring(0, MAX_TASK_RESULT_INFO_LEN);
     }


### PR DESCRIPTION
Helix task framework put task result info message into Znode, we limit helix task result info message size to 1000 to avoid the Znode grows too large. 

We use 1000 as the limit for the following reasons:
1. Task results reported (inlcudeing info messages) here will be saved into znode
   (<pinot cluster name>/PROPERTYSTORE/TaskRebalancer/<Helix job name>), which has a default limit of 1M.
    Since tasks belonging to the same helix job will be saved in the same znode, info messages cannot be too long,
    Otherwise, the znode may be too large, causing communication issue between zookeeper clients and zookeeper,
    which results in instance crash and znode not updatable.
2. Info messages stored in znode are fetched by minion task APIs (/tasks/{taskType}/debug, /tasks/{taskType}/debug,
    /tasks/task/{taskName}/debug) for debugging purpose, so the info must contain enough info.
1000 is a reasonable choice, because with this length, the info message will contain relatively rich info for
debugging. At the same time, with znode compressed, the helix job znode can hold ~1000 helix tasks (1M/1000=1000),
which is enough in most use cases.