### PR TITLE
Add Spark connector option for passing Pinot query options

### DIFF
--- a/pinot-connectors/pinot-spark-2-connector/README.md
+++ b/pinot-connectors/pinot-spark-2-connector/README.md
@@ -28,12 +28,14 @@ Detailed read model documentation is here; [Spark-Pinot Connector Read Model](do
 ## Features
 - Query realtime, offline or hybrid tables
 - Distributed, parallel scan
+- Streaming reads using gRPC (optional)
 - SQL support instead of PQL
 - Column and filter push down to optimize performance
 - Overlap between realtime and offline segments is queried exactly once for hybrid tables
 - Schema discovery 
   - Dynamic inference
   - Static analysis of case class
+- Supports query options
 
 ## Quick Start
 ```scala

--- a/pinot-connectors/pinot-spark-2-connector/documentation/read_model.md
+++ b/pinot-connectors/pinot-spark-2-connector/documentation/read_model.md
@@ -138,3 +138,4 @@ val df = spark.read
 | segmentsPerSplit | Represents the maximum segment count that will be scanned by pinot server in one connection | No | 3 | 
 | pinotServerTimeoutMs | The maximum timeout(ms) to get data from pinot server | No | 10 mins |
 | useGrpcServer | Boolean value to enable reads via gRPC. This option is more memory efficient both on Pinot server and Spark executor side because it utilizes streaming. Requires gRPC to be enabled on Pinot server. | No | false |
+| queryOptions | Comma separated list of Pinot query options (e.g. "enableNullHandling=true,skipUpsert=true") | No | "" |

--- a/pinot-connectors/pinot-spark-3-connector/README.md
+++ b/pinot-connectors/pinot-spark-3-connector/README.md
@@ -35,6 +35,7 @@ Detailed read model documentation is here; [Spark-Pinot Connector Read Model](do
 - Schema discovery 
   - Dynamic inference
   - Static analysis of case class
+- Supports query options
 
 ## Quick Start
 ```scala

--- a/pinot-connectors/pinot-spark-3-connector/documentation/read_model.md
+++ b/pinot-connectors/pinot-spark-3-connector/documentation/read_model.md
@@ -138,3 +138,4 @@ val df = spark.read
 | segmentsPerSplit | Represents the maximum segment count that will be scanned by pinot server in one connection | No | 3 | 
 | pinotServerTimeoutMs | The maximum timeout(ms) to get data from pinot server | No | 10 mins |
 | useGrpcServer | Boolean value to enable reads via gRPC. This option is more memory efficient both on Pinot server and Spark executor side because it utilizes streaming. Requires gRPC to be enabled on Pinot server. | No | false |
+| queryOptions | Comma separated list of Pinot query options (e.g. "enableNullHandling=true,skipUpsert=true") | No | "" |

--- a/pinot-connectors/pinot-spark-3-connector/src/main/scala/org/apache/pinot/connector/spark/v3/datasource/PinotScanBuilder.scala
+++ b/pinot-connectors/pinot-spark-3-connector/src/main/scala/org/apache/pinot/connector/spark/v3/datasource/PinotScanBuilder.scala
@@ -54,7 +54,8 @@ class PinotScanBuilder(readParameters: PinotDataSourceReadOptions)
       readParameters.tableType,
       timeBoundaryInfo,
       currentSchema.fieldNames,
-      whereCondition
+      whereCondition,
+      readParameters.queryOptions
     )
 
     new PinotScan(scanQuery, currentSchema, readParameters)

--- a/pinot-connectors/pinot-spark-3-connector/src/main/scala/org/apache/pinot/connector/spark/v3/datasource/TypeConverter.scala
+++ b/pinot-connectors/pinot-spark-3-connector/src/main/scala/org/apache/pinot/connector/spark/v3/datasource/TypeConverter.scala
@@ -66,6 +66,9 @@ private[pinot] object TypeConverter {
       dataTable: DataTable,
       sparkSchema: StructType): Seq[InternalRow] = {
     val dataTableColumnNames = dataTable.getDataSchema.getColumnNames
+    val nullRowIdsByColumn = (0 until dataTable.getDataSchema.size()).map{ col =>
+      dataTable.getNullRowIds(col)
+    }
     (0 until dataTable.getNumberOfRows).map { rowIndex =>
       // spark schema is used to ensure columns order
       val columns = sparkSchema.fields.map { field =>
@@ -73,10 +76,13 @@ private[pinot] object TypeConverter {
         if (colIndex < 0) {
           throw PinotException(s"'${field.name}' not found in Pinot server response")
         } else {
-          // pinot column data type can be used directly,
-          // because all of them is supported in spark schema
-          val columnDataType = dataTable.getDataSchema.getColumnDataType(colIndex)
-          readPinotColumnData(dataTable, columnDataType, rowIndex, colIndex)
+          if (nullRowIdsByColumn(colIndex) != null
+              && nullRowIdsByColumn(colIndex).contains(rowIndex)) {
+            null
+          } else {
+            val columnDataType = dataTable.getDataSchema.getColumnDataType(colIndex)
+            readPinotColumnData(dataTable, columnDataType, rowIndex, colIndex)
+          }
         }
       }
       InternalRow.fromSeq(columns)

--- a/pinot-connectors/pinot-spark-3-connector/src/test/scala/org/apache/pinot/connector/spark/v3/datasource/TypeConverterTest.scala
+++ b/pinot-connectors/pinot-spark-3-connector/src/test/scala/org/apache/pinot/connector/spark/v3/datasource/TypeConverterTest.scala
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.connector.spark.v3.datasource
 
+import org.apache.pinot.common.datatable.DataTableFactory
 import org.apache.pinot.common.utils.DataSchema
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType
 import org.apache.pinot.connector.spark.common.PinotException
@@ -27,6 +28,7 @@ import org.apache.pinot.spi.utils.ByteArray
 import org.apache.spark.sql.catalyst.util.ArrayData
 import org.apache.spark.sql.types._
 import org.apache.spark.unsafe.types.UTF8String
+import org.roaringbitmap.RoaringBitmap
 
 import scala.io.Source
 
@@ -158,6 +160,37 @@ class TypeConverterTest extends BaseTest {
     }
 
     exception.getMessage shouldEqual s"'longCol' not found in Pinot server response"
+  }
+
+  test("Converter should identify and correctly return null rows") {
+    val columnNames = Array("strCol", "intCol")
+    val columnTypes = Array(ColumnDataType.STRING, ColumnDataType.INT)
+    val dataSchema = new DataSchema(columnNames, columnTypes)
+    DataTableBuilderFactory.setDataTableVersion(DataTableFactory.VERSION_4)
+
+    val dataTableBuilder = DataTableBuilderFactory.getDataTableBuilder(dataSchema)
+    dataTableBuilder.startRow()
+    dataTableBuilder.setColumn(0, "null")
+    dataTableBuilder.setColumn(1, 5)
+    dataTableBuilder.finishRow()
+
+    val nullRowIds = new RoaringBitmap()
+    nullRowIds.add(0)
+    dataTableBuilder.setNullRowIds(nullRowIds)
+    dataTableBuilder.setNullRowIds(null)
+
+
+    val dataTable = dataTableBuilder.build()
+
+    val schema = StructType(
+      Seq(
+        StructField("strCol", StringType, true),
+        StructField("intCol", IntegerType, true)
+      )
+    )
+
+    val result = TypeConverter.pinotDataTableToInternalRows(dataTable, schema).head
+    result.get(0, StringType) shouldEqual null
   }
 
   test("Pinot schema should be converted to spark schema") {

--- a/pinot-connectors/pinot-spark-common/src/main/scala/org/apache/pinot/connector/spark/common/PinotDataSourceReadOptions.scala
+++ b/pinot-connectors/pinot-spark-common/src/main/scala/org/apache/pinot/connector/spark/common/PinotDataSourceReadOptions.scala
@@ -36,6 +36,8 @@ object PinotDataSourceReadOptions {
   val CONFIG_SEGMENTS_PER_SPLIT = "segmentsPerSplit"
   val CONFIG_PINOT_SERVER_TIMEOUT_MS = "pinotServerTimeoutMs"
   var CONFIG_USE_GRPC_SERVER = "useGrpcServer"
+  val CONFIG_QUERY_OPTIONS = "queryOptions"
+  val QUERY_OPTIONS_DELIMITER = ","
   private[pinot] val DEFAULT_CONTROLLER: String = "localhost:9000"
   private[pinot] val DEFAULT_USE_PUSH_DOWN_FILTERS: Boolean = true
   private[pinot] val DEFAULT_SEGMENTS_PER_SPLIT: Int = 3
@@ -83,6 +85,8 @@ object PinotDataSourceReadOptions {
     val pinotServerTimeoutMs =
       options.getLong(CONFIG_PINOT_SERVER_TIMEOUT_MS, DEFAULT_PINOT_SERVER_TIMEOUT_MS)
     val useGrpcServer = options.getBoolean(CONFIG_USE_GRPC_SERVER, DEFAULT_USE_GRPC_SERVER)
+    val queryOptions = options.getOrDefault(CONFIG_QUERY_OPTIONS, "")
+      .split(QUERY_OPTIONS_DELIMITER).filter(_.nonEmpty).toSet
 
     PinotDataSourceReadOptions(
       tableName,
@@ -92,7 +96,8 @@ object PinotDataSourceReadOptions {
       usePushDownFilters,
       segmentsPerSplit,
       pinotServerTimeoutMs,
-      useGrpcServer
+      useGrpcServer,
+      queryOptions
     )
   }
 }
@@ -106,4 +111,6 @@ private[pinot] case class PinotDataSourceReadOptions(
     usePushDownFilters: Boolean,
     segmentsPerSplit: Int,
     pinotServerTimeoutMs: Long,
-    useGrpcServer: Boolean)
+    useGrpcServer: Boolean,
+    queryOptions: Set[String])
+

--- a/pinot-connectors/pinot-spark-common/src/main/scala/org/apache/pinot/connector/spark/common/query/ScanQueryGenerator.scala
+++ b/pinot-connectors/pinot-spark-common/src/main/scala/org/apache/pinot/connector/spark/common/query/ScanQueryGenerator.scala
@@ -29,7 +29,8 @@ private[pinot] class ScanQueryGenerator(
     tableType: Option[TableType],
     timeBoundaryInfo: Option[TimeBoundaryInfo],
     columns: Array[String],
-    whereClause: Option[String]) {
+    whereClause: Option[String],
+    queryOptions: Set[String]) {
   private val columnsExpression = columnsAsExpression()
 
   def generateSQLs(): ScanQuery = {
@@ -56,7 +57,11 @@ private[pinot] class ScanQueryGenerator(
     }
 
     val tableNameWithType = s"${tableName}_${tableType.toString}"
-    val queryBuilder = new StringBuilder(s"SELECT $columnsExpression FROM $tableNameWithType")
+    val queryBuilder = new StringBuilder()
+
+    // add Query Options and SELECT clause
+    queryOptions.foreach(opt => queryBuilder.append(s"SET $opt;"))
+    queryBuilder.append(s"SELECT $columnsExpression FROM $tableNameWithType")
 
     // add where clause if exists
     whereClause.foreach(c => queryBuilder.append(s" WHERE $c"))
@@ -84,8 +89,9 @@ private[pinot] object ScanQueryGenerator {
       tableType: Option[TableType],
       timeBoundaryInfo: Option[TimeBoundaryInfo],
       columns: Array[String],
-      whereClause: Option[String]): ScanQuery = {
-    new ScanQueryGenerator(tableName, tableType, timeBoundaryInfo, columns, whereClause)
+      whereClause: Option[String],
+      queryOptions: Set[String]): ScanQuery = {
+    new ScanQueryGenerator(tableName, tableType, timeBoundaryInfo, columns, whereClause, queryOptions)
       .generateSQLs()
   }
 }

--- a/pinot-connectors/pinot-spark-common/src/test/scala/org/apache/pinot/connector/spark/common/PinotDataSourceReadOptionsTest.scala
+++ b/pinot-connectors/pinot-spark-common/src/test/scala/org/apache/pinot/connector/spark/common/PinotDataSourceReadOptionsTest.scala
@@ -34,6 +34,7 @@ class PinotDataSourceReadOptionsTest extends BaseTest {
       PinotDataSourceReadOptions.CONFIG_SEGMENTS_PER_SPLIT -> "1",
       PinotDataSourceReadOptions.CONFIG_USE_PUSH_DOWN_FILTERS -> "false",
       PinotDataSourceReadOptions.CONFIG_USE_GRPC_SERVER -> "false",
+      PinotDataSourceReadOptions.CONFIG_QUERY_OPTIONS -> "a=1,b=2"
     )
 
     val pinotDataSourceReadOptions = PinotDataSourceReadOptions.from(options.asJava)
@@ -47,7 +48,8 @@ class PinotDataSourceReadOptionsTest extends BaseTest {
         false,
         1,
         10000,
-        false
+        false,
+        Set("a=1", "b=2")
       )
 
     pinotDataSourceReadOptions shouldEqual expected

--- a/pinot-connectors/pinot-spark-common/src/test/scala/org/apache/pinot/connector/spark/common/PinotSplitterTest.scala
+++ b/pinot-connectors/pinot-spark-common/src/test/scala/org/apache/pinot/connector/spark/common/PinotSplitterTest.scala
@@ -56,7 +56,8 @@ class PinotSplitterTest extends BaseTest {
       false,
       segmentsPerSplit,
       1000,
-      false)
+      false,
+      Set())
   }
 
   test("Total 5 partition splits should be created for maxNumSegmentPerServerRequest = 3") {
@@ -112,7 +113,8 @@ class PinotSplitterTest extends BaseTest {
       false,
       1,
       1000,
-      true)
+      true,
+      Set())
 
     val inputGrpcPortReader = (server: String) => {
       InstanceInfo(server, "192.168.1.100", "9000", 8090)


### PR DESCRIPTION
Adding Spark connector option for passing Pinot query options.

Example:
```
val data = spark.read
  .format("pinot")
  .option("table", "myTable")
  .option("tableType", "OFFLINE")
  .option("queryOptions", "enableNullHandling=true,maxExecutionThreads=1") // <- new
  .load()
```

Also includes a bugfix which allows the Spark connector to return `null` values instead of their placeholders.

**Testing**
- Unit tests are updated
- Ran the suite of integration tests (`ExampleSparkPinotConnectorTest`) against a Pinot cluster successfully 

`feature` `bugfix`
`release-notes` (Spark connector now accepts Pinot query options)