### PR TITLE
append UUID to segment name in SegmentGenerationAndPushTask

### DIFF
--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskExecutor.java
@@ -321,6 +321,8 @@ public class SegmentGenerationAndPushTaskExecutor extends BaseTaskExecutor {
       segmentNameGeneratorSpec.setType(taskConfigs.get(BatchConfigProperties.SEGMENT_NAME_GENERATOR_TYPE));
       segmentNameGeneratorSpec.setConfigs(IngestionConfigUtils.getConfigMapWithPrefix(taskConfigs,
           BatchConfigProperties.SEGMENT_NAME_GENERATOR_PROP_PREFIX));
+      segmentNameGeneratorSpec.addConfig(SegmentGenerationTaskRunner.APPEND_UUID_TO_SEGMENT_NAME,
+          taskConfigs.getOrDefault(BatchConfigProperties.APPEND_UUID_TO_SEGMENT_NAME, Boolean.toString(false)));
       taskSpec.setSegmentNameGeneratorSpec(segmentNameGeneratorSpec);
       taskSpec.setCustomProperty(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
@@ -300,6 +300,14 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
             segmentName);
       }
     }
+    // The SEQUENCE_ID used to identify each segment is only unique to each round of task generation. Across multiple
+    // rounds of task generation, the SEQUENCE_ID can be the same.
+    // This may lead to segment name collision, and existing segments will be overridden. Since old segments are
+    // overridden, corresponding files become un-ingested, the generator will generate new tasks, which generates
+    // segments with same names, and override existing segments again... It becomes an endless loop
+    // We add uuid to segment name to avoid segment collision across multiple rounds of task generation to solve the
+    // problem.
+    singleFileGenerationTaskConfig.put(BatchConfigProperties.APPEND_UUID_TO_SEGMENT_NAME, Boolean.toString(true));
     if ((outputDirURI == null) || (pushMode == null)) {
       singleFileGenerationTaskConfig.put(BatchConfigProperties.PUSH_MODE, DEFAULT_SEGMENT_PUSH_TYPE.toString());
     } else {


### PR DESCRIPTION
In SegmentGenerationAndPushTask, the SEQUENCE_ID used to identify each segment is only unique to each round of task generation. Across multiple rounds of task generation, the SEQUENCE_ID can be the same.

This may lead to segment name collision (if segment prefixes are the same), and existing segments will be overridden. Since old segments are overridden, corresponding files become un-ingested, the generator will generate new tasks, which generates segments with same names, and override existing segments again... It becomes an endless loop

We add uuid to segment name to avoid segment collision across multiple rounds of task generation to solve the problem.