### PR TITLE
Add controller API to fetch all segment zookeeper metadata for a table

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -40,6 +40,7 @@ import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
 import javax.inject.Inject;
@@ -103,6 +104,7 @@ import static org.apache.pinot.spi.utils.CommonConstants.SWAGGER_AUTHORIZATION_K
  *       <li>"/segments/{tableName}/crc": get a map from segment to CRC of the segment (OFFLINE table only)</li>
  *       <li>"/segments/{tableName}/{segmentName}/metadata: get the metadata for a segment</li>
  *       <li>"/segments/{tableName}/metadata: get the metadata for all segments from the server</li>
+ *       <li>"/segments/{tableName}/zkmetadata: get the zk metadata for all segments of a table</li>
  *       <li>"/segments/{tableName}/{segmentName}/tiers": get storage tier for the segment in the table</li>
  *       <li>"/segments/{tableName}/tiers": get storage tier for all segments in the table</li>
  *     </ul>
@@ -899,6 +901,35 @@ public class PinotSegmentRestletResource {
           Status.INTERNAL_SERVER_ERROR, ioe);
     }
     return segmentsMetadata;
+  }
+
+  @GET
+  @Path("segments/{tableName}/zkmetadata")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get the zookeeper metadata for all table segments",
+          notes = "Get the zookeeper metadata for all table segments")
+  public String getZookeeperMetadata(
+          @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
+          @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr)
+          throws JsonProcessingException {
+    LOGGER.info("Received a request to fetch zookeeper metadata for all segments for table {}", tableName);
+    TableType tableType = Constants.validateTableType(tableTypeStr);
+
+    List<String> tableNamesWithType =
+            ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableType, LOGGER);
+    Map<String, JsonNode> tableTypeToSegmentMetadata = new HashMap<>();
+    for (String tableNameWithType: tableNamesWithType) {
+      List<SegmentZKMetadata> segmentZKMetadataList =
+              _pinotHelixResourceManager.getSegmentsZKMetadata(tableNameWithType);
+      Map<String, JsonNode> segmentToMetadataMap = new HashMap<>();
+      for (SegmentZKMetadata segmentZKMetadata: segmentZKMetadataList) {
+        segmentToMetadataMap.put(segmentZKMetadata.getSegmentName(), JsonUtils.objectToJsonNode(segmentZKMetadata));
+      }
+      tableTypeToSegmentMetadata.put(Objects.requireNonNull(
+              TableNameBuilder.getTableTypeFromTableName(tableNameWithType)).toString(),
+              JsonUtils.objectToJsonNode(segmentToMetadataMap));
+    }
+    return JsonUtils.objectToPrettyString(tableTypeToSegmentMetadata);
   }
 
   @GET

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -906,27 +906,27 @@ public class PinotSegmentRestletResource {
   @GET
   @Path("segments/{tableName}/zkmetadata")
   @Produces(MediaType.APPLICATION_JSON)
-  @ApiOperation(value = "Get the zookeeper metadata for all table segments",
-          notes = "Get the zookeeper metadata for all table segments")
+  @ApiOperation(value = "Get the zookeeper metadata for all table segments", notes = "Get the zookeeper metadata for "
+      + "all table segments")
   public String getZookeeperMetadata(
-          @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
-          @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr)
-          throws JsonProcessingException {
+      @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr)
+      throws JsonProcessingException {
     LOGGER.info("Received a request to fetch zookeeper metadata for all segments for table {}", tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);
 
     List<String> tableNamesWithType =
-            ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableType, LOGGER);
+        ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableType, LOGGER);
     Map<String, JsonNode> tableTypeToSegmentMetadata = new HashMap<>();
-    for (String tableNameWithType: tableNamesWithType) {
+    for (String tableNameWithType : tableNamesWithType) {
       List<SegmentZKMetadata> segmentZKMetadataList =
-              _pinotHelixResourceManager.getSegmentsZKMetadata(tableNameWithType);
+          _pinotHelixResourceManager.getSegmentsZKMetadata(tableNameWithType);
       Map<String, JsonNode> segmentToMetadataMap = new HashMap<>();
-      for (SegmentZKMetadata segmentZKMetadata: segmentZKMetadataList) {
+      for (SegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {
         segmentToMetadataMap.put(segmentZKMetadata.getSegmentName(), JsonUtils.objectToJsonNode(segmentZKMetadata));
       }
-      tableTypeToSegmentMetadata.put(Objects.requireNonNull(
-              TableNameBuilder.getTableTypeFromTableName(tableNameWithType)).toString(),
+      tableTypeToSegmentMetadata
+          .put(Objects.requireNonNull(TableNameBuilder.getTableTypeFromTableName(tableNameWithType)).toString(),
               JsonUtils.objectToJsonNode(segmentToMetadataMap));
     }
     return JsonUtils.objectToPrettyString(tableTypeToSegmentMetadata);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -907,28 +907,21 @@ public class PinotSegmentRestletResource {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Get the zookeeper metadata for all table segments", notes = "Get the zookeeper metadata for "
       + "all table segments")
-  public Map<String, Map<String, Object>> getZookeeperMetadata(
+  public Map<String, Map<String, String>> getZookeeperMetadata(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr)
       throws JsonProcessingException {
     LOGGER.info("Received a request to fetch zookeeper metadata for all segments for table {}", tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);
 
-    List<String> tableNamesWithType =
-        ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableType, LOGGER);
-    String tableNameWithType;
-    if (tableNamesWithType.size() == 1) {
-      tableNameWithType = tableNamesWithType.get(0);
-    } else {
-      tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
-    }
-    Map<String, Map<String, Object>> segmentToMetadataMap = new HashMap<>();
+    String tableNameWithType =
+        ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableType, LOGGER).get(0);
+    Map<String, Map<String, String>> segmentToMetadataMap = new HashMap<>();
     List<SegmentZKMetadata> segmentZKMetadataList =
         _pinotHelixResourceManager.getSegmentsZKMetadata(tableNameWithType);
 
     for (SegmentZKMetadata segmentZKMetadata : segmentZKMetadataList) {
-      Map<String, Object> segmentZKMetadataObject = new HashMap<>(segmentZKMetadata.toMap());
-      segmentToMetadataMap.put(segmentZKMetadata.getSegmentName(), segmentZKMetadataObject);
+      segmentToMetadataMap.put(segmentZKMetadata.getSegmentName(), segmentZKMetadata.toMap());
     }
     return segmentToMetadataMap;
   }


### PR DESCRIPTION
`/segments/{tableName}/metadata` returns the metadata for all table segments from server. This misses out on Zookeeper metadata like `downloadUrl`, `segmentPartitionMetadata` which can be obtained only by hitting this API `/segments/{tableName}/{segmentName}/metadata` for each segment separately.