### PR TITLE
(WIP) Use inverted index for count(*) group by <column> filter queries

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator.java
@@ -24,14 +24,20 @@ import org.apache.pinot.core.common.ExplainPlanRows;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.FilterBlock;
 import org.apache.pinot.core.operator.docidsets.MatchAllDocIdSet;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
 public class MatchAllFilterOperator extends BaseFilterOperator {
   public static final String EXPLAIN_NAME = "FILTER_MATCH_ENTIRE_SEGMENT";
   private final int _numDocs;
+  private final ImmutableRoaringBitmap _bitmap;
 
   public MatchAllFilterOperator(int numDocs) {
     _numDocs = numDocs;
+    MutableRoaringBitmap bitmap = new MutableRoaringBitmap();
+    bitmap.add(0, numDocs + 1);
+    _bitmap = bitmap.toImmutableRoaringBitmap();
   }
 
   @Override
@@ -53,6 +59,16 @@ public class MatchAllFilterOperator extends BaseFilterOperator {
   @Override
   public boolean canOptimizeCount() {
     return true;
+  }
+
+  @Override
+  public boolean canProduceBitmaps() {
+    return true;
+  }
+
+  @Override
+  public BitmapCollection getBitmaps() {
+    return new BitmapCollection(_bitmap.getCardinality(), false, _bitmap);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator.java
@@ -63,11 +63,32 @@ public class OrFilterOperator extends BaseFilterOperator {
 
   @Override
   public boolean canOptimizeCount() {
+    return isAllChildrenProduceBitmaps();
+  }
+
+  @Override
+  public boolean canProduceBitmaps() {
+    return isAllChildrenProduceBitmaps();
+  }
+
+  private boolean isAllChildrenProduceBitmaps() {
     boolean allChildrenProduceBitmaps = true;
     for (BaseFilterOperator child : _filterOperators) {
       allChildrenProduceBitmaps &= child.canProduceBitmaps();
     }
     return allChildrenProduceBitmaps;
+  }
+
+  @Override
+  public BitmapCollection getBitmaps() {
+    ImmutableRoaringBitmap[] bitmaps = new ImmutableRoaringBitmap[_filterOperators.size()];
+    int i = 0;
+    for (BaseFilterOperator child : _filterOperators) {
+      bitmaps[i++] = child.getBitmaps().reduce();
+    }
+
+    ImmutableRoaringBitmap finalBitmap = BufferFastAggregation.or(bitmaps);
+    return new BitmapCollection(finalBitmap.getCardinality(), false, finalBitmap);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
@@ -26,7 +26,6 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
-import org.apache.pinot.core.operator.filter.MatchAllFilterOperator;
 import org.apache.pinot.core.operator.query.FilteredGroupByOperator;
 import org.apache.pinot.core.operator.query.GroupByOperator;
 import org.apache.pinot.core.operator.transform.PassThroughTransformOperator;
@@ -124,11 +123,11 @@ public class GroupByPlanNode implements PlanNode {
             filterOperator).run();
 
     // use inverted index to solve the query if possible
-    if (transformPlanNode instanceof PassThroughTransformOperator && filterOperator instanceof MatchAllFilterOperator
+    if (transformPlanNode instanceof PassThroughTransformOperator && (filterOperator.canProduceBitmaps())
         && canUseInvertedIndexForGroupBy()) {
       TransformOperator invertedIndexTransformOp =
           new InvertedIndexFastCountStarGroupByPlanNode(_queryContext, groupByExpressions[0],
-              _indexSegment.getDataSource(groupByExpressions[0].getIdentifier())).run();
+              _indexSegment.getDataSource(groupByExpressions[0].getIdentifier()), filterOperator).run();
 
       return new GroupByOperator(aggregationFunctions, groupByExpressions, invertedIndexTransformOp, numTotalDocs,
           _queryContext, true);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
@@ -24,7 +24,6 @@ import java.util.Set;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.Operator;
-import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.operator.filter.MatchAllFilterOperator;
@@ -128,11 +127,11 @@ public class GroupByPlanNode implements PlanNode {
     if (transformPlanNode instanceof PassThroughTransformOperator && filterOperator instanceof MatchAllFilterOperator
         && canUseInvertedIndexForGroupBy()) {
       TransformOperator invertedIndexTransformOp =
-          new InvertedIndexFastCountStarGroupByPlanNode(_queryContext, groupByExpressions[0], filterOperator,
+          new InvertedIndexFastCountStarGroupByPlanNode(_queryContext, groupByExpressions[0],
               _indexSegment.getDataSource(groupByExpressions[0].getIdentifier())).run();
 
       return new GroupByOperator(aggregationFunctions, groupByExpressions, invertedIndexTransformOp, numTotalDocs,
-          _queryContext, false);
+          _queryContext, true);
     }
 
     return new GroupByOperator(aggregationFunctions, groupByExpressions, transformPlanNode, numTotalDocs, _queryContext,

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
@@ -153,6 +153,7 @@ public class GroupByPlanNode implements PlanNode {
     ExpressionContext groupByExpression = groupByExpressions[0];
 
     return _indexSegment.getDataSource(groupByExpression.getIdentifier()).getInvertedIndex() != null
-        && _indexSegment.getDataSource(groupByExpression.getIdentifier()).getDictionary() != null;
+        && _indexSegment.getDataSource(groupByExpression.getIdentifier()).getDictionary() != null
+        && Boolean.parseBoolean(_queryContext.getQueryOptions().getOrDefault("enableInvertedIndexGroupBy", "false"));
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByPlanNode.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.plan;
 
 import java.util.List;
 import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
@@ -33,12 +34,12 @@ public class InvertedIndexFastCountStarGroupByPlanNode implements PlanNode {
       _invertedIndexFastCountStarGroupByProjectionPlanNode;
 
   public InvertedIndexFastCountStarGroupByPlanNode(QueryContext queryContext, ExpressionContext groupByExpression,
-      DataSource dataSource) {
+      DataSource dataSource, BaseFilterOperator filterOperator) {
     _queryContext = queryContext;
     _groupByExpression = groupByExpression;
 
     _invertedIndexFastCountStarGroupByProjectionPlanNode =
-        new InvertedIndexFastCountStarGroupByProjectionPlanNode(dataSource);
+        new InvertedIndexFastCountStarGroupByProjectionPlanNode(dataSource, filterOperator);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByPlanNode.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.plan;
+
+import java.util.List;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.core.operator.filter.BaseFilterOperator;
+import org.apache.pinot.core.operator.transform.TransformOperator;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+
+
+public class InvertedIndexFastCountStarGroupByPlanNode implements PlanNode {
+
+  private final ExpressionContext _groupByExpression;
+  private final QueryContext _queryContext;
+  private final InvertedIndexFastCountStarGroupByProjectionPlanNode
+      _invertedIndexFastCountStarGroupByProjectionPlanNode;
+
+  public InvertedIndexFastCountStarGroupByPlanNode(QueryContext queryContext, ExpressionContext groupByExpression,
+      BaseFilterOperator filterOperator, DataSource dataSource) {
+    _queryContext = queryContext;
+    _groupByExpression = groupByExpression;
+
+    _invertedIndexFastCountStarGroupByProjectionPlanNode =
+        new InvertedIndexFastCountStarGroupByProjectionPlanNode(filterOperator, dataSource);
+  }
+
+  @Override
+  public TransformOperator run() {
+    return new TransformOperator(_queryContext, _invertedIndexFastCountStarGroupByProjectionPlanNode.run(),
+        List.of(_groupByExpression));
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByPlanNode.java
@@ -33,13 +33,12 @@ public class InvertedIndexFastCountStarGroupByPlanNode implements PlanNode {
   private final InvertedIndexFastCountStarGroupByProjectionPlanNode
       _invertedIndexFastCountStarGroupByProjectionPlanNode;
 
-  public InvertedIndexFastCountStarGroupByPlanNode(QueryContext queryContext, ExpressionContext groupByExpression,
-      BaseFilterOperator filterOperator, DataSource dataSource) {
+  public InvertedIndexFastCountStarGroupByPlanNode(QueryContext queryContext, ExpressionContext groupByExpression, DataSource dataSource) {
     _queryContext = queryContext;
     _groupByExpression = groupByExpression;
 
     _invertedIndexFastCountStarGroupByProjectionPlanNode =
-        new InvertedIndexFastCountStarGroupByProjectionPlanNode(filterOperator, dataSource);
+        new InvertedIndexFastCountStarGroupByProjectionPlanNode(dataSource);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByPlanNode.java
@@ -32,7 +32,8 @@ public class InvertedIndexFastCountStarGroupByPlanNode implements PlanNode {
   private final InvertedIndexFastCountStarGroupByProjectionPlanNode
       _invertedIndexFastCountStarGroupByProjectionPlanNode;
 
-  public InvertedIndexFastCountStarGroupByPlanNode(QueryContext queryContext, ExpressionContext groupByExpression, DataSource dataSource) {
+  public InvertedIndexFastCountStarGroupByPlanNode(QueryContext queryContext, ExpressionContext groupByExpression,
+      DataSource dataSource) {
     _queryContext = queryContext;
     _groupByExpression = groupByExpression;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByPlanNode.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.plan;
 
 import java.util.List;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByProjectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByProjectionPlanNode.java
@@ -42,11 +42,11 @@ public class InvertedIndexFastCountStarGroupByProjectionPlanNode implements Plan
   private final Map<String, DataSource> _dataSourceMap;
 
   private static class CountStarForwardIndexReader implements ForwardIndexReader<ForwardIndexReaderContext> {
-    private final InvertedIndexReader<ImmutableRoaringBitmap> invIndex;
+    private final InvertedIndexReader<ImmutableRoaringBitmap> _invIndex;
     private final long _size;
 
     public CountStarForwardIndexReader(InvertedIndexReader<ImmutableRoaringBitmap> invertedIndexReader, long size) {
-      invIndex = invertedIndexReader;
+      _invIndex = invertedIndexReader;
       _size = size;
     }
 
@@ -72,7 +72,7 @@ public class InvertedIndexFastCountStarGroupByProjectionPlanNode implements Plan
 
     @Override
     public long getLong(int docId, ForwardIndexReaderContext context) {
-      return invIndex.getDocIds(docId).getLongCardinality();
+      return _invIndex.getDocIds(docId).getLongCardinality();
     }
 
     @Override
@@ -141,7 +141,6 @@ public class InvertedIndexFastCountStarGroupByProjectionPlanNode implements Plan
     @Override
     public void close()
         throws IOException {
-
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByProjectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByProjectionPlanNode.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.plan;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.pinot.core.common.Block;
+import org.apache.pinot.core.common.Operator;
+import org.apache.pinot.core.operator.DocIdSetOperator;
+import org.apache.pinot.core.operator.ProjectionOperator;
+import org.apache.pinot.core.operator.filter.BaseFilterOperator;
+import org.apache.pinot.segment.local.startree.v2.store.StarTreeDataSource;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.segment.spi.index.reader.InvertedIndexReader;
+import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+
+
+public class InvertedIndexFastCountStarGroupByProjectionPlanNode implements PlanNode {
+  private final BaseFilterOperator _filterOperator;
+  private final DataSource _dataSource;
+  private final Map<String, DataSource> _dataSourceMap;
+
+  private static class CountStarForwardIndexReader implements ForwardIndexReader<ForwardIndexReaderContext> {
+    private final InvertedIndexReader<ImmutableRoaringBitmap> invIndex;
+    private final long _size;
+
+    public CountStarForwardIndexReader(InvertedIndexReader<ImmutableRoaringBitmap> invertedIndexReader, long size) {
+      invIndex = invertedIndexReader;
+      _size = size;
+    }
+
+    @Override
+    public boolean isDictionaryEncoded() {
+      return false;
+    }
+
+    @Override
+    public boolean isSingleValue() {
+      return true;
+    }
+
+    @Override
+    public FieldSpec.DataType getStoredType() {
+      return FieldSpec.DataType.LONG;
+    }
+
+    @Override
+    public int getLengthOfLongestEntry() {
+      return FieldSpec.DataType.LONG.size();
+    }
+
+    @Override
+    public long getLong(int docId, ForwardIndexReaderContext context) {
+      return invIndex.getDocIds(docId).getLongCardinality();
+    }
+
+    @Override
+    public void close()
+        throws IOException {
+    }
+  }
+
+  public InvertedIndexFastCountStarGroupByProjectionPlanNode(BaseFilterOperator filterOperator, DataSource dataSource) {
+    _filterOperator = filterOperator;
+    _dataSource = dataSource;
+
+    _dataSourceMap = new HashMap<>();
+    _dataSourceMap.put(_dataSource.getDataSourceMetadata().getFieldSpec().getName(), _dataSource);
+    _dataSourceMap.put(AggregationFunctionColumnPair.COUNT_STAR.toColumnName(), new StarTreeDataSource(
+        new DimensionFieldSpec(AggregationFunctionColumnPair.COUNT_STAR.toColumnName(),
+            DimensionFieldSpec.DataType.LONG, true), dataSource.getDictionary().length(),
+        new CountStarForwardIndexReader((InvertedIndexReader<ImmutableRoaringBitmap>) _dataSource.getInvertedIndex(), dataSource.getDictionary().length()),
+        null));
+  }
+
+  @Override
+  public ProjectionOperator run() {
+    return new ProjectionOperator(_dataSourceMap,
+        new DocIdSetOperator(_filterOperator, DocIdSetPlanNode.MAX_DOC_PER_CALL));
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByProjectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByProjectionPlanNode.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.plan;
 
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.pinot.core.operator.DocIdSetOperator;
@@ -105,6 +106,36 @@ public class InvertedIndexFastCountStarGroupByProjectionPlanNode implements Plan
     @Override
     public int getInt(int docId, ForwardIndexReaderContext context) {
       return _dictionary.getIntValue(docId);
+    }
+
+    @Override
+    public long getLong(int docId, ForwardIndexReaderContext context) {
+      return _dictionary.getIntValue(docId);
+    }
+
+    @Override
+    public float getFloat(int docId, ForwardIndexReaderContext context) {
+      return _dictionary.getFloatValue(docId);
+    }
+
+    @Override
+    public double getDouble(int docId, ForwardIndexReaderContext context) {
+      return _dictionary.getDoubleValue(docId);
+    }
+
+    @Override
+    public BigDecimal getBigDecimal(int docId, ForwardIndexReaderContext context) {
+      return _dictionary.getBigDecimalValue(docId);
+    }
+
+    @Override
+    public String getString(int docId, ForwardIndexReaderContext context) {
+      return _dictionary.getStringValue(docId);
+    }
+
+    @Override
+    public byte[] getBytes(int docId, ForwardIndexReaderContext context) {
+      return _dictionary.getBytesValue(docId);
     }
 
     @Override


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Query uses inverted index for count\(\*\) group by when filter can produce bitmaps and conditions are met\.

```mermaid
flowchart TD
  N0["GroupByPlanNode#58; check inverted index conditions #40;F4#41;"]:::stModified
  N1["BaseFilterOperator#46;canProduceBitmaps#40;#41; #40;F1#44; F2#44; F3#41;"]:::stModified
  N2["GroupByPlanNode#46;canUseInvertedIndexForGroupBy#40;#41; #40;F4#41;"]:::stModified
  N3["InvertedIndexFastCountStarGroupByPlanNode#46;run#40;#41; #40;F5#41;"]:::stAdded
  N4["InvertedIndexFastCountStarGroupByProjectionPlanNode#46;run#40;#41; #40;F6#41;"]:::stAdded
  N5["ProjectionOperator construction with DocIdSetOperator #40;F6#41;"]:::stAdded
  N6["FilterOperator#46;getBitmaps#40;#41; #40;F1#44; F2#44; F3#41;"]:::stModified
  N7["CountStarForwardIndexReader#46;getLong#40;#41; #40;F6#41;"]:::stAdded
  N8["GroupByOperator construction with inverted index transform #40;F4#41;"]:::stModified
  N0 -->|"condition check"| N1
  N0 -->|"condition check"| N2
  N0 -->|"instantiate and run"| N3
  N3 -->|"get projection"| N4
  N4 -->|"return projection operator"| N5
  N5 -->|"use forward index reader for count#42;"| N7
  N7 -->|"apply filter bitmap"| N6
  N3 -->|"supply transform to GroupByOperator"| N8
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator\.java — [before](https://github.com/apache/pinot/blob/246f4db352b282d576be44348b5652638894e8e4/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java) · [after](https://github.com/apache/pinot/blob/cb2ab88f8fcaf8186803c909f458cb02e52e57be/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator\.java — [before](https://github.com/apache/pinot/blob/246f4db352b282d576be44348b5652638894e8e4/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator.java) · [after](https://github.com/apache/pinot/blob/cb2ab88f8fcaf8186803c909f458cb02e52e57be/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator.java)
- F3: pinot\-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator\.java — [before](https://github.com/apache/pinot/blob/246f4db352b282d576be44348b5652638894e8e4/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator.java) · [after](https://github.com/apache/pinot/blob/cb2ab88f8fcaf8186803c909f458cb02e52e57be/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator.java)
- F4: pinot\-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode\.java — [before](https://github.com/apache/pinot/blob/246f4db352b282d576be44348b5652638894e8e4/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java) · [after](https://github.com/apache/pinot/blob/cb2ab88f8fcaf8186803c909f458cb02e52e57be/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java)
- F5: pinot\-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByPlanNode\.java — [after](https://github.com/apache/pinot/blob/cb2ab88f8fcaf8186803c909f458cb02e52e57be/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByPlanNode.java)
- F6: pinot\-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByProjectionPlanNode\.java — [after](https://github.com/apache/pinot/blob/cb2ab88f8fcaf8186803c909f458cb02e52e57be/pinot-core/src/main/java/org/apache/pinot/core/plan/InvertedIndexFastCountStarGroupByProjectionPlanNode.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjI0NmY0ZGIzNTJiMjgyZDU3NmJlNDQzNDhiNTY1MjYzODg5NGU4ZTQiLCJjb250ZXh0X2hhc2giOiJjZDBmM2NmMzcwNzYwNzI0MTFkMTk4NDVlOGUyZWU1ODhjMDNkMjU5YTBmNmJmZTQyOWEzMjIyMzE0MWE4M2JlIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTA0Njk4LCJoZWFkX3NoYSI6ImNiMmFiODhmOGZjYWY4MTg2ODAzYzkwOWY0NThjYjAyZTUyZTU3YmUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJkNDc1NzEyZDMxMzZmMzg0MTE2OWU2NmQyYWQ0ZGExMDQ3MTc2MThiIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 905c232f054e5d080cfa9d3b8e2e434f8525d66bd922fc2763c616faf15c44dd -->
<!-- pinot-pr-flow:end -->

Trying to use inverted index for count(*) group by <col> since it could be much cheaper