### PR TITLE
[multistage] properly support query hint

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -109,10 +109,17 @@ public class CalciteSqlParser {
 
   public static SqlNodeAndOptions compileToSqlNodeAndOptions(String sql)
       throws SqlCompilationException {
+    return compileToSqlNodeAndOptions(sql, true);
+  }
+
+  public static SqlNodeAndOptions compileToSqlNodeAndOptions(String sql, boolean isRemoveComments)
+      throws SqlCompilationException {
     long parseStartTimeNs = System.nanoTime();
 
     // Remove the comments from the query
-    sql = removeComments(sql);
+    if (isRemoveComments) {
+      sql = removeComments(sql);
+    }
 
     // Remove the terminating semicolon from the query
     sql = removeTerminatingSemicolon(sql);

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -866,15 +866,11 @@ public class CalciteSqlCompilerTest {
     testRemoveComments("select * from myTable--hello\n", "select * from myTable");
     testRemoveComments("select * from--hello\nmyTable", "select * from myTable");
     testRemoveComments("select * from/*hello*/myTable", "select * from myTable");
-    // Multi-line comment must have end indicator
-    testRemoveComments("select * from myTable/*hello", "select * from myTable/*hello");
     testRemoveComments("select * from myTable--", "select * from myTable");
     testRemoveComments("select * from myTable--\n", "select * from myTable");
     testRemoveComments("select * from--\nmyTable", "select * from myTable");
     testRemoveComments("select * from/**/myTable", "select * from myTable");
-    // End indicator itself has no effect
     testRemoveComments("select * from\nmyTable", "select * from\nmyTable");
-    testRemoveComments("select * from*/myTable", "select * from*/myTable");
 
     // Mix of single line and multi-line comment indicators
     testRemoveComments("select * from myTable--hello--world", "select * from myTable");
@@ -906,7 +902,9 @@ public class CalciteSqlCompilerTest {
   }
 
   private void testRemoveComments(String sqlWithComments, String expectedSqlWithoutComments) {
-    Assert.assertEquals(CalciteSqlParser.removeComments(sqlWithComments).trim(), expectedSqlWithoutComments.trim());
+    PinotQuery commentedResult = CalciteSqlParser.compileToPinotQuery(sqlWithComments);
+    PinotQuery expectedResult = CalciteSqlParser.compileToPinotQuery(expectedSqlWithoutComments);
+    Assert.assertEquals(commentedResult, expectedResult);
   }
 
   @Test

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintStrategyTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintStrategyTable.java
@@ -16,19 +16,21 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.query.planner.hints;
-
-import org.apache.calcite.rel.hint.RelHint;
-
+package org.apache.calcite.rel.hint;
 
 /**
- * Provide certain relational hint to query planner for better optimization.
+ * Default hint strategy set for Pinot query.
  */
-public class PinotRelationalHints {
-  public static final RelHint AGG_INTERMEDIATE_STAGE = RelHint.builder("AGG_INTERMEDIATE_STAGE").build();
-  public static final RelHint AGG_LEAF_STAGE = RelHint.builder("AGG_LEAF_STAGE").build();
+public class PinotHintStrategyTable {
+  public static final String INTERNAL_AGG_INTERMEDIATE_STAGE = "aggIntermediateStage";
+  public static final String INTERNAL_AGG_FINAL_STAGE = "aggFinalStage";
 
-  private PinotRelationalHints() {
+  private PinotHintStrategyTable() {
     // do not instantiate.
   }
+
+  public static final HintStrategyTable PINOT_HINT_STRATEGY_TABLE = HintStrategyTable.builder()
+      .hintStrategy(INTERNAL_AGG_INTERMEDIATE_STAGE, HintPredicates.AGGREGATE)
+      .hintStrategy(INTERNAL_AGG_FINAL_STAGE, HintPredicates.AGGREGATE)
+      .build();
 }

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
@@ -37,6 +37,9 @@ public class PinotQueryRuleSets {
           EnumerableRules.ENUMERABLE_PROJECT_RULE, EnumerableRules.ENUMERABLE_WINDOW_RULE,
           EnumerableRules.ENUMERABLE_SORT_RULE, EnumerableRules.ENUMERABLE_TABLE_SCAN_RULE,
 
+          // ------------------------------------------------------------------
+          // Calcite core rules
+
           // push a filter into a join
           CoreRules.FILTER_INTO_JOIN,
           // push filter through an aggregation
@@ -95,10 +98,14 @@ public class PinotQueryRuleSets {
           PruneEmptyRules.JOIN_RIGHT_INSTANCE, PruneEmptyRules.PROJECT_INSTANCE, PruneEmptyRules.SORT_INSTANCE,
           PruneEmptyRules.UNION_INSTANCE,
 
+          // ------------------------------------------------------------------
           // Pinot specific rules
+          // ------------------------------------------------------------------
+
+          // ---- rules apply before exchange insertion.
           PinotFilterExpandSearchRule.INSTANCE,
 
-          // Pinot exchange rules
+          // ---- rules that insert exchange.
           // add an extra exchange for sort
           PinotSortExchangeNodeInsertRule.INSTANCE,
           // copy exchanges down, this must be done after SortExchangeNodeInsertRule

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -35,6 +35,7 @@ import org.apache.calcite.prepare.Prepare;
 import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.RelRoot;
 import org.apache.calcite.rel.hint.HintStrategyTable;
+import org.apache.calcite.rel.hint.PinotHintStrategyTable;
 import org.apache.calcite.rel.rules.PinotQueryRuleSets;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rex.RexBuilder;
@@ -238,6 +239,6 @@ public class QueryEnvironment {
   // --------------------------------------------------------------------------
 
   private HintStrategyTable getHintStrategyTable() {
-    return HintStrategyTable.builder().build();
+    return PinotHintStrategyTable.PINOT_HINT_STRATEGY_TABLE;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -173,12 +173,12 @@ public class QueryEnvironment {
 
   @VisibleForTesting
   public QueryPlan planQuery(String sqlQuery) {
-    return planQuery(sqlQuery, CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery), 0);
+    return planQuery(sqlQuery, CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery, false), 0);
   }
 
   @VisibleForTesting
   public String explainQuery(String sqlQuery) {
-    return explainQuery(sqlQuery, CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery));
+    return explainQuery(sqlQuery, CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery, false));
   }
 
   // --------------------------------------------------------------------------

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -173,12 +173,12 @@ public class QueryEnvironment {
 
   @VisibleForTesting
   public QueryPlan planQuery(String sqlQuery) {
-    return planQuery(sqlQuery, CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery, false), 0);
+    return planQuery(sqlQuery, CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery), 0);
   }
 
   @VisibleForTesting
   public String explainQuery(String sqlQuery) {
-    return explainQuery(sqlQuery, CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery, false));
+    return explainQuery(sqlQuery, CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery));
   }
 
   // --------------------------------------------------------------------------

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/StageMetadata.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/StageMetadata.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
-import org.apache.pinot.query.planner.hints.PinotRelationalHints;
 import org.apache.pinot.query.planner.stage.AggregateNode;
 import org.apache.pinot.query.planner.stage.SortNode;
 import org.apache.pinot.query.planner.stage.StageNode;
@@ -75,7 +74,7 @@ public class StageMetadata implements Serializable {
     if (stageNode instanceof AggregateNode) {
       AggregateNode aggNode = (AggregateNode) stageNode;
       _requiresSingletonInstance = _requiresSingletonInstance || (aggNode.getGroupSet().size() == 0
-          && aggNode.getRelHints().contains(PinotRelationalHints.AGG_INTERMEDIATE_STAGE));
+          && AggregateNode.isFinalStage(aggNode));
     }
     if (stageNode instanceof SortNode) {
       SortNode sortNode = (SortNode) stageNode;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/AggregateNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/AggregateNode.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.planner.stage;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.hint.PinotHintStrategyTable;
 import org.apache.calcite.rel.hint.RelHint;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
@@ -28,6 +29,10 @@ import org.apache.pinot.query.planner.serde.ProtoProperties;
 
 
 public class AggregateNode extends AbstractStageNode {
+  public static final RelHint FINAL_STAGE_HINT = RelHint.builder(
+      PinotHintStrategyTable.INTERNAL_AGG_FINAL_STAGE).build();
+  public static final RelHint INTERMEDIATE_STAGE_HINT = RelHint.builder(
+      PinotHintStrategyTable.INTERNAL_AGG_INTERMEDIATE_STAGE).build();
 
   private List<RelHint> _relHints;
   @ProtoProperties
@@ -45,6 +50,14 @@ public class AggregateNode extends AbstractStageNode {
     _aggCalls = aggCalls.stream().map(RexExpression::toRexExpression).collect(Collectors.toList());
     _groupSet = groupSet;
     _relHints = relHints;
+  }
+
+  public static boolean isFinalStage(AggregateNode aggNode) {
+    return aggNode.getRelHints().contains(FINAL_STAGE_HINT);
+  }
+
+  public static boolean isIntermediateStage(AggregateNode aggNode) {
+    return aggNode.getRelHints().contains(INTERMEDIATE_STAGE_HINT);
   }
 
   public List<RexExpression> getAggCalls() {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/AggregateNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/stage/AggregateNode.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.planner.stage;
 
+import com.google.common.base.Preconditions;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.calcite.rel.core.AggregateCall;
@@ -50,6 +51,8 @@ public class AggregateNode extends AbstractStageNode {
     _aggCalls = aggCalls.stream().map(RexExpression::toRexExpression).collect(Collectors.toList());
     _groupSet = groupSet;
     _relHints = relHints;
+    Preconditions.checkState(!(isFinalStage(this) && isIntermediateStage(this)),
+        "Unable to compile aggregation with both hints for final and intermediate agg type.");
   }
 
   public static boolean isFinalStage(AggregateNode aggNode) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -230,18 +230,17 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
       throws Exception {
     // Hinting the query to use final stage aggregation makes server directly return final result
     // This is useful when data is already partitioned by col1
-    String query = "SELECT /*+ aggFinalStage */ col1, COUNT(*) FROM a GROUP BY col1";
+    String query = "SELECT /*+ aggFinalStage */ col1, COUNT(*) FROM b GROUP BY col1";
     QueryPlan queryPlan = _queryEnvironment.planQuery(query);
-    Assert.assertEquals(queryPlan.getQueryStageMap().size(), 3);
-    Assert.assertEquals(queryPlan.getStageMetadataMap().size(), 3);
+    Assert.assertEquals(queryPlan.getQueryStageMap().size(), 2);
+    Assert.assertEquals(queryPlan.getStageMetadataMap().size(), 2);
     for (Map.Entry<Integer, StageMetadata> e : queryPlan.getStageMetadataMap().entrySet()) {
       List<String> tables = e.getValue().getScannedTables();
-      if (tables.size() == 1) {
-        // table scan stages; for tableA it should have 2 hosts, for tableB it should have only 1
+      if (tables.size() != 0) {
+        // table scan stages; for tableB it should have only 1
         Assert.assertEquals(e.getValue().getServerInstances().stream()
                 .map(VirtualServer::toString).sorted().collect(Collectors.toList()),
-            tables.get(0).equals("a") ? ImmutableList.of("0@Server_localhost_1", "0@Server_localhost_2")
-                : ImmutableList.of("0@Server_localhost_1"));
+            ImmutableList.of("0@Server_localhost_1"));
       } else if (!PlannerUtils.isRootStage(e.getKey())) {
         // join stage should have both servers used.
         Assert.assertEquals(e.getValue().getServerInstances().stream()


### PR DESCRIPTION
previously we support hinting by directly creating relHint with builder. this is sort of a short-term solution.
This PR creates HintStrategyTable based on Calcite's recommended way of hinting planner. 

See: https://calcite.apache.org/javadocAggregate/org/apache/calcite/rel/hint/package-summary.html