### PR TITLE
Add Theta Sketch Aggregation for StarTree Indexes

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountThetaSketchStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountThetaSketchStarTreeV2Test.java
@@ -18,12 +18,11 @@
  */
 package org.apache.pinot.core.startree.v2;
 
+import java.util.Random;
 import org.apache.datasketches.theta.Sketch;
 import org.apache.pinot.segment.local.aggregator.DistinctCountThetaSketchValueAggregator;
 import org.apache.pinot.segment.local.aggregator.ValueAggregator;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
-
-import java.util.Random;
 
 import static org.testng.Assert.assertEquals;
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountThetaSketchStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountThetaSketchStarTreeV2Test.java
@@ -1,0 +1,52 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.startree.v2;
+
+import org.apache.datasketches.theta.Sketch;
+import org.apache.pinot.segment.local.aggregator.DistinctCountThetaSketchValueAggregator;
+import org.apache.pinot.segment.local.aggregator.ValueAggregator;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+import java.util.Random;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class DistinctCountThetaSketchStarTreeV2Test extends BaseStarTreeV2Test<Object, Sketch> {
+
+  @Override
+  ValueAggregator<Object, Sketch> getValueAggregator() {
+    return new DistinctCountThetaSketchValueAggregator();
+  }
+
+  @Override
+  DataType getRawValueType() {
+    return DataType.INT;
+  }
+
+  @Override
+  Object getRandomRawValue(Random random) {
+    return random.nextInt(100);
+  }
+
+  @Override
+  void assertAggregatedValue(Sketch starTreeResult, Sketch nonStarTreeResult) {
+    assertEquals(starTreeResult.getEstimate(), nonStarTreeResult.getEstimate());
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
@@ -35,10 +35,8 @@ public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<
 
   public DistinctCountThetaSketchValueAggregator() {
     // TODO: Handle configurable nominal entries for StarTreeBuilder
-    _union = Union.builder()
-            .setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES)
-            .buildUnion();
-  };
+    _union = Union.builder().setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES).buildUnion();
+  }
 
   @Override
   public AggregationFunctionType getAggregationType() {
@@ -56,9 +54,9 @@ public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<
   // Utility method to create a theta sketch with one item in it
   private Sketch singleItemSketch(Object rawValue) {
     // TODO: Handle configurable nominal entries for StarTreeBuilder
-    UpdateSketch sketch = Sketches.updateSketchBuilder()
-      .setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES)
-      .build();
+    UpdateSketch sketch =
+        Sketches.updateSketchBuilder().setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES)
+            .build();
     if (rawValue instanceof String) {
       sketch.update((String) rawValue);
     } else if (rawValue instanceof Integer) {
@@ -94,7 +92,6 @@ public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<
     return initialValue;
   }
 
-
   @Override
   public Sketch applyRawValue(Sketch value, Object rawValue) {
     Sketch right;
@@ -107,7 +104,6 @@ public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<
     _maxByteSize = Math.max(_maxByteSize, result.getCurrentBytes());
     return result;
   }
-
 
   @Override
   public Sketch applyAggregatedValue(Sketch value, Sketch aggregatedValue) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
@@ -1,0 +1,118 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.aggregator;
+
+import org.apache.datasketches.theta.SingleItemSketch;
+import org.apache.datasketches.theta.Sketch;
+import org.apache.datasketches.theta.Sketches;
+import org.apache.datasketches.theta.Union;
+import org.apache.datasketches.theta.UpdateSketch;
+import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
+import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.CommonConstants;
+
+
+public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<Object, Sketch> {
+  public static final DataType AGGREGATED_VALUE_TYPE = DataType.BYTES;
+  private static final int DEFAULT_LOG2M_BYTE_SIZE = 180;
+
+  @Override
+  public AggregationFunctionType getAggregationType() {
+    return AggregationFunctionType.DISTINCTCOUNTHLL;
+  }
+
+  @Override
+  public DataType getAggregatedValueType() {
+    return AGGREGATED_VALUE_TYPE;
+  }
+
+  // This changes a lot similar to the Bitmap aggregator
+  private int _maxByteSize;
+
+  // Utility method to create a theta sketch with one item in it
+  private Sketch singleItemSketch(Object rawValue) {
+    return SingleItemSketch.create(rawValue.hashCode()).compact();
+  }
+
+  // Utility method to merge two sketches
+  private Sketch union(Sketch left, Sketch right) {
+    // TODO: Handle configurable nominal entries for StarTreeBuilder
+    Union u = Union.builder().setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES).buildUnion();
+    u.update(left);
+    u.update(right);
+    return u.getResult().compact();
+  }
+
+  @Override
+  public Sketch getInitialAggregatedValue(Object rawValue) {
+    Sketch initialValue;
+    if (rawValue instanceof byte[]) {
+      byte[] bytes = (byte[]) rawValue;
+      initialValue = deserializeAggregatedValue(bytes);
+      _maxByteSize = Math.max(_maxByteSize, bytes.length);
+    } else {
+      initialValue = singleItemSketch(rawValue);
+      _maxByteSize = Math.max(_maxByteSize, initialValue.getCurrentBytes(true));
+    }
+    return initialValue;
+  }
+
+
+  @Override
+  public Sketch applyRawValue(Sketch value, Object rawValue) {
+    Sketch right;
+    if (rawValue instanceof byte[]) {
+      right = deserializeAggregatedValue((byte[]) rawValue);
+    } else {
+      right = singleItemSketch(rawValue);
+    }
+    Sketch result = union(value, right).compact();
+    _maxByteSize = Math.max(_maxByteSize, result.getCurrentBytes(true));
+    return result;
+  }
+
+
+  @Override
+  public Sketch applyAggregatedValue(Sketch value, Sketch aggregatedValue) {
+    Sketch result = union(value, aggregatedValue);
+    _maxByteSize = Math.max(_maxByteSize, result.getCurrentBytes(true));
+    return result;
+  }
+
+  @Override
+  public Sketch cloneAggregatedValue(Sketch value) {
+    return deserializeAggregatedValue(serializeAggregatedValue(value));
+  }
+
+  @Override
+  public int getMaxAggregatedValueByteSize() {
+    return _maxByteSize;
+  }
+
+  @Override
+  public byte[] serializeAggregatedValue(Sketch value) {
+    return CustomSerDeUtils.DATA_SKETCH_SER_DE.serialize(value);
+  }
+
+  @Override
+  public Sketch deserializeAggregatedValue(byte[] bytes) {
+    return CustomSerDeUtils.DATA_SKETCH_SER_DE.deserialize(bytes);
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
@@ -20,9 +20,7 @@ package org.apache.pinot.segment.local.aggregator;
 
 import org.apache.datasketches.theta.SingleItemSketch;
 import org.apache.datasketches.theta.Sketch;
-import org.apache.datasketches.theta.Sketches;
 import org.apache.datasketches.theta.Union;
-import org.apache.datasketches.theta.UpdateSketch;
 import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -54,7 +52,9 @@ public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<
   // Utility method to merge two sketches
   private Sketch union(Sketch left, Sketch right) {
     // TODO: Handle configurable nominal entries for StarTreeBuilder
-    Union u = Union.builder().setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES).buildUnion();
+    Union u = Union.builder()
+      .setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES)
+      .buildUnion();
     u.update(left);
     u.update(right);
     return u.getResult().compact();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
@@ -31,11 +31,11 @@ import org.apache.pinot.spi.utils.CommonConstants;
 public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<Object, Sketch> {
   public static final DataType AGGREGATED_VALUE_TYPE = DataType.BYTES;
 
-  Union union;
+  Union _union;
 
   public DistinctCountThetaSketchValueAggregator() {
     // TODO: Handle configurable nominal entries for StarTreeBuilder
-    this.union = Union.builder()
+    this._union = Union.builder()
             .setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES)
             .buildUnion();
   };
@@ -77,7 +77,7 @@ public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<
 
   // Utility method to merge two sketches
   private Sketch union(Sketch left, Sketch right) {
-    return union.union(left, right);
+    return _union.union(left, right);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
@@ -35,7 +35,7 @@ public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<
 
   public DistinctCountThetaSketchValueAggregator() {
     // TODO: Handle configurable nominal entries for StarTreeBuilder
-    this._union = Union.builder()
+    _union = Union.builder()
             .setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES)
             .buildUnion();
   };

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
@@ -31,7 +31,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<Object, Sketch> {
   public static final DataType AGGREGATED_VALUE_TYPE = DataType.BYTES;
 
-  Union _union;
+  private final Union _union;
 
   public DistinctCountThetaSketchValueAggregator() {
     // TODO: Handle configurable nominal entries for StarTreeBuilder

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
@@ -29,7 +29,6 @@ import org.apache.pinot.spi.utils.CommonConstants;
 
 public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<Object, Sketch> {
   public static final DataType AGGREGATED_VALUE_TYPE = DataType.BYTES;
-  private static final int DEFAULT_LOG2M_BYTE_SIZE = 180;
 
   @Override
   public AggregationFunctionType getAggregationType() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregator.java
@@ -32,7 +32,7 @@ public class DistinctCountThetaSketchValueAggregator implements ValueAggregator<
 
   @Override
   public AggregationFunctionType getAggregationType() {
-    return AggregationFunctionType.DISTINCTCOUNTHLL;
+    return AggregationFunctionType.DISTINCTCOUNTTHETASKETCH;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
@@ -63,6 +63,9 @@ public class ValueAggregatorFactory {
       case PERCENTILETDIGEST:
       case PERCENTILERAWTDIGEST:
         return new PercentileTDigestValueAggregator();
+      case DISTINCTCOUNTTHETASKETCH:
+      case DISTINCTCOUNTRAWTHETASKETCH:
+        return new DistinctCountThetaSketchValueAggregator();
       default:
         throw new IllegalStateException("Unsupported aggregation type: " + aggregationType);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
@@ -104,6 +104,9 @@ public class ValueAggregatorFactory {
       case PERCENTILETDIGEST:
       case PERCENTILERAWTDIGEST:
         return PercentileTDigestValueAggregator.AGGREGATED_VALUE_TYPE;
+      case DISTINCTCOUNTTHETASKETCH:
+      case DISTINCTCOUNTRAWTHETASKETCH:
+        return DistinctCountThetaSketchValueAggregator.AGGREGATED_VALUE_TYPE;
       default:
         throw new IllegalStateException("Unsupported aggregation type: " + aggregationType);
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregatorTest.java
@@ -55,7 +55,7 @@ public class DistinctCountThetaSketchValueAggregatorTest {
         // and should update the max size
         assertEquals(
                 agg.getMaxAggregatedValueByteSize(),
-                result.getCurrentBytes(true)
+                result.getCurrentBytes()
         );
     }
 
@@ -66,23 +66,23 @@ public class DistinctCountThetaSketchValueAggregatorTest {
         Sketch result1 = input1.compact();
         UpdateSketch input2 = Sketches.updateSketchBuilder().build();
         IntStream.range(0, 1000).forEach(input2::update);
-        Sketch result2 = input1.compact();
+        Sketch result2 = input2.compact();
         DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
         Sketch result = agg.applyAggregatedValue(result1, result2);
         Union union = Union.builder()
           .setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES).buildUnion();
-        union.update(result1);
-        union.update(result2);
+
+        Sketch merged = union.union(result1, result2);
 
         assertEquals(
                 result.getEstimate(),
-                union.getResult().getEstimate()
+                merged.getEstimate()
         );
 
         // and should update the max size
         assertEquals(
                 agg.getMaxAggregatedValueByteSize(),
-                union.getResult().getCurrentBytes(true)
+                merged.getCurrentBytes()
         );
     }
 
@@ -93,24 +93,24 @@ public class DistinctCountThetaSketchValueAggregatorTest {
         Sketch result1 = input1.compact();
         UpdateSketch input2 = Sketches.updateSketchBuilder().build();
         IntStream.range(0, 1000).forEach(input2::update);
-        Sketch result2 = input1.compact();
+        Sketch result2 = input2.compact();
         DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
         byte[] result2bytes = agg.serializeAggregatedValue(result2);
         Sketch result = agg.applyRawValue(result1, result2bytes);
         Union union = Union.builder()
           .setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES).buildUnion();
-        union.update(result1);
-        union.update(result2);
+
+        Sketch merged = union.union(result1, result2);
 
         assertEquals(
                 result.getEstimate(),
-                union.getResult().getEstimate()
+                merged.getEstimate()
         );
 
         // and should update the max size
         assertEquals(
                 agg.getMaxAggregatedValueByteSize(),
-                union.getResult().getCurrentBytes(true)
+                merged.getCurrentBytes()
         );
     }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregatorTest.java
@@ -24,7 +24,6 @@ import org.apache.datasketches.theta.Sketches;
 import org.apache.datasketches.theta.Union;
 import org.apache.datasketches.theta.UpdateSketch;
 import org.apache.pinot.spi.utils.CommonConstants;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregatorTest.java
@@ -18,14 +18,13 @@
  */
 package org.apache.pinot.segment.local.aggregator;
 
+import java.util.stream.IntStream;
 import org.apache.datasketches.theta.Sketch;
 import org.apache.datasketches.theta.Sketches;
 import org.apache.datasketches.theta.Union;
 import org.apache.datasketches.theta.UpdateSketch;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.annotations.Test;
-
-import java.util.stream.IntStream;
 
 import static org.testng.Assert.assertEquals;
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregatorTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.segment.local.aggregator;
 
 import org.testng.annotations.Test;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/aggregator/DistinctCountThetaSketchValueAggregatorTest.java
@@ -1,0 +1,18 @@
+package org.apache.pinot.segment.local.aggregator;
+
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class DistinctCountThetaSketchValueAggregatorTest {
+
+
+    @Test
+    public void shouldCreateSingleItemSketch() {
+        DistinctCountThetaSketchValueAggregator agg = new DistinctCountThetaSketchValueAggregator();
+        assertEquals(
+                agg.getInitialAggregatedValue("hello world").getEstimate(),
+                1
+        );
+    }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -91,7 +91,8 @@ public class CommonConstants {
     public static final String DEFAULT_HYPERLOGLOG_LOG2M_KEY = "default.hyperloglog.log2m";
     public static final int DEFAULT_HYPERLOGLOG_LOG2M = 8;
 
-    // 2 to the power of 16, for tradeoffs see datasketches library
+    // 2 to the power of 16, for tradeoffs see datasketches library documentation:
+    // https://datasketches.apache.org/docs/Theta/ThetaErrorTable.html
     public static final int DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES = 65536;
 
     // Whether to rewrite DistinctCount to DistinctCountBitmap

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -91,6 +91,8 @@ public class CommonConstants {
     public static final String DEFAULT_HYPERLOGLOG_LOG2M_KEY = "default.hyperloglog.log2m";
     public static final int DEFAULT_HYPERLOGLOG_LOG2M = 8;
 
+    public static final int DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES = 65536; // 2 to the power of 16, for tradeoffs see datasketches library
+
     // Whether to rewrite DistinctCount to DistinctCountBitmap
     public static final String ENABLE_DISTINCT_COUNT_BITMAP_OVERRIDE_KEY = "enable.distinct.count.bitmap.override";
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -46,6 +46,7 @@ public class CommonConstants {
       "org.apache.pinot.plugin.metrics.yammer.YammerMetricsFactory";
 
   public static final String SWAGGER_AUTHORIZATION_KEY = "oauth";
+
   /**
    * The state of the consumer for a given segment
    */
@@ -266,8 +267,7 @@ public class CommonConstants {
 
     public static final String CONTROLLER_URL = "pinot.broker.controller.url";
 
-    public static final String CONFIG_OF_BROKER_REQUEST_CLIENT_IP_LOGGING =
-        "pinot.broker.request.client.ip.logging";
+    public static final String CONFIG_OF_BROKER_REQUEST_CLIENT_IP_LOGGING = "pinot.broker.request.client.ip.logging";
 
     // TODO: Support populating clientIp for GrpcRequestIdentity.
     public static final boolean DEFAULT_BROKER_REQUEST_CLIENT_IP_LOGGING = false;
@@ -275,10 +275,10 @@ public class CommonConstants {
     public static final String CONFIG_OF_LOGGER_ROOT_DIR = "pinot.broker.logger.root.dir";
     public static final String CONFIG_OF_SWAGGER_BROKER_ENABLED = "pinot.broker.swagger.enabled";
     public static final boolean DEFAULT_SWAGGER_BROKER_ENABLED = true;
-    public static final String CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT
-        = "pinot.broker.instance.enableThreadCpuTimeMeasurement";
-    public static final String CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT
-        = "pinot.broker.instance.enableThreadAllocatedBytesMeasurement";
+    public static final String CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT =
+        "pinot.broker.instance.enableThreadCpuTimeMeasurement";
+    public static final String CONFIG_OF_ENABLE_THREAD_ALLOCATED_BYTES_MEASUREMENT =
+        "pinot.broker.instance.enableThreadAllocatedBytesMeasurement";
     public static final boolean DEFAULT_ENABLE_THREAD_CPU_TIME_MEASUREMENT = false;
     public static final boolean DEFAULT_THREAD_ALLOCATED_BYTES_MEASUREMENT = false;
 
@@ -776,8 +776,8 @@ public class CommonConstants {
     public static final String CONFIG_OF_SLEEP_TIME_DENOMINATOR = "accounting.sleep.time.denominator";
     public static final int DEFAULT_SLEEP_TIME_DENOMINATOR = 3;
 
-    public static final String CONFIG_OF_MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO
-        = "accounting.min.memory.footprint.to.kill.ratio";
+    public static final String CONFIG_OF_MIN_MEMORY_FOOTPRINT_TO_KILL_RATIO =
+        "accounting.min.memory.footprint.to.kill.ratio";
     public static final double DEFAULT_MEMORY_FOOTPRINT_TO_KILL_RATIO = 0.025;
 
     public static final String CONFIG_OF_GC_BACKOFF_COUNT = "accounting.gc.backoff.count";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -91,7 +91,8 @@ public class CommonConstants {
     public static final String DEFAULT_HYPERLOGLOG_LOG2M_KEY = "default.hyperloglog.log2m";
     public static final int DEFAULT_HYPERLOGLOG_LOG2M = 8;
 
-    public static final int DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES = 65536; // 2 to the power of 16, for tradeoffs see datasketches library
+    // 2 to the power of 16, for tradeoffs see datasketches library
+    public static final int DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES = 65536;
 
     // Whether to rewrite DistinctCount to DistinctCountBitmap
     public static final String ENABLE_DISTINCT_COUNT_BITMAP_OVERRIDE_KEY = "enable.distinct.count.bitmap.override";


### PR DESCRIPTION
# Summary

This implements `ValueAggregator` for the apache datasketches theta `Sketch`.

This should allow `DISTINCT_COUNT_THETA_SKETCH` and `DISTINCT_COUNT_RAW_THETA_SKETCH` to be used in `StarTree` indexes.

# Assumptions:
* The default number of nominal entries is `2 ^ 16`, I haven't made this configurable because I wasn't sure which mechanism to use
* the `_maxByteSize` implementation is similar to the `Bitmap` implementation since it can grow a lot
* unit tests have been added to cover the main methods
* when offering things to the sketch I've matched on the type so we can use the native sketch offer methods, and fallen back to hashCode otherwise