### PR TITLE
Add Sketch Creation Scalar Functions for HLL/Theta

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/function/scalar/SketchFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/function/scalar/SketchFunctions.java
@@ -39,6 +39,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
  * datasketches/clearspring analytics.
  *
  * Example usage:
+ *
  * {
  *   "transformConfigs": [
  *     {
@@ -46,8 +47,16 @@ import org.apache.pinot.spi.utils.CommonConstants;
  *       "transformFunction": "DistinctCountRawThetaSketch(playerID)"
  *     },
  *     {
+ *       "columnName": "players",
+ *       "transformFunction": "DistinctCountRawThetaSketch(playerID, 1024)"
+ *     },
+ *     {
  *       "columnName": "names",
  *       "transformFunction": "DistinctCountRawHLL(playerName)"
+ *     },
+ *     {
+ *       "columnName": "names",
+ *       "transformFunction": "DistinctCountRawHLL(playerName, 8)"
  *     }
  *   ]
  * }

--- a/pinot-core/src/main/java/org/apache/pinot/core/function/scalar/SketchFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/function/scalar/SketchFunctions.java
@@ -47,8 +47,8 @@ import org.apache.pinot.spi.utils.CommonConstants;
  *     {
  *       "columnName": "names",
  *       "transformFunction": "DistinctCountRawHLL(playerName)"
- *     },
- *   }
+ *     }
+ *   ]
  * }
  */
 public class SketchFunctions {

--- a/pinot-core/src/main/java/org/apache/pinot/core/function/scalar/SketchFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/function/scalar/SketchFunctions.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.function.scalar;
+
+import com.clearspring.analytics.stream.cardinality.HyperLogLog;
+import java.math.BigDecimal;
+import org.apache.datasketches.theta.Sketches;
+import org.apache.datasketches.theta.UpdateSketch;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.apache.pinot.spi.annotations.ScalarFunction;
+import org.apache.pinot.spi.utils.CommonConstants;
+
+
+/**
+ * Inbuilt Sketch Transformation Functions
+ * The functions can be used as UDFs in Query when added in the FunctionRegistry.
+ * @ScalarFunction annotation is used with each method for the registration
+ *
+ * These are intended to be used during ingestion to create sketches from raw data, which can be rolled up later.
+ *
+ * Note this is defined in pinot-core rather than pinot-common because pinot-core has dependencies on
+ * datasketches/clearspring analytics.
+ *
+ * Example usage:
+ * {
+ *   "transformConfigs": [
+ *     {
+ *       "columnName": "players",
+ *       "transformFunction": "DistinctCountRawThetaSketch(playerID)"
+ *     },
+ *     {
+ *       "columnName": "names",
+ *       "transformFunction": "DistinctCountRawHLL(playerName)"
+ *     },
+ *   }
+ * }
+ */
+public class SketchFunctions {
+  private SketchFunctions() {
+  }
+
+  /**
+   * Create a Theta Sketch containing the input
+   *
+   * @param input an Object we want to insert into the sketch, may be null to return an empty sketch
+   * @return serialized theta sketch as bytes
+   */
+  @ScalarFunction(nullableParameters = true)
+  public static byte[] distinctCountRawThetaSketch(Object input) {
+    // TODO make nominal entries configurable
+    UpdateSketch sketch =
+        Sketches.updateSketchBuilder().setNominalEntries(CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES)
+            .build();
+    if (input instanceof String) {
+      sketch.update((String) input);
+    } else if (input instanceof Long) {
+      sketch.update((Long) input);
+    } else if (input instanceof Integer) {
+      sketch.update((Integer) input);
+    } else if (input instanceof BigDecimal) {
+      sketch.update(((BigDecimal) input).toString());
+    } else if (input instanceof Float) {
+      sketch.update((Float) input);
+    } else if (input instanceof Double) {
+      sketch.update((Double) input);
+    } else if (input instanceof byte[]) {
+      sketch.update((byte[]) input);
+    }
+    return ObjectSerDeUtils.DATA_SKETCH_SER_DE.serialize(sketch.compact());
+  }
+
+  /**
+   * Create a HyperLogLog containing the input
+   *
+   * @param input an Object we want to insert into the HLL, may be null to return an empty HLL
+   * @return serialized HLL as bytes
+   */
+  @ScalarFunction(nullableParameters = true)
+  public static byte[] distinctCountRawHLL(Object input) {
+    // TODO make log2m configurable
+    HyperLogLog hll = new HyperLogLog.Builder(CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M).build();
+    if (input != null) {
+      hll.offer(input);
+    }
+    return ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.serialize(hll);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/function/scalar/SketchFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/function/scalar/SketchFunctions.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.function.scalar;
 
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import java.math.BigDecimal;
+import javax.annotation.Nullable;
 import org.apache.datasketches.theta.Sketches;
 import org.apache.datasketches.theta.UpdateSketch;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
@@ -44,19 +45,19 @@ import org.apache.pinot.spi.utils.CommonConstants;
  *   "transformConfigs": [
  *     {
  *       "columnName": "players",
- *       "transformFunction": "DistinctCountRawThetaSketch(playerID)"
+ *       "transformFunction": "toThetaSketch(playerID)"
  *     },
  *     {
  *       "columnName": "players",
- *       "transformFunction": "DistinctCountRawThetaSketch(playerID, 1024)"
+ *       "transformFunction": "toThetaSketch(playerID, 1024)"
  *     },
  *     {
  *       "columnName": "names",
- *       "transformFunction": "DistinctCountRawHLL(playerName)"
+ *       "transformFunction": "toHLL(playerName)"
  *     },
  *     {
  *       "columnName": "names",
- *       "transformFunction": "DistinctCountRawHLL(playerName, 8)"
+ *       "transformFunction": "toHLL(playerName, 8)"
  *     }
  *   ]
  * }
@@ -72,8 +73,8 @@ public class SketchFunctions {
    * @return serialized theta sketch as bytes
    */
   @ScalarFunction(nullableParameters = true)
-  public static byte[] distinctCountRawThetaSketch(Object input) {
-    return distinctCountRawThetaSketch(input, CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES);
+  public static byte[] toThetaSketch(@Nullable Object input) {
+    return toThetaSketch(input, CommonConstants.Helix.DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES);
   }
 
   /**
@@ -84,20 +85,20 @@ public class SketchFunctions {
    * @return serialized theta sketch as bytes
    */
   @ScalarFunction(nullableParameters = true)
-  public static byte[] distinctCountRawThetaSketch(Object input, int nominalEntries) {
+  public static byte[] toThetaSketch(@Nullable Object input, int nominalEntries) {
     UpdateSketch sketch = Sketches.updateSketchBuilder().setNominalEntries(nominalEntries).build();
-    if (input instanceof String) {
-      sketch.update((String) input);
+    if (input instanceof Integer) {
+      sketch.update((Integer) input);
     } else if (input instanceof Long) {
       sketch.update((Long) input);
-    } else if (input instanceof Integer) {
-      sketch.update((Integer) input);
-    } else if (input instanceof BigDecimal) {
-      sketch.update(((BigDecimal) input).toString());
     } else if (input instanceof Float) {
       sketch.update((Float) input);
     } else if (input instanceof Double) {
       sketch.update((Double) input);
+    } else if (input instanceof BigDecimal) {
+      sketch.update(((BigDecimal) input).toString());
+    } else if (input instanceof String) {
+      sketch.update((String) input);
     } else if (input instanceof byte[]) {
       sketch.update((byte[]) input);
     }
@@ -111,8 +112,8 @@ public class SketchFunctions {
    * @return serialized HLL as bytes
    */
   @ScalarFunction(nullableParameters = true)
-  public static byte[] distinctCountRawHLL(Object input) {
-    return distinctCountRawHLL(input, CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M);
+  public static byte[] toHLL(@Nullable Object input) {
+    return toHLL(input, CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M);
   }
 
   /**
@@ -123,7 +124,7 @@ public class SketchFunctions {
    * @return serialized HLL as bytes
    */
   @ScalarFunction(nullableParameters = true)
-  public static byte[] distinctCountRawHLL(Object input, int log2m) {
+  public static byte[] toHLL(@Nullable Object input, int log2m) {
     HyperLogLog hll = new HyperLogLog(log2m);
     if (input != null) {
       hll.offer(input);

--- a/pinot-core/src/test/java/org/apache/pinot/core/function/scalar/SketchFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/function/scalar/SketchFunctionsTest.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.function.scalar;
+
+import java.math.BigDecimal;
+import org.apache.pinot.core.common.ObjectSerDeUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class SketchFunctionsTest {
+
+  private double thetaEstimate(byte[] bytes) {
+    return ObjectSerDeUtils.DATA_SKETCH_SER_DE.deserialize(bytes).getEstimate();
+  }
+
+  byte[] _bytes = {1, 2, 3};
+
+  Object[] _inputs = {
+      "string", 1, 1L, 1.0f, 1.0d, BigDecimal.valueOf(1), _bytes
+  };
+
+  @Test
+  public void testThetaSketchCreation() {
+    for (Object i : _inputs) {
+      Assert.assertEquals(thetaEstimate(SketchFunctions.distinctCountRawThetaSketch(i)), 1.0);
+      Assert.assertEquals(thetaEstimate(SketchFunctions.distinctCountRawThetaSketch(i, 1024)), 1.0);
+    }
+    Assert.assertEquals(thetaEstimate(SketchFunctions.distinctCountRawThetaSketch(null)), 0.0);
+    Assert.assertEquals(thetaEstimate(SketchFunctions.distinctCountRawThetaSketch(null, 1024)), 0.0);
+  }
+
+  private long hllEstimate(byte[] bytes) {
+    return ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize(bytes).cardinality();
+  }
+
+  @Test
+  public void hllCreation() {
+    for (Object i : _inputs) {
+      Assert.assertEquals(hllEstimate(SketchFunctions.distinctCountRawHLL(i)), 1);
+      Assert.assertEquals(hllEstimate(SketchFunctions.distinctCountRawHLL(i, 8)), 1);
+    }
+    Assert.assertEquals(hllEstimate(SketchFunctions.distinctCountRawHLL(null)), 0);
+    Assert.assertEquals(hllEstimate(SketchFunctions.distinctCountRawHLL(null, 8)), 0);
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/function/scalar/SketchFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/function/scalar/SketchFunctionsTest.java
@@ -39,11 +39,11 @@ public class SketchFunctionsTest {
   @Test
   public void testThetaSketchCreation() {
     for (Object i : _inputs) {
-      Assert.assertEquals(thetaEstimate(SketchFunctions.distinctCountRawThetaSketch(i)), 1.0);
-      Assert.assertEquals(thetaEstimate(SketchFunctions.distinctCountRawThetaSketch(i, 1024)), 1.0);
+      Assert.assertEquals(thetaEstimate(SketchFunctions.toThetaSketch(i)), 1.0);
+      Assert.assertEquals(thetaEstimate(SketchFunctions.toThetaSketch(i, 1024)), 1.0);
     }
-    Assert.assertEquals(thetaEstimate(SketchFunctions.distinctCountRawThetaSketch(null)), 0.0);
-    Assert.assertEquals(thetaEstimate(SketchFunctions.distinctCountRawThetaSketch(null, 1024)), 0.0);
+    Assert.assertEquals(thetaEstimate(SketchFunctions.toThetaSketch(null)), 0.0);
+    Assert.assertEquals(thetaEstimate(SketchFunctions.toThetaSketch(null, 1024)), 0.0);
   }
 
   private long hllEstimate(byte[] bytes) {
@@ -53,10 +53,10 @@ public class SketchFunctionsTest {
   @Test
   public void hllCreation() {
     for (Object i : _inputs) {
-      Assert.assertEquals(hllEstimate(SketchFunctions.distinctCountRawHLL(i)), 1);
-      Assert.assertEquals(hllEstimate(SketchFunctions.distinctCountRawHLL(i, 8)), 1);
+      Assert.assertEquals(hllEstimate(SketchFunctions.toHLL(i)), 1);
+      Assert.assertEquals(hllEstimate(SketchFunctions.toHLL(i, 8)), 1);
     }
-    Assert.assertEquals(hllEstimate(SketchFunctions.distinctCountRawHLL(null)), 0);
-    Assert.assertEquals(hllEstimate(SketchFunctions.distinctCountRawHLL(null, 8)), 0);
+    Assert.assertEquals(hllEstimate(SketchFunctions.toHLL(null)), 0);
+    Assert.assertEquals(hllEstimate(SketchFunctions.toHLL(null, 8)), 0);
   }
 }


### PR DESCRIPTION
This enables creation of `BYTES` columns containing Theta/HLL sketches during ingestion.

Note I've added these in `pinot-core` as I didn't know if I should add the datasketches/clearspring dependencies to `pinot-common`

Can be activated like so:

```json
{
  "transformConfigs": [
    {
      "columnName": "players",
      "transformFunction": "toThetaSketch(playerID)"
    },
    {
      "columnName": "players",
      "transformFunction": "toThetaSketch(playerID, 1024)"
    },
    {
      "columnName": "names",
      "transformFunction": "toHLL(playerName)"
    },
    {
      "columnName": "names",
      "transformFunction": "toHLL(playerName, 8)"
    }
  ]
}
```