### PR TITLE
Adding dropResults parameter in queryOptions to drop the resultTable field from the response

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -253,17 +253,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     BrokerResponse brokerResponse = handleRequest(requestId, query, sqlNodeAndOptions, request,
             requesterIdentity, requestContext);
 
-    boolean dropResults = false;
-    if (request.has(Broker.Request.QUERY_OPTIONS)) {
-      String queryOptions = request.get(Broker.Request.QUERY_OPTIONS).asText();
-      Map<String, String> optionsFromString = RequestUtils.getOptionsFromString(queryOptions);
-      if (optionsFromString.getOrDefault(Broker.Request.QueryOptionKey.DROP_RESULTS, "false")
-              .equalsIgnoreCase("true")) {
-        dropResults = true;
-      }
-    }
-
-    if (dropResults) {
+    if (QueryOptionsUtils.isDropResultsEnabled(request)) {
       brokerResponse.setResultTable(null);
     }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -253,8 +253,12 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     BrokerResponse brokerResponse = handleRequest(requestId, query, sqlNodeAndOptions, request,
             requesterIdentity, requestContext);
 
-    if (QueryOptionsUtils.isDropResultsEnabled(request)) {
-      brokerResponse.setResultTable(null);
+    if (request.has(Broker.Request.QUERY_OPTIONS)) {
+      String queryOptions = request.get(Broker.Request.QUERY_OPTIONS).asText();
+      Map<String, String> optionsFromString = RequestUtils.getOptionsFromString(queryOptions);
+      if (QueryOptionsUtils.shouldDropResults(optionsFromString)) {
+        brokerResponse.setResultTable(null);
+      }
     }
 
     return brokerResponse;

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -321,7 +321,10 @@ public class BrokerResponseNative implements BrokerResponse {
   @Override
   public void setResultTable(ResultTable resultTable) {
     _resultTable = resultTable;
-    _numRowsResultSet = resultTable.getRows().size();
+    // If query level parameter is set to not return the results, then resultTable will be null.
+    if (resultTable != null) {
+      _numRowsResultSet = resultTable.getRows().size();
+    }
   }
 
   @JsonProperty("exceptions")

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.common.utils.config;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import java.lang.reflect.Field;
@@ -26,7 +25,6 @@ import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionValue;
@@ -194,17 +192,7 @@ public class QueryOptionsUtils {
     return groupByTrimThreshold != null ? Integer.parseInt(groupByTrimThreshold) : null;
   }
 
-  public static boolean isDropResultsEnabled(final JsonNode request) {
-    boolean dropResults = false;
-
-    if (request.has(CommonConstants.Broker.Request.QUERY_OPTIONS)) {
-      String queryOptions = request.get(CommonConstants.Broker.Request.QUERY_OPTIONS).asText();
-      Map<String, String> optionsFromString = RequestUtils.getOptionsFromString(queryOptions);
-      if (Boolean.parseBoolean(optionsFromString.get(CommonConstants.Broker.Request.QueryOptionKey.DROP_RESULTS))) {
-        dropResults = true;
-      }
-    }
-
-    return dropResults;
+  public static boolean shouldDropResults(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(CommonConstants.Broker.Request.QueryOptionKey.DROP_RESULTS));
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.utils.config;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableMap;
 import java.lang.reflect.Field;
@@ -25,6 +26,8 @@ import java.lang.reflect.Modifier;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionValue;
 
@@ -189,5 +192,19 @@ public class QueryOptionsUtils {
   public static Integer getGroupTrimThreshold(Map<String, String> queryOptions) {
     String groupByTrimThreshold = queryOptions.get(QueryOptionKey.GROUP_TRIM_THRESHOLD);
     return groupByTrimThreshold != null ? Integer.parseInt(groupByTrimThreshold) : null;
+  }
+
+  public static boolean isDropResultsEnabled(final JsonNode request) {
+    boolean dropResults = false;
+
+    if (request.has(CommonConstants.Broker.Request.QUERY_OPTIONS)) {
+      String queryOptions = request.get(CommonConstants.Broker.Request.QUERY_OPTIONS).asText();
+      Map<String, String> optionsFromString = RequestUtils.getOptionsFromString(queryOptions);
+      if (Boolean.parseBoolean(optionsFromString.get(CommonConstants.Broker.Request.QueryOptionKey.DROP_RESULTS))) {
+        dropResults = true;
+      }
+    }
+
+    return dropResults;
   }
 }

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -466,6 +466,16 @@ public abstract class ClusterTest extends ControllerTest {
   }
 
   /**
+   * Queries the broker's sql query endpoint (/query/sql) using query and queryOptions strings
+   */
+  protected JsonNode postQueryWithOptions(String query, String queryOptions) throws Exception {
+    ObjectNode payload = JsonUtils.newObjectNode();
+    payload.put("sql", query);
+    payload.put("queryOptions", queryOptions);
+    return JsonUtils.stringToJsonNode(sendPostRequest(_brokerBaseApiUrl + "/query/sql", payload.toString(), null));
+  }
+
+  /**
    * Queries the controller's sql query endpoint (/query/sql)
    */
   protected JsonNode postQueryToController(String query)

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -211,6 +211,21 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
   }
 
   @Test
+  public void testDropResults() throws Exception {
+    final String query = String.format("SELECT * FROM %s limit 10", getTableName());
+    final String resultTag = "resultTable";
+
+    // dropResults=true - resultTable must not be in the response
+    Assert.assertFalse(postQueryWithOptions(query, "dropResults=true").has(resultTag));
+
+    // dropResults=TrUE (case insensitive match) - resultTable must not be in the response
+    Assert.assertFalse(postQueryWithOptions(query, "dropResults=TrUE").has(resultTag));
+
+    // dropResults=truee - (anything other than true, is taken as false) - resultTable must be in the response
+    Assert.assertTrue(postQueryWithOptions(query, "dropResults=truee").has(resultTag));
+  }
+
+  @Test
   @Override
   public void testHardcodedQueries()
       throws Exception {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -317,6 +317,8 @@ public class CommonConstants {
         // Handle IN predicate evaluation for big IN lists
         public static final String IN_PREDICATE_SORT_THRESHOLD = "inPredicateSortThreshold";
 
+        public static final String DROP_RESULTS = "dropResults";
+
         // TODO: Remove these keys (only apply to PQL) after releasing 0.11.0
         @Deprecated
         public static final String PRESERVE_TYPE = "preserveType";


### PR DESCRIPTION
This PR adds a parameter to queryOptions to drop the resultTable from the response. This mode can be used to troubleshoot a customer's query (which may have sensitive data in the result) using metadata only.

Manual testing report:
```
% ./bin/quick-start-batch.sh
...
% curl http://localhost:9000/sql -d '{"sql":"select * from billing limit 10","trace":false}'
{"resultTable":{"dataSchema":{"columnNames":["alternateCharge","alternateUsage","baseCharge","baseUsage","billingMonth","buildingType","city","creditHistory","customerId","firstName","isCarOwner","lastName","levy","maritalStatus","missedPayment","overdueBalance","standingCharge","tax","totalNet","totalToPay"],"columnDataTypes":["BIG_DECIMAL","BIG_DECIMAL","BIG_DECIMAL","BIG_DECIMAL","STRING","STRING","STRING","STRING","INT","STRING","BOOLEAN","STRING","BIG_DECIMAL","STRING","STRING","BIG_DECIMAL","BIG_DECIMAL","BIG_DECIMAL","BIG_DECIMAL","BIG_DECIMAL"]},"rows":[[10.16,112.62,67.44,457.56,"201904","Condominium","Palo Alto","A",341,"Rebecca",false,"Effertz",2.55,"U","Paid",0,7.49,17.18,87.65,104.82],[0,0,150.32,1161.67,"201903","Condominium","Mountain View","A",374,"Reba",true,"OKeefe",4.68,"S","Paid",0,5.62,31.48,160.62,192.1],[0,0,58.13,449.21,"201904","Condominium","Palo Alto","A",398,"Sydnee",false,"Farrell",1.91,"S","Paid",0,5.62,12.87,65.66,78.53],[0,0,114.91,888.02,"201901","Apartment","Cupertino","A",427,"Susanna",false,"Schaefer",3.62,"S","Paid",0,5.62,24.33,124.15,148.48],[0,0,86.72,670.17,"201808","Apartment","Cupertino","B",435,"Stephen",true,"Conn",3.05,"M","Paid",0,14.87,20.51,104.64,125.15],[0,0,115.73,894.34,"201808","Apartment","Palo Alto","A",441,"Rickey",false,"Smitham",3.64,"M","Paid",0,5.62,24.5,124.99,149.49],[0,0,184.78,1427.99,"201808","Apartment","Cupertino","A",465,"Kristina",true,"Towne",5.99,"U","Paid",0,14.87,40.31,205.64,245.95],[0,0,57.59,445.09,"201904","Apartment","Mountain View","A",499,"Alexane",false,"Weber",1.95,"M","Paid",0,7.35,13.11,66.89,80],[0,0,95.55,738.44,"201810","Apartment","Santa Clara","A - Excellent",503,"Elouise",true,"Hickle",3.31,"U","Paid",0,14.87,22.29,113.74,136.03],[0,0,128.86,995.82,"201906","Apartment","Mountain View","A - Excellent",533,"Ansley",true,"Bogisich",4.03,"M","Paid",0,5.62,27.15,138.51,165.66]]},"exceptions":[],"numServersQueried":1,"numServersResponded":1,"numSegmentsQueried":1,"numSegmentsProcessed":1,"numSegmentsMatched":1,"numConsumingSegmentsQueried":0,"numConsumingSegmentsProcessed":0,"numConsumingSegmentsMatched":0,"numDocsScanned":10,"numEntriesScannedInFilter":0,"numEntriesScannedPostFilter":200,"numGroupsLimitReached":false,"totalDocs":694,"timeUsedMs":9,"offlineThreadCpuTimeNs":0,"realtimeThreadCpuTimeNs":0,"offlineSystemActivitiesCpuTimeNs":0,"realtimeSystemActivitiesCpuTimeNs":0,"offlineResponseSerializationCpuTimeNs":0,"realtimeResponseSerializationCpuTimeNs":0,"offlineTotalCpuTimeNs":0,"realtimeTotalCpuTimeNs":0,"segmentStatistics":[],"traceInfo":{},"minConsumingFreshnessTimeMs":0,"numSegmentsPrunedByBroker":0,"numSegmentsPrunedByServer":0,"numSegmentsPrunedInvalid":0,"numSegmentsPrunedByLimit":0,"numSegmentsPrunedByValue":0,"explainPlanNumEmptyFilterSegments":0,"explainPlanNumMatchAllFilterSegments":0,"numRowsResultSet":10}
% curl http://localhost:9000/sql -d '{"sql":"select * from billing limit 10","trace":false,"queryOptions":"dropResults=true"}'
{"exceptions":[],"numServersQueried":1,"numServersResponded":1,"numSegmentsQueried":1,"numSegmentsProcessed":1,"numSegmentsMatched":1,"numConsumingSegmentsQueried":0,"numConsumingSegmentsProcessed":0,"numConsumingSegmentsMatched":0,"numDocsScanned":10,"numEntriesScannedInFilter":0,"numEntriesScannedPostFilter":200,"numGroupsLimitReached":false,"totalDocs":694,"timeUsedMs":6,"offlineThreadCpuTimeNs":0,"realtimeThreadCpuTimeNs":0,"offlineSystemActivitiesCpuTimeNs":0,"realtimeSystemActivitiesCpuTimeNs":0,"offlineResponseSerializationCpuTimeNs":0,"realtimeResponseSerializationCpuTimeNs":0,"offlineTotalCpuTimeNs":0,"realtimeTotalCpuTimeNs":0,"segmentStatistics":[],"traceInfo":{},"minConsumingFreshnessTimeMs":0,"numSegmentsPrunedByBroker":0,"numSegmentsPrunedByServer":0,"numSegmentsPrunedInvalid":0,"numSegmentsPrunedByLimit":0,"numSegmentsPrunedByValue":0,"explainPlanNumEmptyFilterSegments":0,"explainPlanNumMatchAllFilterSegments":0,"numRowsResultSet":10}
% curl http://localhost:9000/sql -d '{"sql":"select * from billing limit 10","trace":false,"queryOptions":"dropResults=TrUE"}'
{"exceptions":[],"numServersQueried":1,"numServersResponded":1,"numSegmentsQueried":1,"numSegmentsProcessed":1,"numSegmentsMatched":1,"numConsumingSegmentsQueried":0,"numConsumingSegmentsProcessed":0,"numConsumingSegmentsMatched":0,"numDocsScanned":10,"numEntriesScannedInFilter":0,"numEntriesScannedPostFilter":200,"numGroupsLimitReached":false,"totalDocs":694,"timeUsedMs":2,"offlineThreadCpuTimeNs":0,"realtimeThreadCpuTimeNs":0,"offlineSystemActivitiesCpuTimeNs":0,"realtimeSystemActivitiesCpuTimeNs":0,"offlineResponseSerializationCpuTimeNs":0,"realtimeResponseSerializationCpuTimeNs":0,"offlineTotalCpuTimeNs":0,"realtimeTotalCpuTimeNs":0,"segmentStatistics":[],"traceInfo":{},"minConsumingFreshnessTimeMs":0,"numSegmentsPrunedByBroker":0,"numSegmentsPrunedByServer":0,"numSegmentsPrunedInvalid":0,"numSegmentsPrunedByLimit":0,"numSegmentsPrunedByValue":0,"explainPlanNumEmptyFilterSegments":0,"explainPlanNumMatchAllFilterSegments":0,"numRowsResultSet":10}
```

Added integration tests as well.