### PR TITLE
[multistage] early terminate from query dispatcher

### DIFF
--- a/pinot-common/src/main/proto/worker.proto
+++ b/pinot-common/src/main/proto/worker.proto
@@ -44,6 +44,16 @@ import "plan.proto";
 service PinotQueryWorker {
   // Dispatch a QueryRequest to a PinotQueryWorker
   rpc Submit(QueryRequest) returns (QueryResponse);
+
+  rpc Cancel(CancelRequest) returns (CancelResponse);
+}
+
+message CancelRequest {
+  int64 requestId = 1;
+}
+
+message CancelResponse {
+  // intentionally left empty
 }
 
 // QueryRequest is the dispatched content for a specific query stage on a specific worker.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -135,7 +135,8 @@ public class QueryRunner {
       _queryRunnerExecutorService = Executors.newFixedThreadPool(
           ResourceManager.DEFAULT_QUERY_RUNNER_THREADS,
           new NamedThreadFactory("query_runner_on_" + _port + "_port"));
-      _scheduler = new OpChainSchedulerService(new RoundRobinScheduler(releaseMs), _queryWorkerExecutorService);
+      _scheduler = new OpChainSchedulerService(new RoundRobinScheduler(releaseMs), _queryWorkerExecutorService,
+          releaseMs);
       _mailboxService = MultiplexingMailboxService.newInstance(_hostname, _port, config, _scheduler::onDataAvailable);
       _serverExecutor = new ServerQueryExecutorV1Impl();
       _serverExecutor.init(config.subset(PINOT_V1_SERVER_QUERY_CONFIG_PREFIX), instanceDataManager, serverMetrics);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -174,6 +174,10 @@ public class QueryRunner {
     }
   }
 
+  public void cancel(long requestId) {
+    _scheduler.cancel(requestId);
+  }
+
   public ExecutorService getQueryWorkerExecutorService() {
     return _queryWorkerExecutorService;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -135,8 +135,7 @@ public class QueryRunner {
       _queryRunnerExecutorService = Executors.newFixedThreadPool(
           ResourceManager.DEFAULT_QUERY_RUNNER_THREADS,
           new NamedThreadFactory("query_runner_on_" + _port + "_port"));
-      _scheduler = new OpChainSchedulerService(new RoundRobinScheduler(releaseMs), _queryWorkerExecutorService,
-          releaseMs);
+      _scheduler = new OpChainSchedulerService(new RoundRobinScheduler(releaseMs), _queryWorkerExecutorService);
       _mailboxService = MultiplexingMailboxService.newInstance(_hostname, _port, config, _scheduler::onDataAvailable);
       _serverExecutor = new ServerQueryExecutorV1Impl();
       _serverExecutor.init(config.subset(PINOT_V1_SERVER_QUERY_CONFIG_PREFIX), instanceDataManager, serverMetrics);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -58,10 +58,10 @@ public class OpChainSchedulerService extends AbstractExecutionThreadService {
     this(scheduler, workerPool, DEFAULT_SCHEDULER_CANCELLATION_SIGNAL_RETENTION_MS);
   }
 
-  public OpChainSchedulerService(OpChainScheduler scheduler, ExecutorService workerPool, long releaseTimeoutMs) {
+  public OpChainSchedulerService(OpChainScheduler scheduler, ExecutorService workerPool, long cancelRetentionMs) {
     _scheduler = scheduler;
     _workerPool = workerPool;
-    _cancelledRequests = CacheBuilder.newBuilder().expireAfterWrite(releaseTimeoutMs, TimeUnit.MILLISECONDS).build();
+    _cancelledRequests = CacheBuilder.newBuilder().expireAfterWrite(cancelRetentionMs, TimeUnit.MILLISECONDS).build();
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -46,8 +46,7 @@ public class OpChainSchedulerService extends AbstractExecutionThreadService {
 
   private final OpChainScheduler _scheduler;
   private final ExecutorService _workerPool;
-  private final Cache<Long, Void> _cancelledRequests;
-  private final Void _aVoid = null;
+  private final Cache<Long, Long> _cancelledRequests;
 
   public OpChainSchedulerService(OpChainScheduler scheduler, ExecutorService workerPool) {
     this(scheduler, workerPool, QueryConfig.DEFAULT_SCHEDULER_RELEASE_TIMEOUT_MS);
@@ -146,7 +145,7 @@ public class OpChainSchedulerService extends AbstractExecutionThreadService {
    * @param requestId requestId to be cancelled.
    */
   public final void cancel(long requestId) {
-    _cancelledRequests.put(requestId, _aVoid);
+    _cancelledRequests.put(requestId, requestId);
   }
 
   /**

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainId.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainId.java
@@ -32,6 +32,10 @@ public class OpChainId {
     _stageId = stageId;
   }
 
+  public long getRequestId() {
+    return _requestId;
+  }
+
   @Override
   public String toString() {
     return String.format("%s_%s_%s", _requestId, _virtualServerId, _stageId);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryServer.java
@@ -106,4 +106,9 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
         .putMetadata(QueryConfig.KEY_OF_SERVER_RESPONSE_STATUS_OK, "").build());
     responseObserver.onCompleted();
   }
+
+  @Override
+  public void cancel(Worker.CancelRequest request, StreamObserver<Worker.CancelResponse> responseObserver) {
+    _queryRunner.cancel(request.getRequestId());
+  }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryServer.java
@@ -110,5 +110,6 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
   @Override
   public void cancel(Worker.CancelRequest request, StreamObserver<Worker.CancelResponse> responseObserver) {
     _queryRunner.cancel(request.getRequestId());
+    responseObserver.onCompleted();
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/CancelObserver.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/CancelObserver.java
@@ -1,0 +1,40 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.service.dispatch;
+
+import io.grpc.stub.StreamObserver;
+import org.apache.pinot.common.proto.Worker;
+
+
+/**
+ * A no-op {@link StreamObserver} for cancellation requests.
+ */
+class CancelObserver implements StreamObserver<Worker.CancelResponse> {
+  @Override
+  public void onNext(Worker.CancelResponse cancelResponse) {
+  }
+
+  @Override
+  public void onError(Throwable throwable) {
+  }
+
+  @Override
+  public void onCompleted() {
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.service.dispatch;
 import io.grpc.Deadline;
 import io.grpc.ManagedChannel;
 import io.grpc.ManagedChannelBuilder;
+import io.grpc.stub.StreamObserver;
 import java.util.function.Consumer;
 import org.apache.pinot.common.proto.PinotQueryWorkerGrpc;
 import org.apache.pinot.common.proto.Worker;
@@ -37,6 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 class DispatchClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(DispatchClient.class);
+  private static final StreamObserver<Worker.CancelResponse> _aVoid = null;
   private final ManagedChannel _channel;
   private final PinotQueryWorkerGrpc.PinotQueryWorkerStub _dispatchStub;
 
@@ -57,6 +59,15 @@ class DispatchClient {
       LOGGER.error("Query Dispatch failed at client-side", e);
       callback.accept(new AsyncQueryDispatchResponse(
           virtualServer, stageId, Worker.QueryResponse.getDefaultInstance(), e));
+    }
+  }
+
+  public void cancel(long requestId) {
+    try {
+      Worker.CancelRequest cancelRequest = Worker.CancelRequest.newBuilder().setRequestId(requestId).build();
+      _dispatchStub.cancel(cancelRequest, _aVoid);
+    } catch (Exception e) {
+      LOGGER.error("Query Cancellation failed at client-side", e);
     }
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
@@ -38,7 +38,7 @@ import org.slf4j.LoggerFactory;
  */
 class DispatchClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(DispatchClient.class);
-  private static final StreamObserver<Worker.CancelResponse> _aVoid = null;
+  private static final StreamObserver<Worker.CancelResponse> NO_OP_CANCEL_STREAM_OBSERVER = new CancelObserver();
   private final ManagedChannel _channel;
   private final PinotQueryWorkerGrpc.PinotQueryWorkerStub _dispatchStub;
 
@@ -65,7 +65,7 @@ class DispatchClient {
   public void cancel(long requestId) {
     try {
       Worker.CancelRequest cancelRequest = Worker.CancelRequest.newBuilder().setRequestId(requestId).build();
-      _dispatchStub.cancel(cancelRequest, _aVoid);
+      _dispatchStub.cancel(cancelRequest, NO_OP_CANCEL_STREAM_OBSERVER);
     } catch (Exception e) {
       LOGGER.error("Query Cancellation failed at client-side", e);
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -43,7 +43,6 @@ import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
 import org.apache.pinot.core.query.reduce.ExecutionStatsAggregator;
-import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.util.trace.TracedThreadFactory;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.planner.ExplainPlanStageVisitor;

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.query.runtime.operator.MultiStageOperator;
 import org.apache.pinot.query.runtime.operator.OpChain;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
+import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -79,7 +80,7 @@ public class OpChainSchedulerServiceTest {
     initExecutor(1);
     OpChain opChain = getChain(_operatorA);
     Mockito.when(_scheduler.next(Mockito.anyLong(), Mockito.any())).thenReturn(opChain).thenReturn(null);
-    OpChainSchedulerService scheduler = new OpChainSchedulerService(_scheduler, _executor);
+    OpChainSchedulerService schedulerService = new OpChainSchedulerService(_scheduler, _executor);
 
     CountDownLatch latch = new CountDownLatch(1);
     Mockito.when(_operatorA.nextBlock()).thenAnswer(inv -> {
@@ -87,11 +88,11 @@ public class OpChainSchedulerServiceTest {
       return TransferableBlockUtils.getEndOfStreamTransferableBlock();
     });
 
-    scheduler.startAsync().awaitRunning();
-    scheduler.register(opChain);
+    schedulerService.startAsync().awaitRunning();
+    schedulerService.register(opChain);
 
     Assert.assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
-    scheduler.stopAsync().awaitTerminated();
+    schedulerService.stopAsync().awaitTerminated();
   }
 
   @Test
@@ -100,7 +101,7 @@ public class OpChainSchedulerServiceTest {
     initExecutor(1);
     OpChain opChain = getChain(_operatorA);
     Mockito.when(_scheduler.next(Mockito.anyLong(), Mockito.any())).thenReturn(opChain).thenReturn(null);
-    OpChainSchedulerService scheduler = new OpChainSchedulerService(_scheduler, _executor);
+    OpChainSchedulerService schedulerService = new OpChainSchedulerService(_scheduler, _executor);
 
     CountDownLatch latch = new CountDownLatch(1);
     Mockito.when(_operatorA.nextBlock()).thenAnswer(inv -> {
@@ -108,11 +109,11 @@ public class OpChainSchedulerServiceTest {
       return TransferableBlockUtils.getEndOfStreamTransferableBlock();
     });
 
-    scheduler.register(opChain);
-    scheduler.startAsync().awaitRunning();
+    schedulerService.register(opChain);
+    schedulerService.startAsync().awaitRunning();
 
     Assert.assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
-    scheduler.stopAsync().awaitTerminated();
+    schedulerService.stopAsync().awaitTerminated();
   }
 
   @Test
@@ -121,7 +122,7 @@ public class OpChainSchedulerServiceTest {
     initExecutor(1);
     OpChain opChain = getChain(_operatorA);
     Mockito.when(_scheduler.next(Mockito.anyLong(), Mockito.any())).thenReturn(opChain).thenReturn(null);
-    OpChainSchedulerService scheduler = new OpChainSchedulerService(_scheduler, _executor);
+    OpChainSchedulerService schedulerService = new OpChainSchedulerService(_scheduler, _executor);
 
     CountDownLatch latch = new CountDownLatch(1);
     Mockito.when(_operatorA.nextBlock()).thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
@@ -130,11 +131,11 @@ public class OpChainSchedulerServiceTest {
       return null;
     }).when(_scheduler).yield(Mockito.any());
 
-    scheduler.startAsync().awaitRunning();
-    scheduler.register(opChain);
+    schedulerService.startAsync().awaitRunning();
+    schedulerService.register(opChain);
 
     Assert.assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
-    scheduler.stopAsync().awaitTerminated();
+    schedulerService.stopAsync().awaitTerminated();
   }
 
   @Test
@@ -152,12 +153,12 @@ public class OpChainSchedulerServiceTest {
       }
       return null;
     });
-    OpChainSchedulerService scheduler = new OpChainSchedulerService(_scheduler, _executor);
+    OpChainSchedulerService schedulerService = new OpChainSchedulerService(_scheduler, _executor);
 
-    scheduler.startAsync().awaitRunning();
+    schedulerService.startAsync().awaitRunning();
 
     Assert.assertTrue(latch.await(10, TimeUnit.SECONDS), "expected opChain to be scheduled");
-    scheduler.stopAsync().awaitTerminated();
+    schedulerService.stopAsync().awaitTerminated();
   }
 
   @Test
@@ -166,7 +167,7 @@ public class OpChainSchedulerServiceTest {
     initExecutor(1);
     OpChain opChain = getChain(_operatorA);
     Mockito.when(_scheduler.next(Mockito.anyLong(), Mockito.any())).thenReturn(opChain).thenReturn(null);
-    OpChainSchedulerService scheduler = new OpChainSchedulerService(_scheduler, _executor);
+    OpChainSchedulerService schedulerService = new OpChainSchedulerService(_scheduler, _executor);
 
     CountDownLatch latch = new CountDownLatch(1);
     Mockito.when(_operatorA.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -175,11 +176,11 @@ public class OpChainSchedulerServiceTest {
       return null;
     }).when(_operatorA).close();
 
-    scheduler.startAsync().awaitRunning();
-    scheduler.register(opChain);
+    schedulerService.startAsync().awaitRunning();
+    schedulerService.register(opChain);
 
     Assert.assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
-    scheduler.stopAsync().awaitTerminated();
+    schedulerService.stopAsync().awaitTerminated();
   }
 
   @Test
@@ -188,7 +189,7 @@ public class OpChainSchedulerServiceTest {
     initExecutor(1);
     OpChain opChain = getChain(_operatorA);
     Mockito.when(_scheduler.next(Mockito.anyLong(), Mockito.any())).thenReturn(opChain).thenReturn(null);
-    OpChainSchedulerService scheduler = new OpChainSchedulerService(_scheduler, _executor);
+    OpChainSchedulerService schedulerService = new OpChainSchedulerService(_scheduler, _executor);
 
     CountDownLatch latch = new CountDownLatch(1);
     Mockito.when(_operatorA.nextBlock()).thenReturn(
@@ -198,13 +199,56 @@ public class OpChainSchedulerServiceTest {
       return null;
     }).when(_operatorA).cancel(Mockito.any());
 
-    scheduler.startAsync().awaitRunning();
-    scheduler.register(opChain);
+    schedulerService.startAsync().awaitRunning();
+    schedulerService.register(opChain);
 
     Assert.assertTrue(latch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
-    scheduler.stopAsync().awaitTerminated();
+    schedulerService.stopAsync().awaitTerminated();
   }
 
+  @Test
+  public void shouldCallCancelOnOpChainsWhenItIsCancelledByDispatch()
+      throws InterruptedException {
+    initExecutor(1);
+    OpChain opChain = getChain(_operatorA);
+    Mockito.when(_scheduler.next(Mockito.anyLong(), Mockito.any())).thenAnswer((Answer<OpChain>) invocation -> {
+      Thread.sleep(100);
+      return opChain;
+    });
+    OpChainSchedulerService schedulerService = new OpChainSchedulerService(_scheduler, _executor);
+
+    Mockito.when(_operatorA.nextBlock()).thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
+
+    CountDownLatch cancelLatch = new CountDownLatch(1);
+    Mockito.doAnswer(inv -> {
+      cancelLatch.countDown();
+      return null;
+    }).when(_operatorA).cancel(Mockito.any());
+    CountDownLatch deregisterLatch = new CountDownLatch(1);
+    Mockito.doAnswer(inv -> {
+      deregisterLatch.countDown();
+      return null;
+    }).when(_scheduler).deregister(Mockito.same(opChain));
+    CountDownLatch awaitLatch = new CountDownLatch(1);
+    Mockito.doAnswer(inv -> {
+      awaitLatch.countDown();
+      return null;
+    }).when(_scheduler).yield(Mockito.any());
+
+    schedulerService.startAsync().awaitRunning();
+    schedulerService.register(opChain);
+
+    Assert.assertTrue(awaitLatch.await(10, TimeUnit.SECONDS), "expected await to be called in less than 10 seconds");
+
+    // now cancel the request.
+    schedulerService.cancel(123);
+
+    Assert.assertTrue(cancelLatch.await(10, TimeUnit.SECONDS), "expected OpChain to be cancelled");
+    Assert.assertTrue(deregisterLatch.await(10, TimeUnit.SECONDS), "expected OpChain to be deregistered");
+    Mockito.verify(_operatorA, Mockito.times(1)).cancel(Mockito.any());
+    Mockito.verify(_scheduler, Mockito.times(1)).deregister(Mockito.any());
+    schedulerService.stopAsync().awaitTerminated();
+  }
 
   @Test
   public void shouldCallCancelOnOpChainsThatThrow()
@@ -212,7 +256,7 @@ public class OpChainSchedulerServiceTest {
     initExecutor(1);
     OpChain opChain = getChain(_operatorA);
     Mockito.when(_scheduler.next(Mockito.anyLong(), Mockito.any())).thenReturn(opChain).thenReturn(null);
-    OpChainSchedulerService scheduler = new OpChainSchedulerService(_scheduler, _executor);
+    OpChainSchedulerService schedulerService = new OpChainSchedulerService(_scheduler, _executor);
 
     CountDownLatch cancelLatch = new CountDownLatch(1);
     CountDownLatch deregisterLatch = new CountDownLatch(1);
@@ -226,13 +270,13 @@ public class OpChainSchedulerServiceTest {
       return null;
     }).when(_scheduler).deregister(Mockito.same(opChain));
 
-    scheduler.startAsync().awaitRunning();
-    scheduler.register(opChain);
+    schedulerService.startAsync().awaitRunning();
+    schedulerService.register(opChain);
 
     Assert.assertTrue(cancelLatch.await(10, TimeUnit.SECONDS), "expected OpChain to be cancelled");
     Assert.assertTrue(deregisterLatch.await(10, TimeUnit.SECONDS), "expected OpChain to be deregistered");
     Mockito.verify(_operatorA, Mockito.times(1)).cancel(Mockito.any());
     Mockito.verify(_scheduler, Mockito.times(1)).deregister(Mockito.any());
-    scheduler.stopAsync().awaitTerminated();
+    schedulerService.stopAsync().awaitTerminated();
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -165,9 +165,8 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
     Map<String, Object> reducerConfig = new HashMap<>();
     reducerConfig.put(QueryConfig.KEY_OF_QUERY_RUNNER_PORT, _reducerGrpcPort);
     reducerConfig.put(QueryConfig.KEY_OF_QUERY_RUNNER_HOSTNAME, _reducerHostname);
-    _mailboxService =
-        new GrpcMailboxService(_reducerHostname, _reducerGrpcPort, new PinotConfiguration(reducerConfig), ignored -> {
-        });
+    _mailboxService = new GrpcMailboxService(QueryConfig.DEFAULT_QUERY_RUNNER_HOSTNAME, _reducerGrpcPort,
+        new PinotConfiguration(reducerConfig), ignored -> { });
     _mailboxService.start();
 
     Map<String, List<String>> tableToSegmentMap1 = factory1.buildTableSegmentNameMap();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -117,6 +117,58 @@ public class QueryDispatcherTest extends QueryTestSet {
     } catch (Exception e) {
       Assert.assertTrue(e.getMessage().contains("Error dispatching query"));
     }
+    dispatcher.shutdown();
+  }
+
+  @Test
+  public void testQueryDispatcherCancelWhenQueryServerCallsOnError()
+      throws Exception {
+    String sql = "SELECT * FROM a WHERE col1 = 'foo'";
+    QueryServer failingQueryServer = _queryServerMap.values().iterator().next();
+    Mockito.doAnswer(new Answer() {
+      @Override
+      public Object answer(InvocationOnMock invocationOnMock)
+          throws Throwable {
+        StreamObserver<Worker.QueryResponse> observer = invocationOnMock.getArgument(1);
+        observer.onError(new RuntimeException("foo"));
+        return null;
+      }
+    }).when(failingQueryServer).submit(Mockito.any(), Mockito.any());
+    QueryPlan queryPlan = _queryEnvironment.planQuery(sql);
+    QueryDispatcher dispatcher = new QueryDispatcher();
+    long requestId = RANDOM_REQUEST_ID_GEN.nextLong();
+    try {
+      dispatcher.submitAndReduce(requestId, queryPlan, null, 10_000L, new HashMap<>(), null);
+      Assert.fail("Method call above should have failed");
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage().contains("Error executing query"));
+    }
+    for (QueryServer queryServer : _queryServerMap.values()) {
+      Mockito.verify(queryServer, Mockito.times(1)).cancel(Mockito.argThat(a -> a.getRequestId() == requestId),
+          Mockito.any());
+    }
+    dispatcher.shutdown();
+  }
+
+  @Test
+  public void testQueryDispatcherCancelWhenQueryReducerThrowsError()
+      throws Exception {
+    String sql = "SELECT * FROM a";
+    QueryPlan queryPlan = _queryEnvironment.planQuery(sql);
+    QueryDispatcher dispatcher = new QueryDispatcher();
+    long requestId = RANDOM_REQUEST_ID_GEN.nextLong();
+    try {
+      // will throw b/c mailboxService is null
+      dispatcher.submitAndReduce(requestId, queryPlan, null, 10_000L, new HashMap<>(), null);
+      Assert.fail("Method call above should have failed");
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage().contains("Error executing query"));
+    }
+    for (QueryServer queryServer : _queryServerMap.values()) {
+      Mockito.verify(queryServer, Mockito.times(1)).cancel(Mockito.argThat(a -> a.getRequestId() == requestId),
+          Mockito.any());
+    }
+    dispatcher.shutdown();
   }
 
   @Test
@@ -141,6 +193,7 @@ public class QueryDispatcherTest extends QueryTestSet {
     } catch (Exception e) {
       Assert.assertTrue(e.getMessage().contains("Error dispatching query"));
     }
+    dispatcher.shutdown();
   }
 
   @Test
@@ -168,6 +221,7 @@ public class QueryDispatcherTest extends QueryTestSet {
           || e.getMessage().contains("Error dispatching query"));
     }
     neverClosingLatch.countDown();
+    dispatcher.shutdown();
   }
 
   @Test
@@ -181,5 +235,6 @@ public class QueryDispatcherTest extends QueryTestSet {
     } catch (Exception e) {
       Assert.assertTrue(e.getMessage().contains("Timed out waiting"));
     }
+    dispatcher.shutdown();
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -143,6 +143,8 @@ public class QueryDispatcherTest extends QueryTestSet {
     } catch (Exception e) {
       Assert.assertTrue(e.getMessage().contains("Error executing query"));
     }
+    // wait just a little, until the cancel is being called.
+    Thread.sleep(50);
     for (QueryServer queryServer : _queryServerMap.values()) {
       Mockito.verify(queryServer, Mockito.times(1)).cancel(Mockito.argThat(a -> a.getRequestId() == requestId),
           Mockito.any());
@@ -164,6 +166,8 @@ public class QueryDispatcherTest extends QueryTestSet {
     } catch (Exception e) {
       Assert.assertTrue(e.getMessage().contains("Error executing query"));
     }
+    // wait just a little, until the cancel is being called.
+    Thread.sleep(50);
     for (QueryServer queryServer : _queryServerMap.values()) {
       Mockito.verify(queryServer, Mockito.times(1)).cancel(Mockito.argThat(a -> a.getRequestId() == requestId),
           Mockito.any());


### PR DESCRIPTION
Create logic for early terminating all requests if broker 
1. received plan-time failure; 
2. received error-block from mailbox

APIs added will also allow future user-facing REST API to cancel query if they took too long.