### PR TITLE
Add operator level stats to response when tracing is enabled

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -169,10 +169,14 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR, e));
     }
 
+    boolean traceEnabled = Boolean.parseBoolean(
+        request.has(CommonConstants.Broker.Request.TRACE) ? request.get(CommonConstants.Broker.Request.TRACE).asText()
+            : "false");
+
     ResultTable queryResults;
     Map<Integer, ExecutionStatsAggregator> stageIdStatsMap = new HashMap<>();
     for (Integer stageId: queryPlan.getStageMetadataMap().keySet()) {
-      stageIdStatsMap.put(stageId, new ExecutionStatsAggregator(false));
+      stageIdStatsMap.put(stageId, new ExecutionStatsAggregator(traceEnabled));
     }
 
     try {

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -81,7 +81,7 @@ public class BrokerResponseNativeV2 extends BrokerResponseNative {
   }
 
   public void addStageStat(Integer stageId, BrokerResponseStats brokerResponseStats) {
-    if (!brokerResponseStats.getOperatorIds().isEmpty()) {
+    if (!brokerResponseStats.getOperatorStats().isEmpty()) {
       _stageIdStats.put(stageId, brokerResponseStats);
     }
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseStats.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseStats.java
@@ -23,7 +23,9 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonPropertyOrder;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.pinot.spi.utils.JsonUtils;
 
 
@@ -38,14 +40,14 @@ import org.apache.pinot.spi.utils.JsonUtils;
     "totalDocs", "timeUsedMs", "offlineThreadCpuTimeNs", "realtimeThreadCpuTimeNs",
     "offlineSystemActivitiesCpuTimeNs", "realtimeSystemActivitiesCpuTimeNs", "offlineResponseSerializationCpuTimeNs",
     "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs", "realtimeTotalCpuTimeNs",
-    "traceInfo", "operatorIds", "tableNames"})
+    "traceInfo", "operatorStats", "tableNames"})
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class BrokerResponseStats extends BrokerResponseNative {
 
   private int _numBlocks = 0;
   private int _numRows = 0;
   private long _stageExecutionTimeMs = 0;
-  private List<String> _operatorIds = new ArrayList<>();
+  private Map<String, Map<String, String>> _operatorStats = new HashMap<>();
   private List<String> _tableNames = new ArrayList<>();
 
   @Override
@@ -88,14 +90,14 @@ public class BrokerResponseStats extends BrokerResponseNative {
     return JsonUtils.objectToString(this);
   }
 
-  @JsonProperty("operatorIds")
-  public List<String> getOperatorIds() {
-    return _operatorIds;
+  @JsonProperty("operatorStats")
+  public Map<String, Map<String, String>> getOperatorStats() {
+    return _operatorStats;
   }
 
-  @JsonProperty("operatorIds")
-  public void setOperatorIds(List<String> operatorIds) {
-    _operatorIds = operatorIds;
+  @JsonProperty("operatorStats")
+  public void setOperatorStats(Map<String, Map<String, String>> operatorStats) {
+    _operatorStats = operatorStats;
   }
 
   @JsonProperty("tableNames")

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -138,7 +138,7 @@ public class PinotQueryResource {
     if (Boolean.parseBoolean(options.get(QueryOptionKey.USE_MULTISTAGE_ENGINE))) {
       if (_controllerConf.getProperty(CommonConstants.Helix.CONFIG_OF_MULTI_STAGE_ENGINE_ENABLED,
           CommonConstants.Helix.DEFAULT_MULTI_STAGE_ENGINE_ENABLED)) {
-        return getMultiStageQueryResponse(sqlQuery, queryOptions, httpHeaders, endpointUrl);
+        return getMultiStageQueryResponse(sqlQuery, queryOptions, httpHeaders, endpointUrl, traceEnabled);
       } else {
         throw new UnsupportedOperationException("V2 Multi-Stage query engine not enabled. "
             + "Please see https://docs.pinot.apache.org/ for instruction to enable V2 engine.");
@@ -161,7 +161,7 @@ public class PinotQueryResource {
   }
 
   private String getMultiStageQueryResponse(String query, String queryOptions, HttpHeaders httpHeaders,
-      String endpointUrl) {
+      String endpointUrl, String traceEnabled) {
 
     // Validate data access
     // we don't have a cross table access control rule so only ADMIN can make request to multi-stage engine.
@@ -185,7 +185,7 @@ public class PinotQueryResource {
 
     // Send query to a random broker.
     String instanceId = instanceIds.get(RANDOM.nextInt(instanceIds.size()));
-    return sendRequestToBroker(query, instanceId, "false", queryOptions, httpHeaders);
+    return sendRequestToBroker(query, instanceId, traceEnabled, queryOptions, httpHeaders);
   }
 
   private String getQueryResponse(String query, @Nullable SqlNode sqlNode, String traceEnabled, String queryOptions,

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
@@ -43,7 +43,6 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 public class ExecutionStatsAggregator {
   private final List<QueryProcessingException> _processingExceptions = new ArrayList<>();
-  private final List<String> _operatorIds = new ArrayList<>();
   private final Map<String, Map<String, String>> _operatorStats = new HashMap<>();
   private final Set<String> _tableNames = new HashSet<>();
   private final Map<String, String> _traceInfo = new HashMap<>();
@@ -117,11 +116,8 @@ public class ExecutionStatsAggregator {
 
     String operatorId = metadata.get(DataTable.MetadataKey.OPERATOR_ID.getName());
     if (operatorId != null) {
-      _operatorIds.add(operatorId);
       if (_enableTrace) {
-        Map<String, String> metadataWithoutOperatorId = new HashMap<>(metadata);
-        metadataWithoutOperatorId.remove(DataTable.MetadataKey.OPERATOR_ID);
-        _operatorStats.put(operatorId, metadataWithoutOperatorId);
+        _operatorStats.put(operatorId, metadata);
       } else {
         _operatorStats.put(operatorId, new HashMap<>());
       }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
@@ -106,13 +106,13 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
         }
       }
       if (executionStatsAggregatorMap != null) {
-        executionStatsAggregatorMap.put(stageId, new ExecutionStatsAggregator(false));
+        executionStatsAggregatorMap.put(stageId, new ExecutionStatsAggregator(true));
       }
     }
     Preconditions.checkNotNull(mailboxReceiveOperator);
     return QueryDispatcher.toResultTable(
         QueryDispatcher.reduceMailboxReceive(mailboxReceiveOperator, CommonConstants.Broker.DEFAULT_BROKER_TIMEOUT_MS,
-            executionStatsAggregatorMap, null),
+            executionStatsAggregatorMap, queryPlan),
         queryPlan.getQueryResultFields(), queryPlan.getQueryStageMap().get(0).getDataSchema()).getRows();
   }
 


### PR DESCRIPTION
When tracing is enabled, stageStats will also contain each operator's stats.