### PR TITLE
10249: Separating the v1beta1 & v1 ingress objects.

### DIFF
--- a/kubernetes/helm/pinot/templates/broker/ingress-v1.yaml
+++ b/kubernetes/helm/pinot/templates/broker/ingress-v1.yaml
@@ -1,34 +1,3 @@
-{{- if .Values.broker.ingress.v1beta1.enabled -}}
-{{- $ingressPath := .Values.broker.ingress.v1beta1.path -}}
-{{- $serviceName := include "pinot.broker.fullname" . -}}
-{{- $servicePort := .Values.broker.service.port -}}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: {{ $serviceName }}
-{{- if .Values.broker.ingress.v1beta1.annotations }}
-  annotations:
-{{ toYaml .Values.broker.ingress.v1beta1.annotations | indent 4 }}
-{{- end }}
-  labels:
-{{- include "pinot.brokerLabels" . | nindent 4 }}
-spec:
-{{- if .Values.broker.ingress.v1beta1.tls }}
-  tls:
-{{ toYaml .Values.broker.ingress.v1beta1.tls | indent 4 }}
-{{- end }}
-  rules:
-    {{- range .Values.broker.ingress.v1beta1.hosts }}
-  - host: {{ . }}
-    http:
-      paths:
-        - path: {{ $ingressPath }}
-          backend:
-            serviceName: {{ $serviceName }}
-            servicePort: {{ $servicePort }}
-    {{- end }}
-{{- end }}
-
 {{- if .Values.broker.ingress.v1.enabled -}}
 {{- $ingressPath := .Values.broker.ingress.v1.path -}}
 {{- $serviceName := include "pinot.broker.fullname" . -}}

--- a/kubernetes/helm/pinot/templates/broker/ingress-v1beta1.yaml
+++ b/kubernetes/helm/pinot/templates/broker/ingress-v1beta1.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.broker.ingress.v1beta1.enabled -}}
+{{- $ingressPath := .Values.broker.ingress.v1beta1.path -}}
+{{- $serviceName := include "pinot.broker.fullname" . -}}
+{{- $servicePort := .Values.broker.service.port -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $serviceName }}
+{{- if .Values.broker.ingress.v1beta1.annotations }}
+  annotations:
+{{ toYaml .Values.broker.ingress.v1beta1.annotations | indent 4 }}
+{{- end }}
+  labels:
+{{- include "pinot.brokerLabels" . | nindent 4 }}
+spec:
+{{- if .Values.broker.ingress.v1beta1.tls }}
+  tls:
+{{ toYaml .Values.broker.ingress.v1beta1.tls | indent 4 }}
+{{- end }}
+  rules:
+    {{- range .Values.broker.ingress.v1beta1.hosts }}
+  - host: {{ . }}
+    http:
+      paths:
+        - path: {{ $ingressPath }}
+          backend:
+            serviceName: {{ $serviceName }}
+            servicePort: {{ $servicePort }}
+    {{- end }}
+{{- end }}

--- a/kubernetes/helm/pinot/templates/controller/ingress-v1.yaml
+++ b/kubernetes/helm/pinot/templates/controller/ingress-v1.yaml
@@ -1,34 +1,3 @@
-{{- if .Values.controller.ingress.v1beta1.enabled -}}
-{{- $ingressPath := .Values.controller.ingress.v1beta1.path -}}
-{{- $serviceName := include "pinot.controller.fullname" . -}}
-{{- $servicePort := .Values.controller.service.port -}}
-apiVersion: extensions/v1beta1
-kind: Ingress
-metadata:
-  name: {{ $serviceName }}
-{{- if .Values.controller.ingress.v1beta1.annotations }}
-  annotations:
-{{ toYaml .Values.controller.ingress.v1beta1.annotations | indent 4 }}
-{{- end }}
-  labels:
-{{- include "pinot.controllerLabels" . | nindent 4 }}
-spec:
-{{- if .Values.controller.ingress.v1beta1.tls }}
-  tls:
-{{ toYaml .Values.controller.ingress.v1beta1.tls | indent 4 }}
-{{- end }}
-  rules:
-    {{- range .Values.controller.ingress.v1beta1.hosts }}
-    - host: {{ . }}
-      http:
-        paths:
-          - path: {{ $ingressPath }}
-            backend:
-              serviceName: {{ $serviceName }}
-              servicePort: {{ $servicePort }}
-    {{- end }}
-{{- end }}
-
 {{- if .Values.controller.ingress.v1.enabled -}}
 {{- $ingressPath := .Values.controller.ingress.v1.path -}}
 {{- $serviceName := include "pinot.controller.fullname" . -}}

--- a/kubernetes/helm/pinot/templates/controller/ingress-v1beta1.yaml
+++ b/kubernetes/helm/pinot/templates/controller/ingress-v1beta1.yaml
@@ -1,0 +1,30 @@
+{{- if .Values.controller.ingress.v1beta1.enabled -}}
+{{- $ingressPath := .Values.controller.ingress.v1beta1.path -}}
+{{- $serviceName := include "pinot.controller.fullname" . -}}
+{{- $servicePort := .Values.controller.service.port -}}
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: {{ $serviceName }}
+{{- if .Values.controller.ingress.v1beta1.annotations }}
+  annotations:
+{{ toYaml .Values.controller.ingress.v1beta1.annotations | indent 4 }}
+{{- end }}
+  labels:
+{{- include "pinot.controllerLabels" . | nindent 4 }}
+spec:
+{{- if .Values.controller.ingress.v1beta1.tls }}
+  tls:
+{{ toYaml .Values.controller.ingress.v1beta1.tls | indent 4 }}
+{{- end }}
+  rules:
+    {{- range .Values.controller.ingress.v1beta1.hosts }}
+    - host: {{ . }}
+      http:
+        paths:
+          - path: {{ $ingressPath }}
+            backend:
+              serviceName: {{ $serviceName }}
+              servicePort: {{ $servicePort }}
+    {{- end }}
+{{- end }}


### PR DESCRIPTION
This PR will separate the `v1beta1` & `v1` ingress objects into two different files as per the [bug](https://github.com/apache/pinot/issues/10249) 

cc @Jackie-Jiang @xiangfu0 