### PR TITLE
[feature] [null support # 1] selection only literal in broker null support

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1347,6 +1347,10 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         columnTypes.add(DataSchema.ColumnDataType.BYTES);
         row.add(BytesUtils.toHexString(literal.getBinaryValue()));
         break;
+      case NULL_VALUE:
+        columnTypes.add(DataSchema.ColumnDataType.UNKNOWN);
+        row.add(null);
+        break;
       default:
         break;
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInvoker.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInvoker.java
@@ -32,12 +32,17 @@ import org.apache.pinot.common.utils.PinotDataType;
  */
 public class FunctionInvoker {
   private final Method _method;
+  // If false, the function should return null if any of its argument is null
+  // Otherwise, the function should deal with null in its own definition.
+  private final boolean _isNullIntolerant;
+
   private final Class<?>[] _parameterClasses;
   private final PinotDataType[] _parameterTypes;
   private final Object _instance;
 
   public FunctionInvoker(FunctionInfo functionInfo) {
     _method = functionInfo.getMethod();
+    _isNullIntolerant = !functionInfo.hasNullableParameters();
     Class<?>[] parameterClasses = _method.getParameterTypes();
     int numParameters = parameterClasses.length;
     _parameterClasses = new Class<?>[numParameters];
@@ -123,6 +128,13 @@ public class FunctionInvoker {
    * {@link #convertTypes(Object[])} to convert the argument types if needed before calling this method.
    */
   public Object invoke(Object[] arguments) {
+    if (_isNullIntolerant) {
+      for (Object arg : arguments) {
+        if (arg == null) {
+          return null;
+        }
+      }
+    }
     try {
       return _method.invoke(_instance, arguments);
     } catch (Exception e) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInvoker.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionInvoker.java
@@ -32,8 +32,8 @@ import org.apache.pinot.common.utils.PinotDataType;
  */
 public class FunctionInvoker {
   private final Method _method;
-  // If false, the function should return null if any of its argument is null
-  // Otherwise, the function should deal with null in its own definition.
+  // If true, the function should return null if any of its argument is null
+  // Otherwise, the function should deal with null in its own implementation.
   private final boolean _isNullIntolerant;
 
   private final Class<?>[] _parameterClasses;

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
@@ -25,6 +25,7 @@ import org.apache.commons.lang3.EnumUtils;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.context.predicate.EqPredicate;
 import org.apache.pinot.common.request.context.predicate.InPredicate;
 import org.apache.pinot.common.request.context.predicate.IsNotNullPredicate;
@@ -229,6 +230,9 @@ public class RequestContextUtils {
     if (thriftExpression.getType() != ExpressionType.LITERAL) {
       throw new BadQueryRequestException(
           "Pinot does not support column or function on the right-hand side of the predicate");
+    }
+    if (thriftExpression.getLiteral().getSetField() == Literal._Fields.NULL_VALUE) {
+      return String.valueOf(null);
     }
     return thriftExpression.getLiteral().getFieldValue().toString();
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
@@ -232,7 +232,7 @@ public class RequestContextUtils {
           "Pinot does not support column or function on the right-hand side of the predicate");
     }
     if (thriftExpression.getLiteral().getSetField() == Literal._Fields.NULL_VALUE) {
-      return String.valueOf(null);
+      return "null";
     }
     return thriftExpression.getLiteral().getFieldValue().toString();
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -263,6 +263,7 @@ public class DataSchema {
     JSON(STRING, ""),
     BYTES(new ByteArray(new byte[0])),
     OBJECT(null),
+    UNKNOWN(null),
     INT_ARRAY(new int[0]),
     LONG_ARRAY(new long[0]),
     FLOAT_ARRAY(new float[0]),
@@ -376,6 +377,8 @@ public class DataSchema {
           return DataType.JSON;
         case BYTES:
           return DataType.BYTES;
+        case UNKNOWN:
+          return DataType.UNKNOWN;
         default:
           throw new IllegalStateException(String.format("Cannot convert ColumnDataType: %s to DataType", this));
       }
@@ -422,6 +425,7 @@ public class DataSchema {
           return toTimestampArray(value);
         case BYTES_ARRAY:
           return (byte[][]) value;
+        case UNKNOWN: // fall through
         case OBJECT:
           return (Serializable) value;
         default:
@@ -586,6 +590,8 @@ public class DataSchema {
           return JSON;
         case BYTES:
           return BYTES;
+        case UNKNOWN:
+          return UNKNOWN;
         default:
           throw new IllegalStateException("Unsupported data type: " + dataType);
       }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -263,7 +263,6 @@ public class DataSchema {
     JSON(STRING, ""),
     BYTES(new ByteArray(new byte[0])),
     OBJECT(null),
-    UNKNOWN(null),
     INT_ARRAY(new int[0]),
     LONG_ARRAY(new long[0]),
     FLOAT_ARRAY(new float[0]),
@@ -271,7 +270,8 @@ public class DataSchema {
     BOOLEAN_ARRAY(INT_ARRAY, new int[0]),
     TIMESTAMP_ARRAY(LONG_ARRAY, new long[0]),
     STRING_ARRAY(new String[0]),
-    BYTES_ARRAY(new byte[0][]);
+    BYTES_ARRAY(new byte[0][]),
+    UNKNOWN(null);
 
     private static final EnumSet<ColumnDataType> NUMERIC_TYPES = EnumSet.of(INT, LONG, FLOAT, DOUBLE, BIG_DECIMAL);
     private static final Ordering<ColumnDataType> NUMERIC_TYPE_ORDERING = Ordering.explicit(INT, LONG, FLOAT, DOUBLE);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -175,7 +175,7 @@ public class RequestUtils {
     return expression;
   }
 
-  public static Expression getUnknownLiteralExpression() {
+  public static Expression getNullLiteralExpression() {
     Expression expression = createNewLiteralExpression();
     expression.getLiteral().setNullValue(true);
     return expression;
@@ -183,7 +183,7 @@ public class RequestUtils {
 
   public static Expression getLiteralExpression(Object object) {
     if (object == null) {
-      return getUnknownLiteralExpression();
+      return getNullLiteralExpression();
     }
     if (object instanceof Integer || object instanceof Long) {
       return RequestUtils.getLiteralExpression(((Number) object).longValue());

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -122,10 +122,12 @@ public class RequestUtils {
         literal.setDoubleValue(node.bigDecimalValue().doubleValue());
       }
     } else {
-      // TODO: Support null literal and other types.
       switch (node.getTypeName()) {
         case BOOLEAN:
           literal.setBoolValue(node.booleanValue());
+          break;
+        case NULL:
+          literal.setNullValue(true);
           break;
         default:
           literal.setStringValue(StringUtils.replace(node.toValue(), "''", "'"));
@@ -173,7 +175,16 @@ public class RequestUtils {
     return expression;
   }
 
+  public static Expression getUnknownLiteralExpression() {
+    Expression expression = createNewLiteralExpression();
+    expression.getLiteral().setNullValue(true);
+    return expression;
+  }
+
   public static Expression getLiteralExpression(Object object) {
+    if (object == null) {
+      return getUnknownLiteralExpression();
+    }
     if (object instanceof Integer || object instanceof Long) {
       return RequestUtils.getLiteralExpression(((Number) object).longValue());
     }

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
@@ -26,6 +26,7 @@ import org.apache.pinot.common.function.FunctionInvoker;
 import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.sql.parsers.SqlCompilationException;
@@ -74,7 +75,12 @@ public class CompileTimeFunctionsInvoker implements QueryRewriter {
       if (functionInfo != null) {
         Object[] arguments = new Object[numOperands];
         for (int i = 0; i < numOperands; i++) {
-          arguments[i] = function.getOperands().get(i).getLiteral().getFieldValue();
+          Literal literal = function.getOperands().get(i).getLiteral();
+          if (literal.getSetField() == Literal._Fields.NULL_VALUE) {
+            arguments[i] = null;
+          } else {
+            arguments[i] = function.getOperands().get(i).getLiteral().getFieldValue();
+          }
         }
         try {
           FunctionInvoker invoker = new FunctionInvoker(functionInfo);

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
@@ -76,7 +76,7 @@ public class CompileTimeFunctionsInvoker implements QueryRewriter {
         Object[] arguments = new Object[numOperands];
         for (int i = 0; i < numOperands; i++) {
           Literal literal = function.getOperands().get(i).getLiteral();
-          if (literal.getSetField() == Literal._Fields.NULL_VALUE) {
+          if (literal.isSetNullValue()) {
             arguments[i] = null;
           } else {
             arguments[i] = function.getOperands().get(i).getLiteral().getFieldValue();

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
@@ -155,7 +155,7 @@ public class DataBlockBuilder {
             setColumn(rowBuilder, byteBuffer, value);
             break;
           case UNKNOWN:
-            setColumn(rowBuilder, byteBuffer, (Object) value);
+            setColumn(rowBuilder, byteBuffer, (Object) null);
             break;
           // Multi-value column
           case INT_ARRAY:

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
@@ -154,6 +154,9 @@ public class DataBlockBuilder {
           case OBJECT:
             setColumn(rowBuilder, byteBuffer, value);
             break;
+          case UNKNOWN:
+            setColumn(rowBuilder, byteBuffer, (Object) value);
+            break;
           // Multi-value column
           case INT_ARRAY:
             setColumn(rowBuilder, byteBuffer, (int[]) value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
@@ -154,9 +154,6 @@ public class DataBlockBuilder {
           case OBJECT:
             setColumn(rowBuilder, byteBuffer, value);
             break;
-          case UNKNOWN:
-            setColumn(rowBuilder, byteBuffer, (Object) null);
-            break;
           // Multi-value column
           case INT_ARRAY:
             setColumn(rowBuilder, byteBuffer, (int[]) value);
@@ -219,6 +216,9 @@ public class DataBlockBuilder {
             long[] longs = new long[length];
             ArrayCopyUtils.copy(timestamps, longs, length);
             setColumn(rowBuilder, byteBuffer, longs);
+            break;
+          case UNKNOWN:
+            setColumn(rowBuilder, byteBuffer, (Object) null);
             break;
           default:
             throw new IllegalStateException(
@@ -347,11 +347,6 @@ public class DataBlockBuilder {
             setColumn(columnarBuilder, byteBuffer, (ByteArray) value);
           }
           break;
-        case UNKNOWN:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
-            setColumn(columnarBuilder, byteBuffer, (Object) null);
-          }
-          break;
         case OBJECT:
           for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
             value = column[rowId];
@@ -468,6 +463,11 @@ public class DataBlockBuilder {
               value = nullPlaceholders[colId];
             }
             setColumn(columnarBuilder, byteBuffer, (String[]) value);
+          }
+          break;
+        case UNKNOWN:
+          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+            setColumn(columnarBuilder, byteBuffer, (Object) null);
           }
           break;
         default:

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
@@ -344,6 +344,11 @@ public class DataBlockBuilder {
             setColumn(columnarBuilder, byteBuffer, (ByteArray) value);
           }
           break;
+        case UNKNOWN:
+          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+            setColumn(columnarBuilder, byteBuffer, (Object) null);
+          }
+          break;
         case OBJECT:
           for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
             value = column[rowId];

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
@@ -127,6 +127,9 @@ public class DataBlockTestUtils {
           }
           row[colId] = timestampArray;
           break;
+        case UNKNOWN:
+          row[colId] = null;
+          break;
         default:
           throw new UnsupportedOperationException("Can't fill random data for column type: " + columnDataTypes[colId]);
       }

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
@@ -176,6 +176,8 @@ public class DataBlockTestUtils {
         return dataBlock.getDoubleArray(rowId, colId);
       case STRING_ARRAY:
         return dataBlock.getStringArray(rowId, colId);
+      case UNKNOWN:
+        return null;
       default:
         throw new UnsupportedOperationException("Can't retrieve data for column type: " + columnDataType);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableSerDeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableSerDeTest.java
@@ -614,6 +614,9 @@ public class DataTableSerDeTest {
             OBJECTS[rowId] = isNull ? null : RANDOM.nextDouble();
             dataTableBuilder.setColumn(colId, OBJECTS[rowId]);
             break;
+          case UNKNOWN:
+            dataTableBuilder.setColumn(colId, (Object) null);
+            break;
           case INT_ARRAY:
             int length = RANDOM.nextInt(20);
             int[] intArray = new int[length];
@@ -742,6 +745,10 @@ public class DataTableSerDeTest {
               Assert.assertNotNull(customObject);
               Assert.assertEquals(ObjectSerDeUtils.deserialize(customObject), OBJECTS[rowId], ERROR_MESSAGE);
             }
+            break;
+          case UNKNOWN:
+            Object nulValue = newDataTable.getCustomObject(rowId, colId);
+            Assert.assertNull(nulValue, ERROR_MESSAGE);
             break;
           case INT_ARRAY:
             Assert.assertTrue(Arrays.equals(newDataTable.getIntArray(rowId, colId), INT_ARRAYS[rowId]), ERROR_MESSAGE);

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableSerDeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datatable/DataTableSerDeTest.java
@@ -614,9 +614,6 @@ public class DataTableSerDeTest {
             OBJECTS[rowId] = isNull ? null : RANDOM.nextDouble();
             dataTableBuilder.setColumn(colId, OBJECTS[rowId]);
             break;
-          case UNKNOWN:
-            dataTableBuilder.setColumn(colId, (Object) null);
-            break;
           case INT_ARRAY:
             int length = RANDOM.nextInt(20);
             int[] intArray = new int[length];
@@ -683,6 +680,9 @@ public class DataTableSerDeTest {
             STRING_ARRAYS[rowId] = stringArray;
             dataTableBuilder.setColumn(colId, stringArray);
             break;
+          case UNKNOWN:
+            dataTableBuilder.setColumn(colId, (Object) null);
+            break;
           default:
             throw new UnsupportedOperationException("Unable to generate random data for: " + columnDataTypes[colId]);
         }
@@ -746,10 +746,6 @@ public class DataTableSerDeTest {
               Assert.assertEquals(ObjectSerDeUtils.deserialize(customObject), OBJECTS[rowId], ERROR_MESSAGE);
             }
             break;
-          case UNKNOWN:
-            Object nulValue = newDataTable.getCustomObject(rowId, colId);
-            Assert.assertNull(nulValue, ERROR_MESSAGE);
-            break;
           case INT_ARRAY:
             Assert.assertTrue(Arrays.equals(newDataTable.getIntArray(rowId, colId), INT_ARRAYS[rowId]), ERROR_MESSAGE);
             break;
@@ -779,6 +775,10 @@ public class DataTableSerDeTest {
           case STRING_ARRAY:
             Assert.assertTrue(Arrays.equals(newDataTable.getStringArray(rowId, colId), STRING_ARRAYS[rowId]),
                 ERROR_MESSAGE);
+            break;
+          case UNKNOWN:
+            Object nulValue = newDataTable.getCustomObject(rowId, colId);
+            Assert.assertNull(nulValue, ERROR_MESSAGE);
             break;
           default:
             throw new UnsupportedOperationException("Unable to generate random data for: " + columnDataTypes[colId]);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -393,12 +393,12 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     BOOLEAN(INT, false, true),
     TIMESTAMP(LONG, false, true),
     STRING(false, true),
-    UNKNOWN(false, true),
     JSON(STRING, false, false),
     BYTES(false, false),
     STRUCT(false, false),
     MAP(false, false),
-    LIST(false, false);
+    LIST(false, false),
+    UNKNOWN(false, true);
 
     private final DataType _storedType;
     private final int _size;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -393,6 +393,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     BOOLEAN(INT, false, true),
     TIMESTAMP(LONG, false, true),
     STRING(false, true),
+    UNKNOWN(false, true),
     JSON(STRING, false, false),
     BYTES(false, false),
     STRUCT(false, false),


### PR DESCRIPTION
Support null literal in broker logic for selection only query. 

Scalar functions are categorized as null tolerant vs intolerant. 

intolerant scalar functions return null when any of the arg is null.

Introduce null columnDataType as passing used to pass broker response back to user.
