### PR TITLE
Moving Zk updates for reload, force_commit to their own Znodes which …

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -118,13 +118,7 @@ public class ZKMetadataProvider {
   }
 
   public static String constructPropertyStorePathForControllerJob(ControllerJobType jobType) {
-    if (jobType == ControllerJobType.TABLE_REBALANCE) {
-      return StringUtil.join("/", PROPERTYSTORE_CONTROLLER_JOBS_PREFIX, jobType.name());
-    } else {
-      // For other types, we will continue to use the root path until we migrate
-      // other types to use separate nodes based on jobType like TABLE_REBALANCE
-      return StringUtil.join("/", PROPERTYSTORE_CONTROLLER_JOBS_PREFIX);
-    }
+    return StringUtil.join("/", PROPERTYSTORE_CONTROLLER_JOBS_PREFIX, jobType.name());
   }
 
   public static String constructPropertyStorePathForResourceConfig(String resourceName) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/controllerjob/ControllerJobType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/controllerjob/ControllerJobType.java
@@ -19,5 +19,5 @@
 package org.apache.pinot.common.metadata.controllerjob;
 
 public enum ControllerJobType {
-  RELOAD_SEGMENT, RELOAD_ALL_SEGMENTS, FORCE_COMMIT, TABLE_REBALANCE
+  RELOAD_SEGMENT, FORCE_COMMIT, TABLE_REBALANCE
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -634,11 +634,10 @@ public class PinotSegmentRestletResource {
         controllerJobZKMetadata.get(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE);
     Map<String, List<String>> serverToSegments;
 
-    String singleSegmentName = null;
-    if (controllerJobZKMetadata.get(CommonConstants.ControllerJob.JOB_TYPE)
-        .equals(ControllerJobType.RELOAD_SEGMENT.toString())) {
+    String singleSegmentName =
+        controllerJobZKMetadata.get(CommonConstants.ControllerJob.SEGMENT_RELOAD_JOB_SEGMENT_NAME);
+    if (singleSegmentName != null) {
       // No need to query servers where this segment is not supposed to be hosted
-      singleSegmentName = controllerJobZKMetadata.get(CommonConstants.ControllerJob.SEGMENT_RELOAD_JOB_SEGMENT_NAME);
       serverToSegments = new HashMap<>();
       List<String> segmentList = Arrays.asList(singleSegmentName);
       _pinotHelixResourceManager.getServers(tableNameWithType, singleSegmentName).forEach(server -> {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -255,6 +255,8 @@ public class PinotHelixResourceManager {
    * as PARTICIPANT,
    * which would be put to lead controller resource and mess up the leadership assignment. Those places should use
    * SPECTATOR other than PARTICIPANT.
+   * TODO:For the <a href="https://github.com/apache/pinot/pull/10451">backwards incompatible change</a>, this is a
+   * reminder to clean up old Zk nodes when the controller starts up.
    */
   public synchronized void start(HelixManager helixZkManager) {
     _helixZkManager = helixZkManager;
@@ -289,7 +291,6 @@ public class PinotHelixResourceManager {
     } catch (Exception e) {
       throw new RuntimeException("Caught exception while adding InstanceConfigChangeListener");
     }
-
     // Initialize TableCache
     HelixConfigScope helixConfigScope =
         new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER).forCluster(_helixClusterName).build();
@@ -2162,11 +2163,11 @@ public class PinotHelixResourceManager {
     Map<String, String> jobMetadata = new HashMap<>();
     jobMetadata.put(CommonConstants.ControllerJob.JOB_ID, jobId);
     jobMetadata.put(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE, tableNameWithType);
-    jobMetadata.put(CommonConstants.ControllerJob.JOB_TYPE, ControllerJobType.RELOAD_ALL_SEGMENTS.toString());
+    jobMetadata.put(CommonConstants.ControllerJob.JOB_TYPE, ControllerJobType.RELOAD_SEGMENT.toString());
     jobMetadata.put(CommonConstants.ControllerJob.SUBMISSION_TIME_MS, Long.toString(System.currentTimeMillis()));
     jobMetadata.put(CommonConstants.ControllerJob.MESSAGE_COUNT, Integer.toString(numberOfMessagesSent));
     return addControllerJobToZK(jobId, jobMetadata,
-        ZKMetadataProvider.constructPropertyStorePathForControllerJob(ControllerJobType.RELOAD_ALL_SEGMENTS));
+        ZKMetadataProvider.constructPropertyStorePathForControllerJob(ControllerJobType.RELOAD_SEGMENT));
   }
 
   public boolean addControllerJobToZK(String jobId, Map<String, String> jobMetadata, String jobResourcePath) {

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -384,7 +384,7 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
       setShowReloadStatusModal(true);
       const [reloadStatusData, tableJobsData] = await Promise.all([
         PinotMethodUtils.reloadStatusOp(tableName, tableType),
-        PinotMethodUtils.fetchTableJobs(tableName, "RELOAD_SEGMENT,RELOAD_ALL_SEGMENTS"),
+        PinotMethodUtils.fetchTableJobs(tableName, "RELOAD_SEGMENT"),
       ]);
 
       if(reloadStatusData.error || tableJobsData.error) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -622,7 +622,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
 
     // Validate all fields are present
     assertEquals(jobStatus.get("metadata").get("jobId").asText(), jobId);
-    assertEquals(jobStatus.get("metadata").get("jobType").asText(), "RELOAD_ALL_SEGMENTS");
+    assertEquals(jobStatus.get("metadata").get("jobType").asText(), "RELOAD_SEGMENT");
     assertEquals(jobStatus.get("metadata").get("tableName").asText(), tableNameWithType);
     return jobId;
   }
@@ -633,7 +633,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     JsonNode jobStatus = JsonUtils.stringToJsonNode(jobStatusResponse);
 
     assertEquals(jobStatus.get("metadata").get("jobId").asText(), reloadJobId);
-    assertEquals(jobStatus.get("metadata").get("jobType").asText(), "RELOAD_ALL_SEGMENTS");
+    assertEquals(jobStatus.get("metadata").get("jobType").asText(), "RELOAD_SEGMENT");
     return jobStatus.get("totalSegmentCount").asInt() == jobStatus.get("successCount").asInt();
   }
 


### PR DESCRIPTION
**Problem**: Currently Zk updates for jobTypes RELOAD, RELOAD_ALL, FORCE_COMMIT goes to the same Znode.  This increases write load on that Znode., especially given updates for all tables for the listed jobTypes goes to that Znode. We discovered the problem while implementing [rebalanceStatus](https://github.com/apache/pinot/pull/10359) and decided to create a separate Znode for TABLE_REBALANCE. This PR is to finish the clean up to move the other types to their separate Znodes. 

**Solution** : Move updates for for jobTypes RELOAD, RELOAD_ALL, FORCE_COMMIT, to their own Znodes. Combined RELOAD, RELOAD_ALL updates into a single Znode as they are related. 
**Note**: This is a **backwards incompatible change**. The status of previously completed reload jobs, will not be available after this change is deployed. Given the low impact and to keep the code changes simple, we made this backwards incompatible. 