### PR TITLE
Add "processAll" support for MergeRollupTask

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -91,6 +91,9 @@ public class MinionConstants {
     // Merge config
     public static final String MERGE_TYPE_KEY = "mergeType";
     public static final String AGGREGATION_TYPE_KEY_SUFFIX = ".aggregationType";
+    public static final String MODE = "mode";
+    public static final String PROCESS_FROM_WATERMARK_MODE = "processFromWatermark";
+    public static final String PROCESS_ALL_MODE = "processAll";
 
     // Segment config
     public static final String MAX_NUM_RECORDS_PER_TASK_KEY = "maxNumRecordsPerTask";

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
@@ -31,6 +31,7 @@ import java.util.concurrent.Future;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.task.TaskState;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.lineage.SegmentLineageAccessHelper;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.MetricValueUtils;
@@ -52,8 +53,10 @@ import org.apache.pinot.spi.config.table.TableTaskConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.tools.utils.KafkaStarterUtils;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -74,6 +77,8 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
   private static final String MULTI_LEVEL_CONCAT_TEST_TABLE = "myTable3";
   private static final String SINGLE_LEVEL_CONCAT_METADATA_TEST_TABLE = "myTable4";
   private static final String SINGLE_LEVEL_CONCAT_TEST_REALTIME_TABLE = "myTable5";
+  private static final String MULTI_LEVEL_CONCAT_PROCESS_ALL_REALTIME_TABLE = "myTable6";
+  private static final String PROCESS_ALL_MODE_KAFKA_TOPIC = "myKafkaTopic";
   private static final long TIMEOUT_IN_MS = 10_000L;
 
   protected PinotHelixTaskResourceManager _helixTaskResourceManager;
@@ -84,16 +89,18 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
   protected final File _segmentDir2 = new File(_tempDir, "segmentDir2");
   protected final File _segmentDir3 = new File(_tempDir, "segmentDir3");
   protected final File _segmentDir4 = new File(_tempDir, "segmentDir4");
+  protected final File _segmentDir5 = new File(_tempDir, "segmentDir5");
   protected final File _tarDir1 = new File(_tempDir, "tarDir1");
   protected final File _tarDir2 = new File(_tempDir, "tarDir2");
   protected final File _tarDir3 = new File(_tempDir, "tarDir3");
   protected final File _tarDir4 = new File(_tempDir, "tarDir4");
+  protected final File _tarDir5 = new File(_tempDir, "tarDir5");
 
   @BeforeClass
   public void setUp()
       throws Exception {
     TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir1, _segmentDir2, _segmentDir3, _segmentDir4,
-        _tarDir1, _tarDir2, _tarDir3, _tarDir4);
+        _segmentDir5, _tarDir1, _tarDir2, _tarDir3, _tarDir4, _tarDir5);
 
     // Start the Pinot cluster
     startZk();
@@ -140,8 +147,24 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     // create the realtime table
     TableConfig tableConfig = createRealtimeTableConfig(avroFiles.get(0));
     addTableConfig(tableConfig);
+    _kafkaStarters.get(0)
+        .createTopic(PROCESS_ALL_MODE_KAFKA_TOPIC, KafkaStarterUtils.getTopicCreationProps(getNumKafkaPartitions()));
+    TableConfig singleLevelConcatProcessAllRealtimeTableConfig =
+        createRealtimeTableConfigWithProcessAllMode(avroFiles.get(0),
+            MULTI_LEVEL_CONCAT_PROCESS_ALL_REALTIME_TABLE, PROCESS_ALL_MODE_KAFKA_TOPIC);
+    addTableConfig(singleLevelConcatProcessAllRealtimeTableConfig);
+
     // Push data into Kafka
     pushAvroIntoKafka(avroFiles);
+    ClusterIntegrationTestUtils.pushAvroIntoKafka(avroFiles.subList(9, 12), "localhost:" + getKafkaPort(),
+        PROCESS_ALL_MODE_KAFKA_TOPIC, getMaxNumKafkaMessagesPerBatch(), getKafkaMessageHeader(), getPartitionColumn(),
+        injectTombstones());
+    ClusterIntegrationTestUtils.pushAvroIntoKafka(avroFiles.subList(0, 3), "localhost:" + getKafkaPort(),
+        PROCESS_ALL_MODE_KAFKA_TOPIC, getMaxNumKafkaMessagesPerBatch(), getKafkaMessageHeader(), getPartitionColumn(),
+        injectTombstones());
+    ClusterIntegrationTestUtils
+        .buildSegmentsFromAvro(avroFiles.subList(3, 9), singleLevelConcatProcessAllRealtimeTableConfig, schema, 0,
+            _segmentDir5, _tarDir5);
     // Wait for all documents loaded
     waitForAllDocsLoaded(600_000L);
 
@@ -191,6 +214,38 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
         .setLoadMode(getLoadMode()).setTaskConfig(taskConfig).setBrokerTenant(getBrokerTenant())
         .setServerTenant(getServerTenant()).setIngestionConfig(getIngestionConfig())
         .setNullHandlingEnabled(getNullHandlingEnabled()).setSegmentPartitionConfig(partitionConfig).build();
+  }
+
+  protected TableConfig createRealtimeTableConfigWithProcessAllMode(File sampleAvroFile, String tableName,
+      String topicName) {
+    AvroFileSchemaKafkaAvroMessageDecoder._avroFile = sampleAvroFile;
+    Map<String, String> streamConfigs = getStreamConfigMap();
+    streamConfigs.put(StreamConfigProperties.constructStreamProperty("kafka", StreamConfigProperties.STREAM_TOPIC_NAME),
+        topicName);
+    Map<String, String> tableTaskConfigs = new HashMap<>();
+    tableTaskConfigs.put("100days.mergeType", "concat");
+    tableTaskConfigs.put("100days.bufferTimePeriod", "1d");
+    tableTaskConfigs.put("100days.bucketTimePeriod", "100d");
+    tableTaskConfigs.put("100days.maxNumRecordsPerSegment", "15000");
+    tableTaskConfigs.put("100days.maxNumRecordsPerTask", "15000");
+    tableTaskConfigs.put("200days.mergeType", "concat");
+    tableTaskConfigs.put("200days.bufferTimePeriod", "1d");
+    tableTaskConfigs.put("200days.bucketTimePeriod", "200d");
+    tableTaskConfigs.put("200days.maxNumRecordsPerSegment", "15000");
+    tableTaskConfigs.put("200days.maxNumRecordsPerTask", "30000");
+    tableTaskConfigs.put("ActualElapsedTime.aggregationType", "min");
+    tableTaskConfigs.put("WeatherDelay.aggregationType", "sum");
+    tableTaskConfigs.put("mode", "processAll");
+    return new TableConfigBuilder(TableType.REALTIME).setTableName(tableName).setSchemaName(getSchemaName())
+        .setTimeColumnName(getTimeColumnName()).setSortedColumn(getSortedColumn())
+        .setInvertedIndexColumns(getInvertedIndexColumns()).setNoDictionaryColumns(getNoDictionaryColumns())
+        .setRangeIndexColumns(getRangeIndexColumns()).setBloomFilterColumns(getBloomFilterColumns())
+        .setFieldConfigList(getFieldConfigs()).setNumReplicas(getNumReplicas()).setSegmentVersion(getSegmentVersion())
+        .setLoadMode(getLoadMode()).setTaskConfig(
+            new TableTaskConfig(Collections.singletonMap(MinionConstants.MergeRollupTask.TASK_TYPE, tableTaskConfigs)))
+        .setBrokerTenant(getBrokerTenant())
+        .setServerTenant(getServerTenant()).setIngestionConfig(getIngestionConfig()).setQueryConfig(getQueryconfig())
+        .setLLC(useLlc()).setStreamConfigs(streamConfigs).setNullHandlingEnabled(getNullHandlingEnabled()).build();
   }
 
   private TableTaskConfig getSingleLevelConcatTaskConfig() {
@@ -894,6 +949,106 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
 
     assertTrue(MetricValueUtils.gaugeExists(_controllerStarter.getControllerMetrics(),
         "mergeRollupTaskDelayInNumBuckets.myTable5_REALTIME.100days"));
+
+    // Drop the table
+    dropRealtimeTable(tableName);
+
+    // Check if the task metadata is cleaned up on table deletion
+    verifyTableDelete(realtimeTableName);
+  }
+
+  @Test
+  public void testRealtimeTableProcessAllModeMultiLevelConcat()
+      throws Exception {
+    // The original segments (time range: [16251, 16428]):
+    // mytable__0__0__{ts00} ... mytable__0__11__{ts011}
+    // mytable__1__0__{ts00} ... mytable__1__11__{ts111}
+    //
+    // Scheduled time ranges and number buckets to process:
+    // round  |        100days          200days
+    //   1    | [16251, 16299], 3  |       []       , 0
+    //   2    | [16300, 16399], 2  |       []       , 0
+    //   3    | [16400, 16428], 1  |  [16251, 16399], 1
+    //   4    |       []      , 0  |  [16400, 16428], 1
+    //
+    // Upload historical segments manually:
+    // myTable_16071_16101_0
+    // myTable_16102_16129_1
+    // myTable_16130_16159_2
+    // myTable_16160_16189_3
+    // myTable_16190_16220_4
+    // myTable_16221_16250_5
+    //
+    // Scheduled time ranges and number buckets to process:
+    // round  |        100days          200days
+    //   5    | [16071, 16099], 3  |       []       , 0
+    //   6    | [16100, 16199], 2  |       []       , 0
+    //   7    | [16200, 16299], 1  |  [16071, 16199], 1
+    //   8    |       []      , 0  |  [16200, 16399], 1
+    PinotHelixTaskResourceManager helixTaskResourceManager = _controllerStarter.getHelixTaskResourceManager();
+    PinotTaskManager taskManager = _controllerStarter.getTaskManager();
+    String tableName = MULTI_LEVEL_CONCAT_PROCESS_ALL_REALTIME_TABLE;
+
+    String sqlQuery = "SELECT count(*) FROM " + tableName;
+    JsonNode expectedJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+    long[] expectedNumBucketsToProcess100Days = {3, 2, 1, 0, 3, 2, 1, 0};
+    long[] expectedNumBucketsToProcess200Days = {0, 0, 1, 1, 0, 0, 1, 1};
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
+    int numTasks = 0;
+    for (String tasks = taskManager.scheduleTasks(realtimeTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE);
+        tasks != null; tasks =
+        taskManager.scheduleTasks(realtimeTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE), numTasks++) {
+      assertTrue(helixTaskResourceManager.getTaskQueues()
+          .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.MergeRollupTask.TASK_TYPE)));
+
+      // Will not schedule task if there's incomplete task
+      assertNull(
+          taskManager.scheduleTasks(realtimeTableName).get(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE));
+      waitForTaskToComplete();
+
+      // Check not using watermarks
+      ZNRecord minionTaskMetadataZNRecord = taskManager.getClusterInfoAccessor()
+          .getMinionTaskMetadataZNRecord(MinionConstants.MergeRollupTask.TASK_TYPE, realtimeTableName);
+      assertNull(minionTaskMetadataZNRecord);
+
+      // Check metrics
+      assertTrue(MetricValueUtils.gaugeExists(_controllerStarter.getControllerMetrics(),
+          "mergeRollupTaskNumBucketsToProcess.myTable6_REALTIME.100days"));
+      assertTrue(MetricValueUtils.gaugeExists(_controllerStarter.getControllerMetrics(),
+          "mergeRollupTaskNumBucketsToProcess.myTable6_REALTIME.200days"));
+      long numBucketsToProcess = MetricValueUtils.getGaugeValue(_controllerStarter.getControllerMetrics(),
+          "mergeRollupTaskNumBucketsToProcess.myTable6_REALTIME.100days");
+      assertEquals(numBucketsToProcess, expectedNumBucketsToProcess100Days[numTasks]);
+      numBucketsToProcess = MetricValueUtils.getGaugeValue(_controllerStarter.getControllerMetrics(),
+          "mergeRollupTaskNumBucketsToProcess.myTable6_REALTIME.200days");
+      assertEquals(numBucketsToProcess, expectedNumBucketsToProcess200Days[numTasks]);
+    }
+    // Check total tasks
+    assertEquals(numTasks, 4);
+
+    // Check query results
+    JsonNode actualJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+    assertTrue(SqlResultComparator.areEqual(actualJson, expectedJson, sqlQuery));
+
+    // Upload historical data and schedule
+    uploadSegments(MULTI_LEVEL_CONCAT_PROCESS_ALL_REALTIME_TABLE, TableType.REALTIME, _tarDir5);
+    waitForAllDocsLoaded(600_000L);
+
+    for (String tasks = taskManager.scheduleTasks(realtimeTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE);
+        tasks != null; tasks =
+        taskManager.scheduleTasks(realtimeTableName).get(MinionConstants.MergeRollupTask.TASK_TYPE), numTasks++) {
+      waitForTaskToComplete();
+      // Check metrics
+      long numBucketsToProcess = MetricValueUtils.getGaugeValue(_controllerStarter.getControllerMetrics(),
+          "mergeRollupTaskNumBucketsToProcess.myTable6_REALTIME.100days");
+      assertEquals(numBucketsToProcess, expectedNumBucketsToProcess100Days[numTasks]);
+      numBucketsToProcess = MetricValueUtils.getGaugeValue(_controllerStarter.getControllerMetrics(),
+          "mergeRollupTaskNumBucketsToProcess.myTable6_REALTIME.200days");
+      assertEquals(numBucketsToProcess, expectedNumBucketsToProcess200Days[numTasks]);
+    }
+
+    // Check total tasks
+    assertEquals(numTasks, 8);
 
     // Drop the table
     dropRealtimeTable(tableName);


### PR DESCRIPTION
Adding "processAll" support for MergeRollupTask, which aims to handle:
1. pushing historical data
2. late stream arrivals

The "processAll" mode can be enabled by adding the following config, which will be applied to all merge levels. If it's enabled, MergeRollupTask will ignore the watermark, and schedule tasks for any bucket having unmerged segments. A new metric `mergeRollupTaskNumBucketsToProcess.<tableName>.<mergeLevel>` will be published . 
```
"task": {
      "taskTypeConfigsMap": {
        "MergeRollupTask": {
          "mode": "processAll",
          "100days.mergeType": "concat",
          "100days.bucketTimePeriod": "100d",
          "100days.bufferTimePeriod": "1d"
        }
      }
    }
```
