### PR TITLE
Fix for flaky test ForwardIndexHandlerTest.testEnableDictionaryForMultipleColumns

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
@@ -271,11 +271,7 @@ public class ForwardIndexHandler extends BaseIndexHandler {
           continue;
         }
 
-        if (newNoDictColumns.contains(column)) {
-          columnOperationsMap.put(column, Collections.singletonList(Operation.ENABLE_FORWARD_INDEX));
-        } else {
-          columnOperationsMap.put(column, Collections.singletonList(Operation.ENABLE_FORWARD_INDEX));
-        }
+        columnOperationsMap.put(column, Collections.singletonList(Operation.ENABLE_FORWARD_INDEX));
       } else if (existingForwardIndexDisabledColumns.contains(column)
           && newForwardIndexDisabledColumns.contains(column)) {
         // Forward index is disabled for the existing column and should remain disabled based on the latest config

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandlerTest.java
@@ -1212,7 +1212,7 @@ public class ForwardIndexHandlerTest {
     String col2;
     do {
       col2 = _noDictionaryColumns.get(rand.nextInt(_noDictionaryColumns.size()));
-    } while (FORWARD_INDEX_DISABLED_RAW_COLUMNS.contains(col2));
+    } while (FORWARD_INDEX_DISABLED_RAW_COLUMNS.contains(col2) || col2.equals(col1));
     indexLoadingConfig.getNoDictionaryColumns().remove(col2);
 
     ForwardIndexHandler fwdIndexHandler = new ForwardIndexHandler(segmentLocalFSDirectory, indexLoadingConfig, _schema);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandlerTest.java
@@ -1204,9 +1204,15 @@ public class ForwardIndexHandlerTest {
     IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(null, _tableConfig);
 
     Random rand = new Random();
-    String col1 = _noDictionaryColumns.get(rand.nextInt(_noDictionaryColumns.size()));
+    String col1;
+    do {
+      col1 = _noDictionaryColumns.get(rand.nextInt(_noDictionaryColumns.size()));
+    } while (FORWARD_INDEX_DISABLED_RAW_COLUMNS.contains(col1));
     indexLoadingConfig.getNoDictionaryColumns().remove(col1);
-    String col2 = _noDictionaryColumns.get(rand.nextInt(_noDictionaryColumns.size()));
+    String col2;
+    do {
+      col2 = _noDictionaryColumns.get(rand.nextInt(_noDictionaryColumns.size()));
+    } while (FORWARD_INDEX_DISABLED_RAW_COLUMNS.contains(col2));
     indexLoadingConfig.getNoDictionaryColumns().remove(col2);
 
     ForwardIndexHandler fwdIndexHandler = new ForwardIndexHandler(segmentLocalFSDirectory, indexLoadingConfig, _schema);


### PR DESCRIPTION
This PR fixes the flaky test `ForwardIndexHandlerTest.testEnableDictionaryForMultipleColumns` as identified in issue: https://github.com/apache/pinot/issues/10365

Issue: Only forward index enabled columns should be used in this test, while due to choosing a random column a forward index disabled column can get picked sometimes.

Fix: Only pick forward index enabled columns

This also fixes a redundant if clause in `ForwardIndexHandler`

cc @Jackie-Jiang @vvivekiyer @siddharthteotia 