### PR TITLE
Enable Pinot realtime table ingestion without a deep store. Segment tar/zip and upload will thus be skipped.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -807,6 +807,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         }
       }
       _leaseExtender.addSegment(_segmentNameStr, buildTimeLeaseMs, _currentOffset);
+      // Skip build the segment jar if there is no deepstore uri to upload to.
       _segmentBuildDescriptor = buildSegmentInternal(true);
     } finally {
       _leaseExtender.removeSegment(_segmentNameStr);
@@ -941,16 +942,20 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           TimeUnit.MILLISECONDS.toSeconds(waitTimeMillis));
 
       if (forCommit) {
-        File segmentTarFile = new File(dataDir, _segmentNameStr + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
-        try {
-          TarGzCompressionUtils.createTarGzFile(indexDir, segmentTarFile);
-        } catch (IOException e) {
-          String errorMessage =
-              String.format("Caught exception while taring index directory from: %s to: %s", indexDir, segmentTarFile);
-          _segmentLogger.error(errorMessage, e);
-          _realtimeTableDataManager
-              .addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
-          return null;
+        File segmentTarFile = null;
+        if (!_tableConfig.getValidationConfig().isSegmentUploadToDeepStoreDisabled()) {
+          segmentTarFile = new File(dataDir, _segmentNameStr + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+          try {
+            TarGzCompressionUtils.createTarGzFile(indexDir, segmentTarFile);
+          } catch (IOException e) {
+            String errorMessage =
+                String.format("Caught exception while taring index directory from: %s to: %s", indexDir, segmentTarFile);
+            _segmentLogger.error(errorMessage, e);
+            _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
+            return null;
+          }
+        } else {
+          _segmentLogger.info("Skip taring segment file because segment upload to deep store is disabled");
         }
 
         File metadataFile = SegmentDirectoryPaths.findMetadataFile(indexDir);
@@ -998,7 +1003,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
   protected boolean commitSegment(String controllerVipUrl, boolean isSplitCommit) {
     File segmentTarFile = _segmentBuildDescriptor.getSegmentTarFile();
-    if (segmentTarFile == null || !segmentTarFile.exists()) {
+    // Even segment tar file is null, we continue if there is no deep store uri.
+    if (!peerDownloadEnabledWithoutDeepstoreUri() && (segmentTarFile == null || !segmentTarFile.exists())) {
       throw new RuntimeException("Segment file does not exist: " + segmentTarFile);
     }
     SegmentCompletionProtocol.Response commitResponse = commit(controllerVipUrl, isSplitCommit);
@@ -1012,6 +1018,11 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     _realtimeTableDataManager.replaceLLSegment(_segmentNameStr, _indexLoadingConfig);
     removeSegmentFile();
     return true;
+  }
+
+  private boolean peerDownloadEnabledWithoutDeepstoreUri() {
+    return this._tableConfig.getValidationConfig().getPeerSegmentDownloadScheme() != null;
+        // && there is no deep store uri configured on the server.
   }
 
   protected SegmentCompletionProtocol.Response commit(String controllerVipUrl, boolean isSplitCommit) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/NoOpSegmentUploader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/NoOpSegmentUploader.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.data.manager.realtime;
+
+import java.io.File;
+import java.net.URI;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+// A NoOpSegmentUploader does not perform any upload operation. Instead, it just returns a peer download url for the
+// segment.
+public class NoOpSegmentUploader implements SegmentUploader {
+  private static final Logger LOGGER = LoggerFactory.getLogger(NoOpSegmentUploader.class);
+  @Override
+  public URI uploadSegment(File segmentFile, LLCSegmentName segmentName) {
+    LOGGER.info("Skip uploading the segment {} ", segmentName);
+    return null;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java
@@ -71,7 +71,9 @@ public class SegmentCommitterFactory {
     String peerSegmentDownloadScheme = _tableConfig.getValidationConfig().getPeerSegmentDownloadScheme();
     String segmentStoreUri = _indexLoadingConfig.getSegmentStoreURI();
 
-    if (uploadToFs || peerSegmentDownloadScheme != null) {
+    if (_tableConfig.getValidationConfig().isSegmentUploadToDeepStoreDisabled()) {
+      segmentUploader = new NoOpSegmentUploader();
+    } else if (uploadToFs || peerSegmentDownloadScheme != null) {
       // TODO: peer scheme non-null check exists for backwards compatibility. remove check once users have migrated
       segmentUploader = new PinotFSSegmentUploader(segmentStoreUri,
           PinotFSSegmentUploader.DEFAULT_SEGMENT_UPLOAD_TIMEOUT_MILLIS);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterWithoutDeepStoreIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterWithoutDeepStoreIntegrationTest.java
@@ -1,0 +1,159 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.integration.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Random;
+import org.apache.avro.reflect.Nullable;
+import org.apache.commons.io.FileUtils;
+import org.apache.helix.model.ExternalView;
+import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.spi.config.table.CompletionConfig;
+import org.apache.pinot.spi.config.table.SegmentsValidationAndRetentionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.controller.ControllerConf.ALLOW_HLC_TABLES;
+import static org.apache.pinot.controller.ControllerConf.ENABLE_SPLIT_COMMIT;
+
+
+// This test verifies that Pinot Low Level Realtime ingestion works properly when there is NO deepstore configured with
+// the cluster
+public class LLCRealtimeClusterWithoutDeepStoreIntegrationTest extends BaseRealtimeClusterIntegrationTest{
+  private static final Logger LOGGER = LoggerFactory.getLogger(LLCRealtimeClusterWithoutDeepStoreIntegrationTest.class);
+
+  private static final String CONSUMER_DIRECTORY = "/tmp/consumer-test";
+  private static final long RANDOM_SEED = System.currentTimeMillis();
+  private static final Random RANDOM = new Random(RANDOM_SEED);
+  private static final int NUM_SERVERS = 2;
+  public static final int UPLOAD_FAILURE_MOD = 5;
+
+  private final boolean _isDirectAlloc = true; //Set as true; otherwise trigger indexing exception.
+  private final boolean _isConsumerDirConfigured = true;
+  private final boolean _enableSplitCommit = true;
+  private final boolean _enableLeadControllerResource = RANDOM.nextBoolean();
+
+  @BeforeClass
+  @Override
+  public void setUp()
+      throws Exception {
+    LOGGER.info(String.format(
+        "Using random seed: %s, isDirectAlloc: %s, isConsumerDirConfigured: %s, enableSplitCommit: %s, "
+            + "enableLeadControllerResource: %s",
+        RANDOM_SEED, _isDirectAlloc, _isConsumerDirConfigured, _enableSplitCommit, _enableLeadControllerResource));
+
+    // Remove the consumer directory
+    File consumerDirectory = new File(CONSUMER_DIRECTORY);
+    if (consumerDirectory.exists()) {
+      FileUtils.deleteDirectory(consumerDirectory);
+    }
+    super.setUp();
+  }
+
+  @AfterClass
+  @Override
+  public void tearDown()
+      throws Exception {
+    FileUtils.deleteDirectory(new File(CONSUMER_DIRECTORY));
+    super.tearDown();
+  }
+
+  @Override
+  public void startServer()
+      throws Exception {
+    startServers(NUM_SERVERS);
+  }
+
+  @Override
+  public void addTableConfig(TableConfig tableConfig)
+      throws IOException {
+    SegmentsValidationAndRetentionConfig segmentsValidationAndRetentionConfig =
+        new SegmentsValidationAndRetentionConfig();
+    CompletionConfig completionConfig = new CompletionConfig("DOWNLOAD");
+    segmentsValidationAndRetentionConfig.setCompletionConfig(completionConfig);
+    segmentsValidationAndRetentionConfig.setReplicasPerPartition(String.valueOf(NUM_SERVERS));
+    // Important: enable peer to peer download.
+    segmentsValidationAndRetentionConfig.setPeerSegmentDownloadScheme("http");
+    // Skip the segment upload to deepstore
+    segmentsValidationAndRetentionConfig.setSegmentUploadToDeepStoreDisabled(true);
+    tableConfig.setValidationConfig(segmentsValidationAndRetentionConfig);
+    tableConfig.getValidationConfig().setTimeColumnName(this.getTimeColumnName());
+
+    sendPostRequest(_controllerRequestURLBuilder.forTableCreate(), tableConfig.toJsonString());
+  }
+
+  @Override
+  public void startController()
+      throws Exception {
+    Map<String, Object> controllerConfig = getDefaultControllerConfiguration();
+    controllerConfig.put(ALLOW_HLC_TABLES, false);
+    controllerConfig.put(ENABLE_SPLIT_COMMIT, _enableSplitCommit);
+    startController(controllerConfig);
+    enableResourceConfigForLeadControllerResource(_enableLeadControllerResource);
+  }
+
+  @Nullable
+  @Override
+  protected String getLoadMode() {
+    return "MMAP";
+  }
+
+  @Override
+  protected void overrideServerConf(PinotConfiguration configuration) {
+    configuration.setProperty(CommonConstants.Server.CONFIG_OF_REALTIME_OFFHEAP_ALLOCATION, true);
+    configuration.setProperty(CommonConstants.Server.CONFIG_OF_REALTIME_OFFHEAP_DIRECT_ALLOCATION, _isDirectAlloc);
+    // For setting the HDFS segment fetcher.
+    configuration
+        .setProperty(CommonConstants.Server.PREFIX_OF_CONFIG_OF_SEGMENT_FETCHER_FACTORY + ".protocols", "file,http");
+    if (_isConsumerDirConfigured) {
+      configuration.setProperty(CommonConstants.Server.CONFIG_OF_CONSUMER_DIR, CONSUMER_DIRECTORY);
+    }
+    if (_enableSplitCommit) {
+      configuration.setProperty(CommonConstants.Server.CONFIG_OF_ENABLE_SPLIT_COMMIT, true);
+      configuration.setProperty(CommonConstants.Server.CONFIG_OF_ENABLE_COMMIT_END_WITH_METADATA, true);
+    }
+  }
+
+  @Test
+  public void testAllSegmentsAreOnlineOrConsuming() {
+    ExternalView externalView = HelixHelper.getExternalViewForResource(_helixAdmin, getHelixClusterName(),
+        TableNameBuilder.REALTIME.tableNameWithType(getTableName()));
+    Assert.assertEquals("2", externalView.getReplicas());
+    // Verify for each segment e, the state of e in its 2 hosting servers is either ONLINE or CONSUMING
+    for (String segment : externalView.getPartitionSet()) {
+      Map<String, String> instanceToStateMap = externalView.getStateMap(segment);
+      Assert.assertEquals(2, instanceToStateMap.size());
+      for (Map.Entry<String, String> instanceState : instanceToStateMap.entrySet()) {
+        Assert.assertTrue("ONLINE".equalsIgnoreCase(instanceState.getValue()) || "CONSUMING"
+            .equalsIgnoreCase(instanceState.getValue()));
+      }
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java
@@ -52,6 +52,10 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
   // Number of replicas per partition of low-level consumers. This config is used for realtime tables only.
   private String _replicasPerPartition;
 
+  // True if and only if the segment upload to deep store is disabled. This is usefully for Pinot cluster which does not
+  // have any deep store.
+  private boolean _segmentUploadToDeepStoreDisabled;
+
   public String getSegmentAssignmentStrategy() {
     return _segmentAssignmentStrategy;
   }
@@ -210,5 +214,13 @@ public class SegmentsValidationAndRetentionConfig extends BaseJsonConfig {
 
   public void setMinimizeDataMovement(boolean minimizeDataMovement) {
     _minimizeDataMovement = minimizeDataMovement;
+  }
+
+  public boolean isSegmentUploadToDeepStoreDisabled() {
+    return _segmentUploadToDeepStoreDisabled;
+  }
+
+  public void setSegmentUploadToDeepStoreDisabled(boolean segmentUploadToDeepStoreDisabled) {
+    _segmentUploadToDeepStoreDisabled = segmentUploadToDeepStoreDisabled;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -120,6 +120,7 @@ public class TableConfigBuilder {
   private IngestionConfig _ingestionConfig;
   private List<TierConfig> _tierConfigList;
   private List<TunerConfig> _tunerConfigList;
+  private boolean _segmentUploadToDeepStoreDisabled;
 
   public TableConfigBuilder(TableType tableType) {
     _tableType = tableType;
@@ -400,6 +401,11 @@ public class TableConfigBuilder {
     return this;
   }
 
+  public TableConfigBuilder setSegmentUploadToDeepStoreDisabled(boolean segmentUploadToDeepStoreDisabled) {
+    _segmentUploadToDeepStoreDisabled = segmentUploadToDeepStoreDisabled;
+    return this;
+  }
+
   public TableConfig build() {
     // Validation config
     SegmentsValidationAndRetentionConfig validationConfig = new SegmentsValidationAndRetentionConfig();
@@ -416,6 +422,7 @@ public class TableConfigBuilder {
     validationConfig.setSchemaName(_schemaName);
     validationConfig.setReplication(_numReplicas);
     validationConfig.setPeerSegmentDownloadScheme(_peerSegmentDownloadScheme);
+    validationConfig.setSegmentUploadToDeepStoreDisabled(_segmentUploadToDeepStoreDisabled);
     if (_isLLC) {
       validationConfig.setReplicasPerPartition(_numReplicas);
     }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Realtime ingestion skips tar/upload when deep store disabled, uses peer download and a no‑op uploader\.

```mermaid
flowchart TD
  N0["segmentUploadToDeepStoreDisabled flag #40;F4#41;"]:::stModified
  N1["buildSegmentInternal#58; tar skip branch #40;F1#41;"]:::stModified
  N2["commitSegment#58; allow null tar if peer download #40;F1#41;"]:::stModified
  N3["peerDownloadEnabledWithoutDeepstoreUri #40;F1#41;"]:::stAdded
  N4["SegmentCommitterFactory#58; choose NoOpUploader #40;F3#41;"]:::stModified
  N5["NoOpSegmentUploader#46;uploadSegment#58; returns null #40;F2#41;"]:::stAdded
  N6["segmentTarFile #61; null #40;F1#41;"]:::stModified
  N0 -->|"read flag"| N1
  N0 -->|"read flag"| N4
  N1 -->|"set segmentTarFile null"| N6
  N6 -->|"get segmentTarFile"| N2
  N3 -->|"check peer download enabled"| N2
  N4 -->|"create uploader"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager\.java — [before](https://github.com/apache/pinot/blob/2e03df02f65d766bde040389e4e6b12ea09710fa/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java) · [after](https://github.com/apache/pinot/blob/a55600e794bbbbb9331d7ff57b4408df9b0829cc/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java)
- F2: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/NoOpSegmentUploader\.java — [after](https://github.com/apache/pinot/blob/a55600e794bbbbb9331d7ff57b4408df9b0829cc/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/NoOpSegmentUploader.java)
- F3: pinot\-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory\.java — [before](https://github.com/apache/pinot/blob/2e03df02f65d766bde040389e4e6b12ea09710fa/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java) · [after](https://github.com/apache/pinot/blob/a55600e794bbbbb9331d7ff57b4408df9b0829cc/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentCommitterFactory.java)
- F4: pinot\-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig\.java — [before](https://github.com/apache/pinot/blob/2e03df02f65d766bde040389e4e6b12ea09710fa/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java) · [after](https://github.com/apache/pinot/blob/a55600e794bbbbb9331d7ff57b4408df9b0829cc/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/SegmentsValidationAndRetentionConfig.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjJlMDNkZjAyZjY1ZDc2NmJkZTA0MDM4OWU0ZTZiMTJlYTA5NzEwZmEiLCJjb250ZXh0X2hhc2giOiI1YjVmYTQwOTlkODcxZmVhMTg4ZmM5NjhhZmJlMzk0OTk1YjI3ZmE1NWU0YzA5YTdhMWU3MTBiODhjMzg5NDczIiwiZ2VuZXJhdGVkX2F0IjoxNzg5Mjk1NDcwLCJoZWFkX3NoYSI6ImE1NTYwMGU3OTRiYmJiYjkzMzFkN2ZmNTdiNDQwOGRmOWIwODI5Y2MiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIzZmZhN2MzZTMyMzcyNzdjNmE2MGZiMzM3OWQwYTVjNDRlODI0MGUwIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature eee303bb860cc57bef606843f8e41e77d9d0e18bae180909aad805f2c0066e45 -->
<!-- pinot-pr-flow:end -->

This PR enables a realtime table ingestion using Low Level Consumer (LLC) to run without deep store configured. The steps to tar/zip a segment and then upload will be skipped. The segment download will then be done through peer servers. A new table config "segmentUploadToDeepStoreDisabled" will be added to support this ingestion mode. 

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
  
2. Remove these instructions before publishing the PR.

(**) Use `release-notes` label for scenarios like:
- New configuration options
