### PR TITLE
Bumping hadoop version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <grizzly.version>2.4.4</grizzly.version>
     <hk2.version>2.6.1</hk2.version>
     <swagger.version>1.6.6</swagger.version>
-    <hadoop.version>2.10.1</hadoop.version>
+    <hadoop.version>2.10.2</hadoop.version>
     <antlr.version>4.6</antlr.version>
     <jsonpath.version>2.7.0</jsonpath.version>
     <jsonsmart.version>2.4.7</jsonsmart.version>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <grizzly.version>2.4.4</grizzly.version>
     <hk2.version>2.6.1</hk2.version>
     <swagger.version>1.6.6</swagger.version>
-    <hadoop.version>2.10.2</hadoop.version>
+    <hadoop.version>3.3.4</hadoop.version>
     <antlr.version>4.6</antlr.version>
     <jsonpath.version>2.7.0</jsonpath.version>
     <jsonsmart.version>2.4.7</jsonsmart.version>


### PR DESCRIPTION
This PR bumps the patch version of hadoop due to several reported CVEs.

CVE-2022-25168 CVE-2021-37404 CVE-2022-26612 CVE-2022-25168 CVE-2021-37404 CVE-2021-33036 CVE-2021-25642

We have a much longer list that will involve updating many packages, so I thought it best to break out these PRs to gain some confidence with pinots resiliency to some of these version bumps. 
