### PR TITLE
Do not record operator stats when tracing is enabled

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -176,8 +176,13 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
     ResultTable queryResults;
     Map<Integer, ExecutionStatsAggregator> stageIdStatsMap = new HashMap<>();
-    for (Integer stageId: queryPlan.getStageMetadataMap().keySet()) {
-      stageIdStatsMap.put(stageId, new ExecutionStatsAggregator(traceEnabled));
+    if (traceEnabled) {
+      for (Integer stageId : queryPlan.getStageMetadataMap().keySet()) {
+        stageIdStatsMap.put(stageId, new ExecutionStatsAggregator(traceEnabled));
+      }
+    } else {
+      // Aggregate only at root stage, ignore other stages
+      stageIdStatsMap.put(0, new ExecutionStatsAggregator(traceEnabled));
     }
 
     try {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -176,13 +176,8 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
     ResultTable queryResults;
     Map<Integer, ExecutionStatsAggregator> stageIdStatsMap = new HashMap<>();
-    if (traceEnabled) {
-      for (Integer stageId : queryPlan.getStageMetadataMap().keySet()) {
-        stageIdStatsMap.put(stageId, new ExecutionStatsAggregator(traceEnabled));
-      }
-    } else {
-      // Aggregate only at root stage, ignore other stages
-      stageIdStatsMap.put(0, new ExecutionStatsAggregator(traceEnabled));
+    for (Integer stageId : queryPlan.getStageMetadataMap().keySet()) {
+      stageIdStatsMap.put(stageId, new ExecutionStatsAggregator(traceEnabled));
     }
 
     try {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -182,7 +182,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
 
     try {
       queryResults = _queryDispatcher.submitAndReduce(requestId, queryPlan, _mailboxService, queryTimeoutMs,
-          sqlNodeAndOptions.getOptions(), stageIdStatsMap);
+          sqlNodeAndOptions.getOptions(), stageIdStatsMap, traceEnabled);
     } catch (Exception e) {
       LOGGER.info("query execution failed", e);
       return new BrokerResponseNative(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.query.reduce;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -363,19 +362,18 @@ public class ExecutionStatsAggregator {
 
   public void setStageLevelStats(@Nullable String rawTableName, BrokerResponseStats brokerResponseStats,
       @Nullable BrokerMetrics brokerMetrics) {
-    setStats(rawTableName, brokerResponseStats, brokerMetrics);
-
-    brokerResponseStats.setNumBlocks(_numBlocks);
-    brokerResponseStats.setNumRows(_numRows);
-    brokerResponseStats.setStageExecutionTimeMs(_stageExecutionTimeMs);
-    brokerResponseStats.setStageExecWallTimeMs(_stageExecEndTimeMs - _stageExecStartTimeMs);
-    brokerResponseStats.setStageExecutionUnit(_stageExecutionUnit);
     if (_enableTrace) {
+      setStats(rawTableName, brokerResponseStats, brokerMetrics);
+      brokerResponseStats.setNumBlocks(_numBlocks);
+      brokerResponseStats.setNumRows(_numRows);
+
+      brokerResponseStats.setStageExecutionTimeMs(_stageExecutionTimeMs);
+      brokerResponseStats.setStageExecWallTimeMs(_stageExecEndTimeMs - _stageExecStartTimeMs);
+      brokerResponseStats.setStageExecutionUnit(_stageExecutionUnit);
+
       brokerResponseStats.setOperatorStats(_operatorStats);
-    } else {
-      brokerResponseStats.setOperatorStats(Collections.emptyMap());
+      brokerResponseStats.setTableNames(new ArrayList<>(_tableNames));
     }
-    brokerResponseStats.setTableNames(new ArrayList<>(_tableNames));
   }
 
   private void withNotNullLongMetadata(Map<String, String> metadata, DataTable.MetadataKey key, LongConsumer consumer) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
@@ -368,11 +368,13 @@ public class ExecutionStatsAggregator {
       brokerResponseStats.setNumRows(_numRows);
 
       brokerResponseStats.setStageExecutionTimeMs(_stageExecutionTimeMs);
-      brokerResponseStats.setStageExecWallTimeMs(_stageExecEndTimeMs - _stageExecStartTimeMs);
       brokerResponseStats.setStageExecutionUnit(_stageExecutionUnit);
 
       brokerResponseStats.setOperatorStats(_operatorStats);
       brokerResponseStats.setTableNames(new ArrayList<>(_tableNames));
+    }
+    if (_stageExecStartTimeMs >= 0 && _stageExecEndTimeMs >= 0) {
+      brokerResponseStats.setStageExecWallTimeMs(_stageExecEndTimeMs - _stageExecStartTimeMs);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
@@ -365,13 +365,13 @@ public class ExecutionStatsAggregator {
     if (_enableTrace) {
       setStats(rawTableName, brokerResponseStats, brokerMetrics);
       brokerResponseStats.setOperatorStats(_operatorStats);
-      brokerResponseStats.setTableNames(new ArrayList<>(_tableNames));
     }
 
     brokerResponseStats.setNumBlocks(_numBlocks);
     brokerResponseStats.setNumRows(_numRows);
     brokerResponseStats.setStageExecutionTimeMs(_stageExecutionTimeMs);
     brokerResponseStats.setStageExecutionUnit(_stageExecutionUnit);
+    brokerResponseStats.setTableNames(new ArrayList<>(_tableNames));
     if (_stageExecStartTimeMs >= 0 && _stageExecEndTimeMs >= 0) {
       brokerResponseStats.setStageExecWallTimeMs(_stageExecEndTimeMs - _stageExecStartTimeMs);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
@@ -364,15 +364,14 @@ public class ExecutionStatsAggregator {
       @Nullable BrokerMetrics brokerMetrics) {
     if (_enableTrace) {
       setStats(rawTableName, brokerResponseStats, brokerMetrics);
-      brokerResponseStats.setNumBlocks(_numBlocks);
-      brokerResponseStats.setNumRows(_numRows);
-
-      brokerResponseStats.setStageExecutionTimeMs(_stageExecutionTimeMs);
-      brokerResponseStats.setStageExecutionUnit(_stageExecutionUnit);
-
       brokerResponseStats.setOperatorStats(_operatorStats);
       brokerResponseStats.setTableNames(new ArrayList<>(_tableNames));
     }
+
+    brokerResponseStats.setNumBlocks(_numBlocks);
+    brokerResponseStats.setNumRows(_numRows);
+    brokerResponseStats.setStageExecutionTimeMs(_stageExecutionTimeMs);
+    brokerResponseStats.setStageExecutionUnit(_stageExecutionUnit);
     if (_stageExecStartTimeMs >= 0 && _stageExecEndTimeMs >= 0) {
       brokerResponseStats.setStageExecWallTimeMs(_stageExecEndTimeMs - _stageExecStartTimeMs);
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -109,10 +109,6 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
         }
       } else {
         _currentIndex = -1;
-        if (!_context.isTraceEnabled()) {
-          _operatorStats.recordSingleStat(DataTable.MetadataKey.OPERATOR_ID.getName(), getOperatorId());
-          _operatorStatsMap.put(getOperatorId(), _operatorStats);
-        }
         return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock());
       }
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -114,6 +114,11 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     }
   }
 
+  @Override
+  protected boolean shouldCollectStats() {
+    return true;
+  }
+
   /**
    * this is data transfer block compose method is here to ensure that V1 results match what the expected projection
    * schema in the calcite logical operator.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -109,6 +109,10 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
         }
       } else {
         _currentIndex = -1;
+        if (!_context.isTraceEnabled()) {
+          _operatorStats.recordSingleStat(DataTable.MetadataKey.OPERATOR_ID.getName(), getOperatorId());
+          _operatorStatsMap.put(getOperatorId(), _operatorStats);
+        }
         return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock());
       }
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -114,6 +114,10 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     }
   }
 
+  /**
+   * Leaf stage operators should always collect stats for the tables used in queries
+   * Otherwise the Broker response will just contain zeros for every stat value
+   */
   @Override
   protected boolean shouldCollectStats() {
     return true;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -178,6 +178,10 @@ public class MailboxSendOperator extends MultiStageOperator {
     return transferableBlock;
   }
 
+  /**
+   * This method is overridden to return true because this operator is last in the chain and needs to collect
+   * execution time stats
+   */
   @Override
   protected boolean shouldCollectStats() {
     return true;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -179,6 +179,11 @@ public class MailboxSendOperator extends MultiStageOperator {
   }
 
   @Override
+  protected boolean shouldCollectStats() {
+    return true;
+  }
+
+  @Override
   public void close() {
     super.close();
     _exchange.close();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -50,10 +50,14 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
     }
     try (InvocationScope ignored = Tracing.getTracer().createScope(getClass())) {
       OperatorStats operatorStats = _opChainStats.getOperatorStats(_context, _operatorId);
-      operatorStats.startTimer();
+      if (_context.isTraceEnabled()) {
+        operatorStats.startTimer();
+      }
       TransferableBlock nextBlock = getNextBlock();
-      operatorStats.recordRow(1, nextBlock.getNumRows());
-      operatorStats.endTimer(nextBlock);
+      if (_context.isTraceEnabled()) {
+        operatorStats.recordRow(1, nextBlock.getNumRows());
+        operatorStats.endTimer(nextBlock);
+      }
       return nextBlock;
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -57,7 +57,6 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
         operatorStats.recordRow(1, nextBlock.getNumRows());
         operatorStats.endTimer(nextBlock);
       } else {
-
         nextBlock = getNextBlock();
       }
       return nextBlock;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -50,11 +50,12 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
     }
     try (InvocationScope ignored = Tracing.getTracer().createScope(getClass())) {
       OperatorStats operatorStats = _opChainStats.getOperatorStats(_context, _operatorId);
-      if (_context.isTraceEnabled()) {
+      TransferableBlock nextBlock;
+      if (operatorStats == null || !_context.isTraceEnabled()) {
+        nextBlock = getNextBlock();
+      } else {
         operatorStats.startTimer();
-      }
-      TransferableBlock nextBlock = getNextBlock();
-      if (_context.isTraceEnabled()) {
+        nextBlock = getNextBlock();
         operatorStats.recordRow(1, nextBlock.getNumRows());
         operatorStats.endTimer(nextBlock);
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -49,15 +49,16 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
       throw new EarlyTerminationException("Interrupted while processing next block");
     }
     try (InvocationScope ignored = Tracing.getTracer().createScope(getClass())) {
-      OperatorStats operatorStats = _opChainStats.getOperatorStats(_context, _operatorId);
       TransferableBlock nextBlock;
-      if (operatorStats == null || !_context.isTraceEnabled()) {
-        nextBlock = getNextBlock();
-      } else {
+      if (shouldCollectStats()) {
+        OperatorStats operatorStats = _opChainStats.getOperatorStats(_context, _operatorId);
         operatorStats.startTimer();
         nextBlock = getNextBlock();
         operatorStats.recordRow(1, nextBlock.getNumRows());
         operatorStats.endTimer(nextBlock);
+      } else {
+
+        nextBlock = getNextBlock();
       }
       return nextBlock;
     }
@@ -69,6 +70,10 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
 
   // Make it protected because we should always call nextBlock()
   protected abstract TransferableBlock getNextBlock();
+
+  protected boolean shouldCollectStats() {
+    return _context.isTraceEnabled();
+  }
 
   @Override
   public List<MultiStageOperator> getChildOperators() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainStats.java
@@ -79,15 +79,13 @@ public class OpChainStats {
   }
 
   public OperatorStats getOperatorStats(OpChainExecutionContext context, String operatorId) {
-    //TODO: remove this check once we have a better way to track the leaf operators
-    if (context.isTraceEnabled() || operatorId.contains("LEAF")) {
       return _operatorStatsMap.computeIfAbsent(operatorId, (id) -> {
         OperatorStats operatorStats = new OperatorStats(context);
-        operatorStats.recordSingleStat(DataTable.MetadataKey.OPERATOR_ID.getName(), operatorId);
+        if (context.isTraceEnabled()) {
+          operatorStats.recordSingleStat(DataTable.MetadataKey.OPERATOR_ID.getName(), operatorId);
+        }
         return operatorStats;
       });
-    }
-    return null;
   }
 
   private void startExecutionTimer() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainStats.java
@@ -79,11 +79,15 @@ public class OpChainStats {
   }
 
   public OperatorStats getOperatorStats(OpChainExecutionContext context, String operatorId) {
-    return _operatorStatsMap.computeIfAbsent(operatorId, (id) -> {
-       OperatorStats operatorStats = new OperatorStats(context);
-       operatorStats.recordSingleStat(DataTable.MetadataKey.OPERATOR_ID.getName(), operatorId);
-       return operatorStats;
-     });
+    //TODO: remove this check once we have a better way to track the leaf operators
+    if (context.isTraceEnabled() || operatorId.contains("LEAF")) {
+      return _operatorStatsMap.computeIfAbsent(operatorId, (id) -> {
+        OperatorStats operatorStats = new OperatorStats(context);
+        operatorStats.recordSingleStat(DataTable.MetadataKey.OPERATOR_ID.getName(), operatorId);
+        return operatorStats;
+      });
+    }
+    return null;
   }
 
   private void startExecutionTimer() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
@@ -94,10 +94,13 @@ public class OperatorStats {
     _executionStats.putIfAbsent(DataTable.MetadataKey.OPERATOR_EXECUTION_TIME_MS.getName(),
         String.valueOf(_executeStopwatch.elapsed(TimeUnit.MILLISECONDS)));
     // wall time are recorded slightly longer than actual execution but it is OK.
-    _executionStats.putIfAbsent(DataTable.MetadataKey.OPERATOR_EXEC_START_TIME_MS.getName(),
-        String.valueOf(_startTimeMs));
-    _executionStats.putIfAbsent(DataTable.MetadataKey.OPERATOR_EXEC_END_TIME_MS.getName(),
-        String.valueOf(System.currentTimeMillis()));
+
+    if (_startTimeMs != -1) {
+      _executionStats.putIfAbsent(DataTable.MetadataKey.OPERATOR_EXEC_START_TIME_MS.getName(),
+          String.valueOf(_startTimeMs));
+      _executionStats.putIfAbsent(DataTable.MetadataKey.OPERATOR_EXEC_END_TIME_MS.getName(),
+          String.valueOf(System.currentTimeMillis()));
+    }
     return _executionStats;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
@@ -41,6 +41,7 @@ public class OperatorStats {
   private int _numBlock = 0;
   private int _numRows = 0;
   private long _startTimeMs = -1;
+  private long _endTimeMs = -1;
   private final Map<String, String> _executionStats;
   private boolean _processingStarted = false;
 
@@ -66,9 +67,11 @@ public class OperatorStats {
   public void endTimer(TransferableBlock block) {
     if (_executeStopwatch.isRunning()) {
       _executeStopwatch.stop();
+      _endTimeMs = System.currentTimeMillis();
     }
     if (!_processingStarted && block.isNoOpBlock()) {
       _startTimeMs = -1;
+      _endTimeMs = -1;
       _executeStopwatch.reset();
     } else {
       _processingStarted = true;
@@ -99,7 +102,7 @@ public class OperatorStats {
       _executionStats.putIfAbsent(DataTable.MetadataKey.OPERATOR_EXEC_START_TIME_MS.getName(),
           String.valueOf(_startTimeMs));
       _executionStats.putIfAbsent(DataTable.MetadataKey.OPERATOR_EXEC_END_TIME_MS.getName(),
-          String.valueOf(System.currentTimeMillis()));
+          String.valueOf(_endTimeMs));
     }
     return _executionStats;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
@@ -101,8 +101,9 @@ public class OperatorStats {
     if (_startTimeMs != -1) {
       _executionStats.putIfAbsent(DataTable.MetadataKey.OPERATOR_EXEC_START_TIME_MS.getName(),
           String.valueOf(_startTimeMs));
+      long endTimeMs = _endTimeMs == -1 ? System.currentTimeMillis() : _endTimeMs;
       _executionStats.putIfAbsent(DataTable.MetadataKey.OPERATOR_EXEC_END_TIME_MS.getName(),
-          String.valueOf(_endTimeMs));
+          String.valueOf(endTimeMs));
     }
     return _executionStats;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
@@ -42,9 +42,11 @@ public class OpChainExecutionContext {
   private final Map<Integer, StageMetadata> _metadataMap;
   private final OpChainId _id;
   private final OpChainStats _stats;
+  private final boolean _traceEnabled;
 
   public OpChainExecutionContext(MailboxService<TransferableBlock> mailboxService, long requestId, int stageId,
-      VirtualServerAddress server, long timeoutMs, long deadlineMs, Map<Integer, StageMetadata> metadataMap) {
+      VirtualServerAddress server, long timeoutMs, long deadlineMs, Map<Integer, StageMetadata> metadataMap,
+      boolean traceEnabled) {
     _mailboxService = mailboxService;
     _requestId = requestId;
     _stageId = stageId;
@@ -54,12 +56,13 @@ public class OpChainExecutionContext {
     _metadataMap = metadataMap;
     _id = new OpChainId(requestId, server.virtualId(), stageId);
     _stats = new OpChainStats(_id.toString());
+    _traceEnabled = traceEnabled;
   }
 
   public OpChainExecutionContext(PlanRequestContext planRequestContext) {
     this(planRequestContext.getMailboxService(), planRequestContext.getRequestId(), planRequestContext.getStageId(),
         planRequestContext.getServer(), planRequestContext.getTimeoutMs(), planRequestContext.getDeadlineMs(),
-        planRequestContext.getMetadataMap());
+        planRequestContext.getMetadataMap(), planRequestContext.isTraceEnabled());
   }
 
   public MailboxService<TransferableBlock> getMailboxService() {
@@ -96,5 +99,9 @@ public class OpChainExecutionContext {
 
   public OpChainStats getStats() {
     return _stats;
+  }
+
+  public boolean isTraceEnabled() {
+    return _traceEnabled;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanRequestContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanRequestContext.java
@@ -40,9 +40,11 @@ public class PlanRequestContext {
   protected final Map<Integer, StageMetadata> _metadataMap;
   protected final List<MailboxIdentifier> _receivingMailboxes = new ArrayList<>();
   private final OpChainExecutionContext _opChainExecutionContext;
+  private final boolean _traceEnabled;
 
   public PlanRequestContext(MailboxService<TransferableBlock> mailboxService, long requestId, int stageId,
-      long timeoutMs, long deadlineMs, VirtualServerAddress server, Map<Integer, StageMetadata> metadataMap) {
+      long timeoutMs, long deadlineMs, VirtualServerAddress server, Map<Integer, StageMetadata> metadataMap,
+      boolean traceEnabled) {
     _mailboxService = mailboxService;
     _requestId = requestId;
     _stageId = stageId;
@@ -50,6 +52,7 @@ public class PlanRequestContext {
     _deadlineMs = deadlineMs;
     _server = server;
     _metadataMap = metadataMap;
+    _traceEnabled = traceEnabled;
     _opChainExecutionContext = new OpChainExecutionContext(this);
   }
 
@@ -91,5 +94,9 @@ public class PlanRequestContext {
 
   public OpChainExecutionContext getOpChainExecutionContext() {
     return _opChainExecutionContext;
+  }
+
+  public boolean isTraceEnabled() {
+    return _traceEnabled;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/ServerRequestPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/ServerRequestPlanVisitor.java
@@ -97,6 +97,7 @@ public class ServerRequestPlanVisitor implements StageNodeVisitor<Void, ServerPl
     long requestId = (Long.parseLong(requestMetadataMap.get(QueryConfig.KEY_OF_BROKER_REQUEST_ID)) << 16)
         + (stagePlan.getStageId() << 8) + (tableType == TableType.REALTIME ? 1 : 0);
     long timeoutMs = Long.parseLong(requestMetadataMap.get(QueryConfig.KEY_OF_BROKER_REQUEST_TIMEOUT_MS));
+    boolean traceEnabled = Boolean.parseBoolean(requestMetadataMap.get(CommonConstants.Broker.Request.TRACE));
     PinotQuery pinotQuery = new PinotQuery();
     Integer leafNodeLimit = QueryOptionsUtils.getMultiStageLeafLimit(requestMetadataMap);
     if (leafNodeLimit != null) {
@@ -109,7 +110,7 @@ public class ServerRequestPlanVisitor implements StageNodeVisitor<Void, ServerPl
     ServerPlanRequestContext context =
         new ServerPlanRequestContext(mailboxService, requestId, stagePlan.getStageId(), timeoutMs, deadlineMs,
             new VirtualServerAddress(stagePlan.getServer()), stagePlan.getMetadataMap(), pinotQuery, tableType,
-            timeBoundaryInfo);
+            timeBoundaryInfo, traceEnabled);
 
     // visit the plan and create query physical plan.
     ServerRequestPlanVisitor.walkStageNode(stagePlan.getStageRoot(), context);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestContext.java
@@ -43,8 +43,8 @@ public class ServerPlanRequestContext extends PlanRequestContext {
 
   public ServerPlanRequestContext(MailboxService<TransferableBlock> mailboxService, long requestId, int stageId,
       long timeoutMs, long deadlineMs, VirtualServerAddress server, Map<Integer, StageMetadata> metadataMap,
-      PinotQuery pinotQuery, TableType tableType, TimeBoundaryInfo timeBoundaryInfo) {
-    super(mailboxService, requestId, stageId, timeoutMs, deadlineMs, server, metadataMap);
+      PinotQuery pinotQuery, TableType tableType, TimeBoundaryInfo timeBoundaryInfo, boolean traceEnabled) {
+    super(mailboxService, requestId, stageId, timeoutMs, deadlineMs, server, metadataMap, traceEnabled);
     _pinotQuery = pinotQuery;
     _tableType = tableType;
     _timeBoundaryInfo = timeBoundaryInfo;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -223,12 +223,14 @@ public class QueryDispatcher {
             OperatorStats operatorStats = entry.getValue();
             ExecutionStatsAggregator rootStatsAggregator = executionStatsAggregatorMap.get(0);
             ExecutionStatsAggregator stageStatsAggregator = executionStatsAggregatorMap.get(operatorStats.getStageId());
-            if (queryPlan != null) {
-              StageMetadata operatorStageMetadata = queryPlan.getStageMetadataMap().get(operatorStats.getStageId());
-              OperatorUtils.recordTableName(operatorStats, operatorStageMetadata);
-            }
             rootStatsAggregator.aggregate(null, entry.getValue().getExecutionStats(), new HashMap<>());
-            stageStatsAggregator.aggregate(null, entry.getValue().getExecutionStats(), new HashMap<>());
+            if (stageStatsAggregator != null) {
+              if (queryPlan != null) {
+                StageMetadata operatorStageMetadata = queryPlan.getStageMetadataMap().get(operatorStats.getStageId());
+                OperatorUtils.recordTableName(operatorStats, operatorStageMetadata);
+              }
+              stageStatsAggregator.aggregate(null, entry.getValue().getExecutionStats(), new HashMap<>());
+            }
           }
         }
         return resultDataBlocks;

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -196,7 +196,8 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
 
     try {
       QueryDispatcher.runReducer(requestId, queryPlan, reducerStageId,
-          Long.parseLong(requestMetadataMap.get(QueryConfig.KEY_OF_BROKER_REQUEST_TIMEOUT_MS)), _mailboxService, null);
+          Long.parseLong(requestMetadataMap.get(QueryConfig.KEY_OF_BROKER_REQUEST_TIMEOUT_MS)), _mailboxService, null,
+          false);
     } catch (RuntimeException rte) {
       Assert.assertTrue(rte.getMessage().contains("Received error query execution result block"));
       Assert.assertTrue(rte.getMessage().contains(exceptionMsg), "Exception should contain: " + exceptionMsg

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
@@ -104,7 +104,7 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
         }
       }
       if (executionStatsAggregatorMap != null) {
-        executionStatsAggregatorMap.put(stageId, new ExecutionStatsAggregator(true));
+        executionStatsAggregatorMap.put(stageId, new ExecutionStatsAggregator(false));
       }
     }
     Preconditions.checkState(reducerStageId != -1);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
@@ -110,7 +110,7 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
     Preconditions.checkState(reducerStageId != -1);
     ResultTable resultTable = QueryDispatcher.runReducer(requestId, queryPlan, reducerStageId,
         Long.parseLong(requestMetadataMap.get(QueryConfig.KEY_OF_BROKER_REQUEST_TIMEOUT_MS)), _mailboxService,
-        executionStatsAggregatorMap);
+        executionStatsAggregatorMap, false);
     return resultTable.getRows();
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
@@ -74,7 +74,7 @@ public class OpChainSchedulerServiceTest {
 
   private OpChain getChain(MultiStageOperator operator) {
     VirtualServerAddress address = new VirtualServerAddress("localhost", 1234, 1);
-    OpChainExecutionContext context = new OpChainExecutionContext(null, 123L, 1, address, 0, 0, null);
+    OpChainExecutionContext context = new OpChainExecutionContext(null, 123L, 1, address, 0, 0, null, true);
     return new OpChain(context, operator, ImmutableList.of());
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/RoundRobinSchedulerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/RoundRobinSchedulerTest.java
@@ -184,6 +184,6 @@ public class RoundRobinSchedulerTest {
 
   private OpChainExecutionContext getOpChainExecutionContext(long requestId, int stageId, int virtualServerId) {
     return new OpChainExecutionContext(null, requestId, stageId,
-        new VirtualServerAddress("localhost", 1234, virtualServerId), 0, 0, null);
+        new VirtualServerAddress("localhost", 1234, virtualServerId), 0, 0, null, true);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -86,7 +86,7 @@ public class MailboxReceiveOperatorTest {
     // shorter timeoutMs should result in error.
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, 10L, 10L,
-            new HashMap<>());
+            new HashMap<>(), false);
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, 10L);
     Thread.sleep(200L);
@@ -97,13 +97,13 @@ public class MailboxReceiveOperatorTest {
 
     // longer timeout or default timeout (10s) doesn't result in error.
     context = new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, 2000L, 2000L,
-        new HashMap<>());
+        new HashMap<>(), false);
     receiveOp = new MailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, 2000L);
     Thread.sleep(200L);
     mailbox = receiveOp.nextBlock();
     Assert.assertFalse(mailbox.isErrorBlock());
     context = new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
-        Long.MAX_VALUE, new HashMap<>());
+        Long.MAX_VALUE, new HashMap<>(), false);
     receiveOp = new MailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, null);
     Thread.sleep(200L);
     mailbox = receiveOp.nextBlock();
@@ -125,7 +125,7 @@ public class MailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
             456, 789, null);
@@ -144,7 +144,7 @@ public class MailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
     MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
         RelDistribution.Type.RANGE_DISTRIBUTED, 456, 789, null);
   }
@@ -172,7 +172,7 @@ public class MailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
@@ -210,7 +210,7 @@ public class MailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
@@ -251,7 +251,7 @@ public class MailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
@@ -290,7 +290,7 @@ public class MailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
@@ -332,7 +332,7 @@ public class MailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
@@ -378,7 +378,7 @@ public class MailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
@@ -424,7 +424,7 @@ public class MailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,
@@ -474,7 +474,7 @@ public class MailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,
@@ -526,7 +526,7 @@ public class MailboxReceiveOperatorTest {
     Mockito.when(_mailbox2.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow3));
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,
@@ -585,7 +585,7 @@ public class MailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,
@@ -632,7 +632,7 @@ public class MailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     MailboxReceiveOperator receiveOp =
         new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -206,7 +206,7 @@ public class MailboxSendOperatorTest {
     Map<Integer, StageMetadata> stageMetadataMap = Collections.singletonMap(DEFAULT_RECEIVER_STAGE_ID, stageMetadata);
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_SENDER_STAGE_ID, new VirtualServerAddress(_server),
-            deadlineMs, deadlineMs, stageMetadataMap);
+            deadlineMs, deadlineMs, stageMetadataMap, false);
     return context;
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -194,6 +194,11 @@ public class MailboxSendOperatorTest {
     ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
     Mockito.verify(_exchange).send(captor.capture());
     Assert.assertSame(captor.getValue().getType(), DataBlock.Type.ROW, "expected data block to propagate");
+
+    // EOS block should contain statistics
+    Assert.assertFalse(context.getStats().getOperatorStatsMap().isEmpty());
+    Assert.assertEquals(context.getStats().getOperatorStatsMap().size(), 1);
+    Assert.assertTrue(context.getStats().getOperatorStatsMap().containsKey(operator.getOperatorId()));
   }
 
   private static TransferableBlock block(DataSchema schema, Object[]... rows) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
@@ -18,14 +18,34 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
+import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Stack;
 import javax.annotation.Nullable;
+import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
+import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.query.mailbox.JsonMailboxIdentifier;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.mailbox.ReceivingMailbox;
+import org.apache.pinot.query.planner.StageMetadata;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.planner.partitioning.KeySelector;
+import org.apache.pinot.query.routing.VirtualServer;
+import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.operator.exchange.BlockExchange;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -41,10 +61,61 @@ public class OpChainTest {
   private MultiStageOperator _upstreamOperator;
 
   private static int _numOperatorsInitialized = 0;
+  private final List<TransferableBlock> _blockList = new ArrayList<>();
+
+  @Mock
+  private MailboxService<TransferableBlock> _mailboxService;
+  @Mock
+  private VirtualServer _server;
+  @Mock
+  private KeySelector<Object[], Object[]> _selector;
+  @Mock
+  private MailboxSendOperator.BlockExchangeFactory _exchangeFactory;
+  @Mock
+  private BlockExchange _exchange;
+
+  @Mock
+  private ReceivingMailbox<TransferableBlock> _mailbox;
+
+
+  @Mock
+  private MailboxService<TransferableBlock> _mailboxService2;
+  @Mock
+  private ReceivingMailbox<TransferableBlock> _mailbox2;
+
 
   @BeforeMethod
   public void setUp() {
     _mocks = MockitoAnnotations.openMocks(this);
+
+    Mockito.when(_exchangeFactory.build(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any(),
+        Mockito.anyLong())).thenReturn(_exchange);
+
+    Mockito.when(_server.getHostname()).thenReturn("mock");
+    Mockito.when(_server.getQueryMailboxPort()).thenReturn(0);
+    Mockito.when(_server.getVirtualId()).thenReturn(0);
+
+    Mockito.when(_mailboxService.getReceivingMailbox(Mockito.any())).thenReturn(_mailbox);
+    Mockito.when(_mailboxService2.getReceivingMailbox(Mockito.any())).thenReturn(_mailbox2);
+
+    try {
+      Mockito.doAnswer(invocation -> {
+        TransferableBlock arg = invocation.getArgument(0);
+        _blockList.add(arg);
+        return null;
+      }).when(_exchange).send(Mockito.any(TransferableBlock.class));
+
+      Mockito.when(_mailbox2.receive()).then(x -> {
+        if (_blockList.isEmpty()) {
+          return TransferableBlockUtils.getNoOpTransferableBlock();
+        }
+        return _blockList.remove(0);
+      });
+
+      Mockito.when(_mailbox2.isClosed()).thenReturn(false);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
   }
 
   @AfterMethod
@@ -117,54 +188,144 @@ public class OpChainTest {
     Assert.assertEquals(opChain.getStats().getOperatorStatsMap().size(), 0);
   }
 
-
   @Test
   public void testStatsCollectionTracingEnabledMultipleOperators() {
-    OpChainExecutionContext context = OperatorTestUtil.getDefaultContext();
-    DummyMultiStageOperator dummyMultiStageOperator = new DummyMultiStageOperator(context);
+    long dummyOperatorWaitTime = 1000L;
 
-    int numOperatorsInChain = 5;
-    Stack<MultiStageOperator> operators = new Stack<>();
-    operators.push(dummyMultiStageOperator);
-    for (int i = 0; i < numOperatorsInChain; i++) {
-      MultiStageOperator nextOperator = new DummyMultiStageCallableOperator(context, operators.peek());
-      operators.push(nextOperator);
-    }
+    int receivedStageId = 2;
+    int senderStageId = 1;
+    StageMetadata stageMetadata = new StageMetadata();
+    stageMetadata.setServerInstances(ImmutableList.of(_server));
+    Map<Integer, StageMetadata> stageMetadataMap = Collections.singletonMap(receivedStageId, stageMetadata);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, 1, senderStageId, new VirtualServerAddress(_server), 1000, 1000,
+            stageMetadataMap, true);
+
+    Stack<MultiStageOperator> operators =
+        getFullOpchain(receivedStageId, senderStageId, context, dummyOperatorWaitTime);
 
     OpChain opChain = new OpChain(context, operators.peek(), new ArrayList<>());
     opChain.getStats().executing();
-    opChain.getRoot().nextBlock();
+    while (!opChain.getRoot().nextBlock().isEndOfStreamBlock()) {
+      // Drain the opchain
+    }
     opChain.getStats().queued();
 
-    Assert.assertTrue(opChain.getStats().getExecutionTime() >= numOperatorsInChain * 1000L);
-    Map<String, OperatorStats> operatorStatsMap = opChain.getStats().getOperatorStatsMap();
-    Assert.assertEquals(operatorStatsMap.size(), numOperatorsInChain + 1);
+    OpChainExecutionContext secondStageContext =
+        new OpChainExecutionContext(_mailboxService2, 1, senderStageId + 1, new VirtualServerAddress(_server), 1000,
+            1000, stageMetadataMap, true);
+
+    MailboxReceiveOperator secondStageReceiveOp =
+        new MailboxReceiveOperator(secondStageContext, ImmutableList.of(_server),
+            RelDistribution.Type.BROADCAST_DISTRIBUTED, Collections.emptyList(), Collections.emptyList(), false, false,
+            null, senderStageId, receivedStageId + 1, null);
+
+    Assert.assertTrue(opChain.getStats().getExecutionTime() >= dummyOperatorWaitTime);
+    int numOperators = operators.size();
+    Assert.assertEquals(opChain.getStats().getOperatorStatsMap().size(), numOperators);
     while (!operators.isEmpty()) {
-      MultiStageOperator operator = operators.pop();
-      Assert.assertTrue(operatorStatsMap.containsKey(operator.getOperatorId()));
+      Assert.assertTrue(opChain.getStats().getOperatorStatsMap().containsKey(operators.pop().getOperatorId()));
     }
+
+    while (!secondStageReceiveOp.nextBlock().isEndOfStreamBlock()) {
+      // Drain the mailbox
+    }
+    Assert.assertEquals(secondStageContext.getStats().getOperatorStatsMap().size(), numOperators + 1);
   }
 
   @Test
-  public void testStatsCollectionTracingDisabledMultipleOperators() {
-    OpChainExecutionContext context = OperatorTestUtil.getDefaultContextWithTracingDisabled();
-    DummyMultiStageOperator dummyMultiStageOperator = new DummyMultiStageOperator(context);
+  public void testStatsCollectionTracingDisableMultipleOperators() {
+    long dummyOperatorWaitTime = 1000L;
 
-    int numOperatorsInChain = 5;
-    Stack<MultiStageOperator> operators = new Stack<>();
-    operators.push(dummyMultiStageOperator);
-    for (int i = 0; i < numOperatorsInChain; i++) {
-      MultiStageOperator nextOperator = new DummyMultiStageCallableOperator(context, operators.peek());
-      operators.push(nextOperator);
-    }
+    int receivedStageId = 2;
+    int senderStageId = 1;
+    StageMetadata stageMetadata = new StageMetadata();
+    stageMetadata.setServerInstances(ImmutableList.of(_server));
+    Map<Integer, StageMetadata> stageMetadataMap = Collections.singletonMap(receivedStageId, stageMetadata);
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, 1, senderStageId, new VirtualServerAddress(_server), 1000, 1000,
+            stageMetadataMap, false);
+
+    Stack<MultiStageOperator> operators =
+        getFullOpchain(receivedStageId, senderStageId, context, dummyOperatorWaitTime);
+
     OpChain opChain = new OpChain(context, operators.peek(), new ArrayList<>());
     opChain.getStats().executing();
     opChain.getRoot().nextBlock();
     opChain.getStats().queued();
 
-    Assert.assertTrue(opChain.getStats().getExecutionTime() >= numOperatorsInChain * 1000L);
-    Assert.assertEquals(opChain.getStats().getOperatorStatsMap().size(), 0);
+    OpChainExecutionContext secondStageContext =
+        new OpChainExecutionContext(_mailboxService2, 1, senderStageId + 1, new VirtualServerAddress(_server), 1000,
+            1000, stageMetadataMap, false);
+
+    MailboxReceiveOperator secondStageReceiveOp =
+        new MailboxReceiveOperator(secondStageContext, ImmutableList.of(_server),
+            RelDistribution.Type.BROADCAST_DISTRIBUTED, Collections.emptyList(), Collections.emptyList(), false, false,
+            null, senderStageId, receivedStageId + 1, null);
+
+    Assert.assertTrue(opChain.getStats().getExecutionTime() >= dummyOperatorWaitTime);
+    Assert.assertEquals(opChain.getStats().getOperatorStatsMap().size(), 2);
+    Assert.assertTrue(opChain.getStats().getOperatorStatsMap().containsKey(operators.pop().getOperatorId()));
+
+    while (!secondStageReceiveOp.nextBlock().isEndOfStreamBlock()) {
+      // Drain the mailbox
+    }
+
+    while (!operators.isEmpty()) {
+      MultiStageOperator operator = operators.pop();
+      if (operator.toExplainString().contains("SEND") || operator.toExplainString().contains("LEAF")) {
+        Assert.assertTrue(opChain.getStats().getOperatorStatsMap().containsKey(operator.getOperatorId()));
+      }
+    }
+    Assert.assertEquals(secondStageContext.getStats().getOperatorStatsMap().size(), 2);
   }
+
+  private Stack<MultiStageOperator> getFullOpchain(int receivedStageId, int senderStageId,
+      OpChainExecutionContext context, long waitTimeInMillis) {
+    Stack<MultiStageOperator> operators = new Stack<>();
+    DataSchema upStreamSchema =
+        new DataSchema(new String[]{"intCol"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT});
+    //Mailbox Receive Operator
+    try {
+      Mockito.when(_mailbox.receive()).thenReturn(OperatorTestUtil.block(upStreamSchema, new Object[]{1}),
+          TransferableBlockUtils.getEndOfStreamTransferableBlock());
+    } catch (Exception e) {
+      Assert.fail("Exception while mocking mailbox receive: " + e.getMessage());
+    }
+
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT intCol FROM tbl");
+    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
+        new SelectionResultsBlock(upStreamSchema, Arrays.asList(new Object[]{1}, new Object[]{2})), queryContext));
+    LeafStageTransferableBlockOperator leafOp =
+        new LeafStageTransferableBlockOperator(context, resultsBlockList, upStreamSchema);
+
+    //Transform operator
+    RexExpression.InputRef ref0 = new RexExpression.InputRef(0);
+    TransformOperator transformOp =
+        new TransformOperator(context, leafOp, upStreamSchema, ImmutableList.of(ref0), upStreamSchema);
+
+    //Filter operator
+    RexExpression booleanLiteral = new RexExpression.Literal(FieldSpec.DataType.BOOLEAN, true);
+    FilterOperator filterOp = new FilterOperator(context, transformOp, upStreamSchema, booleanLiteral);
+
+    // Dummy operator
+    MultiStageOperator dummyWaitOperator = new DummyMultiStageCallableOperator(context, filterOp, waitTimeInMillis);
+
+    //Mailbox Send operator
+    MailboxSendOperator sendOperator =
+        new MailboxSendOperator(context, dummyWaitOperator, RelDistribution.Type.HASH_DISTRIBUTED, _selector, null,
+            null, false,
+            server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", senderStageId, receivedStageId),
+            _exchangeFactory, receivedStageId);
+
+    operators.push(leafOp);
+    operators.push(transformOp);
+    operators.push(filterOp);
+    operators.push(dummyWaitOperator);
+    operators.push(sendOperator);
+    return operators;
+  }
+
 
   static class DummyMultiStageOperator extends MultiStageOperator {
 
@@ -191,16 +352,19 @@ public class OpChainTest {
 
   static class DummyMultiStageCallableOperator extends MultiStageOperator {
     private final MultiStageOperator _upstream;
+    private final long _sleepTimeInMillis;
 
-    public DummyMultiStageCallableOperator(OpChainExecutionContext context, MultiStageOperator upstream) {
+    public DummyMultiStageCallableOperator(OpChainExecutionContext context, MultiStageOperator upstream,
+        long sleepTimeInMillis) {
       super(context);
       _upstream = upstream;
+      _sleepTimeInMillis = sleepTimeInMillis;
     }
 
     @Override
     protected TransferableBlock getNextBlock() {
       try {
-        Thread.sleep(1000);
+        Thread.sleep(_sleepTimeInMillis);
         _upstream.nextBlock();
       } catch (InterruptedException e) {
         // IGNORE

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
@@ -217,8 +217,7 @@ public class OpChainTest {
 
     MailboxReceiveOperator secondStageReceiveOp =
         new MailboxReceiveOperator(secondStageContext, ImmutableList.of(_server),
-            RelDistribution.Type.BROADCAST_DISTRIBUTED, Collections.emptyList(), Collections.emptyList(), false, false,
-            null, senderStageId, receivedStageId + 1, null);
+            RelDistribution.Type.BROADCAST_DISTRIBUTED, senderStageId, receivedStageId + 1, null);
 
     Assert.assertTrue(opChain.getStats().getExecutionTime() >= dummyOperatorWaitTime);
     int numOperators = operators.size();
@@ -260,8 +259,7 @@ public class OpChainTest {
 
     MailboxReceiveOperator secondStageReceiveOp =
         new MailboxReceiveOperator(secondStageContext, ImmutableList.of(_server),
-            RelDistribution.Type.BROADCAST_DISTRIBUTED, Collections.emptyList(), Collections.emptyList(), false, false,
-            null, senderStageId, receivedStageId + 1, null);
+            RelDistribution.Type.BROADCAST_DISTRIBUTED, senderStageId, receivedStageId + 1, null);
 
     Assert.assertTrue(opChain.getStats().getExecutionTime() >= dummyOperatorWaitTime);
     Assert.assertEquals(opChain.getStats().getOperatorStatsMap().size(), 2);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
@@ -100,6 +100,20 @@ public class OpChainTest {
         Long.parseLong(executionStats.get(DataTable.MetadataKey.OPERATOR_EXECUTION_TIME_MS.getName())) <= 2000);
   }
 
+  @Test
+  public void testStatsCollectionTracingDisabled() {
+    OpChainExecutionContext context = OperatorTestUtil.getDefaultContextWithTracingDisabled();
+    DummyMultiStageOperator dummyMultiStageOperator = new DummyMultiStageOperator(context);
+
+    OpChain opChain = new OpChain(context, dummyMultiStageOperator, new ArrayList<>());
+    opChain.getStats().executing();
+    opChain.getRoot().nextBlock();
+    opChain.getStats().queued();
+
+    Assert.assertTrue(opChain.getStats().getExecutionTime() >= 1000);
+    Assert.assertEquals(opChain.getStats().getOperatorStatsMap().size(), 0);
+  }
+
   static class DummyMultiStageOperator extends MultiStageOperator {
     public DummyMultiStageOperator(OpChainExecutionContext context) {
       super(context);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
@@ -65,12 +65,18 @@ public class OperatorTestUtil {
   public static OpChainExecutionContext getDefaultContext() {
     VirtualServerAddress virtualServerAddress = new VirtualServerAddress("mock", 80, 0);
     return new OpChainExecutionContext(null, 1, 2, virtualServerAddress, Long.MAX_VALUE, Long.MAX_VALUE,
+        new HashMap<>(), true);
+  }
+
+  public static OpChainExecutionContext getDefaultContextWithTracingDisabled() {
+    VirtualServerAddress virtualServerAddress = new VirtualServerAddress("mock", 80, 0);
+    return new OpChainExecutionContext(null, 1, 2, virtualServerAddress, Long.MAX_VALUE, Long.MAX_VALUE,
         new HashMap<>(), false);
   }
 
   public static OpChainExecutionContext getContext(long requestId, int stageId,
       VirtualServerAddress virtualServerAddress) {
     return new OpChainExecutionContext(null, requestId, stageId, virtualServerAddress, Long.MAX_VALUE, Long.MAX_VALUE,
-        new HashMap<>(), false);
+        new HashMap<>(), true);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
@@ -65,12 +65,12 @@ public class OperatorTestUtil {
   public static OpChainExecutionContext getDefaultContext() {
     VirtualServerAddress virtualServerAddress = new VirtualServerAddress("mock", 80, 0);
     return new OpChainExecutionContext(null, 1, 2, virtualServerAddress, Long.MAX_VALUE, Long.MAX_VALUE,
-        new HashMap<>());
+        new HashMap<>(), false);
   }
 
   public static OpChainExecutionContext getContext(long requestId, int stageId,
       VirtualServerAddress virtualServerAddress) {
     return new OpChainExecutionContext(null, requestId, stageId, virtualServerAddress, Long.MAX_VALUE, Long.MAX_VALUE,
-        new HashMap<>());
+        new HashMap<>(), false);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
@@ -97,7 +97,7 @@ public class SortedMailboxReceiveOperatorTest {
     DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, 10L, 10L,
-            new HashMap<>());
+            new HashMap<>(), false);
     SortedMailboxReceiveOperator receiveOp =
         new SortedMailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON, collationKeys,
             collationDirections, false, true, inSchema, 456, 789, 10L);
@@ -109,14 +109,14 @@ public class SortedMailboxReceiveOperatorTest {
 
     // longer timeout or default timeout (10s) doesn't result in error.
     context = new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, 2000L, 2000L,
-        new HashMap<>());
+        new HashMap<>(), false);
     receiveOp = new SortedMailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON,
         collationKeys, collationDirections, false, true, inSchema, 456, 789, 2000L);
     Thread.sleep(200L);
     mailbox = receiveOp.nextBlock();
     Assert.assertFalse(mailbox.isErrorBlock());
     context = new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
-        Long.MAX_VALUE, new HashMap<>());
+        Long.MAX_VALUE, new HashMap<>(), false);
     receiveOp = new SortedMailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON,
         collationKeys, collationDirections, false, true, inSchema, 456, 789, null);
     Thread.sleep(200L);
@@ -146,7 +146,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
     SortedMailboxReceiveOperator receiveOp =
         new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
             collationKeys, collationDirections, false, true, inSchema, 456, 789, null);
@@ -172,7 +172,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
     SortedMailboxReceiveOperator receiveOp = new SortedMailboxReceiveOperator(context,
         ImmutableList.of(_server1, _server2), RelDistribution.Type.RANGE_DISTRIBUTED, collationKeys,
         collationDirections, false, true, inSchema, 456, 789, null);
@@ -208,7 +208,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     SortedMailboxReceiveOperator receiveOp =
         new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
@@ -254,7 +254,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     SortedMailboxReceiveOperator receiveOp =
         new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
@@ -303,7 +303,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     SortedMailboxReceiveOperator receiveOp =
         new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
@@ -350,7 +350,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     SortedMailboxReceiveOperator receiveOp =
         new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
@@ -398,7 +398,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     SortedMailboxReceiveOperator receiveOp =
         new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
@@ -450,7 +450,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     SortedMailboxReceiveOperator receiveOp =
         new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
@@ -489,7 +489,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     SortedMailboxReceiveOperator receiveOp =
         new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
@@ -526,7 +526,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     SortedMailboxReceiveOperator receiveOp =
         new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
@@ -574,7 +574,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     SortedMailboxReceiveOperator receiveOp =
         new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
@@ -630,7 +630,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     SortedMailboxReceiveOperator receiveOp =
         new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
@@ -686,7 +686,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     SortedMailboxReceiveOperator receiveOp =
         new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
@@ -739,7 +739,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     SortedMailboxReceiveOperator receiveOp =
         new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
@@ -798,7 +798,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     SortedMailboxReceiveOperator receiveOp = new SortedMailboxReceiveOperator(context,
         ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, collationKeys, collationDirection,
@@ -882,7 +882,7 @@ public class SortedMailboxReceiveOperatorTest {
 
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
+            Long.MAX_VALUE, new HashMap<>(), false);
 
     SortedMailboxReceiveOperator receiveOp = new SortedMailboxReceiveOperator(context,
         ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, collationKeys, collationDirection,

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -246,6 +246,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
       Assert.assertEquals(brokerResponseNative.getNumSegmentsQueried(), numSegments);
 
       Map<Integer, BrokerResponseStats> stageIdStats = brokerResponseNative.getStageIdStats();
+      int numTables = 0;
       for (Integer stageId : stageIdStats.keySet()) {
         // check stats only for leaf stage
         BrokerResponseStats brokerResponseStats = stageIdStats.get(stageId);
@@ -256,7 +257,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
 
         String tableName = brokerResponseStats.getTableNames().get(0);
         Assert.assertEquals(brokerResponseStats.getTableNames().size(), 1);
-
+        numTables++;
         TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
         if (tableType == null) {
           tableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
@@ -275,6 +276,8 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
           }
         }
       }
+
+      Assert.assertTrue(numTables > 0);
     });
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -138,7 +138,7 @@ public class QueryDispatcherTest extends QueryTestSet {
     QueryDispatcher dispatcher = new QueryDispatcher();
     long requestId = RANDOM_REQUEST_ID_GEN.nextLong();
     try {
-      dispatcher.submitAndReduce(requestId, queryPlan, null, 10_000L, new HashMap<>(), null);
+      dispatcher.submitAndReduce(requestId, queryPlan, null, 10_000L, new HashMap<>(), null, false);
       Assert.fail("Method call above should have failed");
     } catch (Exception e) {
       Assert.assertTrue(e.getMessage().contains("Error executing query"));
@@ -161,7 +161,7 @@ public class QueryDispatcherTest extends QueryTestSet {
     long requestId = RANDOM_REQUEST_ID_GEN.nextLong();
     try {
       // will throw b/c mailboxService is null
-      dispatcher.submitAndReduce(requestId, queryPlan, null, 10_000L, new HashMap<>(), null);
+      dispatcher.submitAndReduce(requestId, queryPlan, null, 10_000L, new HashMap<>(), null, false);
       Assert.fail("Method call above should have failed");
     } catch (Exception e) {
       Assert.assertTrue(e.getMessage().contains("Error executing query"));


### PR DESCRIPTION
Only LeafStageOperator and MailboxSend stats are recorded and passed when tracing is off.

This is done to reduce the overhead of stats collection during high throughput workload.

Once Tracing is turned on, we revert back to the existing way where each and every operator's stats is reported.
