### PR TITLE
Simplify filtered aggregate transform operator creation

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
@@ -53,36 +53,37 @@ import org.apache.pinot.spi.trace.Tracing;
 public class FilteredGroupByOperator extends BaseOperator<GroupByResultsBlock> {
   private static final String EXPLAIN_NAME = "GROUP_BY_FILTERED";
 
+  private final QueryContext _queryContext;
   private final AggregationFunction[] _aggregationFunctions;
-  private final List<Pair<AggregationFunction[], TransformOperator>> _aggFunctionsWithTransformOperator;
   private final ExpressionContext[] _groupByExpressions;
+  private final List<Pair<AggregationFunction[], TransformOperator>> _aggFunctionsWithTransformOperator;
   private final long _numTotalDocs;
+  private final DataSchema _dataSchema;
+
   private long _numDocsScanned;
   private long _numEntriesScannedInFilter;
   private long _numEntriesScannedPostFilter;
-  private final DataSchema _dataSchema;
-  private final QueryContext _queryContext;
 
-  public FilteredGroupByOperator(AggregationFunction[] aggregationFunctions,
-      List<Pair<AggregationFunction, FilterContext>> filteredAggregationFunctions,
-      List<Pair<AggregationFunction[], TransformOperator>> aggFunctionsWithTransformOperator,
-      ExpressionContext[] groupByExpressions, long numTotalDocs, QueryContext queryContext) {
-    _aggregationFunctions = aggregationFunctions;
-    _aggFunctionsWithTransformOperator = aggFunctionsWithTransformOperator;
-    _groupByExpressions = groupByExpressions;
-    _numTotalDocs = numTotalDocs;
+  public FilteredGroupByOperator(QueryContext queryContext,
+      List<Pair<AggregationFunction[], TransformOperator>> aggFunctionsWithTransformOperator, long numTotalDocs) {
+    assert queryContext.getAggregationFunctions() != null && queryContext.getFilteredAggregationFunctions() != null
+        && queryContext.getGroupByExpressions() != null;
     _queryContext = queryContext;
+    _aggregationFunctions = queryContext.getAggregationFunctions();
+    _groupByExpressions = queryContext.getGroupByExpressions().toArray(new ExpressionContext[0]);
+    _aggFunctionsWithTransformOperator = aggFunctionsWithTransformOperator;
+    _numTotalDocs = numTotalDocs;
 
     // NOTE: The indexedTable expects that the data schema will have group by columns before aggregation columns
-    int numGroupByExpressions = groupByExpressions.length;
-    int numAggregationFunctions = aggregationFunctions.length;
+    int numGroupByExpressions = _groupByExpressions.length;
+    int numAggregationFunctions = _aggregationFunctions.length;
     int numColumns = numGroupByExpressions + numAggregationFunctions;
     String[] columnNames = new String[numColumns];
     DataSchema.ColumnDataType[] columnDataTypes = new DataSchema.ColumnDataType[numColumns];
 
     // Extract column names and data types for group-by columns
     for (int i = 0; i < numGroupByExpressions; i++) {
-      ExpressionContext groupByExpression = groupByExpressions[i];
+      ExpressionContext groupByExpression = _groupByExpressions[i];
       columnNames[i] = groupByExpression.toString();
       columnDataTypes[i] = DataSchema.ColumnDataType.fromDataTypeSV(
           aggFunctionsWithTransformOperator.get(i).getRight().getResultMetadata(groupByExpression).getDataType());
@@ -91,10 +92,9 @@ public class FilteredGroupByOperator extends BaseOperator<GroupByResultsBlock> {
     // Extract column names and data types for aggregation functions
     for (int i = 0; i < numAggregationFunctions; i++) {
       int index = numGroupByExpressions + i;
-      Pair<AggregationFunction, FilterContext> filteredAggPair = filteredAggregationFunctions.get(i);
-      AggregationFunction aggregationFunction = filteredAggPair.getLeft();
-      String columnName =
-          AggregationFunctionUtils.getResultColumnName(aggregationFunction, filteredAggPair.getRight());
+      Pair<AggregationFunction, FilterContext> pair = queryContext.getFilteredAggregationFunctions().get(i);
+      AggregationFunction aggregationFunction = pair.getLeft();
+      String columnName = AggregationFunctionUtils.getResultColumnName(aggregationFunction, pair.getRight());
       columnNames[index] = columnName;
       columnDataTypes[index] = aggregationFunction.getIntermediateResultColumnType();
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -80,18 +80,10 @@ public class AggregationPlanNode implements PlanNode {
    * Build the operator to be used for filtered aggregations
    */
   private FilteredAggregationOperator buildFilteredAggOperator() {
-    int numTotalDocs = _indexSegment.getSegmentMetadata().getTotalDocs();
-    // Build the operator chain for the main predicate
-    Pair<FilterPlanNode, BaseFilterOperator> filterOperatorPair =
-        AggregationFunctionUtils.buildFilterOperator(_indexSegment, _queryContext);
-    TransformOperator transformOperator =
-        AggregationFunctionUtils.buildTransformOperatorForFilteredAggregates(_indexSegment, _queryContext,
-            filterOperatorPair.getRight(), null);
-
-    List<Pair<AggregationFunction[], TransformOperator>> aggToTransformOpList =
-        AggregationFunctionUtils.buildFilteredAggTransformPairs(_indexSegment, _queryContext,
-            filterOperatorPair.getRight(), transformOperator, null);
-    return new FilteredAggregationOperator(_queryContext.getAggregationFunctions(), aggToTransformOpList, numTotalDocs);
+    List<Pair<AggregationFunction[], TransformOperator>> transformOperators =
+        AggregationFunctionUtils.buildFilteredAggregateTransformOperators(_indexSegment, _queryContext);
+    return new FilteredAggregationOperator(_queryContext.getAggregationFunctions(), transformOperators,
+        _indexSegment.getSegmentMetadata().getTotalDocs());
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationSingleValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InnerSegmentAggregationSingleValueQueriesTest.java
@@ -67,7 +67,7 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     FilteredAggregationOperator aggregationOperator = getOperator(query);
     AggregationResultsBlock resultsBlock = aggregationOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 150000L, 0L,
-        450000L, 30000L);
+        120000L, 30000L);
     QueriesTestUtils.testInnerSegmentAggregationResult(resultsBlock.getResults(), 22266008882250L, 30000, 2147419555,
         32289159189150L, 28175373944314L, 30000L);
 
@@ -77,7 +77,7 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     aggregationOperator = getOperator(query);
     resultsBlock = aggregationOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 150000L, 0L,
-        450000L, 30000L);
+        120000L, 30000L);
     QueriesTestUtils.testInnerSegmentAggregationResult(resultsBlock.getResults(), 22266008882250L, 30000, 2147419555,
         32289159189150L, 28175373944314L, 30000L);
 
@@ -87,7 +87,7 @@ public class InnerSegmentAggregationSingleValueQueriesTest extends BaseSingleVal
     aggregationOperator = getOperator(query);
     resultsBlock = aggregationOperator.nextBlock();
     QueriesTestUtils.testInnerSegmentExecutionStatistics(aggregationOperator.getExecutionStatistics(), 120000L, 0L,
-        360000L, 30000L);
+        90000L, 30000L);
     QueriesTestUtils.testInnerSegmentAggregationResult(resultsBlock.getResults(), 22266008882250L, 30000, 2147419555,
         32289159189150L, 0L, 0L);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueQueriesTest.java
@@ -595,7 +595,7 @@ public class InterSegmentAggregationMultiValueQueriesTest extends BaseMultiValue
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
     ResultTable expectedResultTable =
         new ResultTable(expectedDataSchema, Collections.singletonList(new Object[]{370236L}));
-    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 370236L, 0L, 0L, 400000L, expectedResultTable);
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 370236L, 400000L, 0L, 400000L, expectedResultTable);
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueRawQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/InterSegmentAggregationMultiValueRawQueriesTest.java
@@ -534,7 +534,7 @@ public class InterSegmentAggregationMultiValueRawQueriesTest extends BaseMultiVa
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.LONG});
     ResultTable expectedResultTable =
         new ResultTable(expectedDataSchema, Collections.singletonList(new Object[]{370236L}));
-    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 370236L, 0L, 0L, 400000L, expectedResultTable);
+    QueriesTestUtils.testInterSegmentsResult(brokerResponse, 370236L, 400000L, 0L, 400000L, expectedResultTable);
   }
 
   @Test


### PR DESCRIPTION
With the following enhancements:
- Do not project columns for other aggregation functions in the transform operator
- Avoid creating `CombinedFilterOperator` when one filter is empty or matches all