### PR TITLE
Add a tight retry block to update ZK during endSegmentReplacement

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/lineage/SegmentLineageTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/lineage/SegmentLineageTest.java
@@ -111,4 +111,28 @@ public class SegmentLineageTest {
     }
     Assert.assertEquals(segmentLineage.getLineageEntryIds().size(), 0);
   }
+
+  @Test
+  public void teatSegmentLineageEntryEquals() {
+    LineageEntry expectedLineageEntry =
+        new LineageEntry(Arrays.asList("seg1", "seg2"), Arrays.asList("seg3", "seg4"), LineageEntryState.IN_PROGRESS,
+            12345L);
+    LineageEntry actualLineageEntry =
+        new LineageEntry(Arrays.asList("seg1", "seg2"), Arrays.asList("seg3", "seg4"), LineageEntryState.IN_PROGRESS,
+            12345L);
+    Assert.assertEquals(actualLineageEntry, expectedLineageEntry);
+    actualLineageEntry =
+        new LineageEntry(Arrays.asList("seg1", "seg2"), Arrays.asList("seg3", "seg4"), LineageEntryState.IN_PROGRESS,
+            12346L);
+    Assert.assertNotEquals(actualLineageEntry, expectedLineageEntry);
+    actualLineageEntry =
+        new LineageEntry(Arrays.asList("seg1"), Arrays.asList("seg3", "seg4"), LineageEntryState.IN_PROGRESS, 12345L);
+    Assert.assertNotEquals(actualLineageEntry, expectedLineageEntry);
+    actualLineageEntry =
+        new LineageEntry(Arrays.asList("seg1"), Arrays.asList("seg3", "seg4"), LineageEntryState.COMPLETED, 12345L);
+    Assert.assertNotEquals(actualLineageEntry, expectedLineageEntry);
+    actualLineageEntry =
+        new LineageEntry(Arrays.asList("seg1"), Arrays.asList("seg3", "seg4"), LineageEntryState.REVERTED, 12345L);
+    Assert.assertNotEquals(actualLineageEntry, expectedLineageEntry);
+  }
 }


### PR DESCRIPTION
- Current implementation waits for all segments to become online.
- By the time we update ZK, it's highly likely that the znode is already changed if there is another replacement protocol is happening at the same time.
- This PR adds a tight retry block for updating ZNode for segment lineage to improve the success rate.