### PR TITLE
Consumer lag unknown

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
@@ -20,7 +20,10 @@ package org.apache.pinot.common.restlet.resources;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import org.apache.pinot.spi.stream.ConsumerPartitionState;
+
 import java.util.Map;
+import java.util.stream.Collectors;
 
 
 /**
@@ -89,6 +92,24 @@ public class SegmentConsumerInfo {
       _latestUpstreamOffsets = latestUpstreamOffsets;
       _recordsLag = recordsLag;
       _availabilityLagMs = availabilityLagMs;
+    }
+
+    public static PartitionOffsetInfo createFrom(
+            Map<String, String> currentOffsets,
+            Map<String, ConsumerPartitionState> partitionStateMap,
+            Map<String, String> recordsLag,
+            Map<String, String> availabilityLagMs
+            ) {
+      return new PartitionOffsetInfo(
+              currentOffsets,
+              partitionStateMap.entrySet().stream().collect(
+                      Collectors.toMap(Map.Entry::getKey, e -> {
+                        ConsumerPartitionState partitionState = e.getValue();
+                        return partitionState.getUpstreamLatestOffset() == null ?
+                                "UNKNOWN" :
+                                partitionState.getUpstreamLatestOffset().toString();
+                      })
+              ), recordsLag, availabilityLagMs);
     }
 
     public Map<String, String> getCurrentOffsets() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfo.java
@@ -20,10 +20,9 @@ package org.apache.pinot.common.restlet.resources;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import org.apache.pinot.spi.stream.ConsumerPartitionState;
-
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.pinot.spi.stream.ConsumerPartitionState;
 
 
 /**
@@ -105,9 +104,8 @@ public class SegmentConsumerInfo {
               partitionStateMap.entrySet().stream().collect(
                       Collectors.toMap(Map.Entry::getKey, e -> {
                         ConsumerPartitionState partitionState = e.getValue();
-                        return partitionState.getUpstreamLatestOffset() == null ?
-                                "UNKNOWN" :
-                                partitionState.getUpstreamLatestOffset().toString();
+                        return partitionState.getUpstreamLatestOffset() == null
+                                ? "UNKNOWN" : partitionState.getUpstreamLatestOffset().toString();
                       })
               ), recordsLag, availabilityLagMs);
     }

--- a/pinot-common/src/test/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfoTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfoTest.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+
+package org.apache.pinot.common.restlet.resources;
+
+import org.apache.pinot.spi.stream.ConsumerPartitionState;
+import org.apache.pinot.spi.stream.LongMsgOffset;
+import org.apache.pinot.spi.stream.RowMetadata;
+import org.testng.annotations.Test;
+
+import java.util.Collections;
+import java.util.Map;
+
+import static org.mockito.Mockito.mock;
+import static org.testng.Assert.assertEquals;
+
+public class SegmentConsumerInfoTest {
+    @Test
+    public void testMissingUpstreamOffset() {
+        Map<String, String> currentOffsets = Collections.singletonMap("0", "5000000");
+        RowMetadata rowMetadata = mock(RowMetadata.class);
+        Map<String, ConsumerPartitionState> partitionStateMap = Collections.singletonMap("0",
+                new ConsumerPartitionState("0", new LongMsgOffset(5000000), 1676890508681L, null, rowMetadata));
+        Map<String, String> recordsLag = Collections.singletonMap("0", "UNKNOWN");
+        Map<String, String> availabilityLagMs = Collections.singletonMap("0", "11605");
+        SegmentConsumerInfo.PartitionOffsetInfo offsetInfo = SegmentConsumerInfo.PartitionOffsetInfo.createFrom(
+                currentOffsets, partitionStateMap, recordsLag, availabilityLagMs
+        );
+
+        Map<String, String> latestUpstreamOffsets = offsetInfo.getLatestUpstreamOffsets();
+        assertEquals(latestUpstreamOffsets.get("0"), "UNKNOWN");
+    }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfoTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/restlet/resources/SegmentConsumerInfoTest.java
@@ -20,13 +20,12 @@
 
 package org.apache.pinot.common.restlet.resources;
 
+import java.util.Collections;
+import java.util.Map;
 import org.apache.pinot.spi.stream.ConsumerPartitionState;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.RowMetadata;
 import org.testng.annotations.Test;
-
-import java.util.Collections;
-import java.util.Map;
 
 import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertEquals;

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -572,15 +572,15 @@ public class TablesResource {
             recordsLagMap.put(k, v.getRecordsLag());
             availabilityLagMsMap.put(k, v.getAvailabilityLagMs());
           });
-          @Deprecated Map<String, String> partitiionToOffsetMap =
+          @Deprecated Map<String, String> partitionToOffsetMap =
               realtimeSegmentDataManager.getPartitionToCurrentOffset();
           segmentConsumerInfoList.add(
               new SegmentConsumerInfo(segmentDataManager.getSegmentName(),
                   realtimeSegmentDataManager.getConsumerState().toString(),
                   realtimeSegmentDataManager.getLastConsumedTimestamp(),
-                  partitiionToOffsetMap,
+                  partitionToOffsetMap,
                   new SegmentConsumerInfo.PartitionOffsetInfo(
-                      partitiionToOffsetMap,
+                      partitionToOffsetMap,
                       partitionStateMap.entrySet().stream().collect(
                           Collectors.toMap(Map.Entry::getKey, e -> e.getValue().getUpstreamLatestOffset().toString())
                       ), recordsLagMap, availabilityLagMsMap)));


### PR DESCRIPTION
When calling the server's `consumingSegmentsInfo` endpoint, I was frequently seeing this error:

```json
{
  "message": "Caught exception when getting consumer info for table: events",
  "status": 500
}
```

Which happens when `getUpstreamLatestOffset` is null in `partitionState`. Some debugging suggested that this error happens when the Kafka consumer is closed before it tries to retrieve the offset. I haven't investigated why that happens, but instead following the pattern of returning 'UNKNOWN' when we can't retrieve a value. 