### PR TITLE
Fix ramping delay caused by long lasting sequence of unfiltered messa…

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -89,7 +89,6 @@ import org.apache.pinot.spi.stream.StreamDataDecoderImpl;
 import org.apache.pinot.spi.stream.StreamDataDecoderResult;
 import org.apache.pinot.spi.stream.StreamDecoderProvider;
 import org.apache.pinot.spi.stream.StreamMessageDecoder;
-import org.apache.pinot.spi.stream.StreamMessageMetadata;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffsetFactory;
@@ -1585,8 +1584,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
   private void updateIngestionDelay(RowMetadata metadata) {
     if (metadata != null) {
-      _realtimeTableDataManager.updateIngestionDelay(metadata.getRecordIngestionTimeMs(), metadata.getFirstStreamRecordIngestionTimeMs(),
-          _partitionGroupId);
+      _realtimeTableDataManager.updateIngestionDelay(metadata.getRecordIngestionTimeMs(),
+          metadata.getFirstStreamRecordIngestionTimeMs(), _partitionGroupId);
     }
   }
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
@@ -32,24 +32,25 @@ public class KafkaMessageBatch implements MessageBatch<StreamMessage<byte[]>> {
   private final List<StreamMessage<byte[]>> _messageList;
   private final int _unfilteredMessageCount;
   private final long _lastOffset;
-  private final StreamMessageMetadata _lastTombstoneMetadata;
+  private final StreamMessageMetadata _lastMessageMetadata;
 
   /**
    * @param unfilteredMessageCount how many messages were received from the topic before being filtered
    * @param lastOffset the offset of the last message in the batch
    * @param batch the messages, which may be smaller than {@see unfilteredMessageCount}
+   * @param lastMessageMetadata metadata for last message in the batch, useful for estimating ingestion delay.
    */
   public KafkaMessageBatch(int unfilteredMessageCount, long lastOffset, List<StreamMessage<byte[]>> batch,
-      StreamMessageMetadata lastTombstoneMetadata) {
+      StreamMessageMetadata lastMessageMetadata) {
     _messageList = batch;
     _lastOffset = lastOffset;
     _unfilteredMessageCount = unfilteredMessageCount;
-    _lastTombstoneMetadata = lastTombstoneMetadata;
+    _lastMessageMetadata = lastMessageMetadata;
   }
 
   @Override
-  public StreamMessageMetadata getLastTombstoneMetadata() {
-    return _lastTombstoneMetadata;
+  public StreamMessageMetadata getLastMessageMetadata() {
+    return _lastMessageMetadata;
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
@@ -38,7 +38,8 @@ public class KafkaMessageBatch implements MessageBatch<StreamMessage<byte[]>> {
    * @param unfilteredMessageCount how many messages were received from the topic before being filtered
    * @param lastOffset the offset of the last message in the batch
    * @param batch the messages, which may be smaller than {@see unfilteredMessageCount}
-   * @param lastMessageMetadata metadata for last message in the batch, useful for estimating ingestion delay.
+   * @param lastMessageMetadata metadata for last filtered message in the batch, useful for estimating ingestion delay
+   *                            when a batch has all messages filtered.
    */
   public KafkaMessageBatch(int unfilteredMessageCount, long lastOffset, List<StreamMessage<byte[]>> batch,
       StreamMessageMetadata lastMessageMetadata) {
@@ -49,6 +50,9 @@ public class KafkaMessageBatch implements MessageBatch<StreamMessage<byte[]>> {
   }
 
   @Override
+  /**
+   * Returns the metadata for the last filtered message if any, null otherwise.
+   */
   public StreamMessageMetadata getLastMessageMetadata() {
     return _lastMessageMetadata;
   }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
@@ -24,6 +24,7 @@ import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.MessageBatch;
 import org.apache.pinot.spi.stream.RowMetadata;
 import org.apache.pinot.spi.stream.StreamMessage;
+import org.apache.pinot.spi.stream.StreamMessageMetadata;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 
 
@@ -31,16 +32,24 @@ public class KafkaMessageBatch implements MessageBatch<StreamMessage<byte[]>> {
   private final List<StreamMessage<byte[]>> _messageList;
   private final int _unfilteredMessageCount;
   private final long _lastOffset;
+  private final StreamMessageMetadata _lastTombstoneMetadata;
 
   /**
    * @param unfilteredMessageCount how many messages were received from the topic before being filtered
    * @param lastOffset the offset of the last message in the batch
    * @param batch the messages, which may be smaller than {@see unfilteredMessageCount}
    */
-  public KafkaMessageBatch(int unfilteredMessageCount, long lastOffset, List<StreamMessage<byte[]>> batch) {
+  public KafkaMessageBatch(int unfilteredMessageCount, long lastOffset, List<StreamMessage<byte[]>> batch,
+      StreamMessageMetadata lastTombstoneMetadata) {
     _messageList = batch;
     _lastOffset = lastOffset;
     _unfilteredMessageCount = unfilteredMessageCount;
+    _lastTombstoneMetadata = lastTombstoneMetadata;
+  }
+
+  @Override
+  public StreamMessageMetadata getLastTombstoneMetadata() {
+    return _lastTombstoneMetadata;
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
@@ -70,20 +70,19 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
     List<ConsumerRecord<String, Bytes>> messageAndOffsets = consumerRecords.records(_topicPartition);
     List<StreamMessage<byte[]>> filtered = new ArrayList<>(messageAndOffsets.size());
     long lastOffset = startOffset;
-    StreamMessageMetadata lastTombstoneMetadata = null;
+    StreamMessageMetadata rowMetadata = null;
     for (ConsumerRecord<String, Bytes> messageAndOffset : messageAndOffsets) {
       long offset = messageAndOffset.offset();
       _lastFetchedOffset = offset;
       if (offset >= startOffset && (endOffset > offset || endOffset < 0)) {
         Bytes message = messageAndOffset.value();
-        StreamMessageMetadata rowMetadata = (StreamMessageMetadata) _kafkaMetadataExtractor.extract(messageAndOffset);
+        rowMetadata = (StreamMessageMetadata) _kafkaMetadataExtractor.extract(messageAndOffset);
         if (message != null) {
           String key = messageAndOffset.key();
           byte[] keyBytes = key != null ? key.getBytes(StandardCharsets.UTF_8) : null;
           filtered.add(new KafkaStreamMessage(keyBytes, message.get(), rowMetadata));
         } else if (LOGGER.isDebugEnabled()) {
           LOGGER.debug("Tombstone message at offset: {}", offset);
-          lastTombstoneMetadata = rowMetadata;
         }
         lastOffset = offset;
       } else if (LOGGER.isDebugEnabled()) {
@@ -91,6 +90,6 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
             endOffset);
       }
     }
-    return new KafkaMessageBatch(messageAndOffsets.size(), lastOffset, filtered, lastTombstoneMetadata);
+    return new KafkaMessageBatch(messageAndOffsets.size(), lastOffset, filtered, rowMetadata);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.spi.stream;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
 
@@ -120,9 +121,12 @@ public interface MessageBatch<T> {
   /**
    * This is useful while determining ingestion delay for a message batch. Retaining metadata for last message in
    * a batch can enable us to estimate the ingestion delay for the batch.
+   * Note that a batch can be fully filtered, and we can still retain the metadata for the last message to facilitate
+   * computing ingestion delay in the face of a fully filtered batch.
    *
    * @return null by default.
    */
+  @Nullable
   default public StreamMessageMetadata getLastMessageMetadata() {
     return null;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
@@ -116,4 +116,12 @@ public interface MessageBatch<T> {
   default boolean isEndOfPartitionGroup() {
     return false;
   }
+
+  /**
+   * We need this to determine ingestion delay when we receive only null messages (Tombstone messages)
+   * @return last metadata for a null message received by the string
+   */
+  default public StreamMessageMetadata getLastTombstoneMetadata() {
+    return null;
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
@@ -119,10 +119,10 @@ public interface MessageBatch<T> {
   }
 
   /**
-   * This is useful while determining ingestion delay for a message batch. Retaining metadata for last message in
-   * a batch can enable us to estimate the ingestion delay for the batch.
-   * Note that a batch can be fully filtered, and we can still retain the metadata for the last message to facilitate
-   * computing ingestion delay in the face of a fully filtered batch.
+   * This is useful while determining ingestion delay for a message batch. Retaining metadata for last filtered message
+   * in a batch can enable us to estimate the ingestion delay for the batch.
+   * Note that a batch can be fully filtered, and we can still retain the metadata for the last filtered message to
+   * facilitate computing ingestion delay in the face of a fully filtered batch.
    *
    * @return null by default.
    */

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
@@ -118,10 +118,12 @@ public interface MessageBatch<T> {
   }
 
   /**
-   * We need this to determine ingestion delay when we receive only null messages (Tombstone messages)
-   * @return last metadata for a null message received by the string
+   * This is useful while determining ingestion delay for a message batch. Retaining metadata for last message in
+   * a batch can enable us to estimate the ingestion delay for the batch.
+   *
+   * @return null by default.
    */
-  default public StreamMessageMetadata getLastTombstoneMetadata() {
+  default public StreamMessageMetadata getLastMessageMetadata() {
     return null;
   }
 }


### PR DESCRIPTION
After observing our last-hop and end to end ingestion delay metrics for a few weeks in our production systems and getting some feedback from users in the OSS community we have come across the following special cases that may require special handling. Note that these scenarios are highly unlikely during normal operation but yet we still want to reflect the most accurate ingestion delay possible in each scenario: 

**_Scenario 1: All messages in a batch are filtered:_** (This change addresses this)

(i.e. messagesAndOffsets.getMessageCount() = 0 and messagesAndOffsets.getUnfilteredMessageCount() > 0)
In this case we currently report the ingestion delay for the last event consumed correctly by Pinot on a preceding batch. If we have continuous streams of all events filtered, this measure may not reflect the actual current situation. We originally thought of setting the delay to zero in this case but that will not be correct in the situation where we have a steady stream of all filtered events arriving as the queue of filtered events may be large. Setting the delay to zero in these cases may also lead to flickering metric in the scenario where batches of all-filtered messages are interspersed with batches with events that are not filtered: metrics would jump between a value and zero in this case. The best solution in this case is to preserve the metadata for the last filtered message on a batch and generate a precise ingestion delay from it. 

**_Scenario 2: All messages in a batch cause exceptions._** (No change for this scenario, current behavior is correct)
In this case we currently report the ingestion delay for the last  not-filtered message ingested correctly by Pinot aged by the time elapsed since the ingestion time. This seems correct by the semantic we intend for our metric: if we have a number of failures in decoding messages we should not count them as correctly ingested by Pinot and the increasing time should be a good signal for users to check other metrics and deal with the errors. 

**_Scenario 3: All transformed rows are empty._**  (this change addresses this)
If we receive events correctly but reusedResult.getTransformedRows() 
Is empty for all events in a batch, we will report the ingestion delay for the last, not-filtered message ingested correctly, aged by the time elapsed since the ingestion time. An alternative here would be to report the delay for the last message processed regardless of the function get transformed row returning empty. The current change does this: when all transformed rows return empty, we still record the timestamp if there was a message received carrying valid metadata.
