### PR TITLE
[multistage] Handle Stream Cancellations for Unstarted Streams

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.mailbox;
 
+import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.protobuf.ByteString;
 import io.grpc.Status;
@@ -100,13 +101,18 @@ public class GrpcSendingMailbox implements SendingMailbox<TransferableBlock> {
           //  anyways as info for now so we can see how frequently this happens.
           LOGGER.info("Unexpected error issuing onError to MailboxContentStreamObserver: {}", e.getMessage());
         }
-      }, DEFAULT_CANCELLATION_DELAY_MS, TimeUnit.MILLISECONDS);
+      }, getCancellationDelayMs(), TimeUnit.MILLISECONDS);
     }
   }
 
   @Override
   public String getMailboxId() {
     return _mailboxId;
+  }
+
+  @VisibleForTesting
+  public long getCancellationDelayMs() {
+    return DEFAULT_CANCELLATION_DELAY_MS;
   }
 
   private void open() {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/GrpcMailboxServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/GrpcMailboxServiceTest.java
@@ -37,6 +37,7 @@ import org.apache.pinot.query.service.QueryConfig;
 import org.apache.pinot.query.testutils.QueryTestUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.util.TestUtils;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
@@ -294,6 +295,10 @@ public class GrpcMailboxServiceTest {
 
     GrpcSendingMailbox grpcSendingMailbox =
         (GrpcSendingMailbox) _mailboxService1.getSendingMailbox(mailboxId, deadlineMs);
+    // Do cancellations immediately for this test
+    grpcSendingMailbox = Mockito.spy(grpcSendingMailbox);
+    Mockito.doReturn(0L).when(grpcSendingMailbox).getCancellationDelayMs();
+
     GrpcReceivingMailbox grpcReceivingMailbox =
         (GrpcReceivingMailbox) _mailboxService2.getReceivingMailbox(mailboxId);
 


### PR DESCRIPTION
We detected this issue due to a flaky test and there was a discussion on this in: #10417

Context: When there's an error, we try to send the error-block via MailboxSendOperator, and after it returns a cancellation is issued for the OpChain, which issues a cancellation for the `MailboxSendOperator` as well.

On looking into the flaky test (which can be reproduced on local by running it separately in IntelliJ), I found that the receiving mailbox is never initialized for the broker's receiver. On looking further I saw that calling `StreamObserver#onNext` doesn't guarantee that the stream has been created. The onNext operation is queued in a executor (see `DelayedClientCall`), and if there's a concurrent cancellation before the queued request is processed, the stream would never get created and the receiver will be stuck waiting to be initialized because neither onNext, onError or onCompleted would be called on its end.

In this patch I have introduced a stop-gap solution for this.

For the full fix I have created this issue: #10424. I have been punting writing the design doc for this. I'll try to finish it this week.