### PR TITLE
[feature] Adding setter to DeletedSegmentsRetentionPeriod in TableConfigBuilder

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -172,6 +172,11 @@ public class TableConfigBuilder {
     return this;
   }
 
+  public TableConfigBuilder setDeletedSegmentsRetentionPeriod(String deletedSegmentsRetentionPeriod) {
+    _deletedSegmentsRetentionPeriod = deletedSegmentsRetentionPeriod;
+    return this;
+  }
+
   /**
    * @deprecated Use {@code segmentIngestionType} from {@link IngestionConfig#getBatchIngestionConfig()}
    */


### PR DESCRIPTION
TableConfigBuilder hard codes the DeletedSegmentsRetentionPeriod as with default value of 7days . 
Making this change to have a setter to make DeletedSegmentsRetentionPeriod configurable from the caller. 