### PR TITLE
Minor: Limit MultiStageQuickstart output

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/MultistageEngineQuickStart.java
@@ -57,7 +57,7 @@ public class MultistageEngineQuickStart extends Quickstart {
     printStatus(Quickstart.Color.YELLOW, "***** Multi-stage engine quickstart setup complete *****");
     Map<String, String> queryOptions = Collections.singletonMap("queryOptions",
         CommonConstants.Broker.Request.QueryOptionKey.USE_MULTISTAGE_ENGINE + "=true");
-    String q1 = "SELECT count(*) FROM baseballStats_OFFLINE";
+    String q1 = "SELECT count(*) FROM baseballStats_OFFLINE LIMIT 10";
     printStatus(Quickstart.Color.YELLOW, "Total number of documents in the table");
     printStatus(Quickstart.Color.CYAN, "Query : " + q1);
     printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q1, queryOptions)));
@@ -65,7 +65,7 @@ public class MultistageEngineQuickStart extends Quickstart {
 
     String q2 = "SELECT a.playerID, a.runs, a.yearID, b.runs, b.yearID"
         + " FROM baseballStats_OFFLINE AS a JOIN baseballStats_OFFLINE AS b ON a.playerID = b.playerID"
-        + " WHERE a.runs > 160 AND b.runs < 2";
+        + " WHERE a.runs > 160 AND b.runs < 2 LIMIT 10";
     printStatus(Quickstart.Color.YELLOW, "Correlate the same player(s) with more than 160-run some year(s) and"
         + " with less than 2-run some other year(s)");
     printStatus(Quickstart.Color.CYAN, "Query : " + q2);
@@ -75,7 +75,7 @@ public class MultistageEngineQuickStart extends Quickstart {
     String q3 = "SELECT a.playerName, a.teamID, b.teamName \n"
         + "FROM baseballStats_OFFLINE AS a\n"
         + "JOIN dimBaseballTeams_OFFLINE AS b\n"
-        + "ON a.teamID = b.teamID";
+        + "ON a.teamID = b.teamID LIMIT 10";
     printStatus(Quickstart.Color.YELLOW, "Baseball Stats with joined team names");
     printStatus(Quickstart.Color.CYAN, "Query : " + q3);
     printStatus(Quickstart.Color.YELLOW, prettyPrintResponse(runner.runQuery(q3, queryOptions)));


### PR DESCRIPTION
The console gets filled with the output of the tables. Better to have only 10 rows.