### PR TITLE
(..........NOT READY FOR REVIEW ........) Unifying aggregation API

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -213,7 +213,6 @@ public class TableRebalancer {
     List<Tier> sortedTiers = getSortedTiers(tableConfig);
     Map<String, InstancePartitions> tierToInstancePartitionsMap =
         getTierToInstancePartitionsMap(tableConfig, sortedTiers, reassignInstances, bootstrap, dryRun);
-
     LOGGER.info("Calculating the target assignment for table: {}", tableNameWithType);
     SegmentAssignment segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(_helixManager, tableConfig);
     Map<String, Map<String, String>> currentAssignment = currentIdealState.getRecord().getMapFields();

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/DistinctCountHLLAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/DistinctCountHLLAggregator.java
@@ -21,7 +21,7 @@ package org.apache.pinot.core.segment.processing.aggregator;
 import com.clearspring.analytics.stream.cardinality.CardinalityMergeException;
 import com.clearspring.analytics.stream.cardinality.HyperLogLog;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
-
+import org.apache.pinot.segment.local.utils.CustomSerDeUtils;
 
 public class DistinctCountHLLAggregator implements ValueAggregator {
   @Override
@@ -30,7 +30,7 @@ public class DistinctCountHLLAggregator implements ValueAggregator {
       HyperLogLog first = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize((byte[]) value1);
       HyperLogLog second = ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.deserialize((byte[]) value2);
       first.addAll(second);
-      return ObjectSerDeUtils.HYPER_LOG_LOG_SER_DE.serialize(first);
+      return CustomSerDeUtils.HYPER_LOG_LOG_SER_DE.serialize(first);
     } catch (CardinalityMergeException e) {
       throw new RuntimeException(e);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/ValueAggregatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/ValueAggregatorFactory.java
@@ -18,6 +18,11 @@
  */
 package org.apache.pinot.core.segment.processing.aggregator;
 
+import org.apache.pinot.segment.local.aggregator.*;
+import org.apache.pinot.segment.local.aggregator.MaxValueAggregator;
+import org.apache.pinot.segment.local.aggregator.MinValueAggregator;
+import org.apache.pinot.segment.local.aggregator.SumValueAggregator;
+import org.apache.pinot.segment.local.aggregator.ValueAggregator;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -33,6 +38,7 @@ public class ValueAggregatorFactory {
    * Constructs a ValueAggregator from the given aggregation type.
    */
   public static ValueAggregator getValueAggregator(AggregationFunctionType aggregationType, DataType dataType) {
+
     switch (aggregationType) {
       case MIN:
         return new MinValueAggregator(dataType);
@@ -42,10 +48,10 @@ public class ValueAggregatorFactory {
         return new SumValueAggregator(dataType);
       case DISTINCTCOUNTHLL:
       case DISTINCTCOUNTRAWHLL:
-        return new DistinctCountHLLAggregator();
+        return new DistinctCountHLLValueAggregator();
       case DISTINCTCOUNTTHETASKETCH:
       case DISTINCTCOUNTRAWTHETASKETCH:
-        return new DistinctCountThetaSketchAggregator();
+        return new DistinctCountThetaSketchValueAggregator();
       default:
         throw new IllegalStateException("Unsupported aggregation type: " + aggregationType);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/RollupReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/RollupReducer.java
@@ -23,8 +23,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.core.segment.processing.aggregator.ValueAggregator;
 import org.apache.pinot.core.segment.processing.aggregator.ValueAggregatorFactory;
+import org.apache.pinot.segment.local.aggregator.ValueAggregator;
 import org.apache.pinot.core.segment.processing.genericrow.GenericRowFileManager;
 import org.apache.pinot.core.segment.processing.genericrow.GenericRowFileReader;
 import org.apache.pinot.core.segment.processing.genericrow.GenericRowFileRecordReader;
@@ -146,7 +146,7 @@ public class RollupReducer implements Reducer {
       } else {
         // Non-null field, aggregate the value
         aggregatedRow.putValue(column,
-            aggregatorContext._aggregator.aggregate(aggregatedRow.getValue(column), rowToAggregate.getValue(column)));
+            aggregatorContext._aggregator.applyAggregatedValue(aggregatedRow.getValue(column), rowToAggregate.getValue(column)));
       }
     }
   }
@@ -156,7 +156,7 @@ public class RollupReducer implements Reducer {
     for (AggregatorContext aggregatorContext : aggregatorContextList) {
       String column = aggregatorContext._column;
       aggregatedRow.putValue(column,
-          aggregatorContext._aggregator.aggregate(aggregatedRow.getValue(column), rowToAggregate.getValue(column)));
+          aggregatorContext._aggregator.applyAggregatedValue(aggregatedRow.getValue(column), rowToAggregate.getValue(column)));
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountHLLStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountHLLStarTreeV2Test.java
@@ -27,10 +27,10 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import static org.testng.Assert.assertEquals;
 
 
-public class DistinctCountHLLStarTreeV2Test extends BaseStarTreeV2Test<Object, HyperLogLog> {
+public class DistinctCountHLLStarTreeV2Test extends BaseStarTreeV2Test<Object, Object> {
 
   @Override
-  ValueAggregator<Object, HyperLogLog> getValueAggregator() {
+  ValueAggregator<Object, Object> getValueAggregator() {
     return new DistinctCountHLLValueAggregator();
   }
 
@@ -45,7 +45,9 @@ public class DistinctCountHLLStarTreeV2Test extends BaseStarTreeV2Test<Object, H
   }
 
   @Override
-  void assertAggregatedValue(HyperLogLog starTreeResult, HyperLogLog nonStarTreeResult) {
-    assertEquals(starTreeResult.cardinality(), nonStarTreeResult.cardinality());
+  void assertAggregatedValue(Object starTreeResult, Object nonStarTreeResult) {
+    HyperLogLog v1 = (HyperLogLog) starTreeResult;
+    HyperLogLog v2 = (HyperLogLog) nonStarTreeResult;
+    assertEquals(v1.cardinality(), v2.cardinality());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountThetaSketchStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/DistinctCountThetaSketchStarTreeV2Test.java
@@ -27,10 +27,10 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import static org.testng.Assert.assertEquals;
 
 
-public class DistinctCountThetaSketchStarTreeV2Test extends BaseStarTreeV2Test<Object, Sketch> {
+public class DistinctCountThetaSketchStarTreeV2Test extends BaseStarTreeV2Test<Object, Object> {
 
   @Override
-  ValueAggregator<Object, Sketch> getValueAggregator() {
+  ValueAggregator<Object, Object> getValueAggregator() {
     return new DistinctCountThetaSketchValueAggregator();
   }
 
@@ -45,7 +45,9 @@ public class DistinctCountThetaSketchStarTreeV2Test extends BaseStarTreeV2Test<O
   }
 
   @Override
-  void assertAggregatedValue(Sketch starTreeResult, Sketch nonStarTreeResult) {
-    assertEquals(starTreeResult.getEstimate(), nonStarTreeResult.getEstimate());
+  void assertAggregatedValue(Object starTreeResult, Object nonStarTreeResult) {
+    Sketch v1 = (Sketch) starTreeResult;
+    Sketch v2 = (Sketch) nonStarTreeResult;
+    assertEquals(v1.getEstimate(), v2.getEstimate());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/MaxStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/MaxStarTreeV2Test.java
@@ -26,11 +26,11 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import static org.testng.Assert.assertEquals;
 
 
-public class MaxStarTreeV2Test extends BaseStarTreeV2Test<Number, Double> {
+public class MaxStarTreeV2Test extends BaseStarTreeV2Test<Number, Number> {
 
   @Override
-  ValueAggregator<Number, Double> getValueAggregator() {
-    return new MaxValueAggregator();
+  ValueAggregator<Number, Number> getValueAggregator() {
+    return new MaxValueAggregator(DataType.DOUBLE);
   }
 
   @Override
@@ -44,7 +44,7 @@ public class MaxStarTreeV2Test extends BaseStarTreeV2Test<Number, Double> {
   }
 
   @Override
-  protected void assertAggregatedValue(Double starTreeResult, Double nonStarTreeResult) {
-    assertEquals(starTreeResult, nonStarTreeResult, 1e-5);
+  protected void assertAggregatedValue(Number starTreeResult, Number nonStarTreeResult) {
+    assertEquals(starTreeResult.doubleValue(), nonStarTreeResult.doubleValue(), 1e-5);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/MinStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/MinStarTreeV2Test.java
@@ -26,16 +26,16 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import static org.testng.Assert.assertEquals;
 
 
-public class MinStarTreeV2Test extends BaseStarTreeV2Test<Number, Double> {
+public class MinStarTreeV2Test extends BaseStarTreeV2Test<Number, Number> {
 
   @Override
-  ValueAggregator<Number, Double> getValueAggregator() {
-    return new MinValueAggregator();
+  ValueAggregator<Number, Number> getValueAggregator() {
+    return new MinValueAggregator(DataType.DOUBLE);
   }
 
   @Override
   DataType getRawValueType() {
-    return DataType.FLOAT;
+    return DataType.DOUBLE;
   }
 
   @Override
@@ -44,7 +44,7 @@ public class MinStarTreeV2Test extends BaseStarTreeV2Test<Number, Double> {
   }
 
   @Override
-  protected void assertAggregatedValue(Double starTreeResult, Double nonStarTreeResult) {
-    assertEquals(starTreeResult, nonStarTreeResult, 1e-5);
+  protected void assertAggregatedValue(Number starTreeResult, Number nonStarTreeResult) {
+    assertEquals(starTreeResult.doubleValue(), nonStarTreeResult.doubleValue(), 1e-5);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/PreAggregatedDistinctCountHLLStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/PreAggregatedDistinctCountHLLStarTreeV2Test.java
@@ -28,12 +28,12 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import static org.testng.Assert.assertEquals;
 
 
-public class PreAggregatedDistinctCountHLLStarTreeV2Test extends BaseStarTreeV2Test<Object, HyperLogLog> {
+public class PreAggregatedDistinctCountHLLStarTreeV2Test extends BaseStarTreeV2Test<Object, Object> {
   // Use non-default log2m
   private static final int LOG2M = 7;
 
   @Override
-  ValueAggregator<Object, HyperLogLog> getValueAggregator() {
+  ValueAggregator<Object, Object> getValueAggregator() {
     return new DistinctCountHLLValueAggregator();
   }
 
@@ -51,7 +51,9 @@ public class PreAggregatedDistinctCountHLLStarTreeV2Test extends BaseStarTreeV2T
   }
 
   @Override
-  void assertAggregatedValue(HyperLogLog starTreeResult, HyperLogLog nonStarTreeResult) {
-    assertEquals(starTreeResult.cardinality(), nonStarTreeResult.cardinality());
+  void assertAggregatedValue(Object starTreeResult, Object nonStarTreeResult) {
+    HyperLogLog v1 = (HyperLogLog) starTreeResult;
+    HyperLogLog v2 = (HyperLogLog) nonStarTreeResult;
+    assertEquals(v1.cardinality(), v2.cardinality());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/SumStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/SumStarTreeV2Test.java
@@ -26,16 +26,16 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 import static org.testng.Assert.assertEquals;
 
 
-public class SumStarTreeV2Test extends BaseStarTreeV2Test<Number, Double> {
+public class SumStarTreeV2Test extends BaseStarTreeV2Test<Number, Number> {
 
   @Override
-  ValueAggregator<Number, Double> getValueAggregator() {
-    return new SumValueAggregator();
+  ValueAggregator<Number, Number> getValueAggregator() {
+    return new SumValueAggregator(DataType.DOUBLE);
   }
 
   @Override
   DataType getRawValueType() {
-    return DataType.INT;
+    return DataType.DOUBLE;
   }
 
   @Override
@@ -44,7 +44,7 @@ public class SumStarTreeV2Test extends BaseStarTreeV2Test<Number, Double> {
   }
 
   @Override
-  protected void assertAggregatedValue(Double starTreeResult, Double nonStarTreeResult) {
-    assertEquals(starTreeResult, nonStarTreeResult, 1e-5);
+  protected void assertAggregatedValue(Number starTreeResult, Number nonStarTreeResult) {
+    assertEquals((double) starTreeResult, (double) nonStarTreeResult, 1e-5);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/MaxValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/MaxValueAggregator.java
@@ -22,9 +22,12 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
-public class MaxValueAggregator implements ValueAggregator<Number, Double> {
+public class MaxValueAggregator implements ValueAggregator<Number, Number> {
   public static final DataType AGGREGATED_VALUE_TYPE = DataType.DOUBLE;
-
+  private DataType _dataType;
+  public MaxValueAggregator(DataType dataType) {
+    _dataType = dataType;
+  }
   @Override
   public AggregationFunctionType getAggregationType() {
     return AggregationFunctionType.MAX;
@@ -36,22 +39,22 @@ public class MaxValueAggregator implements ValueAggregator<Number, Double> {
   }
 
   @Override
-  public Double getInitialAggregatedValue(Number rawValue) {
-    return rawValue.doubleValue();
+  public Number getInitialAggregatedValue(Number rawValue) {
+    return rawValue;
   }
 
   @Override
-  public Double applyRawValue(Double value, Number rawValue) {
-    return Math.max(value, rawValue.doubleValue());
+  public Number applyRawValue(Number value, Number rawValue) {
+    return getMax(value, rawValue);
   }
 
   @Override
-  public Double applyAggregatedValue(Double value, Double aggregatedValue) {
-    return Math.max(value, aggregatedValue);
+  public Number applyAggregatedValue(Number value, Number aggregatedValue) {
+    return getMax(value, aggregatedValue);
   }
 
   @Override
-  public Double cloneAggregatedValue(Double value) {
+  public Number cloneAggregatedValue(Number value) {
     return value;
   }
 
@@ -61,12 +64,33 @@ public class MaxValueAggregator implements ValueAggregator<Number, Double> {
   }
 
   @Override
-  public byte[] serializeAggregatedValue(Double value) {
+  public byte[] serializeAggregatedValue(Number value) {
     throw new UnsupportedOperationException();
   }
 
   @Override
   public Double deserializeAggregatedValue(byte[] bytes) {
     throw new UnsupportedOperationException();
+  }
+
+  private Number getMax(Number value1, Number value2) {
+    Number result;
+    switch (_dataType) {
+      case INT:
+        result = Math.max(value1.intValue(), value2.intValue());
+        break;
+      case LONG:
+        result = Math.max(value1.longValue(), value2.longValue());
+        break;
+      case FLOAT:
+        result = Math.max(value1.floatValue(), value2.floatValue());
+        break;
+      case DOUBLE:
+        result = Math.max(value1.doubleValue(), value2.doubleValue());
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported metric type : " + _dataType);
+    }
+    return result;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/MinValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/MinValueAggregator.java
@@ -22,8 +22,13 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
-public class MinValueAggregator implements ValueAggregator<Number, Double> {
+public class MinValueAggregator implements ValueAggregator<Number, Number> {
   public static final DataType AGGREGATED_VALUE_TYPE = DataType.DOUBLE;
+  private DataType _dataType;
+
+  public MinValueAggregator(DataType dataType) {
+    _dataType = dataType;
+  }
 
   @Override
   public AggregationFunctionType getAggregationType() {
@@ -36,22 +41,22 @@ public class MinValueAggregator implements ValueAggregator<Number, Double> {
   }
 
   @Override
-  public Double getInitialAggregatedValue(Number rawValue) {
-    return rawValue.doubleValue();
+  public Number getInitialAggregatedValue(Number rawValue) {
+    return rawValue;
   }
 
   @Override
-  public Double applyRawValue(Double value, Number rawValue) {
-    return Math.min(value, rawValue.doubleValue());
+  public Number applyRawValue(Number value, Number rawValue) {
+    return getMinimum(value, rawValue);
   }
 
   @Override
-  public Double applyAggregatedValue(Double value, Double aggregatedValue) {
-    return Math.min(value, aggregatedValue);
+  public Number applyAggregatedValue(Number value, Number aggregatedValue) {
+    return getMinimum(value, aggregatedValue);
   }
 
   @Override
-  public Double cloneAggregatedValue(Double value) {
+  public Number cloneAggregatedValue(Number value) {
     return value;
   }
 
@@ -61,12 +66,33 @@ public class MinValueAggregator implements ValueAggregator<Number, Double> {
   }
 
   @Override
-  public byte[] serializeAggregatedValue(Double value) {
+  public byte[] serializeAggregatedValue(Number value) {
     throw new UnsupportedOperationException();
   }
 
   @Override
   public Double deserializeAggregatedValue(byte[] bytes) {
     throw new UnsupportedOperationException();
+  }
+
+  private Number getMinimum(Number value1, Number value2) {
+    Number result;
+    switch (_dataType) {
+      case INT:
+        result = Math.min(value1.intValue(), value2.intValue());
+        break;
+      case LONG:
+        result = Math.min(value1.longValue(), value2.longValue());
+        break;
+      case FLOAT:
+        result = Math.min(value1.floatValue(), value2.floatValue());
+        break;
+      case DOUBLE:
+        result = Math.min(value1.doubleValue(), value2.doubleValue());
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported metric type : " + _dataType);
+    }
+    return result;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/SumValueAggregator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/SumValueAggregator.java
@@ -22,8 +22,13 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
-public class SumValueAggregator implements ValueAggregator<Number, Double> {
+public class SumValueAggregator implements ValueAggregator<Number, Number> {
   public static final DataType AGGREGATED_VALUE_TYPE = DataType.DOUBLE;
+  private final DataType _dataType;
+
+  public SumValueAggregator(DataType dataType) {
+    _dataType = dataType;
+  }
 
   @Override
   public AggregationFunctionType getAggregationType() {
@@ -36,22 +41,22 @@ public class SumValueAggregator implements ValueAggregator<Number, Double> {
   }
 
   @Override
-  public Double getInitialAggregatedValue(Number rawValue) {
-    return rawValue.doubleValue();
+  public Number getInitialAggregatedValue(Number rawValue) {
+    return rawValue;
   }
 
   @Override
-  public Double applyRawValue(Double value, Number rawValue) {
-    return value + rawValue.doubleValue();
+  public Number applyRawValue(Number value, Number rawValue) {
+    return sum(value, rawValue);
   }
 
   @Override
-  public Double applyAggregatedValue(Double value, Double aggregatedValue) {
-    return value + aggregatedValue;
+  public Number applyAggregatedValue(Number value, Number aggregatedValue) {
+    return sum(value, aggregatedValue);
   }
 
   @Override
-  public Double cloneAggregatedValue(Double value) {
+  public Number cloneAggregatedValue(Number value) {
     return value;
   }
 
@@ -61,12 +66,33 @@ public class SumValueAggregator implements ValueAggregator<Number, Double> {
   }
 
   @Override
-  public byte[] serializeAggregatedValue(Double value) {
+  public byte[] serializeAggregatedValue(Number value) {
     throw new UnsupportedOperationException();
   }
 
   @Override
   public Double deserializeAggregatedValue(byte[] bytes) {
     throw new UnsupportedOperationException();
+  }
+
+  private Number sum(Number value1, Number value2) {
+    Number result;
+    switch (_dataType) {
+      case INT:
+        result = value1.intValue() + value2.intValue();
+        break;
+      case LONG:
+        result = value1.longValue() + value2.longValue();
+        break;
+      case FLOAT:
+        result = value1.floatValue() + value2.floatValue();
+        break;
+      case DOUBLE:
+        result = value1.doubleValue() + value2.doubleValue();
+        break;
+      default:
+        throw new IllegalArgumentException("Unsupported metric type for SUM aggregator : " + AGGREGATED_VALUE_TYPE);
+    }
+    return result;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/aggregator/ValueAggregatorFactory.java
@@ -41,11 +41,11 @@ public class ValueAggregatorFactory {
       case COUNT:
         return new CountValueAggregator();
       case MIN:
-        return new MinValueAggregator();
+        return new MinValueAggregator(DataType.DOUBLE);
       case MAX:
-        return new MaxValueAggregator();
+        return new MaxValueAggregator(DataType.DOUBLE);
       case SUM:
-        return new SumValueAggregator();
+        return new SumValueAggregator(DataType.DOUBLE);
       case SUMPRECISION:
         return new SumPrecisionValueAggregator();
       case AVG:


### PR DESCRIPTION
[**Still WIP....**.]

**Problem**:
Today we have 2 aggregation apis ([batch](https://github.com/apache/pinot/blob/f809e50d678ddd0963350a6e59743788c31d13bd/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/aggregator/ValueAggregator.java), [streaming + startree](https://github.com/apache/pinot/blob/b323d44e2768c24828f92ff4c32594d07c2101fc/pinot-core/src/main/java/com/linkedin/pinot/core/data/aggregator/ValueAggregator.java#L28)), that have the same functionality. The core logic of aggregation (aggregate 2 given values) is the same for both these APIs. 
This leads to the following problems

- Different pieces of code in 2 places can lead to inconsistency in aggregation logic between batch and nearline.
- Productivity impact for both devs and reviewers (eg: multiple PRs submitted for a new aggregation implementation - [batch](https://github.com/apache/pinot/pull/10328), [startree/streaming](https://github.com/apache/pinot/pull/10288) and they have to be in sync).

As a consequence of unifying the apis, the batch side will get to use startree/nearline aggregation implementations for free .

**Solution**: Reuse the startree/nearline interface for batch (rollup/merge) as well and get rid of the batch valueAggregation interface. 
