### PR TITLE
Make IndexLoadingConfig directly read configs from TableConfig and Schema

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/TableDataManagerTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/TableDataManagerTestUtils.java
@@ -38,7 +38,6 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.crypt.PinotCrypterFactory;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.utils.ReadMode;
 
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -92,16 +91,6 @@ public class TableDataManagerTestUtils {
     InstanceDataManagerConfig idmc = mock(InstanceDataManagerConfig.class);
     when(idmc.getSegmentDirectoryLoader()).thenReturn(segDirLoader);
     when(idmc.getConfig()).thenReturn(new PinotConfiguration());
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(idmc, tableConfig, schema);
-    indexLoadingConfig.setSegmentVersion(SegmentVersion.v3);
-    indexLoadingConfig.setReadMode(ReadMode.mmap);
-    return indexLoadingConfig;
-  }
-
-  public static IndexLoadingConfig createIndexLoadingConfig() {
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
-    indexLoadingConfig.setSegmentVersion(SegmentVersion.v3);
-    indexLoadingConfig.setReadMode(ReadMode.mmap);
-    return indexLoadingConfig;
+    return new IndexLoadingConfig(idmc, tableConfig, schema);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -54,7 +54,6 @@ import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.LongMsgOffsetFactory;
@@ -328,11 +327,12 @@ public class LLRealtimeSegmentDataManagerTest {
   }
 
   @Test
-  public void testCommitAfterCatchupWithPeriodOffset() throws Exception {
+  public void testCommitAfterCatchupWithPeriodOffset()
+      throws Exception {
     TableConfig tableConfig = createTableConfig();
-    tableConfig.getIndexingConfig().getStreamConfigs()
-        .put(StreamConfigProperties.constructStreamProperty(
-            StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA, "fakeStream"), "2d");
+    tableConfig.getIndexingConfig().getStreamConfigs().put(
+        StreamConfigProperties.constructStreamProperty(StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA,
+            "fakeStream"), "2d");
     FakeLLRealtimeSegmentDataManager segmentDataManager =
         createFakeSegmentManager(false, new TimeSupplier(), null, null, tableConfig);
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
@@ -375,11 +375,12 @@ public class LLRealtimeSegmentDataManagerTest {
   }
 
   @Test
-  public void testCommitAfterCatchupWithTimestampOffset() throws Exception {
+  public void testCommitAfterCatchupWithTimestampOffset()
+      throws Exception {
     TableConfig tableConfig = createTableConfig();
-    tableConfig.getIndexingConfig().getStreamConfigs()
-        .put(StreamConfigProperties.constructStreamProperty(
-            StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA, "fakeStream"), Instant.now().toString());
+    tableConfig.getIndexingConfig().getStreamConfigs().put(
+        StreamConfigProperties.constructStreamProperty(StreamConfigProperties.STREAM_CONSUMER_OFFSET_CRITERIA,
+            "fakeStream"), Instant.now().toString());
     FakeLLRealtimeSegmentDataManager segmentDataManager =
         createFakeSegmentManager(false, new TimeSupplier(), null, null, tableConfig);
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
@@ -873,8 +874,7 @@ public class LLRealtimeSegmentDataManagerTest {
       }
     };
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager(true, timeSupplier,
-        String.valueOf(FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS * 2),
-        segmentTimeThresholdMins + "m", null);
+        String.valueOf(FakeStreamConfigUtils.SEGMENT_FLUSH_THRESHOLD_ROWS * 2), segmentTimeThresholdMins + "m", null);
     segmentDataManager._stubConsumeLoop = false;
     segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.INITIAL_CONSUMING);
 
@@ -983,24 +983,13 @@ public class LLRealtimeSegmentDataManagerTest {
     public boolean _stubConsumeLoop = true;
     private TimeSupplier _timeSupplier;
 
-    private static InstanceDataManagerConfig makeInstanceDataManagerConfig() {
-      InstanceDataManagerConfig dataManagerConfig = mock(InstanceDataManagerConfig.class);
-      when(dataManagerConfig.getReadMode()).thenReturn(null);
-      when(dataManagerConfig.getAvgMultiValueCount()).thenReturn(null);
-      when(dataManagerConfig.getSegmentFormatVersion()).thenReturn(null);
-      when(dataManagerConfig.isEnableSplitCommit()).thenReturn(false);
-      when(dataManagerConfig.isRealtimeOffHeapAllocation()).thenReturn(false);
-      when(dataManagerConfig.getConfig()).thenReturn(new PinotConfiguration());
-      return dataManagerConfig;
-    }
-
     public FakeLLRealtimeSegmentDataManager(SegmentZKMetadata segmentZKMetadata, TableConfig tableConfig,
         RealtimeTableDataManager realtimeTableDataManager, String resourceDataDir, Schema schema,
         LLCSegmentName llcSegmentName, Map<Integer, Semaphore> semaphoreMap, ServerMetrics serverMetrics,
         TimeSupplier timeSupplier)
         throws Exception {
       super(segmentZKMetadata, tableConfig, realtimeTableDataManager, resourceDataDir,
-          new IndexLoadingConfig(makeInstanceDataManagerConfig(), tableConfig), schema, llcSegmentName,
+          new IndexLoadingConfig(tableConfig, schema), schema, llcSegmentName,
           semaphoreMap.get(llcSegmentName.getPartitionGroupId()), serverMetrics, null, null, () -> true);
       _state = LLRealtimeSegmentDataManager.class.getDeclaredField("_state");
       _state.setAccessible(true);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseJsonQueryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseJsonQueryTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.queries;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashSet;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
@@ -35,7 +34,6 @@ import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.utils.ReadMode;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
 
@@ -145,7 +143,8 @@ public abstract class BaseJsonQueryTest extends BaseQueriesTest {
     List<String> jsonIndexColumns = new ArrayList<>();
     jsonIndexColumns.add("jsonColumn");
     tableConfig.getIndexingConfig().setJsonIndexColumns(jsonIndexColumns);
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema());
+    Schema schema = schema();
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
     segmentGeneratorConfig.setOutDir(indexDir.getPath());
@@ -154,13 +153,8 @@ public abstract class BaseJsonQueryTest extends BaseQueriesTest {
     driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
     driver.build();
 
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
-    indexLoadingConfig.setTableConfig(tableConfig);
-    indexLoadingConfig.setJsonIndexColumns(new HashSet<>(jsonIndexColumns));
-    indexLoadingConfig.setReadMode(ReadMode.mmap);
-
     ImmutableSegment immutableSegment =
-        ImmutableSegmentLoader.load(new File(indexDir, SEGMENT_NAME), indexLoadingConfig);
+        ImmutableSegmentLoader.load(new File(indexDir, SEGMENT_NAME), new IndexLoadingConfig(tableConfig, schema));
     _indexSegment = immutableSegment;
     _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -262,20 +262,19 @@ public abstract class BaseQueriesTest {
    * Helper function to call reloadSegment on an existing index directory. The segment is preprocessed using the
    * config provided in indexLoadingConfig. It returns an immutable segment.
    */
-  protected ImmutableSegment reloadSegment(File indexDir, IndexLoadingConfig indexLoadingConfig, Schema schema)
+  protected ImmutableSegment reloadSegment(File indexDir, TableConfig tableConfig, Schema schema)
       throws Exception {
     Map<String, Object> props = new HashMap<>();
     props.put(IndexLoadingConfig.READ_MODE_KEY, ReadMode.mmap.toString());
     PinotConfiguration configuration = new PinotConfiguration(props);
-
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(tableConfig, schema);
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig, schema)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig)) {
       processor.process();
     }
-    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(indexDir, indexLoadingConfig);
-    return immutableSegment;
+    return ImmutableSegmentLoader.load(indexDir, indexLoadingConfig);
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/FilteredAggregationsTest.java
@@ -88,12 +88,10 @@ public class FilteredAggregationsTest extends BaseQueriesTest {
 
     buildSegment(FIRST_SEGMENT_NAME);
     buildSegment(SECOND_SEGMENT_NAME);
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
 
-    Set<String> invertedIndexCols = new HashSet<>();
-    invertedIndexCols.add(INT_COL_NAME);
-
-    indexLoadingConfig.setInvertedIndexColumns(invertedIndexCols);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
+        .setInvertedIndexColumns(Collections.singletonList(INT_COL_NAME)).build();
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(tableConfig);
     ImmutableSegment firstImmutableSegment =
         ImmutableSegmentLoader.load(new File(INDEX_DIR, FIRST_SEGMENT_NAME), indexLoadingConfig);
     ImmutableSegment secondImmutableSegment =

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ForwardIndexDisabledMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ForwardIndexDisabledMultiValueQueriesTest.java
@@ -20,13 +20,10 @@ package org.apache.pinot.queries;
 
 import java.io.File;
 import java.net.URL;
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
@@ -44,19 +41,13 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.spi.data.TimeGranularitySpec;
-import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
-import static org.testng.Assert.assertNotNull;
-import static org.testng.Assert.assertNull;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
 
 
 /**
@@ -80,8 +71,8 @@ import static org.testng.Assert.assertTrue;
  */
 public class ForwardIndexDisabledMultiValueQueriesTest extends BaseQueriesTest {
   private static final String AVRO_DATA = "data" + File.separator + "test_data-mv.avro";
-  private static final String SEGMENT_NAME_1 = "testTable_1756015688_1756015688";
-  private static final String SEGMENT_NAME_2 = "testTable_1756015689_1756015689";
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String SEGMENT_NAME = "testSegment";
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(),
       "ForwardIndexDisabledMultiValueQueriesTest");
 
@@ -94,13 +85,21 @@ public class ForwardIndexDisabledMultiValueQueriesTest extends BaseQueriesTest {
       + " AND (column6 < 500000 OR column7 NOT IN (225, 407))"
       + " AND daysSinceEpoch = 1756015683";
 
+  private static final Schema SCHEMA =
+      new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME).addMetric("column1", FieldSpec.DataType.INT)
+          .addMetric("column2", FieldSpec.DataType.INT).addSingleValueDimension("column3", FieldSpec.DataType.STRING)
+          .addSingleValueDimension("column5", FieldSpec.DataType.STRING)
+          .addMultiValueDimension("column6", FieldSpec.DataType.INT)
+          .addMultiValueDimension("column7", FieldSpec.DataType.INT)
+          .addSingleValueDimension("column8", FieldSpec.DataType.INT).addMetric("column9", FieldSpec.DataType.INT)
+          .addMetric("column10", FieldSpec.DataType.INT)
+          .addDateTime("daysSinceEpoch", FieldSpec.DataType.INT, "EPOCH|DAYS", "1:DAYS").build();
+
+  private TableConfig _tableConfig;
   private IndexSegment _indexSegment;
   // Contains 2 identical index segments.
   private List<IndexSegment> _indexSegments;
 
-  private TableConfig _tableConfig;
-  private List<String> _invertedIndexColumns;
-  private List<String> _forwardIndexDisabledColumns;
 
   @BeforeMethod
   public void buildSegment()
@@ -112,51 +111,29 @@ public class ForwardIndexDisabledMultiValueQueriesTest extends BaseQueriesTest {
     assertNotNull(resource);
     String filePath = resource.getFile();
 
-    // Build the segment schema.
-    Schema schema = new Schema.SchemaBuilder().setSchemaName("testTable").addMetric("column1", FieldSpec.DataType.INT)
-        .addMetric("column2", FieldSpec.DataType.INT).addSingleValueDimension("column3", FieldSpec.DataType.STRING)
-        .addSingleValueDimension("column5", FieldSpec.DataType.STRING)
-        .addMultiValueDimension("column6", FieldSpec.DataType.INT)
-        .addMultiValueDimension("column7", FieldSpec.DataType.INT)
-        .addSingleValueDimension("column8", FieldSpec.DataType.INT).addMetric("column9", FieldSpec.DataType.INT)
-        .addMetric("column10", FieldSpec.DataType.INT)
-        .addTime(new TimeGranularitySpec(FieldSpec.DataType.INT, TimeUnit.DAYS, "daysSinceEpoch"), null).build();
+    createSegment(filePath);
+    ImmutableSegment immutableSegment = loadSegmentWithMetadataChecks();
 
-    createSegment(filePath, SEGMENT_NAME_1, schema);
-    createSegment(filePath, SEGMENT_NAME_2, schema);
-
-    ImmutableSegment immutableSegment1 = loadSegmentWithMetadataChecks(SEGMENT_NAME_1);
-    ImmutableSegment immutableSegment2 = loadSegmentWithMetadataChecks(SEGMENT_NAME_2);
-
-    _indexSegment = immutableSegment1;
-    _indexSegments = Arrays.asList(immutableSegment1, immutableSegment2);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
   }
 
-  private void createSegment(String filePath, String segmentName, Schema schema)
+  private void createSegment(String filePath)
       throws Exception {
-    // Create field configs for the no forward index columns
-    List<FieldConfig> fieldConfigList = new ArrayList<>();
-    fieldConfigList.add(new FieldConfig("column6", FieldConfig.EncodingType.DICTIONARY, Collections.emptyList(), null,
-        Collections.singletonMap(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString())));
-    if (segmentName.equals(SEGMENT_NAME_1)) {
-      fieldConfigList.add(new FieldConfig("column7", FieldConfig.EncodingType.DICTIONARY, Collections.emptyList(),
-          null, Collections.singletonMap(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString())));
-
-      // Build table config based on segment 1 as it contains both columns under no forward index
-      _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setNoDictionaryColumns(Arrays.asList("column5"))
-          .setTableName("testTable").setTimeColumnName("daysSinceEpoch").setFieldConfigList(fieldConfigList).build();
-    }
+    _tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setTimeColumnName("daysSinceEpoch")
+            .setInvertedIndexColumns(Arrays.asList("column3", "column6", "column7", "column8", "column9"))
+            .setNoDictionaryColumns(Collections.singletonList("column5")).setFieldConfigList(Arrays.asList(
+                new FieldConfig("column6", FieldConfig.EncodingType.DICTIONARY, Collections.emptyList(), null,
+                    Collections.singletonMap(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString())),
+                new FieldConfig("column7", FieldConfig.EncodingType.DICTIONARY, Collections.emptyList(), null,
+                    Collections.singletonMap(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.TRUE.toString())))).build();
 
     // Create the segment generator config.
-    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(_tableConfig, schema);
+    SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(_tableConfig, SCHEMA);
     segmentGeneratorConfig.setInputFilePath(filePath);
-    segmentGeneratorConfig.setTableName("testTable");
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getAbsolutePath());
-    segmentGeneratorConfig.setSegmentName(segmentName);
-    _invertedIndexColumns = Arrays.asList("column3", "column6", "column7", "column8", "column9");
-    segmentGeneratorConfig.setInvertedIndexCreationColumns(_invertedIndexColumns);
-    _forwardIndexDisabledColumns = new ArrayList<>(Arrays.asList("column6", "column7"));
-    segmentGeneratorConfig.setForwardIndexDisabledColumns(_forwardIndexDisabledColumns);
+    segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
     // The segment generation code in SegmentColumnarIndexCreator will throw
     // exception if start and end time in time column are not in acceptable
     // range. For this test, we first need to fix the input avro data
@@ -170,16 +147,10 @@ public class ForwardIndexDisabledMultiValueQueriesTest extends BaseQueriesTest {
     driver.build();
   }
 
-  private ImmutableSegment loadSegmentWithMetadataChecks(String segmentName)
+  private ImmutableSegment loadSegmentWithMetadataChecks()
       throws Exception {
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
-    indexLoadingConfig.setTableConfig(_tableConfig);
-    indexLoadingConfig.setInvertedIndexColumns(new HashSet<>(_invertedIndexColumns));
-    indexLoadingConfig.setForwardIndexDisabledColumns(new HashSet<>(_forwardIndexDisabledColumns));
-    indexLoadingConfig.setReadMode(ReadMode.heap);
-
-    ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, segmentName),
-        indexLoadingConfig);
+    ImmutableSegment immutableSegment =
+        ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), new IndexLoadingConfig(_tableConfig));
 
     Map<String, ColumnMetadata> columnMetadataMap1 = immutableSegment.getSegmentMetadata().getColumnMetadataMap();
     columnMetadataMap1.forEach((column, metadata) -> {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -34,7 +34,6 @@ import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.SegmentMetadata;
-import org.apache.pinot.spi.data.Schema;
 
 
 /**
@@ -93,12 +92,11 @@ public interface TableDataManager {
    * @param zkMetadata the segment metadata from zookeeper
    * @param localMetadata the segment metadata object held by server right now,
    *                      which must not be null to reload the segment
-   * @param schema the latest table schema to load segment
    * @param forceDownload whether to force to download raw segment to reload
    * @throws Exception thrown upon failure when to reload the segment
    */
   void reloadSegment(String segmentName, IndexLoadingConfig indexLoadingConfig, SegmentZKMetadata zkMetadata,
-      SegmentMetadata localMetadata, @Nullable Schema schema, boolean forceDownload)
+      SegmentMetadata localMetadata, boolean forceDownload)
       throws Exception;
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerConfig.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.pinot.common.utils.config.TierConfigUtils;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -35,8 +36,6 @@ import org.apache.pinot.spi.env.PinotConfiguration;
  */
 public class TableDataManagerConfig {
   public static final String AUTH_CONFIG_PREFIX = "auth";
-  public static final String TIER_CONFIGS_PREFIX = "tierConfigs";
-  public static final String TIER_NAMES = "tierNames";
 
   private final InstanceDataManagerConfig _instanceDataManagerConfig;
   private final TableConfig _tableConfig;
@@ -97,17 +96,6 @@ public class TableDataManagerConfig {
   }
 
   public Map<String, Map<String, String>> getInstanceTierConfigs() {
-    PinotConfiguration tierConfigs = _instanceDataManagerConfig.getConfig().subset(TIER_CONFIGS_PREFIX);
-    List<String> tierNames = tierConfigs.getProperty(TIER_NAMES, Collections.emptyList());
-    if (tierNames.isEmpty()) {
-      return Collections.emptyMap();
-    }
-    Map<String, Map<String, String>> instanceTierConfigs = new HashMap<>();
-    for (String tierName : tierNames) {
-      Map<String, String> tierConfigMap = new HashMap<>();
-      tierConfigs.subset(tierName).toMap().forEach((k, v) -> tierConfigMap.put(k, String.valueOf(v)));
-      instanceTierConfigs.put(tierName, tierConfigMap);
-    }
-    return instanceTierConfigs;
+    return TierConfigUtils.getInstanceTierConfigs(_instanceDataManagerConfig);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexHandlerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexHandlerFactory.java
@@ -28,7 +28,6 @@ import org.apache.pinot.segment.local.segment.index.loader.invertedindex.TextInd
 import org.apache.pinot.segment.spi.creator.IndexCreatorProvider;
 import org.apache.pinot.segment.spi.store.ColumnIndexType;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
-import org.apache.pinot.spi.data.Schema;
 
 
 public class IndexHandlerFactory {
@@ -51,7 +50,7 @@ public class IndexHandlerFactory {
   };
 
   public static IndexHandler getIndexHandler(ColumnIndexType type, SegmentDirectory segmentDirectory,
-      IndexLoadingConfig indexLoadingConfig, Schema schema) {
+      IndexLoadingConfig indexLoadingConfig) {
     switch (type) {
       case INVERTED_INDEX:
         return new InvertedIndexHandler(segmentDirectory, indexLoadingConfig);
@@ -68,7 +67,7 @@ public class IndexHandlerFactory {
       case BLOOM_FILTER:
         return new BloomFilterHandler(segmentDirectory, indexLoadingConfig);
       case FORWARD_INDEX:
-        return new ForwardIndexHandler(segmentDirectory, indexLoadingConfig, schema);
+        return new ForwardIndexHandler(segmentDirectory, indexLoadingConfig);
       default:
         return NO_OP_HANDLER;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -125,11 +125,11 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
   private PropertiesConfiguration _segmentProperties;
 
   protected BaseDefaultColumnHandler(File indexDir, SegmentMetadata segmentMetadata,
-      IndexLoadingConfig indexLoadingConfig, Schema schema, SegmentDirectory.Writer segmentWriter) {
+      IndexLoadingConfig indexLoadingConfig, SegmentDirectory.Writer segmentWriter) {
     _indexDir = indexDir;
     _segmentMetadata = segmentMetadata;
     _indexLoadingConfig = indexLoadingConfig;
-    _schema = schema;
+    _schema = indexLoadingConfig.getSchema();
     _segmentWriter = segmentWriter;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/DefaultColumnHandlerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/DefaultColumnHandlerFactory.java
@@ -31,11 +31,11 @@ public class DefaultColumnHandlerFactory {
   }
 
   public static DefaultColumnHandler getDefaultColumnHandler(File indexDir, SegmentMetadataImpl segmentMetadata,
-      IndexLoadingConfig indexLoadingConfig, Schema schema, SegmentDirectory.Writer segmentWriter) {
+      IndexLoadingConfig indexLoadingConfig, SegmentDirectory.Writer segmentWriter) {
     if (segmentMetadata.getVersion() == SegmentVersion.v3) {
-      return new V3DefaultColumnHandler(indexDir, segmentMetadata, indexLoadingConfig, schema, segmentWriter);
+      return new V3DefaultColumnHandler(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter);
     } else {
-      return new V1DefaultColumnHandler(indexDir, segmentMetadata, indexLoadingConfig, schema, segmentWriter);
+      return new V1DefaultColumnHandler(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter);
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/V1DefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/V1DefaultColumnHandler.java
@@ -22,7 +22,6 @@ import java.io.File;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
-import org.apache.pinot.spi.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -31,8 +30,8 @@ public class V1DefaultColumnHandler extends BaseDefaultColumnHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(V1DefaultColumnHandler.class);
 
   public V1DefaultColumnHandler(File indexDir, SegmentMetadataImpl segmentMetadata,
-      IndexLoadingConfig indexLoadingConfig, Schema schema, SegmentDirectory.Writer segmentWriter) {
-    super(indexDir, segmentMetadata, indexLoadingConfig, schema, segmentWriter);
+      IndexLoadingConfig indexLoadingConfig, SegmentDirectory.Writer segmentWriter) {
+    super(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/V3DefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/V3DefaultColumnHandler.java
@@ -27,7 +27,6 @@ import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.store.ColumnIndexType;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.data.FieldSpec;
-import org.apache.pinot.spi.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -36,8 +35,8 @@ public class V3DefaultColumnHandler extends BaseDefaultColumnHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(V3DefaultColumnHandler.class);
 
   public V3DefaultColumnHandler(File indexDir, SegmentMetadataImpl segmentMetadata,
-      IndexLoadingConfig indexLoadingConfig, Schema schema, SegmentDirectory.Writer segmentWriter) {
-    super(indexDir, segmentMetadata, indexLoadingConfig, schema, segmentWriter);
+      IndexLoadingConfig indexLoadingConfig, SegmentDirectory.Writer segmentWriter) {
+    super(indexDir, segmentMetadata, indexLoadingConfig, segmentWriter);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/FSTIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/invertedindex/FSTIndexHandler.java
@@ -22,6 +22,7 @@ package org.apache.pinot.segment.local.segment.index.loader.invertedindex;
 import java.io.File;
 import java.io.IOException;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.segment.local.segment.index.loader.BaseIndexHandler;
@@ -67,12 +68,12 @@ public class FSTIndexHandler extends BaseIndexHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(FSTIndexHandler.class);
 
   private final Set<String> _columnsToAddIdx;
-  private final FSTType _fstType;
+  private final Map<String, FSTType> _fstTypes;
 
   public FSTIndexHandler(SegmentDirectory segmentDirectory, IndexLoadingConfig indexLoadingConfig) {
     super(segmentDirectory, indexLoadingConfig);
-    _fstType = indexLoadingConfig.getFSTIndexType();
     _columnsToAddIdx = indexLoadingConfig.getFSTIndexColumns();
+    _fstTypes = indexLoadingConfig.getFSTTypes();
   }
 
   @Override
@@ -171,7 +172,7 @@ public class FSTIndexHandler extends BaseIndexHandler {
 
     TextIndexCreator fstIndexCreator = indexCreatorProvider.newTextIndexCreator(
         IndexCreationContext.builder().withIndexDir(indexDir).withColumnMetadata(columnMetadata).build()
-            .forFSTIndex(_fstType, null));
+            .forFSTIndex(_fstTypes.get(columnName), null));
 
     try (Dictionary dictionary = LoaderUtils.getDictionary(segmentWriter, columnMetadata)) {
       for (int dictId = 0; dictId < dictionary.length(); dictId++) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
@@ -70,6 +70,17 @@ public class TextIndexUtils {
     return false;
   }
 
+  public static FSTType getFstType(@Nullable Map<String, String> fieldProperties, FSTType defaultFstType) {
+    if (fieldProperties == null) {
+      return defaultFstType;
+    }
+    String fieldFstType = fieldProperties.get(FieldConfig.TEXT_FST_TYPE);
+    if (fieldFstType != null) {
+      return FSTType.valueOf(fieldFstType.toUpperCase());
+    }
+    return defaultFstType;
+  }
+
   public static FSTType getFSTTypeOfIndex(File indexDir, String column) {
     return SegmentDirectoryPaths.findTextIndexIndexFile(indexDir, column) != null ? FSTType.LUCENE : FSTType.NATIVE;
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.segment.local.segment.index.loader;
 
-import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.net.URL;
 import java.nio.file.Files;
@@ -27,11 +26,9 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.function.Consumer;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
@@ -42,12 +39,12 @@ import org.apache.pinot.segment.local.segment.index.converter.SegmentV1V2ToV3For
 import org.apache.pinot.segment.local.segment.index.loader.columnminmaxvalue.ColumnMinMaxValueGeneratorMode;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.ColumnMetadata;
+import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
-import org.apache.pinot.segment.spi.index.creator.H3IndexConfig;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
@@ -57,6 +54,7 @@ import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
 import org.apache.pinot.segment.spi.utils.SegmentMetadataUtils;
 import org.apache.pinot.spi.config.table.BloomFilterConfig;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -71,7 +69,6 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
@@ -136,10 +133,8 @@ public class SegmentPreProcessorTest {
 
   private File _indexDir;
   private PinotConfiguration _configuration;
-  private IndexLoadingConfig _indexLoadingConfig;
   private File _avroFile;
   private Schema _schema;
-  private TableConfig _tableConfig;
   private Schema _newColumnsSchema1;
   private Schema _newColumnsSchema2;
   private Schema _newColumnsSchema3;
@@ -156,26 +151,6 @@ public class SegmentPreProcessorTest {
     Map<String, Object> props = new HashMap<>();
     props.put(IndexLoadingConfig.READ_MODE_KEY, ReadMode.mmap.toString());
     _configuration = new PinotConfiguration(props);
-
-    // The segment generation code in SegmentColumnarIndexCreator will throw
-    // exception if start and end time in time column are not in acceptable
-    // range. For this test, we first need to fix the input avro data
-    // to have the time column values in allowed range. Until then, the check
-    // is explicitly disabled
-    IngestionConfig ingestionConfig = new IngestionConfig();
-    ingestionConfig.setRowTimeValueCheck(false);
-    ingestionConfig.setSegmentTimeValueCheck(false);
-    _tableConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setTimeColumnName("daysSinceEpoch")
-            .setIngestionConfig(ingestionConfig).setNullHandlingEnabled(true).build();
-    _indexLoadingConfig = getDefaultIndexLoadingConfig();
-
-    // We specify two columns without inverted index ('column1', 'column13'), one non-existing column ('noSuchColumn')
-    // and one column with existed inverted index ('column7').
-    _indexLoadingConfig.setInvertedIndexColumns(
-        new HashSet<>(Arrays.asList(COLUMN1_NAME, COLUMN7_NAME, COLUMN13_NAME, NO_SUCH_COLUMN_NAME)));
-
-    _indexLoadingConfig.setTableConfig(_tableConfig);
 
     ClassLoader classLoader = getClass().getClassLoader();
     URL resourceUrl = classLoader.getResource(AVRO_DATA);
@@ -216,49 +191,36 @@ public class SegmentPreProcessorTest {
     FileUtils.deleteQuietly(INDEX_DIR);
   }
 
-  private IndexLoadingConfig getDefaultIndexLoadingConfig() {
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
-
-    // Set RAW columns. Otherwise, they will end up being converted to dict columns (default) during segment reload.
-    indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_STRING_COL_RAW);
-    indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW_MV);
-    indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW);
-
-    indexLoadingConfig.setTableConfig(_tableConfig);
-    return indexLoadingConfig;
+  private TableConfig getDefaultTableConfig() {
+    // The segment generation code in SegmentColumnarIndexCreator will throw exception if start and end time in time
+    // column are not in acceptable range. For this test, we first need to fix the input avro data to have the time
+    // column values in allowed range. Until then, the check is explicitly disabled
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setRowTimeValueCheck(false);
+    ingestionConfig.setSegmentTimeValueCheck(false);
+    // Make the list modifiable
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").setTimeColumnName("daysSinceEpoch")
+        .setInvertedIndexColumns(
+            new ArrayList<>(Arrays.asList(COLUMN1_NAME, COLUMN7_NAME, COLUMN13_NAME, NO_SUCH_COLUMN_NAME)))
+        .setNoDictionaryColumns(
+            new ArrayList<>(Arrays.asList(EXISTING_INT_COL_RAW, EXISTING_INT_COL_RAW_MV, EXISTING_STRING_COL_RAW)))
+        .setIngestionConfig(ingestionConfig).setNullHandlingEnabled(true).build();
   }
 
-  private void constructV1Segment(List<String> invertedIndexCols, List<String> textIndexCols,
-      List<String> rangeIndexCols, List<String> forwardIndexDisabledCols)
+  private TableConfig getTableConfigNoIndex() {
+    TableConfig tableConfig = getDefaultTableConfig();
+    tableConfig.getIndexingConfig().setInvertedIndexColumns(null);
+    return tableConfig;
+  }
+
+  private void constructV1Segment(TableConfig tableConfig)
       throws Exception {
     FileUtils.deleteQuietly(INDEX_DIR);
 
-    List<String> rawCols = new ArrayList<>();
-    rawCols.add(EXISTING_STRING_COL_RAW);
-    rawCols.add(EXISTING_INT_COL_RAW_MV);
-    rawCols.add(EXISTING_INT_COL_RAW);
-
     // Create inverted index for 'column7' when constructing the segment.
     SegmentGeneratorConfig segmentGeneratorConfig =
-        SegmentTestUtils.getSegmentGeneratorConfigWithSchema(_avroFile, INDEX_DIR, "testTable", _tableConfig, _schema);
-    segmentGeneratorConfig.setRawIndexCreationColumns(rawCols);
+        SegmentTestUtils.getSegmentGeneratorConfigWithSchema(_avroFile, INDEX_DIR, "testTable", tableConfig, _schema);
     segmentGeneratorConfig.setInvertedIndexCreationColumns(Collections.singletonList(COLUMN7_NAME));
-    if (invertedIndexCols.size() > 0) {
-      for (String col : invertedIndexCols) {
-        segmentGeneratorConfig.getInvertedIndexCreationColumns().add(col);
-      }
-    }
-    if (textIndexCols.size() > 0) {
-      segmentGeneratorConfig.setTextIndexCreationColumns(textIndexCols);
-    }
-    if (rangeIndexCols.size() > 0) {
-      segmentGeneratorConfig.setRangeIndexCreationColumns(rangeIndexCols);
-    }
-    if (forwardIndexDisabledCols.size() > 0) {
-      segmentGeneratorConfig.setForwardIndexDisabledColumns(forwardIndexDisabledCols);
-      segmentGeneratorConfig.getInvertedIndexCreationColumns().addAll(forwardIndexDisabledCols);
-    }
-
     SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
     driver.init(segmentGeneratorConfig);
     driver.build();
@@ -266,607 +228,473 @@ public class SegmentPreProcessorTest {
     _indexDir = new File(INDEX_DIR, driver.getSegmentName());
   }
 
-  private void constructV3Segment()
+  private void constructV1Segment()
       throws Exception {
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
+    constructV1Segment(getDefaultTableConfig());
+  }
+
+  private void constructV3Segment(TableConfig tableConfig)
+      throws Exception {
+    constructV1Segment(tableConfig);
     new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
   }
 
+  private void constructV3Segment()
+      throws Exception {
+    constructV3Segment(getDefaultTableConfig());
+  }
+
   /**
-   * Test to check for default column handling and text index creation during
-   * segment load after a new raw column is added to the schema with text index
-   * creation enabled.
+   * Test to check for default column handling and text index creation during segment load after new columns are added
+   * to the schema with text index creation enabled.
    * This will exercise both code paths in SegmentPreprocessor (segment load):
    * (1) Default column handler to add forward index and dictionary
    * (2) Text index handler to add text index
    */
   @Test
-  public void testEnableTextIndexOnNewColumnRaw()
+  public void testEnableTextIndexOnNewColumn()
       throws Exception {
-    Set<String> textIndexColumns = new HashSet<>();
-    textIndexColumns.add(NEWLY_ADDED_STRING_COL_RAW);
-    textIndexColumns.add(NEWLY_ADDED_STRING_MV_COL_RAW);
-    _indexLoadingConfig.setTextIndexColumns(textIndexColumns);
+    TableConfig tableConfig = getDefaultTableConfig();
+    List<FieldConfig> fieldConfigs = new ArrayList<>();
+    for (String column : Arrays.asList(NEWLY_ADDED_STRING_COL_DICT, NEWLY_ADDED_STRING_MV_COL_DICT)) {
+      fieldConfigs.add(new FieldConfig(column, FieldConfig.EncodingType.DICTIONARY,
+          Collections.singletonList(FieldConfig.IndexType.TEXT), null, null));
+    }
+    List<String> noDictionaryColumns = tableConfig.getIndexingConfig().getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    for (String column : Arrays.asList(NEWLY_ADDED_STRING_COL_RAW, NEWLY_ADDED_STRING_MV_COL_RAW)) {
+      noDictionaryColumns.add(column);
+      fieldConfigs.add(
+          new FieldConfig(column, FieldConfig.EncodingType.RAW, Collections.singletonList(FieldConfig.IndexType.TEXT),
+              FieldConfig.CompressionCodec.LZ4, null));
+    }
+    tableConfig.setFieldConfigList(fieldConfigs);
 
-    // Create a segment in V3, add a new raw column with text index enabled
+    // All new columns (default column) should have dictionary regardless of the config
+    constructV1Segment();
+    createAndValidateIndex(tableConfig, _newColumnsSchemaWithText, NEWLY_ADDED_STRING_COL_DICT,
+        Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 1, 1, true, true, true, 4, true, 0, null,
+        DataType.STRING, 100000);
+    validateIndex(NEWLY_ADDED_STRING_MV_COL_DICT, Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 1, 1,
+        true, true, false, 4, false, 1, null, DataType.STRING, 100000);
+    validateIndex(NEWLY_ADDED_STRING_COL_RAW, Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 1, 1, true,
+        true, true, 4, true, 0, null, DataType.STRING, 100000);
+    validateIndex(NEWLY_ADDED_STRING_MV_COL_RAW, Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 1, 1,
+        true, true, false, 4, false, 1, null, DataType.STRING, 100000);
+
     constructV3Segment();
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_STRING_COL_RAW);
-    // should be null since column does not exist in the schema
-    assertNull(columnMetadata);
-    checkTextIndexCreation(NEWLY_ADDED_STRING_COL_RAW, 1, 1, _newColumnsSchemaWithText, true, true, true, 4);
-    checkTextIndexCreation(NEWLY_ADDED_STRING_MV_COL_RAW, 1, 1, _newColumnsSchemaWithText, true, true, false, 4, false,
-        1);
+    createAndValidateIndex(tableConfig, _newColumnsSchemaWithText, NEWLY_ADDED_STRING_COL_DICT,
+        Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 1, 1, true, true, true, 4, true, 0, null,
+        DataType.STRING, 100000);
+    validateIndex(NEWLY_ADDED_STRING_MV_COL_DICT, Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 1, 1,
+        true, true, false, 4, false, 1, null, DataType.STRING, 100000);
+    validateIndex(NEWLY_ADDED_STRING_COL_RAW, Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 1, 1, true,
+        true, true, 4, true, 0, null, DataType.STRING, 100000);
+    validateIndex(NEWLY_ADDED_STRING_MV_COL_RAW, Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 1, 1,
+        true, true, false, 4, false, 1, null, DataType.STRING, 100000);
+  }
 
-    // Create a segment in V1, add a new raw column with text index enabled
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_STRING_COL_RAW);
-    // should be null since column does not exist in the schema
-    assertNull(columnMetadata);
-    checkTextIndexCreation(NEWLY_ADDED_STRING_COL_RAW, 1, 1, _newColumnsSchemaWithText, true, true, true, 4);
+  /**
+   * Test to check text index creation during segment load after text index creation is enabled on existing columns.
+   */
+  @Test
+  public void testEnableTextIndexOnExistingColumn()
+      throws Exception {
+    TableConfig tableConfig = getDefaultTableConfig();
+    List<FieldConfig> fieldConfigs = new ArrayList<>();
+    fieldConfigs.add(new FieldConfig(EXISTING_STRING_COL_DICT, FieldConfig.EncodingType.DICTIONARY,
+        Collections.singletonList(FieldConfig.IndexType.TEXT), null, null));
+    fieldConfigs.add(new FieldConfig(EXISTING_STRING_COL_RAW, FieldConfig.EncodingType.RAW,
+        Collections.singletonList(FieldConfig.IndexType.TEXT), null, null));
+    tableConfig.setFieldConfigList(fieldConfigs);
+
+    constructV1Segment();
+    createAndValidateIndex(tableConfig, _schema, EXISTING_STRING_COL_DICT,
+        Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 9, 4, false, true, false, 26, true, 0, null,
+        DataType.STRING, 100000);
+    validateIndex(EXISTING_STRING_COL_RAW, Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 5, 3, false,
+        false, false, 0, true, 0, ChunkCompressionType.LZ4, DataType.STRING, 100000);
+
+    constructV3Segment();
+    createAndValidateIndex(tableConfig, _schema, EXISTING_STRING_COL_DICT,
+        Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 9, 4, false, true, false, 26, true, 0, null,
+        DataType.STRING, 100000);
+    validateIndex(EXISTING_STRING_COL_RAW, Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 5, 3, false,
+        false, false, 0, true, 0, ChunkCompressionType.LZ4, DataType.STRING, 100000);
   }
 
   @Test
-  public void testEnableFSTIndexOnExistingColumnRaw()
+  public void testEnableFSTIndexOnNewColumn()
       throws Exception {
-    Set<String> fstColumns = new HashSet<>();
-    fstColumns.add(EXISTING_STRING_COL_RAW);
-    _indexLoadingConfig.setFSTIndexColumns(fstColumns);
-    constructV3Segment();
-    SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
-        .load(_indexDir.toURI(),
-            new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-    SegmentPreProcessor v3Processor =
-        new SegmentPreProcessor(segmentDirectory, _indexLoadingConfig, _newColumnsSchemaWithFST);
-    expectThrows(UnsupportedOperationException.class, () -> v3Processor.process());
+    TableConfig tableConfig = getDefaultTableConfig();
+    tableConfig.setFieldConfigList(Collections.singletonList(
+        new FieldConfig(NEWLY_ADDED_FST_COL_DICT, FieldConfig.EncodingType.DICTIONARY,
+            Collections.singletonList(FieldConfig.IndexType.FST), null, null)));
 
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader().load(_indexDir.toURI(),
-        new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-    SegmentPreProcessor v1Processor =
-        new SegmentPreProcessor(segmentDirectory, _indexLoadingConfig, _newColumnsSchemaWithFST);
-    expectThrows(UnsupportedOperationException.class, () -> v1Processor.process());
-  }
-
-  @Test
-  public void testEnableFSTIndexOnNewColumnDictEncoded()
-      throws Exception {
-    Set<String> fstColumns = new HashSet<>();
-    fstColumns.add(NEWLY_ADDED_FST_COL_DICT);
-    _indexLoadingConfig.setFSTIndexColumns(fstColumns);
+    constructV1Segment();
+    createAndValidateIndex(tableConfig, _newColumnsSchemaWithFST, NEWLY_ADDED_FST_COL_DICT,
+        Collections.singletonList(ColumnIndexType.FST_INDEX), false, 1, 1, true, true, true, 4, true, 0, null,
+        DataType.STRING, 100000);
 
     constructV3Segment();
-    checkFSTIndexCreation(NEWLY_ADDED_FST_COL_DICT, 1, 1, _newColumnsSchemaWithFST, true, true, 4);
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    checkFSTIndexCreation(NEWLY_ADDED_FST_COL_DICT, 1, 1, _newColumnsSchemaWithFST, true, true, 4);
+    createAndValidateIndex(tableConfig, _newColumnsSchemaWithFST, NEWLY_ADDED_FST_COL_DICT,
+        Collections.singletonList(ColumnIndexType.FST_INDEX), false, 1, 1, true, true, true, 4, true, 0, null,
+        DataType.STRING, 100000);
   }
 
   @Test
   public void testEnableFSTIndexOnExistingColumnDictEncoded()
       throws Exception {
-    Set<String> fstColumns = new HashSet<>();
-    fstColumns.add(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.setFSTIndexColumns(fstColumns);
+    TableConfig tableConfig = getDefaultTableConfig();
+    tableConfig.setFieldConfigList(Collections.singletonList(
+        new FieldConfig(EXISTING_STRING_COL_DICT, FieldConfig.EncodingType.DICTIONARY,
+            Collections.singletonList(FieldConfig.IndexType.FST), null, null)));
 
-    constructV3Segment();
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_DICT);
-    assertNotNull(columnMetadata);
-    checkFSTIndexCreation(EXISTING_STRING_COL_DICT, 9, 4, _newColumnsSchemaWithFST, false, false, 26);
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_DICT);
-    assertNotNull(columnMetadata);
-    checkFSTIndexCreation(EXISTING_STRING_COL_DICT, 9, 4, _newColumnsSchemaWithFST, false, false, 26);
-  }
-
-  @Test
-  public void testSimpleEnableDictionarySV()
-      throws Exception {
-    // TEST 1. Check running forwardIndexHandler on a V1 segment. No-op for all existing raw columns.
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    checkForwardIndexCreation(EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0, ChunkCompressionType.LZ4,
-        true, 0, DataType.STRING, 100000);
-    validateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_INT_COL_RAW, 42242, 16, _schema, false, false, false, 0, true,
-        0, ChunkCompressionType.LZ4, false, DataType.INT, 100000);
-
-    // Convert the segment to V3.
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-
-    // TEST 2: Enable dictionary on EXISTING_STRING_COL_RAW
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_STRING_COL_RAW);
-    checkForwardIndexCreation(EXISTING_STRING_COL_RAW, 5, 3, _schema, false, true, false, 4, null, true, 0,
+    constructV1Segment();
+    createAndValidateIndex(tableConfig, _schema, EXISTING_STRING_COL_DICT,
+        Collections.singletonList(ColumnIndexType.FST_INDEX), false, 9, 4, false, true, false, 26, true, 0, null,
         DataType.STRING, 100000);
 
-    // TEST 3: Enable dictionary on EXISTING_INT_COL_RAW
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_INT_COL_RAW);
-    checkForwardIndexCreation(EXISTING_INT_COL_RAW, 42242, 16, _schema, false, true, false, 0, null, true, 0,
-        DataType.INT, 100000);
+    constructV3Segment();
+    createAndValidateIndex(tableConfig, _schema, EXISTING_STRING_COL_DICT,
+        Collections.singletonList(ColumnIndexType.FST_INDEX), false, 9, 4, false, true, false, 26, true, 0, null,
+        DataType.STRING, 100000);
   }
 
   @Test
-  public void testSimpleEnableDictionaryMV()
+  public void testEnableFSTIndexOnExistingColumnRaw()
       throws Exception {
-    // Add raw columns in indexingConfig so that the ForwardIndexHandler doesn't end up converting them to dictionary
-    // enabled columns
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW_MV);
+    TableConfig tableConfig = getDefaultTableConfig();
+    tableConfig.setFieldConfigList(Collections.singletonList(
+        new FieldConfig(EXISTING_STRING_COL_RAW, FieldConfig.EncodingType.RAW,
+            Collections.singletonList(FieldConfig.IndexType.FST), FieldConfig.CompressionCodec.LZ4, null)));
 
-    // TEST 1. Check running forwardIndexHandler on a V1 segment. No-op for all existing raw columns.
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    checkForwardIndexCreation(EXISTING_INT_COL_RAW_MV, 18499, 15, _schema, false, false, false, 0,
-        ChunkCompressionType.LZ4, false, 13, DataType.INT, 106688);
+    constructV1Segment();
+    SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
+        .load(_indexDir.toURI(),
+            new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
+    SegmentPreProcessor v3Processor =
+        new SegmentPreProcessor(segmentDirectory, new IndexLoadingConfig(tableConfig, _schema));
+    expectThrows(UnsupportedOperationException.class, v3Processor::process);
 
-    // Convert the segment to V3.
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
+    constructV3Segment();
+    segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader().load(_indexDir.toURI(),
+        new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
+    SegmentPreProcessor v1Processor =
+        new SegmentPreProcessor(segmentDirectory, new IndexLoadingConfig(tableConfig, _schema));
+    expectThrows(UnsupportedOperationException.class, v1Processor::process);
+  }
 
-    // TEST 2: Enable dictionary on EXISTING_STRING_COL_RAW
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_INT_COL_RAW_MV);
-    checkForwardIndexCreation(EXISTING_INT_COL_RAW_MV, 18499, 15, _schema, false, true, false, 0, null, false, 13,
-        DataType.INT, 106688);
+  @Test
+  public void testEnableDictionary()
+      throws Exception {
+    // Enable dictionary on EXISTING_INT_COL_RAW, EXISTING_STRING_COL_RAW and EXISTING_INT_COL_RAW_MV
+    constructV3Segment();
+    TableConfig tableConfig = getDefaultTableConfig();
+    List<String> noDictionaryColumns = tableConfig.getIndexingConfig().getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    assertTrue(noDictionaryColumns.remove(EXISTING_INT_COL_RAW));
+    assertTrue(noDictionaryColumns.remove(EXISTING_STRING_COL_RAW));
+    assertTrue(noDictionaryColumns.remove(EXISTING_INT_COL_RAW_MV));
+
+    createAndValidateIndex(tableConfig, _schema, EXISTING_INT_COL_RAW, Collections.emptyList(), false, 42242, 16, false,
+        true, false, 0, true, 0, null, DataType.INT, 100000);
+    validateIndex(EXISTING_STRING_COL_RAW, Collections.emptyList(), false, 5, 3, false, true, false, 4, true, 0, null,
+        DataType.STRING, 100000);
+    validateIndex(EXISTING_INT_COL_RAW_MV, Collections.emptyList(), false, 18499, 15, false, true, false, 0, false, 13,
+        null, DataType.INT, 106688);
   }
 
   @Test
   public void testEnableDictAndOtherIndexesSV()
       throws Exception {
-    // Add raw columns in indexingConfig so that the ForwardIndexHandler doesn't end up converting them to dictionary
-    // enabled columns
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW);
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_STRING_COL_RAW);
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-
     // TEST 1: EXISTING_STRING_COL_RAW. Enable dictionary. Also add inverted index and text index. Reload code path
     // will create dictionary, inverted index and text index.
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_STRING_COL_RAW);
-    _indexLoadingConfig.getInvertedIndexColumns().add(EXISTING_STRING_COL_RAW);
-    _indexLoadingConfig.getTextIndexColumns().add(EXISTING_STRING_COL_RAW);
-    checkForwardIndexCreation(EXISTING_STRING_COL_RAW, 5, 3, _schema, false, true, false, 4, null, true, 0,
-        DataType.STRING, 100000);
-    validateIndex(ColumnIndexType.INVERTED_INDEX, EXISTING_STRING_COL_RAW, 5, 3, _schema, false, true, false, 4, true,
-        0, null, false, DataType.STRING, 100000);
-    validateIndex(ColumnIndexType.TEXT_INDEX, EXISTING_STRING_COL_RAW, 5, 3, _schema, false, true, false, 4, true, 0,
-        null, false, DataType.STRING, 100000);
+    constructV3Segment();
+    TableConfig tableConfig = getDefaultTableConfig();
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    assertTrue(noDictionaryColumns.remove(EXISTING_STRING_COL_RAW));
+    List<String> invertedIndexColumns = indexingConfig.getInvertedIndexColumns();
+    assertNotNull(invertedIndexColumns);
+    assertFalse(invertedIndexColumns.contains(EXISTING_STRING_COL_RAW));
+    invertedIndexColumns.add(EXISTING_STRING_COL_RAW);
+    tableConfig.setFieldConfigList(Collections.singletonList(
+        new FieldConfig(EXISTING_STRING_COL_RAW, FieldConfig.EncodingType.DICTIONARY,
+            Collections.singletonList(FieldConfig.IndexType.TEXT), null, null)));
+    createAndValidateIndex(tableConfig, _schema, EXISTING_STRING_COL_RAW,
+        Arrays.asList(ColumnIndexType.INVERTED_INDEX, ColumnIndexType.TEXT_INDEX), false, 5, 3, false, true, false, 4,
+        true, 0, null, DataType.STRING, 100000);
 
     // TEST 2: EXISTING_STRING_COL_RAW. Enable dictionary on a raw column that already has text index.
-    List<String> textIndexCols = new ArrayList<>();
-    textIndexCols.add(EXISTING_STRING_COL_RAW);
-    constructV1Segment(Collections.emptyList(), textIndexCols, Collections.emptyList(),
-        Collections.emptyList());
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    validateIndex(ColumnIndexType.TEXT_INDEX, EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0, true, 0,
-        null, false, DataType.STRING, 100000);
-
-    // At this point, the segment has text index. Now, the reload path should create a dictionary.
-    checkForwardIndexCreation(EXISTING_STRING_COL_RAW, 5, 3, _schema, false, true, false, 4, null, true, 0,
+    tableConfig = getDefaultTableConfig();
+    tableConfig.setFieldConfigList(Collections.singletonList(
+        new FieldConfig(EXISTING_STRING_COL_RAW, FieldConfig.EncodingType.RAW,
+            Collections.singletonList(FieldConfig.IndexType.TEXT), null, null)));
+    constructV3Segment(tableConfig);
+    validateIndex(EXISTING_STRING_COL_RAW, Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 5, 3, false,
+        false, false, 0, true, 0, ChunkCompressionType.LZ4, DataType.STRING, 100000);
+    noDictionaryColumns = tableConfig.getIndexingConfig().getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    assertTrue(noDictionaryColumns.remove(EXISTING_STRING_COL_RAW));
+    tableConfig.setFieldConfigList(Collections.singletonList(
+        new FieldConfig(EXISTING_STRING_COL_RAW, FieldConfig.EncodingType.DICTIONARY,
+            Collections.singletonList(FieldConfig.IndexType.TEXT), null, null)));
+    createAndValidateIndex(tableConfig, _schema, EXISTING_STRING_COL_RAW,
+        Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 5, 3, false, true, false, 4, true, 0, null,
         DataType.STRING, 100000);
-    validateIndex(ColumnIndexType.TEXT_INDEX, EXISTING_STRING_COL_RAW, 5, 3, _schema, false, true, false, 4, true, 0,
-        null, false, DataType.STRING, 100000);
-    // Add it back so that this column is not rewritten for the other tests below.
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_STRING_COL_RAW);
 
     // TEST 3: EXISTING_INT_COL_RAW. Enable dictionary on a column that already has range index.
-    List<String> rangeIndexCols = new ArrayList<>();
-    rangeIndexCols.add(EXISTING_INT_COL_RAW);
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), rangeIndexCols, Collections.emptyList());
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    validateIndex(ColumnIndexType.RANGE_INDEX, EXISTING_INT_COL_RAW, 42242, 16, _schema, false, false, false, 0, true,
-        0, ChunkCompressionType.LZ4, false, DataType.INT, 100000);
+    tableConfig = getDefaultTableConfig();
+    indexingConfig = tableConfig.getIndexingConfig();
+    indexingConfig.setRangeIndexColumns(Collections.singletonList(EXISTING_INT_COL_RAW));
+    constructV3Segment(tableConfig);
+    validateIndex(EXISTING_INT_COL_RAW, Collections.singletonList(ColumnIndexType.RANGE_INDEX), false, 42242, 16, false,
+        false, false, 0, true, 0, ChunkCompressionType.LZ4, DataType.INT, 100000);
     long oldRangeIndexSize =
         new SegmentMetadataImpl(_indexDir).getColumnMetadataFor(EXISTING_INT_COL_RAW).getIndexSizeMap()
             .get(ColumnIndexType.RANGE_INDEX);
     // At this point, the segment has range index. Now the reload path should create a dictionary and rewrite the
     // range index.
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_INT_COL_RAW);
-    _indexLoadingConfig.getRangeIndexColumns().add(EXISTING_INT_COL_RAW);
-    checkForwardIndexCreation(EXISTING_INT_COL_RAW, 42242, 16, _schema, false, true, false, 0, null, true, 0,
+    noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    assertTrue(noDictionaryColumns.remove(EXISTING_INT_COL_RAW));
+    createAndValidateIndex(tableConfig, _schema, EXISTING_INT_COL_RAW,
+        Collections.singletonList(ColumnIndexType.RANGE_INDEX), false, 42242, 16, false, true, false, 0, true, 0, null,
         DataType.INT, 100000);
-    validateIndex(ColumnIndexType.RANGE_INDEX, EXISTING_INT_COL_RAW, 42242, 16, _schema, false, true, false, 0, true, 0,
-        null, false, DataType.INT, 100000);
     long newRangeIndexSize =
         new SegmentMetadataImpl(_indexDir).getColumnMetadataFor(EXISTING_INT_COL_RAW).getIndexSizeMap()
             .get(ColumnIndexType.RANGE_INDEX);
-    assertNotEquals(oldRangeIndexSize, newRangeIndexSize);
-    // Add it back so that this column is not rewritten for the other tests below.
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW);
+    assertNotEquals(newRangeIndexSize, oldRangeIndexSize);
   }
 
   @Test
   public void testEnableDictAndOtherIndexesMV()
       throws Exception {
-    // Add raw columns in indexingConfig so that the ForwardIndexHandler doesn't end up converting them to dictionary
-    // enabled columns
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW_MV);
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-
     // TEST 1: EXISTING_INT_COL_RAW_MV. Enable dictionary for an MV column. Also enable inverted index and range index.
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_INT_COL_RAW_MV);
-    _indexLoadingConfig.getInvertedIndexColumns().add(EXISTING_INT_COL_RAW_MV);
-    _indexLoadingConfig.getRangeIndexColumns().add(EXISTING_INT_COL_RAW_MV);
-    checkForwardIndexCreation(EXISTING_INT_COL_RAW_MV, 18499, 15, _schema, false, true, false, 0, null, false, 13,
-        DataType.INT, 106688);
-    validateIndex(ColumnIndexType.INVERTED_INDEX, EXISTING_INT_COL_RAW_MV, 18499, 15, _schema, false, true, false, 0,
-        false, 13, null, false, DataType.INT, 106688);
-    validateIndex(ColumnIndexType.RANGE_INDEX, EXISTING_INT_COL_RAW_MV, 18499, 15, _schema, false, true, false, 0,
-        false, 13, null, false, DataType.INT, 106688);
+    constructV3Segment();
+    TableConfig tableConfig = getDefaultTableConfig();
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    assertTrue(noDictionaryColumns.remove(EXISTING_INT_COL_RAW_MV));
+    List<String> invertedIndexColumns = indexingConfig.getInvertedIndexColumns();
+    assertNotNull(invertedIndexColumns);
+    assertFalse(invertedIndexColumns.contains(EXISTING_INT_COL_RAW_MV));
+    invertedIndexColumns.add(EXISTING_INT_COL_RAW_MV);
+    indexingConfig.setRangeIndexColumns(Collections.singletonList(EXISTING_INT_COL_RAW_MV));
+    createAndValidateIndex(tableConfig, _schema, EXISTING_INT_COL_RAW_MV,
+        Arrays.asList(ColumnIndexType.INVERTED_INDEX, ColumnIndexType.RANGE_INDEX), false, 18499, 15, false, true,
+        false, 0, false, 13, null, DataType.INT, 106688);
 
     // TEST 2: EXISTING_INT_COL_RAW_MV. Enable dictionary for an MV column that already has range index.
-    List<String> rangeIndexCols = new ArrayList<>();
-    rangeIndexCols.add(EXISTING_INT_COL_RAW_MV);
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), rangeIndexCols, Collections.emptyList());
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    validateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_INT_COL_RAW_MV, 18499, 15, _schema, false, false, false, 0,
-        false, 13, ChunkCompressionType.LZ4, false, DataType.INT, 106688);
-    validateIndex(ColumnIndexType.RANGE_INDEX, EXISTING_INT_COL_RAW_MV, 18499, 15, _schema, false, false, false, 0,
-        false, 13, ChunkCompressionType.LZ4, false, DataType.INT, 106688);
-
+    tableConfig = getDefaultTableConfig();
+    indexingConfig = tableConfig.getIndexingConfig();
+    indexingConfig.setRangeIndexColumns(Collections.singletonList(EXISTING_INT_COL_RAW_MV));
+    constructV3Segment(tableConfig);
+    validateIndex(EXISTING_INT_COL_RAW_MV, Collections.singletonList(ColumnIndexType.RANGE_INDEX), false, 18499, 15,
+        false, false, false, 0, false, 13, ChunkCompressionType.LZ4, DataType.INT, 106688);
     // Enable dictionary.
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_INT_COL_RAW_MV);
-    checkForwardIndexCreation(EXISTING_INT_COL_RAW_MV, 18499, 15, _schema, false, true, false, 0, null, false, 13,
-        DataType.INT, 106688);
-    validateIndex(ColumnIndexType.RANGE_INDEX, EXISTING_INT_COL_RAW_MV, 18499, 15, _schema, false, true, false, 0,
-        false, 13, null, false, DataType.INT, 106688);
+    noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    assertTrue(noDictionaryColumns.remove(EXISTING_INT_COL_RAW_MV));
+    createAndValidateIndex(tableConfig, _schema, EXISTING_INT_COL_RAW_MV,
+        Collections.singletonList(ColumnIndexType.RANGE_INDEX), false, 18499, 15, false, true, false, 0, false, 13,
+        null, DataType.INT, 106688);
   }
 
   @Test
-  public void testSimpleDisableDictionary()
+  public void testDisableDictionary()
       throws Exception {
-    // TEST 1. Check running forwardIndexHandler on a V1 segment. No-op for all existing dict columns.
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    checkForwardIndexCreation(EXISTING_STRING_COL_DICT, 9, 4, _schema, false, true, false, 26, null, true, 0,
-        DataType.STRING, 100000);
-    validateIndex(ColumnIndexType.FORWARD_INDEX, COLUMN10_NAME, 3960, 12, _schema, false, true, false, 0, true, 0, null,
-        false, DataType.INT, 100000);
+    // Disable dictionary for EXISTING_STRING_COL_DICT
+    TableConfig tableConfig = getDefaultTableConfig();
+    List<String> noDictionaryColumns = tableConfig.getIndexingConfig().getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    assertFalse(noDictionaryColumns.contains(EXISTING_STRING_COL_DICT));
+    noDictionaryColumns.add(EXISTING_STRING_COL_DICT);
 
-    // Convert the segment to V3.
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
+    // No-op on V1 segment
+    constructV1Segment();
+    createAndValidateIndex(tableConfig, _schema, EXISTING_STRING_COL_DICT, Collections.emptyList(), false, 9, 4, false,
+        true, false, 26, true, 0, null, DataType.STRING, 100000);
 
-    // TEST 2: Disable dictionary for EXISTING_STRING_COL_DICT.
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_STRING_COL_DICT);
-    checkForwardIndexCreation(EXISTING_STRING_COL_DICT, 9, 4, _schema, false, false, false, 0, ChunkCompressionType.LZ4,
-        true, 0, DataType.STRING, 100000);
+    constructV3Segment();
+    createAndValidateIndex(tableConfig, _schema, EXISTING_STRING_COL_DICT, Collections.emptyList(), false, 9, 4, false,
+        false, false, 0, true, 0, ChunkCompressionType.LZ4, DataType.STRING, 100000);
 
-    // TEST 3: Disable dictionary for COLUMN10_NAME
-    _indexLoadingConfig.getNoDictionaryColumns().add(COLUMN10_NAME);
-    checkForwardIndexCreation(COLUMN10_NAME, 3960, 12, _schema, false, false, false, 0, ChunkCompressionType.LZ4, true,
-        0, DataType.INT, 100000);
+    // Disable dictionary for COLUMN10_NAME
+    constructV3Segment();
+    tableConfig = getDefaultTableConfig();
+    noDictionaryColumns = tableConfig.getIndexingConfig().getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    assertFalse(noDictionaryColumns.contains(COLUMN10_NAME));
+    noDictionaryColumns.add(COLUMN10_NAME);
+    createAndValidateIndex(tableConfig, _schema, COLUMN10_NAME, Collections.emptyList(), false, 3960, 12, false, false,
+        false, 0, true, 0, ChunkCompressionType.LZ4, DataType.INT, 100000);
   }
 
   @Test
   public void testDisableDictAndOtherIndexesSV()
       throws Exception {
-    // Validate No-op.
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-
     // TEST 1: Disable dictionary on a column that has inverted index. Should be a no-op and column should still have
     // a dictionary.
-    _indexLoadingConfig.getNoDictionaryColumns().add(COLUMN1_NAME);
-    checkForwardIndexCreation(COLUMN1_NAME, 51594, 16, _schema, false, true, false, 0, null, true, 0, DataType.INT,
-        100000);
+    constructV3Segment();
+    TableConfig tableConfig = getDefaultTableConfig();
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    assertFalse(noDictionaryColumns.contains(COLUMN1_NAME));
+    noDictionaryColumns.add(COLUMN1_NAME);
+    createAndValidateIndex(tableConfig, _schema, COLUMN1_NAME,
+        Collections.singletonList(ColumnIndexType.INVERTED_INDEX), false, 51594, 16, false, true, false, 0, true, 0,
+        null, DataType.INT, 100000);
 
     // TEST 2: Disable dictionary. Also remove inverted index on column1.
-    _indexLoadingConfig.getNoDictionaryColumns().add(COLUMN1_NAME);
-    _indexLoadingConfig.getInvertedIndexColumns().remove(COLUMN1_NAME);
-    checkForwardIndexCreation(COLUMN1_NAME, 51594, 16, _schema, false, false, false, 0, null, true, 0, DataType.INT,
-        100000);
+    List<String> invertedIndexColumns = indexingConfig.getInvertedIndexColumns();
+    assertNotNull(invertedIndexColumns);
+    assertTrue(invertedIndexColumns.remove(COLUMN1_NAME));
+    createAndValidateIndex(tableConfig, _schema, COLUMN1_NAME, Collections.emptyList(), false, 51594, 16, false, false,
+        false, 0, true, 0, ChunkCompressionType.LZ4, DataType.INT, 100000);
+    validateIndexDoesNotExist(COLUMN1_NAME, ColumnIndexType.INVERTED_INDEX);
 
     // TEST 3: Disable dictionary for a column (Column10) that has range index.
-    List<String> rangeIndexCols = new ArrayList<>();
-    rangeIndexCols.add(COLUMN10_NAME);
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), rangeIndexCols, Collections.emptyList());
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    validateIndex(ColumnIndexType.FORWARD_INDEX, COLUMN10_NAME, 3960, 12, _schema, false, true, false, 0, true, 0, null,
-        false, DataType.INT, 100000);
-    validateIndex(ColumnIndexType.RANGE_INDEX, COLUMN10_NAME, 3960, 12, _schema, false, true, false, 0, true, 0, null,
-        false, DataType.INT, 100000);
+    tableConfig = getDefaultTableConfig();
+    indexingConfig = tableConfig.getIndexingConfig();
+    indexingConfig.setRangeIndexColumns(Collections.singletonList(COLUMN10_NAME));
+    constructV3Segment(tableConfig);
+    validateIndex(COLUMN10_NAME, Collections.singletonList(ColumnIndexType.RANGE_INDEX), false, 3960, 12, false, true,
+        false, 0, true, 0, null, DataType.INT, 100000);
     long oldRangeIndexSize = new SegmentMetadataImpl(_indexDir).getColumnMetadataFor(COLUMN10_NAME).getIndexSizeMap()
         .get(ColumnIndexType.RANGE_INDEX);
-
-
-    _indexLoadingConfig.getNoDictionaryColumns().add(COLUMN10_NAME);
-    _indexLoadingConfig.getRangeIndexColumns().add(COLUMN10_NAME);
-    checkForwardIndexCreation(COLUMN10_NAME, 3960, 12, _schema, false, false, false, 0, ChunkCompressionType.LZ4, true,
-        0, DataType.INT, 100000);
-    validateIndex(ColumnIndexType.RANGE_INDEX, COLUMN10_NAME, 3960, 12, _schema, false, false, false, 0, true, 0,
-        ChunkCompressionType.LZ4, false, DataType.INT, 100000);
+    noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    assertFalse(noDictionaryColumns.contains(COLUMN10_NAME));
+    noDictionaryColumns.add(COLUMN10_NAME);
+    createAndValidateIndex(tableConfig, _schema, COLUMN10_NAME, Collections.singletonList(ColumnIndexType.RANGE_INDEX),
+        false, 3960, 12, false, false, false, 0, true, 0, ChunkCompressionType.LZ4, DataType.INT, 100000);
     long newRangeIndexSize = new SegmentMetadataImpl(_indexDir).getColumnMetadataFor(COLUMN10_NAME).getIndexSizeMap()
         .get(ColumnIndexType.RANGE_INDEX);
-    assertNotEquals(oldRangeIndexSize, newRangeIndexSize);
+    assertNotEquals(newRangeIndexSize, oldRangeIndexSize);
 
     // TEST4: Disable dictionary but add text index.
-    validateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_DICT, 9, 4, _schema, false, true, false, 26, true,
-        0, null, false, DataType.STRING, 100000);
-
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.getTextIndexColumns().add(EXISTING_STRING_COL_DICT);
-    checkForwardIndexCreation(EXISTING_STRING_COL_DICT, 9, 4, _schema, false, false, false, 0, ChunkCompressionType.LZ4,
-        true, 0, DataType.STRING, 100000);
-    validateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_DICT, 9, 4, _schema, false, false, false, 0, true,
-        0, null, false, DataType.STRING, 100000);
+    constructV3Segment();
+    tableConfig = getDefaultTableConfig();
+    noDictionaryColumns = tableConfig.getIndexingConfig().getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    assertFalse(noDictionaryColumns.contains(EXISTING_STRING_COL_DICT));
+    noDictionaryColumns.add(EXISTING_STRING_COL_DICT);
+    tableConfig.setFieldConfigList(Collections.singletonList(
+        new FieldConfig(EXISTING_STRING_COL_DICT, FieldConfig.EncodingType.RAW,
+            Collections.singletonList(FieldConfig.IndexType.TEXT), FieldConfig.CompressionCodec.SNAPPY, null)));
+    createAndValidateIndex(tableConfig, _schema, EXISTING_STRING_COL_DICT,
+        Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 9, 4, false, false, false, 0, true, 0,
+        ChunkCompressionType.SNAPPY, DataType.STRING, 100000);
   }
 
   @Test
   public void testDisableDictAndOtherIndexesMV()
       throws Exception {
-    // Set up: Enable dictionary on MV column6 and validate.
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_INT_COL_RAW_MV);
-    _indexLoadingConfig.getRangeIndexColumns().add(EXISTING_INT_COL_RAW_MV);
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    checkForwardIndexCreation(EXISTING_INT_COL_RAW_MV, 18499, 15, _schema, false, true, false, 0, null, false, 13,
-        DataType.INT, 106688);
-    validateIndex(ColumnIndexType.RANGE_INDEX, EXISTING_INT_COL_RAW_MV, 18499, 15, _schema, false, true, false, 0,
-        false, 13, null, false, DataType.INT, 106688);
-
     // TEST 1: Disable dictionary on a column where range index is already enabled.
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW_MV);
-    checkForwardIndexCreation(EXISTING_INT_COL_RAW_MV, 18499, 15, _schema, false, false, false, 0, null, false, 13,
-        DataType.INT, 106688);
-    validateIndex(ColumnIndexType.RANGE_INDEX, EXISTING_INT_COL_RAW_MV, 18499, 15, _schema, false, false, false, 0,
-        false, 13, null, false, DataType.INT, 106688);
+    TableConfig tableConfig = getDefaultTableConfig();
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    assertTrue(noDictionaryColumns.remove(EXISTING_INT_COL_RAW_MV));
+    constructV3Segment(tableConfig);
+    validateIndex(EXISTING_INT_COL_RAW_MV, Collections.emptyList(), false, 18499, 15, false, true, false, 0, false, 13,
+        null, DataType.INT, 106688);
+    noDictionaryColumns.add(EXISTING_INT_COL_RAW_MV);
+    indexingConfig.setRangeIndexColumns(Collections.singletonList(EXISTING_INT_COL_RAW_MV));
+    createAndValidateIndex(tableConfig, _schema, EXISTING_INT_COL_RAW_MV,
+        Collections.singletonList(ColumnIndexType.RANGE_INDEX), false, 18499, 15, false, false, false, 0, false, 13,
+        ChunkCompressionType.LZ4, DataType.INT, 106688);
 
     // TEST 2. Disable dictionary on a column where inverted index is enabled. Should be a no-op.
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    validateIndex(ColumnIndexType.FORWARD_INDEX, COLUMN7_NAME, 359, 9, _newColumnsSchemaWithForwardIndexDisabled, false,
-        true, false, 0, false, 24, null, false, DataType.INT, 134090);
-    validateIndex(ColumnIndexType.INVERTED_INDEX, COLUMN7_NAME, 359, 9, _newColumnsSchemaWithForwardIndexDisabled,
-        false, true, false, 0, false, 24, null, false, DataType.INT, 134090);
-
-    _indexLoadingConfig.getNoDictionaryColumns().add(COLUMN7_NAME);
-    checkForwardIndexCreation(COLUMN7_NAME, 359, 9, _schema, false, true, false, 0, null, false, 24, DataType.INT,
-        134090);
-    validateIndex(ColumnIndexType.INVERTED_INDEX, COLUMN7_NAME, 359, 9, _newColumnsSchemaWithForwardIndexDisabled,
-        false, true, false, 0, false, 24, null, false, DataType.INT, 134090);
+    noDictionaryColumns.add(COLUMN7_NAME);
+    createAndValidateIndex(tableConfig, _schema, COLUMN7_NAME,
+        Collections.singletonList(ColumnIndexType.INVERTED_INDEX), false, 359, 9, false, true, false, 0, false, 24,
+        null, DataType.INT, 134090);
 
     // TEST 3: Disable dictionary and disable inverted index on column7.
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-
-    _indexLoadingConfig.getNoDictionaryColumns().add(COLUMN7_NAME);
-    _indexLoadingConfig.getInvertedIndexColumns().remove(COLUMN7_NAME);
-    checkForwardIndexCreation(COLUMN7_NAME, 359, 9, _schema, false, false, false, 0, null, false, 24, DataType.INT,
-        134090);
+    List<String> invertedIndexColumns = indexingConfig.getInvertedIndexColumns();
+    assertNotNull(invertedIndexColumns);
+    assertTrue(invertedIndexColumns.remove(COLUMN7_NAME));
+    createAndValidateIndex(tableConfig, _schema, COLUMN7_NAME, Collections.emptyList(), false, 359, 9, false, false,
+        false, 0, false, 24, ChunkCompressionType.LZ4, DataType.INT, 134090);
+    validateIndexDoesNotExist(COLUMN7_NAME, ColumnIndexType.INVERTED_INDEX);
   }
 
   @Test
   public void testForwardIndexHandlerChangeCompression()
       throws Exception {
-    Map<String, ChunkCompressionType> compressionConfigs = new HashMap<>();
-    ChunkCompressionType newCompressionType = ChunkCompressionType.ZSTANDARD;
-    compressionConfigs.put(EXISTING_STRING_COL_RAW, newCompressionType);
-    _indexLoadingConfig.setCompressionConfigs(compressionConfigs);
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_STRING_COL_RAW);
+    TableConfig tableConfig = getDefaultTableConfig();
+    tableConfig.setFieldConfigList(Collections.singletonList(
+        new FieldConfig(EXISTING_STRING_COL_RAW, FieldConfig.EncodingType.RAW, Collections.emptyList(),
+            FieldConfig.CompressionCodec.ZSTANDARD, null)));
 
     // Test1: Rewriting forward index will be a no-op for v1 segments. Default LZ4 compressionType will be retained.
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    checkForwardIndexCreation(EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0, ChunkCompressionType.LZ4,
-        true, 0, DataType.STRING, 100000);
+    constructV1Segment();
+    createAndValidateIndex(tableConfig, _schema, EXISTING_STRING_COL_RAW, Collections.emptyList(), false, 5, 3, false,
+        false, false, 0, true, 0, ChunkCompressionType.LZ4, DataType.STRING, 100000);
 
-    // Convert the segment to V3.
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-
-    // Test2: Now forward index will be rewritten with ZSTANDARD compressionType.
-    checkForwardIndexCreation(EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0, newCompressionType, true,
-        0, DataType.STRING, 100000);
+    // Test2: For v3 segments, forward index will be rewritten with ZSTANDARD compressionType.
+    constructV3Segment();
+    createAndValidateIndex(tableConfig, _schema, EXISTING_STRING_COL_RAW, Collections.emptyList(), false, 5, 3, false,
+        false, false, 0, true, 0, ChunkCompressionType.ZSTANDARD, DataType.STRING, 100000);
 
     // Test3: Change compression on existing raw index column. Also add text index on same column. Check correctness.
-    newCompressionType = ChunkCompressionType.SNAPPY;
-    compressionConfigs.put(EXISTING_STRING_COL_RAW, newCompressionType);
-    Set<String> textIndexColumns = new HashSet<>();
-    textIndexColumns.add(EXISTING_STRING_COL_RAW);
-    _indexLoadingConfig.setTextIndexColumns(textIndexColumns);
-
     constructV3Segment();
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    assertNotNull(columnMetadata);
-    checkTextIndexCreation(EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0);
-    validateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0, true,
-        0, newCompressionType, false, DataType.STRING, 100000);
+    tableConfig.setFieldConfigList(Collections.singletonList(
+        new FieldConfig(EXISTING_STRING_COL_RAW, FieldConfig.EncodingType.RAW,
+            Collections.singletonList(FieldConfig.IndexType.TEXT), FieldConfig.CompressionCodec.ZSTANDARD, null)));
+    createAndValidateIndex(tableConfig, _schema, EXISTING_STRING_COL_RAW,
+        Collections.singletonList(ColumnIndexType.TEXT_INDEX), false, 5, 3, false, false, false, 0, true, 0,
+        ChunkCompressionType.ZSTANDARD, DataType.STRING, 100000);
 
     // Test4: Change compression on RAW index column. Change another index on another column. Check correctness.
-    newCompressionType = ChunkCompressionType.ZSTANDARD;
-    compressionConfigs.put(EXISTING_STRING_COL_RAW, newCompressionType);
-    Set<String> fstColumns = new HashSet<>();
-    fstColumns.add(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.setFSTIndexColumns(fstColumns);
-
     constructV3Segment();
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_DICT);
-    assertNotNull(columnMetadata);
-    // Check FST index
-    checkFSTIndexCreation(EXISTING_STRING_COL_DICT, 9, 4, _newColumnsSchemaWithFST, false, false, 26);
-    // Check forward index.
-    validateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0, true,
-        0, newCompressionType, false, DataType.STRING, 100000);
+    tableConfig.setFieldConfigList(Arrays.asList(
+        new FieldConfig(EXISTING_STRING_COL_RAW, FieldConfig.EncodingType.RAW, Collections.emptyList(),
+            FieldConfig.CompressionCodec.ZSTANDARD, null),
+        new FieldConfig(EXISTING_STRING_COL_DICT, FieldConfig.EncodingType.DICTIONARY,
+            Collections.singletonList(FieldConfig.IndexType.FST), null, null)));
+    createAndValidateIndex(tableConfig, _schema, EXISTING_STRING_COL_RAW, Collections.emptyList(), false, 5, 3, false,
+        false, false, 0, true, 0, ChunkCompressionType.ZSTANDARD, DataType.STRING, 100000);
+    validateIndex(EXISTING_STRING_COL_DICT, Collections.singletonList(ColumnIndexType.FST_INDEX), false, 9, 4, false,
+        true, false, 26, true, 0, null, DataType.STRING, 100000);
 
     // Test5: Change compressionType for an MV column
-    newCompressionType = ChunkCompressionType.ZSTANDARD;
-    compressionConfigs.put(EXISTING_INT_COL_RAW_MV, newCompressionType);
-    _indexLoadingConfig.setCompressionConfigs(compressionConfigs);
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW_MV);
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    checkForwardIndexCreation(EXISTING_INT_COL_RAW_MV, 18499, 15, _schema, false, false, false, 0,
-        ChunkCompressionType.ZSTANDARD, false, 13, DataType.INT, 106688);
-  }
-
-  /**
-   * Test to check for default column handling and text index creation during
-   * segment load after a new dictionary encoded column is added to the schema
-   * with text index creation enabled.
-   * This will exercise both code paths in SegmentPreprocessor (segment load):
-   * (1) Default column handler to add forward index and dictionary
-   * (2) Text index handler to add text index
-   */
-  @Test
-  public void testEnableTextIndexOnNewColumnDictEncoded()
-      throws Exception {
-    Set<String> textIndexColumns = new HashSet<>();
-    textIndexColumns.add(NEWLY_ADDED_STRING_COL_DICT);
-    textIndexColumns.add(NEWLY_ADDED_STRING_MV_COL_DICT);
-    _indexLoadingConfig.setTextIndexColumns(textIndexColumns);
-
-    // Create a segment in V3, add a new dict encoded column with text index enabled
     constructV3Segment();
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_STRING_COL_RAW);
-    // should be null since column does not exist in the schema
-    assertNull(columnMetadata);
-    checkTextIndexCreation(NEWLY_ADDED_STRING_COL_DICT, 1, 1, _newColumnsSchemaWithText, true, true, true, 4);
-
-    checkTextIndexCreation(NEWLY_ADDED_STRING_MV_COL_DICT, 1, 1, _newColumnsSchemaWithText, true, true, false, 4, false,
-        1);
-
-    // Create a segment in V1, add a new dict encoded column with text index enabled
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_STRING_COL_RAW);
-    // should be null since column does not exist in the schema
-    assertNull(columnMetadata);
-    checkTextIndexCreation(NEWLY_ADDED_STRING_COL_DICT, 1, 1, _newColumnsSchemaWithText, true, true, true, 4);
+    tableConfig.setFieldConfigList(Collections.singletonList(
+        new FieldConfig(EXISTING_INT_COL_RAW_MV, FieldConfig.EncodingType.RAW, Collections.emptyList(),
+            FieldConfig.CompressionCodec.ZSTANDARD, null)));
+    createAndValidateIndex(tableConfig, _schema, EXISTING_INT_COL_RAW_MV, Collections.emptyList(), false, 18499, 15,
+        false, false, false, 0, false, 13, ChunkCompressionType.ZSTANDARD, DataType.INT, 106688);
   }
 
-  /**
-   * Test to check text index creation during segment load after text index
-   * creation is enabled on an existing raw column.
-   * This will exercise the SegmentPreprocessor code path during segment load
-   * @throws Exception
-   */
-  @Test
-  public void testEnableTextIndexOnExistingRawColumn()
-      throws Exception {
-    Set<String> textIndexColumns = new HashSet<>();
-    textIndexColumns.add(EXISTING_STRING_COL_RAW);
-    _indexLoadingConfig.setTextIndexColumns(textIndexColumns);
-
-    // Create a segment in V3, enable text index on existing column
-    constructV3Segment();
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    assertNotNull(columnMetadata);
-    checkTextIndexCreation(EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0);
-
-    // Create a segment in V1, add a new column with text index enabled
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    assertNotNull(columnMetadata);
-    checkTextIndexCreation(EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0);
-  }
-
-  /**
-   * Test to check text index creation during segment load after text index
-   * creation is enabled on an existing dictionary encoded column.
-   * This will exercise the SegmentPreprocessor code path during segment load
-   * @throws Exception
-   */
-  @Test
-  public void testEnableTextIndexOnExistingDictEncodedColumn()
-      throws Exception {
-    constructV3Segment();
-    Set<String> textIndexColumns = new HashSet<>();
-    textIndexColumns.add(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.setTextIndexColumns(textIndexColumns);
-
-    // Create a segment in V3, enable text index on existing column
-    constructV3Segment();
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    assertNotNull(columnMetadata);
-    // SegmentPreprocessor should have created the text index using TextIndexHandler
-    checkTextIndexCreation(EXISTING_STRING_COL_DICT, 9, 4, _schema, false, true, false, 26);
-
-    // Create a segment in V1, add a new column with text index enabled
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    assertNotNull(columnMetadata);
-    // SegmentPreprocessor should have created the text index using TextIndexHandler
-    checkTextIndexCreation(EXISTING_STRING_COL_DICT, 9, 4, _schema, false, true, false, 26);
-  }
-
-  private void checkFSTIndexCreation(String column, int cardinality, int bits, Schema schema, boolean isAutoGenerated,
-      boolean isSorted, int dictionaryElementSize)
-      throws Exception {
-    createAndValidateIndex(ColumnIndexType.FST_INDEX, column, cardinality, bits, schema, isAutoGenerated, true,
-        isSorted, dictionaryElementSize, true, 0, null, false, DataType.STRING, 100000);
-  }
-
-  private void checkTextIndexCreation(String column, int cardinality, int bits, Schema schema, boolean isAutoGenerated,
-      boolean hasDictionary, boolean isSorted, int dictionaryElementSize)
-      throws Exception {
-    createAndValidateIndex(ColumnIndexType.TEXT_INDEX, column, cardinality, bits, schema, isAutoGenerated,
-        hasDictionary, isSorted, dictionaryElementSize, true, 0, null, false, DataType.STRING, 100000);
-  }
-
-  private void checkTextIndexCreation(String column, int cardinality, int bits, Schema schema, boolean isAutoGenerated,
-      boolean hasDictionary, boolean isSorted, int dictionaryElementSize, boolean isSingleValue,
-      int maxNumberOfMultiValues)
-      throws Exception {
-    createAndValidateIndex(ColumnIndexType.TEXT_INDEX, column, cardinality, bits, schema, isAutoGenerated,
-        hasDictionary, isSorted, dictionaryElementSize, isSingleValue, maxNumberOfMultiValues, null, false,
-        DataType.STRING, 100000);
-  }
-
-  private void checkForwardIndexCreation(String column, int cardinality, int bits, Schema schema,
+  private void createAndValidateIndex(TableConfig tableConfig, Schema schema, String column,
+      List<ColumnIndexType> indexTypes, boolean forwardIndexDisabled, int cardinality, int bits,
       boolean isAutoGenerated, boolean hasDictionary, boolean isSorted, int dictionaryElementSize,
-      ChunkCompressionType expectedCompressionType, boolean isSingleValue, int maxNumberOfMultiValues,
+      boolean isSingleValued, int maxNumberOfMultiValues, ChunkCompressionType expectedCompressionType,
       DataType dataType, int totalNumberOfEntries)
       throws Exception {
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, column, cardinality, bits, schema, isAutoGenerated,
-        hasDictionary, isSorted, dictionaryElementSize, isSingleValue, maxNumberOfMultiValues, expectedCompressionType,
-        false, dataType, totalNumberOfEntries);
-  }
-
-  private void createAndValidateIndex(ColumnIndexType indexType, String column, int cardinality, int bits,
-      Schema schema, boolean isAutoGenerated, boolean hasDictionary, boolean isSorted, int dictionaryElementSize,
-      boolean isSingleValued, int maxNumberOfMultiValues, ChunkCompressionType expectedCompressionType,
-      boolean forwardIndexDisabled, DataType dataType, int totalNumberOfEntries)
-      throws Exception {
-
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, _indexLoadingConfig, schema)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, schema))) {
       processor.process();
-      validateIndex(indexType, column, cardinality, bits, schema, isAutoGenerated, hasDictionary, isSorted,
-          dictionaryElementSize, isSingleValued, maxNumberOfMultiValues, expectedCompressionType, forwardIndexDisabled,
-          dataType, totalNumberOfEntries);
+      validateIndex(column, indexTypes, forwardIndexDisabled, cardinality, bits, isAutoGenerated, hasDictionary,
+          isSorted, dictionaryElementSize, isSingleValued, maxNumberOfMultiValues, expectedCompressionType, dataType,
+          totalNumberOfEntries);
     }
   }
 
-  private void validateIndex(ColumnIndexType indexType, String column, int cardinality, int bits, Schema schema,
-      boolean isAutoGenerated, boolean hasDictionary, boolean isSorted, int dictionaryElementSize,
-      boolean isSingleValued, int maxNumberOfMultiValues, ChunkCompressionType expectedCompressionType,
-      boolean forwardIndexDisabled, DataType dataType, int totalNumberOfEntries)
+  private void validateIndex(String column, List<ColumnIndexType> indexTypes, boolean forwardIndexDisabled,
+      int cardinality, int bits, boolean isAutoGenerated, boolean hasDictionary, boolean isSorted,
+      int dictionaryElementSize, boolean isSingleValued, int maxNumberOfMultiValues,
+      ChunkCompressionType expectedCompressionType, DataType dataType, int totalNumberOfEntries)
       throws Exception {
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
     ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(column);
@@ -885,9 +713,10 @@ public class SegmentPreProcessorTest {
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
         SegmentDirectory.Reader reader = segmentDirectory1.createReader()) {
-      if (indexType != ColumnIndexType.FORWARD_INDEX || !forwardIndexDisabled) {
+      for (ColumnIndexType indexType : indexTypes) {
         assertTrue(reader.hasIndexFor(column, indexType));
       }
+      assertEquals(reader.hasIndexFor(column, ColumnIndexType.DICTIONARY), hasDictionary);
       if (isSingleValued && isSorted && forwardIndexDisabled) {
         // Disabling the forward index for sorted columns should be a no-op
         assertTrue(reader.hasIndexFor(column, ColumnIndexType.FORWARD_INDEX));
@@ -904,37 +733,16 @@ public class SegmentPreProcessorTest {
       }
 
       // Check if the raw forward index compressionType is correct.
-      if (expectedCompressionType != null) {
-        assertFalse(hasDictionary);
-
+      if (!hasDictionary) {
+        assertNotNull(expectedCompressionType);
         try (ForwardIndexReader fwdIndexReader = LoaderUtils.getForwardIndexReader(reader, columnMetadata)) {
           ChunkCompressionType compressionType = fwdIndexReader.getCompressionType();
-          assertEquals(expectedCompressionType, compressionType, compressionType.toString());
+          assertEquals(compressionType, expectedCompressionType);
         }
-
         File inProgressFile = new File(_indexDir, column + ".fwd.inprogress");
         assertFalse(inProgressFile.exists());
-
-        String fwdIndexFileExtension;
-        if (isSingleValued) {
-          fwdIndexFileExtension = V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION;
-        } else {
-          fwdIndexFileExtension = V1Constants.Indexes.RAW_MV_FORWARD_INDEX_FILE_EXTENSION;
-        }
-        File v1FwdIndexFile = new File(_indexDir, column + fwdIndexFileExtension);
-        if (segmentMetadata.getVersion() == SegmentVersion.v3) {
-          assertFalse(v1FwdIndexFile.exists());
-        } else {
-          assertTrue(v1FwdIndexFile.exists());
-        }
-      }
-
-      // if the text index is enabled on a new column with dictionary,
-      // then dictionary should be created by the default column handler
-      if (hasDictionary) {
-        assertTrue(reader.hasIndexFor(column, ColumnIndexType.DICTIONARY));
       } else {
-        assertFalse(reader.hasIndexFor(column, ColumnIndexType.DICTIONARY));
+        assertNull(expectedCompressionType);
       }
     }
   }
@@ -952,9 +760,7 @@ public class SegmentPreProcessorTest {
   @Test
   public void testV1CreateInvertedIndices()
       throws Exception {
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-
+    constructV1Segment();
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
     assertEquals(segmentMetadata.getVersion(), SegmentVersion.v1);
 
@@ -973,8 +779,8 @@ public class SegmentPreProcessorTest {
     assertFalse(badColFile.exists());
     FileTime col7LastModifiedTime = Files.getLastModifiedTime(col7File.toPath());
 
-    // Sleep 2 seconds to prevent the same last modified time when modifying the file.
-    Thread.sleep(2000);
+    // Sleep 10ms to prevent the same last modified time when modifying the file.
+    Thread.sleep(10);
 
     // Create inverted index the first time.
     checkInvertedIndexCreation(false);
@@ -988,8 +794,8 @@ public class SegmentPreProcessorTest {
     FileTime col1LastModifiedTime = Files.getLastModifiedTime(col1File.toPath());
     FileTime col13LastModifiedTime = Files.getLastModifiedTime(col13File.toPath());
 
-    // Sleep 2 seconds to prevent the same last modified time when modifying the file.
-    Thread.sleep(2000);
+    // Sleep 10ms to prevent the same last modified time when modifying the file.
+    Thread.sleep(10);
 
     // Create inverted index the second time.
     checkInvertedIndexCreation(true);
@@ -1006,7 +812,6 @@ public class SegmentPreProcessorTest {
   public void testV3CreateInvertedIndices()
       throws Exception {
     constructV3Segment();
-
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
     assertEquals(segmentMetadata.getVersion(), SegmentVersion.v3);
 
@@ -1015,8 +820,8 @@ public class SegmentPreProcessorTest {
     FileTime lastModifiedTime = Files.getLastModifiedTime(singleFileIndex.toPath());
     long fileSize = singleFileIndex.length();
 
-    // Sleep 2 seconds to prevent the same last modified time when modifying the file.
-    Thread.sleep(2000);
+    // Sleep 10ms to prevent the same last modified time when modifying the file.
+    Thread.sleep(10);
 
     // Create inverted index the first time.
     checkInvertedIndexCreation(false);
@@ -1034,8 +839,8 @@ public class SegmentPreProcessorTest {
     long newFileSize = singleFileIndex.length();
     assertEquals(fileSize + addedLength, newFileSize);
 
-    // Sleep 2 seconds to prevent the same last modified time when modifying the file.
-    Thread.sleep(2000);
+    // Sleep 10ms to prevent the same last modified time when modifying the file.
+    Thread.sleep(10);
 
     // Create inverted index the second time.
     checkInvertedIndexCreation(true);
@@ -1065,7 +870,8 @@ public class SegmentPreProcessorTest {
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, _indexLoadingConfig, null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(getDefaultTableConfig()))) {
       processor.process();
     }
 
@@ -1083,103 +889,35 @@ public class SegmentPreProcessorTest {
   @Test
   public void testV1UpdateDefaultColumns()
       throws Exception {
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    IngestionConfig ingestionConfig = new IngestionConfig();
-    ingestionConfig.setTransformConfigs(
-        Collections.singletonList(new TransformConfig(NEW_INT_SV_DIMENSION_COLUMN_NAME, "plus(column1, 1)")));
-    _tableConfig.setIngestionConfig(ingestionConfig);
-    _indexLoadingConfig.getInvertedIndexColumns().add(NEW_COLUMN_INVERTED_INDEX);
+    constructV1Segment();
     checkUpdateDefaultColumns();
-
-    // Try to use the third schema and update default value again.
-    // For the third schema, we changed the default value for column 'newStringMVDimension' to 'notSameLength',
-    // which is not the same length as before. This should be fine for segment format v1.
-    // We added two new columns and also removed the NEW_INT_SV_DIMENSION_COLUMN_NAME from schema.
-    // NEW_INT_SV_DIMENSION_COLUMN_NAME exists before processing but removed afterwards.
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    assertNotNull(segmentMetadata.getColumnMetadataFor(NEW_INT_SV_DIMENSION_COLUMN_NAME));
-    try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
-        .load(_indexDir.toURI(),
-            new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, _indexLoadingConfig,
-            _newColumnsSchema3)) {
-      processor.process();
-    }
-
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    assertNull(segmentMetadata.getColumnMetadataFor(NEW_INT_SV_DIMENSION_COLUMN_NAME));
-
-    ColumnMetadata hllMetricMetadata = segmentMetadata.getColumnMetadataFor(NEW_HLL_BYTE_METRIC_COLUMN_NAME);
-    FieldSpec expectedHllMetricFieldSpec = _newColumnsSchema3.getFieldSpecFor(NEW_HLL_BYTE_METRIC_COLUMN_NAME);
-    assertEquals(hllMetricMetadata.getFieldSpec(), expectedHllMetricFieldSpec);
-    ByteArray expectedDefaultValue = new ByteArray((byte[]) expectedHllMetricFieldSpec.getDefaultNullValue());
-    assertEquals(hllMetricMetadata.getMinValue(), expectedDefaultValue);
-    assertEquals(hllMetricMetadata.getMaxValue(), expectedDefaultValue);
-
-    ColumnMetadata tDigestMetricMetadata = segmentMetadata.getColumnMetadataFor(NEW_TDIGEST_BYTE_METRIC_COLUMN_NAME);
-    FieldSpec expectedTDigestMetricFieldSpec = _newColumnsSchema3.getFieldSpecFor(NEW_TDIGEST_BYTE_METRIC_COLUMN_NAME);
-    assertEquals(tDigestMetricMetadata.getFieldSpec(), expectedTDigestMetricFieldSpec);
-    expectedDefaultValue = new ByteArray((byte[]) expectedTDigestMetricFieldSpec.getDefaultNullValue());
-    assertEquals(tDigestMetricMetadata.getMinValue(), expectedDefaultValue);
-    assertEquals(tDigestMetricMetadata.getMaxValue(), expectedDefaultValue);
   }
 
   @Test
   public void testV3UpdateDefaultColumns()
       throws Exception {
     constructV3Segment();
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    assertEquals(segmentMetadata.getVersion(), SegmentVersion.v3);
-
-    IngestionConfig ingestionConfig = new IngestionConfig();
-    ingestionConfig.setTransformConfigs(
-        Collections.singletonList(new TransformConfig(NEW_INT_SV_DIMENSION_COLUMN_NAME, "plus(column1, 1)")));
-    _tableConfig.setIngestionConfig(ingestionConfig);
-    _indexLoadingConfig.getInvertedIndexColumns().add(NEW_COLUMN_INVERTED_INDEX);
     checkUpdateDefaultColumns();
-
-    // Try to use the third schema and update default value again.
-    // For the third schema, we changed the default value for column 'newStringMVDimension' to 'notSameLength', which
-    // is not the same length as before. This should be fine for segment format v3 as well.
-    // We added two new columns and also removed the NEW_INT_SV_DIMENSION_COLUMN_NAME from schema.
-    // NEW_INT_SV_DIMENSION_COLUMN_NAME exists before processing but removed afterwards.
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    assertNotNull(segmentMetadata.getColumnMetadataFor(NEW_INT_SV_DIMENSION_COLUMN_NAME));
-    try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
-        .load(_indexDir.toURI(),
-            new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, _indexLoadingConfig,
-            _newColumnsSchema3)) {
-      processor.process();
-    }
-
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    assertNull(segmentMetadata.getColumnMetadataFor(NEW_INT_SV_DIMENSION_COLUMN_NAME));
-
-    ColumnMetadata hllMetricMetadata = segmentMetadata.getColumnMetadataFor(NEW_HLL_BYTE_METRIC_COLUMN_NAME);
-    FieldSpec expectedHllMetricFieldSpec = _newColumnsSchema3.getFieldSpecFor(NEW_HLL_BYTE_METRIC_COLUMN_NAME);
-    assertEquals(hllMetricMetadata.getFieldSpec(), expectedHllMetricFieldSpec);
-    ByteArray expectedDefaultValue = new ByteArray((byte[]) expectedHllMetricFieldSpec.getDefaultNullValue());
-    assertEquals(hllMetricMetadata.getMinValue(), expectedDefaultValue);
-    assertEquals(hllMetricMetadata.getMaxValue(), expectedDefaultValue);
-
-    ColumnMetadata tDigestMetricMetadata = segmentMetadata.getColumnMetadataFor(NEW_TDIGEST_BYTE_METRIC_COLUMN_NAME);
-    FieldSpec expectedTDigestMetricFieldSpec = _newColumnsSchema3.getFieldSpecFor(NEW_TDIGEST_BYTE_METRIC_COLUMN_NAME);
-    assertEquals(tDigestMetricMetadata.getFieldSpec(), expectedTDigestMetricFieldSpec);
-    expectedDefaultValue = new ByteArray((byte[]) expectedTDigestMetricFieldSpec.getDefaultNullValue());
-    assertEquals(tDigestMetricMetadata.getMinValue(), expectedDefaultValue);
-    assertEquals(tDigestMetricMetadata.getMaxValue(), expectedDefaultValue);
   }
 
   private void checkUpdateDefaultColumns()
       throws Exception {
+    TableConfig tableConfig = getDefaultTableConfig();
+    List<String> invertedIndexColumns = tableConfig.getIndexingConfig().getInvertedIndexColumns();
+    assertNotNull(invertedIndexColumns);
+    assertFalse(invertedIndexColumns.contains(NEW_COLUMN_INVERTED_INDEX));
+    invertedIndexColumns.add(NEW_COLUMN_INVERTED_INDEX);
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ingestionConfig.setTransformConfigs(
+        Collections.singletonList(new TransformConfig(NEW_INT_SV_DIMENSION_COLUMN_NAME, "plus(column1, 1)")));
+    tableConfig.setIngestionConfig(ingestionConfig);
+
     // Update default value.
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, _indexLoadingConfig,
-            _newColumnsSchema1)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchema1))) {
       processor.process();
     }
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
@@ -1277,8 +1015,8 @@ public class SegmentPreProcessorTest {
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, _indexLoadingConfig,
-            _newColumnsSchema2)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchema2))) {
       processor.process();
     }
     segmentMetadata = new SegmentMetadataImpl(_indexDir);
@@ -1293,23 +1031,56 @@ public class SegmentPreProcessorTest {
     assertEquals(columnMetadata.getMinValue(), "abcd");
     assertEquals(columnMetadata.getMaxValue(), "abcd");
     assertEquals(columnMetadata.getFieldSpec().getDefaultNullValue(), "abcd");
+
+    // Use the third schema and update default value again.
+    // For the third schema, we changed the default value for column 'newStringMVDimension' to 'notSameLength', which is
+    // not the same length as before.
+    // We added two new columns and also removed the NEW_INT_SV_DIMENSION_COLUMN_NAME from schema.
+    // NEW_INT_SV_DIMENSION_COLUMN_NAME exists before processing but removed afterwards.
+    segmentMetadata = new SegmentMetadataImpl(_indexDir);
+    assertNotNull(segmentMetadata.getColumnMetadataFor(NEW_INT_SV_DIMENSION_COLUMN_NAME));
+    try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
+        .load(_indexDir.toURI(),
+            new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchema3))) {
+      processor.process();
+    }
+
+    segmentMetadata = new SegmentMetadataImpl(_indexDir);
+    assertNull(segmentMetadata.getColumnMetadataFor(NEW_INT_SV_DIMENSION_COLUMN_NAME));
+
+    ColumnMetadata hllMetricMetadata = segmentMetadata.getColumnMetadataFor(NEW_HLL_BYTE_METRIC_COLUMN_NAME);
+    FieldSpec expectedHllMetricFieldSpec = _newColumnsSchema3.getFieldSpecFor(NEW_HLL_BYTE_METRIC_COLUMN_NAME);
+    assertEquals(hllMetricMetadata.getFieldSpec(), expectedHllMetricFieldSpec);
+    ByteArray expectedDefaultValue = new ByteArray((byte[]) expectedHllMetricFieldSpec.getDefaultNullValue());
+    assertEquals(hllMetricMetadata.getMinValue(), expectedDefaultValue);
+    assertEquals(hllMetricMetadata.getMaxValue(), expectedDefaultValue);
+
+    ColumnMetadata tDigestMetricMetadata = segmentMetadata.getColumnMetadataFor(NEW_TDIGEST_BYTE_METRIC_COLUMN_NAME);
+    FieldSpec expectedTDigestMetricFieldSpec = _newColumnsSchema3.getFieldSpecFor(NEW_TDIGEST_BYTE_METRIC_COLUMN_NAME);
+    assertEquals(tDigestMetricMetadata.getFieldSpec(), expectedTDigestMetricFieldSpec);
+    expectedDefaultValue = new ByteArray((byte[]) expectedTDigestMetricFieldSpec.getDefaultNullValue());
+    assertEquals(tDigestMetricMetadata.getMinValue(), expectedDefaultValue);
+    assertEquals(tDigestMetricMetadata.getMaxValue(), expectedDefaultValue);
   }
 
   @Test
   public void testColumnMinMaxValue()
       throws Exception {
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
+    constructV1Segment();
 
     // Remove min/max value from the metadata
     removeMinMaxValuesFromMetadataFile(_indexDir);
 
-    IndexLoadingConfig indexLoadingConfig = getDefaultIndexLoadingConfig();
-    indexLoadingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.NONE);
+    TableConfig tableConfig = getDefaultTableConfig();
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    indexingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.NONE.name());
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig, null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig))) {
       processor.process();
     }
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
@@ -1323,11 +1094,12 @@ public class SegmentPreProcessorTest {
     assertNull(metricColumnMetadata.getMinValue());
     assertNull(metricColumnMetadata.getMaxValue());
 
-    indexLoadingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.TIME);
+    indexingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.TIME.name());
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig, null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig))) {
       processor.process();
     }
     segmentMetadata = new SegmentMetadataImpl(_indexDir);
@@ -1341,11 +1113,12 @@ public class SegmentPreProcessorTest {
     assertNull(metricColumnMetadata.getMinValue());
     assertNull(metricColumnMetadata.getMaxValue());
 
-    indexLoadingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.NON_METRIC);
+    indexingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.NON_METRIC.name());
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig, null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig))) {
       processor.process();
     }
     segmentMetadata = new SegmentMetadataImpl(_indexDir);
@@ -1359,11 +1132,12 @@ public class SegmentPreProcessorTest {
     assertNull(metricColumnMetadata.getMinValue());
     assertNull(metricColumnMetadata.getMaxValue());
 
-    indexLoadingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.ALL);
+    indexingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.ALL.name());
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig, null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig))) {
       processor.process();
     }
     segmentMetadata = new SegmentMetadataImpl(_indexDir);
@@ -1381,21 +1155,17 @@ public class SegmentPreProcessorTest {
   @Test
   public void testV1CleanupIndices()
       throws Exception {
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    assertEquals(segmentMetadata.getVersion(), SegmentVersion.v1);
+    constructV1Segment();
 
     // Need to create two default columns with Bytes and JSON string for H3 and JSON index.
     // Other kinds of indices can all be put on column3 with String values.
     String strColumn = "column3";
-    IndexLoadingConfig indexLoadingConfig = getDefaultIndexLoadingConfig();
-    indexLoadingConfig.setInvertedIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
-    indexLoadingConfig.setRangeIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
-    indexLoadingConfig.setTextIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
-    indexLoadingConfig.setFSTIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
-    indexLoadingConfig.setBloomFilterConfigs(ImmutableMap.of(strColumn, new BloomFilterConfig(0.1, 1024, true)));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
+        .setInvertedIndexColumns(Collections.singletonList(strColumn))
+        .setRangeIndexColumns(Collections.singletonList(strColumn))
+        .setBloomFilterConfigs(Collections.singletonMap(strColumn, new BloomFilterConfig(0.1, 1024, true)))
+        .setFieldConfigList(Collections.singletonList(new FieldConfig(strColumn, FieldConfig.EncodingType.DICTIONARY,
+            Arrays.asList(FieldConfig.IndexType.FST, FieldConfig.IndexType.TEXT), null, null))).build();
 
     // V1 use separate file for each column index.
     File iiFile = new File(_indexDir, strColumn + V1Constants.Indexes.BITMAP_INVERTED_INDEX_FILE_EXTENSION);
@@ -1414,7 +1184,8 @@ public class SegmentPreProcessorTest {
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig, null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig))) {
       processor.process();
     }
     assertTrue(iiFile.exists());
@@ -1427,8 +1198,8 @@ public class SegmentPreProcessorTest {
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, getDefaultIndexLoadingConfig(),
-            null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(getDefaultTableConfig()))) {
       processor.process();
     }
     assertFalse(iiFile.exists());
@@ -1442,21 +1213,19 @@ public class SegmentPreProcessorTest {
   public void testV3CleanupIndices()
       throws Exception {
     constructV3Segment();
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    assertEquals(segmentMetadata.getVersion(), SegmentVersion.v3);
 
     // V3 use single file for all column indices.
     File segmentDirectoryPath = SegmentDirectoryPaths.segmentDirectoryFor(_indexDir, SegmentVersion.v3);
     File singleFileIndex = new File(segmentDirectoryPath, "columns.psf");
 
     // There are a few indices initially. Remove them to prepare an initial state.
+    TableConfig tableConfigNoIndex = getTableConfigNoIndex();
     long initFileSize = singleFileIndex.length();
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, getDefaultIndexLoadingConfig(),
-            null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfigNoIndex))) {
       processor.process();
     }
     assertTrue(singleFileIndex.length() < initFileSize);
@@ -1465,18 +1234,19 @@ public class SegmentPreProcessorTest {
     // Need to create two default columns with Bytes and JSON string for H3 and JSON index.
     // Other kinds of indices can all be put on column3 with String values.
     String strColumn = "column3";
-    IndexLoadingConfig indexLoadingConfig = getDefaultIndexLoadingConfig();
-    indexLoadingConfig.setInvertedIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
-    indexLoadingConfig.setRangeIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
-    indexLoadingConfig.setTextIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
-    indexLoadingConfig.setFSTIndexColumns(new HashSet<>(Collections.singletonList(strColumn)));
-    indexLoadingConfig.setBloomFilterConfigs(ImmutableMap.of(strColumn, new BloomFilterConfig(0.1, 1024, true)));
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
+        .setInvertedIndexColumns(Collections.singletonList(strColumn))
+        .setRangeIndexColumns(Collections.singletonList(strColumn))
+        .setBloomFilterConfigs(Collections.singletonMap(strColumn, new BloomFilterConfig(0.1, 1024, true)))
+        .setFieldConfigList(Collections.singletonList(new FieldConfig(strColumn, FieldConfig.EncodingType.DICTIONARY,
+            Arrays.asList(FieldConfig.IndexType.FST, FieldConfig.IndexType.TEXT), null, null))).build();
 
     // Create all kinds of indices.
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig, null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig))) {
       processor.process();
     }
 
@@ -1497,49 +1267,35 @@ public class SegmentPreProcessorTest {
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, getDefaultIndexLoadingConfig(),
-            null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfigNoIndex))) {
       processor.process();
     }
     assertEquals(singleFileIndex.length(), initFileSize);
   }
 
   @Test
-  public void testV1CleanupH3AndTextIndices()
+  public void testV1CleanupH3AndJsonIndices()
       throws Exception {
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-
-    // Remove all indices and add the two derived columns for H3 and Json index.
-    try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
-        .load(_indexDir.toURI(),
-            new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, getDefaultIndexLoadingConfig(),
-            _newColumnsSchemaWithH3Json)) {
-      processor.process();
-    }
-
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    assertNotNull(segmentMetadata.getColumnMetadataFor("newH3Col"));
-    assertNotNull(segmentMetadata.getColumnMetadataFor("newJsonCol"));
-
-    _indexLoadingConfig = getDefaultIndexLoadingConfig();
-    _indexLoadingConfig.setH3IndexConfigs(
-        ImmutableMap.of("newH3Col", new H3IndexConfig(ImmutableMap.of("resolutions", "5"))));
-    _indexLoadingConfig.setJsonIndexColumns(new HashSet<>(Collections.singletonList("newJsonCol")));
+    constructV1Segment();
 
     // V1 use separate file for each column index.
     File h3File = new File(_indexDir, "newH3Col" + V1Constants.Indexes.H3_INDEX_FILE_EXTENSION);
     File jsFile = new File(_indexDir, "newJsonCol" + V1Constants.Indexes.JSON_INDEX_FILE_EXTENSION);
-
     assertFalse(h3File.exists());
     assertFalse(jsFile.exists());
 
     // Create H3 and Json indices.
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
+        .setJsonIndexColumns(Collections.singletonList("newJsonCol")).setFieldConfigList(Collections.singletonList(
+            new FieldConfig("newH3Col", FieldConfig.EncodingType.DICTIONARY,
+                Collections.singletonList(FieldConfig.IndexType.H3), null,
+                Collections.singletonMap("resolutions", "5")))).build();
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, _indexLoadingConfig, null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchemaWithH3Json))) {
       processor.process();
     }
     assertTrue(h3File.exists());
@@ -1549,8 +1305,8 @@ public class SegmentPreProcessorTest {
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, getDefaultIndexLoadingConfig(),
-            null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(getDefaultTableConfig(), _newColumnsSchemaWithH3Json))) {
       processor.process();
     }
     assertFalse(h3File.exists());
@@ -1561,8 +1317,6 @@ public class SegmentPreProcessorTest {
   public void testV3CleanupH3AndTextIndices()
       throws Exception {
     constructV3Segment();
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    assertEquals(segmentMetadata.getVersion(), SegmentVersion.v3);
 
     // V3 use single file for all column indices.
     File segmentDirectoryPath = SegmentDirectoryPaths.segmentDirectoryFor(_indexDir, SegmentVersion.v3);
@@ -1570,28 +1324,30 @@ public class SegmentPreProcessorTest {
 
     // There are a few indices initially. Remove them to prepare an initial state.
     // Also use the schema with columns for H3 and Json index to add those columns.
+    TableConfig tableConfigNoIndex = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build();
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, getDefaultIndexLoadingConfig(),
-            _newColumnsSchemaWithH3Json)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfigNoIndex, _newColumnsSchemaWithH3Json))) {
       processor.process();
     }
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
+    SegmentMetadata segmentMetadata = new SegmentMetadataImpl(_indexDir);
     assertNotNull(segmentMetadata.getColumnMetadataFor("newH3Col"));
     assertNotNull(segmentMetadata.getColumnMetadataFor("newJsonCol"));
     long initFileSize = singleFileIndex.length();
 
-    IndexLoadingConfig indexLoadingConfig = getDefaultIndexLoadingConfig();
-    indexLoadingConfig.setH3IndexConfigs(
-        ImmutableMap.of("newH3Col", new H3IndexConfig(ImmutableMap.of("resolutions", "5"))));
-    indexLoadingConfig.setJsonIndexColumns(new HashSet<>(Collections.singletonList("newJsonCol")));
-
     // Create H3 and Json indices.
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
+        .setJsonIndexColumns(Collections.singletonList("newJsonCol")).setFieldConfigList(Collections.singletonList(
+            new FieldConfig("newH3Col", FieldConfig.EncodingType.DICTIONARY,
+                Collections.singletonList(FieldConfig.IndexType.H3), null,
+                Collections.singletonMap("resolutions", "5")))).build();
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig, null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchemaWithH3Json))) {
       processor.process();
     }
 
@@ -1609,8 +1365,8 @@ public class SegmentPreProcessorTest {
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, getDefaultIndexLoadingConfig(),
-            null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfigNoIndex, _newColumnsSchemaWithH3Json))) {
       processor.process();
     }
     assertEquals(singleFileIndex.length(), initFileSize);
@@ -1619,11 +1375,7 @@ public class SegmentPreProcessorTest {
   @Test
   public void testV1IfNeedProcess()
       throws Exception {
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    assertEquals(segmentMetadata.getVersion(), SegmentVersion.v1);
-
+    constructV1Segment();
     testIfNeedProcess();
   }
 
@@ -1631,32 +1383,18 @@ public class SegmentPreProcessorTest {
   public void testV3IfNeedProcess()
       throws Exception {
     constructV3Segment();
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    assertEquals(segmentMetadata.getVersion(), SegmentVersion.v3);
-
-    testIfNeedProcess();
-  }
-
-  @Test
-  public void testV3IfNeedProcessWithForwardIndexDisabledColumn()
-      throws Exception {
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.singletonList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV));
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    assertEquals(segmentMetadata.getVersion(), SegmentVersion.v3);
-
     testIfNeedProcess();
   }
 
   private void testIfNeedProcess()
       throws Exception {
-    // There are a few indices initially. Require to remove them with an empty IndexLoadingConfig.
+    // There are a few indices initially. Remove them to prepare an initial state.
+    TableConfig tableConfigNoIndex = getTableConfigNoIndex();
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, getDefaultIndexLoadingConfig(),
-            null)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfigNoIndex))) {
       assertTrue(processor.needProcess());
       processor.process();
       assertFalse(processor.needProcess());
@@ -1666,38 +1404,38 @@ public class SegmentPreProcessorTest {
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, getDefaultIndexLoadingConfig(),
-            _newColumnsSchemaWithH3Json)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfigNoIndex, _newColumnsSchemaWithH3Json))) {
       assertTrue(processor.needProcess());
       processor.process();
       assertFalse(processor.needProcess());
     }
 
     // No preprocessing needed if required to add certain index on non-existing, sorted or non-dictionary column.
-    for (Map.Entry<String, Consumer<IndexLoadingConfig>> entry : createConfigPrepFunctionNeedNoops().entrySet()) {
+    for (Map.Entry<String, Consumer<TableConfig>> entry : createConfigPrepFunctionNeedNoops().entrySet()) {
       String testCase = entry.getKey();
-      IndexLoadingConfig config = getDefaultIndexLoadingConfig();
-      entry.getValue().accept(config);
+      TableConfig tableConfig = getTableConfigNoIndex();
+      entry.getValue().accept(tableConfig);
       try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
           .load(_indexDir.toURI(),
               new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-          SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, config,
-              _newColumnsSchemaWithH3Json)) {
+          SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+              new IndexLoadingConfig(tableConfig, _newColumnsSchemaWithH3Json))) {
         assertFalse(processor.needProcess(), testCase);
       }
     }
 
     // Require to add different types of indices. Add one new index a time
     // to test the index handlers separately.
-    IndexLoadingConfig config = getDefaultIndexLoadingConfig();
-    for (Map.Entry<String, Consumer<IndexLoadingConfig>> entry : createConfigPrepFunctions().entrySet()) {
+    TableConfig tableConfig = getTableConfigNoIndex();
+    for (Map.Entry<String, Consumer<TableConfig>> entry : createConfigPrepFunctions().entrySet()) {
       String testCase = entry.getKey();
-      entry.getValue().accept(config);
+      entry.getValue().accept(tableConfig);
       try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
           .load(_indexDir.toURI(),
               new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-          SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, config,
-              _newColumnsSchemaWithH3Json)) {
+          SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+              new IndexLoadingConfig(tableConfig, _newColumnsSchemaWithH3Json))) {
         assertTrue(processor.needProcess(), testCase);
         processor.process();
         assertFalse(processor.needProcess(), testCase);
@@ -1705,21 +1443,14 @@ public class SegmentPreProcessorTest {
     }
 
     // Require to add startree index.
-    IndexingConfig indexingConfig = new IndexingConfig();
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
     indexingConfig.setEnableDynamicStarTreeCreation(true);
     indexingConfig.setEnableDefaultStarTree(true);
-    _tableConfig.setIndexingConfig(indexingConfig);
-    IndexLoadingConfig configWithStarTreeIndex = new IndexLoadingConfig(null, _tableConfig);
-    // Set RAW columns. Otherwise, they will end up being converted to dict columns (default) during segment reload.
-    configWithStarTreeIndex.getNoDictionaryColumns().add(EXISTING_STRING_COL_RAW);
-    configWithStarTreeIndex.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW_MV);
-    configWithStarTreeIndex.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW);
-    createConfigPrepFunctions().forEach((k, v) -> v.accept(configWithStarTreeIndex));
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, configWithStarTreeIndex,
-            _newColumnsSchemaWithH3Json)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchemaWithH3Json))) {
       assertTrue(processor.needProcess());
       processor.process();
       assertFalse(processor.needProcess());
@@ -1735,8 +1466,8 @@ public class SegmentPreProcessorTest {
     try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(_indexDir.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, configWithStarTreeIndex,
-            _newColumnsSchemaWithH3Json)) {
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchemaWithH3Json))) {
       assertTrue(processor.needProcess());
       processor.process();
     }
@@ -1755,7 +1486,6 @@ public class SegmentPreProcessorTest {
   @Test
   public void testNeedAddMinMaxValue()
       throws Exception {
-
     String[] stringValuesInvalid = {"A,", "B,", "C,", "D,", "E"};
     String[] stringValuesValid = {"A", "B", "C", "D", "E"};
     long[] longValues = {1588316400000L, 1588489200000L, 1588662000000L, 1588834800000L, 1589007600000L};
@@ -1763,43 +1493,39 @@ public class SegmentPreProcessorTest {
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("stringCol", FieldSpec.DataType.STRING)
         .addMetric("longCol", FieldSpec.DataType.LONG).build();
 
-    FileUtils.deleteQuietly(INDEX_DIR);
-
     // build good segment, no needPreprocess
     File segment = buildTestSegmentForMinMax(tableConfig, schema, "validSegment", stringValuesValid, longValues);
     SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
         .load(segment.toURI(),
             new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-    IndexLoadingConfig indexLoadingConfig = getDefaultIndexLoadingConfig();
-    indexLoadingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.ALL);
-    SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig, schema);
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    indexingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.ALL.name());
+    SegmentPreProcessor processor =
+        new SegmentPreProcessor(segmentDirectory, new IndexLoadingConfig(tableConfig, schema));
     assertFalse(processor.needProcess());
+    FileUtils.deleteQuietly(INDEX_DIR);
 
     // build bad segment, still no needPreprocess, since minMaxInvalid flag should be set
-    FileUtils.deleteQuietly(INDEX_DIR);
     segment = buildTestSegmentForMinMax(tableConfig, schema, "invalidSegment", stringValuesInvalid, longValues);
     segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader().load(segment.toURI(),
         new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-    indexLoadingConfig = getDefaultIndexLoadingConfig();
-    indexLoadingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.NONE);
-    processor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig, schema);
+    indexingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.NONE.name());
+    processor = new SegmentPreProcessor(segmentDirectory, new IndexLoadingConfig(tableConfig, schema));
     assertFalse(processor.needProcess());
 
-    indexLoadingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.ALL);
-    processor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig, schema);
+    indexingConfig.setColumnMinMaxValueGeneratorMode(ColumnMinMaxValueGeneratorMode.ALL.name());
+    processor = new SegmentPreProcessor(segmentDirectory, new IndexLoadingConfig(tableConfig, schema));
     assertFalse(processor.needProcess());
 
     // modify metadata, to remove min/max, now needPreprocess
     removeMinMaxValuesFromMetadataFile(segment);
     segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader().load(segment.toURI(),
         new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
-    processor = new SegmentPreProcessor(segmentDirectory, indexLoadingConfig, schema);
+    processor = new SegmentPreProcessor(segmentDirectory, new IndexLoadingConfig(tableConfig, schema));
     assertTrue(processor.needProcess());
-
-    FileUtils.deleteQuietly(INDEX_DIR);
   }
 
-  private File buildTestSegmentForMinMax(final TableConfig tableConfig, final Schema schema, String segmentName,
+  private File buildTestSegmentForMinMax(TableConfig tableConfig, Schema schema, String segmentName,
       String[] stringValues, long[] longValues)
       throws Exception {
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
@@ -1835,52 +1561,58 @@ public class SegmentPreProcessorTest {
     SegmentMetadataUtils.savePropertiesConfiguration(configuration);
   }
 
-  private static Map<String, Consumer<IndexLoadingConfig>> createConfigPrepFunctions() {
-    Map<String, Consumer<IndexLoadingConfig>> testCases = new HashMap<>();
-    testCases.put("addInvertedIndex", (IndexLoadingConfig config) -> config.setInvertedIndexColumns(
-        new HashSet<>(Collections.singletonList("column3"))));
-    testCases.put("addRangeIndex", (IndexLoadingConfig config) -> config.setRangeIndexColumns(
-        new HashSet<>(Collections.singletonList("column3"))));
-    testCases.put("addTextIndex",
-        (IndexLoadingConfig config) -> config.setTextIndexColumns(new HashSet<>(Collections.singletonList("column3"))));
-    testCases.put("addFSTIndex",
-        (IndexLoadingConfig config) -> config.setFSTIndexColumns(new HashSet<>(Collections.singletonList("column3"))));
-    testCases.put("addBloomFilter", (IndexLoadingConfig config) -> config.setBloomFilterConfigs(
-        ImmutableMap.of("column3", new BloomFilterConfig(0.1, 1024, true))));
-    testCases.put("addH3Index", (IndexLoadingConfig config) -> config.setH3IndexConfigs(
-        ImmutableMap.of("newH3Col", new H3IndexConfig(ImmutableMap.of("resolutions", "5")))));
-    testCases.put("addJsonIndex", (IndexLoadingConfig config) -> config.setJsonIndexColumns(
-        new HashSet<>(Collections.singletonList("newJsonCol"))));
+  private static Map<String, Consumer<TableConfig>> createConfigPrepFunctions() {
+    Map<String, Consumer<TableConfig>> testCases = new HashMap<>();
+    testCases.put("addInvertedIndex", (TableConfig config) -> config.getIndexingConfig()
+        .setInvertedIndexColumns(Collections.singletonList("column3")));
+    testCases.put("addRangeIndex",
+        (TableConfig config) -> config.getIndexingConfig().setRangeIndexColumns(Collections.singletonList("column3")));
+    testCases.put("addTextIndex", (TableConfig config) -> config.setFieldConfigList(Collections.singletonList(
+        new FieldConfig("column3", FieldConfig.EncodingType.DICTIONARY,
+            Collections.singletonList(FieldConfig.IndexType.TEXT), null, null))));
+    testCases.put("addFSTIndex", (TableConfig config) -> config.setFieldConfigList(Collections.singletonList(
+        new FieldConfig("column3", FieldConfig.EncodingType.DICTIONARY,
+            Collections.singletonList(FieldConfig.IndexType.FST), null, null))));
+    testCases.put("addBloomFilter", (TableConfig config) -> config.getIndexingConfig()
+        .setBloomFilterConfigs(Collections.singletonMap("column3", new BloomFilterConfig(0.1, 1024, true))));
+    testCases.put("addH3Index", (TableConfig config) -> config.setFieldConfigList(Collections.singletonList(
+        new FieldConfig("newH3Col", FieldConfig.EncodingType.DICTIONARY,
+            Collections.singletonList(FieldConfig.IndexType.H3), null, Collections.singletonMap("resolutions", "5")))));
+    testCases.put("addJsonIndex", (TableConfig config) -> config.getIndexingConfig()
+        .setJsonIndexColumns(Collections.singletonList("newJsonCol")));
     return testCases;
   }
 
-  private static Map<String, Consumer<IndexLoadingConfig>> createConfigPrepFunctionNeedNoops() {
-    Map<String, Consumer<IndexLoadingConfig>> testCases = new HashMap<>();
+  private static Map<String, Consumer<TableConfig>> createConfigPrepFunctionNeedNoops() {
+    Map<String, Consumer<TableConfig>> testCases = new HashMap<>();
     // daysSinceEpoch is a sorted column, thus inverted index and range index skip it.
-    testCases.put("addInvertedIndexOnSortedColumn", (IndexLoadingConfig config) -> config.setInvertedIndexColumns(
-        new HashSet<>(Collections.singletonList("daysSinceEpoch"))));
-    testCases.put("addRangeIndexOnSortedColumn", (IndexLoadingConfig config) -> config.setRangeIndexColumns(
-        new HashSet<>(Collections.singletonList("daysSinceEpoch"))));
+    testCases.put("addInvertedIndexOnSortedColumn", (TableConfig config) -> config.getIndexingConfig()
+        .setInvertedIndexColumns(Collections.singletonList("daysSinceEpoch")));
+    testCases.put("addRangeIndexOnSortedColumn", (TableConfig config) -> config.getIndexingConfig()
+        .setRangeIndexColumns(Collections.singletonList("daysSinceEpoch")));
     // column4 is unsorted non-dictionary encoded column, so inverted index and bloom filter skip it.
     // In fact, the validation logic when updating index configs already blocks this to happen.
-    testCases.put("addInvertedIndexOnNonDictColumn", (IndexLoadingConfig config) -> config.setInvertedIndexColumns(
-        new HashSet<>(Collections.singletonList("column4"))));
+    testCases.put("addInvertedIndexOnNonDictColumn", (TableConfig config) -> config.getIndexingConfig()
+        .setInvertedIndexColumns(Collections.singletonList("column4")));
     // No index is added on non-existing columns.
     // The validation logic when updating index configs already blocks this to happen.
-    testCases.put("addInvertedIndexOnAbsentColumn", (IndexLoadingConfig config) -> config.setInvertedIndexColumns(
-        new HashSet<>(Collections.singletonList("newColumnX"))));
-    testCases.put("addRangeIndexOnAbsentColumn", (IndexLoadingConfig config) -> config.setRangeIndexColumns(
-        new HashSet<>(Collections.singletonList("newColumnX"))));
-    testCases.put("addTextIndexOnAbsentColumn", (IndexLoadingConfig config) -> config.setTextIndexColumns(
-        new HashSet<>(Collections.singletonList("newColumnX"))));
-    testCases.put("addFSTIndexOnAbsentColumn", (IndexLoadingConfig config) -> config.setFSTIndexColumns(
-        new HashSet<>(Collections.singletonList("newColumnX"))));
-    testCases.put("addBloomFilterOnAbsentColumn", (IndexLoadingConfig config) -> config.setBloomFilterConfigs(
-        ImmutableMap.of("newColumnX", new BloomFilterConfig(0.1, 1024, true))));
-    testCases.put("addH3IndexOnAbsentColumn", (IndexLoadingConfig config) -> config.setH3IndexConfigs(
-        ImmutableMap.of("newColumnX", new H3IndexConfig(ImmutableMap.of("resolutions", "5")))));
-    testCases.put("addJsonIndexOnAbsentColumn", (IndexLoadingConfig config) -> config.setJsonIndexColumns(
-        new HashSet<>(Collections.singletonList("newColumnX"))));
+    testCases.put("addInvertedIndexOnAbsentColumn", (TableConfig config) -> config.getIndexingConfig()
+        .setInvertedIndexColumns(Collections.singletonList("newColumnX")));
+    testCases.put("addRangeIndexOnAbsentColumn", (TableConfig config) -> config.getIndexingConfig()
+        .setRangeIndexColumns(Collections.singletonList("newColumnX")));
+    testCases.put("addTextIndexOnAbsentColumn", (TableConfig config) -> config.setFieldConfigList(
+        Collections.singletonList(new FieldConfig("newColumnX", FieldConfig.EncodingType.DICTIONARY,
+            Collections.singletonList(FieldConfig.IndexType.TEXT), null, null))));
+    testCases.put("addFSTIndexOnAbsentColumn", (TableConfig config) -> config.setFieldConfigList(
+        Collections.singletonList(new FieldConfig("newColumnX", FieldConfig.EncodingType.DICTIONARY,
+            Collections.singletonList(FieldConfig.IndexType.FST), null, null))));
+    testCases.put("addBloomFilterOnAbsentColumn", (TableConfig config) -> config.getIndexingConfig()
+        .setBloomFilterConfigs(Collections.singletonMap("newColumnX", new BloomFilterConfig(0.1, 1024, true))));
+    testCases.put("addH3IndexOnAbsentColumn", (TableConfig config) -> config.setFieldConfigList(
+        Collections.singletonList(new FieldConfig("newColumnX", FieldConfig.EncodingType.DICTIONARY,
+            Collections.singletonList(FieldConfig.IndexType.H3), null, Collections.singletonMap("resolutions", "5")))));
+    testCases.put("addJsonIndexOnAbsentColumn", (TableConfig config) -> config.getIndexingConfig()
+        .setJsonIndexColumns(Collections.singletonList("newColumnX")));
     return testCases;
   }
 
@@ -1890,15 +1622,19 @@ public class SegmentPreProcessorTest {
   @Test
   public void testForwardIndexDisabledOnNewColumnsSV()
       throws Exception {
-    Set<String> forwardIndexDisabledColumns = new HashSet<>();
-    forwardIndexDisabledColumns.add(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV);
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    Set<String> invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-    _indexLoadingConfig.setInvertedIndexColumns(invertedIndexColumns);
+    TableConfig tableConfig = getDefaultTableConfig();
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    List<String> invertedIndexColumns = indexingConfig.getInvertedIndexColumns();
+    assertNotNull(invertedIndexColumns);
+    assertFalse(invertedIndexColumns.contains(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV));
+    invertedIndexColumns.add(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV);
+    tableConfig.setFieldConfigList(Collections.singletonList(
+        new FieldConfig(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV, FieldConfig.EncodingType.DICTIONARY,
+            Collections.singletonList(FieldConfig.IndexType.INVERTED), null,
+            Collections.singletonMap(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.toString(true)))));
 
-    // Create a segment in V3, add a new column with no forward index enabled
-    constructV3Segment();
+    // Create a segment in V1, add a new column with no forward index enabled
+    constructV1Segment();
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
     ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV);
     // should be null since column does not exist in the schema
@@ -1906,12 +1642,12 @@ public class SegmentPreProcessorTest {
 
     // Forward index is always going to be present for default SV columns with forward index disabled. This is because
     // such default columns are going to be sorted and the forwardIndexDisabled flag is a no-op for sorted columns
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV, 1, 1,
-        _newColumnsSchemaWithForwardIndexDisabled, true, true, true, 4, true, 0, null, true, DataType.STRING, 100000);
+    createAndValidateIndex(tableConfig, _newColumnsSchemaWithForwardIndexDisabled,
+        NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV, Collections.emptyList(), false, 1, 1, true, true, true, 4, true, 0,
+        null, DataType.STRING, 100000);
 
-    // Create a segment in V1, add a column with no forward index enabled
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
+    // Create a segment in V3, add a column with no forward index enabled
+    constructV3Segment();
     segmentMetadata = new SegmentMetadataImpl(_indexDir);
     columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV);
     // should be null since column does not exist in the schema
@@ -1919,12 +1655,34 @@ public class SegmentPreProcessorTest {
 
     // Forward index is always going to be present for default SV columns with forward index disabled. This is because
     // such default columns are going to be sorted and the forwardIndexDisabled flag is a no-op for sorted columns
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV, 1, 1,
-        _newColumnsSchemaWithForwardIndexDisabled, true, true, true, 4, true, 0, null, true, DataType.STRING, 100000);
+    createAndValidateIndex(tableConfig, _newColumnsSchemaWithForwardIndexDisabled,
+        NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV, Collections.emptyList(), false, 1, 1, true, true, true, 4, true, 0,
+        null, DataType.STRING, 100000);
 
     // Add the column to the no dictionary column list
-    Set<String> existingNoDictionaryColumns = _indexLoadingConfig.getNoDictionaryColumns();
-    _indexLoadingConfig.setNoDictionaryColumns(forwardIndexDisabledColumns);
+    List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    assertFalse(noDictionaryColumns.contains(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV));
+    noDictionaryColumns.add(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV);
+
+    // Create a segment in v1, add a new column with no forward index enabled
+    constructV1Segment();
+    segmentMetadata = new SegmentMetadataImpl(_indexDir);
+    columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV);
+    // should be null since column does not exist in the schema
+    assertNull(columnMetadata);
+
+    try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
+        .load(_indexDir.toURI(),
+            new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchemaWithForwardIndexDisabled))) {
+      processor.process();
+      fail("Forward index cannot be disabled for dictionary disabled columns!");
+    } catch (IllegalStateException e) {
+      assertEquals(e.getMessage(),
+          "Dictionary disabled column: newForwardIndexDisabledColumnSV cannot disable the forward index");
+    }
 
     // Create a segment in V3, add a new column with no forward index enabled
     constructV3Segment();
@@ -1933,39 +1691,36 @@ public class SegmentPreProcessorTest {
     // should be null since column does not exist in the schema
     assertNull(columnMetadata);
 
-    try {
-      createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV, 1, 1,
-          _newColumnsSchemaWithForwardIndexDisabled, true, true, false, 4, false, 1, null, false, DataType.STRING,
-          100000);
-      Assert.fail("Forward index cannot be disabled for dictionary disabled columns!");
+    try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
+        .load(_indexDir.toURI(),
+            new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchemaWithForwardIndexDisabled))) {
+      processor.process();
+      fail("Forward index cannot be disabled for dictionary disabled columns!");
     } catch (IllegalStateException e) {
-      assertEquals(e.getMessage(), "Dictionary disabled column: newForwardIndexDisabledColumnSV cannot disable the "
-          + "forward index");
-    }
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV);
-    // should be null since column does not exist in the schema
-    assertNull(columnMetadata);
-
-    try {
-      createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV, 1, 1,
-          _newColumnsSchemaWithForwardIndexDisabled, true, true, false, 4, false, 1, null, false, DataType.STRING,
-          100000);
-      Assert.fail("Forward index cannot be disabled for dictionary disabled columns!");
-    } catch (IllegalStateException e) {
-      assertEquals(e.getMessage(), "Dictionary disabled column: newForwardIndexDisabledColumnSV cannot disable the "
-          + "forward index");
+      assertEquals(e.getMessage(),
+          "Dictionary disabled column: newForwardIndexDisabledColumnSV cannot disable the forward index");
     }
 
     // Reset the no dictionary columns
-    _indexLoadingConfig.setNoDictionaryColumns(existingNoDictionaryColumns);
+    assertTrue(noDictionaryColumns.remove(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV));
 
     // Add the column to the sorted list
-    List<String> existingSortedColumns = _indexLoadingConfig.getSortedColumns();
-    _indexLoadingConfig.setSortedColumn(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV);
+    indexingConfig.setSortedColumn(Collections.singletonList(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV));
+
+    // Create a segment in V1, add a new column with no forward index enabled
+    constructV1Segment();
+    segmentMetadata = new SegmentMetadataImpl(_indexDir);
+    columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV);
+    // should be null since column does not exist in the schema
+    assertNull(columnMetadata);
+
+    // Column should be sorted and should be created successfully since for SV columns the forwardIndexDisabled flag
+    // is a no-op
+    createAndValidateIndex(tableConfig, _newColumnsSchemaWithForwardIndexDisabled,
+        NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV, Collections.emptyList(), false, 1, 1, true, true, true, 4, true, 0,
+        null, DataType.STRING, 100000);
 
     // Create a segment in V3, add a new column with no forward index enabled
     constructV3Segment();
@@ -1976,64 +1731,51 @@ public class SegmentPreProcessorTest {
 
     // Column should be sorted and should be created successfully since for SV columns the forwardIndexDisabled flag
     // is a no-op
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX,
-        NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV, 1, 1, _newColumnsSchemaWithForwardIndexDisabled, true, true, true,
-        4, true, 0, null, false, DataType.STRING, 100000);
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV);
-    // should be null since column does not exist in the schema
-    assertNull(columnMetadata);
-
-    // Column should be sorted and should be created successfully since for SV columns the forwardIndexDisabled flag
-    // is a no-op
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV, 1, 1,
-        _newColumnsSchemaWithForwardIndexDisabled, true, true, true, 4, true, 0, null, false, DataType.STRING, 100000);
+    createAndValidateIndex(tableConfig, _newColumnsSchemaWithForwardIndexDisabled,
+        NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV, Collections.emptyList(), false, 1, 1, true, true, true, 4, true, 0,
+        null, DataType.STRING, 100000);
 
     // Reset the sorted column list
-    _indexLoadingConfig.setSortedColumn(existingSortedColumns.isEmpty() ? null : existingSortedColumns.get(0));
+    indexingConfig.setSortedColumn(null);
 
     // Remove the column from the inverted index column list and validate that it fails
-    invertedIndexColumns.removeAll(forwardIndexDisabledColumns);
-    _indexLoadingConfig.setInvertedIndexColumns(invertedIndexColumns);
+    assertTrue(invertedIndexColumns.remove(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV));
 
-    // Create a segment in V3, add a new column with no forward index enabled
+    constructV1Segment();
+    segmentMetadata = new SegmentMetadataImpl(_indexDir);
+    columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV);
+    // should be null since column does not exist in the schema
+    assertNull(columnMetadata);
+
+    try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
+        .load(_indexDir.toURI(),
+            new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchemaWithForwardIndexDisabled))) {
+      processor.process();
+      fail("Should not be able to disable forward index without inverted index for column");
+    } catch (IllegalStateException e) {
+      assertEquals(e.getMessage(),
+          "Inverted index must be enabled for forward index disabled column: newForwardIndexDisabledColumnSV");
+    }
+
     constructV3Segment();
     segmentMetadata = new SegmentMetadataImpl(_indexDir);
     columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV);
     // should be null since column does not exist in the schema
     assertNull(columnMetadata);
 
-    try {
-      createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV, 1, 1,
-          _newColumnsSchemaWithForwardIndexDisabled, true, true, true, 4, true, 0, null, false, DataType.STRING,
-          100000);
-      Assert.fail("Forward index cannot be disabled without enabling the inverted index!");
+    try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
+        .load(_indexDir.toURI(),
+            new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchemaWithForwardIndexDisabled))) {
+      processor.process();
+      fail("Forward index cannot be disabled without enabling the inverted index!");
     } catch (IllegalStateException e) {
-      assertEquals(e.getMessage(), "Inverted index must be enabled for forward index disabled column: "
-          + "newForwardIndexDisabledColumnSV");
+      assertEquals(e.getMessage(),
+          "Inverted index must be enabled for forward index disabled column: newForwardIndexDisabledColumnSV");
     }
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV);
-    // should be null since column does not exist in the schema
-    assertNull(columnMetadata);
-
-    try {
-      createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_SV, 1, 1,
-          _newColumnsSchemaWithForwardIndexDisabled, true, true, true, 4, true, 0, null, false, DataType.STRING,
-          100000);
-      Assert.fail("Should not be able to disable forward index without inverted index for column");
-    } catch (IllegalStateException e) {
-      assertEquals(e.getMessage(), "Inverted index must be enabled for forward index disabled column: "
-          + "newForwardIndexDisabledColumnSV");
-    }
-
-    _indexLoadingConfig.setForwardIndexDisabledColumns(new HashSet<>());
   }
 
   /**
@@ -2042,43 +1784,67 @@ public class SegmentPreProcessorTest {
   @Test
   public void testForwardIndexDisabledOnNewColumnsMV()
       throws Exception {
-    Set<String> forwardIndexDisabledColumns = new HashSet<>();
-    forwardIndexDisabledColumns.add(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV);
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    Set<String> invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-    _indexLoadingConfig.setInvertedIndexColumns(invertedIndexColumns);
+    TableConfig tableConfig = getDefaultTableConfig();
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    List<String> invertedIndexColumns = indexingConfig.getInvertedIndexColumns();
+    assertNotNull(invertedIndexColumns);
+    assertFalse(invertedIndexColumns.contains(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV));
+    invertedIndexColumns.add(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV);
+    tableConfig.setFieldConfigList(Collections.singletonList(
+        new FieldConfig(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV, FieldConfig.EncodingType.DICTIONARY,
+            Collections.singletonList(FieldConfig.IndexType.INVERTED), null,
+            Collections.singletonMap(FieldConfig.FORWARD_INDEX_DISABLED, Boolean.toString(true)))));
 
-    // Create a segment in V3, add a new column with no forward index enabled
-    constructV3Segment();
+    // Create a segment in V1, add a new column with no forward index enabled
+    constructV1Segment();
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
     ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV);
     // should be null since column does not exist in the schema
     assertNull(columnMetadata);
 
-    // Validate that the forward index doesn't exist and that inverted index does exist
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV, 1, 1,
-        _newColumnsSchemaWithForwardIndexDisabled, true, true, false, 4, false, 1, null, true, DataType.STRING, 100000);
-    createAndValidateIndex(ColumnIndexType.INVERTED_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV, 1, 1,
-        _newColumnsSchemaWithForwardIndexDisabled, true, true, false, 4, false, 1, null, true, DataType.STRING, 100000);
+    // Forward index is always going to be present for default SV columns with forward index disabled. This is because
+    // such default columns are going to be sorted and the forwardIndexDisabled flag is a no-op for sorted columns
+    createAndValidateIndex(tableConfig, _newColumnsSchemaWithForwardIndexDisabled,
+        NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV, Collections.singletonList(ColumnIndexType.INVERTED_INDEX), false, 1,
+        1, true, true, false, 4, false, 1, null, DataType.STRING, 100000);
 
-    // Create a segment in V1, add a column with no forward index enabled
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
+    // Create a segment in V3, add a column with no forward index enabled
+    constructV3Segment();
     segmentMetadata = new SegmentMetadataImpl(_indexDir);
     columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV);
     // should be null since column does not exist in the schema
     assertNull(columnMetadata);
 
-    // Validate that the forward index doesn't exist and that inverted index does exist
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV, 1, 1,
-        _newColumnsSchemaWithForwardIndexDisabled, true, true, false, 4, false, 1, null, true, DataType.STRING, 100000);
-    createAndValidateIndex(ColumnIndexType.INVERTED_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV, 1, 1,
-        _newColumnsSchemaWithForwardIndexDisabled, true, true, false, 4, false, 1, null, true, DataType.STRING, 100000);
+    // Forward index is always going to be present for default SV columns with forward index disabled. This is because
+    // such default columns are going to be sorted and the forwardIndexDisabled flag is a no-op for sorted columns
+    createAndValidateIndex(tableConfig, _newColumnsSchemaWithForwardIndexDisabled,
+        NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV, Collections.singletonList(ColumnIndexType.INVERTED_INDEX), false, 1,
+        1, true, true, false, 4, false, 1, null, DataType.STRING, 100000);
 
     // Add the column to the no dictionary column list
-    Set<String> existingNoDictionaryColumns = _indexLoadingConfig.getNoDictionaryColumns();
-    _indexLoadingConfig.setNoDictionaryColumns(forwardIndexDisabledColumns);
+    List<String> noDictionaryColumns = indexingConfig.getNoDictionaryColumns();
+    assertNotNull(noDictionaryColumns);
+    assertFalse(noDictionaryColumns.contains(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV));
+    noDictionaryColumns.add(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV);
+
+    // Create a segment in v1, add a new column with no forward index enabled
+    constructV1Segment();
+    segmentMetadata = new SegmentMetadataImpl(_indexDir);
+    columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV);
+    // should be null since column does not exist in the schema
+    assertNull(columnMetadata);
+
+    try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
+        .load(_indexDir.toURI(),
+            new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchemaWithForwardIndexDisabled))) {
+      processor.process();
+      fail("Forward index cannot be disabled for dictionary disabled columns!");
+    } catch (IllegalStateException e) {
+      assertEquals(e.getMessage(),
+          "Dictionary disabled column: newForwardIndexDisabledColumnMV cannot disable the forward index");
+    }
 
     // Create a segment in V3, add a new column with no forward index enabled
     constructV3Segment();
@@ -2087,799 +1853,58 @@ public class SegmentPreProcessorTest {
     // should be null since column does not exist in the schema
     assertNull(columnMetadata);
 
-    try {
-      createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV, 1, 1,
-          _newColumnsSchemaWithForwardIndexDisabled, true, true, false, 4, false, 1, null, false, DataType.STRING,
-          100000);
-      Assert.fail("Should not be able to disable forward index for raw column");
+    try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
+        .load(_indexDir.toURI(),
+            new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchemaWithForwardIndexDisabled))) {
+      processor.process();
+      fail("Forward index cannot be disabled for dictionary disabled columns!");
     } catch (IllegalStateException e) {
-      assertEquals(e.getMessage(), "Dictionary disabled column: newForwardIndexDisabledColumnMV cannot disable the "
-          + "forward index");
-    }
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV);
-    // should be null since column does not exist in the schema
-    assertNull(columnMetadata);
-
-    try {
-      createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV, 1, 1,
-          _newColumnsSchemaWithForwardIndexDisabled, true, true, false, 4, false, 1, null, false, DataType.STRING,
-          100000);
-      Assert.fail("Should not be able to disable forward index for raw column");
-    } catch (IllegalStateException e) {
-      assertEquals(e.getMessage(), "Dictionary disabled column: newForwardIndexDisabledColumnMV cannot disable the "
-          + "forward index");
+      assertEquals(e.getMessage(),
+          "Dictionary disabled column: newForwardIndexDisabledColumnMV cannot disable the forward index");
     }
 
     // Reset the no dictionary columns
-    _indexLoadingConfig.setNoDictionaryColumns(existingNoDictionaryColumns);
+    assertTrue(noDictionaryColumns.remove(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV));
 
     // Remove the column from the inverted index column list and validate that it fails
-    invertedIndexColumns.removeAll(forwardIndexDisabledColumns);
-    _indexLoadingConfig.setInvertedIndexColumns(invertedIndexColumns);
+    assertTrue(invertedIndexColumns.remove(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV));
 
-    // Create a segment in V3, add a new column with no forward index enabled
+    constructV1Segment();
+    segmentMetadata = new SegmentMetadataImpl(_indexDir);
+    columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV);
+    // should be null since column does not exist in the schema
+    assertNull(columnMetadata);
+
+    try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
+        .load(_indexDir.toURI(),
+            new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchemaWithForwardIndexDisabled))) {
+      processor.process();
+      fail("Should not be able to disable forward index without inverted index for column");
+    } catch (IllegalStateException e) {
+      assertEquals(e.getMessage(),
+          "Inverted index must be enabled for forward index disabled column: newForwardIndexDisabledColumnMV");
+    }
+
     constructV3Segment();
     segmentMetadata = new SegmentMetadataImpl(_indexDir);
     columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV);
     // should be null since column does not exist in the schema
     assertNull(columnMetadata);
 
-    try {
-      createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV, 1, 1,
-          _newColumnsSchemaWithForwardIndexDisabled, true, true, false, 4, false, 1, null, false, DataType.STRING,
-          100000);
-      Assert.fail("Should not be able to disable forward index for raw column");
+    try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
+        .load(_indexDir.toURI(),
+            new SegmentDirectoryLoaderContext.Builder().setSegmentDirectoryConfigs(_configuration).build());
+        SegmentPreProcessor processor = new SegmentPreProcessor(segmentDirectory,
+            new IndexLoadingConfig(tableConfig, _newColumnsSchemaWithForwardIndexDisabled))) {
+      processor.process();
+      fail("Forward index cannot be disabled without enabling the inverted index!");
     } catch (IllegalStateException e) {
-      assertEquals(e.getMessage(), "Inverted index must be enabled for forward index disabled column: "
-          + "newForwardIndexDisabledColumnMV");
+      assertEquals(e.getMessage(),
+          "Inverted index must be enabled for forward index disabled column: newForwardIndexDisabledColumnMV");
     }
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV);
-    // should be null since column does not exist in the schema
-    assertNull(columnMetadata);
-
-    try {
-      createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, NEWLY_ADDED_FORWARD_INDEX_DISABLED_COL_MV, 1, 1,
-          _newColumnsSchemaWithForwardIndexDisabled, true, true, false, 4, false, 1, null, false, DataType.STRING,
-          100000);
-      Assert.fail("Should not be able to disable forward index for raw column");
-    } catch (IllegalStateException e) {
-      assertEquals(e.getMessage(), "Inverted index must be enabled for forward index disabled column: "
-          + "newForwardIndexDisabledColumnMV");
-    }
-
-    _indexLoadingConfig.setForwardIndexDisabledColumns(new HashSet<>());
-  }
-
-  /**
-   * Test to check the behavior of the forward index disabled feature
-   * when enabled on an existing dictionary encoded column
-   */
-  @Test
-  public void testForwardIndexDisabledOnExistingColumnDictEncoded()
-      throws Exception {
-    Set<String> forwardIndexDisabledColumns = new HashSet<>();
-    forwardIndexDisabledColumns.add(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    Set<String> invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-
-    constructV3Segment();
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_DICT);
-    assertNotNull(columnMetadata);
-
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, true, DataType.STRING,
-        100000);
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, true, DataType.STRING,
-        100000);
-
-    // Add the column to the noDictionaryColumns list
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_STRING_COL_DICT);
-
-    constructV3Segment();
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_DICT);
-    assertNotNull(columnMetadata);
-
-    try {
-      createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-          _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, true, DataType.STRING,
-          100000);
-    } catch (IllegalStateException e) {
-      assertEquals(e.getMessage(), "Must enable dictionary to disable the forward index for column: column5");
-    }
-
-    // Reset the noDictionaryColumns list
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_STRING_COL_DICT);
-
-    // Remove te column from the inverted index list
-    _indexLoadingConfig.getInvertedIndexColumns().remove(EXISTING_STRING_COL_DICT);
-
-    constructV3Segment();
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_DICT);
-    assertNotNull(columnMetadata);
-
-    try {
-      createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-          _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, true, DataType.STRING,
-          100000);
-    } catch (IllegalStateException e) {
-      assertEquals(e.getMessage(), "Must enable inverted index to disable the forward index for column: column5");
-    }
-
-    // Reset the inverted index list
-    _indexLoadingConfig.getInvertedIndexColumns().add(EXISTING_STRING_COL_DICT);
-
-    // Test updating two columns to be forward index disabled, one being a MV column
-    forwardIndexDisabledColumns = new HashSet<>();
-    forwardIndexDisabledColumns.add(EXISTING_STRING_COL_DICT);
-    forwardIndexDisabledColumns.add(COLUMN7_NAME);
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-
-    constructV3Segment();
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_DICT);
-    assertNotNull(columnMetadata);
-    ColumnMetadata columnMetadata2 = segmentMetadata.getColumnMetadataFor(COLUMN7_NAME);
-    assertNotNull(columnMetadata2);
-
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, true, DataType.STRING,
-        100000);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, COLUMN7_NAME, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, true, DataType.INT,
-        134090);
-
-    // Add another index on the column which has forward index disabled
-    forwardIndexDisabledColumns = new HashSet<>();
-    forwardIndexDisabledColumns.add(EXISTING_STRING_COL_DICT);
-    forwardIndexDisabledColumns.add(COLUMN1_NAME);
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    _indexLoadingConfig.getTextIndexColumns().add(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.getFSTIndexColumns().add(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.getRangeIndexColumns().add(COLUMN1_NAME);
-    invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-
-    constructV3Segment();
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_DICT);
-    assertNotNull(columnMetadata);
-    columnMetadata2 = segmentMetadata.getColumnMetadataFor(COLUMN1_NAME);
-    assertNotNull(columnMetadata2);
-
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, true, DataType.STRING,
-        100000);
-    createAndValidateIndex(ColumnIndexType.TEXT_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, true, DataType.STRING,
-        100000);
-    createAndValidateIndex(ColumnIndexType.FST_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, true, DataType.STRING,
-        100000);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, COLUMN1_NAME, 51594, 16,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, true, DataType.INT,
-        100000);
-    createAndValidateIndex(ColumnIndexType.RANGE_INDEX, COLUMN1_NAME, 51594, 16,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, true, DataType.INT,
-        100000);
-
-    // Reset indexLoadingConfig to remove the column from additional index lists
-    _indexLoadingConfig.getTextIndexColumns().remove(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.getFSTIndexColumns().remove(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.getRangeIndexColumns().remove(COLUMN1_NAME);
-  }
-
-  /**
-   * Test to check the behavior of the forward index disabled feature
-   * when enabled on an existing raw column
-   */
-  @Test
-  public void testForwardIndexDisabledOnExistingColumnRaw()
-      throws Exception {
-    Set<String> forwardIndexDisabledColumns = new HashSet<>();
-    forwardIndexDisabledColumns.add(EXISTING_STRING_COL_RAW);
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_STRING_COL_RAW);
-    Set<String> invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-
-    constructV3Segment();
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    assertNotNull(columnMetadata);
-
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_RAW, 5, 3,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 4, true, 0, null, true, DataType.STRING,
-        100000);
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.emptyList());
-
-    // No dictionary is created nor is the forward index disabled since this is a v1 type segment
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_RAW, 5, 3,
-        _newColumnsSchemaWithForwardIndexDisabled, false, false, false, 0, true, 0, null, true, DataType.STRING,
-        100000);
-
-    // Add the column back to the noDictionaryColumns list
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_STRING_COL_RAW);
-
-    constructV3Segment();
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    assertNotNull(columnMetadata);
-
-    try {
-      createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_RAW, 5, 3,
-          _newColumnsSchemaWithForwardIndexDisabled, false, false, false, 0, true, 0, null, true, DataType.STRING,
-          100000);
-    } catch (IllegalStateException e) {
-      assertEquals(e.getMessage(), "Must enable dictionary to disable the forward index for column: column4");
-    }
-
-    // Reset the noDictionaryColumns list
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_STRING_COL_RAW);
-
-    // Remove te column from the inverted index list
-    _indexLoadingConfig.getInvertedIndexColumns().remove(EXISTING_STRING_COL_RAW);
-
-    constructV3Segment();
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    assertNotNull(columnMetadata);
-
-    try {
-      createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_RAW, 5, 3,
-          _newColumnsSchemaWithForwardIndexDisabled, false, false, false, 0, true, 0, null, true, DataType.STRING,
-          100000);
-    } catch (IllegalStateException e) {
-      assertEquals(e.getMessage(), "Must enable inverted index to disable the forward index for column: column4");
-    }
-
-    // Reset the inverted index list
-    _indexLoadingConfig.getInvertedIndexColumns().add(EXISTING_STRING_COL_RAW);
-
-    // Test updating two columns to be forward index disabled, one being a MV column
-    forwardIndexDisabledColumns = new HashSet<>();
-    forwardIndexDisabledColumns.add(EXISTING_STRING_COL_RAW);
-    forwardIndexDisabledColumns.add(EXISTING_INT_COL_RAW_MV);
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_STRING_COL_RAW);
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_INT_COL_RAW_MV);
-    invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-
-    constructV3Segment();
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    assertNotNull(columnMetadata);
-    ColumnMetadata columnMetadata2 = segmentMetadata.getColumnMetadataFor(EXISTING_INT_COL_RAW_MV);
-    assertNotNull(columnMetadata2);
-
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_RAW, 5, 3,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 4, true, 0, null, true, DataType.STRING,
-        100000);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_INT_COL_RAW_MV, 18499, 15,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 13, null, true, DataType.INT,
-        106688);
-
-    // Add another index on the column which has forward index disabled
-    forwardIndexDisabledColumns = new HashSet<>();
-    forwardIndexDisabledColumns.add(EXISTING_STRING_COL_RAW);
-    forwardIndexDisabledColumns.add(EXISTING_INT_COL_RAW);
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_INT_COL_RAW);
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_STRING_COL_RAW);
-    _indexLoadingConfig.getTextIndexColumns().add(EXISTING_STRING_COL_RAW);
-    _indexLoadingConfig.getFSTIndexColumns().add(EXISTING_STRING_COL_RAW);
-    _indexLoadingConfig.getRangeIndexColumns().add(EXISTING_INT_COL_RAW);
-    invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-
-    constructV3Segment();
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
-    assertNotNull(columnMetadata);
-    columnMetadata2 = segmentMetadata.getColumnMetadataFor(EXISTING_INT_COL_RAW);
-    assertNotNull(columnMetadata2);
-
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_RAW, 5, 3,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 4, true, 0, null, true, DataType.STRING,
-        100000);
-    createAndValidateIndex(ColumnIndexType.TEXT_INDEX, EXISTING_STRING_COL_RAW, 5, 3,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 4, true, 0, null, true, DataType.STRING,
-        100000);
-    createAndValidateIndex(ColumnIndexType.FST_INDEX, EXISTING_STRING_COL_RAW, 5, 3,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 4, true, 0, null, true, DataType.STRING,
-        100000);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_INT_COL_RAW, 42242, 16,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, true, DataType.INT,
-        100000);
-    createAndValidateIndex(ColumnIndexType.RANGE_INDEX, EXISTING_INT_COL_RAW, 42242, 16,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, true, DataType.INT,
-        100000);
-
-    // Reset indexLoadingConfig to remove the column from additional index lists
-    _indexLoadingConfig.getTextIndexColumns().remove(EXISTING_STRING_COL_RAW);
-    _indexLoadingConfig.getFSTIndexColumns().remove(EXISTING_STRING_COL_RAW);
-    _indexLoadingConfig.getRangeIndexColumns().remove(EXISTING_INT_COL_RAW);
-
-    // Add back columns to noDictionaryColumns list
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_STRING_COL_RAW);
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW_MV);
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW);
-
-    // EXISTING_INT_COL_RAW: Disable forward index and enable dictionary and inverted index on a column that already
-    // has range index.
-    List<String> rangeIndexCols = new ArrayList<>();
-    rangeIndexCols.add(EXISTING_INT_COL_RAW);
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), rangeIndexCols, Collections.emptyList());
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    validateIndex(ColumnIndexType.RANGE_INDEX, EXISTING_INT_COL_RAW, 42242, 16, _schema, false, false, false, 0, true,
-        0, ChunkCompressionType.LZ4, false, DataType.INT, 100000);
-
-    // At this point, the segment has range index. Now the reload path should disable the forward index create a
-    // dictionary and inverted index and rewrite the range index.
-    forwardIndexDisabledColumns = new HashSet<>();
-    forwardIndexDisabledColumns.add(EXISTING_INT_COL_RAW);
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_INT_COL_RAW);
-    _indexLoadingConfig.getRangeIndexColumns().add(EXISTING_INT_COL_RAW);
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_INT_COL_RAW, 42242, 16,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, true, DataType.INT,
-        100000);
-    validateIndex(ColumnIndexType.RANGE_INDEX, EXISTING_INT_COL_RAW, 42242, 16,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, true, DataType.INT,
-        100000);
-
-    // Add it back so that this column is not rewritten for the other tests below.
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_INT_COL_RAW);
-  }
-
-  /**
-   * Test to check the behavior of enabling a dictionary based forward
-   * index on a column which has forward index disabled
-   */
-  @Test
-  public void testForwardIndexEnabledWithDictOnExistingForwardIndexDisabledColumn()
-      throws Exception {
-    Set<String> forwardIndexDisabledColumns = new HashSet<>();
-    forwardIndexDisabledColumns.add(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    Set<String> invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.singletonList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV));
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-    assertNotNull(columnMetadata);
-
-    // Forward index should be disabled for column10
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, true, DataType.INT,
-        100000);
-
-    // At this point, the segment has forward index disabled for column10. Enable the forward index and invoke reload
-    forwardIndexDisabledColumns = new HashSet<>();
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-
-    // Forward index should be enabled for column10 along with inverted index and dictionary
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, false, DataType.INT,
-        100000);
-    validateIndex(ColumnIndexType.DICTIONARY, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, false, DataType.INT,
-        100000);
-    validateIndex(ColumnIndexType.INVERTED_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, false, DataType.INT,
-        100000);
-
-    // Enable the forward index but disable the inverted index
-    forwardIndexDisabledColumns = new HashSet<>();
-    forwardIndexDisabledColumns.add(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.singletonList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV));
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-    assertNotNull(columnMetadata);
-
-    // Forward index should be disabled for column10
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, true, DataType.INT,
-        100000);
-
-    // At this point, the segment has forward index disabled for column10. Enable the forward index and invoke reload.
-    // Disable the inverted index and ensure it gets removed.
-    forwardIndexDisabledColumns = new HashSet<>();
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    _indexLoadingConfig.getInvertedIndexColumns().remove(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-
-    // Forward index should be enabled for column10 dictionary. Inverted index should be disabled.
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, false, DataType.INT,
-        100000);
-    validateIndex(ColumnIndexType.DICTIONARY, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, false, DataType.INT,
-        100000);
-    validateIndexDoesNotExist(EXISTING_FORWARD_INDEX_DISABLED_COL_SV, ColumnIndexType.INVERTED_INDEX);
-
-    // Enable the forward index for two columns at once, one being a MV column
-    forwardIndexDisabledColumns = new HashSet<>(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV));
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV, EXISTING_FORWARD_INDEX_DISABLED_COL_MV));
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-    assertNotNull(columnMetadata);
-    ColumnMetadata columnMetadata2 = segmentMetadata.getColumnMetadataFor(EXISTING_FORWARD_INDEX_DISABLED_COL_MV);
-    assertNotNull(columnMetadata2);
-
-    // Forward index should be disabled for column10 and column7
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, true, DataType.INT,
-        100000);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, true, DataType.INT,
-        134090);
-
-    // At this point, the segment has forward index disabled for column10 and column7. Enable the forward index and
-    // invoke reload.
-    forwardIndexDisabledColumns = new HashSet<>();
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-
-    // Forward index should be enabled for column10 and column7 along with inverted index and dictionary
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, false, DataType.INT,
-        100000);
-    validateIndex(ColumnIndexType.DICTIONARY, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, false, DataType.INT,
-        100000);
-    validateIndex(ColumnIndexType.INVERTED_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, false, DataType.INT,
-        100000);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, false, DataType.INT,
-        134090);
-    validateIndex(ColumnIndexType.DICTIONARY, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, false, DataType.INT,
-        134090);
-    validateIndex(ColumnIndexType.INVERTED_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, false, DataType.INT,
-        134090);
-
-    //  Enable the forward index for multiple columns at once and enable other indexes
-    forwardIndexDisabledColumns = new HashSet<>(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV, EXISTING_STRING_COL_DICT));
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV, EXISTING_FORWARD_INDEX_DISABLED_COL_MV,
-            EXISTING_STRING_COL_DICT));
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-    assertNotNull(columnMetadata);
-    columnMetadata2 = segmentMetadata.getColumnMetadataFor(EXISTING_FORWARD_INDEX_DISABLED_COL_MV);
-    assertNotNull(columnMetadata2);
-    ColumnMetadata columnMetadata3 = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_DICT);
-    assertNotNull(columnMetadata3);
-
-    // Forward index should be disabled for column10 and column7
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, true, DataType.INT,
-        100000);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, true, DataType.INT,
-        134090);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, true, DataType.STRING,
-        100000);
-
-    // At this point, the segment has forward index disabled for column10, column5 and column7. Enable the forward
-    // index and invoke reload.
-    forwardIndexDisabledColumns = new HashSet<>();
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    _indexLoadingConfig.getRangeIndexColumns().addAll(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV));
-    _indexLoadingConfig.getTextIndexColumns().add(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.getFSTIndexColumns().add(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.getInvertedIndexColumns().remove(EXISTING_FORWARD_INDEX_DISABLED_COL_MV);
-
-    // Forward index should be enabled for column10 and column7 along with inverted index and dictionary
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, false, DataType.INT,
-        100000);
-    validateIndex(ColumnIndexType.DICTIONARY, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, false, DataType.INT,
-        100000);
-    validateIndex(ColumnIndexType.INVERTED_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, false, DataType.INT,
-        100000);
-    validateIndex(ColumnIndexType.RANGE_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, false, DataType.INT,
-        100000);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, false, DataType.INT,
-        134090);
-    validateIndex(ColumnIndexType.DICTIONARY, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, false, DataType.INT,
-        134090);
-    validateIndexDoesNotExist(EXISTING_FORWARD_INDEX_DISABLED_COL_MV, ColumnIndexType.INVERTED_INDEX);
-    validateIndex(ColumnIndexType.RANGE_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, false, DataType.INT,
-        134090);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, false, DataType.STRING,
-        100000);
-    validateIndex(ColumnIndexType.DICTIONARY, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, false, DataType.STRING,
-        100000);
-    validateIndex(ColumnIndexType.INVERTED_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, false, DataType.STRING,
-        100000);
-    validateIndex(ColumnIndexType.TEXT_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, false, DataType.STRING,
-        100000);
-    validateIndex(ColumnIndexType.FST_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, false, DataType.STRING,
-        100000);
-
-    // Reset the indexLoadingConfig
-    _indexLoadingConfig.getRangeIndexColumns().removeAll(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV));
-    _indexLoadingConfig.getTextIndexColumns().remove(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.getFSTIndexColumns().remove(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.getInvertedIndexColumns().removeAll(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_STRING_COL_DICT));
-  }
-
-  /**
-   * Test to check the behavior of enabling a no dictionary based forward
-   * index on a column which has forward index disabled
-   */
-  @Test
-  public void testForwardIndexEnabledWithRawOnExistingForwardIndexDisabledColumn()
-      throws Exception {
-    Set<String> forwardIndexDisabledColumns = new HashSet<>();
-    forwardIndexDisabledColumns.add(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    Set<String> invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Collections.singletonList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV));
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-    assertNotNull(columnMetadata);
-
-    // Forward index should be disabled for column10
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, true, DataType.INT,
-        100000);
-
-    // At this point, the segment has forward index disabled for column10. Enable the forward index, disable the
-    // dictionary and inverted index
-    forwardIndexDisabledColumns = new HashSet<>();
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    _indexLoadingConfig.getInvertedIndexColumns().remove(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-
-    // Forward index should be enabled for column10. Dictionary and inverted index shouldn't be present.
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, false, false, 0, true, 0, ChunkCompressionType.LZ4, false,
-        DataType.INT, 100000);
-    validateIndexDoesNotExist(EXISTING_FORWARD_INDEX_DISABLED_COL_SV, ColumnIndexType.DICTIONARY);
-    validateIndexDoesNotExist(EXISTING_FORWARD_INDEX_DISABLED_COL_SV, ColumnIndexType.INVERTED_INDEX);
-
-    // Reset indexLoadingConfig
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-
-    // Enable the forward index for two columns at once, one being a MV column
-    forwardIndexDisabledColumns = new HashSet<>(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV));
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV, EXISTING_FORWARD_INDEX_DISABLED_COL_MV));
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-    assertNotNull(columnMetadata);
-    ColumnMetadata columnMetadata2 = segmentMetadata.getColumnMetadataFor(EXISTING_FORWARD_INDEX_DISABLED_COL_MV);
-    assertNotNull(columnMetadata2);
-
-    // Forward index should be disabled for column10 and column7
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, true, DataType.INT,
-        100000);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, true, DataType.INT,
-        134090);
-
-    // At this point, the segment has forward index disabled for column10 and column7. Enable the forward index and
-    // invoke reload.
-    forwardIndexDisabledColumns = new HashSet<>();
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    _indexLoadingConfig.getInvertedIndexColumns().removeAll(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV));
-    _indexLoadingConfig.getNoDictionaryColumns().addAll(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV));
-
-    // Forward index should be enabled for column10 and column7. No dictionary or inverted index should exist.
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, false, false, 0, true, 0, ChunkCompressionType.LZ4, false,
-        DataType.INT, 100000);
-    validateIndexDoesNotExist(EXISTING_FORWARD_INDEX_DISABLED_COL_SV, ColumnIndexType.DICTIONARY);
-    validateIndexDoesNotExist(EXISTING_FORWARD_INDEX_DISABLED_COL_SV, ColumnIndexType.INVERTED_INDEX);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, false, false, 0, false, 24, ChunkCompressionType.LZ4, false,
-        DataType.INT, 134090);
-    validateIndexDoesNotExist(EXISTING_FORWARD_INDEX_DISABLED_COL_MV, ColumnIndexType.DICTIONARY);
-    validateIndexDoesNotExist(EXISTING_FORWARD_INDEX_DISABLED_COL_MV, ColumnIndexType.INVERTED_INDEX);
-
-    // Reset indexLoadingConfig
-    _indexLoadingConfig.getNoDictionaryColumns().removeAll(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV));
-
-    // Enable the forward index for two columns at once, one as raw another as dictionary enabled
-    forwardIndexDisabledColumns = new HashSet<>(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV));
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV, EXISTING_FORWARD_INDEX_DISABLED_COL_MV));
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-    assertNotNull(columnMetadata);
-    columnMetadata2 = segmentMetadata.getColumnMetadataFor(EXISTING_FORWARD_INDEX_DISABLED_COL_MV);
-    assertNotNull(columnMetadata2);
-
-    // Forward index should be disabled for column10 and column7
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, true, DataType.INT,
-        100000);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, true, DataType.INT,
-        134090);
-
-    // At this point, the segment has forward index disabled for column10 and column7. Enable the forward index and
-    // invoke reload.
-    forwardIndexDisabledColumns = new HashSet<>();
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    _indexLoadingConfig.getInvertedIndexColumns().remove(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-    _indexLoadingConfig.getNoDictionaryColumns().add(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-
-    // Forward index should be enabled for column10 and column7. No dictionary or inverted index should exist.
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, false, false, 0, true, 0, ChunkCompressionType.LZ4, false,
-        DataType.INT, 100000);
-    validateIndexDoesNotExist(EXISTING_FORWARD_INDEX_DISABLED_COL_SV, ColumnIndexType.DICTIONARY);
-    validateIndexDoesNotExist(EXISTING_FORWARD_INDEX_DISABLED_COL_SV, ColumnIndexType.INVERTED_INDEX);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, false, DataType.INT,
-        134090);
-    validateIndex(ColumnIndexType.DICTIONARY, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, false, DataType.INT,
-        134090);
-    validateIndex(ColumnIndexType.INVERTED_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, false, DataType.INT,
-        134090);
-
-    // Reset indexLoadingConfig
-    _indexLoadingConfig.getNoDictionaryColumns().remove(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-    _indexLoadingConfig.getInvertedIndexColumns().remove(EXISTING_FORWARD_INDEX_DISABLED_COL_MV);
-
-    //  Enable the forward index for multiple columns at once and enable other indexes
-    forwardIndexDisabledColumns = new HashSet<>(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV, EXISTING_STRING_COL_DICT));
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    invertedIndexColumns = _indexLoadingConfig.getInvertedIndexColumns();
-    invertedIndexColumns.addAll(forwardIndexDisabledColumns);
-
-    constructV1Segment(Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-        Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV, EXISTING_FORWARD_INDEX_DISABLED_COL_MV,
-            EXISTING_STRING_COL_DICT));
-    new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
-    segmentMetadata = new SegmentMetadataImpl(_indexDir);
-    columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_FORWARD_INDEX_DISABLED_COL_SV);
-    assertNotNull(columnMetadata);
-    columnMetadata2 = segmentMetadata.getColumnMetadataFor(EXISTING_FORWARD_INDEX_DISABLED_COL_MV);
-    assertNotNull(columnMetadata2);
-    ColumnMetadata columnMetadata3 = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_DICT);
-    assertNotNull(columnMetadata3);
-
-    // Forward index should be disabled for column10 and column7
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, true, 0, null, true, DataType.INT,
-        100000);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 0, false, 24, null, true, DataType.INT,
-        134090);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, true, false, 26, true, 0, null, true, DataType.STRING,
-        100000);
-
-    // At this point, the segment has forward index disabled for column10, column5 and column7. Enable the forward
-    // index and invoke reload.
-    forwardIndexDisabledColumns = new HashSet<>();
-    _indexLoadingConfig.setForwardIndexDisabledColumns(forwardIndexDisabledColumns);
-    _indexLoadingConfig.getRangeIndexColumns().addAll(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV));
-    _indexLoadingConfig.getTextIndexColumns().add(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.getInvertedIndexColumns().removeAll(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV, EXISTING_STRING_COL_DICT));
-    _indexLoadingConfig.getNoDictionaryColumns().addAll(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV, EXISTING_STRING_COL_DICT));
-
-    // Forward index should be enabled for column10 and column7. Dictionary and inverted index should not exist
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, false, false, 0, true, 0, ChunkCompressionType.LZ4, false,
-        DataType.INT, 100000);
-    validateIndexDoesNotExist(EXISTING_FORWARD_INDEX_DISABLED_COL_SV, ColumnIndexType.DICTIONARY);
-    validateIndexDoesNotExist(EXISTING_FORWARD_INDEX_DISABLED_COL_SV, ColumnIndexType.INVERTED_INDEX);
-    validateIndex(ColumnIndexType.RANGE_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_SV, 3960, 12,
-        _newColumnsSchemaWithForwardIndexDisabled, false, false, false, 0, true, 0, ChunkCompressionType.LZ4, false,
-        DataType.INT, 100000);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, false, false, 0, false, 24, ChunkCompressionType.LZ4, false,
-        DataType.INT, 134090);
-    validateIndexDoesNotExist(EXISTING_FORWARD_INDEX_DISABLED_COL_MV, ColumnIndexType.DICTIONARY);
-    validateIndexDoesNotExist(EXISTING_FORWARD_INDEX_DISABLED_COL_MV, ColumnIndexType.INVERTED_INDEX);
-    validateIndex(ColumnIndexType.RANGE_INDEX, EXISTING_FORWARD_INDEX_DISABLED_COL_MV, 359, 9,
-        _newColumnsSchemaWithForwardIndexDisabled, false, false, false, 0, false, 24, ChunkCompressionType.LZ4, false,
-        DataType.INT, 134090);
-    createAndValidateIndex(ColumnIndexType.FORWARD_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, false, false, 0, true, 0, ChunkCompressionType.LZ4, false,
-        DataType.STRING, 100000);
-    validateIndexDoesNotExist(EXISTING_STRING_COL_DICT, ColumnIndexType.DICTIONARY);
-    validateIndexDoesNotExist(EXISTING_STRING_COL_DICT, ColumnIndexType.INVERTED_INDEX);
-    validateIndex(ColumnIndexType.TEXT_INDEX, EXISTING_STRING_COL_DICT, 9, 4,
-        _newColumnsSchemaWithForwardIndexDisabled, false, false, false, 0, true, 0, ChunkCompressionType.LZ4, false,
-        DataType.STRING, 100000);
-
-    // Reset the indexLoadingConfig
-    _indexLoadingConfig.getRangeIndexColumns().removeAll(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV));
-    _indexLoadingConfig.getTextIndexColumns().remove(EXISTING_STRING_COL_DICT);
-    _indexLoadingConfig.getNoDictionaryColumns().removeAll(Arrays.asList(EXISTING_FORWARD_INDEX_DISABLED_COL_SV,
-        EXISTING_FORWARD_INDEX_DISABLED_COL_MV, EXISTING_STRING_COL_DICT));
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandlerTest.java
@@ -33,9 +33,11 @@ import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterMethod;
@@ -60,9 +62,9 @@ public class BaseDefaultColumnHandlerTest {
         TestUtils.getFileFromResourceUrl(SegmentMetadataImplTest.class.getClassLoader().getResource(AVRO_DATA));
 
     // intentionally changed this to TimeUnit.Hours to make it non-default for testing
-    final SegmentGeneratorConfig config = SegmentTestUtils
-        .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), _indexDir, "daysSinceEpoch", TimeUnit.HOURS,
-            "testTable");
+    final SegmentGeneratorConfig config =
+        SegmentTestUtils.getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), _indexDir, "daysSinceEpoch",
+            TimeUnit.HOURS, "testTable");
     config.setSegmentNamePostfix("1");
     config.setTimeColumnName("daysSinceEpoch");
     final SegmentIndexCreationDriver driver = SegmentCreationDriverFactory.get(null);
@@ -80,8 +82,8 @@ public class BaseDefaultColumnHandlerTest {
 
   @Test
   public void testComputeDefaultColumnActionMapForCommittedSegment() {
-    // Dummy IndexLoadingConfig
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
+    IndexLoadingConfig indexLoadingConfig =
+        new IndexLoadingConfig(new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable").build());
 
     // Same schema
     Schema schema0 =
@@ -99,9 +101,9 @@ public class BaseDefaultColumnHandlerTest {
             .addSingleValueDimension("count", FieldSpec.DataType.INT)
             .addSingleValueDimension("daysSinceEpoch", FieldSpec.DataType.INT)
             .addSingleValueDimension("weeksSinceEpochSunday", FieldSpec.DataType.INT).build();
-
+    indexLoadingConfig.setSchema(schema0);
     BaseDefaultColumnHandler defaultColumnHandler =
-        new V3DefaultColumnHandler(_segmentDirectory, _committedSegmentMetadata, indexLoadingConfig, schema0, _writer);
+        new V3DefaultColumnHandler(_segmentDirectory, _committedSegmentMetadata, indexLoadingConfig, _writer);
     Assert.assertEquals(defaultColumnHandler.computeDefaultColumnActionMap(), Collections.EMPTY_MAP);
 
     // Add single-value dimension in the schema
@@ -121,8 +123,9 @@ public class BaseDefaultColumnHandlerTest {
             .addSingleValueDimension("count", FieldSpec.DataType.INT)
             .addSingleValueDimension("daysSinceEpoch", FieldSpec.DataType.INT)
             .addSingleValueDimension("weeksSinceEpochSunday", FieldSpec.DataType.INT).build();
+    indexLoadingConfig.setSchema(schema1);
     defaultColumnHandler =
-        new V3DefaultColumnHandler(_segmentDirectory, _committedSegmentMetadata, indexLoadingConfig, schema1, _writer);
+        new V3DefaultColumnHandler(_segmentDirectory, _committedSegmentMetadata, indexLoadingConfig, _writer);
     Assert.assertEquals(defaultColumnHandler.computeDefaultColumnActionMap(),
         ImmutableMap.of("column11", BaseDefaultColumnHandler.DefaultColumnAction.ADD_DIMENSION));
 
@@ -143,8 +146,9 @@ public class BaseDefaultColumnHandlerTest {
             .addSingleValueDimension("count", FieldSpec.DataType.INT)
             .addSingleValueDimension("daysSinceEpoch", FieldSpec.DataType.INT)
             .addSingleValueDimension("weeksSinceEpochSunday", FieldSpec.DataType.INT).build();
+    indexLoadingConfig.setSchema(schema2);
     defaultColumnHandler =
-        new V3DefaultColumnHandler(_segmentDirectory, _committedSegmentMetadata, indexLoadingConfig, schema2, _writer);
+        new V3DefaultColumnHandler(_segmentDirectory, _committedSegmentMetadata, indexLoadingConfig, _writer);
     Assert.assertEquals(defaultColumnHandler.computeDefaultColumnActionMap(),
         ImmutableMap.of("column11", BaseDefaultColumnHandler.DefaultColumnAction.ADD_DIMENSION));
 
@@ -165,8 +169,9 @@ public class BaseDefaultColumnHandlerTest {
             .addSingleValueDimension("daysSinceEpoch", FieldSpec.DataType.INT)
             .addSingleValueDimension("weeksSinceEpochSunday", FieldSpec.DataType.INT)
             .addMetric("column11", FieldSpec.DataType.INT).build(); // add column11
+    indexLoadingConfig.setSchema(schema3);
     defaultColumnHandler =
-        new V3DefaultColumnHandler(_segmentDirectory, _committedSegmentMetadata, indexLoadingConfig, schema3, _writer);
+        new V3DefaultColumnHandler(_segmentDirectory, _committedSegmentMetadata, indexLoadingConfig, _writer);
     Assert.assertEquals(defaultColumnHandler.computeDefaultColumnActionMap(),
         ImmutableMap.of("column11", BaseDefaultColumnHandler.DefaultColumnAction.ADD_METRIC));
 
@@ -187,8 +192,9 @@ public class BaseDefaultColumnHandlerTest {
             .addSingleValueDimension("daysSinceEpoch", FieldSpec.DataType.INT)
             .addSingleValueDimension("weeksSinceEpochSunday", FieldSpec.DataType.INT)
             .addDateTime("column11", FieldSpec.DataType.INT, "1:HOURS:EPOCH", "1:HOURS").build(); // add column11
+    indexLoadingConfig.setSchema(schema4);
     defaultColumnHandler =
-        new V3DefaultColumnHandler(_segmentDirectory, _committedSegmentMetadata, indexLoadingConfig, schema4, _writer);
+        new V3DefaultColumnHandler(_segmentDirectory, _committedSegmentMetadata, indexLoadingConfig, _writer);
     Assert.assertEquals(defaultColumnHandler.computeDefaultColumnActionMap(),
         ImmutableMap.of("column11", BaseDefaultColumnHandler.DefaultColumnAction.ADD_DATE_TIME));
 
@@ -207,8 +213,9 @@ public class BaseDefaultColumnHandlerTest {
             .addSingleValueDimension("count", FieldSpec.DataType.INT)
             .addSingleValueDimension("daysSinceEpoch", FieldSpec.DataType.INT)
             .addSingleValueDimension("weeksSinceEpochSunday", FieldSpec.DataType.INT).build();
+    indexLoadingConfig.setSchema(schema5);
     defaultColumnHandler =
-        new V3DefaultColumnHandler(_segmentDirectory, _committedSegmentMetadata, indexLoadingConfig, schema5, _writer);
+        new V3DefaultColumnHandler(_segmentDirectory, _committedSegmentMetadata, indexLoadingConfig, _writer);
     Assert.assertEquals(defaultColumnHandler.computeDefaultColumnActionMap(), Collections.EMPTY_MAP);
 
     // Do not update non-autogenerated column in the schema
@@ -227,8 +234,9 @@ public class BaseDefaultColumnHandlerTest {
             .addSingleValueDimension("count", FieldSpec.DataType.INT)
             .addSingleValueDimension("daysSinceEpoch", FieldSpec.DataType.INT)
             .addSingleValueDimension("weeksSinceEpochSunday", FieldSpec.DataType.INT).build();
+    indexLoadingConfig.setSchema(schema6);
     defaultColumnHandler =
-        new V3DefaultColumnHandler(_segmentDirectory, _committedSegmentMetadata, indexLoadingConfig, schema6, _writer);
+        new V3DefaultColumnHandler(_segmentDirectory, _committedSegmentMetadata, indexLoadingConfig, _writer);
     Assert.assertEquals(defaultColumnHandler.computeDefaultColumnActionMap(), Collections.EMPTY_MAP);
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectoryPaths.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/store/SegmentDirectoryPaths.java
@@ -63,12 +63,12 @@ public class SegmentDirectoryPaths {
 
   @Nullable
   public static File findMetadataFile(File indexDir) {
-    return findFormatFile(indexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
+    return findFile(indexDir, V1Constants.MetadataKeys.METADATA_FILE_NAME);
   }
 
   @Nullable
   public static File findCreationMetaFile(File indexDir) {
-    return findFormatFile(indexDir, V1Constants.SEGMENT_CREATION_META);
+    return findFile(indexDir, V1Constants.SEGMENT_CREATION_META);
   }
 
   /**
@@ -80,7 +80,7 @@ public class SegmentDirectoryPaths {
   @Nullable
   public static File findTextIndexIndexFile(File indexDir, String column) {
     String luceneIndexDirectory = column + V1Constants.Indexes.LUCENE_TEXT_INDEX_FILE_EXTENSION;
-    return findFormatFile(indexDir, luceneIndexDirectory);
+    return findFile(indexDir, luceneIndexDirectory);
   }
 
   /**
@@ -92,19 +92,19 @@ public class SegmentDirectoryPaths {
   @Nullable
   public static File findNativeTextIndexIndexFile(File indexDir, String column) {
     String nativeIndexDirectory = column + V1Constants.Indexes.NATIVE_TEXT_INDEX_FILE_EXTENSION;
-    return findFormatFile(indexDir, nativeIndexDirectory);
+    return findFile(indexDir, nativeIndexDirectory);
   }
 
   public static File findFSTIndexIndexFile(File indexDir, String column) {
     String luceneIndexDirectory = column + V1Constants.Indexes.FST_INDEX_FILE_EXTENSION;
-    return findFormatFile(indexDir, luceneIndexDirectory);
+    return findFile(indexDir, luceneIndexDirectory);
   }
 
   @Nullable
   @VisibleForTesting
   public static File findTextIndexDocIdMappingFile(File indexDir, String column) {
     String file = column + V1Constants.Indexes.LUCENE_TEXT_INDEX_DOCID_MAPPING_FILE_EXTENSION;
-    return findFormatFile(indexDir, file);
+    return findFile(indexDir, file);
   }
 
   /**
@@ -113,7 +113,7 @@ public class SegmentDirectoryPaths {
    * <p>If file exists in multiple segment version, return the one in highest segment version.
    */
   @Nullable
-  private static File findFormatFile(File indexDir, String fileName) {
+  public static File findFile(File indexDir, String fileName) {
     Preconditions.checkArgument(indexDir.isDirectory(), "Path: %s is not a directory", indexDir);
 
     // Try to find v3 file first

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/DummyInstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/DummyInstanceDataManagerConfig.java
@@ -1,0 +1,144 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.instance;
+
+import com.google.common.annotations.VisibleForTesting;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.ReadMode;
+
+
+@VisibleForTesting
+public class DummyInstanceDataManagerConfig implements InstanceDataManagerConfig {
+
+  @Override
+  public PinotConfiguration getConfig() {
+    return new PinotConfiguration();
+  }
+
+  @Override
+  public String getInstanceId() {
+    return "dummyInstance";
+  }
+
+  @Override
+  public String getInstanceDataDir() {
+    return CommonConstants.Server.DEFAULT_INSTANCE_DATA_DIR;
+  }
+
+  @Override
+  public String getConsumerDir() {
+    return null;
+  }
+
+  @Override
+  public String getInstanceSegmentTarDir() {
+    return CommonConstants.Server.DEFAULT_INSTANCE_SEGMENT_TAR_DIR;
+  }
+
+  @Override
+  public String getInstanceBootstrapSegmentDir() {
+    return null;
+  }
+
+  @Override
+  public String getSegmentStoreUri() {
+    return null;
+  }
+
+  @Override
+  public ReadMode getReadMode() {
+    return ReadMode.DEFAULT_MODE;
+  }
+
+  @Override
+  public String getSegmentFormatVersion() {
+    return null;
+  }
+
+  @Override
+  public String getAvgMultiValueCount() {
+    return null;
+  }
+
+  @Override
+  public boolean isEnableSplitCommit() {
+    return false;
+  }
+
+  @Override
+  public boolean isEnableSplitCommitEndWithMetadata() {
+    return false;
+  }
+
+  @Override
+  public boolean isRealtimeOffHeapAllocation() {
+    return false;
+  }
+
+  @Override
+  public boolean isDirectRealtimeOffHeapAllocation() {
+    return false;
+  }
+
+  @Override
+  public int getMaxParallelSegmentBuilds() {
+    return 0;
+  }
+
+  @Override
+  public int getMaxParallelSegmentDownloads() {
+    return 0;
+  }
+
+  @Override
+  public String getSegmentDirectoryLoader() {
+    return null;
+  }
+
+  @Override
+  public long getErrorCacheSize() {
+    return 0;
+  }
+
+  @Override
+  public boolean isStreamSegmentDownloadUntar() {
+    return false;
+  }
+
+  @Override
+  public long getStreamSegmentDownloadUntarRateLimit() {
+    return 0;
+  }
+
+  @Override
+  public int getDeletedSegmentsCacheSize() {
+    return 0;
+  }
+
+  @Override
+  public int getDeletedSegmentsCacheTtlMinutes() {
+    return 0;
+  }
+
+  @Override
+  public String getSegmentPeerDownloadScheme() {
+    return null;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FSTType.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FSTType.java
@@ -22,5 +22,5 @@ package org.apache.pinot.spi.config.table;
  * Type of FST to be used
  */
 public enum FSTType {
-    LUCENE, NATIVE
+  LUCENE, NATIVE
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexingConfig.java
@@ -35,7 +35,6 @@ public class IndexingConfig extends BaseJsonConfig {
   @Deprecated
   private List<String> _jsonIndexColumns;
   private Map<String, JsonIndexConfig> _jsonIndexConfigs;
-  private List<String> _h3IndexColumns;
   private List<String> _sortedColumn;
   private List<String> _bloomFilterColumns;
   private Map<String, BloomFilterConfig> _bloomFilterConfigs;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -22,6 +22,7 @@ import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import org.apache.pinot.spi.config.table.BloomFilterConfig;
 import org.apache.pinot.spi.config.table.CompletionConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.DimensionTableConfig;
@@ -95,6 +96,7 @@ public class TableConfigBuilder {
   private List<String> _noDictionaryColumns;
   private List<String> _onHeapDictionaryColumns;
   private List<String> _bloomFilterColumns;
+  private Map<String, BloomFilterConfig> _bloomFilterConfigs;
   private List<String> _rangeIndexColumns;
   private Map<String, String> _streamConfigs;
   private SegmentPartitionConfig _segmentPartitionConfig;
@@ -272,6 +274,11 @@ public class TableConfigBuilder {
     return this;
   }
 
+  public TableConfigBuilder setBloomFilterConfigs(Map<String, BloomFilterConfig> bloomFilterConfigs) {
+    _bloomFilterConfigs = bloomFilterConfigs;
+    return this;
+  }
+
   public TableConfigBuilder setRangeIndexColumns(List<String> rangeIndexColumns) {
     _rangeIndexColumns = rangeIndexColumns;
     return this;
@@ -431,6 +438,7 @@ public class TableConfigBuilder {
     indexingConfig.setNoDictionaryColumns(_noDictionaryColumns);
     indexingConfig.setOnHeapDictionaryColumns(_onHeapDictionaryColumns);
     indexingConfig.setBloomFilterColumns(_bloomFilterColumns);
+    indexingConfig.setBloomFilterConfigs(_bloomFilterConfigs);
     indexingConfig.setRangeIndexColumns(_rangeIndexColumns);
     indexingConfig.setStreamConfigs(_streamConfigs);
     indexingConfig.setSegmentPartitionConfig(_segmentPartitionConfig);


### PR DESCRIPTION
There are still some tests need to be modified to apply the change
Use this PR to show the idea of how the `IndexLoadingConfig` should access the configs