### PR TITLE
Add min / max values to virtual column metadata to allow segment pruning

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
@@ -122,7 +122,7 @@ public class DefaultNullValueVirtualColumnProvider extends BaseVirtualColumnProv
             .setMaxValue(new ByteArray((byte[]) defaultNullValue));
         break;
       default:
-        break;
+        throw new IllegalStateException();
     }
 
     return builder.build();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProvider.java
@@ -88,6 +88,11 @@ public class DefaultNullValueVirtualColumnProvider extends BaseVirtualColumnProv
     ColumnMetadataImpl.Builder builder = getColumnMetadataBuilder(context).setCardinality(1).setHasDictionary(true);
     if (context.getFieldSpec().isSingleValueField()) {
       builder.setSorted(true);
+
+      if (context.getFieldSpec().getDefaultNullValue() instanceof Comparable) {
+        builder.setMinValue((Comparable) context.getFieldSpec().getDefaultNullValue());
+        builder.setMaxValue((Comparable) context.getFieldSpec().getDefaultNullValue());
+      }
     } else {
       // When there is no value for a multi-value column, the maxNumberOfMultiValues and cardinality should be
       // set as 1 because the MV column bitmap uses 1 to delimit the rows for a MV column. Each MV column will have a

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
@@ -30,6 +30,7 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -54,28 +55,28 @@ public class DefaultNullValueVirtualColumnProviderTest {
   public void testBuildMetadata() {
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_INT, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_INT).setTotalDocs(1).setCardinality(1).setSorted(true)
-            .setHasDictionary(true).setMinValue((Comparable) SV_INT.getDefaultNullValue())
-            .setMaxValue((Comparable) SV_INT.getDefaultNullValue()).build());
+            .setHasDictionary(true).setMinValue((int) SV_INT.getDefaultNullValue())
+            .setMaxValue((int) SV_INT.getDefaultNullValue()).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_LONG, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_LONG).setTotalDocs(1).setCardinality(1).setSorted(true)
-            .setHasDictionary(true).setMinValue((Comparable) SV_LONG.getDefaultNullValue())
-            .setMaxValue((Comparable) SV_LONG.getDefaultNullValue()).build());
+            .setHasDictionary(true).setMinValue((long) SV_LONG.getDefaultNullValue())
+            .setMaxValue((long) SV_LONG.getDefaultNullValue()).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_FLOAT, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_FLOAT).setTotalDocs(1).setCardinality(1).setSorted(true)
-            .setHasDictionary(true).setMinValue((Comparable) SV_FLOAT.getDefaultNullValue())
-            .setMaxValue((Comparable) SV_FLOAT.getDefaultNullValue()).build());
+            .setHasDictionary(true).setMinValue((float) SV_FLOAT.getDefaultNullValue())
+            .setMaxValue((float) SV_FLOAT.getDefaultNullValue()).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_DOUBLE, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_DOUBLE).setTotalDocs(1).setCardinality(1).setSorted(true)
-            .setHasDictionary(true).setMinValue((Comparable) SV_DOUBLE.getDefaultNullValue())
-            .setMaxValue((Comparable) SV_DOUBLE.getDefaultNullValue()).build());
+            .setHasDictionary(true).setMinValue((double) SV_DOUBLE.getDefaultNullValue())
+            .setMaxValue((double) SV_DOUBLE.getDefaultNullValue()).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_STRING, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_STRING).setTotalDocs(1).setCardinality(1).setSorted(true)
-            .setHasDictionary(true).setMinValue((Comparable) SV_STRING.getDefaultNullValue())
-            .setMaxValue((Comparable) SV_STRING.getDefaultNullValue()).build());
+            .setHasDictionary(true).setMinValue((String) SV_STRING.getDefaultNullValue())
+            .setMaxValue((String) SV_STRING.getDefaultNullValue()).build());
 
     assertEquals(
         new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_STRING_WITH_DEFAULT, 1)),
@@ -84,27 +85,33 @@ public class DefaultNullValueVirtualColumnProviderTest {
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_BYTES, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_BYTES).setTotalDocs(1).setCardinality(1).setSorted(true)
-            .setHasDictionary(true).build());
+            .setHasDictionary(true).setMinValue(new ByteArray((byte[]) SV_BYTES.getDefaultNullValue()))
+            .setMaxValue(new ByteArray((byte[]) SV_BYTES.getDefaultNullValue())).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_INT, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(MV_INT).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).setMaxNumberOfMultiValues(1).build());
+            .setHasDictionary(true).setMaxNumberOfMultiValues(1).setMinValue((int) MV_INT.getDefaultNullValue())
+            .setMaxValue((int) MV_INT.getDefaultNullValue()).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_LONG, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(MV_LONG).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).setMaxNumberOfMultiValues(1).build());
+            .setHasDictionary(true).setMaxNumberOfMultiValues(1).setMinValue((long) MV_LONG.getDefaultNullValue())
+            .setMaxValue((long) MV_LONG.getDefaultNullValue()).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_FLOAT, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(MV_FLOAT).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).setMaxNumberOfMultiValues(1).build());
+            .setHasDictionary(true).setMaxNumberOfMultiValues(1).setMinValue((float) MV_FLOAT.getDefaultNullValue())
+        .setMaxValue((float) MV_FLOAT.getDefaultNullValue()).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_DOUBLE, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(MV_DOUBLE).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).setMaxNumberOfMultiValues(1).build());
+            .setHasDictionary(true).setMaxNumberOfMultiValues(1).setMinValue((double) MV_DOUBLE.getDefaultNullValue())
+            .setMaxValue((double) MV_DOUBLE.getDefaultNullValue()).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(MV_STRING, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(MV_STRING).setTotalDocs(1).setCardinality(1).setSorted(false)
-            .setHasDictionary(true).setMaxNumberOfMultiValues(1).build());
+            .setHasDictionary(true).setMaxNumberOfMultiValues(1).setMinValue((String) MV_STRING.getDefaultNullValue())
+            .setMaxValue((String) MV_STRING.getDefaultNullValue()).build());
   }
 
   @Test

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/column/DefaultNullValueVirtualColumnProviderTest.java
@@ -41,6 +41,8 @@ public class DefaultNullValueVirtualColumnProviderTest {
   private static final FieldSpec SV_FLOAT = new DimensionFieldSpec("svFloatColumn", DataType.FLOAT, true);
   private static final FieldSpec SV_DOUBLE = new DimensionFieldSpec("svDoubleColumn", DataType.DOUBLE, true);
   private static final FieldSpec SV_STRING = new DimensionFieldSpec("svStringColumn", DataType.STRING, true);
+  private static final FieldSpec SV_STRING_WITH_DEFAULT =
+      new DimensionFieldSpec("svStringColumn", DataType.STRING, true, "default");
   private static final FieldSpec SV_BYTES = new DimensionFieldSpec("svBytesColumn", DataType.BYTES, true);
   private static final FieldSpec MV_INT = new DimensionFieldSpec("mvIntColumn", DataType.INT, false);
   private static final FieldSpec MV_LONG = new DimensionFieldSpec("mvLongColumn", DataType.LONG, false);
@@ -52,23 +54,33 @@ public class DefaultNullValueVirtualColumnProviderTest {
   public void testBuildMetadata() {
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_INT, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_INT).setTotalDocs(1).setCardinality(1).setSorted(true)
-            .setHasDictionary(true).build());
+            .setHasDictionary(true).setMinValue((Comparable) SV_INT.getDefaultNullValue())
+            .setMaxValue((Comparable) SV_INT.getDefaultNullValue()).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_LONG, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_LONG).setTotalDocs(1).setCardinality(1).setSorted(true)
-            .setHasDictionary(true).build());
+            .setHasDictionary(true).setMinValue((Comparable) SV_LONG.getDefaultNullValue())
+            .setMaxValue((Comparable) SV_LONG.getDefaultNullValue()).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_FLOAT, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_FLOAT).setTotalDocs(1).setCardinality(1).setSorted(true)
-            .setHasDictionary(true).build());
+            .setHasDictionary(true).setMinValue((Comparable) SV_FLOAT.getDefaultNullValue())
+            .setMaxValue((Comparable) SV_FLOAT.getDefaultNullValue()).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_DOUBLE, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_DOUBLE).setTotalDocs(1).setCardinality(1).setSorted(true)
-            .setHasDictionary(true).build());
+            .setHasDictionary(true).setMinValue((Comparable) SV_DOUBLE.getDefaultNullValue())
+            .setMaxValue((Comparable) SV_DOUBLE.getDefaultNullValue()).build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_STRING, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_STRING).setTotalDocs(1).setCardinality(1).setSorted(true)
-            .setHasDictionary(true).build());
+            .setHasDictionary(true).setMinValue((Comparable) SV_STRING.getDefaultNullValue())
+            .setMaxValue((Comparable) SV_STRING.getDefaultNullValue()).build());
+
+    assertEquals(
+        new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_STRING_WITH_DEFAULT, 1)),
+        new ColumnMetadataImpl.Builder().setFieldSpec(SV_STRING_WITH_DEFAULT).setTotalDocs(1).setCardinality(1)
+            .setSorted(true).setHasDictionary(true).setMinValue("default").setMaxValue("default").build());
 
     assertEquals(new DefaultNullValueVirtualColumnProvider().buildMetadata(new VirtualColumnContext(SV_BYTES, 1)),
         new ColumnMetadataImpl.Builder().setFieldSpec(SV_BYTES).setTotalDocs(1).setCardinality(1).setSorted(true)


### PR DESCRIPTION
When running queries with predicates on $segmentName, segments are not pruned due to missing min / max value metadata. This PR adds that to all virtual columns. Ideally this is something that can be handled as a broker side pruner too (will raise a followup PR for that).