### PR TITLE
Bug Fix: Handle empty validDocId snapshots during reloading

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -102,6 +102,10 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     _validDocIds = validDocIds;
   }
 
+  public void setValidDocIds(ThreadSafeMutableRoaringBitmap validDocIds) {
+    _validDocIds = validDocIds;
+  }
+
   @Nullable
   public MutableRoaringBitmap loadValidDocIdsFromSnapshot() {
     File validDocIdsSnapshotFile = getValidDocIdsSnapshotFile();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -102,10 +102,6 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     _validDocIds = validDocIds;
   }
 
-  public void setValidDocIds(ThreadSafeMutableRoaringBitmap validDocIds) {
-    _validDocIds = validDocIds;
-  }
-
   @Nullable
   public MutableRoaringBitmap loadValidDocIdsFromSnapshot() {
     File validDocIdsSnapshotFile = getValidDocIdsSnapshotFile();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -124,6 +124,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       if (validDocIds != null && validDocIds.isEmpty()) {
         _logger.info("Skip adding segment: {} without valid doc, current primary key count: {}",
             segment.getSegmentName(), getNumPrimaryKeys());
+       immutableSegmentImpl.setValidDocIds(new ThreadSafeMutableRoaringBitmap());
         return;
       }
     } else {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -124,7 +124,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       if (validDocIds != null && validDocIds.isEmpty()) {
         _logger.info("Skip adding segment: {} without valid doc, current primary key count: {}",
             segment.getSegmentName(), getNumPrimaryKeys());
-       immutableSegmentImpl.setValidDocIds(new ThreadSafeMutableRoaringBitmap());
+       immutableSegmentImpl.enableUpsert(this, new ThreadSafeMutableRoaringBitmap());
         return;
       }
     } else {


### PR DESCRIPTION
If a segment has `validDocIds` as empty and `enableSnapshot: true`, we persist an empty `validDocIdSnapshot` file on disk.

During the next restart however, if we find the `validDocIdSnapshot` file is empty and not null, we simply do not read any rows from that segment for upsert. 

```java
    if (_enableSnapshot) {
      validDocIds = immutableSegmentImpl.loadValidDocIdsFromSnapshot();
      if (validDocIds != null && validDocIds.isEmpty()) {
        _logger.info("Skip adding segment: {} without valid doc, current primary key count: {}",
            segment.getSegmentName(), getNumPrimaryKeys());
        return;
      }
    }
```

This however has a side effect that we never set `validDocIds` value for that segment inside memory. Ideally in this case, that value should be empty. But currently, it is set `null`.
 
During the query phase, we check for `validDocIds` from the segment. If a segment has `null` validDocIds, we assume that all rows inside segment to be valid. This leads to older rows being returned in the query from this segment after restart.
 
 ```java
      BaseFilterOperator filterOperator = constructPhysicalOperator(filter, numDocs);
      if (validDocIdsSnapshot != null) {
        BaseFilterOperator validDocFilter = new BitmapBasedFilterOperator(validDocIdsSnapshot, false, numDocs);
        return FilterOperatorUtils.getAndFilterOperator(_queryContext, Arrays.asList(filterOperator, validDocFilter),
            numDocs);
      } else {
        return filterOperator;
      }
```

Possible Solutions:

* Simply set an empty bitmap instead of null during restart. Rows still not read from the segment so it is fast.

* Do not persist empty snapshot file. This works however during restart we will end up reading each and every row from this segment and then discarding them later on. This will affect server restart time significantly.


I have taken the first approach for this solution since it gives better performance.



 