### PR TITLE
allow to customize the httpclient used to create S3PinotFS

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-s3/pom.xml
@@ -137,6 +137,11 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>software.amazon.awssdk</groupId>
+      <artifactId>apache-client</artifactId>
+      <version>${aws.sdk.version}</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpclient</artifactId>
       <version>${http.client.version}</version>

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
@@ -141,25 +141,25 @@ public class S3Config {
     if (value != null) {
       Duration pv = parseDuration(value);
       httpClientBuilder.socketTimeout(pv);
-      LOGGER.debug("Set socketTimeout to {}sec for http client builder", pv.toSeconds());
+      LOGGER.debug("Set socketTimeout to {}ms for http client builder", pv.toMillis());
     }
     value = config.getProperty(HTTP_CLIENT_CONFIG_CONNECTION_TIMEOUT);
     if (value != null) {
       Duration pv = parseDuration(value);
       httpClientBuilder.connectionTimeout(pv);
-      LOGGER.debug("Set connectionTimeout to {}sec for http client builder", pv.toSeconds());
+      LOGGER.debug("Set connectionTimeout to {}ms for http client builder", pv.toMillis());
     }
     value = config.getProperty(HTTP_CLIENT_CONFIG_CONNECTION_TIME_TO_LIVE);
     if (value != null) {
       Duration pv = parseDuration(value);
       httpClientBuilder.connectionTimeToLive(pv);
-      LOGGER.debug("Set connectionTimeToLive to {}sec for http client builder", pv.toSeconds());
+      LOGGER.debug("Set connectionTimeToLive to {}ms for http client builder", pv.toMillis());
     }
     value = config.getProperty(HTTP_CLIENT_CONFIG_CONNECTION_ACQUISITION_TIMEOUT);
     if (value != null) {
       Duration pv = parseDuration(value);
       httpClientBuilder.connectionAcquisitionTimeout(pv);
-      LOGGER.debug("Set connectionAcquisitionTimeout to {}sec for http client builder", pv.toSeconds());
+      LOGGER.debug("Set connectionAcquisitionTimeout to {}ms for http client builder", pv.toMillis());
     }
     return httpClientBuilder;
   }

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
@@ -171,8 +171,13 @@ public class S3Config {
       return Duration.ofMillis(TimeUtils.convertPeriodToMillis(durStr));
     } catch (Exception ignore) {
     }
-    // try format like 'PT1H20S'
-    return Duration.parse(durStr);
+    try {
+      // try format like 'PT1H20S'
+      return Duration.parse(durStr);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          String.format("Invalid time duration '%s', for examples '1hr20s' or 'PT1H20S'", durStr), e);
+    }
   }
 
   public String getAccessKey() {

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3Config.java
@@ -26,7 +26,6 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import software.amazon.awssdk.http.SdkHttpConfigurationOption;
 import software.amazon.awssdk.http.apache.ApacheHttpClient;
 
 

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -147,6 +147,9 @@ public class S3PinotFS extends BasePinotFS {
           throw new RuntimeException(e);
         }
       }
+      if (s3Config.getHttpClientBuilder() != null) {
+        s3ClientBuilder.httpClientBuilder(s3Config.getHttpClientBuilder());
+      }
       _s3Client = s3ClientBuilder.build();
       setMultiPartUploadConfigs(s3Config);
     } catch (S3Exception e) {

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/test/java/org/apache/pinot/plugin/filesystem/S3ConfigTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/test/java/org/apache/pinot/plugin/filesystem/S3ConfigTest.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.plugin.filesystem;
 
-import java.time.format.DateTimeParseException;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -40,9 +39,9 @@ public class S3ConfigTest {
     Assert.assertNotNull(cfg.getHttpClientBuilder());
   }
 
-  @Test(expectedExceptions = DateTimeParseException.class)
+  @Test(expectedExceptions = IllegalArgumentException.class)
   public void testParseDuration() {
     Assert.assertEquals(S3Config.parseDuration("P1DT2H30S"), S3Config.parseDuration("1d2h30s"));
-    S3Config.parseDuration("unknown_format");
+    S3Config.parseDuration("10");
   }
 }

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/test/java/org/apache/pinot/plugin/filesystem/S3ConfigTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/test/java/org/apache/pinot/plugin/filesystem/S3ConfigTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.plugin.filesystem;
 
+import java.time.format.DateTimeParseException;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -31,11 +32,17 @@ public class S3ConfigTest {
     Assert.assertNull(cfg.getHttpClientBuilder());
 
     pinotConfig.setProperty("httpclient.maxConnections", 100);
-    pinotConfig.setProperty("httpclient.socketTimeout", "PT10S");
-    pinotConfig.setProperty("httpclient.connectionTimeout", "PT20S");
-    pinotConfig.setProperty("httpclient.connectionTimeToLive", "PT30S");
-    pinotConfig.setProperty("httpclient.connectionAcquisitionTimeout", "PT40S");
+    pinotConfig.setProperty("httpclient.socketTimeout", "PT1M10S");
+    pinotConfig.setProperty("httpclient.connectionTimeout", "PT2M20S");
+    pinotConfig.setProperty("httpclient.connectionTimeToLive", "3m30s");
+    pinotConfig.setProperty("httpclient.connectionAcquisitionTimeout", "4m40s");
     cfg = new S3Config(pinotConfig);
     Assert.assertNotNull(cfg.getHttpClientBuilder());
+  }
+
+  @Test(expectedExceptions = DateTimeParseException.class)
+  public void testParseDuration() {
+    Assert.assertEquals(S3Config.parseDuration("P1DT2H30S"), S3Config.parseDuration("1d2h30s"));
+    S3Config.parseDuration("unknown_format");
   }
 }

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/test/java/org/apache/pinot/plugin/filesystem/S3ConfigTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/test/java/org/apache/pinot/plugin/filesystem/S3ConfigTest.java
@@ -1,0 +1,41 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.filesystem;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class S3ConfigTest {
+  @Test
+  public void testGetHttpClientBuilder() {
+    PinotConfiguration pinotConfig = new PinotConfiguration();
+    S3Config cfg = new S3Config(pinotConfig);
+    Assert.assertNull(cfg.getHttpClientBuilder());
+
+    pinotConfig.setProperty("httpclient.maxConnections", 100);
+    pinotConfig.setProperty("httpclient.socketTimeout", "PT10S");
+    pinotConfig.setProperty("httpclient.connectionTimeout", "PT20S");
+    pinotConfig.setProperty("httpclient.connectionTimeToLive", "PT30S");
+    pinotConfig.setProperty("httpclient.connectionAcquisitionTimeout", "PT40S");
+    cfg = new S3Config(pinotConfig);
+    Assert.assertNotNull(cfg.getHttpClientBuilder());
+  }
+}


### PR DESCRIPTION
This PR exposes some configs to customize the httpclient used to create s3client, when to init the S3PinotFS. 

## Release Note ##
the exposed httpclient configs are 
`httpclient.maxConnections`, e.g. 100 (this is more required for now. when we increased helixExecutorTask thread number via STATE_TRANSITION.maxThreads to load segments with more threads, some threads threw exceptions about timeout to get a http conn to download raw segments from deep store)

`httpclient.socketTimeout`, e.g. 10s
`httpclient.connectionTimeout`, e.g. 1m20s
`httpclient.connectionTimeToLive`, e.g. ..
`httpclient.connectionAcquisitionTimeout`, e.g. ..

