### PR TITLE
[bugfix] Fix bug with PERCENT_SEGMENTS_AVAILABLE metric rounding down

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -298,7 +298,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
         (nReplicasIdealMax > 0) ? (nReplicasExternal * 100 / nReplicasIdealMax) : 100);
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.SEGMENTS_IN_ERROR_STATE, nErrors);
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE,
-        (nSegments > 0) ? (long) (100 - (nOffline * 100.0 / nSegments)) : 100);
+        (nSegments > 0) ? (nSegments - nOffline) * 100 / nSegments : 100);
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_COMPRESSED_SIZE,
         tableCompressedSize);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -298,7 +298,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
         (nReplicasIdealMax > 0) ? (nReplicasExternal * 100 / nReplicasIdealMax) : 100);
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.SEGMENTS_IN_ERROR_STATE, nErrors);
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE,
-        (nSegments > 0) ? (100 - (nOffline * 100 / nSegments)) : 100);
+        (nSegments > 0) ? (long) (100 - (nOffline * 100.0 / nSegments)) : 100);
     _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_COMPRESSED_SIZE,
         tableCompressedSize);
 


### PR DESCRIPTION
# Description
For tables that have high number of segments PERCENT_SEGMENTS_AVAILABLE reports 100% availability despite a few replicas being offline. Caused by rounding down `(nOffline * 100 / nSegments)` to `int` before subtraction from 100. 

This PR changes metric logic to properly round down PERCENT_SEGMENTS_AVAILABLE and report 99% availability in such scenarios.

# Testing
- Added unit test to verify
 
