### PR TITLE
Let applyAnd to be applied using different window sizes

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/BitmapDocIdSetOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/BitmapDocIdSetOperator.java
@@ -52,6 +52,11 @@ public class BitmapDocIdSetOperator extends BaseOperator<DocIdSetBlock> {
     _docIdBuffer = new int[Math.min(numDocs, DocIdSetPlanNode.MAX_DOC_PER_CALL)];
   }
 
+  public BitmapDocIdSetOperator(IntIterator intIterator, int[] docIdBuffer) {
+    _intIterator = intIterator;
+    _docIdBuffer = docIdBuffer;
+  }
+
   public BitmapDocIdSetOperator(ImmutableBitmapDataProvider bitmap, int[] docIdBuffer) {
     _intIterator = bitmap.getIntIterator();
     _docIdBuffer = docIdBuffer;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ExpressionScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ExpressionScanDocIdIterator.java
@@ -114,8 +114,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
   }
 
   @Override
-  public MutableRoaringBitmap applyAnd(BatchIterator batchIterator, OptionalInt firstDoc, OptionalInt lastDoc,
-      int bufferSize) {
+  public MutableRoaringBitmap applyAnd(BatchIterator batchIterator, OptionalInt firstDoc, OptionalInt lastDoc) {
     IntIterator intIterator = batchIterator.asIntIterator(new int[OPTIMAL_ITERATOR_BATCH_SIZE]);
     ProjectionOperator projectionOperator =
         new ProjectionOperator(_dataSourceMap, new BitmapDocIdSetOperator(intIterator, _docIdBuffer));

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.dociditerators;
 
+import java.util.OptionalInt;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.segment.spi.datasource.DataSource;
@@ -26,7 +27,6 @@ import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
 import org.apache.pinot.spi.utils.CommonConstants.Query.OptimizationConstants;
 import org.roaringbitmap.BatchIterator;
 import org.roaringbitmap.RoaringBitmapWriter;
-import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
@@ -79,14 +79,23 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
   }
 
   @Override
-  public MutableRoaringBitmap applyAnd(ImmutableRoaringBitmap docIds) {
-    if (docIds.isEmpty()) {
+  public MutableRoaringBitmap applyAnd(BatchIterator docIdIterator, OptionalInt firstDoc, OptionalInt lastDoc,
+      int bufferSize) {
+    if (!docIdIterator.hasNext()) {
       return new MutableRoaringBitmap();
     }
-    RoaringBitmapWriter<MutableRoaringBitmap> result = RoaringBitmapWriter.bufferWriter()
-        .expectedRange(docIds.first(), docIds.last()).runCompress(false).get();
-    BatchIterator docIdIterator = docIds.getBatchIterator();
-    int[] buffer = new int[OPTIMAL_ITERATOR_BATCH_SIZE];
+    RoaringBitmapWriter<MutableRoaringBitmap> result;
+    if (firstDoc.isPresent() && lastDoc.isPresent()) {
+      result = RoaringBitmapWriter.bufferWriter()
+          .expectedRange(firstDoc.getAsInt(), lastDoc.getAsInt())
+          .runCompress(false)
+          .get();
+    } else {
+      result = RoaringBitmapWriter.bufferWriter()
+          .runCompress(false)
+          .get();
+    }
+    int[] buffer = new int[bufferSize];
     while (docIdIterator.hasNext()) {
       int limit = docIdIterator.nextBatch(buffer);
       for (int i = 0; i < limit; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/MVScanDocIdIterator.java
@@ -47,9 +47,8 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
 
   private int _nextDocId = 0;
   private long _numEntriesScanned = 0L;
-  private final int _batchSize;
 
-  public MVScanDocIdIterator(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs, int batchSize) {
+  public MVScanDocIdIterator(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs) {
     _predicateEvaluator = predicateEvaluator;
     _reader = dataSource.getForwardIndex();
     _readerContext = _reader.createContext();
@@ -57,7 +56,6 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
     _maxNumValuesPerMVEntry = dataSource.getDataSourceMetadata().getMaxNumValuesPerMVEntry();
     _valueMatcher = getValueMatcher();
     _cardinality = dataSource.getDataSourceMetadata().getCardinality();
-    _batchSize = batchSize;
   }
 
   @Override
@@ -96,7 +94,7 @@ public final class MVScanDocIdIterator implements ScanBasedDocIdIterator {
           .runCompress(false)
           .get();
     }
-    int[] buffer = new int[_batchSize];
+    int[] buffer = new int[OPTIMAL_ITERATOR_BATCH_SIZE];
     while (docIdIterator.hasNext()) {
       int limit = docIdIterator.nextBatch(buffer);
       for (int i = 0; i < limit; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
@@ -53,12 +53,10 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
 
   private int _nextDocId = 0;
   private long _numEntriesScanned = 0L;
-  private final int _batchSize;
 
   public SVScanDocIdIterator(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs,
       @Nullable NullValueVectorReader nullValueReader, int batchSize) {
-    _batchSize = batchSize;
-    _batch = new int[_batchSize];
+    _batch = new int[batchSize];
     _predicateEvaluator = predicateEvaluator;
     _reader = dataSource.getForwardIndex();
     _readerContext = _reader.createContext();
@@ -74,8 +72,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
   // for testing
   public SVScanDocIdIterator(PredicateEvaluator predicateEvaluator, ForwardIndexReader reader, int numDocs,
       @Nullable NullValueVectorReader nullValueReader) {
-    _batchSize = BlockDocIdIterator.OPTIMAL_ITERATOR_BATCH_SIZE;
-    _batch = new int[_batchSize];
+    _batch = new int[BlockDocIdIterator.OPTIMAL_ITERATOR_BATCH_SIZE];
     _predicateEvaluator = predicateEvaluator;
     _reader = reader;
     _readerContext = reader.createContext();
@@ -143,7 +140,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
           .runCompress(false)
           .get();
     }
-    int[] buffer = new int[_batchSize];
+    int[] buffer = new int[_batch.length];
     while (docIdIterator.hasNext()) {
       int limit = docIdIterator.nextBatch(buffer);
       if (limit > 0) {
@@ -279,7 +276,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
 
   private class DictIdMatcher implements ValueMatcher {
 
-    private final int[] _buffer = new int[_batchSize];
+    private final int[] _buffer = new int[_batch.length];
 
     @Override
     public boolean doesValueMatch(int docId) {
@@ -295,7 +292,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
 
   private class DictIdMatcherAndNullHandler implements ValueMatcher {
 
-    private final int[] _buffer = new int[_batchSize];
+    private final int[] _buffer = new int[_batch.length];
     private final ImmutableRoaringBitmap _nullBitmap;
 
     public DictIdMatcherAndNullHandler(ImmutableRoaringBitmap nullBitmap) {
@@ -323,7 +320,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
 
   private class IntMatcher implements ValueMatcher {
 
-    private final int[] _buffer = new int[_batchSize];
+    private final int[] _buffer = new int[_batch.length];
 
     @Override
     public boolean doesValueMatch(int docId) {
@@ -340,7 +337,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
   private class IntMatcherAndNullHandler implements ValueMatcher {
 
     private final ImmutableRoaringBitmap _nullBitmap;
-    private final int[] _buffer = new int[_batchSize];
+    private final int[] _buffer = new int[_batch.length];
 
     public IntMatcherAndNullHandler(ImmutableRoaringBitmap nullBitmap) {
       _nullBitmap = nullBitmap;
@@ -364,7 +361,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
 
   private class LongMatcher implements ValueMatcher {
 
-    private final long[] _buffer = new long[_batchSize];
+    private final long[] _buffer = new long[_batch.length];
 
     @Override
     public boolean doesValueMatch(int docId) {
@@ -381,7 +378,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
   private class LongMatcherAndNullHandler implements ValueMatcher {
 
     private final ImmutableRoaringBitmap _nullBitmap;
-    private final long[] _buffer = new long[_batchSize];
+    private final long[] _buffer = new long[_batch.length];
 
     public LongMatcherAndNullHandler(ImmutableRoaringBitmap nullBitmap) {
       _nullBitmap = nullBitmap;
@@ -405,7 +402,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
 
   private class FloatMatcher implements ValueMatcher {
 
-    private final float[] _buffer = new float[_batchSize];
+    private final float[] _buffer = new float[_batch.length];
 
     @Override
     public boolean doesValueMatch(int docId) {
@@ -422,7 +419,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
   private class FloatMatcherAndNullHandler implements ValueMatcher {
 
     private final ImmutableRoaringBitmap _nullBitmap;
-    private final float[] _buffer = new float[_batchSize];
+    private final float[] _buffer = new float[_batch.length];
 
     public FloatMatcherAndNullHandler(ImmutableRoaringBitmap nullBitmap) {
       _nullBitmap = nullBitmap;
@@ -446,7 +443,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
 
   private class DoubleMatcher implements ValueMatcher {
 
-    private final double[] _buffer = new double[_batchSize];
+    private final double[] _buffer = new double[_batch.length];
 
     @Override
     public boolean doesValueMatch(int docId) {
@@ -463,7 +460,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
   private class DoubleMatcherAndNullHandler implements ValueMatcher {
 
     private final ImmutableRoaringBitmap _nullBitmap;
-    private final double[] _buffer = new double[_batchSize];
+    private final double[] _buffer = new double[_batch.length];
 
     public DoubleMatcherAndNullHandler(ImmutableRoaringBitmap nullBitmap) {
       _nullBitmap = nullBitmap;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
@@ -178,7 +178,7 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
 
   private ValueMatcher getValueMatcher(@Nullable ImmutableRoaringBitmap nullBitmap) {
     if (_reader.isDictionaryEncoded()) {
-      return nullBitmap == null ? new DictIdMatcher() : new DictIdMatcherAndNullHandler(nullBitmap, _batchSize);
+      return nullBitmap == null ? new DictIdMatcher() : new DictIdMatcherAndNullHandler(nullBitmap);
     } else {
       switch (_reader.getStoredType()) {
         case INT:
@@ -295,12 +295,11 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
 
   private class DictIdMatcherAndNullHandler implements ValueMatcher {
 
-    private final int[] _buffer;
+    private final int[] _buffer = new int[_batchSize];
     private final ImmutableRoaringBitmap _nullBitmap;
 
-    public DictIdMatcherAndNullHandler(ImmutableRoaringBitmap nullBitmap, int batchSize) {
+    public DictIdMatcherAndNullHandler(ImmutableRoaringBitmap nullBitmap) {
       _nullBitmap = nullBitmap;
-      _buffer = new int[batchSize];
     }
 
     @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/SVScanDocIdIterator.java
@@ -57,6 +57,8 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
 
   public SVScanDocIdIterator(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs,
       @Nullable NullValueVectorReader nullValueReader, int batchSize) {
+    _batchSize = batchSize;
+    _batch = new int[_batchSize];
     _predicateEvaluator = predicateEvaluator;
     _reader = dataSource.getForwardIndex();
     _readerContext = _reader.createContext();
@@ -67,13 +69,13 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
     }
     _valueMatcher = getValueMatcher(nullBitmap);
     _cardinality = dataSource.getDataSourceMetadata().getCardinality();
-    _batchSize = batchSize;
-    _batch = new int[_batchSize];
   }
 
   // for testing
   public SVScanDocIdIterator(PredicateEvaluator predicateEvaluator, ForwardIndexReader reader, int numDocs,
       @Nullable NullValueVectorReader nullValueReader) {
+    _batchSize = BlockDocIdIterator.OPTIMAL_ITERATOR_BATCH_SIZE;
+    _batch = new int[_batchSize];
     _predicateEvaluator = predicateEvaluator;
     _reader = reader;
     _readerContext = reader.createContext();
@@ -84,8 +86,6 @@ public final class SVScanDocIdIterator implements ScanBasedDocIdIterator {
     }
     _valueMatcher = getValueMatcher(nullBitmap);
     _cardinality = -1;
-    _batchSize = BlockDocIdIterator.OPTIMAL_ITERATOR_BATCH_SIZE;
-    _batch = new int[_batchSize];
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
@@ -42,6 +42,9 @@ public interface ScanBasedDocIdIterator extends BlockDocIdIterator {
    * Applies AND operation to the given bitmap of document ids, returns a bitmap of the matching document ids.
    */
   default MutableRoaringBitmap applyAnd(ImmutableRoaringBitmap docIds) {
+    if (docIds.isEmpty()) {
+      return new MutableRoaringBitmap();
+    }
     return applyAnd(docIds.getBatchIterator(), OptionalInt.of(docIds.first()), OptionalInt.of(docIds.last()),
         OPTIMAL_ITERATOR_BATCH_SIZE);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
@@ -36,7 +36,7 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
  */
 public interface ScanBasedDocIdIterator extends BlockDocIdIterator {
 
-  MutableRoaringBitmap applyAnd(BatchIterator batchIterator, OptionalInt firstDoc, OptionalInt lastDoc, int bufferSize);
+  MutableRoaringBitmap applyAnd(BatchIterator batchIterator, OptionalInt firstDoc, OptionalInt lastDoc);
 
   /**
    * Applies AND operation to the given bitmap of document ids, returns a bitmap of the matching document ids.
@@ -45,8 +45,7 @@ public interface ScanBasedDocIdIterator extends BlockDocIdIterator {
     if (docIds.isEmpty()) {
       return new MutableRoaringBitmap();
     }
-    return applyAnd(docIds.getBatchIterator(), OptionalInt.of(docIds.first()), OptionalInt.of(docIds.last()),
-        OPTIMAL_ITERATOR_BATCH_SIZE);
+    return applyAnd(docIds.getBatchIterator(), OptionalInt.of(docIds.first()), OptionalInt.of(docIds.last()));
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ScanBasedDocIdIterator.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.core.operator.dociditerators;
 
+import java.util.OptionalInt;
 import org.apache.pinot.core.common.BlockDocIdIterator;
+import org.roaringbitmap.BatchIterator;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
@@ -34,10 +36,15 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
  */
 public interface ScanBasedDocIdIterator extends BlockDocIdIterator {
 
+  MutableRoaringBitmap applyAnd(BatchIterator batchIterator, OptionalInt firstDoc, OptionalInt lastDoc, int bufferSize);
+
   /**
    * Applies AND operation to the given bitmap of document ids, returns a bitmap of the matching document ids.
    */
-  MutableRoaringBitmap applyAnd(ImmutableRoaringBitmap docIds);
+  default MutableRoaringBitmap applyAnd(ImmutableRoaringBitmap docIds) {
+    return applyAnd(docIds.getBatchIterator(), OptionalInt.of(docIds.first()), OptionalInt.of(docIds.last()),
+        OPTIMAL_ITERATOR_BATCH_SIZE);
+  }
 
   /**
    * Returns the number of entries (SV value contains one entry, MV value contains multiple entries) scanned during the

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/MVScanDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/MVScanDocIdSet.java
@@ -27,8 +27,8 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 public final class MVScanDocIdSet implements BlockDocIdSet {
   private final MVScanDocIdIterator _docIdIterator;
 
-  public MVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs, int batchSize) {
-    _docIdIterator = new MVScanDocIdIterator(predicateEvaluator, dataSource, numDocs, batchSize);
+  public MVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs) {
+    _docIdIterator = new MVScanDocIdIterator(predicateEvaluator, dataSource, numDocs);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/MVScanDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/MVScanDocIdSet.java
@@ -27,8 +27,8 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
 public final class MVScanDocIdSet implements BlockDocIdSet {
   private final MVScanDocIdIterator _docIdIterator;
 
-  public MVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs) {
-    _docIdIterator = new MVScanDocIdIterator(predicateEvaluator, dataSource, numDocs);
+  public MVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs, int batchSize) {
+    _docIdIterator = new MVScanDocIdIterator(predicateEvaluator, dataSource, numDocs, batchSize);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/SVScanDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/SVScanDocIdSet.java
@@ -29,9 +29,9 @@ public final class SVScanDocIdSet implements BlockDocIdSet {
   private final SVScanDocIdIterator _docIdIterator;
 
   public SVScanDocIdSet(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs,
-      boolean nullHandlingEnabled) {
+      boolean nullHandlingEnabled, int batchSize) {
     NullValueVectorReader nullValueVector = nullHandlingEnabled ? dataSource.getNullValueVector() : null;
-    _docIdIterator = new SVScanDocIdIterator(predicateEvaluator, dataSource, numDocs, nullValueVector);
+    _docIdIterator = new SVScanDocIdIterator(predicateEvaluator, dataSource, numDocs, nullValueVector, batchSize);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ScanBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ScanBasedFilterOperator.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.operator.filter;
 import com.google.common.base.Preconditions;
 import java.util.Collections;
 import java.util.List;
+import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.FilterBlock;
 import org.apache.pinot.core.operator.docidsets.MVScanDocIdSet;
@@ -37,9 +38,15 @@ public class ScanBasedFilterOperator extends BaseFilterOperator {
   private final DataSource _dataSource;
   private final int _numDocs;
   private final boolean _nullHandlingEnabled;
+  private final int _batchSize;
 
   public ScanBasedFilterOperator(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs,
       boolean nullHandlingEnabled) {
+    this(predicateEvaluator, dataSource, numDocs, nullHandlingEnabled, BlockDocIdIterator.OPTIMAL_ITERATOR_BATCH_SIZE);
+  }
+
+  public ScanBasedFilterOperator(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs,
+      boolean nullHandlingEnabled, int batchSize) {
     _predicateEvaluator = predicateEvaluator;
     _dataSource = dataSource;
     _numDocs = numDocs;
@@ -47,15 +54,17 @@ public class ScanBasedFilterOperator extends BaseFilterOperator {
     Preconditions.checkState(_dataSource.getForwardIndex() != null,
         "Forward index disabled for column: %s, scan based filtering not supported!",
         _dataSource.getDataSourceMetadata().getFieldSpec().getName());
+    _batchSize = batchSize;
   }
 
   @Override
   protected FilterBlock getNextBlock() {
     DataSourceMetadata dataSourceMetadata = _dataSource.getDataSourceMetadata();
     if (dataSourceMetadata.isSingleValue()) {
-      return new FilterBlock(new SVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs, _nullHandlingEnabled));
+      return new FilterBlock(new SVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs, _nullHandlingEnabled,
+          _batchSize));
     } else {
-      return new FilterBlock(new MVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs));
+      return new FilterBlock(new MVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs, _batchSize));
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ScanBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ScanBasedFilterOperator.java
@@ -64,7 +64,7 @@ public class ScanBasedFilterOperator extends BaseFilterOperator {
       return new FilterBlock(new SVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs, _nullHandlingEnabled,
           _batchSize));
     } else {
-      return new FilterBlock(new MVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs, _batchSize));
+      return new FilterBlock(new MVScanDocIdSet(_predicateEvaluator, _dataSource, _numDocs));
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ScanBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ScanBasedFilterOperator.java
@@ -38,7 +38,7 @@ public class ScanBasedFilterOperator extends BaseFilterOperator {
   private final int _numDocs;
   private final boolean _nullHandlingEnabled;
 
-  ScanBasedFilterOperator(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs,
+  public ScanBasedFilterOperator(PredicateEvaluator predicateEvaluator, DataSource dataSource, int numDocs,
       boolean nullHandlingEnabled) {
     _predicateEvaluator = predicateEvaluator;
     _dataSource = dataSource;


### PR DESCRIPTION
Before this PR, `ScanBasedDocIdIterator.applyAnd` was always applied using windows of OPTIMAL_ITERATOR_BATCH_SIZE, which is defined as 256.

At StarTree we found some inefficiencies when fetching data from slower backends (for example when a network request is needed). Therefore we would like to be able to decide the window size depending on the situation.

This PR is a little bit larger than expected because we also needed to modify `ValueMatcher` in order to do not contain a buffer of predefined size. Instead is the caller the one that creates and supply the buffer that has to be used.