### PR TITLE
Add excludeReplacedSegments param into table metadata API

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/lineage/SegmentLineageUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/lineage/SegmentLineageUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.lineage;
 
+import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
@@ -52,5 +53,20 @@ public class SegmentLineageUtils {
         }
       }
     }
+  }
+
+  public static Set<String> getReplacedSegments(SegmentLineage segmentLineage) {
+    Set<String> segmentsToFilterOut = new HashSet<>();
+    if (segmentLineage != null) {
+      for (String lineageEntryId : segmentLineage.getLineageEntryIds()) {
+        LineageEntry lineageEntry = segmentLineage.getLineageEntry(lineageEntryId);
+        if (lineageEntry.getState() == LineageEntryState.COMPLETED) {
+          segmentsToFilterOut.addAll(lineageEntry.getSegmentsFrom());
+        } else {
+          segmentsToFilterOut.addAll(lineageEntry.getSegmentsTo());
+        }
+      }
+    }
+    return segmentsToFilterOut;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -114,8 +114,8 @@ public class TableMetadataReader {
    * Currently supports only OFFLINE tables.
    * @return a map of segmentName to its metadata
    */
-  public JsonNode getAggregateTableMetadata(String tableNameWithType, List<String> columns, int numReplica,
-      int timeoutMs)
+  public JsonNode getAggregateTableMetadata(String tableNameWithType, List<String> columns,
+      boolean excludeReplacedSegments, int numReplica, int timeoutMs)
       throws InvalidConfigException, IOException {
     final Map<String, List<String>> serverToSegments =
         _pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType);
@@ -125,7 +125,8 @@ public class TableMetadataReader {
         new ServerSegmentMetadataReader(_executor, _connectionManager);
 
     TableMetadataInfo aggregateTableMetadataInfo = serverSegmentMetadataReader
-        .getAggregatedTableMetadataFromServer(tableNameWithType, endpoints, columns, numReplica, timeoutMs);
+        .getAggregatedTableMetadataFromServer(tableNameWithType, endpoints, columns, excludeReplacedSegments,
+            numReplica, timeoutMs);
     return JsonUtils.objectToJsonNode(aggregateTableMetadataInfo);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -140,6 +140,15 @@ public interface TableDataManager {
   List<SegmentDataManager> acquireAllSegments();
 
   /**
+   * Acquires all segments of the table.
+   * <p>It is the caller's responsibility to return the segments by calling {@link #releaseSegment(SegmentDataManager)}.
+   *
+   * @param excludeReplacedSegments Whether to exclude replaced segments
+   * @return List of segment data managers
+   */
+  List<SegmentDataManager> acquireAllSegments(boolean excludeReplacedSegments);
+
+  /**
    * Acquires the segments with the given segment names.
    * <p>It is the caller's responsibility to return the segments by calling {@link #releaseSegment(SegmentDataManager)}.
    * This method may return some recently deleted segments in missingSegments. The caller can identify those segments


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds excludeReplacedSegments flag to table metadata APIs, propagates it to segment acquisition, and filters replaced segments using lineage info\.

```mermaid
flowchart TD
  N0["Controller endpoint receives excludeReplacedSegments #40;F6#41;"]:::stAdded
  N1["Controller prepares call with excludeReplacedSegments flag #40;F6#41;"]:::stAdded
  N2["TableMetadataReader passes flag to ServerSegmentMetadataReader #40;F3#41;"]:::stAdded
  N3["ServerSegmentMetadataReader builds URL with excludeReplacedSegments param #40;F2#41;"]:::stAdded
  N4["Server endpoint receives excludeReplacedSegments #40;F8#41;"]:::stAdded
  N5["Server converts flag and calls tableDataManager#46;acquireAllSegments #40;F8#41;"]:::stAdded
  N6["BaseTableDataManager#46;acquireAllSegments#40;boolean#41; receives flag #40;F4#41;"]:::stAdded
  N7["BaseTableDataManager fetches SegmentLineage #40;F4#41;"]:::stAdded
  N8["BaseTableDataManager calls SegmentLineageUtils#46;getReplacedSegments #40;F4#44; F1#41;"]:::stAdded
  N9["SegmentLineageUtils builds set of replaced segments #40;F1#41;"]:::stAdded
  N10["BaseTableDataManager filters out replaced segments #40;F4#41;"]:::stAdded
  N11["BaseTableDataManager returns filtered segment list #40;F4#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"calls"| N2
  N2 -->|"calls"| N3
  N3 -->|"uses generateExcludeReplacedSegmentsParam"| N3
  N4 -->|"calls"| N5
  N5 -->|"calls"| N6
  N6 -->|"enters"| N7
  N7 -->|"calls"| N8
  N8 -->|"calls"| N9
  N9 -->|"builds set"| N9
  N9 -->|"returns set"| N10
  N10 -->|"filters"| N11
  N11 -->|"returns list"| N11
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/lineage/SegmentLineageUtils\.java — [before](https://github.com/apache/pinot/blob/ba8aad7ad0c2e13a2e357ab68ccb817c375ae190/pinot-common/src/main/java/org/apache/pinot/common/lineage/SegmentLineageUtils.java) · [after](https://github.com/apache/pinot/blob/244d445a87e94fa3855630f66c07ef8139284d61/pinot-common/src/main/java/org/apache/pinot/common/lineage/SegmentLineageUtils.java)
- F2: pinot\-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader\.java — [before](https://github.com/apache/pinot/blob/ba8aad7ad0c2e13a2e357ab68ccb817c375ae190/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java) · [after](https://github.com/apache/pinot/blob/244d445a87e94fa3855630f66c07ef8139284d61/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java)
- F3: pinot\-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader\.java — [before](https://github.com/apache/pinot/blob/ba8aad7ad0c2e13a2e357ab68ccb817c375ae190/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java) · [after](https://github.com/apache/pinot/blob/244d445a87e94fa3855630f66c07ef8139284d61/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java)
- F4: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager\.java — [before](https://github.com/apache/pinot/blob/ba8aad7ad0c2e13a2e357ab68ccb817c375ae190/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java) · [after](https://github.com/apache/pinot/blob/244d445a87e94fa3855630f66c07ef8139284d61/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java)
- F6: pinot\-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource\.java — [before](https://github.com/apache/pinot/blob/ba8aad7ad0c2e13a2e357ab68ccb817c375ae190/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java) · [after](https://github.com/apache/pinot/blob/244d445a87e94fa3855630f66c07ef8139284d61/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java)
- F8: pinot\-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource\.java — [before](https://github.com/apache/pinot/blob/ba8aad7ad0c2e13a2e357ab68ccb817c375ae190/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java) · [after](https://github.com/apache/pinot/blob/244d445a87e94fa3855630f66c07ef8139284d61/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImJhOGFhZDdhZDBjMmUxM2EyZTM1N2FiNjhjY2I4MTdjMzc1YWUxOTAiLCJjb250ZXh0X2hhc2giOiJjMzBlZjIwNWRhMjAwNTM5YmU5MTBmZTljOTRkOGU5MGJiZjFlZTkxMDM3Zjc4ZjNiNWEwZGRmMTk4MTA3NzczIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTA0NjMwLCJoZWFkX3NoYSI6IjI0NGQ0NDVhODdlOTRmYTM4NTU2MzBmNjZjMDdlZjgxMzkyODRkNjEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI4M2NkYjM5OGU5YjkzOWI1ZjQxMjBiNDAzNTE2YjlmNjgxYzZhZDNmIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature de9aaf4f707fb1d36777d0be5c99037c9c77b45bbfd115c5da21b8be8446ad8e -->
<!-- pinot-pr-flow:end -->

This PR adds the new param `excludeReplacedSegments` for the table metadata API as described in issue: [#10244](https://github.com/apache/pinot/issues/10244). 