### PR TITLE
[Clean up] Remove getColumnName() from AggregationFunction interface

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
@@ -23,12 +23,15 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.Collections;
 import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.request.context.FilterContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
 import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.RoaringBitmap;
@@ -62,13 +65,17 @@ public class AggregationResultsBlock extends BaseResultsBlock {
 
   @Override
   public DataSchema getDataSchema(QueryContext queryContext) {
-    boolean returnFinalResult = queryContext.isServerReturnFinalResult();
-    int numColumns = _aggregationFunctions.length;
+    List<Pair<AggregationFunction, FilterContext>> filteredAggregationFunctions =
+        queryContext.getFilteredAggregationFunctions();
+    assert filteredAggregationFunctions != null;
+    int numColumns = filteredAggregationFunctions.size();
     String[] columnNames = new String[numColumns];
     ColumnDataType[] columnDataTypes = new ColumnDataType[numColumns];
+    boolean returnFinalResult = queryContext.isServerReturnFinalResult();
     for (int i = 0; i < numColumns; i++) {
-      AggregationFunction aggregationFunction = _aggregationFunctions[i];
-      columnNames[i] = aggregationFunction.getColumnName();
+      Pair<AggregationFunction, FilterContext> pair = filteredAggregationFunctions.get(i);
+      AggregationFunction aggregationFunction = pair.getLeft();
+      columnNames[i] = AggregationFunctionUtils.getResultColumnName(aggregationFunction, pair.getRight());
       columnDataTypes[i] = returnFinalResult ? aggregationFunction.getFinalResultColumnType()
           : aggregationFunction.getIntermediateResultColumnType();
     }
@@ -83,12 +90,12 @@ public class AggregationResultsBlock extends BaseResultsBlock {
   @Override
   public DataTable getDataTable(QueryContext queryContext)
       throws IOException {
-    boolean returnFinalResult = queryContext.isServerReturnFinalResult();
     DataSchema dataSchema = getDataSchema(queryContext);
     assert dataSchema != null;
     ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
     int numColumns = columnDataTypes.length;
     DataTableBuilder dataTableBuilder = DataTableBuilderFactory.getDataTableBuilder(dataSchema);
+    boolean returnFinalResult = queryContext.isServerReturnFinalResult();
     if (queryContext.isNullHandlingEnabled()) {
       RoaringBitmap[] nullBitmaps = new RoaringBitmap[numColumns];
       for (int i = 0; i < numColumns; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtils.java
@@ -71,8 +71,6 @@ public class ResultsBlockUtils {
 
   private static AggregationResultsBlock buildEmptyAggregationQueryResults(QueryContext queryContext) {
     AggregationFunction[] aggregationFunctions = queryContext.getAggregationFunctions();
-    List<Pair<AggregationFunction, FilterContext>> filteredAggregationFunctions =
-        queryContext.getFilteredAggregationFunctions();
     assert aggregationFunctions != null;
     int numAggregations = aggregationFunctions.length;
     List<Object> results = new ArrayList<>(numAggregations);
@@ -85,9 +83,8 @@ public class ResultsBlockUtils {
   private static GroupByResultsBlock buildEmptyGroupByQueryResults(QueryContext queryContext) {
     List<Pair<AggregationFunction, FilterContext>> filteredAggregationFunctions =
         queryContext.getFilteredAggregationFunctions();
-
     List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
-    assert groupByExpressions != null;
+    assert filteredAggregationFunctions != null && groupByExpressions != null;
     int numColumns = groupByExpressions.size() + filteredAggregationFunctions.size();
     String[] columnNames = new String[numColumns];
     ColumnDataType[] columnDataTypes = new ColumnDataType[numColumns];
@@ -98,12 +95,9 @@ public class ResultsBlockUtils {
       columnDataTypes[index] = ColumnDataType.STRING;
       index++;
     }
-    for (Pair<AggregationFunction, FilterContext> aggFilterPair : filteredAggregationFunctions) {
-      // NOTE: Use AggregationFunction.getResultColumnName() for SQL format response
-      AggregationFunction aggregationFunction = aggFilterPair.getLeft();
-      String columnName =
-          AggregationFunctionUtils.getResultColumnName(aggregationFunction, aggFilterPair.getRight());
-      columnNames[index] = columnName;
+    for (Pair<AggregationFunction, FilterContext> pair : filteredAggregationFunctions) {
+      AggregationFunction aggregationFunction = pair.getLeft();
+      columnNames[index] = AggregationFunctionUtils.getResultColumnName(aggregationFunction, pair.getRight());
       columnDataTypes[index] = aggregationFunction.getIntermediateResultColumnType();
       index++;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunction.java
@@ -47,11 +47,6 @@ public interface AggregationFunction<IntermediateResult, FinalResult extends Com
   AggregationFunctionType getType();
 
   /**
-   * Returns the result column name for the given aggregation column, e.g. 'SUM(foo)' -> 'sum_foo'.
-   */
-  String getColumnName();
-
-  /**
    * Returns the column name to be used in the data schema of results.
    * e.g. 'MINMAXRANGEMV( foo)' -> 'minmaxrangemv(foo)', 'PERCENTILE75(bar)' -> 'percentile75(bar)'
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseSingleInputAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseSingleInputAggregationFunction.java
@@ -39,11 +39,6 @@ public abstract class BaseSingleInputAggregationFunction<I, F extends Comparable
   }
 
   @Override
-  public String getColumnName() {
-    return getType().getName() + "_" + _expression;
-  }
-
-  @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + ")";
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountAggregationFunction.java
@@ -34,7 +34,6 @@ import org.roaringbitmap.RoaringBitmap;
 
 
 public class CountAggregationFunction extends BaseSingleInputAggregationFunction<Long, Long> {
-  private static final String COUNT_STAR_COLUMN_NAME = "count_star";
   private static final String COUNT_STAR_RESULT_COLUMN_NAME = "count(*)";
   private static final double DEFAULT_INITIAL_VALUE = 0.0;
   // Special expression used by star-tree to pass in BlockValSet
@@ -60,11 +59,6 @@ public class CountAggregationFunction extends BaseSingleInputAggregationFunction
   @Override
   public AggregationFunctionType getType() {
     return AggregationFunctionType.COUNT;
-  }
-
-  @Override
-  public String getColumnName() {
-    return _nullHandlingEnabled ? super.getColumnName() : COUNT_STAR_COLUMN_NAME;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
@@ -46,11 +46,6 @@ public class CountMVAggregationFunction extends CountAggregationFunction {
   }
 
   @Override
-  public String getColumnName() {
-    return AggregationFunctionType.COUNTMV.getName() + "_" + _expression;
-  }
-
-  @Override
   public String getResultColumnName() {
     return AggregationFunctionType.COUNTMV.getName().toLowerCase() + "(" + _expression + ")";
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CovarianceAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CovarianceAggregationFunction.java
@@ -69,11 +69,6 @@ public class CovarianceAggregationFunction implements AggregationFunction<Covari
   }
 
   @Override
-  public String getColumnName() {
-    return getType().getName() + "_" + _expression1 + "_" + _expression2;
-  }
-
-  @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression1 + "," + _expression2 + ")";
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAggregationFunction.java
@@ -21,7 +21,6 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
@@ -80,23 +79,18 @@ public class DistinctAggregationFunction implements AggregationFunction<Object, 
   }
 
   @Override
-  public String getColumnName() {
-    return AggregationFunctionType.DISTINCT.getName() + "_" + StringUtils.join(_columns, ':');
-  }
-
-  @Override
-  public String getResultColumnName() {
-    return AggregationFunctionType.DISTINCT.getName().toLowerCase() + "(" + StringUtils.join(_columns, ':') + ")";
-  }
-
-  @Override
   public List<ExpressionContext> getInputExpressions() {
     return _expressions;
   }
 
   @Override
+  public String getResultColumnName() {
+    throw new UnsupportedOperationException("Operation not supported for DISTINCT aggregation function");
+  }
+
+  @Override
   public ColumnDataType getIntermediateResultColumnType() {
-    return ColumnDataType.OBJECT;
+    throw new UnsupportedOperationException("Operation not supported for DISTINCT aggregation function");
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstDoubleValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstDoubleValueWithTimeAggregationFunction.java
@@ -38,15 +38,10 @@ import org.apache.pinot.segment.local.customobject.ValueLongPair;
  *   Numeric column</li>
  * </ul>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class FirstDoubleValueWithTimeAggregationFunction extends FirstWithTimeAggregationFunction<Double> {
+  private final static ValueLongPair<Double> DEFAULT_VALUE_TIME_PAIR = new DoubleLongPair(Double.NaN, Long.MAX_VALUE);
 
-  private final static ValueLongPair<Double> DEFAULT_VALUE_TIME_PAIR
-      = new DoubleLongPair(Double.NaN, Long.MAX_VALUE);
-
-  public FirstDoubleValueWithTimeAggregationFunction(
-      ExpressionContext dataCol,
-      ExpressionContext timeCol) {
+  public FirstDoubleValueWithTimeAggregationFunction(ExpressionContext dataCol, ExpressionContext timeCol) {
     super(dataCol, timeCol, ObjectSerDeUtils.DOUBLE_LONG_PAIR_SER_DE);
   }
 
@@ -81,8 +76,7 @@ public class FirstDoubleValueWithTimeAggregationFunction extends FirstWithTimeAg
 
   @Override
   public void aggregateGroupResultWithRawDataSv(int length, int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet, BlockValSet timeValSet) {
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     double[] doubleValues = blockValSet.getDoubleValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -93,11 +87,8 @@ public class FirstDoubleValueWithTimeAggregationFunction extends FirstWithTimeAg
   }
 
   @Override
-  public void aggregateGroupResultWithRawDataMv(int length,
-      int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet,
-      BlockValSet timeValSet) {
+  public void aggregateGroupResultWithRawDataMv(int length, int[][] groupKeysArray,
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     double[] doubleValues = blockValSet.getDoubleValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -112,11 +103,6 @@ public class FirstDoubleValueWithTimeAggregationFunction extends FirstWithTimeAg
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'DOUBLE')";
-  }
-
-  @Override
-  public String getColumnName() {
-    return getType().getName() + "_" + _expression + "_" + _timeCol + "_DOUBLE";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstFloatValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstFloatValueWithTimeAggregationFunction.java
@@ -38,14 +38,10 @@ import org.apache.pinot.segment.local.customobject.ValueLongPair;
  *   Numeric column</li>
  * </ul>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class FirstFloatValueWithTimeAggregationFunction extends FirstWithTimeAggregationFunction<Float> {
-
   private final static ValueLongPair<Float> DEFAULT_VALUE_TIME_PAIR = new FloatLongPair(Float.NaN, Long.MAX_VALUE);
 
-  public FirstFloatValueWithTimeAggregationFunction(
-      ExpressionContext dataCol,
-      ExpressionContext timeCol) {
+  public FirstFloatValueWithTimeAggregationFunction(ExpressionContext dataCol, ExpressionContext timeCol) {
     super(dataCol, timeCol, ObjectSerDeUtils.FLOAT_LONG_PAIR_SER_DE);
   }
 
@@ -79,11 +75,8 @@ public class FirstFloatValueWithTimeAggregationFunction extends FirstWithTimeAgg
   }
 
   @Override
-  public void aggregateGroupResultWithRawDataSv(int length,
-      int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet,
-      BlockValSet timeValSet) {
+  public void aggregateGroupResultWithRawDataSv(int length, int[] groupKeyArray,
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     float[] floatValues = blockValSet.getFloatValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -94,11 +87,8 @@ public class FirstFloatValueWithTimeAggregationFunction extends FirstWithTimeAgg
   }
 
   @Override
-  public void aggregateGroupResultWithRawDataMv(int length,
-      int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet,
-      BlockValSet timeValSet) {
+  public void aggregateGroupResultWithRawDataMv(int length, int[][] groupKeysArray,
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     float[] floatValues = blockValSet.getFloatValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -113,11 +103,6 @@ public class FirstFloatValueWithTimeAggregationFunction extends FirstWithTimeAgg
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'FLOAT')";
-  }
-
-  @Override
-  public String getColumnName() {
-    return getType().getName() + "_" + _expression + "_" + _timeCol + "_FLOAT";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstIntValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstIntValueWithTimeAggregationFunction.java
@@ -39,16 +39,13 @@ import org.apache.pinot.segment.local.customobject.ValueLongPair;
  *   Numeric column</li>
  * </ul>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class FirstIntValueWithTimeAggregationFunction extends FirstWithTimeAggregationFunction<Integer> {
+  private final static ValueLongPair<Integer> DEFAULT_VALUE_TIME_PAIR =
+      new IntLongPair(Integer.MIN_VALUE, Long.MAX_VALUE);
 
-  private final static ValueLongPair<Integer> DEFAULT_VALUE_TIME_PAIR
-      = new IntLongPair(Integer.MIN_VALUE, Long.MAX_VALUE);
   private final boolean _isBoolean;
 
-  public FirstIntValueWithTimeAggregationFunction(
-      ExpressionContext dataCol,
-      ExpressionContext timeCol,
+  public FirstIntValueWithTimeAggregationFunction(ExpressionContext dataCol, ExpressionContext timeCol,
       boolean isBoolean) {
     super(dataCol, timeCol, ObjectSerDeUtils.INT_LONG_PAIR_SER_DE);
     _isBoolean = isBoolean;
@@ -85,8 +82,7 @@ public class FirstIntValueWithTimeAggregationFunction extends FirstWithTimeAggre
 
   @Override
   public void aggregateGroupResultWithRawDataSv(int length, int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet, BlockValSet timeValSet) {
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     int[] intValues = blockValSet.getIntValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -97,11 +93,8 @@ public class FirstIntValueWithTimeAggregationFunction extends FirstWithTimeAggre
   }
 
   @Override
-  public void aggregateGroupResultWithRawDataMv(int length,
-      int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet,
-      BlockValSet timeValSet) {
+  public void aggregateGroupResultWithRawDataMv(int length, int[][] groupKeysArray,
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     int[] intValues = blockValSet.getIntValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -119,15 +112,6 @@ public class FirstIntValueWithTimeAggregationFunction extends FirstWithTimeAggre
       return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'BOOLEAN')";
     } else {
       return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'INT')";
-    }
-  }
-
-  @Override
-  public String getColumnName() {
-    if (_isBoolean) {
-      return getType().getName() + "_" + _expression + "_" + _timeCol + "_BOOLEAN";
-    } else {
-      return getType().getName() + "_" + _expression + "_" + _timeCol + "_INT";
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstLongValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstLongValueWithTimeAggregationFunction.java
@@ -38,15 +38,10 @@ import org.apache.pinot.segment.local.customobject.ValueLongPair;
  *   Numeric column</li>
  * </ul>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class FirstLongValueWithTimeAggregationFunction extends FirstWithTimeAggregationFunction<Long> {
+  private final static ValueLongPair<Long> DEFAULT_VALUE_TIME_PAIR = new LongLongPair(Long.MIN_VALUE, Long.MAX_VALUE);
 
-  private final static ValueLongPair<Long> DEFAULT_VALUE_TIME_PAIR
-      = new LongLongPair(Long.MIN_VALUE, Long.MAX_VALUE);
-
-  public FirstLongValueWithTimeAggregationFunction(
-      ExpressionContext dataCol,
-      ExpressionContext timeCol) {
+  public FirstLongValueWithTimeAggregationFunction(ExpressionContext dataCol, ExpressionContext timeCol) {
     super(dataCol, timeCol, ObjectSerDeUtils.LONG_LONG_PAIR_SER_DE);
   }
 
@@ -81,8 +76,7 @@ public class FirstLongValueWithTimeAggregationFunction extends FirstWithTimeAggr
 
   @Override
   public void aggregateGroupResultWithRawDataSv(int length, int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet, BlockValSet timeValSet) {
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     long[] longValues = blockValSet.getLongValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -93,11 +87,8 @@ public class FirstLongValueWithTimeAggregationFunction extends FirstWithTimeAggr
   }
 
   @Override
-  public void aggregateGroupResultWithRawDataMv(int length,
-      int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet,
-      BlockValSet timeValSet) {
+  public void aggregateGroupResultWithRawDataMv(int length, int[][] groupKeysArray,
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     long[] longValues = blockValSet.getLongValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -112,11 +103,6 @@ public class FirstLongValueWithTimeAggregationFunction extends FirstWithTimeAggr
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'LONG')";
-  }
-
-  @Override
-  public String getColumnName() {
-    return getType().getName() + "_" + _expression + "_" + _timeCol + "_LONG";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstStringValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/FirstStringValueWithTimeAggregationFunction.java
@@ -38,13 +38,10 @@ import org.apache.pinot.segment.local.customobject.ValueLongPair;
  *   Numeric column</li>
  * </ul>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class FirstStringValueWithTimeAggregationFunction extends FirstWithTimeAggregationFunction<String> {
   private final static ValueLongPair<String> DEFAULT_VALUE_TIME_PAIR = new StringLongPair("", Long.MAX_VALUE);
 
-  public FirstStringValueWithTimeAggregationFunction(
-      ExpressionContext dataCol,
-      ExpressionContext timeCol) {
+  public FirstStringValueWithTimeAggregationFunction(ExpressionContext dataCol, ExpressionContext timeCol) {
     super(dataCol, timeCol, ObjectSerDeUtils.STRING_LONG_PAIR_SER_DE);
   }
 
@@ -79,8 +76,7 @@ public class FirstStringValueWithTimeAggregationFunction extends FirstWithTimeAg
 
   @Override
   public void aggregateGroupResultWithRawDataSv(int length, int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet, BlockValSet timeValSet) {
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     String[] stringValues = blockValSet.getStringValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -91,11 +87,8 @@ public class FirstStringValueWithTimeAggregationFunction extends FirstWithTimeAg
   }
 
   @Override
-  public void aggregateGroupResultWithRawDataMv(int length,
-      int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet,
-      BlockValSet timeValSet) {
+  public void aggregateGroupResultWithRawDataMv(int length, int[][] groupKeysArray,
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     String[] stringValues = blockValSet.getStringValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -110,11 +103,6 @@ public class FirstStringValueWithTimeAggregationFunction extends FirstWithTimeAg
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'STRING')";
-  }
-
-  @Override
-  public String getColumnName() {
-    return getType().getName() + "_" + _expression + "_" + _timeCol + "_STRING";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastDoubleValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastDoubleValueWithTimeAggregationFunction.java
@@ -38,15 +38,10 @@ import org.apache.pinot.segment.local.customobject.ValueLongPair;
  *   Numeric column</li>
  * </ul>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class LastDoubleValueWithTimeAggregationFunction extends LastWithTimeAggregationFunction<Double> {
+  private final static ValueLongPair<Double> DEFAULT_VALUE_TIME_PAIR = new DoubleLongPair(Double.NaN, Long.MIN_VALUE);
 
-  private final static ValueLongPair<Double> DEFAULT_VALUE_TIME_PAIR
-      = new DoubleLongPair(Double.NaN, Long.MIN_VALUE);
-
-  public LastDoubleValueWithTimeAggregationFunction(
-      ExpressionContext dataCol,
-      ExpressionContext timeCol) {
+  public LastDoubleValueWithTimeAggregationFunction(ExpressionContext dataCol, ExpressionContext timeCol) {
     super(dataCol, timeCol, ObjectSerDeUtils.DOUBLE_LONG_PAIR_SER_DE);
   }
 
@@ -81,8 +76,7 @@ public class LastDoubleValueWithTimeAggregationFunction extends LastWithTimeAggr
 
   @Override
   public void aggregateGroupResultWithRawDataSv(int length, int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet, BlockValSet timeValSet) {
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     double[] doubleValues = blockValSet.getDoubleValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -93,11 +87,8 @@ public class LastDoubleValueWithTimeAggregationFunction extends LastWithTimeAggr
   }
 
   @Override
-  public void aggregateGroupResultWithRawDataMv(int length,
-      int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet,
-      BlockValSet timeValSet) {
+  public void aggregateGroupResultWithRawDataMv(int length, int[][] groupKeysArray,
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     double[] doubleValues = blockValSet.getDoubleValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -112,11 +103,6 @@ public class LastDoubleValueWithTimeAggregationFunction extends LastWithTimeAggr
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'DOUBLE')";
-  }
-
-  @Override
-  public String getColumnName() {
-    return getType().getName() + "_" + _expression + "_" + _timeCol + "_DOUBLE";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastFloatValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastFloatValueWithTimeAggregationFunction.java
@@ -38,14 +38,10 @@ import org.apache.pinot.segment.local.customobject.ValueLongPair;
  *   Numeric column</li>
  * </ul>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class LastFloatValueWithTimeAggregationFunction extends LastWithTimeAggregationFunction<Float> {
-
   private final static ValueLongPair<Float> DEFAULT_VALUE_TIME_PAIR = new FloatLongPair(Float.NaN, Long.MIN_VALUE);
 
-  public LastFloatValueWithTimeAggregationFunction(
-      ExpressionContext dataCol,
-      ExpressionContext timeCol) {
+  public LastFloatValueWithTimeAggregationFunction(ExpressionContext dataCol, ExpressionContext timeCol) {
     super(dataCol, timeCol, ObjectSerDeUtils.FLOAT_LONG_PAIR_SER_DE);
   }
 
@@ -79,11 +75,8 @@ public class LastFloatValueWithTimeAggregationFunction extends LastWithTimeAggre
   }
 
   @Override
-  public void aggregateGroupResultWithRawDataSv(int length,
-      int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet,
-      BlockValSet timeValSet) {
+  public void aggregateGroupResultWithRawDataSv(int length, int[] groupKeyArray,
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     float[] floatValues = blockValSet.getFloatValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -94,11 +87,8 @@ public class LastFloatValueWithTimeAggregationFunction extends LastWithTimeAggre
   }
 
   @Override
-  public void aggregateGroupResultWithRawDataMv(int length,
-      int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet,
-      BlockValSet timeValSet) {
+  public void aggregateGroupResultWithRawDataMv(int length, int[][] groupKeysArray,
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     float[] floatValues = blockValSet.getFloatValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -113,11 +103,6 @@ public class LastFloatValueWithTimeAggregationFunction extends LastWithTimeAggre
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'FLOAT')";
-  }
-
-  @Override
-  public String getColumnName() {
-    return getType().getName() + "_" + _expression + "_" + _timeCol + "_FLOAT";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastIntValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastIntValueWithTimeAggregationFunction.java
@@ -39,16 +39,13 @@ import org.apache.pinot.segment.local.customobject.ValueLongPair;
  *   Numeric column</li>
  * </ul>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class LastIntValueWithTimeAggregationFunction extends LastWithTimeAggregationFunction<Integer> {
+  private final static ValueLongPair<Integer> DEFAULT_VALUE_TIME_PAIR =
+      new IntLongPair(Integer.MIN_VALUE, Long.MIN_VALUE);
 
-  private final static ValueLongPair<Integer> DEFAULT_VALUE_TIME_PAIR
-      = new IntLongPair(Integer.MIN_VALUE, Long.MIN_VALUE);
   private final boolean _isBoolean;
 
-  public LastIntValueWithTimeAggregationFunction(
-      ExpressionContext dataCol,
-      ExpressionContext timeCol,
+  public LastIntValueWithTimeAggregationFunction(ExpressionContext dataCol, ExpressionContext timeCol,
       boolean isBoolean) {
     super(dataCol, timeCol, ObjectSerDeUtils.INT_LONG_PAIR_SER_DE);
     _isBoolean = isBoolean;
@@ -85,8 +82,7 @@ public class LastIntValueWithTimeAggregationFunction extends LastWithTimeAggrega
 
   @Override
   public void aggregateGroupResultWithRawDataSv(int length, int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet, BlockValSet timeValSet) {
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     int[] intValues = blockValSet.getIntValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -97,11 +93,8 @@ public class LastIntValueWithTimeAggregationFunction extends LastWithTimeAggrega
   }
 
   @Override
-  public void aggregateGroupResultWithRawDataMv(int length,
-      int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet,
-      BlockValSet timeValSet) {
+  public void aggregateGroupResultWithRawDataMv(int length, int[][] groupKeysArray,
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     int[] intValues = blockValSet.getIntValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -119,15 +112,6 @@ public class LastIntValueWithTimeAggregationFunction extends LastWithTimeAggrega
       return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'BOOLEAN')";
     } else {
       return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'INT')";
-    }
-  }
-
-  @Override
-  public String getColumnName() {
-    if (_isBoolean) {
-      return getType().getName() + "_" + _expression + "_" + _timeCol + "_BOOLEAN";
-    } else {
-      return getType().getName() + "_" + _expression + "_" + _timeCol + "_INT";
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastLongValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastLongValueWithTimeAggregationFunction.java
@@ -38,15 +38,10 @@ import org.apache.pinot.segment.local.customobject.ValueLongPair;
  *   Numeric column</li>
  * </ul>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class LastLongValueWithTimeAggregationFunction extends LastWithTimeAggregationFunction<Long> {
+  private final static ValueLongPair<Long> DEFAULT_VALUE_TIME_PAIR = new LongLongPair(Long.MIN_VALUE, Long.MIN_VALUE);
 
-  private final static ValueLongPair<Long> DEFAULT_VALUE_TIME_PAIR
-      = new LongLongPair(Long.MIN_VALUE, Long.MIN_VALUE);
-
-  public LastLongValueWithTimeAggregationFunction(
-      ExpressionContext dataCol,
-      ExpressionContext timeCol) {
+  public LastLongValueWithTimeAggregationFunction(ExpressionContext dataCol, ExpressionContext timeCol) {
     super(dataCol, timeCol, ObjectSerDeUtils.LONG_LONG_PAIR_SER_DE);
   }
 
@@ -81,8 +76,7 @@ public class LastLongValueWithTimeAggregationFunction extends LastWithTimeAggreg
 
   @Override
   public void aggregateGroupResultWithRawDataSv(int length, int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet, BlockValSet timeValSet) {
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     long[] longValues = blockValSet.getLongValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -93,11 +87,8 @@ public class LastLongValueWithTimeAggregationFunction extends LastWithTimeAggreg
   }
 
   @Override
-  public void aggregateGroupResultWithRawDataMv(int length,
-      int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet,
-      BlockValSet timeValSet) {
+  public void aggregateGroupResultWithRawDataMv(int length, int[][] groupKeysArray,
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     long[] longValues = blockValSet.getLongValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -112,11 +103,6 @@ public class LastLongValueWithTimeAggregationFunction extends LastWithTimeAggreg
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'LONG')";
-  }
-
-  @Override
-  public String getColumnName() {
-    return getType().getName() + "_" + _expression + "_" + _timeCol + "_LONG";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastStringValueWithTimeAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/LastStringValueWithTimeAggregationFunction.java
@@ -38,13 +38,10 @@ import org.apache.pinot.segment.local.customobject.ValueLongPair;
  *   Numeric column</li>
  * </ul>
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class LastStringValueWithTimeAggregationFunction extends LastWithTimeAggregationFunction<String> {
   private final static ValueLongPair<String> DEFAULT_VALUE_TIME_PAIR = new StringLongPair("", Long.MIN_VALUE);
 
-  public LastStringValueWithTimeAggregationFunction(
-      ExpressionContext dataCol,
-      ExpressionContext timeCol) {
+  public LastStringValueWithTimeAggregationFunction(ExpressionContext dataCol, ExpressionContext timeCol) {
     super(dataCol, timeCol, ObjectSerDeUtils.STRING_LONG_PAIR_SER_DE);
   }
 
@@ -79,8 +76,7 @@ public class LastStringValueWithTimeAggregationFunction extends LastWithTimeAggr
 
   @Override
   public void aggregateGroupResultWithRawDataSv(int length, int[] groupKeyArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet, BlockValSet timeValSet) {
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     String[] stringValues = blockValSet.getStringValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -91,11 +87,8 @@ public class LastStringValueWithTimeAggregationFunction extends LastWithTimeAggr
   }
 
   @Override
-  public void aggregateGroupResultWithRawDataMv(int length,
-      int[][] groupKeysArray,
-      GroupByResultHolder groupByResultHolder,
-      BlockValSet blockValSet,
-      BlockValSet timeValSet) {
+  public void aggregateGroupResultWithRawDataMv(int length, int[][] groupKeysArray,
+      GroupByResultHolder groupByResultHolder, BlockValSet blockValSet, BlockValSet timeValSet) {
     String[] stringValues = blockValSet.getStringValuesSV();
     long[] timeValues = timeValSet.getLongValuesSV();
     for (int i = 0; i < length; i++) {
@@ -110,11 +103,6 @@ public class LastStringValueWithTimeAggregationFunction extends LastWithTimeAggr
   @Override
   public String getResultColumnName() {
     return getType().getName().toLowerCase() + "(" + _expression + "," + _timeCol + ",'STRING')";
-  }
-
-  @Override
-  public String getColumnName() {
-    return getType().getName() + "_" + _expression + "_" + _timeCol + "_STRING";
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileAggregationFunction.java
@@ -57,12 +57,6 @@ public class PercentileAggregationFunction extends BaseSingleInputAggregationFun
   }
 
   @Override
-  public String getColumnName() {
-    return _version == 0 ? AggregationFunctionType.PERCENTILE.getName() + (int) _percentile + "_" + _expression
-        : AggregationFunctionType.PERCENTILE.getName() + _percentile + "_" + _expression;
-  }
-
-  @Override
   public String getResultColumnName() {
     return _version == 0 ? AggregationFunctionType.PERCENTILE.getName().toLowerCase() + (int) _percentile + "("
         + _expression + ")"

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstAggregationFunction.java
@@ -58,12 +58,6 @@ public class PercentileEstAggregationFunction extends BaseSingleInputAggregation
   }
 
   @Override
-  public String getColumnName() {
-    return _version == 0 ? AggregationFunctionType.PERCENTILEEST.getName() + (int) _percentile + "_" + _expression
-        : AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "_" + _expression;
-  }
-
-  @Override
   public String getResultColumnName() {
     return _version == 0 ? AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + (int) _percentile + "("
         + _expression + ")"

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileEstMVAggregationFunction.java
@@ -43,12 +43,6 @@ public class PercentileEstMVAggregationFunction extends PercentileEstAggregation
   }
 
   @Override
-  public String getColumnName() {
-    return _version == 0 ? AggregationFunctionType.PERCENTILEEST.getName() + (int) _percentile + "MV_" + _expression
-        : AggregationFunctionType.PERCENTILEEST.getName() + _percentile + "MV_" + _expression;
-  }
-
-  @Override
   public String getResultColumnName() {
     return _version == 0 ? AggregationFunctionType.PERCENTILEEST.getName().toLowerCase() + (int) _percentile + "mv("
         + _expression + ")"

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileMVAggregationFunction.java
@@ -43,12 +43,6 @@ public class PercentileMVAggregationFunction extends PercentileAggregationFuncti
   }
 
   @Override
-  public String getColumnName() {
-    return _version == 0 ? AggregationFunctionType.PERCENTILE.getName() + (int) _percentile + "MV_" + _expression
-        : AggregationFunctionType.PERCENTILE.getName() + _percentile + "MV_" + _expression;
-  }
-
-  @Override
   public String getResultColumnName() {
     return _version == 0 ? AggregationFunctionType.PERCENTILE.getName().toLowerCase() + (int) _percentile + "mv("
         + _expression + ")"

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawEstAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawEstAggregationFunction.java
@@ -57,15 +57,6 @@ public class PercentileRawEstAggregationFunction
   }
 
   @Override
-  public String getColumnName() {
-    final double percentile = _percentileEstAggregationFunction._percentile;
-    final int version = _percentileEstAggregationFunction._version;
-    final String type = getType().getName();
-
-    return version == 0 ? type + (int) percentile + "_" + _expression : type + percentile + "_" + _expression;
-  }
-
-  @Override
   public String getResultColumnName() {
     final double percentile = _percentileEstAggregationFunction._percentile;
     final int version = _percentileEstAggregationFunction._version;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileRawTDigestAggregationFunction.java
@@ -57,15 +57,6 @@ public class PercentileRawTDigestAggregationFunction
   }
 
   @Override
-  public String getColumnName() {
-    final double percentile = _percentileTDigestAggregationFunction._percentile;
-    final int version = _percentileTDigestAggregationFunction._version;
-    final String type = getType().getName();
-
-    return version == 0 ? type + (int) percentile + "_" + _expression : type + percentile + "_" + _expression;
-  }
-
-  @Override
   public String getResultColumnName() {
     final double percentile = _percentileTDigestAggregationFunction._percentile;
     final int version = _percentileTDigestAggregationFunction._version;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileSmartTDigestAggregationFunction.java
@@ -94,11 +94,6 @@ public class PercentileSmartTDigestAggregationFunction extends BaseSingleInputAg
   }
 
   @Override
-  public String getColumnName() {
-    return AggregationFunctionType.PERCENTILESMARTTDIGEST.getName() + _percentile + "_" + _expression;
-  }
-
-  @Override
   public String getResultColumnName() {
     return AggregationFunctionType.PERCENTILESMARTTDIGEST.getName().toLowerCase() + "(" + _expression + ", "
         + _percentile + ")";

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestAggregationFunction.java
@@ -61,12 +61,6 @@ public class PercentileTDigestAggregationFunction extends BaseSingleInputAggrega
   }
 
   @Override
-  public String getColumnName() {
-    return _version == 0 ? AggregationFunctionType.PERCENTILETDIGEST.getName() + (int) _percentile + "_" + _expression
-        : AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "_" + _expression;
-  }
-
-  @Override
   public String getResultColumnName() {
     return _version == 0 ? AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + (int) _percentile + "("
         + _expression + ")"

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/PercentileTDigestMVAggregationFunction.java
@@ -43,12 +43,6 @@ public class PercentileTDigestMVAggregationFunction extends PercentileTDigestAgg
   }
 
   @Override
-  public String getColumnName() {
-    return _version == 0 ? AggregationFunctionType.PERCENTILETDIGEST.getName() + (int) _percentile + "MV_" + _expression
-        : AggregationFunctionType.PERCENTILETDIGEST.getName() + _percentile + "MV_" + _expression;
-  }
-
-  @Override
   public String getResultColumnName() {
     return _version == 0 ? AggregationFunctionType.PERCENTILETDIGEST.getName().toLowerCase() + (int) _percentile + "mv("
         + _expression + ")"

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
@@ -45,13 +45,9 @@ import org.roaringbitmap.RoaringBitmap;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class AggregationDataTableReducer implements DataTableReducer {
   private final QueryContext _queryContext;
-  private final AggregationFunction[] _aggregationFunctions;
-  private final List<Pair<AggregationFunction, FilterContext>> _filteredAggregationFunctions;
 
   AggregationDataTableReducer(QueryContext queryContext) {
     _queryContext = queryContext;
-    _aggregationFunctions = queryContext.getAggregationFunctions();
-    _filteredAggregationFunctions = queryContext.getFilteredAggregationFunctions();
   }
 
   /**
@@ -80,7 +76,9 @@ public class AggregationDataTableReducer implements DataTableReducer {
 
   private void reduceWithIntermediateResult(DataSchema dataSchema, Collection<DataTable> dataTables,
       BrokerResponseNative brokerResponseNative) {
-    int numAggregationFunctions = _aggregationFunctions.length;
+    AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
+    assert aggregationFunctions != null;
+    int numAggregationFunctions = aggregationFunctions.length;
     Object[] intermediateResults = new Object[numAggregationFunctions];
     for (DataTable dataTable : dataTables) {
       for (int i = 0; i < numAggregationFunctions; i++) {
@@ -100,14 +98,14 @@ public class AggregationDataTableReducer implements DataTableReducer {
         if (mergedIntermediateResult == null) {
           intermediateResults[i] = intermediateResultToMerge;
         } else {
-          intermediateResults[i] = _aggregationFunctions[i].merge(mergedIntermediateResult, intermediateResultToMerge);
+          intermediateResults[i] = aggregationFunctions[i].merge(mergedIntermediateResult, intermediateResultToMerge);
         }
         Tracing.ThreadAccountantOps.sampleAndCheckInterruptionPeriodically(i);
       }
     }
     Object[] finalResults = new Object[numAggregationFunctions];
     for (int i = 0; i < numAggregationFunctions; i++) {
-      AggregationFunction aggregationFunction = _aggregationFunctions[i];
+      AggregationFunction aggregationFunction = aggregationFunctions[i];
       Comparable result = aggregationFunction.extractFinalResult(intermediateResults[i]);
       finalResults[i] = result == null ? null : aggregationFunction.getFinalResultColumnType().convert(result);
     }
@@ -116,7 +114,9 @@ public class AggregationDataTableReducer implements DataTableReducer {
 
   private void reduceWithFinalResult(DataSchema dataSchema, DataTable dataTable,
       BrokerResponseNative brokerResponseNative) {
-    int numAggregationFunctions = _aggregationFunctions.length;
+    AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
+    assert aggregationFunctions != null;
+    int numAggregationFunctions = aggregationFunctions.length;
     Object[] finalResults = new Object[numAggregationFunctions];
     for (int i = 0; i < numAggregationFunctions; i++) {
       ColumnDataType columnDataType = dataSchema.getColumnDataType(i);
@@ -154,20 +154,18 @@ public class AggregationDataTableReducer implements DataTableReducer {
    * Constructs the DataSchema for the rows before the post-aggregation (SQL mode).
    */
   private DataSchema getPrePostAggregationDataSchema() {
-    int numAggregationFunctions = _aggregationFunctions.length;
-    String[] columnNames = new String[numAggregationFunctions];
-    ColumnDataType[] columnDataTypes = new ColumnDataType[numAggregationFunctions];
-
-    int i = 0;
-    for (Pair<AggregationFunction, FilterContext> aggFilterPair : _filteredAggregationFunctions) {
-      AggregationFunction aggregationFunction = aggFilterPair.getLeft();
-      String columnName =
-          AggregationFunctionUtils.getResultColumnName(aggregationFunction, aggFilterPair.getRight());
-      columnNames[i] = columnName;
+    List<Pair<AggregationFunction, FilterContext>> filteredAggregationFunctions =
+        _queryContext.getFilteredAggregationFunctions();
+    assert filteredAggregationFunctions != null;
+    int numColumns = filteredAggregationFunctions.size();
+    String[] columnNames = new String[numColumns];
+    ColumnDataType[] columnDataTypes = new ColumnDataType[numColumns];
+    for (int i = 0; i < numColumns; i++) {
+      Pair<AggregationFunction, FilterContext> pair = filteredAggregationFunctions.get(i);
+      AggregationFunction aggregationFunction = pair.getLeft();
+      columnNames[i] = AggregationFunctionUtils.getResultColumnName(aggregationFunction, pair.getRight());
       columnDataTypes[i] = aggregationFunction.getFinalResultColumnType();
-      i++;
     }
-
     return new DataSchema(columnNames, columnDataTypes);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtilsTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.operator.blocks.results;
 import java.io.IOException;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.testng.annotations.Test;
@@ -38,7 +39,7 @@ public class ResultsBlockUtilsTest {
     DataTable dataTable = ResultsBlockUtils.buildEmptyQueryResults(queryContext).getDataTable(queryContext);
     DataSchema dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"*"});
-    assertEquals(dataSchema.getColumnDataTypes(), new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING});
+    assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{ColumnDataType.STRING});
     assertEquals(dataTable.getNumberOfRows(), 0);
 
     // Aggregation
@@ -46,9 +47,9 @@ public class ResultsBlockUtilsTest {
         QueryContextConverterUtils.getQueryContext("SELECT COUNT(*), SUM(a), MAX(b) FROM testTable WHERE foo = 'bar'");
     dataTable = ResultsBlockUtils.buildEmptyQueryResults(queryContext).getDataTable(queryContext);
     dataSchema = dataTable.getDataSchema();
-    assertEquals(dataSchema.getColumnNames(), new String[]{"count_star", "sum_a", "max_b"});
-    assertEquals(dataSchema.getColumnDataTypes(), new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE
+    assertEquals(dataSchema.getColumnNames(), new String[]{"count(*)", "sum(a)", "max(b)"});
+    assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+        ColumnDataType.LONG, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
     });
     assertEquals(dataTable.getNumberOfRows(), 1);
     assertEquals(dataTable.getLong(0, 0), 0L);
@@ -61,9 +62,8 @@ public class ResultsBlockUtilsTest {
     dataTable = ResultsBlockUtils.buildEmptyQueryResults(queryContext).getDataTable(queryContext);
     dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"c", "d", "count(*)", "sum(a)", "max(b)"});
-    assertEquals(dataSchema.getColumnDataTypes(), new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.LONG,
-        DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE
+    assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.LONG, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
     });
     assertEquals(dataTable.getNumberOfRows(), 0);
 
@@ -72,8 +72,9 @@ public class ResultsBlockUtilsTest {
     dataTable = ResultsBlockUtils.buildEmptyQueryResults(queryContext).getDataTable(queryContext);
     dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"a", "b"});
-    assertEquals(dataSchema.getColumnDataTypes(), new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING,
-        DataSchema.ColumnDataType.STRING});
+    assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING
+    });
     assertEquals(dataTable.getNumberOfRows(), 0);
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.util.Arrays;
+import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.core.query.request.context.QueryContext;
@@ -43,435 +45,373 @@ public class AggregationFunctionFactoryTest {
         AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof CountAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.COUNT);
-    assertEquals(aggregationFunction.getColumnName(), "count_star");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("MiN");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof MinAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.MIN);
-    assertEquals(aggregationFunction.getColumnName(), "min_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("MaX");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof MaxAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.MAX);
-    assertEquals(aggregationFunction.getColumnName(), "max_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("SuM");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof SumAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.SUM);
-    assertEquals(aggregationFunction.getColumnName(), "sum_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("SuMPreCIsiON");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof SumPrecisionAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.SUMPRECISION);
-    assertEquals(aggregationFunction.getColumnName(), "sumPrecision_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("AvG");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof AvgAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVG);
-    assertEquals(aggregationFunction.getColumnName(), "avg_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("MoDe");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof ModeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.MODE);
-    assertEquals(aggregationFunction.getColumnName(), "mode_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("FiRsTwItHtImE", "(column,timeColumn,'BOOLEAN')");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof FirstIntValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.FIRSTWITHTIME);
-    assertEquals(aggregationFunction.getColumnName(), "firstWithTime_column_timeColumn_BOOLEAN");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("FiRsTwItHtImE", "(column,timeColumn,'INT')");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof FirstIntValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.FIRSTWITHTIME);
-    assertEquals(aggregationFunction.getColumnName(), "firstWithTime_column_timeColumn_INT");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("FiRsTwItHtImE", "(column,timeColumn,'LONG')");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof FirstLongValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.FIRSTWITHTIME);
-    assertEquals(aggregationFunction.getColumnName(), "firstWithTime_column_timeColumn_LONG");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("FiRsTwItHtImE", "(column,timeColumn,'FLOAT')");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof FirstFloatValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.FIRSTWITHTIME);
-    assertEquals(aggregationFunction.getColumnName(), "firstWithTime_column_timeColumn_FLOAT");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("FiRsTwItHtImE", "(column,timeColumn,'DOUBLE')");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof FirstDoubleValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.FIRSTWITHTIME);
-    assertEquals(aggregationFunction.getColumnName(), "firstWithTime_column_timeColumn_DOUBLE");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("FiRsTwItHtImE", "(column,timeColumn,'STRING')");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof FirstStringValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.FIRSTWITHTIME);
-    assertEquals(aggregationFunction.getColumnName(), "firstWithTime_column_timeColumn_STRING");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("LaStWiThTiMe", "(column,timeColumn,'BOOLEAN')");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof LastIntValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.LASTWITHTIME);
-    assertEquals(aggregationFunction.getColumnName(), "lastWithTime_column_timeColumn_BOOLEAN");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("LaStWiThTiMe", "(column,timeColumn,'INT')");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof LastIntValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.LASTWITHTIME);
-    assertEquals(aggregationFunction.getColumnName(), "lastWithTime_column_timeColumn_INT");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("LaStWiThTiMe", "(column,timeColumn,'LONG')");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof LastLongValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.LASTWITHTIME);
-    assertEquals(aggregationFunction.getColumnName(), "lastWithTime_column_timeColumn_LONG");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("LaStWiThTiMe", "(column,timeColumn,'FLOAT')");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof LastFloatValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.LASTWITHTIME);
-    assertEquals(aggregationFunction.getColumnName(), "lastWithTime_column_timeColumn_FLOAT");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("LaStWiThTiMe", "(column,timeColumn,'DOUBLE')");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof LastDoubleValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.LASTWITHTIME);
-    assertEquals(aggregationFunction.getColumnName(), "lastWithTime_column_timeColumn_DOUBLE");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("LaStWiThTiMe", "(column,timeColumn,'STRING')");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof LastStringValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.LASTWITHTIME);
-    assertEquals(aggregationFunction.getColumnName(), "lastWithTime_column_timeColumn_STRING");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("MiNmAxRaNgE");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof MinMaxRangeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMAXRANGE);
-    assertEquals(aggregationFunction.getColumnName(), "minMaxRange_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnT");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof DistinctCountAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNT);
-    assertEquals(aggregationFunction.getColumnName(), "distinctCount_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnThLl");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof DistinctCountHLLAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLL);
-    assertEquals(aggregationFunction.getColumnName(), "distinctCountHLL_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnTrAwHlL");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof DistinctCountRawHLLAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTRAWHLL);
-    assertEquals(aggregationFunction.getColumnName(), "distinctCountRawHLL_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("FaStHlL");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof FastHLLAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.FASTHLL);
-    assertEquals(aggregationFunction.getColumnName(), "fastHLL_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLe5");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILE);
-    assertEquals(aggregationFunction.getColumnName(), "percentile5_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLeEsT50");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileEstAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEEST);
-    assertEquals(aggregationFunction.getColumnName(), "percentileEst50_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLeRaWEsT50");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileRawEstAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILERAWEST);
-    assertEquals(aggregationFunction.getColumnName(), "percentileRawEst50_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLeTdIgEsT99");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGEST);
-    assertEquals(aggregationFunction.getColumnName(), "percentileTDigest99_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLeRaWTdIgEsT99");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileRawTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILERAWTDIGEST);
-    assertEquals(aggregationFunction.getColumnName(), "percentileRawTDigest99_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLe", "(column, 5)");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILE);
-    assertEquals(aggregationFunction.getColumnName(), "percentile5.0_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentile(column, 5.0)");
 
     function = getFunction("PeRcEnTiLe", "(column, 5.5)");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILE);
-    assertEquals(aggregationFunction.getColumnName(), "percentile5.5_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentile(column, 5.5)");
 
     function = getFunction("PeRcEnTiLeEsT", "(column, 50)");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileEstAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEEST);
-    assertEquals(aggregationFunction.getColumnName(), "percentileEst50.0_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentileest(column, 50.0)");
 
     function = getFunction("PeRcEnTiLeRaWeSt", "(column, 50)");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileRawEstAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILERAWEST);
-    assertEquals(aggregationFunction.getColumnName(), "percentileRawEst50.0_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentilerawest(column, 50.0)");
 
     function = getFunction("PeRcEnTiLeEsT", "(column, 55.555)");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileEstAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEEST);
-    assertEquals(aggregationFunction.getColumnName(), "percentileEst55.555_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentileest(column, 55.555)");
 
     function = getFunction("PeRcEnTiLeRaWeSt", "(column, 55.555)");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileRawEstAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILERAWEST);
-    assertEquals(aggregationFunction.getColumnName(), "percentileRawEst55.555_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentilerawest(column, 55.555)");
 
     function = getFunction("PeRcEnTiLeTdIgEsT", "(column, 99)");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGEST);
-    assertEquals(aggregationFunction.getColumnName(), "percentileTDigest99.0_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigest(column, 99.0)");
 
     function = getFunction("PeRcEnTiLeTdIgEsT", "(column, 99.9999)");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGEST);
-    assertEquals(aggregationFunction.getColumnName(), "percentileTDigest99.9999_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigest(column, 99.9999)");
 
     function = getFunction("PeRcEnTiLeRaWtDiGeSt", "(column, 99)");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileRawTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILERAWTDIGEST);
-    assertEquals(aggregationFunction.getColumnName(), "percentileRawTDigest99.0_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentilerawtdigest(column, 99.0)");
 
     function = getFunction("PeRcEnTiLeRaWtDiGeSt", "(column, 99.9999)");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileRawTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILERAWTDIGEST);
-    assertEquals(aggregationFunction.getColumnName(), "percentileRawTDigest99.9999_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentilerawtdigest(column, 99.9999)");
 
     function = getFunction("CoUnTmV");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof CountMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.COUNTMV);
-    assertEquals(aggregationFunction.getColumnName(), "countMV_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("MiNmV");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof MinMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMV);
-    assertEquals(aggregationFunction.getColumnName(), "minMV_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("MaXmV");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof MaxMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.MAXMV);
-    assertEquals(aggregationFunction.getColumnName(), "maxMV_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("SuMmV");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof SumMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.SUMMV);
-    assertEquals(aggregationFunction.getColumnName(), "sumMV_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("AvGmV");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof AvgMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVGMV);
-    assertEquals(aggregationFunction.getColumnName(), "avgMV_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("AvG_mV");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof AvgMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVGMV);
-    assertEquals(aggregationFunction.getColumnName(), "avgMV_column");
-    assertEquals(aggregationFunction.getResultColumnName(), "avgmv(column)");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("MiNmAxRaNgEmV");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof MinMaxRangeMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMAXRANGEMV);
-    assertEquals(aggregationFunction.getColumnName(), "minMaxRangeMV_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnTmV");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof DistinctCountMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTMV);
-    assertEquals(aggregationFunction.getColumnName(), "distinctCountMV_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnThLlMv");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof DistinctCountHLLMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLLMV);
-    assertEquals(aggregationFunction.getColumnName(), "distinctCountHLLMV_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCt_CoUnT_hLl_Mv");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof DistinctCountHLLMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLLMV);
-    assertEquals(aggregationFunction.getColumnName(), "distinctCountHLLMV_column");
-    assertEquals(aggregationFunction.getResultColumnName(), "distinctcounthllmv(column)");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnTrAwHlLmV");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof DistinctCountRawHLLMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTRAWHLLMV);
-    assertEquals(aggregationFunction.getColumnName(), "distinctCountRawHLLMV_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLe10Mv");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEMV);
-    assertEquals(aggregationFunction.getColumnName(), "percentile10MV_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLeEsT90mV");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileEstMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEESTMV);
-    assertEquals(aggregationFunction.getColumnName(), "percentileEst90MV_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLeTdIgEsT95mV");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
-    assertEquals(aggregationFunction.getColumnName(), "percentileTDigest95MV_column");
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLe_TdIgEsT_95_mV");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
-    assertEquals(aggregationFunction.getColumnName(), "percentileTDigest95MV_column");
-    assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigest95mv(column)");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLeMv", "(column, 10)");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEMV);
-    assertEquals(aggregationFunction.getColumnName(), "percentile10.0MV_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentilemv(column, 10.0)");
 
     function = getFunction("PeRcEnTiLeEsTmV", "(column, 90)");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileEstMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEESTMV);
-    assertEquals(aggregationFunction.getColumnName(), "percentileEst90.0MV_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentileestmv(column, 90.0)");
 
     function = getFunction("PeRcEnTiLeTdIgEsTmV", "(column, 95)");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
-    assertEquals(aggregationFunction.getColumnName(), "percentileTDigest95.0MV_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigestmv(column, 95.0)");
 
     function = getFunction("PeRcEnTiLe_TdIgEsT_mV", "(column, 95)");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
-    assertEquals(aggregationFunction.getColumnName(), "percentileTDigest95.0MV_column");
     assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigestmv(column, 95.0)");
 
     function = getFunction("bool_and");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof BooleanAndAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.BOOLAND);
-    assertEquals(aggregationFunction.getColumnName(), "boolAnd_column");
-    assertEquals(aggregationFunction.getResultColumnName(), "booland(column)");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("bool_or");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof BooleanOrAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.BOOLOR);
-    assertEquals(aggregationFunction.getColumnName(), "boolOr_column");
-    assertEquals(aggregationFunction.getResultColumnName(), "boolor(column)");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("skewness");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof FourthMomentAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.SKEWNESS);
-    assertEquals(aggregationFunction.getColumnName(), "skewness_column");
-    assertEquals(aggregationFunction.getResultColumnName(), "skewness(column)");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("kurtosis");
     aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, DUMMY_QUERY_CONTEXT);
     assertTrue(aggregationFunction instanceof FourthMomentAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.KURTOSIS);
-    assertEquals(aggregationFunction.getColumnName(), "kurtosis_column");
-    assertEquals(aggregationFunction.getResultColumnName(), "kurtosis(column)");
+    assertEquals(aggregationFunction.getResultColumnName(), function.toString());
   }
 
   private FunctionContext getFunction(String functionName) {
@@ -486,11 +426,13 @@ public class AggregationFunctionFactoryTest {
   public void testAggregationFunctionWithMultipleArgs() {
     QueryContext queryContext =
         QueryContextConverterUtils.getQueryContext("SELECT DISTINCT column1, column2, column3 FROM testTable");
-    AggregationFunction aggregationFunction = AggregationFunctionFactory
-        .getAggregationFunction(queryContext.getSelectExpressions().get(0).getFunction(), queryContext);
+    AggregationFunction aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(queryContext.getSelectExpressions().get(0).getFunction(),
+            queryContext);
     assertTrue(aggregationFunction instanceof DistinctAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCT);
-    assertEquals(aggregationFunction.getColumnName(), "distinct_column1:column2:column3");
-    assertEquals(aggregationFunction.getResultColumnName(), "distinct(column1:column2:column3)");
+    assertEquals(aggregationFunction.getInputExpressions(),
+        Arrays.asList(ExpressionContext.forIdentifier("column1"), ExpressionContext.forIdentifier("column2"),
+            ExpressionContext.forIdentifier("column3")));
   }
 }


### PR DESCRIPTION
`getColumnName()` is only used in the data schema of the server side aggregation results. Since we are not using the column name in the `AggregationDataTableReducer` (broker side reduce), we can safely remove it.