### PR TITLE
Refactor: Pass context instead on individual arguments to operator

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -210,8 +210,9 @@ public class QueryRunner {
           "RequestId:" + requestId + " StageId:" + distributedStagePlan.getStageId() + " Leaf stage v1 processing time:"
               + (System.currentTimeMillis() - leafStageStartMillis) + " ms");
       MailboxSendNode sendNode = (MailboxSendNode) distributedStagePlan.getStageRoot();
-      OpChainExecutionContext opChainExecutionContext = new OpChainExecutionContext(_mailboxService, requestId, sendNode.getStageId(),
-          _rootServer, deadlineMs, deadlineMs, distributedStagePlan.getMetadataMap());
+      OpChainExecutionContext opChainExecutionContext =
+          new OpChainExecutionContext(_mailboxService, requestId, sendNode.getStageId(), _rootServer, deadlineMs,
+              deadlineMs, distributedStagePlan.getMetadataMap());
       mailboxSendOperator = new MailboxSendOperator(
           new LeafStageTransferableBlockOperator(serverQueryResults, sendNode.getDataSchema(), opChainExecutionContext),
           sendNode.getExchangeType(), sendNode.getPartitionKeySelector(), sendNode.getStageId(),

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -213,10 +213,10 @@ public class QueryRunner {
       OpChainExecutionContext opChainExecutionContext =
           new OpChainExecutionContext(_mailboxService, requestId, sendNode.getStageId(), _rootServer, deadlineMs,
               deadlineMs, distributedStagePlan.getMetadataMap());
-      mailboxSendOperator = new MailboxSendOperator(
-          new LeafStageTransferableBlockOperator(serverQueryResults, sendNode.getDataSchema(), opChainExecutionContext),
+      mailboxSendOperator = new MailboxSendOperator(opChainExecutionContext,
+          new LeafStageTransferableBlockOperator(opChainExecutionContext, serverQueryResults, sendNode.getDataSchema()),
           sendNode.getExchangeType(), sendNode.getPartitionKeySelector(), sendNode.getStageId(),
-          sendNode.getReceiverStageId(), opChainExecutionContext);
+          sendNode.getReceiverStageId());
       int blockCounter = 0;
       while (!TransferableBlockUtils.isEndOfStream(mailboxSendOperator.nextBlock())) {
         LOGGER.debug("Acquired transferable block: {}", blockCounter++);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -39,6 +39,7 @@ import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.utils.AggregationUtils;
+import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
 import org.apache.pinot.segment.local.customobject.PinotFourthMoment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -85,6 +86,12 @@ public class AggregateOperator extends MultiStageOperator {
       VirtualServerAddress virtualServerAddress) {
     this(inputOperator, dataSchema, aggCalls, groupSet, inputSchema, AggregateOperator.AggregateAccumulator.AGG_MERGERS,
         requestId, stageId, virtualServerAddress);
+  }
+
+  public AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema, List<RexExpression> aggCalls,
+      List<RexExpression> groupSet, DataSchema inputSchema, OperatorExecutionContext context) {
+    this(inputOperator, dataSchema, aggCalls, groupSet, inputSchema, AggregateOperator.AggregateAccumulator.MERGERS,
+        context.getRequestId(), context.getStageId(), context.getServer());
   }
 
   @VisibleForTesting

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -89,7 +89,8 @@ public class AggregateOperator extends MultiStageOperator {
   @VisibleForTesting
   AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema, List<RexExpression> aggCalls,
       List<RexExpression> groupSet, DataSchema inputSchema,
-      Map<String, Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> mergers, OpChainExecutionContext context) {
+      Map<String, Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> mergers,
+      OpChainExecutionContext context) {
     super(context);
     _inputOperator = inputOperator;
     _groupSet = groupSet;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -84,15 +84,14 @@ public class AggregateOperator extends MultiStageOperator {
   public AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema, List<RexExpression> aggCalls,
       List<RexExpression> groupSet, DataSchema inputSchema, OperatorExecutionContext context) {
     this(inputOperator, dataSchema, aggCalls, groupSet, inputSchema, AggregateOperator.AggregateAccumulator.AGG_MERGERS,
-        context.getRequestId(), context.getStageId(), context.getServer());
+        context);
   }
 
   @VisibleForTesting
   AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema, List<RexExpression> aggCalls,
       List<RexExpression> groupSet, DataSchema inputSchema,
-      Map<String, Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> mergers, long requestId, int stageId,
-      VirtualServerAddress serverAddress) {
-    super(requestId, stageId, serverAddress);
+      Map<String, Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> mergers, OperatorExecutionContext context) {
+    super(context);
     _inputOperator = inputOperator;
     _groupSet = groupSet;
     _upstreamErrorBlock = null;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -83,7 +83,7 @@ public class AggregateOperator extends MultiStageOperator {
   // TODO: Add these two checks when we confirm we can handle error in upstream ctor call.
   public AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema, List<RexExpression> aggCalls,
       List<RexExpression> groupSet, DataSchema inputSchema, OperatorExecutionContext context) {
-    this(inputOperator, dataSchema, aggCalls, groupSet, inputSchema, AggregateOperator.AggregateAccumulator.MERGERS,
+    this(inputOperator, dataSchema, aggCalls, groupSet, inputSchema, AggregateOperator.AggregateAccumulator.AGG_MERGERS,
         context.getRequestId(), context.getStageId(), context.getServer());
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -82,13 +82,6 @@ public class AggregateOperator extends MultiStageOperator {
   // groupSet has to be a list of InputRef and cannot be null
   // TODO: Add these two checks when we confirm we can handle error in upstream ctor call.
   public AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema, List<RexExpression> aggCalls,
-      List<RexExpression> groupSet, DataSchema inputSchema, long requestId, int stageId,
-      VirtualServerAddress virtualServerAddress) {
-    this(inputOperator, dataSchema, aggCalls, groupSet, inputSchema, AggregateOperator.AggregateAccumulator.AGG_MERGERS,
-        requestId, stageId, virtualServerAddress);
-  }
-
-  public AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema, List<RexExpression> aggCalls,
       List<RexExpression> groupSet, DataSchema inputSchema, OperatorExecutionContext context) {
     this(inputOperator, dataSchema, aggCalls, groupSet, inputSchema, AggregateOperator.AggregateAccumulator.MERGERS,
         context.getRequestId(), context.getStageId(), context.getServer());

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -80,17 +80,16 @@ public class AggregateOperator extends MultiStageOperator {
   // aggCalls has to be a list of FunctionCall and cannot be null
   // groupSet has to be a list of InputRef and cannot be null
   // TODO: Add these two checks when we confirm we can handle error in upstream ctor call.
-  public AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema, List<RexExpression> aggCalls,
-      List<RexExpression> groupSet, DataSchema inputSchema, OpChainExecutionContext context) {
-    this(inputOperator, dataSchema, aggCalls, groupSet, inputSchema, AggregateOperator.AggregateAccumulator.AGG_MERGERS,
-        context);
+  public AggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator, DataSchema dataSchema,
+      List<RexExpression> aggCalls, List<RexExpression> groupSet, DataSchema inputSchema) {
+    this(context, inputOperator, dataSchema, aggCalls, groupSet, inputSchema,
+        AggregateOperator.AggregateAccumulator.AGG_MERGERS);
   }
 
   @VisibleForTesting
-  AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema, List<RexExpression> aggCalls,
-      List<RexExpression> groupSet, DataSchema inputSchema,
-      Map<String, Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> mergers,
-      OpChainExecutionContext context) {
+  AggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator, DataSchema dataSchema,
+      List<RexExpression> aggCalls, List<RexExpression> groupSet, DataSchema inputSchema,
+      Map<String, Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> mergers) {
     super(context);
     _inputOperator = inputOperator;
     _groupSet = groupSet;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -35,11 +35,10 @@ import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.query.planner.logical.RexExpression;
-import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.utils.AggregationUtils;
-import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.segment.local.customobject.PinotFourthMoment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -82,7 +81,7 @@ public class AggregateOperator extends MultiStageOperator {
   // groupSet has to be a list of InputRef and cannot be null
   // TODO: Add these two checks when we confirm we can handle error in upstream ctor call.
   public AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema, List<RexExpression> aggCalls,
-      List<RexExpression> groupSet, DataSchema inputSchema, OperatorExecutionContext context) {
+      List<RexExpression> groupSet, DataSchema inputSchema, OpChainExecutionContext context) {
     this(inputOperator, dataSchema, aggCalls, groupSet, inputSchema, AggregateOperator.AggregateAccumulator.AGG_MERGERS,
         context);
   }
@@ -90,7 +89,7 @@ public class AggregateOperator extends MultiStageOperator {
   @VisibleForTesting
   AggregateOperator(MultiStageOperator inputOperator, DataSchema dataSchema, List<RexExpression> aggCalls,
       List<RexExpression> groupSet, DataSchema inputSchema,
-      Map<String, Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> mergers, OperatorExecutionContext context) {
+      Map<String, Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> mergers, OpChainExecutionContext context) {
     super(context);
     _inputOperator = inputOperator;
     _groupSet = groupSet;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -25,7 +25,6 @@ import javax.annotation.Nullable;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
-import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
@@ -58,12 +57,7 @@ public class FilterOperator extends MultiStageOperator {
 
   public FilterOperator(MultiStageOperator upstreamOperator, DataSchema dataSchema, RexExpression filter,
       OperatorExecutionContext context) {
-    this(upstreamOperator, dataSchema, filter, context.getRequestId(), context.getStageId(), context.getServer());
-  }
-
-  public FilterOperator(MultiStageOperator upstreamOperator, DataSchema dataSchema, RexExpression filter,
-      long requestId, int stageId, VirtualServerAddress serverAddress) {
-    super(requestId, stageId, serverAddress);
+    super(context.getRequestId(), context.getStageId(), context.getServer());
     _upstreamOperator = upstreamOperator;
     _dataSchema = dataSchema;
     _filterOperand = TransformOperand.toTransformOperand(filter, dataSchema);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -30,6 +30,7 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.utils.FunctionInvokeUtils;
+import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +55,11 @@ public class FilterOperator extends MultiStageOperator {
   private final TransformOperand _filterOperand;
   private final DataSchema _dataSchema;
   private TransferableBlock _upstreamErrorBlock;
+
+  public FilterOperator(MultiStageOperator upstreamOperator, DataSchema dataSchema, RexExpression filter,
+      OperatorExecutionContext context) {
+    this(upstreamOperator, dataSchema, filter, context.getRequestId(), context.getStageId(), context.getServer());
+  }
 
   public FilterOperator(MultiStageOperator upstreamOperator, DataSchema dataSchema, RexExpression filter,
       long requestId, int stageId, VirtualServerAddress serverAddress) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -55,8 +55,8 @@ public class FilterOperator extends MultiStageOperator {
   private final DataSchema _dataSchema;
   private TransferableBlock _upstreamErrorBlock;
 
-  public FilterOperator(MultiStageOperator upstreamOperator, DataSchema dataSchema, RexExpression filter,
-      OpChainExecutionContext context) {
+  public FilterOperator(OpChainExecutionContext context, MultiStageOperator upstreamOperator, DataSchema dataSchema,
+      RexExpression filter) {
     super(context);
     _upstreamOperator = upstreamOperator;
     _dataSchema = dataSchema;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -29,7 +29,7 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.utils.FunctionInvokeUtils;
-import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ public class FilterOperator extends MultiStageOperator {
   private TransferableBlock _upstreamErrorBlock;
 
   public FilterOperator(MultiStageOperator upstreamOperator, DataSchema dataSchema, RexExpression filter,
-      OperatorExecutionContext context) {
+      OpChainExecutionContext context) {
     super(context);
     _upstreamOperator = upstreamOperator;
     _dataSchema = dataSchema;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -57,7 +57,7 @@ public class FilterOperator extends MultiStageOperator {
 
   public FilterOperator(MultiStageOperator upstreamOperator, DataSchema dataSchema, RexExpression filter,
       OperatorExecutionContext context) {
-    super(context.getRequestId(), context.getStageId(), context.getServer());
+    super(context);
     _upstreamOperator = upstreamOperator;
     _dataSchema = dataSchema;
     _filterOperand = TransformOperand.toTransformOperand(filter, dataSchema);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -88,8 +88,8 @@ public class HashJoinOperator extends MultiStageOperator {
   private KeySelector<Object[], Object[]> _leftKeySelector;
   private KeySelector<Object[], Object[]> _rightKeySelector;
 
-  public HashJoinOperator(MultiStageOperator leftTableOperator, MultiStageOperator rightTableOperator,
-      DataSchema leftSchema, JoinNode node, OpChainExecutionContext context) {
+  public HashJoinOperator(OpChainExecutionContext context, MultiStageOperator leftTableOperator,
+      MultiStageOperator rightTableOperator, DataSchema leftSchema, JoinNode node) {
     super(context);
     Preconditions.checkState(SUPPORTED_JOIN_TYPES.contains(node.getJoinRelType()),
         "Join type: " + node.getJoinRelType() + " is not supported!");

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -39,7 +39,7 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.utils.FunctionInvokeUtils;
-import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -89,7 +89,7 @@ public class HashJoinOperator extends MultiStageOperator {
   private KeySelector<Object[], Object[]> _rightKeySelector;
 
   public HashJoinOperator(MultiStageOperator leftTableOperator, MultiStageOperator rightTableOperator,
-      DataSchema leftSchema, JoinNode node, OperatorExecutionContext context) {
+      DataSchema leftSchema, JoinNode node, OpChainExecutionContext context) {
     super(context);
     Preconditions.checkState(SUPPORTED_JOIN_TYPES.contains(node.getJoinRelType()),
         "Join type: " + node.getJoinRelType() + " is not supported!");

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -40,6 +40,7 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.utils.FunctionInvokeUtils;
+import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -87,6 +88,12 @@ public class HashJoinOperator extends MultiStageOperator {
   private TransferableBlock _upstreamErrorBlock;
   private KeySelector<Object[], Object[]> _leftKeySelector;
   private KeySelector<Object[], Object[]> _rightKeySelector;
+
+  public HashJoinOperator(MultiStageOperator leftTableOperator, MultiStageOperator rightTableOperator,
+      DataSchema leftSchema, JoinNode node, OperatorExecutionContext context) {
+    this(leftTableOperator, rightTableOperator, leftSchema, node, context.getRequestId(), context.getStageId(),
+        context.getServer());
+  }
 
   public HashJoinOperator(MultiStageOperator leftTableOperator, MultiStageOperator rightTableOperator,
       DataSchema leftSchema, JoinNode node, long requestId, int stageId, VirtualServerAddress serverAddress) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -35,7 +35,6 @@ import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.planner.stage.JoinNode;
-import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
@@ -91,13 +90,7 @@ public class HashJoinOperator extends MultiStageOperator {
 
   public HashJoinOperator(MultiStageOperator leftTableOperator, MultiStageOperator rightTableOperator,
       DataSchema leftSchema, JoinNode node, OperatorExecutionContext context) {
-    this(leftTableOperator, rightTableOperator, leftSchema, node, context.getRequestId(), context.getStageId(),
-        context.getServer());
-  }
-
-  public HashJoinOperator(MultiStageOperator leftTableOperator, MultiStageOperator rightTableOperator,
-      DataSchema leftSchema, JoinNode node, long requestId, int stageId, VirtualServerAddress serverAddress) {
-    super(requestId, stageId, serverAddress);
+    super(context.getRequestId(), context.getStageId(), context.getServer());
     Preconditions.checkState(SUPPORTED_JOIN_TYPES.contains(node.getJoinRelType()),
         "Join type: " + node.getJoinRelType() + " is not supported!");
     _joinType = node.getJoinRelType();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -90,7 +90,7 @@ public class HashJoinOperator extends MultiStageOperator {
 
   public HashJoinOperator(MultiStageOperator leftTableOperator, MultiStageOperator rightTableOperator,
       DataSchema leftSchema, JoinNode node, OperatorExecutionContext context) {
-    super(context.getRequestId(), context.getStageId(), context.getServer());
+    super(context);
     Preconditions.checkState(SUPPORTED_JOIN_TYPES.contains(node.getJoinRelType()),
         "Join type: " + node.getJoinRelType() + " is not supported!");
     _joinType = node.getJoinRelType();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -41,6 +41,7 @@ import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -66,6 +67,11 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
   private final List<InstanceResponseBlock> _baseResultBlock;
   private final DataSchema _desiredDataSchema;
   private int _currentIndex;
+
+  public LeafStageTransferableBlockOperator(List<InstanceResponseBlock> baseResultBlock, DataSchema dataSchema,
+      OperatorExecutionContext context) {
+    this(baseResultBlock, dataSchema, context.getRequestId(), context.getStageId(), context.getServer());
+  }
 
   public LeafStageTransferableBlockOperator(List<InstanceResponseBlock> baseResultBlock, DataSchema dataSchema,
       long requestId, int stageId, VirtualServerAddress serverAddress) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -70,12 +70,7 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
 
   public LeafStageTransferableBlockOperator(List<InstanceResponseBlock> baseResultBlock, DataSchema dataSchema,
       OpChainExecutionContext context) {
-    this(baseResultBlock, dataSchema, context.getRequestId(), context.getStageId(), context.getServer());
-  }
-
-  public LeafStageTransferableBlockOperator(List<InstanceResponseBlock> baseResultBlock, DataSchema dataSchema,
-      long requestId, int stageId, VirtualServerAddress serverAddress) {
-    super(requestId, stageId, serverAddress);
+    super(context);
     _baseResultBlock = baseResultBlock;
     _desiredDataSchema = dataSchema;
     _errorBlock = baseResultBlock.stream().filter(e -> !e.getExceptions().isEmpty()).findFirst().orElse(null);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -67,8 +67,8 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
   private final DataSchema _desiredDataSchema;
   private int _currentIndex;
 
-  public LeafStageTransferableBlockOperator(List<InstanceResponseBlock> baseResultBlock, DataSchema dataSchema,
-      OpChainExecutionContext context) {
+  public LeafStageTransferableBlockOperator(OpChainExecutionContext context,
+      List<InstanceResponseBlock> baseResultBlock, DataSchema dataSchema) {
     super(context);
     _baseResultBlock = baseResultBlock;
     _desiredDataSchema = dataSchema;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -39,7 +39,6 @@ import org.apache.pinot.core.operator.blocks.results.DistinctResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
-import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.slf4j.Logger;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -41,7 +41,7 @@ import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
-import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -69,7 +69,7 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
   private int _currentIndex;
 
   public LeafStageTransferableBlockOperator(List<InstanceResponseBlock> baseResultBlock, DataSchema dataSchema,
-      OperatorExecutionContext context) {
+      OpChainExecutionContext context) {
     this(baseResultBlock, dataSchema, context.getRequestId(), context.getStageId(), context.getServer());
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -25,7 +25,6 @@ import javax.annotation.Nullable;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
-import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
@@ -43,12 +42,7 @@ public class LiteralValueOperator extends MultiStageOperator {
 
   public LiteralValueOperator(DataSchema dataSchema, List<List<RexExpression>> rexLiteralRows,
       OperatorExecutionContext context) {
-    this(dataSchema, rexLiteralRows, context.getRequestId(), context.getStageId(), context.getServer());
-  }
-
-  public LiteralValueOperator(DataSchema dataSchema, List<List<RexExpression>> rexLiteralRows,
-      long requestId, int stageId, VirtualServerAddress serverAddress) {
-    super(requestId, stageId, serverAddress);
+    super(context.getRequestId(), context.getStageId(), context.getServer());
     _dataSchema = dataSchema;
     _rexLiteralBlock = constructBlock(rexLiteralRows);
     _isLiteralBlockReturned = false;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -27,7 +27,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,7 +41,7 @@ public class LiteralValueOperator extends MultiStageOperator {
   private boolean _isLiteralBlockReturned;
 
   public LiteralValueOperator(DataSchema dataSchema, List<List<RexExpression>> rexLiteralRows,
-      OperatorExecutionContext context) {
+      OpChainExecutionContext context) {
     super(context);
     _dataSchema = dataSchema;
     _rexLiteralBlock = constructBlock(rexLiteralRows);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -42,7 +42,7 @@ public class LiteralValueOperator extends MultiStageOperator {
 
   public LiteralValueOperator(DataSchema dataSchema, List<List<RexExpression>> rexLiteralRows,
       OperatorExecutionContext context) {
-    super(context.getRequestId(), context.getStageId(), context.getServer());
+    super(context);
     _dataSchema = dataSchema;
     _rexLiteralBlock = constructBlock(rexLiteralRows);
     _isLiteralBlockReturned = false;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -28,6 +28,7 @@ import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -39,6 +40,11 @@ public class LiteralValueOperator extends MultiStageOperator {
   private final DataSchema _dataSchema;
   private final TransferableBlock _rexLiteralBlock;
   private boolean _isLiteralBlockReturned;
+
+  public LiteralValueOperator(DataSchema dataSchema, List<List<RexExpression>> rexLiteralRows,
+      OperatorExecutionContext context) {
+    this(dataSchema, rexLiteralRows, context.getRequestId(), context.getStageId(), context.getServer());
+  }
 
   public LiteralValueOperator(DataSchema dataSchema, List<List<RexExpression>> rexLiteralRows,
       long requestId, int stageId, VirtualServerAddress serverAddress) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -40,8 +40,8 @@ public class LiteralValueOperator extends MultiStageOperator {
   private final TransferableBlock _rexLiteralBlock;
   private boolean _isLiteralBlockReturned;
 
-  public LiteralValueOperator(DataSchema dataSchema, List<List<RexExpression>> rexLiteralRows,
-      OpChainExecutionContext context) {
+  public LiteralValueOperator(OpChainExecutionContext context, DataSchema dataSchema,
+      List<List<RexExpression>> rexLiteralRows) {
     super(context);
     _dataSchema = dataSchema;
     _rexLiteralBlock = constructBlock(rexLiteralRows);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -85,8 +85,8 @@ public class MailboxReceiveOperator extends MultiStageOperator {
 
   // TODO: Move deadlineInNanoSeconds to OperatorContext.
   //TODO: Remove boxed timeoutMs value from here and use long deadlineMs from context.
-  public MailboxReceiveOperator(List<VirtualServer> sendingStageInstances,
-      RelDistribution.Type exchangeType, int senderStageId, int receiverStageId, Long timeoutMs, OpChainExecutionContext context) {
+  public MailboxReceiveOperator(List<VirtualServer> sendingStageInstances, RelDistribution.Type exchangeType,
+      int senderStageId, int receiverStageId, Long timeoutMs, OpChainExecutionContext context) {
     super(context);
     _mailboxService = context.getMailboxService();
     VirtualServerAddress receiver = context.getServer();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -36,6 +36,7 @@ import org.apache.pinot.query.routing.VirtualServer;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
 import org.apache.pinot.query.service.QueryConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,6 +75,12 @@ public class MailboxReceiveOperator extends MultiStageOperator {
         receiver,
         senderStageId,
         receiverStageId);
+  }
+
+  public MailboxReceiveOperator(RelDistribution.Type exchangeType, int senderStageId,
+      int receiverStageId, OperatorExecutionContext context) {
+    this(context.getMailboxService(), context.getMetadataMap().get(senderStageId).getServerInstances(), exchangeType,
+        context.getServer(), context.getRequestId(), senderStageId, receiverStageId, context.getTimeoutMs());
   }
 
   // TODO: Move deadlineInNanoSeconds to OperatorContext.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -77,22 +77,23 @@ public class MailboxReceiveOperator extends MultiStageOperator {
         receiverStageId);
   }
 
-  public MailboxReceiveOperator(RelDistribution.Type exchangeType, int senderStageId,
-      int receiverStageId, OpChainExecutionContext context) {
-    this(context.getMetadataMap().get(senderStageId).getServerInstances(), exchangeType, senderStageId, receiverStageId, context);
+  public MailboxReceiveOperator(RelDistribution.Type exchangeType, int senderStageId, int receiverStageId,
+      OpChainExecutionContext context) {
+    this(context.getMetadataMap().get(senderStageId).getServerInstances(), exchangeType, senderStageId, receiverStageId,
+        context.getTimeoutMs(), context);
   }
 
   // TODO: Move deadlineInNanoSeconds to OperatorContext.
+  //TODO: Remove boxed timeoutMs value from here and use long deadlineMs from context.
   public MailboxReceiveOperator(List<VirtualServer> sendingStageInstances,
-      RelDistribution.Type exchangeType, int senderStageId, int receiverStageId, OpChainExecutionContext context) {
+      RelDistribution.Type exchangeType, int senderStageId, int receiverStageId, Long timeoutMs, OpChainExecutionContext context) {
     super(context);
     _mailboxService = context.getMailboxService();
     VirtualServerAddress receiver = context.getServer();
     long jobId = context.getRequestId();
     Preconditions.checkState(SUPPORTED_EXCHANGE_TYPES.contains(exchangeType),
         "Exchange/Distribution type: " + exchangeType + " is not supported!");
-    //TODO: Should I be using the Long.MAX_VALUE here instead of -1 or previous null check?
-    long timeoutNano = (context.getTimeoutMs() != Long.MAX_VALUE ? context.getTimeoutMs() : QueryConfig.DEFAULT_MAILBOX_TIMEOUT_MS) * 1_000_000L;
+    long timeoutNano = (timeoutMs != null ? timeoutMs : QueryConfig.DEFAULT_MAILBOX_TIMEOUT_MS) * 1_000_000L;
     _deadlineTimestampNano = timeoutNano + System.nanoTime();
 
     _exchangeType = exchangeType;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -36,7 +36,7 @@ import org.apache.pinot.query.routing.VirtualServer;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.query.service.QueryConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -78,7 +78,7 @@ public class MailboxReceiveOperator extends MultiStageOperator {
   }
 
   public MailboxReceiveOperator(RelDistribution.Type exchangeType, int senderStageId,
-      int receiverStageId, OperatorExecutionContext context) {
+      int receiverStageId, OpChainExecutionContext context) {
     this(context.getMailboxService(), context.getMetadataMap().get(senderStageId).getServerInstances(), exchangeType,
         context.getServer(), context.getRequestId(), senderStageId, receiverStageId, context.getTimeoutMs());
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -77,16 +77,16 @@ public class MailboxReceiveOperator extends MultiStageOperator {
         receiverStageId);
   }
 
-  public MailboxReceiveOperator(RelDistribution.Type exchangeType, int senderStageId, int receiverStageId,
-      OpChainExecutionContext context) {
-    this(context.getMetadataMap().get(senderStageId).getServerInstances(), exchangeType, senderStageId, receiverStageId,
-        context.getTimeoutMs(), context);
+  public MailboxReceiveOperator(OpChainExecutionContext context, RelDistribution.Type exchangeType, int senderStageId,
+      int receiverStageId) {
+    this(context, context.getMetadataMap().get(senderStageId).getServerInstances(), exchangeType, senderStageId,
+        receiverStageId, context.getTimeoutMs());
   }
 
   // TODO: Move deadlineInNanoSeconds to OperatorContext.
   //TODO: Remove boxed timeoutMs value from here and use long deadlineMs from context.
-  public MailboxReceiveOperator(List<VirtualServer> sendingStageInstances, RelDistribution.Type exchangeType,
-      int senderStageId, int receiverStageId, Long timeoutMs, OpChainExecutionContext context) {
+  public MailboxReceiveOperator(OpChainExecutionContext context, List<VirtualServer> sendingStageInstances,
+      RelDistribution.Type exchangeType, int senderStageId, int receiverStageId, Long timeoutMs) {
     super(context);
     _mailboxService = context.getMailboxService();
     VirtualServerAddress receiver = context.getServer();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -69,17 +69,18 @@ public class MailboxSendOperator extends MultiStageOperator {
     MailboxIdentifier generate(VirtualServer server);
   }
 
-  public MailboxSendOperator(MultiStageOperator dataTableBlockBaseOperator, RelDistribution.Type exchangeType,
-      KeySelector<Object[], Object[]> keySelector, int senderStageId, int receiverStageId,
-      OpChainExecutionContext context) {
-    this(dataTableBlockBaseOperator, exchangeType, keySelector, (server) -> toMailboxId(server, context.getRequestId(),
-        senderStageId, receiverStageId, context.getServer()), BlockExchange::getExchange, receiverStageId, context);
+  public MailboxSendOperator(OpChainExecutionContext context, MultiStageOperator dataTableBlockBaseOperator,
+      RelDistribution.Type exchangeType, KeySelector<Object[], Object[]> keySelector, int senderStageId,
+      int receiverStageId) {
+    this(context, dataTableBlockBaseOperator, exchangeType, keySelector,
+        (server) -> toMailboxId(server, context.getRequestId(), senderStageId, receiverStageId, context.getServer()),
+        BlockExchange::getExchange, receiverStageId);
   }
 
   @VisibleForTesting
-  MailboxSendOperator(MultiStageOperator dataTableBlockBaseOperator, RelDistribution.Type exchangeType,
-      KeySelector<Object[], Object[]> keySelector, MailboxIdGenerator mailboxIdGenerator,
-      BlockExchangeFactory blockExchangeFactory, int receiverStageId, OpChainExecutionContext context) {
+  MailboxSendOperator(OpChainExecutionContext context, MultiStageOperator dataTableBlockBaseOperator,
+      RelDistribution.Type exchangeType, KeySelector<Object[], Object[]> keySelector,
+      MailboxIdGenerator mailboxIdGenerator, BlockExchangeFactory blockExchangeFactory, int receiverStageId) {
     super(context);
     _dataTableBlockBaseOperator = dataTableBlockBaseOperator;
     MailboxService<TransferableBlock> mailboxService = context.getMailboxService();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -111,8 +111,9 @@ public class MailboxSendOperator extends MultiStageOperator {
     }
 
     BlockSplitter splitter = TransferableBlockUtils::splitBlock;
-    _exchange = blockExchangeFactory.build(context.getMailboxService(), receivingMailboxes, exchangeType, keySelector, splitter,
-        context.getDeadlineMs());
+    _exchange =
+        blockExchangeFactory.build(context.getMailboxService(), receivingMailboxes, exchangeType, keySelector, splitter,
+            context.getDeadlineMs());
 
     Preconditions.checkState(SUPPORTED_EXCHANGE_TYPE.contains(exchangeType),
         String.format("Exchange type '%s' is not supported yet", exchangeType));

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -38,6 +38,7 @@ import org.apache.pinot.query.runtime.blocks.BlockSplitter;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.exchange.BlockExchange;
+import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,6 +76,14 @@ public class MailboxSendOperator extends MultiStageOperator {
     this(mailboxService, dataTableBlockBaseOperator, receivingStageInstances, exchangeType, keySelector,
         server -> toMailboxId(server, jobId, senderStageId, receiverStageId, sendingServer), BlockExchange::getExchange,
         jobId, senderStageId, receiverStageId, sendingServer, deadlineMs);
+  }
+
+  public MailboxSendOperator(MultiStageOperator dataTableBlockBaseOperator, RelDistribution.Type exchangeType,
+      KeySelector<Object[], Object[]> keySelector, int senderStageId, int receiverStageId,
+      OperatorExecutionContext context) {
+    this(context.getMailboxService(), dataTableBlockBaseOperator,
+        context.getMetadataMap().get(receiverStageId).getServerInstances(), exchangeType, keySelector,
+        context.getServer(), context.getRequestId(), senderStageId, receiverStageId, context.getDeadlineMs());
   }
 
   @VisibleForTesting

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -38,7 +38,7 @@ import org.apache.pinot.query.runtime.blocks.BlockSplitter;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.exchange.BlockExchange;
-import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -80,7 +80,7 @@ public class MailboxSendOperator extends MultiStageOperator {
 
   public MailboxSendOperator(MultiStageOperator dataTableBlockBaseOperator, RelDistribution.Type exchangeType,
       KeySelector<Object[], Object[]> keySelector, int senderStageId, int receiverStageId,
-      OperatorExecutionContext context) {
+      OpChainExecutionContext context) {
     this(context.getMailboxService(), dataTableBlockBaseOperator,
         context.getMetadataMap().get(receiverStageId).getServerInstances(), exchangeType, keySelector,
         context.getServer(), context.getRequestId(), senderStageId, receiverStageId, context.getDeadlineMs());

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -28,7 +28,7 @@ import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.utils.OperatorUtils;
-import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.apache.pinot.spi.trace.InvocationScope;
 import org.apache.pinot.spi.trace.Tracing;
@@ -46,7 +46,7 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
   protected final Map<String, OperatorStats> _operatorStatsMap;
   private final String _operatorId;
 
-  public MultiStageOperator(OperatorExecutionContext context) {
+  public MultiStageOperator(OpChainExecutionContext context) {
     this(context.getRequestId(), context.getStageId(), context.getServer());
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -39,24 +39,18 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
   private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(MultiStageOperator.class);
 
   // TODO: Move to OperatorContext class.
-  protected final long _requestId;
-  protected final int _stageId;
-  protected final VirtualServerAddress _serverAddress;
   protected final OperatorStats _operatorStats;
   protected final Map<String, OperatorStats> _operatorStatsMap;
   private final String _operatorId;
+  private final OpChainExecutionContext _context;
 
   public MultiStageOperator(OpChainExecutionContext context) {
-    this(context.getRequestId(), context.getStageId(), context.getServer());
-  }
-
-  public MultiStageOperator(long requestId, int stageId, VirtualServerAddress serverAddress) {
-    _requestId = requestId;
-    _stageId = stageId;
-    _operatorStats = new OperatorStats(requestId, stageId, serverAddress, toExplainString());
-    _serverAddress = serverAddress;
+    _context = context;
+    _operatorStats =
+        new OperatorStats(_context, toExplainString());
     _operatorStatsMap = new HashMap<>();
-    _operatorId = Joiner.on("_").join(toExplainString(), _requestId, _stageId, _serverAddress);
+    _operatorId =
+        Joiner.on("_").join(toExplainString(), _context.getRequestId(), _context.getStageId(), _context.getServer());
   }
 
   public Map<String, OperatorStats> getOperatorStatsMap() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -28,6 +28,7 @@ import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.utils.OperatorUtils;
+import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.apache.pinot.spi.trace.InvocationScope;
 import org.apache.pinot.spi.trace.Tracing;
@@ -44,6 +45,10 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
   protected final OperatorStats _operatorStats;
   protected final Map<String, OperatorStats> _operatorStatsMap;
   private final String _operatorId;
+
+  public MultiStageOperator(OperatorExecutionContext context) {
+    this(context.getRequestId(), context.getStageId(), context.getServer());
+  }
 
   public MultiStageOperator(long requestId, int stageId, VirtualServerAddress serverAddress) {
     _requestId = requestId;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.core.common.Operator;
-import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.utils.OperatorUtils;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
@@ -24,6 +24,7 @@ import java.util.Set;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.query.mailbox.MailboxIdentifier;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
 
 
 /**
@@ -42,6 +43,11 @@ public class OpChain implements AutoCloseable {
     _receivingMailbox = new HashSet<>(receivingMailboxes);
     _id = new OpChainId(requestId, virtualServerId, stageId);
     _stats = new OpChainStats(_id.toString());
+  }
+
+  public OpChain(MultiStageOperator root, List<MailboxIdentifier> receivingMailboxes, int virtualServerId,
+      OperatorExecutionContext context) {
+    this(root, receivingMailboxes, virtualServerId, context.getRequestId(), context.getStageId());
   }
 
   public Operator<TransferableBlock> getRoot() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
@@ -24,7 +24,7 @@ import java.util.Set;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.query.mailbox.MailboxIdentifier;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
-import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 
 
 /**
@@ -46,7 +46,7 @@ public class OpChain implements AutoCloseable {
   }
 
   public OpChain(MultiStageOperator root, List<MailboxIdentifier> receivingMailboxes, int virtualServerId,
-      OperatorExecutionContext context) {
+      OpChainExecutionContext context) {
     this(root, receivingMailboxes, virtualServerId, context.getRequestId(), context.getStageId());
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
@@ -45,9 +45,8 @@ public class OpChain implements AutoCloseable {
     _stats = new OpChainStats(_id.toString());
   }
 
-  public OpChain(MultiStageOperator root, List<MailboxIdentifier> receivingMailboxes, int virtualServerId,
-      OpChainExecutionContext context) {
-    this(root, receivingMailboxes, virtualServerId, context.getRequestId(), context.getStageId());
+  public OpChain(OpChainExecutionContext context, MultiStageOperator root, List<MailboxIdentifier> receivingMailboxes) {
+    this(root, receivingMailboxes, context.getServer().virtualId(), context.getRequestId(), context.getStageId());
   }
 
   public Operator<TransferableBlock> getRoot() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.operator.utils.OperatorUtils;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 
 
 public class OperatorStats {
@@ -42,6 +43,11 @@ public class OperatorStats {
   private long _startTimeMs = -1;
   private final Map<String, String> _executionStats;
 
+  public OperatorStats(OpChainExecutionContext context, String operatorType) {
+    this(context.getRequestId(), context.getStageId(), context.getServer(), operatorType);
+  }
+
+  //TODO: remove this constructor after the context constructor can be used in serialization and deserialization
   public OperatorStats(long requestId, int stageId, VirtualServerAddress serverAddress, String operatorType) {
     _stageId = stageId;
     _requestId = requestId;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -57,16 +57,10 @@ public class SortOperator extends MultiStageOperator {
 
   public SortOperator(MultiStageOperator upstreamOperator, List<RexExpression> collationKeys,
       List<RelFieldCollation.Direction> collationDirections, int fetch, int offset, DataSchema dataSchema,
-      long requestId, int stageId, VirtualServerAddress serverAddress) {
-    this(upstreamOperator, collationKeys, collationDirections, fetch, offset, dataSchema,
-        SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY, requestId, stageId, serverAddress);
-  }
-
-  public SortOperator(MultiStageOperator upstreamOperator, List<RexExpression> collationKeys,
-      List<RelFieldCollation.Direction> collationDirections, int fetch, int offset, DataSchema dataSchema,
       OperatorExecutionContext context) {
-    this(upstreamOperator, collationKeys, collationDirections, fetch, offset, dataSchema, context.getRequestId(),
-        context.getStageId(), context.getServer());
+    this(upstreamOperator, collationKeys, collationDirections, fetch, offset, dataSchema,
+        SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY, context.getRequestId(), context.getStageId(),
+        context.getServer());
   }
 
   @VisibleForTesting

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -54,17 +54,17 @@ public class SortOperator extends MultiStageOperator {
   private boolean _isSortedBlockConstructed;
   private TransferableBlock _upstreamErrorBlock;
 
-  public SortOperator(MultiStageOperator upstreamOperator, List<RexExpression> collationKeys,
-      List<RelFieldCollation.Direction> collationDirections, int fetch, int offset, DataSchema dataSchema,
-      OpChainExecutionContext context) {
-    this(upstreamOperator, collationKeys, collationDirections, fetch, offset, dataSchema,
-        SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY, context);
+  public SortOperator(OpChainExecutionContext context, MultiStageOperator upstreamOperator,
+      List<RexExpression> collationKeys, List<RelFieldCollation.Direction> collationDirections, int fetch, int offset,
+      DataSchema dataSchema) {
+    this(context, upstreamOperator, collationKeys, collationDirections, fetch, offset, dataSchema,
+        SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY);
   }
 
   @VisibleForTesting
-  SortOperator(MultiStageOperator upstreamOperator, List<RexExpression> collationKeys,
+  SortOperator(OpChainExecutionContext context, MultiStageOperator upstreamOperator, List<RexExpression> collationKeys,
       List<RelFieldCollation.Direction> collationDirections, int fetch, int offset, DataSchema dataSchema,
-      int defaultHolderCapacity, OpChainExecutionContext context) {
+      int defaultHolderCapacity) {
     super(context);
     _upstreamOperator = upstreamOperator;
     _fetch = fetch;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -59,15 +59,14 @@ public class SortOperator extends MultiStageOperator {
       List<RelFieldCollation.Direction> collationDirections, int fetch, int offset, DataSchema dataSchema,
       OperatorExecutionContext context) {
     this(upstreamOperator, collationKeys, collationDirections, fetch, offset, dataSchema,
-        SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY, context.getRequestId(), context.getStageId(),
-        context.getServer());
+        SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY, context);
   }
 
   @VisibleForTesting
   SortOperator(MultiStageOperator upstreamOperator, List<RexExpression> collationKeys,
       List<RelFieldCollation.Direction> collationDirections, int fetch, int offset, DataSchema dataSchema,
-      int defaultHolderCapacity, long requestId, int stageId, VirtualServerAddress serverAddress) {
-    super(requestId, stageId, serverAddress);
+      int defaultHolderCapacity, OperatorExecutionContext context) {
+    super(context);
     _upstreamOperator = upstreamOperator;
     _fetch = fetch;
     _offset = Math.max(offset, 0);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -34,6 +34,7 @@ import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,6 +60,13 @@ public class SortOperator extends MultiStageOperator {
       long requestId, int stageId, VirtualServerAddress serverAddress) {
     this(upstreamOperator, collationKeys, collationDirections, fetch, offset, dataSchema,
         SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY, requestId, stageId, serverAddress);
+  }
+
+  public SortOperator(MultiStageOperator upstreamOperator, List<RexExpression> collationKeys,
+      List<RelFieldCollation.Direction> collationDirections, int fetch, int offset, DataSchema dataSchema,
+      OperatorExecutionContext context) {
+    this(upstreamOperator, collationKeys, collationDirections, fetch, offset, dataSchema, context.getRequestId(),
+        context.getStageId(), context.getServer());
   }
 
   @VisibleForTesting

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -31,10 +31,9 @@ import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.query.planner.logical.RexExpression;
-import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -57,7 +56,7 @@ public class SortOperator extends MultiStageOperator {
 
   public SortOperator(MultiStageOperator upstreamOperator, List<RexExpression> collationKeys,
       List<RelFieldCollation.Direction> collationDirections, int fetch, int offset, DataSchema dataSchema,
-      OperatorExecutionContext context) {
+      OpChainExecutionContext context) {
     this(upstreamOperator, collationKeys, collationDirections, fetch, offset, dataSchema,
         SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY, context);
   }
@@ -65,7 +64,7 @@ public class SortOperator extends MultiStageOperator {
   @VisibleForTesting
   SortOperator(MultiStageOperator upstreamOperator, List<RexExpression> collationKeys,
       List<RelFieldCollation.Direction> collationDirections, int fetch, int offset, DataSchema dataSchema,
-      int defaultHolderCapacity, OperatorExecutionContext context) {
+      int defaultHolderCapacity, OpChainExecutionContext context) {
     super(context);
     _upstreamOperator = upstreamOperator;
     _fetch = fetch;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -55,8 +55,8 @@ public class TransformOperator extends MultiStageOperator {
   private final DataSchema _resultSchema;
   private TransferableBlock _upstreamErrorBlock;
 
-  public TransformOperator(MultiStageOperator upstreamOperator, DataSchema resultSchema, List<RexExpression> transforms,
-      DataSchema upstreamDataSchema, OpChainExecutionContext context) {
+  public TransformOperator(OpChainExecutionContext context, MultiStageOperator upstreamOperator,
+      DataSchema resultSchema, List<RexExpression> transforms, DataSchema upstreamDataSchema) {
     super(context);
     Preconditions.checkState(!transforms.isEmpty(), "transform operand should not be empty.");
     Preconditions.checkState(resultSchema.size() == transforms.size(),

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -57,8 +57,7 @@ public class TransformOperator extends MultiStageOperator {
 
   public TransformOperator(MultiStageOperator upstreamOperator, DataSchema resultSchema, List<RexExpression> transforms,
       DataSchema upstreamDataSchema, OperatorExecutionContext context) {
-    super(context.getRequestId(), context.getStageId(),
-        context.getServer());
+    super(context);
     Preconditions.checkState(!transforms.isEmpty(), "transform operand should not be empty.");
     Preconditions.checkState(resultSchema.size() == transforms.size(),
         "result schema size:" + resultSchema.size() + " doesn't match transform operand size:" + transforms.size());

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -31,6 +31,7 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.utils.FunctionInvokeUtils;
+import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,6 +55,12 @@ public class TransformOperator extends MultiStageOperator {
   // TODO: Check type matching between resultSchema and the actual result.
   private final DataSchema _resultSchema;
   private TransferableBlock _upstreamErrorBlock;
+
+  public TransformOperator(MultiStageOperator upstreamOperator, DataSchema resultSchema, List<RexExpression> transforms,
+      DataSchema upstreamDataSchema, OperatorExecutionContext context) {
+    this(upstreamOperator, resultSchema, transforms, upstreamDataSchema, context.getRequestId(), context.getStageId(),
+        context.getServer());
+  }
 
   public TransformOperator(MultiStageOperator upstreamOperator, DataSchema resultSchema, List<RexExpression> transforms,
       DataSchema upstreamDataSchema, long requestId, int stageId, VirtualServerAddress serverAddress) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -26,7 +26,6 @@ import javax.annotation.Nullable;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
-import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
@@ -58,13 +57,8 @@ public class TransformOperator extends MultiStageOperator {
 
   public TransformOperator(MultiStageOperator upstreamOperator, DataSchema resultSchema, List<RexExpression> transforms,
       DataSchema upstreamDataSchema, OperatorExecutionContext context) {
-    this(upstreamOperator, resultSchema, transforms, upstreamDataSchema, context.getRequestId(), context.getStageId(),
+    super(context.getRequestId(), context.getStageId(),
         context.getServer());
-  }
-
-  public TransformOperator(MultiStageOperator upstreamOperator, DataSchema resultSchema, List<RexExpression> transforms,
-      DataSchema upstreamDataSchema, long requestId, int stageId, VirtualServerAddress serverAddress) {
-    super(requestId, stageId, serverAddress);
     Preconditions.checkState(!transforms.isEmpty(), "transform operand should not be empty.");
     Preconditions.checkState(resultSchema.size() == transforms.size(),
         "result schema size:" + resultSchema.size() + " doesn't match transform operand size:" + transforms.size());

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -30,7 +30,7 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.utils.FunctionInvokeUtils;
-import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -56,7 +56,7 @@ public class TransformOperator extends MultiStageOperator {
   private TransferableBlock _upstreamErrorBlock;
 
   public TransformOperator(MultiStageOperator upstreamOperator, DataSchema resultSchema, List<RexExpression> transforms,
-      DataSchema upstreamDataSchema, OperatorExecutionContext context) {
+      DataSchema upstreamDataSchema, OpChainExecutionContext context) {
     super(context);
     Preconditions.checkState(!transforms.isEmpty(), "transform operand should not be empty.");
     Preconditions.checkState(resultSchema.size() == transforms.size(),

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
@@ -41,6 +41,7 @@ import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.utils.AggregationUtils;
+import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -97,6 +98,16 @@ public class WindowAggregateOperator extends MultiStageOperator {
     this(inputOperator, groupSet, orderSet, orderSetDirection, orderSetNullDirection, aggCalls, lowerBound,
         upperBound, windowFrameType, constants, resultSchema, inputSchema, AggregationUtils.Accumulator.MERGERS,
         requestId, stageId, virtualServerAddress);
+  }
+
+  public WindowAggregateOperator(MultiStageOperator inputOperator, List<RexExpression> groupSet,
+      List<RexExpression> orderSet, List<RelFieldCollation.Direction> orderSetDirection,
+      List<RelFieldCollation.NullDirection> orderSetNullDirection, List<RexExpression> aggCalls, int lowerBound,
+      int upperBound, WindowNode.WindowFrameType windowFrameType, List<RexExpression> constants,
+      DataSchema resultSchema, DataSchema inputSchema, OperatorExecutionContext context) {
+    this(inputOperator, groupSet, orderSet, orderSetDirection, orderSetNullDirection, aggCalls, lowerBound,
+        upperBound, windowFrameType, constants, resultSchema, inputSchema, AggregationUtils.Accumulator.MERGERS,
+        context.getRequestId(), context.getStageId(), context.getServer());
   }
 
   @VisibleForTesting

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
@@ -93,17 +93,6 @@ public class WindowAggregateOperator extends MultiStageOperator {
       List<RexExpression> orderSet, List<RelFieldCollation.Direction> orderSetDirection,
       List<RelFieldCollation.NullDirection> orderSetNullDirection, List<RexExpression> aggCalls, int lowerBound,
       int upperBound, WindowNode.WindowFrameType windowFrameType, List<RexExpression> constants,
-      DataSchema resultSchema, DataSchema inputSchema, long requestId, int stageId,
-      VirtualServerAddress virtualServerAddress) {
-    this(inputOperator, groupSet, orderSet, orderSetDirection, orderSetNullDirection, aggCalls, lowerBound,
-        upperBound, windowFrameType, constants, resultSchema, inputSchema, AggregationUtils.Accumulator.MERGERS,
-        requestId, stageId, virtualServerAddress);
-  }
-
-  public WindowAggregateOperator(MultiStageOperator inputOperator, List<RexExpression> groupSet,
-      List<RexExpression> orderSet, List<RelFieldCollation.Direction> orderSetDirection,
-      List<RelFieldCollation.NullDirection> orderSetNullDirection, List<RexExpression> aggCalls, int lowerBound,
-      int upperBound, WindowNode.WindowFrameType windowFrameType, List<RexExpression> constants,
       DataSchema resultSchema, DataSchema inputSchema, OperatorExecutionContext context) {
     this(inputOperator, groupSet, orderSet, orderSetDirection, orderSetNullDirection, aggCalls, lowerBound,
         upperBound, windowFrameType, constants, resultSchema, inputSchema, AggregationUtils.Accumulator.MERGERS,

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
@@ -88,23 +88,22 @@ public class WindowAggregateOperator extends MultiStageOperator {
   private boolean _readyToConstruct;
   private boolean _hasReturnedWindowAggregateBlock;
 
-  public WindowAggregateOperator(MultiStageOperator inputOperator, List<RexExpression> groupSet,
-      List<RexExpression> orderSet, List<RelFieldCollation.Direction> orderSetDirection,
+  public WindowAggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator,
+      List<RexExpression> groupSet, List<RexExpression> orderSet, List<RelFieldCollation.Direction> orderSetDirection,
       List<RelFieldCollation.NullDirection> orderSetNullDirection, List<RexExpression> aggCalls, int lowerBound,
       int upperBound, WindowNode.WindowFrameType windowFrameType, List<RexExpression> constants,
-      DataSchema resultSchema, DataSchema inputSchema, OpChainExecutionContext context) {
-    this(inputOperator, groupSet, orderSet, orderSetDirection, orderSetNullDirection, aggCalls, lowerBound,
-        upperBound, windowFrameType, constants, resultSchema, inputSchema, AggregationUtils.Accumulator.MERGERS,
-        context);
+      DataSchema resultSchema, DataSchema inputSchema) {
+    this(context, inputOperator, groupSet, orderSet, orderSetDirection, orderSetNullDirection, aggCalls, lowerBound,
+        upperBound, windowFrameType, constants, resultSchema, inputSchema, AggregationUtils.Accumulator.MERGERS);
   }
 
   @VisibleForTesting
-  public WindowAggregateOperator(MultiStageOperator inputOperator, List<RexExpression> groupSet,
-      List<RexExpression> orderSet, List<RelFieldCollation.Direction> orderSetDirection,
+  public WindowAggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator,
+      List<RexExpression> groupSet, List<RexExpression> orderSet, List<RelFieldCollation.Direction> orderSetDirection,
       List<RelFieldCollation.NullDirection> orderSetNullDirection, List<RexExpression> aggCalls, int lowerBound,
       int upperBound, WindowNode.WindowFrameType windowFrameType, List<RexExpression> constants,
-      DataSchema resultSchema, DataSchema inputSchema, Map<String,
-      Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> mergers, OpChainExecutionContext context) {
+      DataSchema resultSchema, DataSchema inputSchema,
+      Map<String, Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> mergers) {
     super(context);
 
     boolean isPartitionByOnly = isPartitionByOnlyQuery(groupSet, orderSet, orderSetDirection, orderSetNullDirection);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
@@ -96,7 +96,7 @@ public class WindowAggregateOperator extends MultiStageOperator {
       DataSchema resultSchema, DataSchema inputSchema, OperatorExecutionContext context) {
     this(inputOperator, groupSet, orderSet, orderSetDirection, orderSetNullDirection, aggCalls, lowerBound,
         upperBound, windowFrameType, constants, resultSchema, inputSchema, AggregationUtils.Accumulator.MERGERS,
-        context.getRequestId(), context.getStageId(), context.getServer());
+        context);
   }
 
   @VisibleForTesting
@@ -105,9 +105,8 @@ public class WindowAggregateOperator extends MultiStageOperator {
       List<RelFieldCollation.NullDirection> orderSetNullDirection, List<RexExpression> aggCalls, int lowerBound,
       int upperBound, WindowNode.WindowFrameType windowFrameType, List<RexExpression> constants,
       DataSchema resultSchema, DataSchema inputSchema, Map<String,
-      Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> mergers, long requestId, int stageId,
-      VirtualServerAddress virtualServerAddress) {
-    super(requestId, stageId, virtualServerAddress);
+      Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> mergers, OperatorExecutionContext context) {
+    super(context);
 
     boolean isPartitionByOnly = isPartitionByOnlyQuery(groupSet, orderSet, orderSetDirection, orderSetNullDirection);
     Preconditions.checkState(orderSet == null || orderSet.isEmpty() || isPartitionByOnly,

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
@@ -37,11 +37,10 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.stage.WindowNode;
-import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.utils.AggregationUtils;
-import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -93,7 +92,7 @@ public class WindowAggregateOperator extends MultiStageOperator {
       List<RexExpression> orderSet, List<RelFieldCollation.Direction> orderSetDirection,
       List<RelFieldCollation.NullDirection> orderSetNullDirection, List<RexExpression> aggCalls, int lowerBound,
       int upperBound, WindowNode.WindowFrameType windowFrameType, List<RexExpression> constants,
-      DataSchema resultSchema, DataSchema inputSchema, OperatorExecutionContext context) {
+      DataSchema resultSchema, DataSchema inputSchema, OpChainExecutionContext context) {
     this(inputOperator, groupSet, orderSet, orderSetDirection, orderSetNullDirection, aggCalls, lowerBound,
         upperBound, windowFrameType, constants, resultSchema, inputSchema, AggregationUtils.Accumulator.MERGERS,
         context);
@@ -105,7 +104,7 @@ public class WindowAggregateOperator extends MultiStageOperator {
       List<RelFieldCollation.NullDirection> orderSetNullDirection, List<RexExpression> aggCalls, int lowerBound,
       int upperBound, WindowNode.WindowFrameType windowFrameType, List<RexExpression> constants,
       DataSchema resultSchema, DataSchema inputSchema, Map<String,
-      Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> mergers, OperatorExecutionContext context) {
+      Function<DataSchema.ColumnDataType, AggregationUtils.Merger>> mergers, OpChainExecutionContext context) {
     super(context);
 
     boolean isPartitionByOnly = isPartitionByOnlyQuery(groupSet, orderSet, orderSetDirection, orderSetNullDirection);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
@@ -25,17 +25,21 @@ import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 
 
-public class OperatorExecutionContext {
+/**
+ *  The {@code OpChainExecutionContext} class contains the information derived from the PlanRequestContext.
+ *  Members of this class should not be changed once initialized.
+ *  This information is then used by the OpChain to create the Operators for a query.
+ */
+public class OpChainExecutionContext {
   private final MailboxService<TransferableBlock> _mailboxService;
   private final long _requestId;
   private final int _stageId;
-
   private final VirtualServerAddress _server;
   private final long _timeoutMs;
   private final long _deadlineMs;
-  protected final Map<Integer, StageMetadata> _metadataMap;
+  private final Map<Integer, StageMetadata> _metadataMap;
 
-  public OperatorExecutionContext(MailboxService<TransferableBlock> mailboxService, long requestId, int stageId,
+  public OpChainExecutionContext(MailboxService<TransferableBlock> mailboxService, long requestId, int stageId,
       VirtualServerAddress server, long timeoutMs, long deadlineMs, Map<Integer, StageMetadata> metadataMap) {
     _mailboxService = mailboxService;
     _requestId = requestId;
@@ -46,7 +50,7 @@ public class OperatorExecutionContext {
     _metadataMap = metadataMap;
   }
 
-  public OperatorExecutionContext(PlanRequestContext planRequestContext) {
+  public OpChainExecutionContext(PlanRequestContext planRequestContext) {
     this(planRequestContext.getMailboxService(), planRequestContext.getRequestId(), planRequestContext.getStageId(),
         planRequestContext.getServer(), planRequestContext.getTimeoutMs(), planRequestContext.getDeadlineMs(),
         planRequestContext.getMetadataMap());

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OperatorExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OperatorExecutionContext.java
@@ -18,38 +18,42 @@
  */
 package org.apache.pinot.query.runtime.plan;
 
-import com.google.common.collect.ImmutableList;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.Map;
-import org.apache.pinot.query.mailbox.MailboxIdentifier;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.planner.StageMetadata;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 
 
-public class PlanRequestContext {
-  protected final MailboxService<TransferableBlock> _mailboxService;
-  protected final long _requestId;
-  protected final int _stageId;
-  // TODO: Timeout is not needed since deadline is already present.
+public class OperatorExecutionContext {
+  private final MailboxService<TransferableBlock> _mailboxService;
+  private final long _requestId;
+  private final int _stageId;
+
+  private final VirtualServerAddress _server;
   private final long _timeoutMs;
   private final long _deadlineMs;
-  protected final VirtualServerAddress _server;
   protected final Map<Integer, StageMetadata> _metadataMap;
-  protected final List<MailboxIdentifier> _receivingMailboxes = new ArrayList<>();
 
-
-  public PlanRequestContext(MailboxService<TransferableBlock> mailboxService, long requestId, int stageId,
-      long timeoutMs, long deadlineMs, VirtualServerAddress server, Map<Integer, StageMetadata> metadataMap) {
+  public OperatorExecutionContext(MailboxService<TransferableBlock> mailboxService, long requestId, int stageId,
+      VirtualServerAddress server, long timeoutMs, long deadlineMs, Map<Integer, StageMetadata> metadataMap) {
     _mailboxService = mailboxService;
     _requestId = requestId;
     _stageId = stageId;
+    _server = server;
     _timeoutMs = timeoutMs;
     _deadlineMs = deadlineMs;
-    _server = server;
     _metadataMap = metadataMap;
+  }
+
+  public OperatorExecutionContext(PlanRequestContext planRequestContext) {
+    this(planRequestContext.getMailboxService(), planRequestContext.getRequestId(), planRequestContext.getStageId(),
+        planRequestContext.getServer(), planRequestContext.getTimeoutMs(), planRequestContext.getDeadlineMs(),
+        planRequestContext.getMetadataMap());
+  }
+
+  public MailboxService<TransferableBlock> getMailboxService() {
+    return _mailboxService;
   }
 
   public long getRequestId() {
@@ -60,6 +64,10 @@ public class PlanRequestContext {
     return _stageId;
   }
 
+  public VirtualServerAddress getServer() {
+    return _server;
+  }
+
   public long getTimeoutMs() {
     return _timeoutMs;
   }
@@ -68,27 +76,7 @@ public class PlanRequestContext {
     return _deadlineMs;
   }
 
-  public VirtualServerAddress getServer() {
-    return _server;
-  }
-
   public Map<Integer, StageMetadata> getMetadataMap() {
     return _metadataMap;
-  }
-
-  public MailboxService<TransferableBlock> getMailboxService() {
-    return _mailboxService;
-  }
-
-  public void addReceivingMailboxes(List<MailboxIdentifier> ids) {
-    _receivingMailboxes.addAll(ids);
-  }
-
-  public List<MailboxIdentifier> getReceivingMailboxes() {
-    return ImmutableList.copyOf(_receivingMailboxes);
-  }
-
-  public OperatorExecutionContext getOperatorExecutionContext() {
-    return new OperatorExecutionContext(this);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -57,14 +57,14 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<MultiStageOperator,
   public static OpChain build(StageNode node, PlanRequestContext context) {
     MultiStageOperator root = node.visit(INSTANCE, context);
     return new OpChain(root, context.getReceivingMailboxes(), context._server.virtualId(),
-        context.getOperatorExecutionContext());
+        context.getOpChainExecutionContext());
   }
 
   @Override
   public MultiStageOperator visitMailboxReceive(MailboxReceiveNode node, PlanRequestContext context) {
     MailboxReceiveOperator mailboxReceiveOperator =
         new MailboxReceiveOperator(node.getExchangeType(), node.getSenderStageId(), node.getStageId(),
-            context.getOperatorExecutionContext());
+            context.getOpChainExecutionContext());
     context.addReceivingMailboxes(mailboxReceiveOperator.getSendingMailbox());
     return mailboxReceiveOperator;
   }
@@ -73,14 +73,14 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<MultiStageOperator,
   public MultiStageOperator visitMailboxSend(MailboxSendNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
     return new MailboxSendOperator(nextOperator, node.getExchangeType(), node.getPartitionKeySelector(),
-        node.getStageId(), node.getReceiverStageId(), context.getOperatorExecutionContext());
+        node.getStageId(), node.getReceiverStageId(), context.getOpChainExecutionContext());
   }
 
   @Override
   public MultiStageOperator visitAggregate(AggregateNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
     return new AggregateOperator(nextOperator, node.getDataSchema(), node.getAggCalls(), node.getGroupSet(),
-        node.getInputs().get(0).getDataSchema(), context.getOperatorExecutionContext());
+        node.getInputs().get(0).getDataSchema(), context.getOpChainExecutionContext());
   }
 
   @Override
@@ -89,14 +89,14 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<MultiStageOperator,
     return new WindowAggregateOperator(nextOperator, node.getGroupSet(), node.getOrderSet(),
         node.getOrderSetDirection(), node.getOrderSetNullDirection(), node.getAggCalls(), node.getLowerBound(),
         node.getUpperBound(), node.getWindowFrameType(), node.getConstants(), node.getDataSchema(),
-        node.getInputs().get(0).getDataSchema(), context.getOperatorExecutionContext());
+        node.getInputs().get(0).getDataSchema(), context.getOpChainExecutionContext());
   }
 
   @Override
   public MultiStageOperator visitFilter(FilterNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
     return new FilterOperator(nextOperator, node.getDataSchema(), node.getCondition(),
-        context.getOperatorExecutionContext());
+        context.getOpChainExecutionContext());
   }
 
   @Override
@@ -108,21 +108,21 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<MultiStageOperator,
     MultiStageOperator rightOperator = right.visit(this, context);
 
     return new HashJoinOperator(leftOperator, rightOperator, left.getDataSchema(), node,
-        context.getOperatorExecutionContext());
+        context.getOpChainExecutionContext());
   }
 
   @Override
   public MultiStageOperator visitProject(ProjectNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
     return new TransformOperator(nextOperator, node.getDataSchema(), node.getProjects(),
-        node.getInputs().get(0).getDataSchema(), context.getOperatorExecutionContext());
+        node.getInputs().get(0).getDataSchema(), context.getOpChainExecutionContext());
   }
 
   @Override
   public MultiStageOperator visitSort(SortNode node, PlanRequestContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
     return new SortOperator(nextOperator, node.getCollationKeys(), node.getCollationDirections(), node.getFetch(),
-        node.getOffset(), node.getDataSchema(), context.getOperatorExecutionContext());
+        node.getOffset(), node.getDataSchema(), context.getOpChainExecutionContext());
   }
 
   @Override
@@ -132,6 +132,6 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<MultiStageOperator,
 
   @Override
   public MultiStageOperator visitValue(ValueNode node, PlanRequestContext context) {
-    return new LiteralValueOperator(node.getDataSchema(), node.getLiteralRows(), context.getOperatorExecutionContext());
+    return new LiteralValueOperator(node.getDataSchema(), node.getLiteralRows(), context.getOpChainExecutionContext());
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanRequestContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanRequestContext.java
@@ -39,7 +39,7 @@ public class PlanRequestContext {
   protected final VirtualServerAddress _server;
   protected final Map<Integer, StageMetadata> _metadataMap;
   protected final List<MailboxIdentifier> _receivingMailboxes = new ArrayList<>();
-
+  private final OpChainExecutionContext _opChainExecutionContext;
 
   public PlanRequestContext(MailboxService<TransferableBlock> mailboxService, long requestId, int stageId,
       long timeoutMs, long deadlineMs, VirtualServerAddress server, Map<Integer, StageMetadata> metadataMap) {
@@ -50,6 +50,7 @@ public class PlanRequestContext {
     _deadlineMs = deadlineMs;
     _server = server;
     _metadataMap = metadataMap;
+    _opChainExecutionContext = new OpChainExecutionContext(this);
   }
 
   public long getRequestId() {
@@ -88,7 +89,7 @@ public class PlanRequestContext {
     return ImmutableList.copyOf(_receivingMailboxes);
   }
 
-  public OperatorExecutionContext getOperatorExecutionContext() {
-    return new OperatorExecutionContext(this);
+  public OpChainExecutionContext getOpChainExecutionContext() {
+    return _opChainExecutionContext;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -278,7 +278,8 @@ public class QueryDispatcher {
   private static MailboxReceiveOperator createReduceStageOperator(MailboxService<TransferableBlock> mailboxService,
       Map<Integer, StageMetadata> stageMetadataMap, long jobId, int stageId, int reducerStageId, DataSchema dataSchema,
       VirtualServerAddress server, long timeoutMs) {
-    OpChainExecutionContext context = new OpChainExecutionContext(mailboxService, jobId, stageId, server, timeoutMs, timeoutMs, stageMetadataMap);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(mailboxService, jobId, stageId, server, timeoutMs, timeoutMs, stageMetadataMap);
     // timeout is set for reduce stage
     MailboxReceiveOperator mailboxReceiveOperator =
         new MailboxReceiveOperator(RelDistribution.Type.RANDOM_DISTRIBUTED, stageId, reducerStageId, context);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -282,7 +282,7 @@ public class QueryDispatcher {
         new OpChainExecutionContext(mailboxService, jobId, stageId, server, timeoutMs, timeoutMs, stageMetadataMap);
     // timeout is set for reduce stage
     MailboxReceiveOperator mailboxReceiveOperator =
-        new MailboxReceiveOperator(RelDistribution.Type.RANDOM_DISTRIBUTED, stageId, reducerStageId, context);
+        new MailboxReceiveOperator(context, RelDistribution.Type.RANDOM_DISTRIBUTED, stageId, reducerStageId);
     return mailboxReceiveOperator;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -57,6 +57,7 @@ import org.apache.pinot.query.runtime.operator.MailboxReceiveOperator;
 import org.apache.pinot.query.runtime.operator.OperatorStats;
 import org.apache.pinot.query.runtime.operator.utils.OperatorUtils;
 import org.apache.pinot.query.runtime.plan.DistributedStagePlan;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.query.runtime.plan.serde.QueryPlanSerDeUtils;
 import org.apache.pinot.query.service.QueryConfig;
 import org.roaringbitmap.RoaringBitmap;
@@ -173,10 +174,10 @@ public class QueryDispatcher {
   public static ResultTable runReducer(long requestId, QueryPlan queryPlan, int reduceStageId, long timeoutMs,
       MailboxService<TransferableBlock> mailboxService, Map<Integer, ExecutionStatsAggregator> statsAggregatorMap) {
     MailboxReceiveNode reduceNode = (MailboxReceiveNode) queryPlan.getQueryStageMap().get(reduceStageId);
-    MailboxReceiveOperator mailboxReceiveOperator = createReduceStageOperator(mailboxService,
-        queryPlan.getStageMetadataMap().get(reduceNode.getSenderStageId()).getServerInstances(), requestId,
-        reduceNode.getSenderStageId(), reduceStageId, reduceNode.getDataSchema(),
-        new VirtualServerAddress(mailboxService.getHostname(), mailboxService.getMailboxPort(), 0), timeoutMs);
+    MailboxReceiveOperator mailboxReceiveOperator =
+        createReduceStageOperator(mailboxService, queryPlan.getStageMetadataMap(), requestId,
+            reduceNode.getSenderStageId(), reduceStageId, reduceNode.getDataSchema(),
+            new VirtualServerAddress(mailboxService.getHostname(), mailboxService.getMailboxPort(), 0), timeoutMs);
     List<DataBlock> resultDataBlocks =
         reduceMailboxReceive(mailboxReceiveOperator, timeoutMs, statsAggregatorMap, queryPlan);
     return toResultTable(resultDataBlocks, queryPlan.getQueryResultFields(),
@@ -275,12 +276,12 @@ public class QueryDispatcher {
   }
 
   private static MailboxReceiveOperator createReduceStageOperator(MailboxService<TransferableBlock> mailboxService,
-      List<VirtualServer> sendingInstances, long jobId, int stageId, int reducerStageId, DataSchema dataSchema,
+      Map<Integer, StageMetadata> stageMetadataMap, long jobId, int stageId, int reducerStageId, DataSchema dataSchema,
       VirtualServerAddress server, long timeoutMs) {
+    OpChainExecutionContext context = new OpChainExecutionContext(mailboxService, jobId, stageId, server, timeoutMs, timeoutMs, stageMetadataMap);
     // timeout is set for reduce stage
     MailboxReceiveOperator mailboxReceiveOperator =
-        new MailboxReceiveOperator(mailboxService, sendingInstances,
-            RelDistribution.Type.RANDOM_DISTRIBUTED, server, jobId, stageId, reducerStageId, timeoutMs);
+        new MailboxReceiveOperator(RelDistribution.Type.RANDOM_DISTRIBUTED, stageId, reducerStageId, context);
     return mailboxReceiveOperator;
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
@@ -77,7 +77,8 @@ public class AggregateOperatorTest {
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, 1, 2, _serverAddress);
+    AggregateOperator operator =
+        new AggregateOperator(_input, outSchema, calls, group, inSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block1 = operator.nextBlock(); // build
@@ -97,7 +98,8 @@ public class AggregateOperatorTest {
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, 1, 2, _serverAddress);
+    AggregateOperator operator =
+        new AggregateOperator(_input, outSchema, calls, group, inSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block = operator.nextBlock();
@@ -119,7 +121,8 @@ public class AggregateOperatorTest {
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, 1, 2, _serverAddress);
+    AggregateOperator operator =
+        new AggregateOperator(_input, outSchema, calls, group, inSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block1 = operator.nextBlock(); // build when reading NoOp block
@@ -142,7 +145,8 @@ public class AggregateOperatorTest {
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, 1, 2, _serverAddress);
+    AggregateOperator operator =
+        new AggregateOperator(_input, outSchema, calls, group, inSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -167,7 +171,8 @@ public class AggregateOperatorTest {
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, 1, 2, _serverAddress);
+    AggregateOperator operator =
+        new AggregateOperator(_input, outSchema, calls, group, inSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -222,7 +227,8 @@ public class AggregateOperatorTest {
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
     AggregateOperator sum0GroupBy1 =
         new AggregateOperator(upstreamOperator, OperatorTestUtil.getDataSchema(OperatorTestUtil.OP_1),
-            Arrays.asList(agg), Arrays.asList(new RexExpression.InputRef(1)), inSchema, 1, 2, _serverAddress);
+            Arrays.asList(agg), Arrays.asList(new RexExpression.InputRef(1)), inSchema,
+            OperatorTestUtil.getDefaultContext());
     TransferableBlock result = sum0GroupBy1.getNextBlock();
     while (result.isNoOpBlock()) {
       result = sum0GroupBy1.getNextBlock();
@@ -245,7 +251,8 @@ public class AggregateOperatorTest {
     DataSchema inSchema = new DataSchema(new String[]{"unknown"}, new ColumnDataType[]{DOUBLE});
 
     // When:
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, 1, 2, _serverAddress);
+    AggregateOperator operator =
+        new AggregateOperator(_input, outSchema, calls, group, inSchema, OperatorTestUtil.getDefaultContext());
   }
 
   @Test
@@ -262,7 +269,8 @@ public class AggregateOperatorTest {
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
-    AggregateOperator operator = new AggregateOperator(_input, outSchema, calls, group, inSchema, 1, 2, _serverAddress);
+    AggregateOperator operator =
+        new AggregateOperator(_input, outSchema, calls, group, inSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block = operator.nextBlock();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
@@ -204,8 +204,8 @@ public class AggregateOperatorTest {
     Mockito.when(merger.initialize(Mockito.any(), Mockito.any())).thenReturn(1d);
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
     AggregateOperator operator =
-        new AggregateOperator(_input, outSchema, calls, group, inSchema, ImmutableMap.of("SUM", cdt -> merger), 1, 2,
-            _serverAddress);
+        new AggregateOperator(_input, outSchema, calls, group, inSchema, ImmutableMap.of("SUM", cdt -> merger),
+            OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock(); // (output result)

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
@@ -78,7 +78,7 @@ public class AggregateOperatorTest {
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
     AggregateOperator operator =
-        new AggregateOperator(_input, outSchema, calls, group, inSchema, OperatorTestUtil.getDefaultContext());
+        new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, calls, group, inSchema);
 
     // When:
     TransferableBlock block1 = operator.nextBlock(); // build
@@ -99,7 +99,7 @@ public class AggregateOperatorTest {
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
     AggregateOperator operator =
-        new AggregateOperator(_input, outSchema, calls, group, inSchema, OperatorTestUtil.getDefaultContext());
+        new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, calls, group, inSchema);
 
     // When:
     TransferableBlock block = operator.nextBlock();
@@ -122,7 +122,7 @@ public class AggregateOperatorTest {
 
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
     AggregateOperator operator =
-        new AggregateOperator(_input, outSchema, calls, group, inSchema, OperatorTestUtil.getDefaultContext());
+        new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, calls, group, inSchema);
 
     // When:
     TransferableBlock block1 = operator.nextBlock(); // build when reading NoOp block
@@ -146,7 +146,7 @@ public class AggregateOperatorTest {
 
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
     AggregateOperator operator =
-        new AggregateOperator(_input, outSchema, calls, group, inSchema, OperatorTestUtil.getDefaultContext());
+        new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, calls, group, inSchema);
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -172,7 +172,7 @@ public class AggregateOperatorTest {
 
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
     AggregateOperator operator =
-        new AggregateOperator(_input, outSchema, calls, group, inSchema, OperatorTestUtil.getDefaultContext());
+        new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, calls, group, inSchema);
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -204,8 +204,8 @@ public class AggregateOperatorTest {
     Mockito.when(merger.initialize(Mockito.any(), Mockito.any())).thenReturn(1d);
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
     AggregateOperator operator =
-        new AggregateOperator(_input, outSchema, calls, group, inSchema, ImmutableMap.of("SUM", cdt -> merger),
-            OperatorTestUtil.getDefaultContext());
+        new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, calls, group, inSchema,
+            ImmutableMap.of("SUM", cdt -> merger));
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock(); // (output result)
@@ -225,10 +225,9 @@ public class AggregateOperatorTest {
     // Create an aggregation call with sum for first column and group by second column.
     RexExpression.FunctionCall agg = getSum(new RexExpression.InputRef(0));
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
-    AggregateOperator sum0GroupBy1 =
-        new AggregateOperator(upstreamOperator, OperatorTestUtil.getDataSchema(OperatorTestUtil.OP_1),
-            Arrays.asList(agg), Arrays.asList(new RexExpression.InputRef(1)), inSchema,
-            OperatorTestUtil.getDefaultContext());
+    AggregateOperator sum0GroupBy1 = new AggregateOperator(OperatorTestUtil.getDefaultContext(), upstreamOperator,
+        OperatorTestUtil.getDataSchema(OperatorTestUtil.OP_1), Arrays.asList(agg),
+        Arrays.asList(new RexExpression.InputRef(1)), inSchema);
     TransferableBlock result = sum0GroupBy1.getNextBlock();
     while (result.isNoOpBlock()) {
       result = sum0GroupBy1.getNextBlock();
@@ -252,7 +251,7 @@ public class AggregateOperatorTest {
 
     // When:
     AggregateOperator operator =
-        new AggregateOperator(_input, outSchema, calls, group, inSchema, OperatorTestUtil.getDefaultContext());
+        new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, calls, group, inSchema);
   }
 
   @Test
@@ -270,7 +269,7 @@ public class AggregateOperatorTest {
 
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
     AggregateOperator operator =
-        new AggregateOperator(_input, outSchema, calls, group, inSchema, OperatorTestUtil.getDefaultContext());
+        new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, calls, group, inSchema);
 
     // When:
     TransferableBlock block = operator.nextBlock();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/FilterOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/FilterOperatorTest.java
@@ -25,7 +25,6 @@ import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
-import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -43,13 +42,9 @@ public class FilterOperatorTest {
   @Mock
   private MultiStageOperator _upstreamOperator;
 
-  @Mock
-  private VirtualServerAddress _serverAddress;
-
   @BeforeMethod
   public void setUp() {
     _mocks = MockitoAnnotations.openMocks(this);
-    Mockito.when(_serverAddress.toString()).thenReturn(new VirtualServerAddress("mock", 80, 0).toString());
   }
 
   @AfterMethod
@@ -66,7 +61,8 @@ public class FilterOperatorTest {
     DataSchema inputSchema = new DataSchema(new String[]{"boolCol"}, new DataSchema.ColumnDataType[]{
         DataSchema.ColumnDataType.BOOLEAN
     });
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, 1, 2, _serverAddress);
+    FilterOperator op =
+        new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, OperatorTestUtil.getDefaultContext());
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
     DataBlock error = errorBlock.getDataBlock();
@@ -81,7 +77,8 @@ public class FilterOperatorTest {
         DataSchema.ColumnDataType.INT
     });
     Mockito.when(_upstreamOperator.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, 1, 2, _serverAddress);
+    FilterOperator op =
+        new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, OperatorTestUtil.getDefaultContext());
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertTrue(dataBlock.isEndOfStreamBlock());
   }
@@ -94,7 +91,8 @@ public class FilterOperatorTest {
         DataSchema.ColumnDataType.INT
     });
     Mockito.when(_upstreamOperator.nextBlock()).thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, 1, 2, _serverAddress);
+    FilterOperator op =
+        new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, OperatorTestUtil.getDefaultContext());
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertTrue(dataBlock.isNoOpBlock());
   }
@@ -109,7 +107,8 @@ public class FilterOperatorTest {
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{0}, new Object[]{1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, 1, 2, _serverAddress);
+    FilterOperator op =
+        new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, OperatorTestUtil.getDefaultContext());
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -127,7 +126,8 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, 1, 2, _serverAddress);
+    FilterOperator op =
+        new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, OperatorTestUtil.getDefaultContext());
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -142,7 +142,8 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, 1, 2, _serverAddress);
+    FilterOperator op =
+        new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, OperatorTestUtil.getDefaultContext());
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
     DataBlock data = errorBlock.getDataBlock();
@@ -157,7 +158,7 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, ref0, 1, 2, _serverAddress);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, ref0, OperatorTestUtil.getDefaultContext());
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
     DataBlock data = errorBlock.getDataBlock();
@@ -172,7 +173,7 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1, true}, new Object[]{2, false}));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, ref1, 1, 2, _serverAddress);
+    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, ref1, OperatorTestUtil.getDefaultContext());
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -192,7 +193,8 @@ public class FilterOperatorTest {
     RexExpression.FunctionCall andCall = new RexExpression.FunctionCall(SqlKind.AND, FieldSpec.DataType.BOOLEAN, "AND",
         ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
 
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, andCall, 1, 2, _serverAddress);
+    FilterOperator op =
+        new FilterOperator(_upstreamOperator, inputSchema, andCall, OperatorTestUtil.getDefaultContext());
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -212,7 +214,8 @@ public class FilterOperatorTest {
     RexExpression.FunctionCall orCall = new RexExpression.FunctionCall(SqlKind.OR, FieldSpec.DataType.BOOLEAN, "OR",
         ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
 
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, orCall, 1, 2, _serverAddress);
+    FilterOperator op =
+        new FilterOperator(_upstreamOperator, inputSchema, orCall, OperatorTestUtil.getDefaultContext());
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -234,7 +237,8 @@ public class FilterOperatorTest {
     RexExpression.FunctionCall notCall = new RexExpression.FunctionCall(SqlKind.NOT, FieldSpec.DataType.BOOLEAN, "NOT",
         ImmutableList.of(new RexExpression.InputRef(0)));
 
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, notCall, 1, 2, _serverAddress);
+    FilterOperator op =
+        new FilterOperator(_upstreamOperator, inputSchema, notCall, OperatorTestUtil.getDefaultContext());
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -253,7 +257,8 @@ public class FilterOperatorTest {
     RexExpression.FunctionCall greaterThan =
         new RexExpression.FunctionCall(SqlKind.GREATER_THAN, FieldSpec.DataType.BOOLEAN, "greaterThan",
             ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, greaterThan, 1, 2, _serverAddress);
+    FilterOperator op =
+        new FilterOperator(_upstreamOperator, inputSchema, greaterThan, OperatorTestUtil.getDefaultContext());
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -273,7 +278,8 @@ public class FilterOperatorTest {
         new RexExpression.FunctionCall(SqlKind.OTHER, FieldSpec.DataType.BOOLEAN, "startsWith",
             ImmutableList.of(new RexExpression.InputRef(0),
                 new RexExpression.Literal(FieldSpec.DataType.STRING, "star")));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, startsWith, 1, 2, _serverAddress);
+    FilterOperator op =
+        new FilterOperator(_upstreamOperator, inputSchema, startsWith, OperatorTestUtil.getDefaultContext());
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -294,6 +300,7 @@ public class FilterOperatorTest {
         new RexExpression.FunctionCall(SqlKind.OTHER, FieldSpec.DataType.BOOLEAN, "startsWithError",
             ImmutableList.of(new RexExpression.InputRef(0),
                 new RexExpression.Literal(FieldSpec.DataType.STRING, "star")));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, startsWith, 1, 2, _serverAddress);
+    FilterOperator op =
+        new FilterOperator(_upstreamOperator, inputSchema, startsWith, OperatorTestUtil.getDefaultContext());
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/FilterOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/FilterOperatorTest.java
@@ -62,7 +62,7 @@ public class FilterOperatorTest {
         DataSchema.ColumnDataType.BOOLEAN
     });
     FilterOperator op =
-        new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, OperatorTestUtil.getDefaultContext());
+        new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, booleanLiteral);
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
     DataBlock error = errorBlock.getDataBlock();
@@ -78,7 +78,7 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
     FilterOperator op =
-        new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, OperatorTestUtil.getDefaultContext());
+        new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, booleanLiteral);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertTrue(dataBlock.isEndOfStreamBlock());
   }
@@ -92,7 +92,7 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock()).thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
     FilterOperator op =
-        new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, OperatorTestUtil.getDefaultContext());
+        new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, booleanLiteral);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertTrue(dataBlock.isNoOpBlock());
   }
@@ -108,7 +108,7 @@ public class FilterOperatorTest {
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{0}, new Object[]{1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
     FilterOperator op =
-        new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, OperatorTestUtil.getDefaultContext());
+        new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, booleanLiteral);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -127,7 +127,7 @@ public class FilterOperatorTest {
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
     FilterOperator op =
-        new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, OperatorTestUtil.getDefaultContext());
+        new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, booleanLiteral);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -143,7 +143,7 @@ public class FilterOperatorTest {
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
     FilterOperator op =
-        new FilterOperator(_upstreamOperator, inputSchema, booleanLiteral, OperatorTestUtil.getDefaultContext());
+        new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, booleanLiteral);
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
     DataBlock data = errorBlock.getDataBlock();
@@ -158,7 +158,7 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, ref0, OperatorTestUtil.getDefaultContext());
+    FilterOperator op = new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, ref0);
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
     DataBlock data = errorBlock.getDataBlock();
@@ -173,7 +173,7 @@ public class FilterOperatorTest {
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1, true}, new Object[]{2, false}));
-    FilterOperator op = new FilterOperator(_upstreamOperator, inputSchema, ref1, OperatorTestUtil.getDefaultContext());
+    FilterOperator op = new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, ref1);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -194,7 +194,7 @@ public class FilterOperatorTest {
         ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
 
     FilterOperator op =
-        new FilterOperator(_upstreamOperator, inputSchema, andCall, OperatorTestUtil.getDefaultContext());
+        new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, andCall);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -215,7 +215,7 @@ public class FilterOperatorTest {
         ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
 
     FilterOperator op =
-        new FilterOperator(_upstreamOperator, inputSchema, orCall, OperatorTestUtil.getDefaultContext());
+        new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, orCall);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -238,7 +238,7 @@ public class FilterOperatorTest {
         ImmutableList.of(new RexExpression.InputRef(0)));
 
     FilterOperator op =
-        new FilterOperator(_upstreamOperator, inputSchema, notCall, OperatorTestUtil.getDefaultContext());
+        new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, notCall);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -258,7 +258,7 @@ public class FilterOperatorTest {
         new RexExpression.FunctionCall(SqlKind.GREATER_THAN, FieldSpec.DataType.BOOLEAN, "greaterThan",
             ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
     FilterOperator op =
-        new FilterOperator(_upstreamOperator, inputSchema, greaterThan, OperatorTestUtil.getDefaultContext());
+        new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, greaterThan);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -279,7 +279,7 @@ public class FilterOperatorTest {
             ImmutableList.of(new RexExpression.InputRef(0),
                 new RexExpression.Literal(FieldSpec.DataType.STRING, "star")));
     FilterOperator op =
-        new FilterOperator(_upstreamOperator, inputSchema, startsWith, OperatorTestUtil.getDefaultContext());
+        new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, startsWith);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
@@ -301,6 +301,6 @@ public class FilterOperatorTest {
             ImmutableList.of(new RexExpression.InputRef(0),
                 new RexExpression.Literal(FieldSpec.DataType.STRING, "star")));
     FilterOperator op =
-        new FilterOperator(_upstreamOperator, inputSchema, startsWith, OperatorTestUtil.getDefaultContext());
+        new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, startsWith);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -96,7 +96,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
     HashJoinOperator joinOnString =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
 
     TransferableBlock result = joinOnString.nextBlock();
     while (result.isNoOpBlock()) {
@@ -134,7 +134,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
     HashJoinOperator joinOnInt =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
     TransferableBlock result = joinOnInt.nextBlock();
     while (result.isNoOpBlock()) {
       result = joinOnInt.nextBlock();
@@ -169,7 +169,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses);
     HashJoinOperator joinOnInt =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
     TransferableBlock result = joinOnInt.nextBlock();
     while (result.isNoOpBlock()) {
       result = joinOnInt.nextBlock();
@@ -210,7 +210,8 @@ public class HashJoinOperatorTest {
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.LEFT,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+    HashJoinOperator join =
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -244,7 +245,8 @@ public class HashJoinOperatorTest {
     List<RexExpression> joinClauses = new ArrayList<>();
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+    HashJoinOperator join =
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -275,7 +277,8 @@ public class HashJoinOperatorTest {
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.LEFT,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+    HashJoinOperator join =
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -310,7 +313,8 @@ public class HashJoinOperatorTest {
 
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+    HashJoinOperator join =
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -348,7 +352,8 @@ public class HashJoinOperatorTest {
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+    HashJoinOperator join =
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -386,7 +391,8 @@ public class HashJoinOperatorTest {
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+    HashJoinOperator join =
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -421,7 +427,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.RIGHT,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
     HashJoinOperator joinOnNum =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
     TransferableBlock result = joinOnNum.nextBlock();
     while (result.isNoOpBlock()) {
       result = joinOnNum.nextBlock();
@@ -470,7 +476,8 @@ public class HashJoinOperatorTest {
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.SEMI,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+    HashJoinOperator join =
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -509,7 +516,8 @@ public class HashJoinOperatorTest {
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.FULL,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+    HashJoinOperator join =
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -561,7 +569,8 @@ public class HashJoinOperatorTest {
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.ANTI,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+    HashJoinOperator join =
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -599,7 +608,8 @@ public class HashJoinOperatorTest {
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+    HashJoinOperator join =
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -632,7 +642,8 @@ public class HashJoinOperatorTest {
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+    HashJoinOperator join =
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -668,7 +679,8 @@ public class HashJoinOperatorTest {
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
-    HashJoinOperator join = new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, 1, 2, _serverAddress);
+    HashJoinOperator join =
+        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
 
     TransferableBlock result = join.nextBlock(); // first no-op consumes first right data block.
     Assert.assertTrue(result.isNoOpBlock());

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -96,7 +96,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
     HashJoinOperator joinOnString =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
     TransferableBlock result = joinOnString.nextBlock();
     while (result.isNoOpBlock()) {
@@ -134,7 +134,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
     HashJoinOperator joinOnInt =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = joinOnInt.nextBlock();
     while (result.isNoOpBlock()) {
       result = joinOnInt.nextBlock();
@@ -169,7 +169,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses);
     HashJoinOperator joinOnInt =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = joinOnInt.nextBlock();
     while (result.isNoOpBlock()) {
       result = joinOnInt.nextBlock();
@@ -211,7 +211,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.LEFT,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
     HashJoinOperator join =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -246,7 +246,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
     HashJoinOperator join =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -278,7 +278,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.LEFT,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
     HashJoinOperator join =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -314,7 +314,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
     HashJoinOperator join =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -353,7 +353,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses);
     HashJoinOperator join =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -392,7 +392,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses);
     HashJoinOperator join =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -427,7 +427,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.RIGHT,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
     HashJoinOperator joinOnNum =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = joinOnNum.nextBlock();
     while (result.isNoOpBlock()) {
       result = joinOnNum.nextBlock();
@@ -477,7 +477,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.SEMI,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
     HashJoinOperator join =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -517,7 +517,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.FULL,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
     HashJoinOperator join =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -570,7 +570,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.ANTI,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
     HashJoinOperator join =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
       result = join.nextBlock();
@@ -609,7 +609,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
     HashJoinOperator join =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -643,7 +643,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
     HashJoinOperator join =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
     TransferableBlock result = join.nextBlock();
     while (result.isNoOpBlock()) {
@@ -680,7 +680,7 @@ public class HashJoinOperatorTest {
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
     HashJoinOperator join =
-        new HashJoinOperator(_leftOperator, _rightOperator, leftSchema, node, OperatorTestUtil.getDefaultContext());
+        new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
     TransferableBlock result = join.nextBlock(); // first no-op consumes first right data block.
     Assert.assertTrue(result.isNoOpBlock());

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperatorTest.java
@@ -75,7 +75,7 @@ public class LeafStageTransferableBlockOperatorTest {
     List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
         new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2})), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2, _serverAddress);
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -101,7 +101,7 @@ public class LeafStageTransferableBlockOperatorTest {
         new SelectionResultsBlock(resultSchema,
             Arrays.asList(new Object[]{1, 1660000000000L}, new Object[]{0, 1600000000000L})), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, desiredSchema, 1, 2, _serverAddress);
+        new LeafStageTransferableBlockOperator(resultsBlockList, desiredSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -123,7 +123,7 @@ public class LeafStageTransferableBlockOperatorTest {
         new SelectionResultsBlock(schema,
             Arrays.asList(new Object[]{1, 1660000000000L}, new Object[]{0, 1600000000000L})), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2, _serverAddress);
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -148,7 +148,7 @@ public class LeafStageTransferableBlockOperatorTest {
             queryContext),
         new InstanceResponseBlock(new SelectionResultsBlock(schema, Collections.emptyList()), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2, _serverAddress);
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock resultBlock1 = operator.nextBlock();
@@ -178,7 +178,7 @@ public class LeafStageTransferableBlockOperatorTest {
         errorBlock,
         new InstanceResponseBlock(new SelectionResultsBlock(schema, Collections.emptyList()), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2, _serverAddress);
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -199,7 +199,7 @@ public class LeafStageTransferableBlockOperatorTest {
         new DistinctResultsBlock(mock(DistinctAggregationFunction.class), new DistinctTable(schema,
             Arrays.asList(new Record(new Object[]{1, "foo"}), new Record(new Object[]{2, "bar"})))), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2, _serverAddress);
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -220,7 +220,7 @@ public class LeafStageTransferableBlockOperatorTest {
         new DistinctResultsBlock(mock(DistinctAggregationFunction.class), new DistinctTable(schema,
             Arrays.asList(new Record(new Object[]{"foo", 1}), new Record(new Object[]{"bar", 2})))), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2, _serverAddress);
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -244,7 +244,7 @@ public class LeafStageTransferableBlockOperatorTest {
     List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(
         new InstanceResponseBlock(new GroupByResultsBlock(schema, Collections.emptyList()), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2, _serverAddress);
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -267,7 +267,7 @@ public class LeafStageTransferableBlockOperatorTest {
     List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(
         new InstanceResponseBlock(new GroupByResultsBlock(schema, Collections.emptyList()), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2, _serverAddress);
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -286,7 +286,7 @@ public class LeafStageTransferableBlockOperatorTest {
     List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
         new AggregationResultsBlock(queryContext.getAggregationFunctions(), Collections.emptyList()), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, 1, 2, _serverAddress);
+        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -308,7 +308,7 @@ public class LeafStageTransferableBlockOperatorTest {
     List<InstanceResponseBlock> responseBlockList = Collections.singletonList(
         new InstanceResponseBlock(new SelectionResultsBlock(resultSchema, Collections.emptyList()), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(responseBlockList, desiredSchema, 1, 2, _serverAddress);
+        new LeafStageTransferableBlockOperator(responseBlockList, desiredSchema, OperatorTestUtil.getDefaultContext());
     TransferableBlock resultBlock = operator.nextBlock();
 
     // Then:
@@ -331,7 +331,7 @@ public class LeafStageTransferableBlockOperatorTest {
         new DistinctResultsBlock(mock(DistinctAggregationFunction.class),
             new DistinctTable(resultSchema, Collections.emptyList())), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(responseBlockList, desiredSchema, 1, 2, _serverAddress);
+        new LeafStageTransferableBlockOperator(responseBlockList, desiredSchema, OperatorTestUtil.getDefaultContext());
     TransferableBlock resultBlock = operator.nextBlock();
 
     // Then:
@@ -353,7 +353,7 @@ public class LeafStageTransferableBlockOperatorTest {
     List<InstanceResponseBlock> responseBlockList = Collections.singletonList(
         new InstanceResponseBlock(new GroupByResultsBlock(resultSchema, Collections.emptyList()), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(responseBlockList, desiredSchema, 1, 2, _serverAddress);
+        new LeafStageTransferableBlockOperator(responseBlockList, desiredSchema, OperatorTestUtil.getDefaultContext());
     TransferableBlock resultBlock = operator.nextBlock();
 
     // Then:

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperatorTest.java
@@ -75,7 +75,7 @@ public class LeafStageTransferableBlockOperatorTest {
     List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
         new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2})), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), resultsBlockList, schema);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -101,7 +101,7 @@ public class LeafStageTransferableBlockOperatorTest {
         new SelectionResultsBlock(resultSchema,
             Arrays.asList(new Object[]{1, 1660000000000L}, new Object[]{0, 1600000000000L})), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, desiredSchema, OperatorTestUtil.getDefaultContext());
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), resultsBlockList, desiredSchema);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -123,7 +123,7 @@ public class LeafStageTransferableBlockOperatorTest {
         new SelectionResultsBlock(schema,
             Arrays.asList(new Object[]{1, 1660000000000L}, new Object[]{0, 1600000000000L})), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), resultsBlockList, schema);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -148,7 +148,7 @@ public class LeafStageTransferableBlockOperatorTest {
             queryContext),
         new InstanceResponseBlock(new SelectionResultsBlock(schema, Collections.emptyList()), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), resultsBlockList, schema);
 
     // When:
     TransferableBlock resultBlock1 = operator.nextBlock();
@@ -178,7 +178,7 @@ public class LeafStageTransferableBlockOperatorTest {
         errorBlock,
         new InstanceResponseBlock(new SelectionResultsBlock(schema, Collections.emptyList()), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), resultsBlockList, schema);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -199,7 +199,7 @@ public class LeafStageTransferableBlockOperatorTest {
         new DistinctResultsBlock(mock(DistinctAggregationFunction.class), new DistinctTable(schema,
             Arrays.asList(new Record(new Object[]{1, "foo"}), new Record(new Object[]{2, "bar"})))), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), resultsBlockList, schema);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -220,7 +220,7 @@ public class LeafStageTransferableBlockOperatorTest {
         new DistinctResultsBlock(mock(DistinctAggregationFunction.class), new DistinctTable(schema,
             Arrays.asList(new Record(new Object[]{"foo", 1}), new Record(new Object[]{"bar", 2})))), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), resultsBlockList, schema);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -244,7 +244,7 @@ public class LeafStageTransferableBlockOperatorTest {
     List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(
         new InstanceResponseBlock(new GroupByResultsBlock(schema, Collections.emptyList()), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), resultsBlockList, schema);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -267,7 +267,7 @@ public class LeafStageTransferableBlockOperatorTest {
     List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(
         new InstanceResponseBlock(new GroupByResultsBlock(schema, Collections.emptyList()), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), resultsBlockList, schema);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -286,7 +286,7 @@ public class LeafStageTransferableBlockOperatorTest {
     List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
         new AggregationResultsBlock(queryContext.getAggregationFunctions(), Collections.emptyList()), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(resultsBlockList, schema, OperatorTestUtil.getDefaultContext());
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), resultsBlockList, schema);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -308,7 +308,7 @@ public class LeafStageTransferableBlockOperatorTest {
     List<InstanceResponseBlock> responseBlockList = Collections.singletonList(
         new InstanceResponseBlock(new SelectionResultsBlock(resultSchema, Collections.emptyList()), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(responseBlockList, desiredSchema, OperatorTestUtil.getDefaultContext());
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), responseBlockList, desiredSchema);
     TransferableBlock resultBlock = operator.nextBlock();
 
     // Then:
@@ -331,7 +331,7 @@ public class LeafStageTransferableBlockOperatorTest {
         new DistinctResultsBlock(mock(DistinctAggregationFunction.class),
             new DistinctTable(resultSchema, Collections.emptyList())), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(responseBlockList, desiredSchema, OperatorTestUtil.getDefaultContext());
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), responseBlockList, desiredSchema);
     TransferableBlock resultBlock = operator.nextBlock();
 
     // Then:
@@ -353,7 +353,7 @@ public class LeafStageTransferableBlockOperatorTest {
     List<InstanceResponseBlock> responseBlockList = Collections.singletonList(
         new InstanceResponseBlock(new GroupByResultsBlock(resultSchema, Collections.emptyList()), queryContext));
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(responseBlockList, desiredSchema, OperatorTestUtil.getDefaultContext());
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), responseBlockList, desiredSchema);
     TransferableBlock resultBlock = operator.nextBlock();
 
     // Then:

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LiteralValueOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LiteralValueOperatorTest.java
@@ -66,7 +66,7 @@ public class LiteralValueOperatorTest {
     List<List<RexExpression>> literals = ImmutableList.of(
         ImmutableList.of(new RexExpression.Literal(DataType.STRING, "foo"), new RexExpression.Literal(DataType.INT, 1)),
         ImmutableList.of(new RexExpression.Literal(DataType.STRING, ""), new RexExpression.Literal(DataType.INT, 2)));
-    LiteralValueOperator operator = new LiteralValueOperator(schema, literals, OperatorTestUtil.getDefaultContext());
+    LiteralValueOperator operator = new LiteralValueOperator(OperatorTestUtil.getDefaultContext(), schema, literals);
 
     // When:
     TransferableBlock transferableBlock = operator.nextBlock();
@@ -82,7 +82,7 @@ public class LiteralValueOperatorTest {
     // Given:
     DataSchema schema = new DataSchema(new String[]{}, new ColumnDataType[]{});
     List<List<RexExpression>> literals = ImmutableList.of(ImmutableList.of());
-    LiteralValueOperator operator = new LiteralValueOperator(schema, literals, OperatorTestUtil.getDefaultContext());
+    LiteralValueOperator operator = new LiteralValueOperator(OperatorTestUtil.getDefaultContext(), schema, literals);
 
     // When:
     TransferableBlock transferableBlock = operator.nextBlock();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LiteralValueOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LiteralValueOperatorTest.java
@@ -66,7 +66,7 @@ public class LiteralValueOperatorTest {
     List<List<RexExpression>> literals = ImmutableList.of(
         ImmutableList.of(new RexExpression.Literal(DataType.STRING, "foo"), new RexExpression.Literal(DataType.INT, 1)),
         ImmutableList.of(new RexExpression.Literal(DataType.STRING, ""), new RexExpression.Literal(DataType.INT, 2)));
-    LiteralValueOperator operator = new LiteralValueOperator(schema, literals, 1, 2, _serverAddress);
+    LiteralValueOperator operator = new LiteralValueOperator(schema, literals, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock transferableBlock = operator.nextBlock();
@@ -82,7 +82,7 @@ public class LiteralValueOperatorTest {
     // Given:
     DataSchema schema = new DataSchema(new String[]{}, new ColumnDataType[]{});
     List<List<RexExpression>> literals = ImmutableList.of(ImmutableList.of());
-    LiteralValueOperator operator = new LiteralValueOperator(schema, literals, 1, 2, _serverAddress);
+    LiteralValueOperator operator = new LiteralValueOperator(schema, literals, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock transferableBlock = operator.nextBlock();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -85,7 +85,7 @@ public class MailboxReceiveOperatorTest {
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, 10L, 10L,
             new HashMap<>());
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, 10L, context);
+        new MailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, 10L);
     Thread.sleep(200L);
     TransferableBlock mailbox = receiveOp.nextBlock();
     Assert.assertTrue(mailbox.isErrorBlock());
@@ -95,13 +95,13 @@ public class MailboxReceiveOperatorTest {
     // longer timeout or default timeout (10s) doesn't result in error.
     context = new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, 2000L, 2000L,
         new HashMap<>());
-    receiveOp = new MailboxReceiveOperator(new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, 2000L, context);
+    receiveOp = new MailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, 2000L);
     Thread.sleep(200L);
     mailbox = receiveOp.nextBlock();
     Assert.assertFalse(mailbox.isErrorBlock());
     context = new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
         Long.MAX_VALUE, new HashMap<>());
-    receiveOp = new MailboxReceiveOperator(new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, null, context);
+    receiveOp = new MailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, null);
     Thread.sleep(200L);
     mailbox = receiveOp.nextBlock();
     Assert.assertFalse(mailbox.isErrorBlock());
@@ -124,8 +124,8 @@ public class MailboxReceiveOperatorTest {
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, 456, 789, null,
-            context);
+        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, 456,
+            789, null);
   }
 
   @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*RANGE_DISTRIBUTED.*")
@@ -142,9 +142,8 @@ public class MailboxReceiveOperatorTest {
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
-    MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.RANGE_DISTRIBUTED, 456,
-            789, null, context);
+    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
+        RelDistribution.Type.RANGE_DISTRIBUTED, 456, 789, null);
   }
 
   @Test
@@ -173,8 +172,8 @@ public class MailboxReceiveOperatorTest {
             Long.MAX_VALUE, new HashMap<>());
 
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, null, context);
+        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
+            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
 
     // Receive end of stream block directly when there is no match.
     Assert.assertTrue(receiveOp.nextBlock().isEndOfStreamBlock());
@@ -211,8 +210,8 @@ public class MailboxReceiveOperatorTest {
             Long.MAX_VALUE, new HashMap<>());
 
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, null, context);
+        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
+            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
 
     // Receive end of stream block directly when mailbox is close.
     Assert.assertTrue(receiveOp.nextBlock().isEndOfStreamBlock());
@@ -251,8 +250,8 @@ public class MailboxReceiveOperatorTest {
             Long.MAX_VALUE, new HashMap<>());
 
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, null, context);
+        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
+            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
     // Receive NoOpBlock.
     Assert.assertTrue(receiveOp.nextBlock().isNoOpBlock());
   }
@@ -289,8 +288,8 @@ public class MailboxReceiveOperatorTest {
             Long.MAX_VALUE, new HashMap<>());
 
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, null, context);
+        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
+            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
     // Receive EosBloc.
     Assert.assertTrue(receiveOp.nextBlock().isEndOfStreamBlock());
   }
@@ -329,8 +328,8 @@ public class MailboxReceiveOperatorTest {
             Long.MAX_VALUE, new HashMap<>());
 
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, null, context);
+        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
+            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     List<Object[]> resultRows = receivedBlock.getContainer();
     Assert.assertEquals(resultRows.size(), 1);
@@ -370,8 +369,8 @@ public class MailboxReceiveOperatorTest {
             Long.MAX_VALUE, new HashMap<>());
 
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, null, context);
+        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
+            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     Assert.assertTrue(receivedBlock.isErrorBlock());
     MetadataBlock error = (MetadataBlock) receivedBlock.getDataBlock();
@@ -414,8 +413,8 @@ public class MailboxReceiveOperatorTest {
             Long.MAX_VALUE, new HashMap<>());
 
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, null, context);
+        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,
+            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     List<Object[]> resultRows = receivedBlock.getContainer();
     Assert.assertEquals(resultRows.size(), 1);
@@ -459,8 +458,8 @@ public class MailboxReceiveOperatorTest {
             Long.MAX_VALUE, new HashMap<>());
 
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, null, context);
+        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,
+            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     List<Object[]> resultRows = receivedBlock.getContainer();
     Assert.assertEquals(resultRows.size(), 1);
@@ -508,8 +507,8 @@ public class MailboxReceiveOperatorTest {
             Long.MAX_VALUE, new HashMap<>());
 
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, null, context);
+        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,
+            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
     // Receive first block from first server.
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     List<Object[]> resultRows = receivedBlock.getContainer();
@@ -566,8 +565,8 @@ public class MailboxReceiveOperatorTest {
             Long.MAX_VALUE, new HashMap<>());
 
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, null, context);
+        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,
+            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
     // Receive error block from first server.
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     Assert.assertTrue(receivedBlock.isErrorBlock());
@@ -612,8 +611,8 @@ public class MailboxReceiveOperatorTest {
             Long.MAX_VALUE, new HashMap<>());
 
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, null, context);
+        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,
+            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     Assert.assertTrue(receivedBlock.isErrorBlock(), "server-1 should have returned an error-block");
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -85,7 +85,7 @@ public class MailboxReceiveOperatorTest {
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, 10L, 10L,
             new HashMap<>());
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, context);
+        new MailboxReceiveOperator(new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, 10L, context);
     Thread.sleep(200L);
     TransferableBlock mailbox = receiveOp.nextBlock();
     Assert.assertTrue(mailbox.isErrorBlock());
@@ -95,13 +95,13 @@ public class MailboxReceiveOperatorTest {
     // longer timeout or default timeout (10s) doesn't result in error.
     context = new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, 2000L, 2000L,
         new HashMap<>());
-    receiveOp = new MailboxReceiveOperator(new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, context);
+    receiveOp = new MailboxReceiveOperator(new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, 2000L, context);
     Thread.sleep(200L);
     mailbox = receiveOp.nextBlock();
     Assert.assertFalse(mailbox.isErrorBlock());
     context = new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
         Long.MAX_VALUE, new HashMap<>());
-    receiveOp = new MailboxReceiveOperator(new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, context);
+    receiveOp = new MailboxReceiveOperator(new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, null, context);
     Thread.sleep(200L);
     mailbox = receiveOp.nextBlock();
     Assert.assertFalse(mailbox.isErrorBlock());
@@ -124,7 +124,7 @@ public class MailboxReceiveOperatorTest {
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, 456, 789,
+        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, 456, 789, null,
             context);
   }
 
@@ -144,7 +144,7 @@ public class MailboxReceiveOperatorTest {
             Long.MAX_VALUE, new HashMap<>());
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.RANGE_DISTRIBUTED, 456,
-            789, context);
+            789,null, context);
   }
 
   @Test
@@ -174,7 +174,7 @@ public class MailboxReceiveOperatorTest {
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, context);
+            DEFAULT_RECEIVER_STAGE_ID, null, context);
 
     // Receive end of stream block directly when there is no match.
     Assert.assertTrue(receiveOp.nextBlock().isEndOfStreamBlock());
@@ -212,7 +212,7 @@ public class MailboxReceiveOperatorTest {
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, context);
+            DEFAULT_RECEIVER_STAGE_ID, null, context);
 
     // Receive end of stream block directly when mailbox is close.
     Assert.assertTrue(receiveOp.nextBlock().isEndOfStreamBlock());
@@ -252,7 +252,7 @@ public class MailboxReceiveOperatorTest {
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, context);
+            DEFAULT_RECEIVER_STAGE_ID, null, context);
     // Receive NoOpBlock.
     Assert.assertTrue(receiveOp.nextBlock().isNoOpBlock());
   }
@@ -290,7 +290,7 @@ public class MailboxReceiveOperatorTest {
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, context);
+            DEFAULT_RECEIVER_STAGE_ID, null, context);
     // Receive EosBloc.
     Assert.assertTrue(receiveOp.nextBlock().isEndOfStreamBlock());
   }
@@ -330,7 +330,7 @@ public class MailboxReceiveOperatorTest {
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, context);
+            DEFAULT_RECEIVER_STAGE_ID, null, context);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     List<Object[]> resultRows = receivedBlock.getContainer();
     Assert.assertEquals(resultRows.size(), 1);
@@ -371,7 +371,7 @@ public class MailboxReceiveOperatorTest {
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, context);
+            DEFAULT_RECEIVER_STAGE_ID, null, context);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     Assert.assertTrue(receivedBlock.isErrorBlock());
     MetadataBlock error = (MetadataBlock) receivedBlock.getDataBlock();
@@ -415,7 +415,7 @@ public class MailboxReceiveOperatorTest {
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, context);
+            DEFAULT_RECEIVER_STAGE_ID, null, context);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     List<Object[]> resultRows = receivedBlock.getContainer();
     Assert.assertEquals(resultRows.size(), 1);
@@ -460,7 +460,7 @@ public class MailboxReceiveOperatorTest {
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, context);
+            DEFAULT_RECEIVER_STAGE_ID, null, context);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     List<Object[]> resultRows = receivedBlock.getContainer();
     Assert.assertEquals(resultRows.size(), 1);
@@ -509,7 +509,7 @@ public class MailboxReceiveOperatorTest {
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, context);
+            DEFAULT_RECEIVER_STAGE_ID, null, context);
     // Receive first block from first server.
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     List<Object[]> resultRows = receivedBlock.getContainer();
@@ -567,7 +567,7 @@ public class MailboxReceiveOperatorTest {
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, context);
+            DEFAULT_RECEIVER_STAGE_ID, null, context);
     // Receive error block from first server.
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     Assert.assertTrue(receivedBlock.isErrorBlock());
@@ -613,7 +613,7 @@ public class MailboxReceiveOperatorTest {
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
-            DEFAULT_RECEIVER_STAGE_ID, context);
+            DEFAULT_RECEIVER_STAGE_ID, null, context);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     Assert.assertTrue(receivedBlock.isErrorBlock(), "server-1 should have returned an error-block");
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.common.datablock.MetadataBlock;
@@ -32,6 +33,7 @@ import org.apache.pinot.query.routing.VirtualServer;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -79,9 +81,11 @@ public class MailboxReceiveOperatorTest {
   public void shouldTimeoutOnExtraLongSleep()
       throws InterruptedException {
     // shorter timeoutMs should result in error.
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, 10L, 10L,
+            new HashMap<>());
     MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(_mailboxService, new ArrayList<>(), RelDistribution.Type.SINGLETON, _testAddr, 456,
-            789, DEFAULT_RECEIVER_STAGE_ID, 10L);
+        new MailboxReceiveOperator(new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, context);
     Thread.sleep(200L);
     TransferableBlock mailbox = receiveOp.nextBlock();
     Assert.assertTrue(mailbox.isErrorBlock());
@@ -89,15 +93,15 @@ public class MailboxReceiveOperatorTest {
     Assert.assertTrue(errorBlock.getExceptions().containsKey(QueryException.EXECUTION_TIMEOUT_ERROR_CODE));
 
     // longer timeout or default timeout (10s) doesn't result in error.
-    receiveOp =
-        new MailboxReceiveOperator(_mailboxService, new ArrayList<>(), RelDistribution.Type.SINGLETON, _testAddr, 456,
-            789, DEFAULT_RECEIVER_STAGE_ID, 2000L);
+    context = new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, 2000L, 2000L,
+        new HashMap<>());
+    receiveOp = new MailboxReceiveOperator(new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, context);
     Thread.sleep(200L);
     mailbox = receiveOp.nextBlock();
     Assert.assertFalse(mailbox.isErrorBlock());
-    receiveOp =
-        new MailboxReceiveOperator(_mailboxService, new ArrayList<>(), RelDistribution.Type.SINGLETON, _testAddr, 456,
-            789, DEFAULT_RECEIVER_STAGE_ID, null);
+    context = new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
+        Long.MAX_VALUE, new HashMap<>());
+    receiveOp = new MailboxReceiveOperator(new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, context);
     Thread.sleep(200L);
     mailbox = receiveOp.nextBlock();
     Assert.assertFalse(mailbox.isErrorBlock());
@@ -116,8 +120,12 @@ public class MailboxReceiveOperatorTest {
     Mockito.when(_server2.getHostname()).thenReturn("singleton");
     Mockito.when(_server2.getQueryMailboxPort()).thenReturn(123);
 
-    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(_mailboxService, ImmutableList.of(_server1, _server2),
-        RelDistribution.Type.SINGLETON, _testAddr, 456, 789, DEFAULT_RECEIVER_STAGE_ID, null);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+    MailboxReceiveOperator receiveOp =
+        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, 456, 789,
+            context);
   }
 
   @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*RANGE_DISTRIBUTED.*")
@@ -131,8 +139,12 @@ public class MailboxReceiveOperatorTest {
     Mockito.when(_server2.getHostname()).thenReturn("singleton");
     Mockito.when(_server2.getQueryMailboxPort()).thenReturn(123);
 
-    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(_mailboxService, ImmutableList.of(_server1, _server2),
-        RelDistribution.Type.RANGE_DISTRIBUTED, _testAddr, 456, 789, DEFAULT_RECEIVER_STAGE_ID, null);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+    MailboxReceiveOperator receiveOp =
+        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.RANGE_DISTRIBUTED, 456,
+            789, context);
   }
 
   @Test
@@ -156,8 +168,13 @@ public class MailboxReceiveOperatorTest {
     String toHost = "toHost";
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
-    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(_mailboxService, ImmutableList.of(_server1, _server2),
-        RelDistribution.Type.SINGLETON, toAddress, jobId, stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    MailboxReceiveOperator receiveOp =
+        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, context);
 
     // Receive end of stream block directly when there is no match.
     Assert.assertTrue(receiveOp.nextBlock().isEndOfStreamBlock());
@@ -184,14 +201,19 @@ public class MailboxReceiveOperatorTest {
     String toHost = "toHost";
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
-    JsonMailboxIdentifier expectedMailboxId =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(serverHost, server2port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(serverHost, server2port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(true);
-    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(_mailboxService, ImmutableList.of(_server1, _server2),
-        RelDistribution.Type.SINGLETON, toAddress, jobId, stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    MailboxReceiveOperator receiveOp =
+        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, context);
+
     // Receive end of stream block directly when mailbox is close.
     Assert.assertTrue(receiveOp.nextBlock().isEndOfStreamBlock());
   }
@@ -218,16 +240,19 @@ public class MailboxReceiveOperatorTest {
     String toHost = "toHost";
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
-    JsonMailboxIdentifier expectedMailboxId =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(serverHost, server2port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(serverHost, server2port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(false);
     // Receive null mailbox during timeout.
     Mockito.when(_mailbox.receive()).thenReturn(null);
-    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(_mailboxService, ImmutableList.of(_server1, _server2),
-        RelDistribution.Type.SINGLETON, toAddress, jobId, stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    MailboxReceiveOperator receiveOp =
+        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, context);
     // Receive NoOpBlock.
     Assert.assertTrue(receiveOp.nextBlock().isNoOpBlock());
   }
@@ -254,15 +279,18 @@ public class MailboxReceiveOperatorTest {
     String toHost = "toHost";
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
-    JsonMailboxIdentifier expectedMailboxId =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(serverHost, server2port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(serverHost, server2port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(false);
     Mockito.when(_mailbox.receive()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
-    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(_mailboxService, ImmutableList.of(_server1, _server2),
-        RelDistribution.Type.SINGLETON, toAddress, jobId, stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    MailboxReceiveOperator receiveOp =
+        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, context);
     // Receive EosBloc.
     Assert.assertTrue(receiveOp.nextBlock().isEndOfStreamBlock());
   }
@@ -289,17 +317,20 @@ public class MailboxReceiveOperatorTest {
     String toHost = "toHost";
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
-    JsonMailboxIdentifier expectedMailboxId =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(serverHost, server2port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(serverHost, server2port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(false);
     Object[] expRow = new Object[]{1, 1};
     DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
     Mockito.when(_mailbox.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow));
-    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(_mailboxService, ImmutableList.of(_server1, _server2),
-        RelDistribution.Type.SINGLETON, toAddress, jobId, stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    MailboxReceiveOperator receiveOp =
+        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, context);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     List<Object[]> resultRows = receivedBlock.getContainer();
     Assert.assertEquals(resultRows.size(), 1);
@@ -328,16 +359,19 @@ public class MailboxReceiveOperatorTest {
     String toHost = "toHost";
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
-    JsonMailboxIdentifier expectedMailboxId =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(serverHost, server2port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(serverHost, server2port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(false);
     Exception e = new Exception("errorBlock");
     Mockito.when(_mailbox.receive()).thenReturn(TransferableBlockUtils.getErrorTransferableBlock(e));
-    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(_mailboxService, ImmutableList.of(_server1, _server2),
-        RelDistribution.Type.SINGLETON, toAddress, jobId, stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    MailboxReceiveOperator receiveOp =
+        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, context);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     Assert.assertTrue(receivedBlock.isErrorBlock());
     MetadataBlock error = (MetadataBlock) receivedBlock.getDataBlock();
@@ -363,24 +397,25 @@ public class MailboxReceiveOperatorTest {
     String toHost = "toHost";
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
-    JsonMailboxIdentifier expectedMailboxId1 =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(server1Host, server1Port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId1 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(server1Host, server1Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId1)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(true);
 
-    JsonMailboxIdentifier expectedMailboxId2 =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(server2Host, server2Port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId2 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(server2Host, server2Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId2)).thenReturn(_mailbox2);
     Mockito.when(_mailbox2.isClosed()).thenReturn(false);
     Object[] expRow = new Object[]{1, 1};
     DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
     Mockito.when(_mailbox2.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow));
-    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(_mailboxService, ImmutableList.of(_server1, _server2),
-        RelDistribution.Type.HASH_DISTRIBUTED, toAddress, jobId, stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    MailboxReceiveOperator receiveOp =
+        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, context);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     List<Object[]> resultRows = receivedBlock.getContainer();
     Assert.assertEquals(resultRows.size(), 1);
@@ -406,25 +441,26 @@ public class MailboxReceiveOperatorTest {
     String toHost = "toHost";
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
-    JsonMailboxIdentifier expectedMailboxId1 =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(server1Host, server1Port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId1 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(server1Host, server1Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId1)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(false);
     Mockito.when(_mailbox.receive()).thenReturn(null);
 
-    JsonMailboxIdentifier expectedMailboxId2 =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(server2Host, server2Port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId2 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(server2Host, server2Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId2)).thenReturn(_mailbox2);
     Mockito.when(_mailbox2.isClosed()).thenReturn(false);
     Object[] expRow = new Object[]{1, 1};
     DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
     Mockito.when(_mailbox2.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow));
-    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(_mailboxService, ImmutableList.of(_server1, _server2),
-        RelDistribution.Type.HASH_DISTRIBUTED, toAddress, jobId, stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    MailboxReceiveOperator receiveOp =
+        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, context);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     List<Object[]> resultRows = receivedBlock.getContainer();
     Assert.assertEquals(resultRows.size(), 1);
@@ -451,10 +487,8 @@ public class MailboxReceiveOperatorTest {
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
     DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
-    JsonMailboxIdentifier expectedMailboxId1 =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(server1Host, server1Port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId1 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(server1Host, server1Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId1)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(false);
     Object[] expRow1 = new Object[]{1, 1};
@@ -464,15 +498,18 @@ public class MailboxReceiveOperatorTest {
             TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     Object[] expRow3 = new Object[]{3, 3};
-    JsonMailboxIdentifier expectedMailboxId2 =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(server2Host, server2Port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId2 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(server2Host, server2Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId2)).thenReturn(_mailbox2);
     Mockito.when(_mailbox2.isClosed()).thenReturn(false);
     Mockito.when(_mailbox2.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow3));
-    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(_mailboxService, ImmutableList.of(_server1, _server2),
-        RelDistribution.Type.HASH_DISTRIBUTED, toAddress, jobId, stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    MailboxReceiveOperator receiveOp =
+        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, context);
     // Receive first block from first server.
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     List<Object[]> resultRows = receivedBlock.getContainer();
@@ -511,25 +548,26 @@ public class MailboxReceiveOperatorTest {
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
     DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
-    JsonMailboxIdentifier expectedMailboxId1 =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(server1Host, server1Port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId1 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(server1Host, server1Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId1)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(false);
     Mockito.when(_mailbox.receive())
         .thenReturn(TransferableBlockUtils.getErrorTransferableBlock(new Exception("mailboxError")));
 
     Object[] expRow3 = new Object[]{3, 3};
-    JsonMailboxIdentifier expectedMailboxId2 =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(server2Host, server2Port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId2 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(server2Host, server2Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId2)).thenReturn(_mailbox2);
     Mockito.when(_mailbox2.isClosed()).thenReturn(false);
     Mockito.when(_mailbox2.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow3));
-    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(_mailboxService, ImmutableList.of(_server1, _server2),
-        RelDistribution.Type.HASH_DISTRIBUTED, toAddress, jobId, stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    MailboxReceiveOperator receiveOp =
+        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, context);
     // Receive error block from first server.
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     Assert.assertTrue(receivedBlock.isErrorBlock());
@@ -557,24 +595,25 @@ public class MailboxReceiveOperatorTest {
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
     DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
-    JsonMailboxIdentifier expectedMailboxId1 =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(server1Host, server1Port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId1 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(server1Host, server1Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId1)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(false);
     Mockito.when(_mailbox.receive()).thenThrow(new Exception("mailboxError"));
 
     Object[] expRow3 = new Object[]{3, 3};
-    JsonMailboxIdentifier expectedMailboxId2 =
-        new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-            new VirtualServerAddress(server2Host, server2Port, 0),
-            toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    JsonMailboxIdentifier expectedMailboxId2 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(server2Host, server2Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId2)).thenReturn(_mailbox2);
     Mockito.when(_mailbox2.isClosed()).thenReturn(false);
     Mockito.when(_mailbox2.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow3));
-    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(_mailboxService, ImmutableList.of(_server1, _server2),
-        RelDistribution.Type.HASH_DISTRIBUTED, toAddress, jobId, stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    MailboxReceiveOperator receiveOp =
+        new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, context);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     Assert.assertTrue(receivedBlock.isErrorBlock(), "server-1 should have returned an error-block");
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -144,7 +144,7 @@ public class MailboxReceiveOperatorTest {
             Long.MAX_VALUE, new HashMap<>());
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(ImmutableList.of(_server1, _server2), RelDistribution.Type.RANGE_DISTRIBUTED, 456,
-            789,null, context);
+            789, null, context);
   }
 
   @Test

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -87,8 +87,6 @@ public class MailboxSendOperatorTest {
       throws Exception {
     long deadlineMs = System.currentTimeMillis() + 10_000;
     // Given:
-//    OpChainExecutionContext context =
-//        OperatorTestUtil.getContext(1, DEFAULT_SENDER_STAGE_ID, new VirtualServerAddress(_server));
     OpChainExecutionContext context = getOpChainContext(deadlineMs);
 
     MailboxSendOperator operator =

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -20,17 +20,21 @@ package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.Map;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.JsonMailboxIdentifier;
 import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.planner.StageMetadata;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.routing.VirtualServer;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.exchange.BlockExchange;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -65,8 +69,7 @@ public class MailboxSendOperatorTest {
   public void setUp() {
     _mocks = MockitoAnnotations.openMocks(this);
     Mockito.when(_exchangeFactory.build(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
-        Mockito.anyLong()))
-        .thenReturn(_exchange);
+        Mockito.anyLong())).thenReturn(_exchange);
 
     Mockito.when(_server.getHostname()).thenReturn("mock");
     Mockito.when(_server.getQueryMailboxPort()).thenReturn(0);
@@ -84,11 +87,14 @@ public class MailboxSendOperatorTest {
       throws Exception {
     long deadlineMs = System.currentTimeMillis() + 10_000;
     // Given:
-    MailboxSendOperator operator = new MailboxSendOperator(_mailboxService, _input, ImmutableList.of(_server),
-        RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+//    OpChainExecutionContext context =
+//        OperatorTestUtil.getContext(1, DEFAULT_SENDER_STAGE_ID, new VirtualServerAddress(_server));
+    OpChainExecutionContext context = getOpChainContext(deadlineMs);
+
+    MailboxSendOperator operator = new MailboxSendOperator(_input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
         server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
-            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, 1, DEFAULT_SENDER_STAGE_ID, DEFAULT_RECEIVER_STAGE_ID,
-        new VirtualServerAddress(_server), deadlineMs);
+            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID, context);
+
     Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
 
     // When:
@@ -104,11 +110,11 @@ public class MailboxSendOperatorTest {
       throws Exception {
     long deadlineMs = System.currentTimeMillis() + 10_000;
     // Given:
-    MailboxSendOperator operator = new MailboxSendOperator(_mailboxService, _input, ImmutableList.of(_server),
-        RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+    OpChainExecutionContext context = getOpChainContext(deadlineMs);
+
+    MailboxSendOperator operator = new MailboxSendOperator(_input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
         server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
-            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, 1, DEFAULT_SENDER_STAGE_ID, DEFAULT_RECEIVER_STAGE_ID,
-        new VirtualServerAddress(_server), deadlineMs);
+            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID, context);
     TransferableBlock errorBlock = TransferableBlockUtils.getErrorTransferableBlock(new Exception("foo!"));
     Mockito.when(_input.nextBlock()).thenReturn(errorBlock);
 
@@ -125,11 +131,11 @@ public class MailboxSendOperatorTest {
       throws Exception {
     long deadlineMs = System.currentTimeMillis() + 10_000;
     // Given:
-    MailboxSendOperator operator = new MailboxSendOperator(_mailboxService, _input, ImmutableList.of(_server),
-        RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+    OpChainExecutionContext context = getOpChainContext(deadlineMs);
+
+    MailboxSendOperator operator = new MailboxSendOperator(_input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
         server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
-            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, 1, DEFAULT_SENDER_STAGE_ID, DEFAULT_RECEIVER_STAGE_ID,
-        new VirtualServerAddress(_server), deadlineMs);
+            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID, context);
     Mockito.when(_input.nextBlock()).thenThrow(new RuntimeException("foo!"));
     ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
 
@@ -147,11 +153,12 @@ public class MailboxSendOperatorTest {
       throws Exception {
     long deadlineMs = System.currentTimeMillis() + 10_000;
     // Given:
-    MailboxSendOperator operator = new MailboxSendOperator(_mailboxService, _input, ImmutableList.of(_server),
-        RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+    OpChainExecutionContext context = getOpChainContext(deadlineMs);
+
+    MailboxSendOperator operator = new MailboxSendOperator(_input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
         server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
-            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, 1, DEFAULT_SENDER_STAGE_ID, DEFAULT_RECEIVER_STAGE_ID,
-        new VirtualServerAddress(_server), deadlineMs);
+            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID, context);
+
     TransferableBlock eosBlock = TransferableBlockUtils.getEndOfStreamTransferableBlock();
     Mockito.when(_input.nextBlock()).thenReturn(eosBlock);
 
@@ -168,11 +175,11 @@ public class MailboxSendOperatorTest {
       throws Exception {
     long deadlineMs = System.currentTimeMillis() + 10_000;
     // Given:
-    MailboxSendOperator operator = new MailboxSendOperator(_mailboxService, _input, ImmutableList.of(_server),
-        RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+    OpChainExecutionContext context = getOpChainContext(deadlineMs);
+
+    MailboxSendOperator operator = new MailboxSendOperator(_input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
         server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
-            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, 1, DEFAULT_SENDER_STAGE_ID, DEFAULT_RECEIVER_STAGE_ID,
-        new VirtualServerAddress(_server), deadlineMs);
+            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID, context);
     TransferableBlock dataBlock = block(new DataSchema(new String[]{}, new DataSchema.ColumnDataType[]{}));
     Mockito.when(_input.nextBlock()).thenReturn(dataBlock)
         .thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
@@ -188,5 +195,15 @@ public class MailboxSendOperatorTest {
 
   private static TransferableBlock block(DataSchema schema, Object[]... rows) {
     return new TransferableBlock(Arrays.asList(rows), schema, DataBlock.Type.ROW);
+  }
+
+  private OpChainExecutionContext getOpChainContext(long deadlineMs) {
+    StageMetadata stageMetadata = new StageMetadata();
+    stageMetadata.setServerInstances(Collections.singletonList(_server));
+    Map<Integer, StageMetadata> stageMetadataMap = Collections.singletonMap(DEFAULT_RECEIVER_STAGE_ID, stageMetadata);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, 1, DEFAULT_SENDER_STAGE_ID, new VirtualServerAddress(_server),
+            deadlineMs, deadlineMs, stageMetadataMap);
+    return context;
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -199,7 +199,7 @@ public class MailboxSendOperatorTest {
 
   private OpChainExecutionContext getOpChainContext(long deadlineMs) {
     StageMetadata stageMetadata = new StageMetadata();
-    stageMetadata.setServerInstances(Collections.singletonList(_server));
+    stageMetadata.setServerInstances(ImmutableList.of(_server));
     Map<Integer, StageMetadata> stageMetadataMap = Collections.singletonMap(DEFAULT_RECEIVER_STAGE_ID, stageMetadata);
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_SENDER_STAGE_ID, new VirtualServerAddress(_server),

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -91,9 +91,10 @@ public class MailboxSendOperatorTest {
 //        OperatorTestUtil.getContext(1, DEFAULT_SENDER_STAGE_ID, new VirtualServerAddress(_server));
     OpChainExecutionContext context = getOpChainContext(deadlineMs);
 
-    MailboxSendOperator operator = new MailboxSendOperator(_input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
-        server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
-            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID, context);
+    MailboxSendOperator operator =
+        new MailboxSendOperator(context, _input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+            server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
+                DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID);
 
     Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
 
@@ -112,9 +113,10 @@ public class MailboxSendOperatorTest {
     // Given:
     OpChainExecutionContext context = getOpChainContext(deadlineMs);
 
-    MailboxSendOperator operator = new MailboxSendOperator(_input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
-        server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
-            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID, context);
+    MailboxSendOperator operator =
+        new MailboxSendOperator(context, _input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+            server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
+                DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID);
     TransferableBlock errorBlock = TransferableBlockUtils.getErrorTransferableBlock(new Exception("foo!"));
     Mockito.when(_input.nextBlock()).thenReturn(errorBlock);
 
@@ -133,9 +135,10 @@ public class MailboxSendOperatorTest {
     // Given:
     OpChainExecutionContext context = getOpChainContext(deadlineMs);
 
-    MailboxSendOperator operator = new MailboxSendOperator(_input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
-        server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
-            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID, context);
+    MailboxSendOperator operator =
+        new MailboxSendOperator(context, _input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+            server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
+                DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_input.nextBlock()).thenThrow(new RuntimeException("foo!"));
     ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
 
@@ -155,9 +158,10 @@ public class MailboxSendOperatorTest {
     // Given:
     OpChainExecutionContext context = getOpChainContext(deadlineMs);
 
-    MailboxSendOperator operator = new MailboxSendOperator(_input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
-        server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
-            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID, context);
+    MailboxSendOperator operator =
+        new MailboxSendOperator(context, _input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+            server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
+                DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID);
 
     TransferableBlock eosBlock = TransferableBlockUtils.getEndOfStreamTransferableBlock();
     Mockito.when(_input.nextBlock()).thenReturn(eosBlock);
@@ -177,9 +181,10 @@ public class MailboxSendOperatorTest {
     // Given:
     OpChainExecutionContext context = getOpChainContext(deadlineMs);
 
-    MailboxSendOperator operator = new MailboxSendOperator(_input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
-        server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
-            DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID, context);
+    MailboxSendOperator operator =
+        new MailboxSendOperator(context, _input, RelDistribution.Type.HASH_DISTRIBUTED, _selector,
+            server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
+                DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID);
     TransferableBlock dataBlock = block(new DataSchema(new String[]{}, new DataSchema.ColumnDataType[]{}));
     Mockito.when(_input.nextBlock()).thenReturn(dataBlock)
         .thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
@@ -19,18 +19,20 @@
 package org.apache.pinot.query.runtime.operator;
 
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
 import org.apache.pinot.query.testutils.MockDataBlockOperatorFactory;
-
 
 public class OperatorTestUtil {
   // simple key-value collision schema/data test set: "Aa" and "BB" have same hash code in java.
-  private static final List<List<Object[]>> SIMPLE_KV_DATA_ROWS = Arrays.asList(
-      Arrays.asList(new Object[]{1, "Aa"}, new Object[]{2, "BB"}, new Object[]{3, "BB"}),
-      Arrays.asList(new Object[]{1, "AA"}, new Object[]{2, "Aa"}));
+  private static final List<List<Object[]>> SIMPLE_KV_DATA_ROWS =
+      Arrays.asList(Arrays.asList(new Object[]{1, "Aa"}, new Object[]{2, "BB"}, new Object[]{3, "BB"}),
+          Arrays.asList(new Object[]{1, "AA"}, new Object[]{2, "Aa"}));
   private static final MockDataBlockOperatorFactory MOCK_OPERATOR_FACTORY;
 
   public static final DataSchema SIMPLE_KV_DATA_SCHEMA = new DataSchema(new String[]{"foo", "bar"},
@@ -40,10 +42,8 @@ public class OperatorTestUtil {
   public static final String OP_2 = "op2";
 
   static {
-    MOCK_OPERATOR_FACTORY = new MockDataBlockOperatorFactory()
-        .registerOperator(OP_1, SIMPLE_KV_DATA_SCHEMA)
-        .registerOperator(OP_2, SIMPLE_KV_DATA_SCHEMA)
-        .addRows(OP_1, SIMPLE_KV_DATA_ROWS.get(0))
+    MOCK_OPERATOR_FACTORY = new MockDataBlockOperatorFactory().registerOperator(OP_1, SIMPLE_KV_DATA_SCHEMA)
+        .registerOperator(OP_2, SIMPLE_KV_DATA_SCHEMA).addRows(OP_1, SIMPLE_KV_DATA_ROWS.get(0))
         .addRows(OP_2, SIMPLE_KV_DATA_ROWS.get(1));
   }
 
@@ -60,5 +60,17 @@ public class OperatorTestUtil {
 
   public static TransferableBlock block(DataSchema schema, Object[]... rows) {
     return new TransferableBlock(Arrays.asList(rows), schema, DataBlock.Type.ROW);
+  }
+
+  public static OperatorExecutionContext getDefaultContext() {
+    VirtualServerAddress virtualServerAddress = new VirtualServerAddress("mock", 80, 0);
+    return new OperatorExecutionContext(null, 1, 2, virtualServerAddress, Long.MAX_VALUE, Long.MAX_VALUE,
+        new HashMap<>());
+  }
+
+  public static OperatorExecutionContext getContext(long requestId, int stageId,
+      VirtualServerAddress virtualServerAddress) {
+    return new OperatorExecutionContext(null, requestId, stageId, virtualServerAddress, Long.MAX_VALUE, Long.MAX_VALUE,
+        new HashMap<>());
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
@@ -25,7 +25,7 @@ import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
-import org.apache.pinot.query.runtime.plan.OperatorExecutionContext;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.query.testutils.MockDataBlockOperatorFactory;
 
 public class OperatorTestUtil {
@@ -62,15 +62,15 @@ public class OperatorTestUtil {
     return new TransferableBlock(Arrays.asList(rows), schema, DataBlock.Type.ROW);
   }
 
-  public static OperatorExecutionContext getDefaultContext() {
+  public static OpChainExecutionContext getDefaultContext() {
     VirtualServerAddress virtualServerAddress = new VirtualServerAddress("mock", 80, 0);
-    return new OperatorExecutionContext(null, 1, 2, virtualServerAddress, Long.MAX_VALUE, Long.MAX_VALUE,
+    return new OpChainExecutionContext(null, 1, 2, virtualServerAddress, Long.MAX_VALUE, Long.MAX_VALUE,
         new HashMap<>());
   }
 
-  public static OperatorExecutionContext getContext(long requestId, int stageId,
+  public static OpChainExecutionContext getContext(long requestId, int stageId,
       VirtualServerAddress virtualServerAddress) {
-    return new OperatorExecutionContext(null, requestId, stageId, virtualServerAddress, Long.MAX_VALUE, Long.MAX_VALUE,
+    return new OpChainExecutionContext(null, requestId, stageId, virtualServerAddress, Long.MAX_VALUE, Long.MAX_VALUE,
         new HashMap<>());
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
@@ -69,7 +69,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock())
         .thenReturn(TransferableBlockUtils.getErrorTransferableBlock(new Exception("foo!")));
@@ -87,7 +88,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
 
@@ -104,7 +106,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
@@ -121,7 +124,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -143,7 +147,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(1);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"ignored", "sort"}, new DataSchema.ColumnDataType[]{INT, INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{1, 2}, new Object[]{2, 1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -165,7 +170,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{STRING});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{"b"}, new Object[]{"a"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -187,7 +193,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.DESCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -209,7 +216,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 1, schema, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, 10, 1, schema, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -231,7 +239,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 1, 1, schema, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, 1, 1, schema, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -273,7 +282,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, -1, 0, schema, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, -1, 0, schema, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -293,7 +303,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}))
         .thenReturn(block(schema, new Object[]{1}))
@@ -316,7 +327,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0, 1);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING, Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"first", "second"}, new DataSchema.ColumnDataType[]{INT, INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{1, 2}, new Object[]{1, 1}, new Object[]{1, 3}))
@@ -340,7 +352,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0, 1);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING, Direction.DESCENDING);
     DataSchema schema = new DataSchema(new String[]{"first", "second"}, new DataSchema.ColumnDataType[]{INT, INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{1, 2}, new Object[]{1, 1}, new Object[]{1, 3}))
@@ -364,7 +377,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 10, 0, schema, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}))
         .thenReturn(TransferableBlockUtils.getNoOpTransferableBlock()).thenReturn(block(schema, new Object[]{1}))

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
@@ -70,7 +70,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(TransferableBlockUtils.getErrorTransferableBlock(new Exception("foo!")));
@@ -89,7 +89,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema);
 
     Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
 
@@ -107,7 +107,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema);
 
     Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
@@ -125,7 +125,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -148,7 +148,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"ignored", "sort"}, new DataSchema.ColumnDataType[]{INT, INT});
     SortOperator op =
-        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{1, 2}, new Object[]{2, 1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -171,7 +171,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{STRING});
     SortOperator op =
-        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{"b"}, new Object[]{"a"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -194,7 +194,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.DESCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -217,7 +217,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(_input, collation, directions, 10, 1, schema, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 1, schema);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -240,7 +240,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(_input, collation, directions, 1, 1, schema, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 1, 1, schema);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -262,7 +262,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(_input, collation, directions, 0, 0, schema, 1, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 0, 0, schema, 1);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -284,7 +284,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(_input, collation, directions, -1, 0, schema, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, -1, 0, schema);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -305,7 +305,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}))
         .thenReturn(block(schema, new Object[]{1}))
@@ -329,7 +329,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING, Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"first", "second"}, new DataSchema.ColumnDataType[]{INT, INT});
     SortOperator op =
-        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{1, 2}, new Object[]{1, 1}, new Object[]{1, 3}))
@@ -354,7 +354,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING, Direction.DESCENDING);
     DataSchema schema = new DataSchema(new String[]{"first", "second"}, new DataSchema.ColumnDataType[]{INT, INT});
     SortOperator op =
-        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{1, 2}, new Object[]{1, 1}, new Object[]{1, 3}))
@@ -379,7 +379,7 @@ public class SortOperatorTest {
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(_input, collation, directions, 10, 0, schema, OperatorTestUtil.getDefaultContext());
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}))
         .thenReturn(TransferableBlockUtils.getNoOpTransferableBlock()).thenReturn(block(schema, new Object[]{1}))

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
@@ -261,7 +261,8 @@ public class SortOperatorTest {
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(_input, collation, directions, 0, 0, schema, 1, 1, 2, _serverAddress);
+    SortOperator op =
+        new SortOperator(_input, collation, directions, 0, 0, schema, 1, OperatorTestUtil.getDefaultContext());
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
@@ -26,7 +26,6 @@ import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
-import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -48,13 +47,9 @@ public class TransformOperatorTest {
   @Mock
   private MultiStageOperator _upstreamOp;
 
-  @Mock
-  private VirtualServerAddress _serverAddress;
-
   @BeforeMethod
   public void setUp() {
     _mocks = MockitoAnnotations.openMocks(this);
-    Mockito.when(_serverAddress.toString()).thenReturn(new VirtualServerAddress("mock", 80, 0).toString());
   }
 
   @AfterMethod
@@ -76,8 +71,8 @@ public class TransformOperatorTest {
     RexExpression.InputRef ref0 = new RexExpression.InputRef(0);
     RexExpression.InputRef ref1 = new RexExpression.InputRef(1);
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(ref0, ref1), upStreamSchema, 1, 2,
-            _serverAddress);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(ref0, ref1), upStreamSchema,
+            OperatorTestUtil.getDefaultContext());
     TransferableBlock result = op.nextBlock();
 
     Assert.assertTrue(!result.isErrorBlock());
@@ -101,8 +96,8 @@ public class TransformOperatorTest {
     RexExpression.Literal boolLiteral = new RexExpression.Literal(FieldSpec.DataType.BOOLEAN, true);
     RexExpression.Literal strLiteral = new RexExpression.Literal(FieldSpec.DataType.STRING, "str");
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema, 1,
-            2, _serverAddress);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema,
+            OperatorTestUtil.getDefaultContext());
     TransferableBlock result = op.nextBlock();
     // Literal operands should just output original literals.
     Assert.assertTrue(!result.isErrorBlock());
@@ -132,8 +127,8 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"plusR", "minusR"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema, 1, 2,
-            _serverAddress);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema,
+            OperatorTestUtil.getDefaultContext());
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(!result.isErrorBlock());
     List<Object[]> resultRows = result.getContainer();
@@ -161,8 +156,8 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"plusR", "minusR"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema, 1, 2,
-            _serverAddress);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema,
+            OperatorTestUtil.getDefaultContext());
 
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
@@ -182,8 +177,8 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"inCol", "strCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema, 1,
-            2, _serverAddress);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema,
+            OperatorTestUtil.getDefaultContext());
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
     DataBlock data = result.getDataBlock();
@@ -206,8 +201,8 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"boolCol", "strCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.STRING});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema, 1,
-            2, _serverAddress);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema,
+            OperatorTestUtil.getDefaultContext());
     TransferableBlock result = op.nextBlock();
     // First block has two rows
     Assert.assertFalse(result.isErrorBlock());
@@ -238,8 +233,8 @@ public class TransformOperatorTest {
     DataSchema upStreamSchema = new DataSchema(new String[]{"string1", "string2"}, new DataSchema.ColumnDataType[]{
         DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING
     });
-    TransformOperator transform =
-        new TransformOperator(_upstreamOp, resultSchema, new ArrayList<>(), upStreamSchema, 1, 2, _serverAddress);
+    TransformOperator transform = new TransformOperator(_upstreamOp, resultSchema, new ArrayList<>(), upStreamSchema,
+        OperatorTestUtil.getDefaultContext());
   }
 
   @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*doesn't match "
@@ -252,6 +247,7 @@ public class TransformOperatorTest {
     });
     RexExpression.InputRef ref0 = new RexExpression.InputRef(0);
     TransformOperator transform =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(ref0), upStreamSchema, 1, 2, _serverAddress);
+        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(ref0), upStreamSchema,
+            OperatorTestUtil.getDefaultContext());
   }
 };

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
@@ -71,8 +71,8 @@ public class TransformOperatorTest {
     RexExpression.InputRef ref0 = new RexExpression.InputRef(0);
     RexExpression.InputRef ref1 = new RexExpression.InputRef(1);
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(ref0, ref1), upStreamSchema,
-            OperatorTestUtil.getDefaultContext());
+        new TransformOperator(OperatorTestUtil.getDefaultContext(),
+            _upstreamOp, resultSchema, ImmutableList.of(ref0, ref1), upStreamSchema);
     TransferableBlock result = op.nextBlock();
 
     Assert.assertTrue(!result.isErrorBlock());
@@ -96,8 +96,8 @@ public class TransformOperatorTest {
     RexExpression.Literal boolLiteral = new RexExpression.Literal(FieldSpec.DataType.BOOLEAN, true);
     RexExpression.Literal strLiteral = new RexExpression.Literal(FieldSpec.DataType.STRING, "str");
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema,
-            OperatorTestUtil.getDefaultContext());
+        new TransformOperator(OperatorTestUtil.getDefaultContext(),
+            _upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema);
     TransferableBlock result = op.nextBlock();
     // Literal operands should just output original literals.
     Assert.assertTrue(!result.isErrorBlock());
@@ -127,8 +127,8 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"plusR", "minusR"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema,
-            OperatorTestUtil.getDefaultContext());
+        new TransformOperator(OperatorTestUtil.getDefaultContext(),
+            _upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema);
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(!result.isErrorBlock());
     List<Object[]> resultRows = result.getContainer();
@@ -156,8 +156,8 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"plusR", "minusR"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema,
-            OperatorTestUtil.getDefaultContext());
+        new TransformOperator(OperatorTestUtil.getDefaultContext(),
+            _upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema);
 
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
@@ -177,8 +177,8 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"inCol", "strCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema,
-            OperatorTestUtil.getDefaultContext());
+        new TransformOperator(OperatorTestUtil.getDefaultContext(),
+            _upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema);
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
     DataBlock data = result.getDataBlock();
@@ -201,8 +201,8 @@ public class TransformOperatorTest {
     DataSchema resultSchema = new DataSchema(new String[]{"boolCol", "strCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.STRING});
     TransformOperator op =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema,
-            OperatorTestUtil.getDefaultContext());
+        new TransformOperator(OperatorTestUtil.getDefaultContext(),
+            _upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema);
     TransferableBlock result = op.nextBlock();
     // First block has two rows
     Assert.assertFalse(result.isErrorBlock());
@@ -233,8 +233,9 @@ public class TransformOperatorTest {
     DataSchema upStreamSchema = new DataSchema(new String[]{"string1", "string2"}, new DataSchema.ColumnDataType[]{
         DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING
     });
-    TransformOperator transform = new TransformOperator(_upstreamOp, resultSchema, new ArrayList<>(), upStreamSchema,
-        OperatorTestUtil.getDefaultContext());
+    TransformOperator transform =
+        new TransformOperator(OperatorTestUtil.getDefaultContext(), _upstreamOp, resultSchema, new ArrayList<>(),
+            upStreamSchema);
   }
 
   @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*doesn't match "
@@ -247,7 +248,7 @@ public class TransformOperatorTest {
     });
     RexExpression.InputRef ref0 = new RexExpression.InputRef(0);
     TransformOperator transform =
-        new TransformOperator(_upstreamOp, resultSchema, ImmutableList.of(ref0), upStreamSchema,
-            OperatorTestUtil.getDefaultContext());
+        new TransformOperator(OperatorTestUtil.getDefaultContext(), _upstreamOp, resultSchema, ImmutableList.of(ref0),
+            upStreamSchema);
   }
 };

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
@@ -321,7 +321,8 @@ public class WindowAggregateOperatorTest {
     WindowAggregateOperator operator =
         new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
             Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
-            Collections.emptyList(), outSchema, inSchema, ImmutableMap.of("SUM", cdt -> merger), 1, 2, _serverAddress);
+            Collections.emptyList(), outSchema, inSchema, ImmutableMap.of("SUM", cdt -> merger),
+            OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock(); // (output result)

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
@@ -78,11 +78,12 @@ public class WindowAggregateOperatorTest {
         .thenReturn(TransferableBlockUtils.getErrorTransferableBlock(new Exception("foo!")));
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, INT});
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, Collections.emptyList(),
-        Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
-        WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema, 1, 2, _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
+            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block1 = operator.nextBlock(); // build
@@ -101,11 +102,12 @@ public class WindowAggregateOperatorTest {
     Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, INT});
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, Collections.emptyList(),
-        Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
-        WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema, 1, 2, _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
+            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block = operator.nextBlock();
@@ -126,11 +128,12 @@ public class WindowAggregateOperatorTest {
         .thenReturn(TransferableBlockUtils.getNoOpTransferableBlock())
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, Collections.emptyList(),
-        Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
-        WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema, 1, 2, _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
+            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block1 = operator.nextBlock(); // build when reading NoOp block
@@ -156,11 +159,12 @@ public class WindowAggregateOperatorTest {
         .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{1, 2}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, Collections.emptyList(),
-        Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
-        WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema, 1, 2, _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
+            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block1 = operator.nextBlock(); // build when reading NoOp block
@@ -189,11 +193,12 @@ public class WindowAggregateOperatorTest {
     Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, 1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, Collections.emptyList(),
-        Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
-        WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema, 1, 2, _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
+            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -218,12 +223,13 @@ public class WindowAggregateOperatorTest {
     Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, 1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, order,
-        Arrays.asList(RelFieldCollation.Direction.ASCENDING), Arrays.asList(RelFieldCollation.NullDirection.LAST),
-        calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE, Collections.emptyList(),
-        outSchema, inSchema, 1, 2, _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, order, Arrays.asList(RelFieldCollation.Direction.ASCENDING),
+            Arrays.asList(RelFieldCollation.NullDirection.LAST), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema,
+            OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -246,12 +252,12 @@ public class WindowAggregateOperatorTest {
     Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, 1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, Collections.emptyList(),
-        Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE,
-        Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema, 1, 2,
-        _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
+            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -275,11 +281,12 @@ public class WindowAggregateOperatorTest {
     Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, 3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, Collections.emptyList(),
-        Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
-        WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema, 1, 2, _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
+            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -309,12 +316,12 @@ public class WindowAggregateOperatorTest {
     AggregationUtils.Merger merger = Mockito.mock(AggregationUtils.Merger.class);
     Mockito.when(merger.merge(Mockito.any(), Mockito.any())).thenReturn(12d);
     Mockito.when(merger.initialize(Mockito.any(), Mockito.any())).thenReturn(1d);
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, Collections.emptyList(),
-        Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
-        WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema,
-        ImmutableMap.of("SUM", cdt -> merger), 1, 2, _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
+            Collections.emptyList(), outSchema, inSchema, ImmutableMap.of("SUM", cdt -> merger), 1, 2, _serverAddress);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock(); // (output result)
@@ -332,28 +339,27 @@ public class WindowAggregateOperatorTest {
         "Expected three columns (original two columns, agg literal value)");
   }
 
-
   @Test
   public void testPartitionByWindowAggregateWithHashCollision() {
     MultiStageOperator upstreamOperator = OperatorTestUtil.getOperator(OperatorTestUtil.OP_1);
     // Create an aggregation call with sum for first column and group by second column.
     RexExpression.FunctionCall agg = getSum(new RexExpression.InputRef(0));
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, INT});
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator sum0PartitionBy1 =
         new WindowAggregateOperator(upstreamOperator, Arrays.asList(new RexExpression.InputRef(1)),
             Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Arrays.asList(agg),
             Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema,
-            inSchema, 1, 2, _serverAddress);
+            inSchema, OperatorTestUtil.getDefaultContext());
 
     TransferableBlock result = sum0PartitionBy1.getNextBlock();
     while (result.isNoOpBlock()) {
       result = sum0PartitionBy1.getNextBlock();
     }
     List<Object[]> resultRows = result.getContainer();
-    List<Object[]> expectedRows = Arrays.asList(new Object[]{2, "BB", 5.0}, new Object[]{3, "BB", 5.0},
-        new Object[]{1, "Aa", 1});
+    List<Object[]> expectedRows =
+        Arrays.asList(new Object[]{2, "BB", 5.0}, new Object[]{3, "BB", 5.0}, new Object[]{1, "Aa", 1});
     Assert.assertEquals(resultRows.size(), expectedRows.size());
     Assert.assertEquals(resultRows.get(0), expectedRows.get(0));
     Assert.assertEquals(resultRows.get(1), expectedRows.get(1));
@@ -371,9 +377,10 @@ public class WindowAggregateOperatorTest {
     DataSchema inSchema = new DataSchema(new String[]{"unknown"}, new DataSchema.ColumnDataType[]{DOUBLE});
 
     // When:
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, Collections.emptyList(),
-        Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
-        WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema, 1, 2, _serverAddress);
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
+            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
   }
 
   @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*Unexpected aggregation "
@@ -388,9 +395,10 @@ public class WindowAggregateOperatorTest {
     DataSchema inSchema = new DataSchema(new String[]{"unknown"}, new DataSchema.ColumnDataType[]{DOUBLE});
 
     // When:
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, Collections.emptyList(),
-        Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
-        WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema, 1, 2, _serverAddress);
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
+            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
   }
 
   @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Order by is not yet "
@@ -403,16 +411,16 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> order = ImmutableList.of(new RexExpression.InputRef(1));
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
-    Mockito.when(_input.nextBlock())
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
+    Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, order,
-        Arrays.asList(RelFieldCollation.Direction.ASCENDING), Arrays.asList(RelFieldCollation.NullDirection.LAST),
-        calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE, Collections.emptyList(),
-        outSchema, inSchema, 1, 2, _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, order, Arrays.asList(RelFieldCollation.Direction.ASCENDING),
+            Arrays.asList(RelFieldCollation.NullDirection.LAST), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema,
+            OperatorTestUtil.getDefaultContext());
   }
 
   @Test
@@ -426,18 +434,18 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> order = ImmutableList.of(new RexExpression.InputRef(1));
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
-    Mockito.when(_input.nextBlock())
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
+    Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
         .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "bar"}))
         .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{3, "foo"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, order,
-        Arrays.asList(RelFieldCollation.Direction.DESCENDING), Arrays.asList(RelFieldCollation.NullDirection.LAST),
-        calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE, Collections.emptyList(),
-        outSchema, inSchema, 1, 2, _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, order, Arrays.asList(RelFieldCollation.Direction.DESCENDING),
+            Arrays.asList(RelFieldCollation.NullDirection.LAST), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema,
+            OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock(); // (output result)
@@ -460,16 +468,15 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
-    Mockito.when(_input.nextBlock())
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
+    Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, Collections.emptyList(),
-        Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
-        WindowNode.WindowFrameType.ROW, Collections.emptyList(), outSchema, inSchema, 1, 2,
-        _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.ROW,
+            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
   }
 
   @Test
@@ -480,16 +487,16 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> order = ImmutableList.of(new RexExpression.InputRef(1));
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
-    Mockito.when(_input.nextBlock())
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
+    Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, order,
-        Arrays.asList(RelFieldCollation.Direction.ASCENDING), Arrays.asList(RelFieldCollation.NullDirection.LAST),
-        calls, Integer.MIN_VALUE, 0, WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema,
-        inSchema, 1, 2, _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, order, Arrays.asList(RelFieldCollation.Direction.ASCENDING),
+            Arrays.asList(RelFieldCollation.NullDirection.LAST), calls, Integer.MIN_VALUE, 0,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema,
+            OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -512,16 +519,15 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
-    Mockito.when(_input.nextBlock())
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
+    Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, Collections.emptyList(),
-        Collections.emptyList(), Collections.emptyList(), calls, 5, Integer.MAX_VALUE,
-        WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema, 1, 2,
-        _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), calls, 5, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
+            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
   }
 
   @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Only default frame is "
@@ -533,15 +539,15 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
-    Mockito.when(_input.nextBlock())
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
+    Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, Collections.emptyList(),
-        Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, 5,
-        WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema, 1, 2, _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, 5, WindowNode.WindowFrameType.RANGE,
+            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
   }
 
   @Test
@@ -553,16 +559,16 @@ public class WindowAggregateOperatorTest {
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
     // TODO: it is necessary to produce two values here, the operator only throws on second
     // (see the comment in WindowAggregate operator)
-    Mockito.when(_input.nextBlock())
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "metallica"}))
+    Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "metallica"}))
         .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "pink floyd"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"},
-        new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
-    WindowAggregateOperator operator = new WindowAggregateOperator(_input, group, Collections.emptyList(),
-        Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
-        WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema, 1, 2, _serverAddress);
+    DataSchema outSchema =
+        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
+    WindowAggregateOperator operator =
+        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
+            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
 
     // When:
     TransferableBlock block = operator.nextBlock();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
@@ -81,9 +81,9 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
-            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
 
     // When:
     TransferableBlock block1 = operator.nextBlock(); // build
@@ -105,9 +105,9 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
-            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
 
     // When:
     TransferableBlock block = operator.nextBlock();
@@ -131,9 +131,9 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
-            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
 
     // When:
     TransferableBlock block1 = operator.nextBlock(); // build when reading NoOp block
@@ -162,9 +162,9 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
-            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
 
     // When:
     TransferableBlock block1 = operator.nextBlock(); // build when reading NoOp block
@@ -196,9 +196,9 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
-            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -226,10 +226,10 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, order, Arrays.asList(RelFieldCollation.Direction.ASCENDING),
-            Arrays.asList(RelFieldCollation.NullDirection.LAST), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
-            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema,
-            OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, order,
+            Arrays.asList(RelFieldCollation.Direction.ASCENDING), Arrays.asList(RelFieldCollation.NullDirection.LAST),
+            calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE, Collections.emptyList(),
+            outSchema, inSchema);
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -255,9 +255,9 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, Collections.emptyList(), Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
-            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE,
+            Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -284,9 +284,9 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
-            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -319,10 +319,10 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
-            Collections.emptyList(), outSchema, inSchema, ImmutableMap.of("SUM", cdt -> merger),
-            OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema,
+            ImmutableMap.of("SUM", cdt -> merger));
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock(); // (output result)
@@ -349,10 +349,10 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator sum0PartitionBy1 =
-        new WindowAggregateOperator(upstreamOperator, Arrays.asList(new RexExpression.InputRef(1)),
-            Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), Arrays.asList(agg),
-            Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema,
-            inSchema, OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), upstreamOperator,
+            Arrays.asList(new RexExpression.InputRef(1)), Collections.emptyList(), Collections.emptyList(),
+            Collections.emptyList(), Arrays.asList(agg), Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
 
     TransferableBlock result = sum0PartitionBy1.getNextBlock();
     while (result.isNoOpBlock()) {
@@ -379,9 +379,9 @@ public class WindowAggregateOperatorTest {
 
     // When:
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
-            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
   }
 
   @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*Unexpected aggregation "
@@ -397,9 +397,9 @@ public class WindowAggregateOperatorTest {
 
     // When:
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
-            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
   }
 
   @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Order by is not yet "
@@ -418,10 +418,10 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, order, Arrays.asList(RelFieldCollation.Direction.ASCENDING),
-            Arrays.asList(RelFieldCollation.NullDirection.LAST), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
-            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema,
-            OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, order,
+            Arrays.asList(RelFieldCollation.Direction.ASCENDING), Arrays.asList(RelFieldCollation.NullDirection.LAST),
+            calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE, Collections.emptyList(),
+            outSchema, inSchema);
   }
 
   @Test
@@ -443,10 +443,10 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, order, Arrays.asList(RelFieldCollation.Direction.DESCENDING),
-            Arrays.asList(RelFieldCollation.NullDirection.LAST), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
-            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema,
-            OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, order,
+            Arrays.asList(RelFieldCollation.Direction.DESCENDING), Arrays.asList(RelFieldCollation.NullDirection.LAST),
+            calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE, Collections.emptyList(),
+            outSchema, inSchema);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock(); // (output result)
@@ -475,9 +475,9 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.ROW,
-            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.ROW, Collections.emptyList(), outSchema, inSchema);
   }
 
   @Test
@@ -494,10 +494,10 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, order, Arrays.asList(RelFieldCollation.Direction.ASCENDING),
-            Arrays.asList(RelFieldCollation.NullDirection.LAST), calls, Integer.MIN_VALUE, 0,
-            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema,
-            OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, order,
+            Arrays.asList(RelFieldCollation.Direction.ASCENDING), Arrays.asList(RelFieldCollation.NullDirection.LAST),
+            calls, Integer.MIN_VALUE, 0, WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema,
+            inSchema);
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -526,9 +526,9 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), calls, 5, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
-            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(), calls, 5, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
   }
 
   @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Only default frame is "
@@ -546,9 +546,9 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), calls, Integer.MIN_VALUE, 5, WindowNode.WindowFrameType.RANGE,
-            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, 5,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
   }
 
   @Test
@@ -567,9 +567,9 @@ public class WindowAggregateOperatorTest {
     DataSchema outSchema =
         new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(_input, group, Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE,
-            Collections.emptyList(), outSchema, inSchema, OperatorTestUtil.getDefaultContext());
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
+            Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
+            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
 
     // When:
     TransferableBlock block = operator.nextBlock();


### PR DESCRIPTION
This will allow us to easily add more params to operators constructors in the future without major refactoring.