### PR TITLE
[WIP] Include partition into routing table

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerDebug.java
@@ -99,9 +99,9 @@ public class PinotBrokerDebug {
       @ApiResponse(code = 404, message = "Routing not found"),
       @ApiResponse(code = 500, message = "Internal server error")
   })
-  public Map<String, Map<ServerInstance, List<String>>> getRoutingTable(
+  public Map<String, Map<ServerInstance, Map<Integer, List<String>>>> getRoutingTable(
       @ApiParam(value = "Name of the table") @PathParam("tableName") String tableName) {
-    Map<String, Map<ServerInstance, List<String>>> result = new TreeMap<>();
+    Map<String, Map<ServerInstance, Map<Integer, List<String>>>> result = new TreeMap<>();
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
     if (tableType != TableType.REALTIME) {
       String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
@@ -135,7 +135,7 @@ public class PinotBrokerDebug {
       @ApiResponse(code = 404, message = "Routing not found"),
       @ApiResponse(code = 500, message = "Internal server error")
   })
-  public Map<ServerInstance, List<String>> getRoutingTableForQuery(
+  public Map<ServerInstance, Map<Integer, List<String>>> getRoutingTableForQuery(
       @ApiParam(value = "SQL query (table name should have type suffix)") @QueryParam("query") String query) {
     RoutingTable routingTable = _routingManager.getRoutingTable(CalciteSqlCompiler.compileToBrokerRequest(query),
         getRequestId());

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -230,9 +230,10 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   @Override
   protected BrokerResponseNative processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
       BrokerRequest serverBrokerRequest, @Nullable BrokerRequest offlineBrokerRequest,
-      @Nullable Map<ServerInstance, List<String>> offlineRoutingTable, @Nullable BrokerRequest realtimeBrokerRequest,
-      @Nullable Map<ServerInstance, List<String>> realtimeRoutingTable, long timeoutMs, ServerStats serverStats,
-      RequestContext requestContext)
+      @Nullable Map<ServerInstance, Map<Integer, List<String>>> offlineRoutingTable,
+      @Nullable BrokerRequest realtimeBrokerRequest,
+      @Nullable Map<ServerInstance, Map<Integer, List<String>>> realtimeRoutingTable, long timeoutMs,
+      ServerStats serverStats, RequestContext requestContext)
       throws Exception {
     throw new UnsupportedOperationException();
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/SingleConnectionBrokerRequestHandler.java
@@ -97,9 +97,10 @@ public class SingleConnectionBrokerRequestHandler extends BaseBrokerRequestHandl
   @Override
   protected BrokerResponseNative processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
       BrokerRequest serverBrokerRequest, @Nullable BrokerRequest offlineBrokerRequest,
-      @Nullable Map<ServerInstance, List<String>> offlineRoutingTable, @Nullable BrokerRequest realtimeBrokerRequest,
-      @Nullable Map<ServerInstance, List<String>> realtimeRoutingTable, long timeoutMs, ServerStats serverStats,
-      RequestContext requestContext)
+      @Nullable Map<ServerInstance, Map<Integer, List<String>>> offlineRoutingTable,
+      @Nullable BrokerRequest realtimeBrokerRequest,
+      @Nullable Map<ServerInstance, Map<Integer, List<String>>> realtimeRoutingTable, long timeoutMs,
+      ServerStats serverStats, RequestContext requestContext)
       throws Exception {
     assert offlineBrokerRequest != null || realtimeBrokerRequest != null;
     if (requestContext.isSampledRequest()) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/SegmentMetadataCache.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/SegmentMetadataCache.java
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing;
+
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import javax.annotation.Nullable;
+import org.apache.helix.AccessOption;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
+import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class SegmentMetadataCache {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentMetadataCache.class);
+  private static final PartitionInfo INVALID_PARTITION_INFO = new PartitionInfo();
+  private final String _tableNameWithType;
+  private final String _partitionColumn;
+  private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private final Map<String, PartitionInfo> _segmentToPartitionInfoMap;
+  private final String _segmentZKMetadataPathPrefix;
+
+  public SegmentMetadataCache(String tableNameWithType, String partitionColumn,
+      ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    _tableNameWithType = tableNameWithType;
+    _partitionColumn = partitionColumn;
+    _propertyStore = propertyStore;
+    _segmentToPartitionInfoMap = new ConcurrentHashMap<>();
+    _segmentZKMetadataPathPrefix = ZKMetadataProvider.constructPropertyStorePathForResource(tableNameWithType) + "/";
+  }
+
+  public void init(Set<String> onlineSegments) {
+    for (String segment : onlineSegments) {
+      PartitionInfo partitionInfo = extractPartitionInfoFromSegmentZKMetadataZNRecord(segment,
+          _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT));
+      _segmentToPartitionInfoMap.put(segment, partitionInfo);
+    }
+  }
+
+  public synchronized void onAssignmentChange(Set<String> onlineSegments) {
+    for (String segment : onlineSegments) {
+      _segmentToPartitionInfoMap.computeIfAbsent(segment, k -> extractPartitionInfoFromSegmentZKMetadataZNRecord(k,
+          _propertyStore.get(_segmentZKMetadataPathPrefix + k, null, AccessOption.PERSISTENT)));
+    }
+    _segmentToPartitionInfoMap.keySet().retainAll(onlineSegments);
+  }
+
+  public synchronized void refreshSegment(String segment) {
+    PartitionInfo partitionInfo = extractPartitionInfoFromSegmentZKMetadataZNRecord(segment,
+        _propertyStore.get(_segmentZKMetadataPathPrefix + segment, null, AccessOption.PERSISTENT));
+    if (partitionInfo != null) {
+      _segmentToPartitionInfoMap.put(segment, partitionInfo);
+    } else {
+      _segmentToPartitionInfoMap.remove(segment);
+    }
+  }
+
+  public int getPartitionId(String segmentName) {
+    PartitionInfo partitionInfo = _segmentToPartitionInfoMap.get(segmentName);
+    if (partitionInfo == null || partitionInfo._partitionId == null) {
+      return -1;
+    }
+    return partitionInfo._partitionId;
+  }
+
+  @Nullable
+  private PartitionInfo extractPartitionInfoFromSegmentZKMetadataZNRecord(String segment, @Nullable
+      ZNRecord znRecord) {
+    if (znRecord == null) {
+      LOGGER.warn("Failed to find segment ZK metadata for segment: {}, table: {}", segment, _tableNameWithType);
+      return null;
+    }
+
+    String partitionMetadataJson = znRecord.getSimpleField(CommonConstants.Segment.PARTITION_METADATA);
+    if (partitionMetadataJson == null) {
+      LOGGER.warn("Failed to find segment partition metadata for segment: {}, table: {}", segment, _tableNameWithType);
+      return INVALID_PARTITION_INFO;
+    }
+
+    SegmentPartitionMetadata segmentPartitionMetadata;
+    try {
+      segmentPartitionMetadata = SegmentPartitionMetadata.fromJsonString(partitionMetadataJson);
+    } catch (Exception e) {
+      LOGGER.warn("Caught exception while extracting segment partition metadata for segment: {}, table: {}", segment,
+          _tableNameWithType, e);
+      return INVALID_PARTITION_INFO;
+    }
+
+    ColumnPartitionMetadata columnPartitionMetadata =
+        segmentPartitionMetadata.getColumnPartitionMap().get(_partitionColumn);
+    if (columnPartitionMetadata == null) {
+      LOGGER.warn("Failed to find column partition metadata for column: {}, segment: {}, table: {}", _partitionColumn,
+          segment, _tableNameWithType);
+      return INVALID_PARTITION_INFO;
+    }
+
+    Set<Integer> partitions = columnPartitionMetadata.getPartitions();
+    if (partitions != null && partitions.size() != 1) {
+      LOGGER.warn("Failed to find singleton partition for column: {}, segment: {}, table: {}. Found partition Ids: {}",
+          _partitionColumn, segment, _tableNameWithType, partitions);
+      return INVALID_PARTITION_INFO;
+    }
+
+    return new PartitionInfo(PartitionFunctionFactory.getPartitionFunction(columnPartitionMetadata.getFunctionName(),
+        columnPartitionMetadata.getNumPartitions(), columnPartitionMetadata.getFunctionConfig()),
+        partitions.iterator().next());
+  }
+
+  static class PartitionInfo {
+    private PartitionFunction _partitionFunction;
+    private Integer _partitionId;
+
+    public PartitionInfo() {
+    }
+
+    public PartitionInfo(PartitionFunction partitionFunction, Integer partitionId) {
+      _partitionFunction = partitionFunction;
+      _partitionId = partitionId;
+    }
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
@@ -198,7 +198,8 @@ public class BaseBrokerRequestHandlerTest {
     when(routingManager.routingExists(anyString())).thenReturn(true);
     RoutingTable rt = mock(RoutingTable.class);
     when(rt.getServerInstanceToSegmentsMap()).thenReturn(Collections
-        .singletonMap(new ServerInstance(new InstanceConfig("server01_9000")), Collections.singletonList("segment01")));
+        .singletonMap(new ServerInstance(new InstanceConfig("server01_9000")),
+            Collections.singletonMap(0, Collections.singletonList("segment01"))));
     when(routingManager.getRoutingTable(any(), Mockito.anyLong())).thenReturn(rt);
     QueryQuotaManager queryQuotaManager = mock(QueryQuotaManager.class);
     when(queryQuotaManager.acquire(anyString())).thenReturn(true);
@@ -220,10 +221,10 @@ public class BaseBrokerRequestHandlerTest {
           @Override
           protected BrokerResponseNative processBrokerRequest(long requestId, BrokerRequest originalBrokerRequest,
               BrokerRequest serverBrokerRequest, @Nullable BrokerRequest offlineBrokerRequest,
-              @Nullable Map<ServerInstance, List<String>> offlineRoutingTable,
+              @Nullable Map<ServerInstance, Map<Integer, List<String>>> offlineRoutingTable,
               @Nullable BrokerRequest realtimeBrokerRequest,
-              @Nullable Map<ServerInstance, List<String>> realtimeRoutingTable, long timeoutMs, ServerStats serverStats,
-              RequestContext requestContext)
+              @Nullable Map<ServerInstance, Map<Integer, List<String>>> realtimeRoutingTable, long timeoutMs,
+              ServerStats serverStats, RequestContext requestContext)
               throws Exception {
             latch.await();
             return null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/RoutingTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/RoutingTable.java
@@ -18,25 +18,43 @@
  */
 package org.apache.pinot.core.routing;
 
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.core.transport.ServerInstance;
 
 
 public class RoutingTable {
-  private final Map<ServerInstance, List<String>> _serverInstanceToSegmentsMap;
+  private final Map<ServerInstance, Map<Integer, List<String>>> _serverInstanceToPartitionedSegmentsMap;
+  private final Map<ServerInstance, Integer> _serverInstancePartitionMap;
   private final List<String> _unavailableSegments;
   private final int _numPrunedSegments;
 
-  public RoutingTable(Map<ServerInstance, List<String>> serverInstanceToSegmentsMap, List<String> unavailableSegments,
-      int numPrunedSegments) {
-    _serverInstanceToSegmentsMap = serverInstanceToSegmentsMap;
+  public RoutingTable(Map<ServerInstance, List<String>> serverInstanceToSegmentsMap,
+      List<String> unavailableSegments, int numPrunedSegments) {
+    _serverInstanceToPartitionedSegmentsMap = new HashMap<>();
+    serverInstanceToSegmentsMap.forEach((key, value) -> {
+      Map<Integer, List<String>> partitionedSegments = new HashMap<>();
+      partitionedSegments.put(0, value);
+      _serverInstanceToPartitionedSegmentsMap.put(key, partitionedSegments);
+    });
     _unavailableSegments = unavailableSegments;
     _numPrunedSegments = numPrunedSegments;
+    _serverInstancePartitionMap = null;
   }
 
-  public Map<ServerInstance, List<String>> getServerInstanceToSegmentsMap() {
-    return _serverInstanceToSegmentsMap;
+  public RoutingTable(Map<ServerInstance, Map<Integer, List<String>>> serverInstanceToPartitionedSegmentsMap,
+      List<String> unavailableSegments, int numPrunedSegments,
+      @Nullable Map<ServerInstance, Integer> serverInstancePartitionMap) {
+    _serverInstanceToPartitionedSegmentsMap = serverInstanceToPartitionedSegmentsMap;
+    _unavailableSegments = unavailableSegments;
+    _numPrunedSegments = numPrunedSegments;
+    _serverInstancePartitionMap = serverInstancePartitionMap;
+  }
+
+  public Map<ServerInstance, Map<Integer, List<String>>> getServerInstanceToSegmentsMap() {
+    return _serverInstanceToPartitionedSegmentsMap;
   }
 
   public List<String> getUnavailableSegments() {
@@ -45,5 +63,9 @@ public class RoutingTable {
 
   public int getNumPrunedSegments() {
     return _numPrunedSegments;
+  }
+
+  public Map<ServerInstance, Integer> getServerInstancePartitionMap() {
+    return _serverInstancePartitionMap;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerInstance.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerInstance.java
@@ -150,6 +150,23 @@ public class ServerInstance {
     }
   }
 
+  public ServerRoutingInstance toServerRoutingInstance(Integer partitionId, TableType tableType,
+      RoutingType routingType) {
+    switch (routingType) {
+      case NETTY:
+        Preconditions.checkState(_port > 0, "Netty port is not configured for server: %s", _instanceId);
+        return new ServerRoutingInstance(_instanceId, _hostname, _port, tableType, partitionId);
+      case GRPC:
+        Preconditions.checkState(_grpcPort > 0, "GRPC port is not configured for server: %s", _instanceId);
+        return new ServerRoutingInstance(_instanceId, _hostname, _grpcPort, tableType, partitionId);
+      case NETTY_TLS:
+        Preconditions.checkState(_nettyTlsPort > 0, "Netty TLS port is not configured for server: %s", _instanceId);
+        return new ServerRoutingInstance(_instanceId, _hostname, _nettyTlsPort, tableType, partitionId, true);
+      default:
+        throw new IllegalStateException("Unsupported routing type: " + routingType);
+    }
+  }
+
   @Override
   public boolean equals(Object o) {
     if (this == o) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerRoutingInstance.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerRoutingInstance.java
@@ -43,14 +43,26 @@ public class ServerRoutingInstance {
   private final String _hostname;
   private final int _port;
   private final TableType _tableType;
+  private final int _partitionId;
   private final boolean _tlsEnabled;
 
-  public ServerRoutingInstance(String instanceId, String hostname, int port, TableType tableType, boolean tlsEnabled) {
+
+  public ServerRoutingInstance(String instanceId, String hostname, int port, TableType tableType, int partitionId,
+      boolean tlsEnabled) {
     _instanceId = instanceId;
     _hostname = hostname;
     _port = port;
     _tableType = tableType;
+    _partitionId = partitionId;
     _tlsEnabled = tlsEnabled;
+  }
+
+  public ServerRoutingInstance(String instanceId, String hostname, int port, TableType tableType, int partitionId) {
+    this(instanceId, hostname, port, tableType, partitionId, false);
+  }
+
+  public ServerRoutingInstance(String instanceId, String hostname, int port, TableType tableType, boolean tlsEnabled) {
+    this(instanceId, hostname, port, tableType, 0, tlsEnabled);
   }
 
   public ServerRoutingInstance(String instanceId, String hostname, int port, TableType tableType) {
@@ -105,18 +117,24 @@ public class ServerRoutingInstance {
     ServerRoutingInstance that = (ServerRoutingInstance) o;
     // NOTE: Only check hostname, port and tableType for performance concern because they can identify a routing
     //       instance within the same query
-    return _hostname.equals(that._hostname) && _port == that._port && _tableType == that._tableType;
+    return _hostname.equals(that._hostname) && _port == that._port && _tableType == that._tableType
+        && _partitionId == that._partitionId;
   }
 
   @Override
   public int hashCode() {
     // NOTE: Only check hostname, port and tableType for performance concern because they can identify a routing
     //       instance within the same query
-    return 31 * 31 * _hostname.hashCode() + 31 * Integer.hashCode(_port) + _tableType.hashCode();
+    return 31 * 31 * 31 + _partitionId + 31 * 31 * _hostname.hashCode() + 31 * Integer.hashCode(_port)
+        + _tableType.hashCode();
   }
 
   @Override
   public String toString() {
     return getShortName();
+  }
+
+  public int getPartitionId() {
+    return _partitionId;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
@@ -59,8 +59,8 @@ public class QueryRoutingTest {
       SERVER_INSTANCE.toServerRoutingInstance(TableType.REALTIME, ServerInstance.RoutingType.NETTY);
   private static final BrokerRequest BROKER_REQUEST =
       CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM testTable");
-  private static final Map<ServerInstance, List<String>> ROUTING_TABLE =
-      Collections.singletonMap(SERVER_INSTANCE, Collections.emptyList());
+  private static final Map<ServerInstance, Map<Integer, List<String>>> ROUTING_TABLE =
+      Collections.singletonMap(SERVER_INSTANCE, Collections.singletonMap(0, Collections.emptyList()));
 
   private QueryRouter _queryRouter;
   private ServerRoutingStatsManager _serverRoutingStatsManager;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -90,11 +90,12 @@ public class WorkerManager {
         String tableType = routingEntry.getKey();
         RoutingTable routingTable = routingEntry.getValue();
         // for each server instance, attach all table types and their associated segment list.
-        for (Map.Entry<ServerInstance, List<String>> serverEntry
+        for (Map.Entry<ServerInstance, Map<Integer, List<String>>> serverEntry
             : routingTable.getServerInstanceToSegmentsMap().entrySet()) {
           serverInstanceToSegmentsMap.putIfAbsent(serverEntry.getKey(), new HashMap<>());
           Map<String, List<String>> tableTypeToSegmentListMap = serverInstanceToSegmentsMap.get(serverEntry.getKey());
-          Preconditions.checkState(tableTypeToSegmentListMap.put(tableType, serverEntry.getValue()) == null,
+          // TODO: support partition routing
+          Preconditions.checkState(tableTypeToSegmentListMap.put(tableType, serverEntry.getValue().get(0)) == null,
               "Entry for server {} and table type: {} already exist!", serverEntry.getKey(), tableType);
         }
       }


### PR DESCRIPTION
Include partition info into the routing table. This will allow us to create partitioned server requests and thus reduce the combined pressure from the server side when data are pre-partitioned.