### PR TITLE
[Multistage] Allow queries on multiple tables of same tenant to be executed from controller UI

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
@@ -73,6 +73,7 @@ public class QueryException {
   public static final int BROKER_REQUEST_SEND_ERROR_CODE = 425;
   public static final int SERVER_NOT_RESPONDING_ERROR_CODE = 427;
   public static final int TOO_MANY_REQUESTS_ERROR_CODE = 429;
+  public static final int TABLES_NOT_ON_SAME_TENANT_CODE = 431;
   public static final int INTERNAL_ERROR_CODE = 450;
   public static final int MERGE_RESPONSE_ERROR_CODE = 500;
   public static final int FEDERATED_BROKER_UNAVAILABLE_ERROR_CODE = 550;
@@ -130,6 +131,8 @@ public class QueryException {
   public static final ProcessingException UNKNOWN_COLUMN_ERROR = new ProcessingException(UNKNOWN_COLUMN_ERROR_CODE);
   public static final ProcessingException UNKNOWN_ERROR = new ProcessingException(UNKNOWN_ERROR_CODE);
   public static final ProcessingException QUOTA_EXCEEDED_ERROR = new ProcessingException(TOO_MANY_REQUESTS_ERROR_CODE);
+  public static final ProcessingException TABLES_NOT_ON_SAME_TENANT_ERROR =
+      new ProcessingException(TABLES_NOT_ON_SAME_TENANT_CODE);
 
   static {
     JSON_PARSING_ERROR.setMessage("JsonParsingError");
@@ -161,6 +164,7 @@ public class QueryException {
     UNKNOWN_COLUMN_ERROR.setMessage("UnknownColumnError");
     UNKNOWN_ERROR.setMessage("UnknownError");
     QUOTA_EXCEEDED_ERROR.setMessage("QuotaExceededError");
+    TABLES_NOT_ON_SAME_TENANT_ERROR.setMessage("TablesNotOnSameTenantError");
   }
 
   public static ProcessingException getException(ProcessingException processingException, Throwable t) {
@@ -219,6 +223,7 @@ public class QueryException {
       case QueryException.SQL_PARSING_ERROR_CODE:
       case QueryException.TOO_MANY_REQUESTS_ERROR_CODE:
       case QueryException.TABLE_DOES_NOT_EXIST_ERROR_CODE:
+      case QueryException.TABLES_NOT_ON_SAME_TENANT_CODE:
         return true;
       default:
         return false;

--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
@@ -73,7 +73,6 @@ public class QueryException {
   public static final int BROKER_REQUEST_SEND_ERROR_CODE = 425;
   public static final int SERVER_NOT_RESPONDING_ERROR_CODE = 427;
   public static final int TOO_MANY_REQUESTS_ERROR_CODE = 429;
-  public static final int TABLES_NOT_ON_SAME_TENANT_CODE = 431;
   public static final int INTERNAL_ERROR_CODE = 450;
   public static final int MERGE_RESPONSE_ERROR_CODE = 500;
   public static final int FEDERATED_BROKER_UNAVAILABLE_ERROR_CODE = 550;
@@ -131,8 +130,8 @@ public class QueryException {
   public static final ProcessingException UNKNOWN_COLUMN_ERROR = new ProcessingException(UNKNOWN_COLUMN_ERROR_CODE);
   public static final ProcessingException UNKNOWN_ERROR = new ProcessingException(UNKNOWN_ERROR_CODE);
   public static final ProcessingException QUOTA_EXCEEDED_ERROR = new ProcessingException(TOO_MANY_REQUESTS_ERROR_CODE);
-  public static final ProcessingException TABLES_NOT_ON_SAME_TENANT_ERROR =
-      new ProcessingException(TABLES_NOT_ON_SAME_TENANT_CODE);
+  public static final ProcessingException BROKER_REQUEST_SEND_ERROR =
+      new ProcessingException(BROKER_REQUEST_SEND_ERROR_CODE);
 
   static {
     JSON_PARSING_ERROR.setMessage("JsonParsingError");
@@ -164,7 +163,6 @@ public class QueryException {
     UNKNOWN_COLUMN_ERROR.setMessage("UnknownColumnError");
     UNKNOWN_ERROR.setMessage("UnknownError");
     QUOTA_EXCEEDED_ERROR.setMessage("QuotaExceededError");
-    TABLES_NOT_ON_SAME_TENANT_ERROR.setMessage("TablesNotOnSameTenantError");
   }
 
   public static ProcessingException getException(ProcessingException processingException, Throwable t) {
@@ -223,7 +221,6 @@ public class QueryException {
       case QueryException.SQL_PARSING_ERROR_CODE:
       case QueryException.TOO_MANY_REQUESTS_ERROR_CODE:
       case QueryException.TABLE_DOES_NOT_EXIST_ERROR_CODE:
-      case QueryException.TABLES_NOT_ON_SAME_TENANT_CODE:
         return true;
       default:
         return false;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.common.utils.request;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Splitter;
 import java.util.HashMap;
@@ -44,16 +45,14 @@ import org.slf4j.LoggerFactory;
 
 public class RequestUtils {
   private static final Logger LOGGER = LoggerFactory.getLogger(RequestUtils.class);
+  private static final JsonNode EMPTY_OBJECT_NODE = new ObjectMapper().createObjectNode();
 
   private RequestUtils() {
   }
 
   public static SqlNodeAndOptions parseQuery(String query)
           throws SqlCompilationException {
-    long parserStartTimeNs = System.nanoTime();
-    SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
-    sqlNodeAndOptions.setParseTimeNs(System.nanoTime() - parserStartTimeNs);
-    return sqlNodeAndOptions;
+    return parseQuery(query, EMPTY_OBJECT_NODE);
   }
 
   public static SqlNodeAndOptions parseQuery(String query, JsonNode request)

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -48,6 +48,14 @@ public class RequestUtils {
   private RequestUtils() {
   }
 
+  public static SqlNodeAndOptions parseQuery(String query)
+          throws SqlCompilationException {
+    long parserStartTimeNs = System.nanoTime();
+    SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
+    sqlNodeAndOptions.setParseTimeNs(System.nanoTime() - parserStartTimeNs);
+    return sqlNodeAndOptions;
+  }
+
   public static SqlNodeAndOptions parseQuery(String query, JsonNode request)
       throws SqlCompilationException {
     long parserStartTimeNs = System.nanoTime();

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -135,6 +135,24 @@ public class CalciteSqlParser {
     }
   }
 
+  public static List<String> extractTableNamesFromNode(SqlNode sqlNode) {
+    List<String> tableNames = new ArrayList<>();
+    if (sqlNode instanceof SqlSelect) {
+      SqlNode fromNode = ((SqlSelect) sqlNode).getFrom();
+      tableNames.addAll(((SqlIdentifier) fromNode).names);
+      tableNames.addAll(extractTableNamesFromNode(((SqlSelect) sqlNode).getWhere()));
+    } else if (sqlNode instanceof SqlBasicCall) {
+      for (SqlNode node: ((SqlBasicCall) sqlNode).getOperandList()) {
+        tableNames.addAll(extractTableNamesFromNode(node));
+      }
+    } else if (sqlNode instanceof SqlOrderBy) {
+      for (SqlNode node : ((SqlOrderBy) sqlNode).getOperandList()) {
+        tableNames.addAll(extractTableNamesFromNode(node));
+      }
+    }
+    return tableNames;
+  }
+
   @VisibleForTesting
   static SqlNodeAndOptions extractSqlNodeAndOptions(String sql, SqlNodeList sqlNodeList) {
     PinotSqlType sqlType = null;

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
 import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.parser.ParseException;
@@ -3008,6 +3009,15 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(fun.operands.get(0).getFunctionCall().operands.size(), 2);
     Assert.assertEquals(fun.operands.get(0).getFunctionCall().operands.get(0).getIdentifier().getName(), "ts");
     Assert.assertEquals(fun.operands.get(0).getFunctionCall().operands.get(1).getLiteral().getStringValue(), "pst");
+  }
+
+  @Test
+  public void testExtractTableNamesFromNode() {
+    String query = "Select * from tbl1 where condition1 = filter1";
+    SqlNodeAndOptions sqlNodeAndOptions = RequestUtils.parseQuery(query);
+    List<String> tableNames = CalciteSqlParser.extractTableNamesFromNode(sqlNodeAndOptions.getSqlNode());
+    Assert.assertEquals(tableNames.size(), 1);
+    Assert.assertEquals(tableNames.get(0), "tbl1");
   }
 
   private static SqlNodeAndOptions testSqlWithCustomSqlParser(String sqlString) {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -22,6 +22,7 @@ import java.io.StringReader;
 import java.time.Instant;
 import java.time.ZoneId;
 import java.time.format.DateTimeFormatter;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.calcite.sql.SqlNodeList;
@@ -3013,11 +3014,44 @@ public class CalciteSqlCompilerTest {
 
   @Test
   public void testExtractTableNamesFromNode() {
+    // A simple filter query with one table
     String query = "Select * from tbl1 where condition1 = filter1";
     SqlNodeAndOptions sqlNodeAndOptions = RequestUtils.parseQuery(query);
     List<String> tableNames = CalciteSqlParser.extractTableNamesFromNode(sqlNodeAndOptions.getSqlNode());
     Assert.assertEquals(tableNames.size(), 1);
     Assert.assertEquals(tableNames.get(0), "tbl1");
+
+    // query with IN / NOT IN clause
+    query = "SELECT COUNT(*) FROM tbl1 WHERE userUUID IN (SELECT userUUID FROM tbl2) "
+            + "and uuid NOT IN (SELECT uuid from tbl3)";
+    sqlNodeAndOptions = RequestUtils.parseQuery(query);
+    tableNames = CalciteSqlParser.extractTableNamesFromNode(sqlNodeAndOptions.getSqlNode());
+    Assert.assertEquals(tableNames.size(), 3);
+    Collections.sort(tableNames);
+    Assert.assertEquals(tableNames.get(0), "tbl1");
+    Assert.assertEquals(tableNames.get(1), "tbl2");
+    Assert.assertEquals(tableNames.get(2), "tbl3");
+
+    // query with JOIN clause
+    query = "SELECT A.col1, B.col2 FROM tbl1 AS A JOIN tbl2 AS B ON A.key = B.key WHERE A.col1 = value1";
+    sqlNodeAndOptions = RequestUtils.parseQuery(query);
+    tableNames = CalciteSqlParser.extractTableNamesFromNode(sqlNodeAndOptions.getSqlNode());
+    Assert.assertEquals(tableNames.size(), 2);
+    Collections.sort(tableNames);
+    Assert.assertEquals(tableNames.get(0), "tbl1");
+    Assert.assertEquals(tableNames.get(1), "tbl2");
+
+    // query with aliases, JOIN, IN/NOT-IN, group-by
+    query = "with tmp as (select col1, count(*) from tbl1 where condition1 = filter1 group by col1), "
+            + "tmp2 as (select A.col1, B.col2 from tbl2 as A JOIN tbl3 AS B on A.key = B.key) "
+            + "select sum(col1) from tmp where col1 in (select col1 from tmp2) and col1 not in (select col1 from tbl4)";
+    sqlNodeAndOptions = RequestUtils.parseQuery(query);
+    tableNames = CalciteSqlParser.extractTableNamesFromNode(sqlNodeAndOptions.getSqlNode());
+    Assert.assertEquals(tableNames.size(), 4);
+    Assert.assertEquals(tableNames.get(0), "tbl1");
+    Assert.assertEquals(tableNames.get(1), "tbl2");
+    Assert.assertEquals(tableNames.get(2), "tbl3");
+    Assert.assertEquals(tableNames.get(3), "tbl4");
   }
 
   private static SqlNodeAndOptions testSqlWithCustomSqlParser(String sqlString) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -180,7 +180,9 @@ public class PinotQueryResource {
     String brokerTenant = getCommonBrokerTenant(tableNames);
     String serverTenant = getCommonServerTenant(tableNames);
     if (brokerTenant == null || serverTenant == null) {
-      return QueryException.TABLES_NOT_ON_SAME_TENANT_ERROR.toString();
+      return QueryException.getException(QueryException.BROKER_REQUEST_SEND_ERROR,
+          new Exception(String.format("Unable to dispatch multistage query with multiple tables : %s "
+              + "on different tenant", tableNames))).toString();
     }
     List<String> instanceIds = new ArrayList<>(_pinotHelixResourceManager.getAllInstancesForBrokerTenant(brokerTenant));
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineCustomTenantIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineCustomTenantIntegrationTest.java
@@ -1,0 +1,173 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.client.Connection;
+import org.apache.pinot.client.ConnectionFactory;
+import org.apache.pinot.common.datatable.DataTableFactory;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
+import org.apache.pinot.query.service.QueryConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class MultiStageEngineCustomTenantIntegrationTest extends MultiStageEngineIntegrationTest {
+  private static final String SCHEMA_FILE_NAME =
+      "On_Time_On_Time_Performance_2014_100k_subset_nonulls_single_value_columns.schema";
+  private static final String TEST_TENANT = "TestTenant";
+
+  @Override
+  protected String getSchemaFileName() {
+    return SCHEMA_FILE_NAME;
+  }
+
+  @Override
+  protected String getBrokerTenant() {
+    return TEST_TENANT;
+  }
+
+  @Override
+  protected String getServerTenant() {
+    return TEST_TENANT;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    // Start the Pinot cluster
+    startZk();
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CLUSTER_TENANT_ISOLATION_ENABLE, false);
+    startController(properties);
+
+    startBroker();
+    startServer();
+    createBrokerTenant(TEST_TENANT, 1);
+    createServerTenant(TEST_TENANT, 1, 0);
+
+    // Create and upload the schema and table config
+    Schema schema = createSchema();
+    addSchema(schema);
+    TableConfig tableConfig = createOfflineTableConfig();
+    addTableConfig(tableConfig);
+
+    // Unpack the Avro files
+    List<File> avroFiles = unpackAvroData(_tempDir);
+
+    // Create and upload segments
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, tableConfig, schema, 0, _segmentDir, _tarDir);
+    uploadSegments(getTableName(), _tarDir);
+
+    // Set up the H2 connection
+    setUpH2Connection(avroFiles);
+
+    // Initialize the query generator
+    setUpQueryGenerator(avroFiles);
+
+    // Wait for all documents loaded
+    waitForAllDocsLoaded(600_000L);
+
+    // Setting data table version to 4
+    DataTableBuilderFactory.setDataTableVersion(DataTableFactory.VERSION_4);
+  }
+
+  @Test
+  @Override
+  public void testHardcodedQueriesMultiStage()
+      throws Exception {
+    super.testHardcodedQueriesMultiStage();
+  }
+
+  @Test
+  @Override
+  public void testGeneratedQueries()
+      throws Exception {
+    // test multistage engine, currently we don't support MV columns.
+    super.testGeneratedQueries(false, true);
+  }
+
+  @Test
+  public void testQueryOptions()
+      throws Exception {
+    String pinotQuery = "SET multistageLeafLimit = 1; SELECT * FROM mytable;";
+    String h2Query = "SELECT * FROM mytable limit 1";
+    ClusterIntegrationTestUtils
+        .testQueryWithMatchingRowCount(pinotQuery, _brokerBaseApiUrl, getPinotConnection(), h2Query, getH2Connection(),
+            null, ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
+  }
+
+  @Override
+  protected Connection getPinotConnection() {
+    Properties properties = new Properties();
+    properties.put("queryOptions", "useMultistageEngine=true");
+    if (_pinotConnection == null) {
+      _pinotConnection = ConnectionFactory.fromZookeeper(properties, getZkUrl() + "/" + getHelixClusterName());
+    }
+    return _pinotConnection;
+  }
+
+  @Override
+  protected void overrideBrokerConf(PinotConfiguration brokerConf) {
+    brokerConf.setProperty(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_ENABLED, true);
+    brokerConf.setProperty(QueryConfig.KEY_OF_QUERY_RUNNER_PORT, 8421);
+  }
+
+  @Override
+  protected void overrideServerConf(PinotConfiguration serverConf) {
+    serverConf.setProperty(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_ENABLED, true);
+    serverConf.setProperty(QueryConfig.KEY_OF_QUERY_SERVER_PORT, 8842);
+    serverConf.setProperty(QueryConfig.KEY_OF_QUERY_RUNNER_PORT, 8422);
+  }
+
+  @Override
+  protected void testQuery(String pinotQuery, String h2Query)
+      throws Exception {
+    ClusterIntegrationTestUtils
+        .testQuery(pinotQuery, _brokerBaseApiUrl, getPinotConnection(), h2Query, getH2Connection(), null,
+            ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    dropOfflineTable(DEFAULT_TABLE_NAME);
+
+    stopServer();
+    stopBroker();
+    stopController();
+    stopZk();
+
+    FileUtils.deleteDirectory(_tempDir);
+  }
+}


### PR DESCRIPTION
At present, via Controller UI we can only execute multistage queries on DefaultTenant. This patch checks if the tables queried are having atleast one common tenant and allows queries to be executed.