### PR TITLE
Handle interrupted exception during Kinesis rate limit

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumer.java
@@ -173,7 +173,12 @@ public class KinesisConsumer extends KinesisConnectionHandler implements Partiti
         }
 
         if (currentWindowRequests >= _rpsLimit) {
-          Thread.sleep(SLEEP_TIME_BETWEEN_REQUESTS);
+          try {
+            Thread.sleep(SLEEP_TIME_BETWEEN_REQUESTS);
+          } catch (InterruptedException e) {
+            LOGGER.debug("Sleep interrupted while rate limiting Kinesis requests", e);
+            break;
+          }
         }
       }
 


### PR DESCRIPTION
Currently if the primary thread is interruptted (either due to `fetchTimeout` or some other reason), the `Thread.sleep` throws an `InterrupttedException` which isn't handled. This leads to consumer not able to proceed beyond a certain number of records.

The solution is to simply handled the exception. The exception is also caught outside the Kinesis exceptions because we don't need to LOG it really and only use it to break the `while` loop. That is the behavior we do while checking for `Thread.interrupted` as well.

