### PR TITLE
Add support to create realtime segment in local

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/CreateSegmentCommand.java
@@ -26,12 +26,14 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
@@ -81,6 +83,10 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
   @CommandLine.Option(names = {"-failOnEmptySegment"},
       description = "Option to fail the segment creation if output is an empty segment.")
   private boolean _failOnEmptySegment = false;
+
+  @CommandLine.Option(names = {"-realtimePartitionId"},
+      description = "If table is realtime, partition id to be used for segment name generation. Default is 0.")
+  private int _realtimePartitionId = 0;
 
   @CommandLine.Option(names = {"-postCreationVerification"},
       description = "Verify segment data file after segment creation. Please ensure you have enough local disk to"
@@ -136,6 +142,11 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
 
   public CreateSegmentCommand setFailOnEmptySegment(boolean failOnEmptySegment) {
     _failOnEmptySegment = failOnEmptySegment;
+    return this;
+  }
+
+  public CreateSegmentCommand setRealtimePartitionId(int realtimePartitionId) {
+    _realtimePartitionId = realtimePartitionId;
     return this;
   }
 
@@ -209,6 +220,7 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
     }
     LOGGER.info("Using table config: {}", tableConfig.toJsonString());
     String rawTableName = TableNameBuilder.extractRawTableName(tableConfig.getTableName());
+    TableType tableType = tableConfig.getTableType();
 
     Preconditions.checkArgument(_schemaFile != null, "'schemaFile' must be specified");
     Schema schema;
@@ -246,6 +258,10 @@ public class CreateSegmentCommand extends AbstractBaseAdminCommand implements Co
         segmentGeneratorConfig.setReaderConfig(recordReaderConfig);
         segmentGeneratorConfig.setTableName(rawTableName);
         segmentGeneratorConfig.setSequenceId(sequenceId);
+        if (tableType == TableType.REALTIME) {
+          segmentGeneratorConfig.setSegmentName(new LLCSegmentName(rawTableName, _realtimePartitionId, sequenceId,
+              System.currentTimeMillis()).getSegmentName());
+        }
         segmentGeneratorConfig.setFailOnEmptySegment(_failOnEmptySegment);
         for (int j = 0; j <= _retry; j++) {
           try {


### PR DESCRIPTION
Realtime segments fail on upload if the segment name and metadata doesn't contain the correct partitionID.
This PR allows users to create realtime segments in local using `CreateSegment` command.

Users just need to mention the integer `realtimePartitionId` for the data file so that the segment can be uploaded to correct partition later on.

