### PR TITLE
enable readonly access to controller UI for users without table restrictions

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
@@ -28,6 +28,7 @@ import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
 import javax.inject.Inject;
+import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;
 import javax.ws.rs.Path;
 import javax.ws.rs.Produces;
@@ -72,13 +73,8 @@ public class PinotControllerAuthResource {
       @ApiResponse(code = 500, message = "Verification error")
   })
   public boolean verify(@ApiParam(value = "Table name without type") @QueryParam("tableName") String tableName,
-      @ApiParam(value = "API access type") @QueryParam("accessType") AccessType accessType,
+      @ApiParam(value = "API access type") @DefaultValue("READ") @QueryParam("accessType") AccessType accessType,
       @ApiParam(value = "Endpoint URL") @QueryParam("endpointUrl") String endpointUrl) {
-
-    if (accessType == null) {
-      accessType = AccessType.READ;
-    }
-
     AccessControl accessControl = _accessControlFactory.create();
     return accessControl.hasAccess(tableName, accessType, _httpHeaders, endpointUrl);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotControllerAuthResource.java
@@ -74,6 +74,11 @@ public class PinotControllerAuthResource {
   public boolean verify(@ApiParam(value = "Table name without type") @QueryParam("tableName") String tableName,
       @ApiParam(value = "API access type") @QueryParam("accessType") AccessType accessType,
       @ApiParam(value = "Endpoint URL") @QueryParam("endpointUrl") String endpointUrl) {
+
+    if (accessType == null) {
+      accessType = AccessType.READ;
+    }
+
     AccessControl accessControl = _accessControlFactory.create();
     return accessControl.hasAccess(tableName, accessType, _httpHeaders, endpointUrl);
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
@@ -47,19 +47,23 @@ public class AuthQuickstart extends Quickstart {
     properties.put("pinot.controller.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
     properties.put("controller.admin.access.control.factory.class",
         "org.apache.pinot.controller.api.access.BasicAuthAccessControlFactory");
-    properties.put("controller.admin.access.control.principals", "admin, user");
+    properties.put("controller.admin.access.control.principals", "admin, user, service, tableonly");
     properties.put("controller.admin.access.control.principals.admin.password", "verysecret");
+    properties.put("controller.admin.access.control.principals.service.password", "verysecrettoo");
     properties.put("controller.admin.access.control.principals.user.password", "secret");
-    properties.put("controller.admin.access.control.principals.user.tables", "baseballStats");
-    properties.put("controller.admin.access.control.principals.user.permissions", "read");
+    properties.put("controller.admin.access.control.principals.user.permissions", "READ");
+    properties.put("controller.admin.access.control.principals.tableonly.password", "secrettoo");
+    properties.put("controller.admin.access.control.principals.tableonly.permissions", "READ");
+    properties.put("controller.admin.access.control.principals.tableonly.tables", "baseballStats");
 
     // broker
     properties.put("pinot.broker.access.control.class", "org.apache.pinot.broker.broker.BasicAuthAccessControlFactory");
-    properties.put("pinot.broker.access.control.principals", "admin, user");
+    properties.put("pinot.broker.access.control.principals", "admin, user, service, tableonly");
     properties.put("pinot.broker.access.control.principals.admin.password", "verysecret");
+    properties.put("pinot.broker.access.control.principals.service.password", "verysecrettoo");
     properties.put("pinot.broker.access.control.principals.user.password", "secret");
-    properties.put("pinot.broker.access.control.principals.user.tables", "baseballStats");
-    properties.put("pinot.broker.access.control.principals.user.permissions", "read");
+    properties.put("pinot.broker.access.control.principals.tableonly.password", "secrettoo");
+    properties.put("pinot.broker.access.control.principals.tableonly.tables", "baseballStats");
 
     // server
     properties.put("pinot.server.segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");


### PR DESCRIPTION
This PR aligns the web UI authentication process with the reasonable expectation of read-only users to have access to the web UI.

The controller UI currently checks for full (aka "admin") access permissions before showing the web interface when basic auth is enabled. Users with blanket READ access (aka "no table restrictions") cannot currently use the web UI, even though they can still access read-only information by hitting the APIs directly.