### PR TITLE
Bug fix: OpChain marked as errorenous incorrectly

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -85,11 +85,12 @@ public class OpChainSchedulerService extends AbstractExecutionThreadService {
               // TODO: There should be a waiting-for-data state in OpChainStats.
               operatorChain.getStats().queued();
               _scheduler.yield(operatorChain);
-            } else if (result.isEndOfStreamBlock()) {
+            } else if (result.isErrorBlock()) {
               isFinished = true;
               LOGGER.error("({}): Completed erroneously {} {}", operatorChain, operatorChain.getStats(),
                   result.getDataBlock().getExceptions());
             } else {
+              isFinished = true;
               operatorChain.getStats().setOperatorStatsMap(result.getResultMetadata());
               LOGGER.debug("({}): Completed {}", operatorChain, operatorChain.getStats());
             }


### PR DESCRIPTION
This bug got introduced with the #10289

We are throwing error even in case the opChain completes successfully as well without exceptions. The change order of the checks is the root cause.
