### PR TITLE
RebalanceStatus API changes

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -31,6 +31,7 @@ import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.helix.zookeeper.zkclient.exception.ZkBadVersionException;
 import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.common.metadata.controllerjob.ControllerJobType;
 import org.apache.pinot.common.metadata.instance.InstanceZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.SchemaUtils;
@@ -112,12 +113,18 @@ public class ZKMetadataProvider {
     return StringUtil.join("/", PROPERTYSTORE_INSTANCE_PARTITIONS_PREFIX, instancePartitionsName);
   }
 
-  public static String constructPropertyStorePathForControllerJob() {
-    return StringUtil.join("/", PROPERTYSTORE_CONTROLLER_JOBS_PREFIX);
-  }
-
   public static String constructPropertyStorePathForResource(String resourceName) {
     return StringUtil.join("/", PROPERTYSTORE_SEGMENTS_PREFIX, resourceName);
+  }
+
+  public static String constructPropertyStorePathForControllerJob(ControllerJobType jobType) {
+    if (jobType == ControllerJobType.TABLE_REBALANCE) {
+      return StringUtil.join("/", PROPERTYSTORE_CONTROLLER_JOBS_PREFIX, jobType.name());
+    } else {
+      // For other types, we will continue to use the root path until we migrate
+      // other types to use separate nodes based on jobType like TABLE_REBALANCE
+      return StringUtil.join("/", PROPERTYSTORE_CONTROLLER_JOBS_PREFIX);
+    }
   }
 
   public static String constructPropertyStorePathForResourceConfig(String resourceName) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -47,6 +47,7 @@ import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.helix.model.IdealState;
+import org.apache.pinot.common.metadata.controllerjob.ControllerJobType;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -165,7 +166,8 @@ public class PinotRealtimeTableResource {
       @ApiParam(value = "Force commit job id", required = true) @PathParam("jobId") String forceCommitJobId)
       throws Exception {
     Map<String, String> controllerJobZKMetadata =
-        _pinotHelixResourceManager.getControllerJobZKMetadata(forceCommitJobId);
+        _pinotHelixResourceManager.getControllerJobZKMetadata(forceCommitJobId,
+            ControllerJobType.FORCE_COMMIT);
     if (controllerJobZKMetadata == null) {
       throw new ControllerApplicationException(LOGGER, "Failed to find controller job id: " + forceCommitJobId,
           Response.Status.NOT_FOUND);
@@ -227,8 +229,8 @@ public class PinotRealtimeTableResource {
       String tableNameWithType = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(realtimeTableName);
       ConsumingSegmentInfoReader consumingSegmentInfoReader =
           new ConsumingSegmentInfoReader(_executor, _connectionManager, _pinotHelixResourceManager);
-      return consumingSegmentInfoReader
-          .getConsumingSegmentsInfo(tableNameWithType, _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
+      return consumingSegmentInfoReader.getConsumingSegmentsInfo(tableNameWithType,
+          _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
           String.format("Failed to get consuming segments info for table %s. %s", realtimeTableName, e.getMessage()),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -623,7 +623,8 @@ public class PinotSegmentRestletResource {
   public ServerReloadControllerJobStatusResponse getReloadJobStatus(
       @ApiParam(value = "Reload job id", required = true) @PathParam("jobId") String reloadJobId)
       throws Exception {
-    Map<String, String> controllerJobZKMetadata = _pinotHelixResourceManager.getControllerJobZKMetadata(reloadJobId);
+    Map<String, String> controllerJobZKMetadata = _pinotHelixResourceManager.
+            getControllerJobZKMetadata(reloadJobId, ControllerJobType.RELOAD_SEGMENT);
     if (controllerJobZKMetadata == null) {
       throw new ControllerApplicationException(LOGGER, "Failed to find controller job id: " + reloadJobId,
           Status.NOT_FOUND);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -76,6 +76,7 @@ import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.exception.SchemaNotFoundException;
 import org.apache.pinot.common.exception.TableNotFoundException;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.controllerjob.ControllerJobType;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.restlet.resources.TableSegmentValidationInfo;
@@ -91,6 +92,8 @@ import org.apache.pinot.controller.api.exception.TableAlreadyExistsException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
 import org.apache.pinot.controller.helix.core.rebalance.RebalanceResult;
+import org.apache.pinot.controller.helix.core.rebalance.TableRebalanceProgressStats;
+import org.apache.pinot.controller.helix.core.rebalance.TableRebalancer;
 import org.apache.pinot.controller.recommender.RecommenderDriver;
 import org.apache.pinot.controller.tuner.TableConfigTunerUtils;
 import org.apache.pinot.controller.util.CompletionServiceHelper;
@@ -176,8 +179,7 @@ public class PinotTableRestletResource {
   @Path("/tables")
   @ApiOperation(value = "Adds a table", notes = "Adds a table")
   @ManualAuthorization // performed after parsing table configs
-  public ConfigSuccessResponse addTable(
-      String tableConfigStr,
+  public ConfigSuccessResponse addTable(String tableConfigStr,
       @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: (ALL|TASK|UPSERT)")
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip, @Context HttpHeaders httpHeaders,
       @Context Request request) {
@@ -204,10 +206,10 @@ public class PinotTableRestletResource {
       TableConfigUtils.validate(tableConfig, schema, typesToSkip, _controllerConf.isDisableIngestionGroovy());
       // TableConfigUtils.validateTableName(...) checks table name rules.
       // So it won't affect already created tables.
-      boolean allowTableNameWithDatabase = _controllerConf.getProperty(
-          CommonConstants.Helix.ALLOW_TABLE_NAME_WITH_DATABASE,
-          CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_WITH_DATABASE);
-        TableConfigUtils.validateTableName(tableConfig, allowTableNameWithDatabase);
+      boolean allowTableNameWithDatabase =
+          _controllerConf.getProperty(CommonConstants.Helix.ALLOW_TABLE_NAME_WITH_DATABASE,
+              CommonConstants.Helix.DEFAULT_ALLOW_TABLE_NAME_WITH_DATABASE);
+      TableConfigUtils.validateTableName(tableConfig, allowTableNameWithDatabase);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST, e);
     }
@@ -322,7 +324,7 @@ public class PinotTableRestletResource {
           tableNamesWithType.set(j, tempTableName);
         };
         Arrays.quickSort(0, numTables, comparator, swapper);
-       tableNames = tableNamesWithType;
+        tableNames = tableNamesWithType;
       }
 
       return JsonUtils.newObjectNode().set("tables", JsonUtils.objectToJsonNode(tableNames)).toString();
@@ -379,8 +381,8 @@ public class PinotTableRestletResource {
 
       // validate if user has permission to change the table state
       String endpointUrl = request.getRequestURL().toString();
-      AccessControlUtils
-          .validatePermission(tableName, AccessType.UPDATE, httpHeaders, endpointUrl, _accessControlFactory.create());
+      AccessControlUtils.validatePermission(tableName, AccessType.UPDATE, httpHeaders, endpointUrl,
+          _accessControlFactory.create());
 
       ArrayNode ret = JsonUtils.newArrayNode();
       boolean tableExists = false;
@@ -540,8 +542,7 @@ public class PinotTableRestletResource {
       notes = "This API returns the table config that matches the one you get from 'GET /tables/{tableName}'."
           + " This allows us to validate table config before apply.")
   @ManualAuthorization // performed after parsing TableConfig
-  public ObjectNode checkTableConfig(
-      String tableConfigStr,
+  public ObjectNode checkTableConfig(String tableConfigStr,
       @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: (ALL|TASK|UPSERT)")
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip, @Context HttpHeaders httpHeaders,
       @Context Request request) {
@@ -577,8 +578,7 @@ public class PinotTableRestletResource {
           + "table name. This API returns the table config that matches the one you get from 'GET /tables/{tableName}'."
           + " This allows us to validate table config before apply.")
   @ManualAuthorization // performed after parsing TableAndSchemaConfig
-  public String validateTableAndSchema(
-      TableAndSchemaConfig tableSchemaConfig,
+  public String validateTableAndSchema(TableAndSchemaConfig tableSchemaConfig,
       @ApiParam(value = "comma separated list of validation type(s) to skip. supported types: (ALL|TASK|UPSERT)")
       @QueryParam("validationTypesToSkip") @Nullable String typesToSkip, @Context HttpHeaders httpHeaders,
       @Context Request request) {
@@ -627,7 +627,7 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Name of the table to rebalance", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME", required = true) @QueryParam("type") String tableTypeStr,
       @ApiParam(value = "Whether to rebalance table in dry-run mode") @DefaultValue("false") @QueryParam("dryRun")
-          boolean dryRun,
+      boolean dryRun,
       @ApiParam(value = "Whether to reassign instances before reassigning segments") @DefaultValue("false")
       @QueryParam("reassignInstances") boolean reassignInstances,
       @ApiParam(value = "Whether to reassign CONSUMING segments for real-time table") @DefaultValue("false")
@@ -636,9 +636,9 @@ public class PinotTableRestletResource {
           + "segments in a round-robin fashion as if adding new segments to an empty table)") @DefaultValue("false")
   @QueryParam("bootstrap") boolean bootstrap,
       @ApiParam(value = "Whether to allow downtime for the rebalance") @DefaultValue("false") @QueryParam("downtime")
-          boolean downtime, @ApiParam(
-      value = "For no-downtime rebalance, minimum number of replicas to keep alive during rebalance, or maximum "
-          + "number of replicas allowed to be unavailable if value is negative") @DefaultValue("1")
+      boolean downtime,
+      @ApiParam(value = "For no-downtime rebalance, minimum number of replicas to keep alive during rebalance, or "
+          + "maximum number of replicas allowed to be unavailable if value is negative") @DefaultValue("1")
   @QueryParam("minAvailableReplicas") int minAvailableReplicas, @ApiParam(
       value = "Whether to use best-efforts to rebalance (not fail the rebalance when the no-downtime contract cannot "
           + "be achieved)") @DefaultValue("false") @QueryParam("bestEfforts") boolean bestEfforts, @ApiParam(
@@ -661,27 +661,30 @@ public class PinotTableRestletResource {
         externalViewCheckIntervalInMs);
     rebalanceConfig.addProperty(RebalanceConfigConstants.EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS,
         externalViewStabilizationTimeoutInMs);
+    rebalanceConfig.addProperty(RebalanceConfigConstants.JOB_ID,
+        TableRebalancer.createUniqueRebalanceJobIdentifier());
 
     try {
       if (dryRun || downtime) {
         // For dry-run or rebalance with downtime, directly return the rebalance result as it should return immediately
-        return _pinotHelixResourceManager.rebalanceTable(tableNameWithType, rebalanceConfig);
+        return _pinotHelixResourceManager.rebalanceTable(tableNameWithType, rebalanceConfig, false);
       } else {
         // Make a dry-run first to get the target assignment
         rebalanceConfig.setProperty(RebalanceConfigConstants.DRY_RUN, true);
-        RebalanceResult dryRunResult = _pinotHelixResourceManager.rebalanceTable(tableNameWithType, rebalanceConfig);
+        RebalanceResult dryRunResult =
+            _pinotHelixResourceManager.rebalanceTable(tableNameWithType, rebalanceConfig, false);
 
         if (dryRunResult.getStatus() == RebalanceResult.Status.DONE) {
           // If dry-run succeeded, run rebalance asynchronously
           rebalanceConfig.setProperty(RebalanceConfigConstants.DRY_RUN, false);
           _executorService.submit(() -> {
             try {
-              _pinotHelixResourceManager.rebalanceTable(tableNameWithType, rebalanceConfig);
+              _pinotHelixResourceManager.rebalanceTable(tableNameWithType, rebalanceConfig, true);
             } catch (Throwable t) {
               LOGGER.error("Caught exception/error while rebalancing table: {}", tableNameWithType, t);
             }
           });
-          return new RebalanceResult(RebalanceResult.Status.IN_PROGRESS,
+          return new RebalanceResult(dryRunResult.getJobId(), RebalanceResult.Status.IN_PROGRESS,
               "In progress, check controller logs for updates", dryRunResult.getInstanceAssignment(),
               dryRunResult.getTierInstanceAssignment(), dryRunResult.getSegmentAssignment());
         } else {
@@ -713,6 +716,37 @@ public class PinotTableRestletResource {
   }
 
   @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Authenticate(AccessType.UPDATE)
+  @Path("/rebalanceStatus/{jobId}")
+  @ApiOperation(value = "Gets detailed stats of a rebalance operation",
+      notes = "Gets detailed stats of a rebalance operation")
+  public ServerRebalanceJobStatusResponse rebalanceStatus(
+      @ApiParam(value = "Rebalance Job Id", required = true) @PathParam("jobId") String jobId)
+      throws JsonProcessingException {
+    Map<String, String> controllerJobZKMetadata =
+        _pinotHelixResourceManager.getControllerJobZKMetadata(jobId, ControllerJobType.TABLE_REBALANCE);
+
+    if (controllerJobZKMetadata == null) {
+      throw new ControllerApplicationException(LOGGER, "Failed to find controller job id: " + jobId,
+          Response.Status.NOT_FOUND);
+    }
+    TableRebalanceProgressStats tableRebalanceProgressStats =
+        JsonUtils.stringToObject(controllerJobZKMetadata.get(RebalanceConfigConstants.REBALANCE_PROGRESS_STATS),
+            TableRebalanceProgressStats.class);
+    long timeSinceStartInSecs = 0L;
+    if (!tableRebalanceProgressStats.getStatus().equals(RebalanceResult.Status.DONE)) {
+      timeSinceStartInSecs =
+          (System.currentTimeMillis() - tableRebalanceProgressStats.getStartTimeMs()) / 1000;
+    }
+
+    ServerRebalanceJobStatusResponse serverRebalanceJobStatusResponse = new ServerRebalanceJobStatusResponse();
+    serverRebalanceJobStatusResponse.setTableRebalanceProgressStats(tableRebalanceProgressStats);
+    serverRebalanceJobStatusResponse.setTimeElapsedSinceStartInSeconds(timeSinceStartInSecs);
+    return serverRebalanceJobStatusResponse;
+  }
+
+  @GET
   @Path("/tables/{tableName}/stats")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "table stats", notes = "Provides metadata info/stats about the table.")
@@ -720,14 +754,14 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "realtime|offline") @QueryParam("type") String tableTypeStr) {
     ObjectNode ret = JsonUtils.newObjectNode();
-    if ((tableTypeStr == null || TableType.OFFLINE.name().equalsIgnoreCase(tableTypeStr)) && _pinotHelixResourceManager
-        .hasOfflineTable(tableName)) {
+    if ((tableTypeStr == null || TableType.OFFLINE.name().equalsIgnoreCase(tableTypeStr))
+        && _pinotHelixResourceManager.hasOfflineTable(tableName)) {
       String tableNameWithType = TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(tableName);
       TableStats tableStats = _pinotHelixResourceManager.getTableStats(tableNameWithType);
       ret.set(TableType.OFFLINE.name(), JsonUtils.objectToJsonNode(tableStats));
     }
-    if ((tableTypeStr == null || TableType.REALTIME.name().equalsIgnoreCase(tableTypeStr)) && _pinotHelixResourceManager
-        .hasRealtimeTable(tableName)) {
+    if ((tableTypeStr == null || TableType.REALTIME.name().equalsIgnoreCase(tableTypeStr))
+        && _pinotHelixResourceManager.hasRealtimeTable(tableName)) {
       String tableNameWithType = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
       TableStats tableStats = _pinotHelixResourceManager.getTableStats(tableNameWithType);
       ret.set(TableType.REALTIME.name(), JsonUtils.objectToJsonNode(tableStats));
@@ -749,9 +783,8 @@ public class PinotTableRestletResource {
   private void checkHybridTableConfig(String rawTableName, TableConfig tableConfig) {
     if (tableConfig.getTableType() == TableType.REALTIME) {
       if (_pinotHelixResourceManager.hasOfflineTable(rawTableName)) {
-        TableConfigUtils
-            .verifyHybridTableConfigs(rawTableName, _pinotHelixResourceManager.getOfflineTableConfig(rawTableName),
-                tableConfig);
+        TableConfigUtils.verifyHybridTableConfigs(rawTableName,
+            _pinotHelixResourceManager.getOfflineTableConfig(rawTableName), tableConfig);
       }
     } else {
       if (_pinotHelixResourceManager.hasRealtimeTable(rawTableName)) {
@@ -782,8 +815,8 @@ public class PinotTableRestletResource {
       }
       TableStatus.IngestionStatus ingestionStatus = null;
       if (TableType.OFFLINE == tableType) {
-        ingestionStatus = TableIngestionStatusHelper
-            .getOfflineTableIngestionStatus(tableNameWithType, _pinotHelixResourceManager,
+        ingestionStatus =
+            TableIngestionStatusHelper.getOfflineTableIngestionStatus(tableNameWithType, _pinotHelixResourceManager,
                 _pinotHelixTaskResourceManager);
       } else {
         ingestionStatus = TableIngestionStatusHelper.getRealtimeTableIngestionStatus(tableNameWithType,
@@ -808,7 +841,7 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
       @ApiParam(value = "Columns name", allowMultiple = true) @QueryParam("columns") @DefaultValue("")
-          List<String> columns) {
+      List<String> columns) {
     LOGGER.info("Received a request to fetch aggregate metadata for a table {}", tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);
     if (tableType == TableType.REALTIME) {
@@ -861,13 +894,21 @@ public class PinotTableRestletResource {
     List<String> tableNamesWithType =
         ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableTypeFromRequest,
             LOGGER);
-    Set<String> jobTypesToFilter = null;
+    Set<ControllerJobType> validJobTypes =
+        java.util.Arrays.stream(ControllerJobType.values()).collect(Collectors.toSet());
+    Set<ControllerJobType> jobTypesToFilter = null;
     if (StringUtils.isNotEmpty(jobTypesString)) {
-      jobTypesToFilter = new HashSet<>(java.util.Arrays.asList(StringUtils.split(jobTypesString, ',')));
+      try {
+        jobTypesToFilter = new HashSet<>(java.util.Arrays.asList(StringUtils.split(jobTypesString, ','))).stream()
+            .map(type -> ControllerJobType.valueOf(type)).collect(Collectors.toSet());
+      } catch (IllegalArgumentException e) {
+        throw new IllegalArgumentException("Valid Types are: " + validJobTypes);
+      }
     }
     Map<String, Map<String, String>> result = new HashMap<>();
     for (String tableNameWithType : tableNamesWithType) {
-      result.putAll(_pinotHelixResourceManager.getAllJobsForTable(tableNameWithType, jobTypesToFilter));
+      result.putAll(_pinotHelixResourceManager.getAllJobsForTable(tableNameWithType,
+          jobTypesToFilter == null ? validJobTypes : jobTypesToFilter));
     }
 
     return result;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ServerRebalanceJobStatusResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ServerRebalanceJobStatusResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import org.apache.pinot.controller.helix.core.rebalance.TableRebalanceProgressStats;
+
+
+public class ServerRebalanceJobStatusResponse {
+  private long _timeElapsedSinceStartInSeconds;
+
+  private TableRebalanceProgressStats _tableRebalanceProgressStats;
+
+  public void setTimeElapsedSinceStartInSeconds(Long timeElapsedSinceStart) {
+    _timeElapsedSinceStartInSeconds = timeElapsedSinceStart;
+  }
+
+  public void setTableRebalanceProgressStats(TableRebalanceProgressStats tableRebalanceProgressStats) {
+    _tableRebalanceProgressStats = tableRebalanceProgressStats;
+  }
+
+  public TableRebalanceProgressStats getTableRebalanceProgressStats() {
+    return _tableRebalanceProgressStats;
+  }
+
+  public long getTimeElapsedSinceStartInSeconds() {
+    return _timeElapsedSinceStartInSeconds;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/NoOpTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/NoOpTableRebalanceObserver.java
@@ -16,8 +16,24 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.metadata.controllerjob;
+package org.apache.pinot.controller.helix.core.rebalance;
 
-public enum ControllerJobType {
-  RELOAD_SEGMENT, RELOAD_ALL_SEGMENTS, FORCE_COMMIT, TABLE_REBALANCE
+import java.util.Map;
+
+/**
+ * Default No-op TableRebalanceObserver.
+ */
+public class NoOpTableRebalanceObserver implements TableRebalanceObserver {
+  @Override
+  public void onTrigger(TableRebalanceObserver.Trigger trigger, Map<String, Map<String, String>> initialState,
+      Map<String, Map<String, String>> targetState) {
+  }
+
+  @Override
+  public void onSuccess(String msg) {
+  }
+
+  @Override
+  public void onError(String errorMsg) {
+  }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceResult.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceResult.java
@@ -29,6 +29,7 @@ import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class RebalanceResult {
+  private final String _jobId;
   private final Status _status;
   private final Map<InstancePartitionsType, InstancePartitions> _instanceAssignment;
   private final Map<String, InstancePartitions> _tierInstanceAssignment;
@@ -36,16 +37,23 @@ public class RebalanceResult {
   private final String _description;
 
   @JsonCreator
-  public RebalanceResult(@JsonProperty(value = "status", required = true) Status status,
+  public RebalanceResult(@JsonProperty(value = "jobId", required = true) String jobId,
+      @JsonProperty(value = "status", required = true) Status status,
       @JsonProperty(value = "description", required = true) String description,
       @JsonProperty("instanceAssignment") @Nullable Map<InstancePartitionsType, InstancePartitions> instanceAssignment,
       @JsonProperty("tierInstanceAssignment") @Nullable Map<String, InstancePartitions> tierInstanceAssignment,
       @JsonProperty("segmentAssignment") @Nullable Map<String, Map<String, String>> segmentAssignment) {
+    _jobId = jobId;
     _status = status;
     _description = description;
     _instanceAssignment = instanceAssignment;
     _tierInstanceAssignment = tierInstanceAssignment;
     _segmentAssignment = segmentAssignment;
+  }
+
+  @JsonProperty
+  public String getJobId() {
+    return _jobId;
   }
 
   @JsonProperty

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalanceObserver.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.rebalance;
+
+import java.util.Map;
+
+
+/**
+ * The <code>TableRebalanceObserver</code> interface provides callbacks to take actions
+ * during critical triggers. The 3 main triggers during a rebalance operation are show below.
+ * For example, we can track stats + status of rebalance during these triggers.
+ */
+
+public interface TableRebalanceObserver {
+  enum Trigger {
+    // Start of rebalance Trigger
+    START_TRIGGER,
+    // Waiting for external view to converge towards ideal state
+    EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER,
+    // Ideal state changes due to external events and new target for rebalance is computed
+    IDEAL_STATE_CHANGE_TRIGGER,
+  }
+
+  void onTrigger(Trigger trigger, Map<String, Map<String, String>> currentState,
+      Map<String, Map<String, String>> targetState);
+
+  void onSuccess(String msg);
+
+  void onError(String errorMsg);
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalanceProgressStats.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalanceProgressStats.java
@@ -1,0 +1,130 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.rebalance;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+/**
+ * These are rebalance stats as to how the current state is, when compared to the target state.
+ * Eg: If the current has 4 segments whose replicas (16) don't match the target state, _segmentsToRebalance
+ * is 4 and _replicasToRebalance is 16.
+ */
+public class TableRebalanceProgressStats {
+  public static class RebalanceStateStats {
+    public int _segmentsMissing;
+    public int _segmentsToRebalance;
+    public double _percentSegmentsToRebalance;
+    public int _replicasToRebalance;
+
+    RebalanceStateStats() {
+      _segmentsMissing = 0;
+      _segmentsToRebalance = 0;
+      _replicasToRebalance = 0;
+      _percentSegmentsToRebalance = 0.0;
+    }
+  }
+
+  // Done/In_progress/Failed
+  private String _status;
+  // When did Rebalance start
+  private long _startTimeMs;
+  // How long did rebalance take
+  private long _timeToFinishInSeconds;
+  // Success/failure message
+  private String _completionStatusMsg;
+  @JsonProperty("initialToTargetStateConvergence")
+  private RebalanceStateStats _initialToTargetStateConvergence;
+  @JsonProperty("currentToTargetConvergence")
+  private RebalanceStateStats _currentToTargetConvergence;
+  @JsonProperty("externalViewToIdealStateConvergence")
+  private RebalanceStateStats _externalViewToIdealStateConvergence;
+
+  public TableRebalanceProgressStats() {
+    _currentToTargetConvergence = new RebalanceStateStats();
+    _externalViewToIdealStateConvergence = new RebalanceStateStats();
+    _initialToTargetStateConvergence = new RebalanceStateStats();
+  }
+
+  public void setStatus(String status) {
+    _status = status;
+  }
+
+  public void setInitialToTargetStateConvergence(RebalanceStateStats initialToTargetStateConvergence) {
+    _initialToTargetStateConvergence = initialToTargetStateConvergence;
+  }
+
+  public void setStartTimeMs(long startTimeMs) {
+    _startTimeMs = startTimeMs;
+  }
+
+  public void setTimeToFinishInSeconds(Long timeToFinishInSeconds) {
+    _timeToFinishInSeconds = timeToFinishInSeconds;
+  }
+
+  public void setExternalViewToIdealStateConvergence(RebalanceStateStats externalViewToIdealStateConvergence) {
+    _externalViewToIdealStateConvergence = externalViewToIdealStateConvergence;
+  }
+
+  public void setCurrentToTargetConvergence(RebalanceStateStats currentToTargetConvergence) {
+    _currentToTargetConvergence = currentToTargetConvergence;
+  }
+
+  public void setCompletionStatusMsg(String completionStatusMsg) {
+    _completionStatusMsg = completionStatusMsg;
+  }
+
+  public String getStatus() {
+    return _status;
+  }
+
+  public String getCompletionStatusMsg() {
+    return _completionStatusMsg;
+  }
+
+  public RebalanceStateStats getInitialToTargetStateConvergence() {
+    return _initialToTargetStateConvergence;
+  }
+
+  public long getStartTimeMs() {
+    return _startTimeMs;
+  }
+
+  public long getTimeToFinishInSeconds() {
+    return _timeToFinishInSeconds;
+  }
+
+  public RebalanceStateStats getExternalViewToIdealStateConvergence() {
+    return _externalViewToIdealStateConvergence;
+  }
+
+  public RebalanceStateStats getCurrentToTargetConvergence() {
+    return _currentToTargetConvergence;
+  }
+
+  public static boolean statsDiffer(RebalanceStateStats base, RebalanceStateStats compare) {
+    if (base._replicasToRebalance != compare._replicasToRebalance
+        || base._segmentsToRebalance != compare._segmentsToRebalance
+        || base._segmentsMissing != compare._segmentsMissing
+        || base._percentSegmentsToRebalance != compare._percentSegmentsToRebalance) {
+      return true;
+    }
+    return false;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
@@ -1,0 +1,197 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.rebalance;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.base.Preconditions;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.controllerjob.ControllerJobType;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.RebalanceConfigConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * <code>ZkBasedTableRebalanceObserver</code> observes rebalance progress and tracks rebalance status,
+ * stats in Zookeeper. This will be used to show the progress of rebalance to users via rebalanceStatus API.
+ */
+public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ZkBasedTableRebalanceObserver.class);
+  private final String _tableNameWithType;
+  private final String _rebalanceJobId;
+  private final PinotHelixResourceManager _pinotHelixResourceManager;
+  private TableRebalanceProgressStats _tableRebalanceProgressStats;
+  // Keep track of number of updates. Useful during debugging.
+  private int _numUpdatesToZk;
+
+  public ZkBasedTableRebalanceObserver(String tableNameWithType, String rebalanceJobId,
+      PinotHelixResourceManager pinotHelixResourceManager) {
+    Preconditions.checkState(tableNameWithType != null, "Table name cannot be null");
+    Preconditions.checkState(rebalanceJobId != null, "rebalanceId cannot be null");
+    Preconditions.checkState(pinotHelixResourceManager != null, "PinotHelixManager cannot be null");
+    _tableNameWithType = tableNameWithType;
+    _rebalanceJobId = rebalanceJobId;
+    _pinotHelixResourceManager = pinotHelixResourceManager;
+    _tableRebalanceProgressStats = new TableRebalanceProgressStats();
+    _numUpdatesToZk = 0;
+  }
+
+  @Override
+  public void onTrigger(Trigger trigger, Map<String, Map<String, String>> currentState,
+      Map<String, Map<String, String>> targetState) {
+    switch (trigger) {
+      case START_TRIGGER:
+        updateOnStart(currentState, targetState);
+        trackStatsInZk();
+        break;
+      // Write to Zk if there's change since previous stats computation
+      case IDEAL_STATE_CHANGE_TRIGGER:
+        TableRebalanceProgressStats.RebalanceStateStats latest =
+            getDifferenceBetweenTableRebalanceStates(targetState, currentState);
+        if (TableRebalanceProgressStats.statsDiffer(_tableRebalanceProgressStats.getCurrentToTargetConvergence(),
+            latest)) {
+          _tableRebalanceProgressStats.setCurrentToTargetConvergence(latest);
+          trackStatsInZk();
+        }
+        break;
+      case EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER:
+        latest = getDifferenceBetweenTableRebalanceStates(targetState, currentState);
+        if (TableRebalanceProgressStats.statsDiffer(
+            _tableRebalanceProgressStats.getExternalViewToIdealStateConvergence(), latest)) {
+          _tableRebalanceProgressStats.setExternalViewToIdealStateConvergence(latest);
+          trackStatsInZk();
+        }
+        break;
+      default:
+        throw new IllegalArgumentException("Unimplemented trigger: " + trigger);
+    }
+  }
+
+  private void updateOnStart(Map<String, Map<String, String>> currentState,
+      Map<String, Map<String, String>> targetState) {
+    Preconditions.checkState(_tableRebalanceProgressStats.getStatus() != RebalanceResult.Status.IN_PROGRESS.toString(),
+        "Rebalance Observer onStart called multiple times");
+    _tableRebalanceProgressStats.setStatus(RebalanceResult.Status.IN_PROGRESS.toString());
+    _tableRebalanceProgressStats.setInitialToTargetStateConvergence(
+        getDifferenceBetweenTableRebalanceStates(targetState, currentState));
+    _tableRebalanceProgressStats.setStartTimeMs(System.currentTimeMillis());
+  }
+
+  @Override
+  public void onSuccess(String msg) {
+    Preconditions.checkState(_tableRebalanceProgressStats.getStatus() != RebalanceResult.Status.DONE.toString(),
+        "Table Rebalance already completed");
+    long timeToFinishInSeconds =
+         (System.currentTimeMillis() - _tableRebalanceProgressStats.getStartTimeMs()) / 1000L;
+    _tableRebalanceProgressStats.setCompletionStatusMsg(msg);
+    _tableRebalanceProgressStats.setTimeToFinishInSeconds(timeToFinishInSeconds);
+    _tableRebalanceProgressStats.setStatus(RebalanceResult.Status.DONE.toString());
+    // Zero out the in_progress convergence stats
+    TableRebalanceProgressStats.RebalanceStateStats stats = new TableRebalanceProgressStats.RebalanceStateStats();
+    _tableRebalanceProgressStats.setExternalViewToIdealStateConvergence(stats);
+    _tableRebalanceProgressStats.setCurrentToTargetConvergence(stats);
+    trackStatsInZk();
+  }
+
+  @Override
+  public void onError(String errorMsg) {
+    long timeToFinishInSeconds =
+        (long) (System.currentTimeMillis() - _tableRebalanceProgressStats.getStartTimeMs()) / 1000;
+    _tableRebalanceProgressStats.setTimeToFinishInSeconds(timeToFinishInSeconds);
+    _tableRebalanceProgressStats.setStatus(RebalanceResult.Status.FAILED.toString());
+    _tableRebalanceProgressStats.setCompletionStatusMsg(errorMsg);
+    trackStatsInZk();
+  }
+
+  public int getNumUpdatesToZk() {
+    return _numUpdatesToZk;
+  }
+
+  private void trackStatsInZk() {
+    Map<String, String> jobMetadata = new HashMap<>();
+    jobMetadata.put(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE, _tableNameWithType);
+    jobMetadata.put(CommonConstants.ControllerJob.JOB_ID, _rebalanceJobId);
+    jobMetadata.put(CommonConstants.ControllerJob.SUBMISSION_TIME_MS, Long.toString(System.currentTimeMillis()));
+    jobMetadata.put(CommonConstants.ControllerJob.JOB_TYPE, ControllerJobType.TABLE_REBALANCE.name());
+    try {
+      jobMetadata.put(RebalanceConfigConstants.REBALANCE_PROGRESS_STATS,
+          JsonUtils.objectToString(_tableRebalanceProgressStats));
+    } catch (JsonProcessingException e) {
+      LOGGER.error("Error serialising rebalance stats to JSON for persisting to ZK {}", _rebalanceJobId, e);
+    }
+    _pinotHelixResourceManager.addControllerJobToZK(_rebalanceJobId, jobMetadata,
+        ZKMetadataProvider.constructPropertyStorePathForControllerJob(ControllerJobType.TABLE_REBALANCE));
+    _numUpdatesToZk++;
+    LOGGER.debug("Number of updates to Zk: {} for rebalanceJob: {}  ", _numUpdatesToZk, _rebalanceJobId);
+  }
+
+  /**
+   * Takes in targetState and sourceState and computes stats based on the comparison
+   * between sourceState and targetState.This captures how far the source state is from
+   * the target state. Example - if there are 4 segments and 16 replicas in the source state
+   * not matching the target state, _segmentsToRebalance is 4 and _replicasToRebalance is 16.
+   * @param targetState- The state that we want to get to
+   * @param sourceState - A given state that needs to converge to targetState
+   * @return RebalanceStats
+   */
+  public static TableRebalanceProgressStats.RebalanceStateStats getDifferenceBetweenTableRebalanceStates(
+      Map<String, Map<String, String>> targetState, Map<String, Map<String, String>> sourceState) {
+
+    TableRebalanceProgressStats.RebalanceStateStats rebalanceStats =
+        new TableRebalanceProgressStats.RebalanceStateStats();
+
+    for (Map.Entry<String, Map<String, String>> entry : targetState.entrySet()) {
+      String segmentName = entry.getKey();
+      Map<String, String> sourceInstanceStateMap = sourceState.get(segmentName);
+      if (sourceInstanceStateMap == null) {
+        // Skip the missing segment
+        rebalanceStats._segmentsMissing++;
+        rebalanceStats._segmentsToRebalance++;
+        continue;
+      }
+      Map<String, String> targetStateInstanceStateMap = entry.getValue();
+      boolean hasSegmentConverged = true;
+      for (Map.Entry<String, String> instanceStateEntry : targetStateInstanceStateMap.entrySet()) {
+        // Ignore OFFLINE state in target state
+        String targetStateInstanceState = instanceStateEntry.getValue();
+        if (targetStateInstanceState.equals(CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE)) {
+          continue;
+        }
+        // Check whether the instance state in source matches the target
+        String instanceName = instanceStateEntry.getKey();
+        String sourceInstanceState = sourceInstanceStateMap.get(instanceName);
+        if (!targetStateInstanceState.equals(sourceInstanceState)) {
+          rebalanceStats._replicasToRebalance++;
+          hasSegmentConverged = false;
+        }
+      }
+      if (!hasSegmentConverged) {
+        rebalanceStats._segmentsToRebalance++;
+      }
+    }
+    int totalSegments = targetState.size();
+    rebalanceStats._percentSegmentsToRebalance =
+        (totalSegments == 0) ? 0 : ((double) rebalanceStats._segmentsToRebalance / totalSegments) * 100.0;
+    return rebalanceStats;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -191,6 +191,8 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
         _externalViewCheckIntervalInMs);
     rebalanceConfig.addProperty(RebalanceConfigConstants.EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS,
         _externalViewStabilizationTimeoutInMs);
+    rebalanceConfig.addProperty(RebalanceConfigConstants.JOB_ID,
+        TableRebalancer.createUniqueRebalanceJobIdentifier());
 
     try {
       // Relocating segments to new tiers needs two sequential actions: table rebalance and local tier migration.
@@ -205,8 +207,7 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
       //       migrating segment to new tier when the hosting server is in the server pool configured for that tier.
       updateTargetTier(tableNameWithType);
 
-      RebalanceResult rebalance =
-          new TableRebalancer(_pinotHelixResourceManager.getHelixZkManager()).rebalance(tableConfig, rebalanceConfig);
+      RebalanceResult rebalance = _pinotHelixResourceManager.rebalanceTable(tableNameWithType, rebalanceConfig, false);
       switch (rebalance.getStatus()) {
         case NO_OP:
           LOGGER.info("All segments are already relocated for table: {}", tableNameWithType);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TestZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TestZkBasedTableRebalanceObserver.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.rebalance;
+
+import java.util.Arrays;
+import java.util.Map;
+import java.util.TreeMap;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
+import org.apache.pinot.controller.helix.core.assignment.segment.SegmentAssignmentUtils;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ERROR;
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+
+
+public class TestZkBasedTableRebalanceObserver {
+
+  @Test
+    // This is a test to verify if Zk stats are pushed out correctly
+  void testZkObserverTracking() {
+    PinotHelixResourceManager pinotHelixResourceManager = mock(PinotHelixResourceManager.class);
+    // Mocking this. We will verify using numZkUpdate stat
+    when(pinotHelixResourceManager.addControllerJobToZK(any(), any(), any())).thenReturn(true);
+    ZkBasedTableRebalanceObserver observer =
+        new ZkBasedTableRebalanceObserver("dummy", "dummyId", pinotHelixResourceManager);
+    Map<String, Map<String, String>> source = new TreeMap<>();
+    Map<String, Map<String, String>> target = new TreeMap<>();
+    target.put("segment1",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
+    source.put("segment2",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
+
+    observer.onTrigger(TableRebalanceObserver.Trigger.START_TRIGGER, source, target);
+    assertEquals(observer.getNumUpdatesToZk(), 1);
+    observer.onTrigger(TableRebalanceObserver.Trigger.IDEAL_STATE_CHANGE_TRIGGER, source, source);
+    observer.onTrigger(TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, source, source);
+    assertEquals(observer.getNumUpdatesToZk(), 1);
+    observer.onTrigger(TableRebalanceObserver.Trigger.IDEAL_STATE_CHANGE_TRIGGER, source, target);
+    observer.onTrigger(TableRebalanceObserver.Trigger.EXTERNAL_VIEW_TO_IDEAL_STATE_CONVERGENCE_TRIGGER, source, target);
+    assertEquals(observer.getNumUpdatesToZk(), 3);
+  }
+
+  @Test
+  void testDifferenceBetweenTableRebalanceStates() {
+    Map<String, Map<String, String>> target = new TreeMap<>();
+    target.put("segment1",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
+    target.put("segment2",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3", "host4"), ONLINE));
+
+    // Stats when there's nothing to rebalance
+    TableRebalanceProgressStats.RebalanceStateStats stats =
+        ZkBasedTableRebalanceObserver.getDifferenceBetweenTableRebalanceStates(target, target);
+    assertEquals(stats._segmentsToRebalance, 0);
+    assertEquals(stats._segmentsMissing, 0);
+    assertEquals(stats._percentSegmentsToRebalance, 0.0);
+
+    // Stats when there's something to converge
+    Map<String, Map<String, String>> current = new TreeMap<>();
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2"), ONLINE));
+
+    stats = ZkBasedTableRebalanceObserver.getDifferenceBetweenTableRebalanceStates(target, current);
+    assertEquals(stats._segmentsToRebalance, 2);
+    assertEquals(stats._percentSegmentsToRebalance, 100.0);
+    assertEquals(stats._replicasToRebalance, 4);
+
+    // Stats when there are errors
+    current = new TreeMap<>();
+    current.put("segment1", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1"), ERROR));
+
+    stats = ZkBasedTableRebalanceObserver.getDifferenceBetweenTableRebalanceStates(target, current);
+    assertEquals(stats._segmentsToRebalance, 2);
+    assertEquals(stats._segmentsMissing, 1);
+    assertEquals(stats._replicasToRebalance, 3);
+
+    // Stats when partially converged
+    current = new TreeMap<>();
+    current.put("segment1",
+        SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host1", "host2", "host3"), ONLINE));
+    current.put("segment2", SegmentAssignmentUtils.getInstanceStateMap(Arrays.asList("host2", "host3"), ONLINE));
+
+    stats = ZkBasedTableRebalanceObserver.getDifferenceBetweenTableRebalanceStates(target, current);
+    assertEquals(stats._percentSegmentsToRebalance, 50.0);
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/RebalanceConfigConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/RebalanceConfigConstants.java
@@ -25,6 +25,12 @@ public class RebalanceConfigConstants {
   private RebalanceConfigConstants() {
   }
 
+  // Unique Id for rebalance
+  public static final String JOB_ID = "jobId";
+
+  // Progress of the Rebalance operartion
+  public static final String REBALANCE_PROGRESS_STATS = "REBALANCE_PROGRESS_STATS";
+
   // Whether to rebalance table in dry-run mode
   public static final String DRY_RUN = "dryRun";
   public static final boolean DEFAULT_DRY_RUN = false;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
@@ -50,6 +50,8 @@ public class PinotTableRebalancer extends PinotZKChanger {
         externalViewCheckIntervalInMs);
     _rebalanceConfig.addProperty(RebalanceConfigConstants.EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS,
         externalViewStabilizationTimeoutInMs);
+    _rebalanceConfig.addProperty(RebalanceConfigConstants.JOB_ID,
+        TableRebalancer.createUniqueRebalanceJobIdentifier());
   }
 
   public RebalanceResult rebalance(String tableNameWithType) {


### PR DESCRIPTION
**Problem**: Unable to track status of table rebalance after it is initiated which leads to

- Not knowing whether a rebalance is taking time or is indefinitely stuck.
- Operational burden (productivity impact) to track status and debug.
Field reported Issues -[ 1](https://github.com/apache/pinot/issues/10313), [2](https://github.com/apache/pinot/issues/9558)

**Solution**: Provide stats that helps users track rebalance progress -

- Difference between initial and target states (**what rebalance starts with**)
- Difference between ideal state and external view (**tells us pending work**)
- Difference between ideal state and recomputed target state (if rebalance takes multiple iterations when ideal state changes, during the rebalance)

Stats are shown in the test section. 
API for stats (rebalanceStatus/jobId)
A rebalance operation will return a rebalanceId which will be used to look at rebalanceStatus.
http://localhost:9000/rebalanceStatus/f83093b1-6b1e-47f3-8721-7984d442815d 

**Code changes**:

- Introduced a uniqueId for rebalance operation (rebalanceJobId). This is a required parameter passed along in the rebalanceConfig.
- Introduced rebalanceStatus API to get rebalance status + stats, given the rebalanceJobId
- Introduced Observer/callback for TableRebalancer that encapsulates the logging of rebalance status + stats to ZooKeeper. rebalanceJobId is the jobId to lookup the Zookeeper state, used by rebalanceStatus API.  rebalanceId is part of rebalanceResult that's returned to the user when a rebalance is initiated. 
- The triggers to the observer in TableRebalancer to collect status + stats are the following 
          1) At the start of rebalance when we have initial and target states. This will tell us amount of work that rebalance starts 
              with.
           2) Rebalance phase that waits for external view to converge to ideal state.  This will tell us the pending work for 
                rebalance.
           3) Phase if/when ideal state changes due to other events and a new target is computed. This will tell us the work 
                involved when ideal state changes multiple times during the rebalance. 
- Created new znode path for rebalance jobType. 
- Enhanced /table/tableName/jobs api to retrieve rebalance jobs as well. This is to discover rebalanceJobs, so as to get the jobId to look at status. 
- Applied pinotStyle codeStyle to files which made formatting changes to unrelated areas of code as well. 
         
**Testing**

- Unit test
- Integration test after a rebalance is initiated  - **initialToTargetStateConvergence** tells us total work when rebalance was initiated, **externalViewToIdealStateConvergence** tells us pending work,  **currentToTargetConvergence** tells us if ideal state changed multiple time since rebalance started and how far is target from ideal state.
{
  "tableRebalanceProgressStats": {
    "status": "DONE",
    "completionStatusMsg": "Finished rebalancing table: billing_OFFLINE with minAvailableReplicas: 1, enableStrictReplicaGroup: false, bestEfforts: false in 32 ms.",
    "initialToTargetStateConvergence": {
      "_segmentsMissing": 0,
      "_segmentsToRebalance": 1,
      "_percentSegmentsToRebalance": 100,
      "_replicasToRebalance": 9
    },
    "externalViewToIdealStateConvergence": {
      "_segmentsMissing": 0,
      "_segmentsToRebalance": 0,
      "_percentSegmentsToRebalance": 0,
      "_replicasToRebalance": 0
    },
    "currentToTargetConvergence": {
      "_segmentsMissing": 0,
      "_segmentsToRebalance": 0,
      "_percentSegmentsToRebalance": 0,
      "_replicasToRebalance": 0
    },
   "startTimeInMilliseconds": 1678214633564,
    "timeToFinishInSeconds": 0,
  },
  "timeElapsedSinceStartInSeconds": 9
}


Output of **http://localhost:9000/table/airlineStats_OFFLINE/jobs?type=OFFLINE**

{
  "178b0d79-92d8-43c7-9aa0-0448da01fa94": {
    "jobId": "178b0d79-92d8-43c7-9aa0-0448da01fa94",
    "messageCount": "10",
    "submissionTimeMs": "1678302700785",
    "jobType": "RELOAD_ALL_SEGMENTS",
    "tableName": "airlineStats_OFFLINE"
  },
  "095855b6-5b9b-48d5-ad97-c7a2db2d1b7b": {
    "jobId": "095855b6-5b9b-48d5-ad97-c7a2db2d1b7b",
    "submissionTimeMs": "1678302711030",
    "REBALANCE_PROGRESS_STATS": "{\"status\":\"DONE\",\"timeToFinishInSeconds\":0,\"completionStatusMsg\":\"Finished rebalancing table: airlineStats_OFFLINE with minAvailableReplicas: 1, enableStrictReplicaGroup: false, bestEfforts: false in 41 ms.\",\"startTimeInMilliseconds\":1.678302711006E12,\"initialToTargetStateConvergence\":{\"_segmentsMissing\":0,\"_segmentsToRebalance\":31,\"_percentSegmentsToRebalance\":100.0,\"_replicasToRebalance\":279},\"externalViewToIdealStateConvergence\":{\"_segmentsMissing\":0,\"_segmentsToRebalance\":0,\"_percentSegmentsToRebalance\":0.0,\"_replicasToRebalance\":0},\"currentToTargetConvergence\":{\"_segmentsMissing\":0,\"_segmentsToRebalance\":0,\"_percentSegmentsToRebalance\":0.0,\"_replicasToRebalance\":0}}",
    "tableName": "airlineStats_OFFLINE"
  }
}