### PR TITLE
Enhance select order-by combine to use merge sort

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.operator.blocks.results;
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import java.io.IOException;
 import java.math.BigDecimal;
-import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.apache.pinot.common.datatable.DataTable;
@@ -77,7 +76,7 @@ public class AggregationResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  public Collection<Object[]> getRows(QueryContext queryContext) {
+  public List<Object[]> getRows(QueryContext queryContext) {
     return Collections.singletonList(_results.toArray());
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/BaseResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/BaseResultsBlock.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.operator.blocks.results;
 import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -171,7 +170,7 @@ public abstract class BaseResultsBlock implements Block {
    * Returns the rows for the results. Return {@code null} when the block only contains metadata.
    */
   @Nullable
-  public abstract Collection<Object[]> getRows(QueryContext queryContext);
+  public abstract List<Object[]> getRows(QueryContext queryContext);
 
   /**
    * Returns a data table without metadata or exception attached.

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/DistinctResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/DistinctResultsBlock.java
@@ -62,7 +62,7 @@ public class DistinctResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  public Collection<Object[]> getRows(QueryContext queryContext) {
+  public List<Object[]> getRows(QueryContext queryContext) {
     List<Object[]> rows = new ArrayList<>(_distinctTable.size());
     for (Record record : _distinctTable.getRecords()) {
       rows.add(record.getValues());

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ExceptionResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ExceptionResultsBlock.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.core.operator.blocks.results;
 
-import java.util.Collection;
+import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.exception.QueryException;
@@ -51,7 +51,7 @@ public class ExceptionResultsBlock extends BaseResultsBlock {
 
   @Nullable
   @Override
-  public Collection<Object[]> getRows(QueryContext queryContext) {
+  public List<Object[]> getRows(QueryContext queryContext) {
     return null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ExplainResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ExplainResultsBlock.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.operator.blocks.results;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -52,7 +51,7 @@ public class ExplainResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  public Collection<Object[]> getRows(QueryContext queryContext) {
+  public List<Object[]> getRows(QueryContext queryContext) {
     List<Object[]> rows = new ArrayList<>(_entries.size());
     for (ExplainEntry entry : _entries) {
       rows.add(entry.toRow());

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
@@ -149,7 +149,7 @@ public class GroupByResultsBlock extends BaseResultsBlock {
 
   @Nullable
   @Override
-  public Collection<Object[]> getRows(QueryContext queryContext) {
+  public List<Object[]> getRows(QueryContext queryContext) {
     if (_table == null) {
       return Collections.emptyList();
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/MetadataResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/MetadataResultsBlock.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.core.operator.blocks.results;
 
-import java.util.Collection;
+import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
@@ -41,7 +41,7 @@ public class MetadataResultsBlock extends BaseResultsBlock {
 
   @Nullable
   @Override
-  public Collection<Object[]> getRows(QueryContext queryContext) {
+  public List<Object[]> getRows(QueryContext queryContext) {
     return null;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/SelectionResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/SelectionResultsBlock.java
@@ -18,12 +18,9 @@
  */
 package org.apache.pinot.core.operator.blocks.results;
 
-import com.google.common.base.Preconditions;
 import java.io.IOException;
-import java.util.Collection;
 import java.util.Comparator;
 import java.util.List;
-import java.util.PriorityQueue;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
@@ -36,30 +33,35 @@ import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
  */
 public class SelectionResultsBlock extends BaseResultsBlock {
   private final DataSchema _dataSchema;
-  private final Collection<Object[]> _rows;
   private final Comparator<? super Object[]> _comparator;
+  private List<Object[]> _rows;
 
-  public SelectionResultsBlock(DataSchema dataSchema, List<Object[]> rows) {
-    this(dataSchema, rows, null);
-  }
-
-  public SelectionResultsBlock(DataSchema dataSchema, PriorityQueue<Object[]> rows) {
-    this(dataSchema, rows, rows.comparator());
-  }
-
-  public SelectionResultsBlock(DataSchema dataSchema, Collection<Object[]> rows,
+  public SelectionResultsBlock(DataSchema dataSchema, List<Object[]> rows,
       @Nullable Comparator<? super Object[]> comparator) {
     _dataSchema = dataSchema;
     _rows = rows;
     _comparator = comparator;
   }
 
+  public SelectionResultsBlock(DataSchema dataSchema, List<Object[]> rows) {
+    this(dataSchema, rows, null);
+  }
+
   public DataSchema getDataSchema() {
     return _dataSchema;
   }
 
-  public Collection<Object[]> getRows() {
+  public List<Object[]> getRows() {
     return _rows;
+  }
+
+  public void setRows(List<Object[]> rows) {
+    _rows = rows;
+  }
+
+  @Nullable
+  public Comparator<? super Object[]> getComparator() {
+    return _comparator;
   }
 
   @Override
@@ -73,23 +75,8 @@ public class SelectionResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  public Collection<Object[]> getRows(QueryContext queryContext) {
+  public List<Object[]> getRows(QueryContext queryContext) {
     return _rows;
-  }
-
-  public SelectionResultsBlock convertToPriorityQueueBased() {
-    if (_rows instanceof PriorityQueue) {
-      return this;
-    }
-    Preconditions.checkState(_comparator != null, "No comparator specified in the results block");
-    PriorityQueue<Object[]> result = new PriorityQueue<>(_comparator);
-    result.addAll(_rows);
-    return new SelectionResultsBlock(_dataSchema, result);
-  }
-
-  public PriorityQueue<Object[]> getRowsAsPriorityQueue() {
-    Preconditions.checkState(_rows instanceof PriorityQueue, "The results block is not backed by a priority queue");
-    return (PriorityQueue<Object[]>) _rows;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
@@ -148,7 +148,7 @@ public abstract class BaseSingleBlockCombineOperator<T extends BaseResultsBlock>
         return blockToMerge;
       }
       if (mergedBlock == null) {
-        mergedBlock = _resultsBlockMerger.convertToMergeableBlock((T) blockToMerge);
+        mergedBlock = (T) blockToMerge;
       } else {
         _resultsBlockMerger.mergeResultsBlocks(mergedBlock, (T) blockToMerge);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/merger/ResultsBlockMerger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/merger/ResultsBlockMerger.java
@@ -44,14 +44,4 @@ public interface ResultsBlockMerger<T extends BaseResultsBlock> {
   default boolean isQuerySatisfied(T resultsBlock) {
     return false;
   }
-
-  /**
-   * Converts the given results block into a mergeable results block.
-   *
-   * <p>This conversion is necessary if a block is used as the first argument for:
-   * {@link ResultsBlockMerger#mergeResultsBlocks(BaseResultsBlock, BaseResultsBlock)}.
-   */
-  default T convertToMergeableBlock(T resultsBlock) {
-    return resultsBlock;
-  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/merger/SelectionOnlyResultsBlockMerger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/merger/SelectionOnlyResultsBlockMerger.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.operator.combine.merger;
 
-import java.util.Collection;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
@@ -56,10 +55,6 @@ public class SelectionOnlyResultsBlockMerger implements ResultsBlockMerger<Selec
           QueryException.getException(QueryException.MERGE_RESPONSE_ERROR, errorMessage));
       return;
     }
-
-    Collection<Object[]> mergedRows = mergedBlock.getRows();
-    Collection<Object[]> rowsToMerge = blockToMerge.getRows();
-    assert mergedRows != null && rowsToMerge != null;
-    SelectionOperatorUtils.mergeWithoutOrdering(mergedRows, rowsToMerge, _numRowsToKeep);
+    SelectionOperatorUtils.mergeWithoutOrdering(mergedBlock, blockToMerge, _numRowsToKeep);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/merger/SelectionOrderByResultsBlockMerger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/merger/SelectionOrderByResultsBlockMerger.java
@@ -18,8 +18,6 @@
  */
 package org.apache.pinot.core.operator.combine.merger;
 
-import java.util.Collection;
-import java.util.PriorityQueue;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
@@ -52,17 +50,6 @@ public class SelectionOrderByResultsBlockMerger implements ResultsBlockMerger<Se
           QueryException.getException(QueryException.MERGE_RESPONSE_ERROR, errorMessage));
       return;
     }
-
-    PriorityQueue<Object[]> mergedRows = mergedBlock.getRowsAsPriorityQueue();
-    Collection<Object[]> rowsToMerge = blockToMerge.getRows();
-    assert mergedRows != null && rowsToMerge != null;
-    SelectionOperatorUtils.mergeWithOrdering(mergedRows, rowsToMerge, _numRowsToKeep);
-  }
-
-  @Override
-  public SelectionResultsBlock convertToMergeableBlock(SelectionResultsBlock resultsBlock) {
-    // This may create a copy or return the same instance. Anyway, this operator is the owner of the
-    // value now, so it can mutate it.
-    return resultsBlock.convertToPriorityQueueBased();
+    SelectionOperatorUtils.mergeWithOrdering(mergedBlock, blockToMerge, _numRowsToKeep);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorService.java
@@ -55,7 +55,6 @@ import org.roaringbitmap.RoaringBitmap;
  *   </li>
  * </ul>
  */
-@SuppressWarnings("rawtypes")
 public class SelectionOperatorService {
   private final QueryContext _queryContext;
   private final List<String> _selectionColumns;
@@ -65,7 +64,7 @@ public class SelectionOperatorService {
   private final PriorityQueue<Object[]> _rows;
 
   /**
-   * Constructor for <code>SelectionOperatorService</code> with {@link DataSchema}. (Inter segment)
+   * Constructor for <code>SelectionOperatorService</code> with {@link DataSchema}. (Broker side)
    *
    * @param queryContext Selection order-by query
    * @param dataSchema data schema.
@@ -78,6 +77,8 @@ public class SelectionOperatorService {
     _offset = queryContext.getOffset();
     _numRowsToKeep = _offset + queryContext.getLimit();
     assert queryContext.getOrderByExpressions() != null;
+    // TODO: Do not use type compatible comparator for performance since we don't support different data schema on
+    //       server side combine
     _rows = new PriorityQueue<>(Math.min(_numRowsToKeep, SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY),
         SelectionOperatorUtils.getTypeCompatibleComparator(queryContext.getOrderByExpressions(), _dataSchema,
             _queryContext.isNullHandlingEnabled()));
@@ -95,6 +96,8 @@ public class SelectionOperatorService {
   /**
    * Reduces a collection of {@link DataTable}s to selection rows for selection queries with <code>ORDER BY</code>.
    * (Broker side)
+   * TODO: Do merge sort after releasing 0.13.0 when server side results are sorted
+   *       Can also consider adding a data table metadata to indicate whether the server side results are sorted
    */
   public void reduceWithOrdering(Collection<DataTable> dataTables, boolean nullHandlingEnabled) {
     for (DataTable dataTable : dataTables) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/utils/OrderByComparatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/utils/OrderByComparatorFactory.java
@@ -38,17 +38,13 @@ public class OrderByComparatorFactory {
   }
 
   public static Comparator<Object[]> getComparator(List<OrderByExpressionContext> orderByExpressions,
-      TransformResultMetadata[] orderByExpressionMetadata, boolean reverse, boolean nullHandlingEnabled) {
-    return getComparator(orderByExpressions, orderByExpressionMetadata, reverse, nullHandlingEnabled, 0,
+      TransformResultMetadata[] orderByExpressionMetadata, boolean nullHandlingEnabled) {
+    return getComparator(orderByExpressions, orderByExpressionMetadata, nullHandlingEnabled, 0,
         orderByExpressions.size());
   }
 
-  /**
-   * @param reverse if false, the comparator will order in the direction indicated by the
-   * {@link OrderByExpressionContext#isAsc()}. Otherwise, it will be in the opposite direction.
-   */
   public static Comparator<Object[]> getComparator(List<OrderByExpressionContext> orderByExpressions,
-      TransformResultMetadata[] orderByExpressionMetadata, boolean reverse, boolean nullHandlingEnabled, int from,
+      TransformResultMetadata[] orderByExpressionMetadata, boolean nullHandlingEnabled, int from,
       int to) {
     Preconditions.checkArgument(to <= orderByExpressions.size(),
         "Trying to access %sth position of orderByExpressions with size %s", to, orderByExpressions.size());
@@ -76,13 +72,11 @@ public class OrderByComparatorFactory {
     FieldSpec.DataType[] storedTypes = new FieldSpec.DataType[numValuesToCompare];
     // Use multiplier -1 or 1 to control ascending/descending order
     int[] multipliers = new int[numValuesToCompare];
-    int ascMult = reverse ? -1 : 1;
-    int descMult = reverse ? 1 : -1;
     for (int i = 0; i < numValuesToCompare; i++) {
       int valueIndex = valueIndexList.get(i);
       valueIndices[i] = valueIndex;
       storedTypes[i] = orderByExpressionMetadata[valueIndex].getDataType().getStoredType();
-      multipliers[i] = orderByExpressions.get(valueIndex).isAsc() ? ascMult : descMult;
+      multipliers[i] = orderByExpressions.get(valueIndex).isAsc() ? 1 : -1;
     }
 
     if (nullHandlingEnabled) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionMultiValueQueriesTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.queries;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.PriorityQueue;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
@@ -175,7 +174,7 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
         DataSchema.ColumnDataType.INT_ARRAY);
-    selectionResult = (List<Object[]>) resultsBlock.getRows();
+    selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
     firstRow = selectionResult.get(0);
     assertEquals(firstRow.length, 3);
@@ -203,9 +202,9 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
         DataSchema.ColumnDataType.INT_ARRAY);
-    PriorityQueue<Object[]> selectionResult = resultsBlock.getRowsAsPriorityQueue();
+    List<Object[]> selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    Object[] lastRow = selectionResult.peek();
+    Object[] lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 4);
     assertEquals((String) lastRow[columnIndexMap.get("column5")], "AKXcXcIqsqOJFsdwxZ");
     assertEquals(lastRow[columnIndexMap.get("column6")], new int[]{1252});
@@ -228,9 +227,9 @@ public class InnerSegmentSelectionMultiValueQueriesTest extends BaseMultiValueQu
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
         DataSchema.ColumnDataType.INT_ARRAY);
-    selectionResult = resultsBlock.getRowsAsPriorityQueue();
+    selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    lastRow = selectionResult.peek();
+    lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 4);
     assertEquals((String) lastRow[columnIndexMap.get("column5")], "AKXcXcIqsqOJFsdwxZ");
     assertEquals(lastRow[columnIndexMap.get("column6")], new int[]{2147483647});

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionMultiValueRawQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionMultiValueRawQueriesTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.queries;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.PriorityQueue;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.ExecutionStatistics;
@@ -203,9 +202,9 @@ public class InnerSegmentSelectionMultiValueRawQueriesTest extends BaseMultiValu
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
         DataSchema.ColumnDataType.INT_ARRAY);
-    PriorityQueue<Object[]> selectionResult = resultsBlock.getRowsAsPriorityQueue();
+    List<Object[]> selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    Object[] lastRow = selectionResult.peek();
+    Object[] lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 4);
     assertEquals((String) lastRow[columnIndexMap.get("column5")], "AKXcXcIqsqOJFsdwxZ");
     assertEquals(lastRow[columnIndexMap.get("column6")], new int[]{1252});
@@ -228,9 +227,9 @@ public class InnerSegmentSelectionMultiValueRawQueriesTest extends BaseMultiValu
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), DataSchema.ColumnDataType.INT);
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")),
         DataSchema.ColumnDataType.INT_ARRAY);
-    selectionResult = resultsBlock.getRowsAsPriorityQueue();
+    selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    lastRow = selectionResult.peek();
+    lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 4);
     assertEquals((String) lastRow[columnIndexMap.get("column5")], "AKXcXcIqsqOJFsdwxZ");
     assertEquals(lastRow[columnIndexMap.get("column6")], new int[]{2147483647});

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentSelectionSingleValueQueriesTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.queries;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.PriorityQueue;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -108,7 +107,7 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertTrue(columnIndexMap.containsKey("daysSinceEpoch"));
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("daysSinceEpoch")), ColumnDataType.INT);
 
-    PriorityQueue<Object[]> selectionResult = resultsBlock.convertToPriorityQueueBased().getRowsAsPriorityQueue();
+    List<Object[]> selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
     for (Object[] row : selectionResult) {
       assertEquals(row.length, 1);
@@ -232,9 +231,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertTrue(columnIndexMap.containsKey("column1"));
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")), ColumnDataType.INT);
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), ColumnDataType.INT);
-    PriorityQueue<Object[]> selectionResult = resultsBlock.getRowsAsPriorityQueue();
+    List<Object[]> selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    Object[] lastRow = selectionResult.peek();
+    Object[] lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 4);
     assertEquals(((Integer) lastRow[columnIndexMap.get("column6")]).intValue(), 6043515);
     assertEquals(((Integer) lastRow[columnIndexMap.get("column1")]).intValue(), 10542595);
@@ -256,9 +255,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertTrue(columnIndexMap.containsKey("column1"));
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")), ColumnDataType.INT);
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), ColumnDataType.INT);
-    selectionResult = resultsBlock.getRowsAsPriorityQueue();
+    selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    lastRow = selectionResult.peek();
+    lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 4);
     assertEquals(((Integer) lastRow[columnIndexMap.get("column6")]).intValue(), 6043515);
     assertEquals(((Integer) lastRow[columnIndexMap.get("column1")]).intValue(), 462769197);
@@ -281,9 +280,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertEquals(dataSchema.getColumnNames(), new String[]{"column5", "column1", "column11"});
     assertEquals(dataSchema.getColumnDataTypes(),
         new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING});
-    PriorityQueue<Object[]> selectionResult = resultsBlock.convertToPriorityQueueBased().getRowsAsPriorityQueue();
+    List<Object[]> selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    Object[] lastRow = selectionResult.peek();
+    Object[] lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 3);
     assertEquals(lastRow[0], "gFuH");
 
@@ -302,9 +301,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertEquals(dataSchema.getColumnNames(), new String[]{"column5", "column1", "column11"});
     assertEquals(dataSchema.getColumnDataTypes(),
         new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING});
-    selectionResult = resultsBlock.convertToPriorityQueueBased().getRowsAsPriorityQueue();
+    selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    lastRow = selectionResult.peek();
+    lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 3);
     assertEquals(lastRow[0], "gFuH");
 
@@ -322,9 +321,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     dataSchema = resultsBlock.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"column5", "daysSinceEpoch"});
     assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT});
-    selectionResult = resultsBlock.convertToPriorityQueueBased().getRowsAsPriorityQueue();
+    selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    lastRow = selectionResult.peek();
+    lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 2);
     assertEquals(lastRow[0], "gFuH");
     assertEquals(lastRow[1], 126164076);
@@ -343,9 +342,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     dataSchema = resultsBlock.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"column5", "daysSinceEpoch"});
     assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT});
-    selectionResult = resultsBlock.convertToPriorityQueueBased().getRowsAsPriorityQueue();
+    selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    lastRow = selectionResult.peek();
+    lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 2);
     assertEquals(lastRow[0], "gFuH");
     assertEquals(lastRow[1], 167572854);
@@ -364,9 +363,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     dataSchema = resultsBlock.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"column5", "daysSinceEpoch"});
     assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT});
-    selectionResult = resultsBlock.convertToPriorityQueueBased().getRowsAsPriorityQueue();
+    selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    lastRow = selectionResult.peek();
+    lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 2);
     assertEquals(lastRow[0], "gFuH");
     assertEquals(lastRow[1], 167572854);
@@ -386,9 +385,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertEquals(dataSchema.getColumnNames(), new String[]{"column5", "column6", "column1"});
     assertEquals(dataSchema.getColumnDataTypes(),
         new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.INT});
-    selectionResult = resultsBlock.convertToPriorityQueueBased().getRowsAsPriorityQueue();
+    selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    lastRow = selectionResult.peek();
+    lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 3);
     assertEquals(lastRow[0], "gFuH");
     // Unsorted column values should be the same as ordering by their own
@@ -410,9 +409,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertEquals(dataSchema.getColumnNames(), new String[]{"column5", "column6", "column1"});
     assertEquals(dataSchema.getColumnDataTypes(),
         new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.INT});
-    selectionResult = resultsBlock.convertToPriorityQueueBased().getRowsAsPriorityQueue();
+    selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    lastRow = selectionResult.peek();
+    lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 3);
     assertEquals(lastRow[0], "gFuH");
     // Unsorted column values should be the same as ordering by their own
@@ -440,9 +439,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertTrue(columnIndexMap.containsKey("column1"));
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")), ColumnDataType.INT);
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), ColumnDataType.INT);
-    PriorityQueue<Object[]> selectionResult = resultsBlock.getRowsAsPriorityQueue();
+    List<Object[]> selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    Object[] lastRow = selectionResult.peek();
+    Object[] lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 11);
     assertEquals(((Integer) lastRow[columnIndexMap.get("column6")]).intValue(), 6043515);
     assertEquals(((Integer) lastRow[columnIndexMap.get("column1")]).intValue(), 10542595);
@@ -465,9 +464,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertTrue(columnIndexMap.containsKey("column1"));
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")), ColumnDataType.INT);
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), ColumnDataType.INT);
-    selectionResult = resultsBlock.getRowsAsPriorityQueue();
+    selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    lastRow = selectionResult.peek();
+    lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 11);
     assertEquals(((Integer) lastRow[columnIndexMap.get("column6")]).intValue(), 6043515);
     assertEquals(((Integer) lastRow[columnIndexMap.get("column1")]).intValue(), 462769197);
@@ -493,9 +492,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertEquals(selectionDataSchema.size(), 11);
     assertTrue(columnIndexMap.containsKey("column5"));
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column5")), ColumnDataType.STRING);
-    PriorityQueue<Object[]> selectionResult = resultsBlock.convertToPriorityQueueBased().getRowsAsPriorityQueue();
+    List<Object[]> selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    Object[] lastRow = selectionResult.peek();
+    Object[] lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 11);
     assertEquals((lastRow[columnIndexMap.get("column5")]), "gFuH");
 
@@ -515,9 +514,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertEquals(selectionDataSchema.size(), 11);
     assertTrue(columnIndexMap.containsKey("column5"));
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column5")), ColumnDataType.STRING);
-    selectionResult = resultsBlock.convertToPriorityQueueBased().getRowsAsPriorityQueue();
+    selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 10);
-    lastRow = selectionResult.peek();
+    lastRow = selectionResult.get(9);
     assertEquals(lastRow.length, 11);
     assertEquals((lastRow[columnIndexMap.get("column5")]), "gFuH");
   }
@@ -544,9 +543,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertTrue(columnIndexMap.containsKey("column1"));
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")), ColumnDataType.INT);
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), ColumnDataType.INT);
-    PriorityQueue<Object[]> selectionResult = resultsBlock.getRowsAsPriorityQueue();
+    List<Object[]> selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 12000);
-    Object[] lastRow = selectionResult.peek();
+    Object[] lastRow = selectionResult.get(11999);
     assertEquals(lastRow.length, 11);
     assertEquals((int) lastRow[columnIndexMap.get("column6")], 296467636);
     assertEquals((int) lastRow[columnIndexMap.get("column1")], 1715964282);
@@ -569,9 +568,9 @@ public class InnerSegmentSelectionSingleValueQueriesTest extends BaseSingleValue
     assertTrue(columnIndexMap.containsKey("column1"));
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column6")), ColumnDataType.INT);
     assertEquals(selectionDataSchema.getColumnDataType(columnIndexMap.get("column1")), ColumnDataType.INT);
-    selectionResult = resultsBlock.getRowsAsPriorityQueue();
+    selectionResult = resultsBlock.getRows();
     assertEquals(selectionResult.size(), 6129);
-    lastRow = selectionResult.peek();
+    lastRow = selectionResult.get(6128);
     assertEquals(lastRow.length, 11);
     assertEquals((int) lastRow[columnIndexMap.get("column6")], 499968041);
     assertEquals((int) lastRow[columnIndexMap.get("column1")], 335520083);


### PR DESCRIPTION
Currently for selection order-by queries, when combining multiple segment results, we maintain a heap (PriorityQueue) of the top values, which has time complexity of O(nlogm) where n is the total number of values, and m is the number of top values to be collected.
This PR enhances that by using the merge sort which has the time complexity of O(n). Within each segment, we do need to convert the heap to a sorted list, but that can be done parallel.
This PR doesn't change the broker side merge logic for backward compatibility. We may optimize the broker side merge after this PR is released.