### PR TITLE
Patch: Allow fetching comparable index from ComparisonColumns

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ComparisonColumns.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ComparisonColumns.java
@@ -33,6 +33,10 @@ public class ComparisonColumns implements Comparable<ComparisonColumns> {
     return _values;
   }
 
+  public int getComparableIndex() {
+    return _comparableIndex;
+  }
+
   @Override
   public int compareTo(ComparisonColumns other) {
     // _comparisonColumns should only at most one non-null comparison value. If not, it is the user's responsibility.


### PR DESCRIPTION
This is required so that the `comparableIndex` value can be serialized as well along with other columns.