### PR TITLE
add the ability to change FilterOperatorUtils code

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
@@ -28,7 +28,205 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 
 
 public class FilterOperatorUtils {
+
+  private static volatile Implementation _instance = new Implementation();
+
   private FilterOperatorUtils() {
+  }
+
+  public static void setImplementation(Implementation newImplementation) {
+    _instance = newImplementation;
+  }
+
+  public static class Implementation {
+
+    /**
+     * Returns the leaf filter operator (i.e. not {@link AndFilterOperator} or {@link OrFilterOperator}).
+     */
+    public BaseFilterOperator getLeafFilterOperator(PredicateEvaluator predicateEvaluator, DataSource dataSource,
+        int numDocs, boolean nullHandlingEnabled) {
+      if (predicateEvaluator.isAlwaysFalse()) {
+        return EmptyFilterOperator.getInstance();
+      } else if (predicateEvaluator.isAlwaysTrue()) {
+        return new MatchAllFilterOperator(numDocs);
+      }
+
+      // Currently sorted index based filtering is supported only for
+      // dictionary encoded columns. The on-disk segment metadata
+      // will indicate if the column is sorted or not regardless of
+      // whether it is raw or dictionary encoded. Here when creating
+      // the filter operator, we need to make sure that sort filter
+      // operator is used only if the column is sorted and has dictionary.
+      Predicate.Type predicateType = predicateEvaluator.getPredicateType();
+      if (predicateType == Predicate.Type.RANGE) {
+        if (dataSource.getDataSourceMetadata().isSorted() && dataSource.getDictionary() != null) {
+          return new SortedIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
+        }
+        if (RangeIndexBasedFilterOperator.canEvaluate(predicateEvaluator, dataSource)) {
+          return new RangeIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
+        }
+        return new ScanBasedFilterOperator(predicateEvaluator, dataSource, numDocs, nullHandlingEnabled);
+      } else if (predicateType == Predicate.Type.REGEXP_LIKE) {
+        if (dataSource.getFSTIndex() != null && dataSource.getDataSourceMetadata().isSorted()) {
+          return new SortedIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
+        }
+        if (dataSource.getFSTIndex() != null && dataSource.getInvertedIndex() != null) {
+          return new BitmapBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
+        }
+        return new ScanBasedFilterOperator(predicateEvaluator, dataSource, numDocs, nullHandlingEnabled);
+      } else {
+        if (dataSource.getDataSourceMetadata().isSorted() && dataSource.getDictionary() != null) {
+          return new SortedIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
+        }
+        if (dataSource.getInvertedIndex() != null) {
+          return new BitmapBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
+        }
+        if (RangeIndexBasedFilterOperator.canEvaluate(predicateEvaluator, dataSource)) {
+          return new RangeIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
+        }
+        return new ScanBasedFilterOperator(predicateEvaluator, dataSource, numDocs, nullHandlingEnabled);
+      }
+    }
+
+    /**
+     * Returns the AND filter operator or equivalent filter operator.
+     */
+    public BaseFilterOperator getAndFilterOperator(QueryContext queryContext,
+        List<BaseFilterOperator> filterOperators, int numDocs) {
+      List<BaseFilterOperator> childFilterOperators = new ArrayList<>(filterOperators.size());
+      for (BaseFilterOperator filterOperator : filterOperators) {
+        if (filterOperator.isResultEmpty()) {
+          return EmptyFilterOperator.getInstance();
+        } else if (!filterOperator.isResultMatchingAll()) {
+          childFilterOperators.add(filterOperator);
+        }
+      }
+      int numChildFilterOperators = childFilterOperators.size();
+      if (numChildFilterOperators == 0) {
+        // Return match all filter operator if all child filter operators match all records
+        return new MatchAllFilterOperator(numDocs);
+      } else if (numChildFilterOperators == 1) {
+        // Return the child filter operator if only one left
+        return childFilterOperators.get(0);
+      } else {
+        // Return the AND filter operator with re-ordered child filter operators
+        reorderAndFilterChildOperators(queryContext, childFilterOperators);
+        return new AndFilterOperator(childFilterOperators, queryContext.getQueryOptions());
+      }
+    }
+
+    /**
+     * Returns the OR filter operator or equivalent filter operator.
+     */
+    public BaseFilterOperator getOrFilterOperator(QueryContext queryContext,
+        List<BaseFilterOperator> filterOperators, int numDocs) {
+      List<BaseFilterOperator> childFilterOperators = new ArrayList<>(filterOperators.size());
+      for (BaseFilterOperator filterOperator : filterOperators) {
+        if (filterOperator.isResultMatchingAll()) {
+          return new MatchAllFilterOperator(numDocs);
+        } else if (!filterOperator.isResultEmpty()) {
+          childFilterOperators.add(filterOperator);
+        }
+      }
+      int numChildFilterOperators = childFilterOperators.size();
+      if (numChildFilterOperators == 0) {
+        // Return empty filter operator if all child filter operators's result is empty
+        return EmptyFilterOperator.getInstance();
+      } else if (numChildFilterOperators == 1) {
+        // Return the child filter operator if only one left
+        return childFilterOperators.get(0);
+      } else {
+        // Return the OR filter operator with child filter operators
+        return new OrFilterOperator(childFilterOperators, numDocs);
+      }
+    }
+
+    /**
+     * Returns the NOT filter operator or equivalent filter operator.
+     */
+    public BaseFilterOperator getNotFilterOperator(QueryContext queryContext, BaseFilterOperator filterOperator,
+        int numDocs) {
+      if (filterOperator.isResultMatchingAll()) {
+        return EmptyFilterOperator.getInstance();
+      } else if (filterOperator.isResultEmpty()) {
+        return new MatchAllFilterOperator(numDocs);
+      }
+
+      return new NotFilterOperator(filterOperator, numDocs);
+    }
+
+    /**
+     * For AND filter operator, reorders its child filter operators based on the their cost and puts the ones with
+     * inverted index first in order to reduce the number of documents to be processed.
+     * <p>Special filter operators such as {@link MatchAllFilterOperator} and {@link EmptyFilterOperator} should be
+     * removed from the list before calling this method.
+     */
+    protected void reorderAndFilterChildOperators(QueryContext queryContext,
+        List<BaseFilterOperator> filterOperators) {
+      filterOperators.sort(new Comparator<BaseFilterOperator>() {
+        @Override
+        public int compare(BaseFilterOperator o1, BaseFilterOperator o2) {
+          return getPriority(o1) - getPriority(o2);
+        }
+
+        int getPriority(BaseFilterOperator filterOperator) {
+          if (filterOperator instanceof SortedIndexBasedFilterOperator) {
+            return 0;
+          }
+          if (filterOperator instanceof BitmapBasedFilterOperator) {
+            return 1;
+          }
+          if (filterOperator instanceof RangeIndexBasedFilterOperator
+              || filterOperator instanceof TextContainsFilterOperator
+              || filterOperator instanceof TextMatchFilterOperator
+              || filterOperator instanceof JsonMatchFilterOperator || filterOperator instanceof H3IndexFilterOperator
+              || filterOperator instanceof H3InclusionIndexFilterOperator) {
+            return 2;
+          }
+          if (filterOperator instanceof AndFilterOperator) {
+            return 3;
+          }
+          if (filterOperator instanceof OrFilterOperator) {
+            return 4;
+          }
+          if (filterOperator instanceof NotFilterOperator) {
+            return getPriority(((NotFilterOperator) filterOperator).getChildFilterOperator());
+          }
+          if (filterOperator instanceof ScanBasedFilterOperator) {
+            return getScanBasedFilterPriority(queryContext, (ScanBasedFilterOperator) filterOperator, 5);
+          }
+          if (filterOperator instanceof ExpressionFilterOperator) {
+            return 10;
+          }
+          throw new IllegalStateException(filterOperator.getClass().getSimpleName()
+              + " should not be reordered, remove it from the list before calling this method");
+        }
+      });
+    }
+
+    /**
+     * Returns the priority for scan based filtering. Multivalue column evaluation is costly, so
+     * reorder such that multivalue columns are evaluated after single value columns.
+     *
+     * TODO: additional cost based prioritization to be added
+     *
+     * @param scanBasedFilterOperator the filter operator to prioritize
+     * @param queryContext query context
+     * @return the priority to be associated with the filter
+     */
+    protected int getScanBasedFilterPriority(QueryContext queryContext,
+        ScanBasedFilterOperator scanBasedFilterOperator, int basePriority) {
+      if (queryContext.isSkipScanFilterReorder()) {
+        return basePriority;
+      }
+
+      if (scanBasedFilterOperator.getDataSourceMetadata().isSingleValue()) {
+        return basePriority;
+      } else {
+        // Lower priority for multi-value column
+        return basePriority + 1;
+      }
+    }
   }
 
   /**
@@ -44,47 +242,7 @@ public class FilterOperatorUtils {
    */
   public static BaseFilterOperator getLeafFilterOperator(PredicateEvaluator predicateEvaluator, DataSource dataSource,
       int numDocs, boolean nullHandlingEnabled) {
-    if (predicateEvaluator.isAlwaysFalse()) {
-      return EmptyFilterOperator.getInstance();
-    } else if (predicateEvaluator.isAlwaysTrue()) {
-      return new MatchAllFilterOperator(numDocs);
-    }
-
-    // Currently sorted index based filtering is supported only for
-    // dictionary encoded columns. The on-disk segment metadata
-    // will indicate if the column is sorted or not regardless of
-    // whether it is raw or dictionary encoded. Here when creating
-    // the filter operator, we need to make sure that sort filter
-    // operator is used only if the column is sorted and has dictionary.
-    Predicate.Type predicateType = predicateEvaluator.getPredicateType();
-    if (predicateType == Predicate.Type.RANGE) {
-      if (dataSource.getDataSourceMetadata().isSorted() && dataSource.getDictionary() != null) {
-        return new SortedIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
-      }
-      if (RangeIndexBasedFilterOperator.canEvaluate(predicateEvaluator, dataSource)) {
-        return new RangeIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
-      }
-      return new ScanBasedFilterOperator(predicateEvaluator, dataSource, numDocs, nullHandlingEnabled);
-    } else if (predicateType == Predicate.Type.REGEXP_LIKE) {
-      if (dataSource.getFSTIndex() != null && dataSource.getDataSourceMetadata().isSorted()) {
-        return new SortedIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
-      }
-      if (dataSource.getFSTIndex() != null && dataSource.getInvertedIndex() != null) {
-        return new BitmapBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
-      }
-      return new ScanBasedFilterOperator(predicateEvaluator, dataSource, numDocs, nullHandlingEnabled);
-    } else {
-      if (dataSource.getDataSourceMetadata().isSorted() && dataSource.getDictionary() != null) {
-        return new SortedIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
-      }
-      if (dataSource.getInvertedIndex() != null) {
-        return new BitmapBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
-      }
-      if (RangeIndexBasedFilterOperator.canEvaluate(predicateEvaluator, dataSource)) {
-        return new RangeIndexBasedFilterOperator(predicateEvaluator, dataSource, numDocs);
-      }
-      return new ScanBasedFilterOperator(predicateEvaluator, dataSource, numDocs, nullHandlingEnabled);
-    }
+    return _instance.getLeafFilterOperator(predicateEvaluator, dataSource, numDocs, nullHandlingEnabled);
   }
 
   /**
@@ -92,26 +250,7 @@ public class FilterOperatorUtils {
    */
   public static BaseFilterOperator getAndFilterOperator(QueryContext queryContext,
       List<BaseFilterOperator> filterOperators, int numDocs) {
-    List<BaseFilterOperator> childFilterOperators = new ArrayList<>(filterOperators.size());
-    for (BaseFilterOperator filterOperator : filterOperators) {
-      if (filterOperator.isResultEmpty()) {
-        return EmptyFilterOperator.getInstance();
-      } else if (!filterOperator.isResultMatchingAll()) {
-        childFilterOperators.add(filterOperator);
-      }
-    }
-    int numChildFilterOperators = childFilterOperators.size();
-    if (numChildFilterOperators == 0) {
-      // Return match all filter operator if all child filter operators match all records
-      return new MatchAllFilterOperator(numDocs);
-    } else if (numChildFilterOperators == 1) {
-      // Return the child filter operator if only one left
-      return childFilterOperators.get(0);
-    } else {
-      // Return the AND filter operator with re-ordered child filter operators
-      FilterOperatorUtils.reorderAndFilterChildOperators(queryContext, childFilterOperators);
-      return new AndFilterOperator(childFilterOperators, queryContext.getQueryOptions());
-    }
+    return _instance.getAndFilterOperator(queryContext, filterOperators, numDocs);
   }
 
   /**
@@ -119,25 +258,7 @@ public class FilterOperatorUtils {
    */
   public static BaseFilterOperator getOrFilterOperator(QueryContext queryContext,
       List<BaseFilterOperator> filterOperators, int numDocs) {
-    List<BaseFilterOperator> childFilterOperators = new ArrayList<>(filterOperators.size());
-    for (BaseFilterOperator filterOperator : filterOperators) {
-      if (filterOperator.isResultMatchingAll()) {
-        return new MatchAllFilterOperator(numDocs);
-      } else if (!filterOperator.isResultEmpty()) {
-        childFilterOperators.add(filterOperator);
-      }
-    }
-    int numChildFilterOperators = childFilterOperators.size();
-    if (numChildFilterOperators == 0) {
-      // Return empty filter operator if all child filter operators's result is empty
-      return EmptyFilterOperator.getInstance();
-    } else if (numChildFilterOperators == 1) {
-      // Return the child filter operator if only one left
-      return childFilterOperators.get(0);
-    } else {
-      // Return the OR filter operator with child filter operators
-      return new OrFilterOperator(childFilterOperators, numDocs);
-    }
+    return _instance.getOrFilterOperator(queryContext, filterOperators, numDocs);
   }
 
   /**
@@ -145,84 +266,6 @@ public class FilterOperatorUtils {
    */
   public static BaseFilterOperator getNotFilterOperator(QueryContext queryContext, BaseFilterOperator filterOperator,
       int numDocs) {
-    if (filterOperator.isResultMatchingAll()) {
-      return EmptyFilterOperator.getInstance();
-    } else if (filterOperator.isResultEmpty()) {
-      return new MatchAllFilterOperator(numDocs);
-    }
-
-    return new NotFilterOperator(filterOperator, numDocs);
-  }
-
-  /**
-   * For AND filter operator, reorders its child filter operators based on the their cost and puts the ones with
-   * inverted index first in order to reduce the number of documents to be processed.
-   * <p>Special filter operators such as {@link MatchAllFilterOperator} and {@link EmptyFilterOperator} should be
-   * removed from the list before calling this method.
-   */
-  private static void reorderAndFilterChildOperators(QueryContext queryContext,
-      List<BaseFilterOperator> filterOperators) {
-    filterOperators.sort(new Comparator<BaseFilterOperator>() {
-      @Override
-      public int compare(BaseFilterOperator o1, BaseFilterOperator o2) {
-        return getPriority(o1) - getPriority(o2);
-      }
-
-      int getPriority(BaseFilterOperator filterOperator) {
-        if (filterOperator instanceof SortedIndexBasedFilterOperator) {
-          return 0;
-        }
-        if (filterOperator instanceof BitmapBasedFilterOperator) {
-          return 1;
-        }
-        if (filterOperator instanceof RangeIndexBasedFilterOperator
-            || filterOperator instanceof TextContainsFilterOperator || filterOperator instanceof TextMatchFilterOperator
-            || filterOperator instanceof JsonMatchFilterOperator || filterOperator instanceof H3IndexFilterOperator
-            || filterOperator instanceof H3InclusionIndexFilterOperator) {
-          return 2;
-        }
-        if (filterOperator instanceof AndFilterOperator) {
-          return 3;
-        }
-        if (filterOperator instanceof OrFilterOperator) {
-          return 4;
-        }
-        if (filterOperator instanceof NotFilterOperator) {
-          return getPriority(((NotFilterOperator) filterOperator).getChildFilterOperator());
-        }
-        if (filterOperator instanceof ScanBasedFilterOperator) {
-          return getScanBasedFilterPriority(queryContext, (ScanBasedFilterOperator) filterOperator, 5);
-        }
-        if (filterOperator instanceof ExpressionFilterOperator) {
-          return 10;
-        }
-        throw new IllegalStateException(filterOperator.getClass().getSimpleName()
-            + " should not be reordered, remove it from the list before calling this method");
-      }
-    });
-  }
-
-  /**
-   * Returns the priority for scan based filtering. Multivalue column evaluation is costly, so
-   * reorder such that multivalue columns are evaluated after single value columns.
-   *
-   * TODO: additional cost based prioritization to be added
-   *
-   * @param scanBasedFilterOperator the filter operator to prioritize
-   * @param queryContext query context
-   * @return the priority to be associated with the filter
-   */
-  private static int getScanBasedFilterPriority(QueryContext queryContext,
-      ScanBasedFilterOperator scanBasedFilterOperator, int basePriority) {
-    if (queryContext.isSkipScanFilterReorder()) {
-      return basePriority;
-    }
-
-    if (scanBasedFilterOperator.getDataSourceMetadata().isSingleValue()) {
-      return basePriority;
-    } else {
-      // Lower priority for multi-value column
-      return basePriority + 1;
-    }
+    return _instance.getNotFilterOperator(queryContext, filterOperator, numDocs);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
@@ -63,15 +63,6 @@ public class FilterOperatorUtils {
      */
     BaseFilterOperator getNotFilterOperator(QueryContext queryContext, BaseFilterOperator filterOperator,
         int numDocs);
-
-    /**
-     * For AND filter operator, reorders its child filter operators based on the their cost and puts the ones with
-     * inverted index first in order to reduce the number of documents to be processed.
-     * <p>Special filter operators such as {@link MatchAllFilterOperator} and {@link EmptyFilterOperator} should be
-     * removed from the list before calling this method.
-     */
-    void reorderAndFilterChildOperators(QueryContext queryContext,
-        List<BaseFilterOperator> filterOperators);
   }
 
   public static class DefaultImplementation implements Implementation {
@@ -182,8 +173,14 @@ public class FilterOperatorUtils {
       return new NotFilterOperator(filterOperator, numDocs);
     }
 
-    @Override
-    public void reorderAndFilterChildOperators(QueryContext queryContext, List<BaseFilterOperator> filterOperators) {
+
+    /**
+     * For AND filter operator, reorders its child filter operators based on the their cost and puts the ones with
+     * inverted index first in order to reduce the number of documents to be processed.
+     * <p>Special filter operators such as {@link MatchAllFilterOperator} and {@link EmptyFilterOperator} should be
+     * removed from the list before calling this method.
+     */
+    protected void reorderAndFilterChildOperators(QueryContext queryContext, List<BaseFilterOperator> filterOperators) {
       filterOperators.sort(new Comparator<BaseFilterOperator>() {
         @Override
         public int compare(BaseFilterOperator o1, BaseFilterOperator o2) {


### PR DESCRIPTION
This PR is related to https://github.com/apache/pinot/pull/10269. While https://github.com/apache/pinot/pull/10269 let us change the PlanMaker, let us change the `FilterOperatorUtils` code.

It would be great to have a proper Query SPI system that let us modify different places in the code, but while we don't have it, this let us change the actual implementation of leaf nodes, which is very useful in a proprietary extension StarTree is creating.