### PR TITLE
[Quickstart] Improve error message and remove NullPointerException when connection fails

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
@@ -32,7 +32,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
-import javax.validation.constraints.NotNull;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
@@ -109,7 +108,7 @@ public class AbstractBaseAdminCommand extends AbstractBaseCommand {
     }
   }
 
-  private static String readInputStream(@NotNull InputStream inputStream)
+  private static String readInputStream(InputStream inputStream)
       throws IOException {
     final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
     final StringBuilder sb = new StringBuilder();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import javax.validation.constraints.NotNull;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
@@ -101,11 +102,14 @@ public class AbstractBaseAdminCommand extends AbstractBaseCommand {
     try {
       return readInputStream(conn.getInputStream());
     } catch (Exception e) {
-      return readInputStream(conn.getErrorStream());
+      if (conn.getErrorStream() != null) {
+        return readInputStream(conn.getErrorStream());
+      }
+      throw new IOException("Request failed due to connection error", e);
     }
   }
 
-  private static String readInputStream(InputStream inputStream)
+  private static String readInputStream(@NotNull InputStream inputStream)
       throws IOException {
     final BufferedReader reader = new BufferedReader(new InputStreamReader(inputStream, "UTF-8"));
     final StringBuilder sb = new StringBuilder();


### PR DESCRIPTION
In the `AbstractBaseAdminCommand` class, while calling `readInputStream(conn.getErrorStream())` leads to NullPointerException if the connection is failed to establish while sending request. According to docs:

> This method will not cause a connection to be initiated. If the connection was not connected, or if the server did not have an error while connecting or if the server had an error but no error data was sent, this method will return null. 

This patch checks if `getErrorStream() != null` and throws exception accordingly.