### PR TITLE
add partition metadata manager

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
@@ -45,6 +45,7 @@ import org.apache.pinot.broker.routing.instanceselector.InstanceSelector;
 import org.apache.pinot.broker.routing.instanceselector.InstanceSelectorFactory;
 import org.apache.pinot.broker.routing.segmentmetadata.SegmentZkMetadataFetchListener;
 import org.apache.pinot.broker.routing.segmentmetadata.SegmentZkMetadataFetcher;
+import org.apache.pinot.broker.routing.segmentpartition.SegmentPartitionMetadataManager;
 import org.apache.pinot.broker.routing.segmentpreselector.SegmentPreSelector;
 import org.apache.pinot.broker.routing.segmentpreselector.SegmentPreSelectorFactory;
 import org.apache.pinot.broker.routing.segmentpruner.SegmentPruner;
@@ -64,7 +65,9 @@ import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.QueryConfig;
+import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
@@ -502,6 +505,17 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
       }
     }
 
+    SegmentPartitionMetadataManager partitionDataManager = null;
+    SegmentPartitionConfig segmentPartitionConfig = tableConfig.getIndexingConfig().getSegmentPartitionConfig();
+    if (segmentPartitionConfig != null && segmentPartitionConfig.getColumnPartitionMap() != null
+        && segmentPartitionConfig.getColumnPartitionMap().size() == 1) {
+      Map<String, ColumnPartitionConfig> columnPartitionMap = segmentPartitionConfig.getColumnPartitionMap();
+      Map.Entry<String, ColumnPartitionConfig> partitionConfig = columnPartitionMap.entrySet().iterator().next();
+      LOGGER.info("Enabling PartitionDataManager for table: {} on {}", tableNameWithType, partitionConfig.getKey());
+      partitionDataManager = new SegmentPartitionMetadataManager(tableNameWithType, partitionConfig.getKey(),
+          partitionConfig.getValue().getFunctionName(), partitionConfig.getValue().getNumPartitions());
+    }
+
     QueryConfig queryConfig = tableConfig.getQueryConfig();
     Long queryTimeoutMs = queryConfig != null ? queryConfig.getTimeoutMs() : null;
 
@@ -509,12 +523,15 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     for (SegmentZkMetadataFetchListener listener : segmentPruners) {
       segmentZkMetadataFetcher.register(listener);
     }
+    if (partitionDataManager != null) {
+      segmentZkMetadataFetcher.register(partitionDataManager);
+    }
     segmentZkMetadataFetcher.init(idealState, externalView, preSelectedOnlineSegments);
 
     RoutingEntry routingEntry =
         new RoutingEntry(tableNameWithType, idealStatePath, externalViewPath, segmentPreSelector, segmentSelector,
             segmentPruners, instanceSelector, idealStateVersion, externalViewVersion, segmentZkMetadataFetcher,
-            timeBoundaryManager, queryTimeoutMs);
+            timeBoundaryManager, partitionDataManager, queryTimeoutMs);
     if (_routingEntryMap.put(tableNameWithType, routingEntry) == null) {
       LOGGER.info("Built routing for table: {}", tableNameWithType);
     } else {
@@ -652,6 +669,26 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     return timeBoundaryManager != null ? timeBoundaryManager.getTimeBoundaryInfo() : null;
   }
 
+  @Nullable
+  public Map<Integer, Set<String>> getPartitionToFullyReplicatedServersMap(String tableNameWithType) {
+    RoutingEntry routingEntry = _routingEntryMap.get(tableNameWithType);
+    if (routingEntry == null) {
+      return null;
+    }
+    SegmentPartitionMetadataManager partitionMetadataManager = routingEntry.getPartitionMetadataManager();
+    return partitionMetadataManager != null ? partitionMetadataManager.getPartitionToFullyReplicatedServersMap() : null;
+  }
+
+  @Nullable
+  public Map<Integer, List<String>> getPartitionToSegmentsMap(String tableNameWithType) {
+    RoutingEntry routingEntry = _routingEntryMap.get(tableNameWithType);
+    if (routingEntry == null) {
+      return null;
+    }
+    SegmentPartitionMetadataManager partitionMetadataManager = routingEntry.getPartitionMetadataManager();
+    return partitionMetadataManager != null ? partitionMetadataManager.getPartitionToSegmentsMap() : null;
+  }
+
   /**
    * Returns the table-level query timeout in milliseconds for the given table, or {@code null} if the timeout is not
    * configured in the table config.
@@ -669,6 +706,7 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     final SegmentPreSelector _segmentPreSelector;
     final SegmentSelector _segmentSelector;
     final List<SegmentPruner> _segmentPruners;
+    final SegmentPartitionMetadataManager _partitionMetadataManager;
     final InstanceSelector _instanceSelector;
     final Long _queryTimeoutMs;
     final SegmentZkMetadataFetcher _segmentZkMetadataFetcher;
@@ -683,7 +721,7 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
         SegmentPreSelector segmentPreSelector, SegmentSelector segmentSelector, List<SegmentPruner> segmentPruners,
         InstanceSelector instanceSelector, int lastUpdateIdealStateVersion, int lastUpdateExternalViewVersion,
         SegmentZkMetadataFetcher segmentZkMetadataFetcher, @Nullable TimeBoundaryManager timeBoundaryManager,
-        @Nullable Long queryTimeoutMs) {
+        @Nullable SegmentPartitionMetadataManager partitionMetadataManager, @Nullable Long queryTimeoutMs) {
       _tableNameWithType = tableNameWithType;
       _idealStatePath = idealStatePath;
       _externalViewPath = externalViewPath;
@@ -694,6 +732,7 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
       _lastUpdateIdealStateVersion = lastUpdateIdealStateVersion;
       _lastUpdateExternalViewVersion = lastUpdateExternalViewVersion;
       _timeBoundaryManager = timeBoundaryManager;
+      _partitionMetadataManager = partitionMetadataManager;
       _queryTimeoutMs = queryTimeoutMs;
       _segmentZkMetadataFetcher = segmentZkMetadataFetcher;
     }
@@ -717,6 +756,11 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     @Nullable
     TimeBoundaryManager getTimeBoundaryManager() {
       return _timeBoundaryManager;
+    }
+
+    @Nullable
+    SegmentPartitionMetadataManager getPartitionMetadataManager() {
+      return _partitionMetadataManager;
     }
 
     Long getQueryTimeoutMs() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionInfo.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionInfo.java
@@ -1,0 +1,54 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.segmentpartition;
+
+import java.util.Set;
+import org.apache.pinot.segment.spi.partition.PartitionFunction;
+
+
+public class SegmentPartitionInfo {
+  private final String _partitionColumn;
+  private final int _numPartitions;
+  private final PartitionFunction _partitionFunction;
+  private final Set<Integer> _partitions;
+
+  public SegmentPartitionInfo(String partitionColumn, int numPartitions, PartitionFunction partitionFunction,
+      Set<Integer> partitions) {
+    _partitionColumn = partitionColumn;
+    _numPartitions = numPartitions;
+    _partitionFunction = partitionFunction;
+    _partitions = partitions;
+  }
+
+  public int getNumPartitions() {
+    return _numPartitions;
+  }
+
+  public String getPartitionColumn() {
+    return _partitionColumn;
+  }
+
+  public PartitionFunction getPartitionFunction() {
+    return _partitionFunction;
+  }
+
+  public Set<Integer> getPartitions() {
+    return _partitions;
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionInfo.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionInfo.java
@@ -24,20 +24,14 @@ import org.apache.pinot.segment.spi.partition.PartitionFunction;
 
 public class SegmentPartitionInfo {
   private final String _partitionColumn;
-  private final int _numPartitions;
   private final PartitionFunction _partitionFunction;
   private final Set<Integer> _partitions;
 
-  public SegmentPartitionInfo(String partitionColumn, int numPartitions, PartitionFunction partitionFunction,
+  public SegmentPartitionInfo(String partitionColumn, PartitionFunction partitionFunction,
       Set<Integer> partitions) {
     _partitionColumn = partitionColumn;
-    _numPartitions = numPartitions;
     _partitionFunction = partitionFunction;
     _partitions = partitions;
-  }
-
-  public int getNumPartitions() {
-    return _numPartitions;
   }
 
   public String getPartitionColumn() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.segmentpartition;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentZkMetadataFetchListener;
+import org.apache.pinot.spi.utils.CommonConstants;
+
+
+/**
+ * The {@code PartitionDataManager} manages partitions of a table. It manages
+ *   1. all the online segments associated with the partition and their allocated servers
+ *   2. all the replica of a specific segment.
+ * It provides API to query
+ *   1. For each partition ID, what are the servers that contains ALL segments belong to this partition ID.
+ *   2. For each server, what are all the partition IDs and list of segments of those partition IDs on this server.
+ */
+public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchListener {
+  private final String _tableNameWithType;
+
+  // static content, if anything changes for the following. a rebuild of routing table is needed.
+  private final String _partitionColumn;
+  private final String _partitionFunctionName;
+  private final int _numPartitions;
+
+  // cache-able content, only follow changes if onlineSegments list (of ideal-state) is changed.
+  private final Map<String, List<String>> _segmentToOnlineServersMap = new HashMap<>();
+  private final Map<String, Integer> _segmentToPartitionMap = new HashMap<>();
+
+  // computed value based on status change.
+  private Map<Integer, Set<String>> _partitionToFullyReplicatedServersMap;
+  private Map<Integer, List<String>> _partitionToSegmentsMap;
+
+  public SegmentPartitionMetadataManager(String tableNameWithType, String partitionColumn, String partitionFunctionName,
+      int numPartitions) {
+    _tableNameWithType = tableNameWithType;
+    _partitionColumn = partitionColumn;
+    _partitionFunctionName = partitionFunctionName;
+    _numPartitions = numPartitions;
+  }
+
+  @Override
+  public void init(IdealState idealState, ExternalView externalView, List<String> onlineSegments,
+      List<ZNRecord> znRecords) {
+    for (int idx = 0; idx < onlineSegments.size(); idx++) {
+      String segment = onlineSegments.get(idx);
+      ZNRecord znRecord = znRecords.get(idx);
+      // extract single partition info
+      SegmentPartitionInfo segmentPartitionInfo = SegmentPartitionUtils.extractPartitionInfoFromSegmentZKMetadata(
+          _tableNameWithType, _partitionColumn, segment, znRecord);
+      if (validate(segmentPartitionInfo)) {
+        // update segment to partition map
+        Integer partitionId = segmentPartitionInfo.getPartitions().iterator().next();
+        _segmentToPartitionMap.put(segment, partitionId);
+      }
+      // update segment to server list.
+      updateSegmentServerOnlineMap(externalView, segment);
+    }
+    computePartitionMaps();
+  }
+
+  private void updateSegmentServerOnlineMap(ExternalView externalView, String segment) {
+    Map<String, String> instanceStateMap = externalView.getStateMap(segment);
+    List<String> serverList = instanceStateMap == null ? Collections.emptyList()
+        : instanceStateMap.entrySet().stream()
+            .filter(entry -> CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE.equals(entry.getValue()))
+            .map(Map.Entry::getKey)
+            .collect(Collectors.toList());
+    _segmentToOnlineServersMap.put(segment, serverList);
+  }
+
+  private boolean validate(SegmentPartitionInfo segmentPartitionInfo) {
+    if (segmentPartitionInfo == null || segmentPartitionInfo.getPartitionFunction() == null
+        || segmentPartitionInfo.getPartitions() == null) {
+      return false;
+    }
+    // TODO: check more than just function name here but also function config.
+    return _partitionFunctionName.equals(segmentPartitionInfo.getPartitionFunction().getName())
+        && _partitionColumn.equals(segmentPartitionInfo.getPartitionColumn())
+        && _numPartitions == segmentPartitionInfo.getNumPartitions()
+        && segmentPartitionInfo.getPartitions().size() == 1;
+  }
+
+  @Override
+  public synchronized void onAssignmentChange(IdealState idealState, ExternalView externalView,
+      Set<String> onlineSegments, List<String> pulledSegments, List<ZNRecord> znRecords) {
+    // update segment zk metadata for the pulled segments
+    for (int idx = 0; idx < pulledSegments.size(); idx++) {
+      String segment = pulledSegments.get(idx);
+      ZNRecord znRecord = znRecords.get(idx);
+      SegmentPartitionInfo segmentPartitionInfo = SegmentPartitionUtils.extractPartitionInfoFromSegmentZKMetadata(
+          _tableNameWithType, _partitionColumn, segment, znRecord);
+      if (validate(segmentPartitionInfo)) {
+        // update segment to partition map
+        Integer partitionId = segmentPartitionInfo.getPartitions().iterator().next();
+        _segmentToPartitionMap.put(segment, partitionId);
+      } else {
+        // remove the segment from the partition map
+        _segmentToPartitionMap.remove(segment);
+      }
+    }
+    // update the server online information based on external view.
+    for (String onlineSegment : onlineSegments) {
+      // update segment to server list.
+      updateSegmentServerOnlineMap(externalView, onlineSegment);
+    }
+    _segmentToPartitionMap.keySet().retainAll(onlineSegments);
+    _segmentToOnlineServersMap.keySet().retainAll(onlineSegments);
+    computePartitionMaps();
+  }
+
+  @Override
+  public synchronized void refreshSegment(String segment, @Nullable ZNRecord znRecord) {
+    SegmentPartitionInfo segmentPartitionInfo = SegmentPartitionUtils.extractPartitionInfoFromSegmentZKMetadata(
+        _tableNameWithType, _partitionColumn, segment, znRecord);
+    if (validate(segmentPartitionInfo)) {
+      // update segment to partition map
+      Integer partitionId = segmentPartitionInfo.getPartitions().iterator().next();
+      _segmentToPartitionMap.put(segment, partitionId);
+    } else {
+      // remove the segment from the partition map
+      _segmentToPartitionMap.remove(segment);
+    }
+    computePartitionMaps();
+  }
+
+  public Map<Integer, Set<String>> getPartitionToFullyReplicatedServersMap() {
+    return _partitionToFullyReplicatedServersMap;
+  }
+
+  public Map<Integer, List<String>> getPartitionToSegmentsMap() {
+    return _partitionToSegmentsMap;
+  }
+
+  private void computePartitionMaps() {
+    Map<Integer, Set<String>> partitionToFullyReplicatedServersMap = new HashMap<>();
+    Map<Integer, List<String>> partitionToSegmentsMap = new HashMap<>();
+    for (Map.Entry<String, List<String>> segmentServerEntry : _segmentToOnlineServersMap.entrySet()) {
+      String segment = segmentServerEntry.getKey();
+      int partitionId = _segmentToPartitionMap.getOrDefault(segment, -1);
+      if (partitionId >= 0) {
+        // update the partition to full replicate server set map.
+        Set<String> existingServerSet = partitionToFullyReplicatedServersMap.get(partitionId);
+        if (existingServerSet == null) {
+          existingServerSet = new HashSet<>(segmentServerEntry.getValue());
+        } else {
+          existingServerSet.retainAll(segmentServerEntry.getValue());
+        }
+        partitionToFullyReplicatedServersMap.put(partitionId, existingServerSet);
+        // update the partition to list of segments map
+        List<String> segmentList = partitionToSegmentsMap.get(partitionId);
+        if (segmentList == null) {
+          segmentList = new ArrayList<>();
+        }
+        segmentList.add(segment);
+        partitionToSegmentsMap.put(partitionId, segmentList);
+      }
+    }
+    _partitionToFullyReplicatedServersMap = partitionToFullyReplicatedServersMap;
+    _partitionToSegmentsMap = partitionToSegmentsMap;
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionUtils.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionUtils.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.segmentpartition;
+
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
+import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class SegmentPartitionUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPartitionUtils.class);
+  public static final SegmentPartitionInfo INVALID_PARTITION_INFO = new SegmentPartitionInfo(null, 0, null, null);
+  public static final Map<String, SegmentPartitionInfo> INVALID_COLUMN_PARTITION_INFO_MAP = Collections.emptyMap();
+
+  private SegmentPartitionUtils() {
+    // do not instantiate.
+  }
+
+  /**
+   * NOTE: Returns {@code null} when the ZNRecord is missing (could be transient Helix issue). Returns
+   *       {@link #INVALID_COLUMN_PARTITION_INFO_MAP} when the segment does not have valid partition metadata in its ZK
+   *       metadata, in which case we won't retry later.
+   */
+  @Nullable
+  public static Map<String, SegmentPartitionInfo> extractPartitionInfoMapFromSegmentZKMetadata(String tableNameWithType,
+      Set<String> partitionColumns, String segment, @Nullable ZNRecord znRecord) {
+    if (znRecord == null) {
+      LOGGER.warn("Failed to find segment ZK metadata for segment: {}, table: {}", segment, tableNameWithType);
+      return null;
+    }
+
+    String partitionMetadataJson = znRecord.getSimpleField(CommonConstants.Segment.PARTITION_METADATA);
+    if (partitionMetadataJson == null) {
+      LOGGER.warn("Failed to find segment partition metadata for segment: {}, table: {}", segment, tableNameWithType);
+      return INVALID_COLUMN_PARTITION_INFO_MAP;
+    }
+
+    SegmentPartitionMetadata segmentPartitionMetadata;
+    try {
+      segmentPartitionMetadata = SegmentPartitionMetadata.fromJsonString(partitionMetadataJson);
+    } catch (Exception e) {
+      LOGGER.warn("Caught exception while extracting segment partition metadata for segment: {}, table: {}", segment,
+          tableNameWithType, e);
+      return INVALID_COLUMN_PARTITION_INFO_MAP;
+    }
+
+    Map<String, SegmentPartitionInfo> columnSegmentPartitionInfoMap = new HashMap<>();
+    for (String partitionColumn : partitionColumns) {
+      ColumnPartitionMetadata columnPartitionMetadata =
+          segmentPartitionMetadata.getColumnPartitionMap().get(partitionColumn);
+      if (columnPartitionMetadata == null) {
+        LOGGER.warn("Failed to find column partition metadata for column: {}, segment: {}, table: {}", partitionColumn,
+            segment, tableNameWithType);
+        continue;
+      }
+      SegmentPartitionInfo segmentPartitionInfo =
+          new SegmentPartitionInfo(partitionColumn, columnPartitionMetadata.getNumPartitions(),
+              PartitionFunctionFactory.getPartitionFunction(columnPartitionMetadata.getFunctionName(),
+                  columnPartitionMetadata.getNumPartitions(), columnPartitionMetadata.getFunctionConfig()),
+              columnPartitionMetadata.getPartitions());
+      columnSegmentPartitionInfoMap.put(partitionColumn, segmentPartitionInfo);
+    }
+    if (columnSegmentPartitionInfoMap.size() == 1) {
+      String partitionColumn = columnSegmentPartitionInfoMap.keySet().iterator().next();
+      return Collections.singletonMap(partitionColumn, columnSegmentPartitionInfoMap.get(partitionColumn));
+    }
+    return columnSegmentPartitionInfoMap.isEmpty() ? INVALID_COLUMN_PARTITION_INFO_MAP : columnSegmentPartitionInfoMap;
+  }
+
+  /**
+   * NOTE: Returns {@code null} when the ZNRecord is missing (could be transient Helix issue). Returns
+   *       {@link #INVALID_PARTITION_INFO} when the segment does not have valid partition metadata in its ZK metadata,
+   *       in which case we won't retry later.
+   */
+  @Nullable
+  public static SegmentPartitionInfo extractPartitionInfoFromSegmentZKMetadata(String tableNameWithType,
+      String partitionColumn, String segment, @Nullable ZNRecord znRecord) {
+    if (znRecord == null) {
+      LOGGER.warn("Failed to find segment ZK metadata for segment: {}, table: {}", segment, tableNameWithType);
+      return null;
+    }
+
+    String partitionMetadataJson = znRecord.getSimpleField(CommonConstants.Segment.PARTITION_METADATA);
+    if (partitionMetadataJson == null) {
+      LOGGER.warn("Failed to find segment partition metadata for segment: {}, table: {}", segment, tableNameWithType);
+      return INVALID_PARTITION_INFO;
+    }
+
+    SegmentPartitionMetadata segmentPartitionMetadata;
+    try {
+      segmentPartitionMetadata = SegmentPartitionMetadata.fromJsonString(partitionMetadataJson);
+    } catch (Exception e) {
+      LOGGER.warn("Caught exception while extracting segment partition metadata for segment: {}, table: {}", segment,
+          tableNameWithType, e);
+      return INVALID_PARTITION_INFO;
+    }
+
+    ColumnPartitionMetadata columnPartitionMetadata =
+        segmentPartitionMetadata.getColumnPartitionMap().get(partitionColumn);
+    if (columnPartitionMetadata == null) {
+      LOGGER.warn("Failed to find column partition metadata for column: {}, segment: {}, table: {}", partitionColumn,
+          segment, tableNameWithType);
+      return INVALID_PARTITION_INFO;
+    }
+
+    return new SegmentPartitionInfo(partitionColumn, columnPartitionMetadata.getNumPartitions(),
+        PartitionFunctionFactory.getPartitionFunction(columnPartitionMetadata.getFunctionName(),
+            columnPartitionMetadata.getNumPartitions(), columnPartitionMetadata.getFunctionConfig()),
+        columnPartitionMetadata.getPartitions());
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/TablePartitionInfo.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/TablePartitionInfo.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.segmentpartition;
+
+import java.util.List;
+import java.util.Set;
+
+
+public class TablePartitionInfo {
+  private final String _tableNameWithType;
+  private final String _partitionColumn;
+  private final String _partitionFunctionName;
+  private final int _numPartitions;
+  private final PartitionInfo[] _partitionInfoMap;
+  private final Set<String> _segmentsWithInvalidPartition;
+
+  public TablePartitionInfo(String tableNameWithType, String partitionColumn, String partitionFunctionName,
+      int numPartitions, PartitionInfo[] partitionInfoMap, Set<String> segmentsWithInvalidPartition) {
+    _tableNameWithType = tableNameWithType;
+    _partitionColumn = partitionColumn;
+    _partitionFunctionName = partitionFunctionName;
+    _numPartitions = numPartitions;
+    _partitionInfoMap = partitionInfoMap;
+    _segmentsWithInvalidPartition = segmentsWithInvalidPartition;
+  }
+
+  public String getTableNameWithType() {
+    return _tableNameWithType;
+  }
+
+  public String getPartitionColumn() {
+    return _partitionColumn;
+  }
+
+  public String getPartitionFunctionName() {
+    return _partitionFunctionName;
+  }
+
+  public int getNumPartitions() {
+    return _numPartitions;
+  }
+
+  public PartitionInfo[] getPartitionInfoMap() {
+    return _partitionInfoMap;
+  }
+
+  public Set<String> getSegmentsWithInvalidPartition() {
+    return _segmentsWithInvalidPartition;
+  }
+
+  public static class PartitionInfo {
+    List<String> _segments;
+    Set<String> _fullyReplicatedServers;
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/MultiPartitionColumnsSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/MultiPartitionColumnsSegmentPruner.java
@@ -19,8 +19,6 @@
 package org.apache.pinot.broker.routing.segmentpruner;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -30,18 +28,13 @@ import javax.annotation.Nullable;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import org.apache.pinot.broker.routing.segmentpartition.SegmentPartitionInfo;
+import org.apache.pinot.broker.routing.segmentpartition.SegmentPartitionUtils;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
-import org.apache.pinot.segment.spi.partition.PartitionFunction;
-import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
-import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
-import org.apache.pinot.spi.utils.CommonConstants.Segment;
 import org.apache.pinot.sql.FilterKind;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -49,12 +42,11 @@ import org.slf4j.LoggerFactory;
  * pruner supports queries with filter (or nested filter) of EQUALITY and IN predicates.
  */
 public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
-  private static final Logger LOGGER = LoggerFactory.getLogger(MultiPartitionColumnsSegmentPruner.class);
-  private static final Map<String, PartitionInfo> INVALID_COLUMN_PARTITION_INFO_MAP = Collections.emptyMap();
 
   private final String _tableNameWithType;
   private final Set<String> _partitionColumns;
-  private final Map<String, Map<String, PartitionInfo>> _segmentColumnPartitionInfoMap = new ConcurrentHashMap<>();
+  private final Map<String, Map<String, SegmentPartitionInfo>> _segmentColumnPartitionInfoMap =
+      new ConcurrentHashMap<>();
 
   public MultiPartitionColumnsSegmentPruner(String tableNameWithType, Set<String> partitionColumns) {
     _tableNameWithType = tableNameWithType;
@@ -67,62 +59,13 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
     // Bulk load partition info for all online segments
     for (int idx = 0; idx < onlineSegments.size(); idx++) {
       String segment = onlineSegments.get(idx);
-      Map<String, PartitionInfo> columnPartitionInfoMap =
-          extractColumnPartitionInfoMapFromSegmentZKMetadataZNRecord(segment, znRecords.get(idx));
+      Map<String, SegmentPartitionInfo> columnPartitionInfoMap =
+          SegmentPartitionUtils.extractPartitionInfoMapFromSegmentZKMetadata(_tableNameWithType, _partitionColumns,
+              segment, znRecords.get(idx));
       if (columnPartitionInfoMap != null) {
         _segmentColumnPartitionInfoMap.put(segment, columnPartitionInfoMap);
       }
     }
-  }
-
-  /**
-   * NOTE: Returns {@code null} when the ZNRecord is missing (could be transient Helix issue). Returns
-   *       {@link #INVALID_COLUMN_PARTITION_INFO_MAP} when the segment does not have valid partition metadata in its ZK
-   *       metadata, in which case we won't retry later.
-   */
-  @Nullable
-  private Map<String, PartitionInfo> extractColumnPartitionInfoMapFromSegmentZKMetadataZNRecord(String segment,
-      @Nullable ZNRecord znRecord) {
-    if (znRecord == null) {
-      LOGGER.warn("Failed to find segment ZK metadata for segment: {}, table: {}", segment, _tableNameWithType);
-      return null;
-    }
-
-    String partitionMetadataJson = znRecord.getSimpleField(Segment.PARTITION_METADATA);
-    if (partitionMetadataJson == null) {
-      LOGGER.warn("Failed to find segment partition metadata for segment: {}, table: {}", segment, _tableNameWithType);
-      return INVALID_COLUMN_PARTITION_INFO_MAP;
-    }
-
-    SegmentPartitionMetadata segmentPartitionMetadata;
-    try {
-      segmentPartitionMetadata = SegmentPartitionMetadata.fromJsonString(partitionMetadataJson);
-    } catch (Exception e) {
-      LOGGER.warn("Caught exception while extracting segment partition metadata for segment: {}, table: {}", segment,
-          _tableNameWithType, e);
-      return INVALID_COLUMN_PARTITION_INFO_MAP;
-    }
-
-    Map<String, PartitionInfo> columnPartitionInfoMap = new HashMap<>();
-    for (String partitionColumn : _partitionColumns) {
-      ColumnPartitionMetadata columnPartitionMetadata =
-          segmentPartitionMetadata.getColumnPartitionMap().get(partitionColumn);
-      if (columnPartitionMetadata == null) {
-        LOGGER.warn("Failed to find column partition metadata for column: {}, segment: {}, table: {}", partitionColumn,
-            segment, _tableNameWithType);
-        continue;
-      }
-      PartitionInfo partitionInfo = new PartitionInfo(
-          PartitionFunctionFactory.getPartitionFunction(columnPartitionMetadata.getFunctionName(),
-              columnPartitionMetadata.getNumPartitions(), columnPartitionMetadata.getFunctionConfig()),
-          columnPartitionMetadata.getPartitions());
-      columnPartitionInfoMap.put(partitionColumn, partitionInfo);
-    }
-    if (columnPartitionInfoMap.size() == 1) {
-      String partitionColumn = columnPartitionInfoMap.keySet().iterator().next();
-      return Collections.singletonMap(partitionColumn, columnPartitionInfoMap.get(partitionColumn));
-    }
-    return columnPartitionInfoMap.isEmpty() ? INVALID_COLUMN_PARTITION_INFO_MAP : columnPartitionInfoMap;
   }
 
   @Override
@@ -134,15 +77,17 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
       String segment = pulledSegments.get(idx);
       ZNRecord znRecord = znRecords.get(idx);
       _segmentColumnPartitionInfoMap.computeIfAbsent(segment,
-          k -> extractColumnPartitionInfoMapFromSegmentZKMetadataZNRecord(k, znRecord));
+          k -> SegmentPartitionUtils.extractPartitionInfoMapFromSegmentZKMetadata(_tableNameWithType, _partitionColumns,
+              k, znRecord));
     }
     _segmentColumnPartitionInfoMap.keySet().retainAll(onlineSegments);
   }
 
   @Override
   public synchronized void refreshSegment(String segment, @Nullable ZNRecord znRecord) {
-    Map<String, PartitionInfo> columnPartitionInfo =
-        extractColumnPartitionInfoMapFromSegmentZKMetadataZNRecord(segment, znRecord);
+    Map<String, SegmentPartitionInfo> columnPartitionInfo =
+        SegmentPartitionUtils.extractPartitionInfoMapFromSegmentZKMetadata(_tableNameWithType, _partitionColumns,
+            segment, znRecord);
     if (columnPartitionInfo != null) {
       _segmentColumnPartitionInfoMap.put(segment, columnPartitionInfo);
     } else {
@@ -158,9 +103,10 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
     }
     Set<String> selectedSegments = new HashSet<>();
     for (String segment : segments) {
-      Map<String, PartitionInfo> columnPartitionInfoMap = _segmentColumnPartitionInfoMap.get(segment);
-      if (columnPartitionInfoMap == null || columnPartitionInfoMap == INVALID_COLUMN_PARTITION_INFO_MAP
-          || isPartitionMatch(filterExpression, columnPartitionInfoMap)) {
+      Map<String, SegmentPartitionInfo> columnPartitionInfoMap = _segmentColumnPartitionInfoMap.get(segment);
+      if (columnPartitionInfoMap == null
+          || columnPartitionInfoMap == SegmentPartitionUtils.INVALID_COLUMN_PARTITION_INFO_MAP || isPartitionMatch(
+          filterExpression, columnPartitionInfoMap)) {
         selectedSegments.add(segment);
       }
     }
@@ -172,7 +118,8 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
     return _partitionColumns;
   }
 
-  private boolean isPartitionMatch(Expression filterExpression, Map<String, PartitionInfo> columnPartitionInfoMap) {
+  private boolean isPartitionMatch(Expression filterExpression,
+      Map<String, SegmentPartitionInfo> columnPartitionInfoMap) {
     Function function = filterExpression.getFunctionCall();
     FilterKind filterKind = FilterKind.valueOf(function.getOperator());
     List<Expression> operands = function.getOperands();
@@ -194,9 +141,9 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
       case EQUALS: {
         Identifier identifier = operands.get(0).getIdentifier();
         if (identifier != null) {
-          PartitionInfo partitionInfo = columnPartitionInfoMap.get(identifier.getName());
-          return partitionInfo == null || partitionInfo._partitions.contains(
-              partitionInfo._partitionFunction.getPartition(operands.get(1).getLiteral().getFieldValue()));
+          SegmentPartitionInfo partitionInfo = columnPartitionInfoMap.get(identifier.getName());
+          return partitionInfo == null || partitionInfo.getPartitions().contains(
+              partitionInfo.getPartitionFunction().getPartition(operands.get(1).getLiteral().getFieldValue()));
         } else {
           return true;
         }
@@ -204,14 +151,14 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
       case IN: {
         Identifier identifier = operands.get(0).getIdentifier();
         if (identifier != null) {
-          PartitionInfo partitionInfo = columnPartitionInfoMap.get(identifier.getName());
+          SegmentPartitionInfo partitionInfo = columnPartitionInfoMap.get(identifier.getName());
           if (partitionInfo == null) {
             return true;
           }
           int numOperands = operands.size();
           for (int i = 1; i < numOperands; i++) {
-            if (partitionInfo._partitions.contains(partitionInfo._partitionFunction.getPartition(
-                operands.get(i).getLiteral().getFieldValue().toString()))) {
+            if (partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction()
+                .getPartition(operands.get(i).getLiteral().getFieldValue().toString()))) {
               return true;
             }
           }
@@ -222,16 +169,6 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
       }
       default:
         return true;
-    }
-  }
-
-  private static class PartitionInfo {
-    final PartitionFunction _partitionFunction;
-    final Set<Integer> _partitions;
-
-    PartitionInfo(PartitionFunction partitionFunction, Set<Integer> partitions) {
-      _partitionFunction = partitionFunction;
-      _partitions = partitions;
     }
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/MultiPartitionColumnsSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/MultiPartitionColumnsSegmentPruner.java
@@ -42,7 +42,6 @@ import org.apache.pinot.sql.FilterKind;
  * pruner supports queries with filter (or nested filter) of EQUALITY and IN predicates.
  */
 public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
-
   private final String _tableNameWithType;
   private final Set<String> _partitionColumns;
   private final Map<String, Map<String, SegmentPartitionInfo>> _segmentColumnPartitionInfoMap =
@@ -60,8 +59,8 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
     for (int idx = 0; idx < onlineSegments.size(); idx++) {
       String segment = onlineSegments.get(idx);
       Map<String, SegmentPartitionInfo> columnPartitionInfoMap =
-          SegmentPartitionUtils.extractPartitionInfoMapFromSegmentZKMetadata(_tableNameWithType, _partitionColumns,
-              segment, znRecords.get(idx));
+          SegmentPartitionUtils.extractPartitionInfoMap(_tableNameWithType, _partitionColumns, segment,
+              znRecords.get(idx));
       if (columnPartitionInfoMap != null) {
         _segmentColumnPartitionInfoMap.put(segment, columnPartitionInfoMap);
       }
@@ -77,8 +76,7 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
       String segment = pulledSegments.get(idx);
       ZNRecord znRecord = znRecords.get(idx);
       _segmentColumnPartitionInfoMap.computeIfAbsent(segment,
-          k -> SegmentPartitionUtils.extractPartitionInfoMapFromSegmentZKMetadata(_tableNameWithType, _partitionColumns,
-              k, znRecord));
+          k -> SegmentPartitionUtils.extractPartitionInfoMap(_tableNameWithType, _partitionColumns, k, znRecord));
     }
     _segmentColumnPartitionInfoMap.keySet().retainAll(onlineSegments);
   }
@@ -86,8 +84,7 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
   @Override
   public synchronized void refreshSegment(String segment, @Nullable ZNRecord znRecord) {
     Map<String, SegmentPartitionInfo> columnPartitionInfo =
-        SegmentPartitionUtils.extractPartitionInfoMapFromSegmentZKMetadata(_tableNameWithType, _partitionColumns,
-            segment, znRecord);
+        SegmentPartitionUtils.extractPartitionInfoMap(_tableNameWithType, _partitionColumns, segment, znRecord);
     if (columnPartitionInfo != null) {
       _segmentColumnPartitionInfoMap.put(segment, columnPartitionInfo);
     } else {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SinglePartitionColumnSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SinglePartitionColumnSegmentPruner.java
@@ -27,18 +27,13 @@ import javax.annotation.Nullable;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import org.apache.pinot.broker.routing.segmentpartition.SegmentPartitionInfo;
+import org.apache.pinot.broker.routing.segmentpartition.SegmentPartitionUtils;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
-import org.apache.pinot.segment.spi.partition.PartitionFunction;
-import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
-import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
-import org.apache.pinot.spi.utils.CommonConstants.Segment;
 import org.apache.pinot.sql.FilterKind;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -46,12 +41,9 @@ import org.slf4j.LoggerFactory;
  * pruner supports queries with filter (or nested filter) of EQUALITY and IN predicates.
  */
 public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
-  private static final Logger LOGGER = LoggerFactory.getLogger(SinglePartitionColumnSegmentPruner.class);
-  private static final PartitionInfo INVALID_PARTITION_INFO = new PartitionInfo(null, null);
-
   private final String _tableNameWithType;
   private final String _partitionColumn;
-  private final Map<String, PartitionInfo> _partitionInfoMap = new ConcurrentHashMap<>();
+  private final Map<String, SegmentPartitionInfo> _partitionInfoMap = new ConcurrentHashMap<>();
 
   public SinglePartitionColumnSegmentPruner(String tableNameWithType, String partitionColumn) {
     _tableNameWithType = tableNameWithType;
@@ -64,51 +56,12 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
     // Bulk load partition info for all online segments
     for (int idx = 0; idx < onlineSegments.size(); idx++) {
       String segment = onlineSegments.get(idx);
-      PartitionInfo partitionInfo = extractPartitionInfoFromSegmentZKMetadataZNRecord(segment, znRecords.get(idx));
+      SegmentPartitionInfo partitionInfo = SegmentPartitionUtils.extractPartitionInfoFromSegmentZKMetadata(
+          _tableNameWithType, _partitionColumn, segment, znRecords.get(idx));
       if (partitionInfo != null) {
         _partitionInfoMap.put(segment, partitionInfo);
       }
     }
-  }
-
-  /**
-   * NOTE: Returns {@code null} when the ZNRecord is missing (could be transient Helix issue). Returns
-   *       {@link #INVALID_PARTITION_INFO} when the segment does not have valid partition metadata in its ZK metadata,
-   *       in which case we won't retry later.
-   */
-  @Nullable
-  private PartitionInfo extractPartitionInfoFromSegmentZKMetadataZNRecord(String segment, @Nullable ZNRecord znRecord) {
-    if (znRecord == null) {
-      LOGGER.warn("Failed to find segment ZK metadata for segment: {}, table: {}", segment, _tableNameWithType);
-      return null;
-    }
-
-    String partitionMetadataJson = znRecord.getSimpleField(Segment.PARTITION_METADATA);
-    if (partitionMetadataJson == null) {
-      LOGGER.warn("Failed to find segment partition metadata for segment: {}, table: {}", segment, _tableNameWithType);
-      return INVALID_PARTITION_INFO;
-    }
-
-    SegmentPartitionMetadata segmentPartitionMetadata;
-    try {
-      segmentPartitionMetadata = SegmentPartitionMetadata.fromJsonString(partitionMetadataJson);
-    } catch (Exception e) {
-      LOGGER.warn("Caught exception while extracting segment partition metadata for segment: {}, table: {}", segment,
-          _tableNameWithType, e);
-      return INVALID_PARTITION_INFO;
-    }
-
-    ColumnPartitionMetadata columnPartitionMetadata =
-        segmentPartitionMetadata.getColumnPartitionMap().get(_partitionColumn);
-    if (columnPartitionMetadata == null) {
-      LOGGER.warn("Failed to find column partition metadata for column: {}, segment: {}, table: {}", _partitionColumn,
-          segment, _tableNameWithType);
-      return INVALID_PARTITION_INFO;
-    }
-
-    return new PartitionInfo(PartitionFunctionFactory.getPartitionFunction(columnPartitionMetadata.getFunctionName(),
-        columnPartitionMetadata.getNumPartitions(), columnPartitionMetadata.getFunctionConfig()),
-        columnPartitionMetadata.getPartitions());
   }
 
   @Override
@@ -119,14 +72,16 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
     for (int idx = 0; idx < pulledSegments.size(); idx++) {
       String segment = pulledSegments.get(idx);
       ZNRecord znRecord = znRecords.get(idx);
-      _partitionInfoMap.computeIfAbsent(segment, k -> extractPartitionInfoFromSegmentZKMetadataZNRecord(k, znRecord));
+      _partitionInfoMap.computeIfAbsent(segment, k -> SegmentPartitionUtils.extractPartitionInfoFromSegmentZKMetadata(
+          _tableNameWithType, _partitionColumn, k, znRecord));
     }
     _partitionInfoMap.keySet().retainAll(onlineSegments);
   }
 
   @Override
   public synchronized void refreshSegment(String segment, @Nullable ZNRecord znRecord) {
-    PartitionInfo partitionInfo = extractPartitionInfoFromSegmentZKMetadataZNRecord(segment, znRecord);
+    SegmentPartitionInfo partitionInfo = SegmentPartitionUtils.extractPartitionInfoFromSegmentZKMetadata(
+        _tableNameWithType, _partitionColumn, segment, znRecord);
     if (partitionInfo != null) {
       _partitionInfoMap.put(segment, partitionInfo);
     } else {
@@ -142,16 +97,16 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
     }
     Set<String> selectedSegments = new HashSet<>();
     for (String segment : segments) {
-      PartitionInfo partitionInfo = _partitionInfoMap.get(segment);
-      if (partitionInfo == null || partitionInfo == INVALID_PARTITION_INFO || isPartitionMatch(filterExpression,
-          partitionInfo)) {
+      SegmentPartitionInfo partitionInfo = _partitionInfoMap.get(segment);
+      if (partitionInfo == null || partitionInfo == SegmentPartitionUtils.INVALID_PARTITION_INFO
+          || isPartitionMatch(filterExpression, partitionInfo)) {
         selectedSegments.add(segment);
       }
     }
     return selectedSegments;
   }
 
-  private boolean isPartitionMatch(Expression filterExpression, PartitionInfo partitionInfo) {
+  private boolean isPartitionMatch(Expression filterExpression, SegmentPartitionInfo partitionInfo) {
     Function function = filterExpression.getFunctionCall();
     FilterKind filterKind = FilterKind.valueOf(function.getOperator());
     List<Expression> operands = function.getOperands();
@@ -173,8 +128,8 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
       case EQUALS: {
         Identifier identifier = operands.get(0).getIdentifier();
         if (identifier != null && identifier.getName().equals(_partitionColumn)) {
-          return partitionInfo._partitions.contains(
-              partitionInfo._partitionFunction.getPartition(operands.get(1).getLiteral().getFieldValue().toString()));
+          return partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction().getPartition(
+              operands.get(1).getLiteral().getFieldValue().toString()));
         } else {
           return true;
         }
@@ -184,7 +139,7 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
         if (identifier != null && identifier.getName().equals(_partitionColumn)) {
           int numOperands = operands.size();
           for (int i = 1; i < numOperands; i++) {
-            if (partitionInfo._partitions.contains(partitionInfo._partitionFunction.getPartition(
+            if (partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction().getPartition(
                 operands.get(i).getLiteral().getFieldValue().toString()))) {
               return true;
             }
@@ -196,16 +151,6 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
       }
       default:
         return true;
-    }
-  }
-
-  private static class PartitionInfo {
-    final PartitionFunction _partitionFunction;
-    final Set<Integer> _partitions;
-
-    PartitionInfo(PartitionFunction partitionFunction, Set<Integer> partitions) {
-      _partitionFunction = partitionFunction;
-      _partitions = partitions;
     }
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SinglePartitionColumnSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SinglePartitionColumnSegmentPruner.java
@@ -56,8 +56,8 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
     // Bulk load partition info for all online segments
     for (int idx = 0; idx < onlineSegments.size(); idx++) {
       String segment = onlineSegments.get(idx);
-      SegmentPartitionInfo partitionInfo = SegmentPartitionUtils.extractPartitionInfoFromSegmentZKMetadata(
-          _tableNameWithType, _partitionColumn, segment, znRecords.get(idx));
+      SegmentPartitionInfo partitionInfo =
+          SegmentPartitionUtils.extractPartitionInfo(_tableNameWithType, _partitionColumn, segment, znRecords.get(idx));
       if (partitionInfo != null) {
         _partitionInfoMap.put(segment, partitionInfo);
       }
@@ -72,16 +72,16 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
     for (int idx = 0; idx < pulledSegments.size(); idx++) {
       String segment = pulledSegments.get(idx);
       ZNRecord znRecord = znRecords.get(idx);
-      _partitionInfoMap.computeIfAbsent(segment, k -> SegmentPartitionUtils.extractPartitionInfoFromSegmentZKMetadata(
-          _tableNameWithType, _partitionColumn, k, znRecord));
+      _partitionInfoMap.computeIfAbsent(segment,
+          k -> SegmentPartitionUtils.extractPartitionInfo(_tableNameWithType, _partitionColumn, k, znRecord));
     }
     _partitionInfoMap.keySet().retainAll(onlineSegments);
   }
 
   @Override
   public synchronized void refreshSegment(String segment, @Nullable ZNRecord znRecord) {
-    SegmentPartitionInfo partitionInfo = SegmentPartitionUtils.extractPartitionInfoFromSegmentZKMetadata(
-        _tableNameWithType, _partitionColumn, segment, znRecord);
+    SegmentPartitionInfo partitionInfo =
+        SegmentPartitionUtils.extractPartitionInfo(_tableNameWithType, _partitionColumn, segment, znRecord);
     if (partitionInfo != null) {
       _partitionInfoMap.put(segment, partitionInfo);
     } else {
@@ -98,8 +98,8 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
     Set<String> selectedSegments = new HashSet<>();
     for (String segment : segments) {
       SegmentPartitionInfo partitionInfo = _partitionInfoMap.get(segment);
-      if (partitionInfo == null || partitionInfo == SegmentPartitionUtils.INVALID_PARTITION_INFO
-          || isPartitionMatch(filterExpression, partitionInfo)) {
+      if (partitionInfo == null || partitionInfo == SegmentPartitionUtils.INVALID_PARTITION_INFO || isPartitionMatch(
+          filterExpression, partitionInfo)) {
         selectedSegments.add(segment);
       }
     }
@@ -128,8 +128,8 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
       case EQUALS: {
         Identifier identifier = operands.get(0).getIdentifier();
         if (identifier != null && identifier.getName().equals(_partitionColumn)) {
-          return partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction().getPartition(
-              operands.get(1).getLiteral().getFieldValue().toString()));
+          return partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction()
+              .getPartition(operands.get(1).getLiteral().getFieldValue().toString()));
         } else {
           return true;
         }
@@ -139,8 +139,8 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
         if (identifier != null && identifier.getName().equals(_partitionColumn)) {
           int numOperands = operands.size();
           for (int i = 1; i < numOperands; i++) {
-            if (partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction().getPartition(
-                operands.get(i).getLiteral().getFieldValue().toString()))) {
+            if (partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction()
+                .getPartition(operands.get(i).getLiteral().getFieldValue().toString()))) {
               return true;
             }
           }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/HelixBrokerStarterTest.java
@@ -104,10 +104,14 @@ public class HelixBrokerStarterTest extends ControllerTest {
     }
 
     TestUtils.waitForCondition(aVoid -> {
+      // should wait for both realtime and offline table external view to be live.
       ExternalView offlineTableExternalView =
           _helixAdmin.getResourceExternalView(getHelixClusterName(), OFFLINE_TABLE_NAME);
+      ExternalView realtimeTableExternalView =
+          _helixAdmin.getResourceExternalView(getHelixClusterName(), REALTIME_TABLE_NAME);
       return offlineTableExternalView != null
-          && offlineTableExternalView.getPartitionSet().size() == NUM_OFFLINE_SEGMENTS;
+          && offlineTableExternalView.getPartitionSet().size() == NUM_OFFLINE_SEGMENTS
+          && realtimeTableExternalView != null;
     }, 30_000L, "Failed to find all OFFLINE segments in the ExternalView");
   }
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcherTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentmetadata/SegmentZkMetadataFetcherTest.java
@@ -51,8 +51,8 @@ public class SegmentZkMetadataFetcherTest extends ControllerTest {
     ExternalView externalView = Mockito.mock(ExternalView.class);
 
     // empty listener at beginning
-    SegmentZkMetadataFetcher segmentZkMetadataFetcher = new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME,
-        mockPropertyStore);
+    SegmentZkMetadataFetcher segmentZkMetadataFetcher =
+        new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME, mockPropertyStore);
     assertEquals(segmentZkMetadataFetcher.getListeners().size(), 0);
 
     // should allow register new listener
@@ -60,7 +60,7 @@ public class SegmentZkMetadataFetcherTest extends ControllerTest {
     assertEquals(segmentZkMetadataFetcher.getListeners().size(), 1);
 
     // should not allow register new listener once initialized
-    segmentZkMetadataFetcher.init(idealState, externalView, Collections.singleton("foo"));
+    segmentZkMetadataFetcher.init(idealState, externalView, Collections.emptySet());
     try {
       segmentZkMetadataFetcher.register(mock(SegmentZkMetadataFetchListener.class));
       fail();
@@ -70,7 +70,7 @@ public class SegmentZkMetadataFetcherTest extends ControllerTest {
 
     // should not allow duplicate init either
     try {
-      segmentZkMetadataFetcher.init(idealState, externalView, Collections.singleton("foo"));
+      segmentZkMetadataFetcher.init(idealState, externalView, Collections.emptySet());
       fail();
     } catch (RuntimeException rte) {
       assertTrue(rte.getMessage().contains("has already been initialized"));
@@ -80,8 +80,8 @@ public class SegmentZkMetadataFetcherTest extends ControllerTest {
   @Test
   public void testSegmentZkMetadataFetcherShouldNotPullZkWhenNoPrunerRegistered() {
     ZkHelixPropertyStore<ZNRecord> mockPropertyStore = Mockito.mock(ZkHelixPropertyStore.class);
-    SegmentZkMetadataFetcher segmentZkMetadataFetcher = new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME,
-        mockPropertyStore);
+    SegmentZkMetadataFetcher segmentZkMetadataFetcher =
+        new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME, mockPropertyStore);
     // NOTE: Ideal state and external view are not used in the current implementation
     IdealState idealState = Mockito.mock(IdealState.class);
     ExternalView externalView = Mockito.mock(ExternalView.class);
@@ -111,8 +111,8 @@ public class SegmentZkMetadataFetcherTest extends ControllerTest {
     });
     SegmentPruner pruner1 = mock(SegmentPruner.class);
     SegmentPruner pruner2 = mock(SegmentPruner.class);
-    SegmentZkMetadataFetcher segmentZkMetadataFetcher = new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME,
-        mockPropertyStore);
+    SegmentZkMetadataFetcher segmentZkMetadataFetcher =
+        new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME, mockPropertyStore);
     segmentZkMetadataFetcher.register(pruner1);
     segmentZkMetadataFetcher.register(pruner2);
     // NOTE: Ideal state and external view are not used in the current implementation

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerTest.java
@@ -1,0 +1,227 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.segmentpartition;
+
+import com.google.common.collect.ImmutableMap;
+import com.google.common.collect.ImmutableSet;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import org.apache.helix.manager.zk.ZkBaseDataAccessor;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.datamodel.serializer.ZNRecordSerializer;
+import org.apache.helix.zookeeper.impl.client.ZkClient;
+import org.apache.pinot.broker.routing.segmentmetadata.SegmentZkMetadataFetcher;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
+import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
+import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE;
+import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
+import static org.testng.Assert.assertEquals;
+
+
+public class SegmentPartitionMetadataManagerTest extends ControllerTest {
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String TABLE_NAME = "testTable_OFFLINE";
+  private static final String PARTITION_COLUMN = "memberId";
+  private static final String PARTITION_COLUMN_FUNC = "Murmur";
+  private static final int PARTITION_COLUMN_SIZE = 2;
+  private static final String PARTITION_COLUMN_FUNC_ALT = "Modulo";
+  private static final int PARTITION_COLUMN_SIZE_ALT = 4;
+  private static final String SERVER_0 = "server0";
+  private static final String SERVER_1 = "server1";
+
+
+  private ZkClient _zkClient;
+  private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+
+  @BeforeClass
+  public void setUp() {
+    startZk();
+    _zkClient =
+        new ZkClient(getZkUrl(), ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
+            new ZNRecordSerializer());
+    _propertyStore =
+        new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(_zkClient), "/TimeBoundaryManagerTest/PROPERTYSTORE", null);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    _zkClient.close();
+    stopZk();
+  }
+
+  @Test
+  public void testPartitionMetadataManagerProcessingThroughSegmentChangesSinglePartitionTable() {
+    // NOTE: Ideal state and external view are not used in the current implementation
+    TableConfig tableConfig = getTableConfig(TABLE_NAME, new String[]{PARTITION_COLUMN},
+        new String[]{PARTITION_COLUMN_FUNC}, new int[]{PARTITION_COLUMN_SIZE});
+    ExternalView externalView = new ExternalView(tableConfig.getTableName());
+    Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
+    Map<String, String> onlineInstanceStateMap = ImmutableMap.of(SERVER_0, ONLINE, SERVER_1, ONLINE);
+    Set<String> onlineSegments = new HashSet<>();
+    // NOTE: Ideal state is not used in the current implementation.
+    IdealState idealState = new IdealState("");
+
+    SegmentPartitionMetadataManager singlePartitionMetadataManager =
+        new SegmentPartitionMetadataManager(TABLE_NAME, PARTITION_COLUMN, PARTITION_COLUMN_FUNC, PARTITION_COLUMN_SIZE);
+    SegmentZkMetadataFetcher segmentZkMetadataFetcher = new SegmentZkMetadataFetcher(TABLE_NAME, _propertyStore);
+    segmentZkMetadataFetcher.register(singlePartitionMetadataManager);
+
+    // 1. initial state should be all empty.
+    segmentZkMetadataFetcher.init(idealState, externalView, onlineSegments);
+    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(), Collections.emptyMap());
+    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), Collections.emptyMap());
+
+    // 2. adding segments without partition metadata should not be recorded in partition metadata manager.
+    String segmentWithoutPartitionMetadata = "segmentWithoutPartitionMetadata";
+    onlineSegments.add(segmentWithoutPartitionMetadata);
+    segmentAssignment.put(segmentWithoutPartitionMetadata, onlineInstanceStateMap);
+    SegmentZKMetadata segmentZKMetadataWithoutPartitionMetadata =
+        new SegmentZKMetadata(segmentWithoutPartitionMetadata);
+    ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, TABLE_NAME,
+        segmentZKMetadataWithoutPartitionMetadata);
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(), Collections.emptyMap());
+    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), Collections.emptyMap());
+
+    // 3. adding segments inline with the partition column config should yield correct partition results.
+    String segment0 = "segment0";
+    onlineSegments.add(segment0);
+    segmentAssignment.put(segment0, Collections.singletonMap(SERVER_0, ONLINE));
+    setSegmentZKPartitionMetadata(TABLE_NAME, segment0, PARTITION_COLUMN_FUNC, PARTITION_COLUMN_SIZE, 0);
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
+        Collections.singletonMap(0, Arrays.asList(segment0)));
+    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), Collections.singletonMap(0,
+        Collections.singleton(SERVER_0)));
+
+    // 4. adding one more segments
+    String segment1 = "segment1";
+    onlineSegments.add(segment1);
+    segmentAssignment.put(segment1, Collections.singletonMap(SERVER_1, ONLINE));
+    setSegmentZKPartitionMetadata(TABLE_NAME, segment1, PARTITION_COLUMN_FUNC, PARTITION_COLUMN_SIZE, 1);
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
+        ImmutableMap.of(0, Arrays.asList(segment0), 1, Arrays.asList(segment1)));
+    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(0,
+        Collections.singleton(SERVER_0), 1, Collections.singleton(SERVER_1)));
+
+    // 4. Update partition metadata without refreshing should have no effect
+    setSegmentZKPartitionMetadata(TABLE_NAME, segment0, PARTITION_COLUMN_FUNC_ALT, PARTITION_COLUMN_SIZE_ALT, 0);
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
+        ImmutableMap.of(0, Arrays.asList(segment0), 1, Arrays.asList(segment1)));
+    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(0,
+        Collections.singleton(SERVER_0), 1, Collections.singleton(SERVER_1)));
+
+    // 5. Refresh the changed segment should update the partition info.
+    segmentZkMetadataFetcher.refreshSegment(segment0);
+    // segment0 is no longer inline with the table config. it should not appear on the list:
+    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
+        ImmutableMap.of(1, Arrays.asList(segment1)));
+    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(1,
+        Collections.singleton(SERVER_1)));
+
+    // 6. Refresh the changed segment back to inline
+    // both segments should now be back on the partition list.
+    setSegmentZKPartitionMetadata(TABLE_NAME, segment0, PARTITION_COLUMN_FUNC, PARTITION_COLUMN_SIZE, 0);
+    segmentZkMetadataFetcher.refreshSegment(segment0);
+    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
+        ImmutableMap.of(0, Arrays.asList(segment0), 1, Arrays.asList(segment1)));
+    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(0,
+        Collections.singleton(SERVER_0), 1, Collections.singleton(SERVER_1)));
+
+    // 7. change one of the segments to be on a different server should update the full replica server amp
+    segmentAssignment.put(segment1, Collections.singletonMap(SERVER_0, ONLINE));
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
+        ImmutableMap.of(0, Arrays.asList(segment0), 1, Arrays.asList(segment1)));
+    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(0,
+        Collections.singleton(SERVER_0), 1, Collections.singleton(SERVER_0)));
+
+    // 8. adding one more segment to partition-1 but located on a different server will update the partition map.
+    // but remove the full replica server map because it is no longer having full replica on a single server
+    String segment2 = "segment2";
+    onlineSegments.add(segment2);
+    segmentAssignment.put(segment2, Collections.singletonMap(SERVER_1, ONLINE));
+    setSegmentZKPartitionMetadata(TABLE_NAME, segment2, PARTITION_COLUMN_FUNC, PARTITION_COLUMN_SIZE, 1);
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
+        ImmutableMap.of(0, Arrays.asList(segment0), 1, Arrays.asList(segment2, segment1)));
+    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(0,
+        Collections.singleton(SERVER_0), 1, Collections.emptySet()));
+
+    // 9. update the new segment to be replicated between 2 servers should add the full replica server back
+    segmentAssignment.put(segment2, ImmutableMap.of(SERVER_0, ONLINE, SERVER_1, ONLINE));
+    segmentAssignment.put(segment1, ImmutableMap.of(SERVER_0, OFFLINE, SERVER_1, ONLINE));
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
+        ImmutableMap.of(0, Arrays.asList(segment0), 1, Arrays.asList(segment2, segment1)));
+    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(0,
+        Collections.singleton(SERVER_0), 1, Collections.singleton(SERVER_1)));
+
+    // 10. making all of them replicated will show full list
+    segmentAssignment.put(segment2, ImmutableMap.of(SERVER_0, ONLINE, SERVER_1, ONLINE));
+    segmentAssignment.put(segment1, ImmutableMap.of(SERVER_0, ONLINE, SERVER_1, ONLINE));
+    segmentAssignment.put(segment0, ImmutableMap.of(SERVER_0, ONLINE, SERVER_1, ONLINE));
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
+        ImmutableMap.of(0, Arrays.asList(segment0), 1, Arrays.asList(segment2, segment1)));
+    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(0,
+        ImmutableSet.of(SERVER_0, SERVER_1), 1, ImmutableSet.of(SERVER_0, SERVER_1)));
+  }
+
+  private TableConfig getTableConfig(String rawTableName, String[] partitionColumns, String[] partitionFunctions,
+      int[] partitionSizes) {
+    Map<String, ColumnPartitionConfig> partitionColumnMetadataMap = new HashMap<>();
+    for (int idx = 0; idx < partitionColumns.length; idx++) {
+      partitionColumnMetadataMap.put(partitionColumns[idx], new ColumnPartitionConfig(partitionFunctions[idx],
+          partitionSizes[idx]));
+    }
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
+        .setSegmentPartitionConfig(new SegmentPartitionConfig(partitionColumnMetadataMap))
+        .build();
+  }
+
+  private void setSegmentZKPartitionMetadata(String tableNameWithType, String segment, String partitionFunction,
+      int numPartitions, int partitionId) {
+    SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(segment);
+    segmentZKMetadata.setPartitionMetadata(new SegmentPartitionMetadata(Collections.singletonMap(PARTITION_COLUMN,
+        new ColumnPartitionMetadata(partitionFunction, numPartitions, Collections.singleton(partitionId), null))));
+    ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, tableNameWithType, segmentZKMetadata);
+  }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerTest.java
@@ -20,7 +20,6 @@ package org.apache.pinot.broker.routing.segmentpartition;
 
 import com.google.common.collect.ImmutableMap;
 import com.google.common.collect.ImmutableSet;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -48,22 +47,22 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE;
 import static org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE;
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertEqualsNoOrder;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
 
 
 public class SegmentPartitionMetadataManagerTest extends ControllerTest {
-  private static final String RAW_TABLE_NAME = "testTable";
-  private static final String TABLE_NAME = "testTable_OFFLINE";
+  private static final String OFFLINE_TABLE_NAME = "testTable_OFFLINE";
   private static final String PARTITION_COLUMN = "memberId";
   private static final String PARTITION_COLUMN_FUNC = "Murmur";
-  private static final int PARTITION_COLUMN_SIZE = 2;
+  private static final int NUM_PARTITIONS = 2;
   private static final String PARTITION_COLUMN_FUNC_ALT = "Modulo";
-  private static final int PARTITION_COLUMN_SIZE_ALT = 4;
+  private static final int NUM_PARTITIONS_ALT = 4;
   private static final String SERVER_0 = "server0";
   private static final String SERVER_1 = "server1";
-
 
   private ZkClient _zkClient;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
@@ -71,9 +70,8 @@ public class SegmentPartitionMetadataManagerTest extends ControllerTest {
   @BeforeClass
   public void setUp() {
     startZk();
-    _zkClient =
-        new ZkClient(getZkUrl(), ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
-            new ZNRecordSerializer());
+    _zkClient = new ZkClient(getZkUrl(), ZkClient.DEFAULT_SESSION_TIMEOUT, ZkClient.DEFAULT_CONNECTION_TIMEOUT,
+        new ZNRecordSerializer());
     _propertyStore =
         new ZkHelixPropertyStore<>(new ZkBaseDataAccessor<>(_zkClient), "/TimeBoundaryManagerTest/PROPERTYSTORE", null);
   }
@@ -87,8 +85,8 @@ public class SegmentPartitionMetadataManagerTest extends ControllerTest {
   @Test
   public void testPartitionMetadataManagerProcessingThroughSegmentChangesSinglePartitionTable() {
     // NOTE: Ideal state and external view are not used in the current implementation
-    TableConfig tableConfig = getTableConfig(TABLE_NAME, new String[]{PARTITION_COLUMN},
-        new String[]{PARTITION_COLUMN_FUNC}, new int[]{PARTITION_COLUMN_SIZE});
+    TableConfig tableConfig =
+        getTableConfig(new String[]{PARTITION_COLUMN}, new String[]{PARTITION_COLUMN_FUNC}, new int[]{NUM_PARTITIONS});
     ExternalView externalView = new ExternalView(tableConfig.getTableName());
     Map<String, Map<String, String>> segmentAssignment = externalView.getRecord().getMapFields();
     Map<String, String> onlineInstanceStateMap = ImmutableMap.of(SERVER_0, ONLINE, SERVER_1, ONLINE);
@@ -96,132 +94,166 @@ public class SegmentPartitionMetadataManagerTest extends ControllerTest {
     // NOTE: Ideal state is not used in the current implementation.
     IdealState idealState = new IdealState("");
 
-    SegmentPartitionMetadataManager singlePartitionMetadataManager =
-        new SegmentPartitionMetadataManager(TABLE_NAME, PARTITION_COLUMN, PARTITION_COLUMN_FUNC, PARTITION_COLUMN_SIZE);
-    SegmentZkMetadataFetcher segmentZkMetadataFetcher = new SegmentZkMetadataFetcher(TABLE_NAME, _propertyStore);
-    segmentZkMetadataFetcher.register(singlePartitionMetadataManager);
+    SegmentPartitionMetadataManager partitionMetadataManager =
+        new SegmentPartitionMetadataManager(OFFLINE_TABLE_NAME, PARTITION_COLUMN, PARTITION_COLUMN_FUNC,
+            NUM_PARTITIONS);
+    SegmentZkMetadataFetcher segmentZkMetadataFetcher =
+        new SegmentZkMetadataFetcher(OFFLINE_TABLE_NAME, _propertyStore);
+    segmentZkMetadataFetcher.register(partitionMetadataManager);
 
-    // 1. initial state should be all empty.
+    // Initial state should be all empty
     segmentZkMetadataFetcher.init(idealState, externalView, onlineSegments);
-    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(), Collections.emptyMap());
-    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), Collections.emptyMap());
+    TablePartitionInfo tablePartitionInfo = partitionMetadataManager.getTablePartitionInfo();
+    assertEquals(tablePartitionInfo.getPartitionInfoMap(), new TablePartitionInfo.PartitionInfo[NUM_PARTITIONS]);
+    assertTrue(tablePartitionInfo.getSegmentsWithInvalidPartition().isEmpty());
 
-    // 2. adding segments without partition metadata should not be recorded in partition metadata manager.
+    // Adding segment without partition metadata should be recorded in the invalid segments
     String segmentWithoutPartitionMetadata = "segmentWithoutPartitionMetadata";
     onlineSegments.add(segmentWithoutPartitionMetadata);
     segmentAssignment.put(segmentWithoutPartitionMetadata, onlineInstanceStateMap);
     SegmentZKMetadata segmentZKMetadataWithoutPartitionMetadata =
         new SegmentZKMetadata(segmentWithoutPartitionMetadata);
-    ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, TABLE_NAME,
+    ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, OFFLINE_TABLE_NAME,
         segmentZKMetadataWithoutPartitionMetadata);
     segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
-    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(), Collections.emptyMap());
-    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), Collections.emptyMap());
+    tablePartitionInfo = partitionMetadataManager.getTablePartitionInfo();
+    assertEquals(tablePartitionInfo.getPartitionInfoMap(), new TablePartitionInfo.PartitionInfo[NUM_PARTITIONS]);
+    assertEquals(tablePartitionInfo.getSegmentsWithInvalidPartition(),
+        Collections.singletonList(segmentWithoutPartitionMetadata));
 
-    // 3. adding segments inline with the partition column config should yield correct partition results.
+    // Removing segment without partition metadata should remove it from the invalid segments
+    onlineSegments.remove(segmentWithoutPartitionMetadata);
+    segmentAssignment.remove(segmentWithoutPartitionMetadata);
+    segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
+    tablePartitionInfo = partitionMetadataManager.getTablePartitionInfo();
+    assertEquals(tablePartitionInfo.getPartitionInfoMap(), new TablePartitionInfo.PartitionInfo[NUM_PARTITIONS]);
+    assertTrue(tablePartitionInfo.getSegmentsWithInvalidPartition().isEmpty());
+
+    // Adding segments inline with the partition column config should yield correct partition results
     String segment0 = "segment0";
     onlineSegments.add(segment0);
     segmentAssignment.put(segment0, Collections.singletonMap(SERVER_0, ONLINE));
-    setSegmentZKPartitionMetadata(TABLE_NAME, segment0, PARTITION_COLUMN_FUNC, PARTITION_COLUMN_SIZE, 0);
+    setSegmentZKPartitionMetadata(segment0, PARTITION_COLUMN_FUNC, NUM_PARTITIONS, 0);
     segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
-    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
-        Collections.singletonMap(0, Arrays.asList(segment0)));
-    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), Collections.singletonMap(0,
-        Collections.singleton(SERVER_0)));
+    tablePartitionInfo = partitionMetadataManager.getTablePartitionInfo();
+    TablePartitionInfo.PartitionInfo[] partitionInfoMap = tablePartitionInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEquals(partitionInfoMap[0]._segments, Collections.singleton(segment0));
+    assertNull(partitionInfoMap[1]);
+    assertTrue(tablePartitionInfo.getSegmentsWithInvalidPartition().isEmpty());
 
-    // 4. adding one more segments
+    // Adding one more segments
     String segment1 = "segment1";
     onlineSegments.add(segment1);
     segmentAssignment.put(segment1, Collections.singletonMap(SERVER_1, ONLINE));
-    setSegmentZKPartitionMetadata(TABLE_NAME, segment1, PARTITION_COLUMN_FUNC, PARTITION_COLUMN_SIZE, 1);
+    setSegmentZKPartitionMetadata(segment1, PARTITION_COLUMN_FUNC, NUM_PARTITIONS, 1);
     segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
-    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
-        ImmutableMap.of(0, Arrays.asList(segment0), 1, Arrays.asList(segment1)));
-    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(0,
-        Collections.singleton(SERVER_0), 1, Collections.singleton(SERVER_1)));
+    tablePartitionInfo = partitionMetadataManager.getTablePartitionInfo();
+    partitionInfoMap = tablePartitionInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEquals(partitionInfoMap[0]._segments, Collections.singleton(segment0));
+    assertEquals(partitionInfoMap[1]._fullyReplicatedServers, Collections.singleton(SERVER_1));
+    assertEquals(partitionInfoMap[1]._segments, Collections.singleton(segment1));
+    assertTrue(tablePartitionInfo.getSegmentsWithInvalidPartition().isEmpty());
 
-    // 4. Update partition metadata without refreshing should have no effect
-    setSegmentZKPartitionMetadata(TABLE_NAME, segment0, PARTITION_COLUMN_FUNC_ALT, PARTITION_COLUMN_SIZE_ALT, 0);
+    // Updating partition metadata without refreshing should have no effect
+    setSegmentZKPartitionMetadata(segment0, PARTITION_COLUMN_FUNC_ALT, NUM_PARTITIONS_ALT, 0);
     segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
-    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
-        ImmutableMap.of(0, Arrays.asList(segment0), 1, Arrays.asList(segment1)));
-    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(0,
-        Collections.singleton(SERVER_0), 1, Collections.singleton(SERVER_1)));
+    tablePartitionInfo = partitionMetadataManager.getTablePartitionInfo();
+    partitionInfoMap = tablePartitionInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEquals(partitionInfoMap[0]._segments, Collections.singleton(segment0));
+    assertEquals(partitionInfoMap[1]._fullyReplicatedServers, Collections.singleton(SERVER_1));
+    assertEquals(partitionInfoMap[1]._segments, Collections.singleton(segment1));
+    assertTrue(tablePartitionInfo.getSegmentsWithInvalidPartition().isEmpty());
 
-    // 5. Refresh the changed segment should update the partition info.
+    // Refreshing the changed segment should update the partition info
     segmentZkMetadataFetcher.refreshSegment(segment0);
-    // segment0 is no longer inline with the table config. it should not appear on the list:
-    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
-        ImmutableMap.of(1, Arrays.asList(segment1)));
-    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(1,
-        Collections.singleton(SERVER_1)));
+    // segment0 is no longer inline with the table config, and it should be recorded in the invalid segments
+    tablePartitionInfo = partitionMetadataManager.getTablePartitionInfo();
+    partitionInfoMap = tablePartitionInfo.getPartitionInfoMap();
+    assertNull(partitionInfoMap[0]);
+    assertEquals(partitionInfoMap[1]._fullyReplicatedServers, Collections.singleton(SERVER_1));
+    assertEquals(partitionInfoMap[1]._segments, Collections.singleton(segment1));
+    assertEquals(tablePartitionInfo.getSegmentsWithInvalidPartition(), Collections.singletonList(segment0));
 
-    // 6. Refresh the changed segment back to inline
-    // both segments should now be back on the partition list.
-    setSegmentZKPartitionMetadata(TABLE_NAME, segment0, PARTITION_COLUMN_FUNC, PARTITION_COLUMN_SIZE, 0);
+    // Refresh the changed segment back to inline, and both segments should now be back on the partition list
+    setSegmentZKPartitionMetadata(segment0, PARTITION_COLUMN_FUNC, NUM_PARTITIONS, 0);
     segmentZkMetadataFetcher.refreshSegment(segment0);
-    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
-        ImmutableMap.of(0, Arrays.asList(segment0), 1, Arrays.asList(segment1)));
-    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(0,
-        Collections.singleton(SERVER_0), 1, Collections.singleton(SERVER_1)));
+    tablePartitionInfo = partitionMetadataManager.getTablePartitionInfo();
+    partitionInfoMap = tablePartitionInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEquals(partitionInfoMap[0]._segments, Collections.singleton(segment0));
+    assertEquals(partitionInfoMap[1]._fullyReplicatedServers, Collections.singleton(SERVER_1));
+    assertEquals(partitionInfoMap[1]._segments, Collections.singleton(segment1));
+    assertTrue(tablePartitionInfo.getSegmentsWithInvalidPartition().isEmpty());
 
-    // 7. change one of the segments to be on a different server should update the full replica server amp
+    // Changing one of the segments to be on a different server should update the fully replicated servers
     segmentAssignment.put(segment1, Collections.singletonMap(SERVER_0, ONLINE));
     segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
-    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
-        ImmutableMap.of(0, Arrays.asList(segment0), 1, Arrays.asList(segment1)));
-    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(0,
-        Collections.singleton(SERVER_0), 1, Collections.singleton(SERVER_0)));
+    tablePartitionInfo = partitionMetadataManager.getTablePartitionInfo();
+    partitionInfoMap = tablePartitionInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEquals(partitionInfoMap[0]._segments, Collections.singleton(segment0));
+    assertEquals(partitionInfoMap[1]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEquals(partitionInfoMap[1]._segments, Collections.singleton(segment1));
+    assertTrue(tablePartitionInfo.getSegmentsWithInvalidPartition().isEmpty());
 
-    // 8. adding one more segment to partition-1 but located on a different server will update the partition map.
-    // but remove the full replica server map because it is no longer having full replica on a single server
+    // Adding one more segment to partition-1 but located on a different server will update the partition map, but
+    // remove the fully replicated server because it is no longer having full replica on a single server
     String segment2 = "segment2";
     onlineSegments.add(segment2);
     segmentAssignment.put(segment2, Collections.singletonMap(SERVER_1, ONLINE));
-    setSegmentZKPartitionMetadata(TABLE_NAME, segment2, PARTITION_COLUMN_FUNC, PARTITION_COLUMN_SIZE, 1);
+    setSegmentZKPartitionMetadata(segment2, PARTITION_COLUMN_FUNC, NUM_PARTITIONS, 1);
     segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
-    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
-        ImmutableMap.of(0, Arrays.asList(segment0), 1, Arrays.asList(segment2, segment1)));
-    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(0,
-        Collections.singleton(SERVER_0), 1, Collections.emptySet()));
+    tablePartitionInfo = partitionMetadataManager.getTablePartitionInfo();
+    partitionInfoMap = tablePartitionInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEquals(partitionInfoMap[0]._segments, Collections.singleton(segment0));
+    assertTrue(partitionInfoMap[1]._fullyReplicatedServers.isEmpty());
+    assertEqualsNoOrder(partitionInfoMap[1]._segments.toArray(), new String[]{segment1, segment2});
+    assertTrue(tablePartitionInfo.getSegmentsWithInvalidPartition().isEmpty());
 
-    // 9. update the new segment to be replicated between 2 servers should add the full replica server back
+    // Updating the new segment to be replicated on 2 servers should add the fully replicated server back
     segmentAssignment.put(segment2, ImmutableMap.of(SERVER_0, ONLINE, SERVER_1, ONLINE));
-    segmentAssignment.put(segment1, ImmutableMap.of(SERVER_0, OFFLINE, SERVER_1, ONLINE));
     segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
-    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
-        ImmutableMap.of(0, Arrays.asList(segment0), 1, Arrays.asList(segment2, segment1)));
-    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(0,
-        Collections.singleton(SERVER_0), 1, Collections.singleton(SERVER_1)));
+    tablePartitionInfo = partitionMetadataManager.getTablePartitionInfo();
+    partitionInfoMap = tablePartitionInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEquals(partitionInfoMap[0]._segments, Collections.singleton(segment0));
+    assertEquals(partitionInfoMap[1]._fullyReplicatedServers, Collections.singleton(SERVER_0));
+    assertEqualsNoOrder(partitionInfoMap[1]._segments.toArray(), new String[]{segment1, segment2});
+    assertTrue(tablePartitionInfo.getSegmentsWithInvalidPartition().isEmpty());
 
-    // 10. making all of them replicated will show full list
-    segmentAssignment.put(segment2, ImmutableMap.of(SERVER_0, ONLINE, SERVER_1, ONLINE));
-    segmentAssignment.put(segment1, ImmutableMap.of(SERVER_0, ONLINE, SERVER_1, ONLINE));
+    // Making all of them replicated will show full list
     segmentAssignment.put(segment0, ImmutableMap.of(SERVER_0, ONLINE, SERVER_1, ONLINE));
+    segmentAssignment.put(segment1, ImmutableMap.of(SERVER_0, ONLINE, SERVER_1, ONLINE));
+    segmentAssignment.put(segment2, ImmutableMap.of(SERVER_0, ONLINE, SERVER_1, ONLINE));
     segmentZkMetadataFetcher.onAssignmentChange(idealState, externalView, onlineSegments);
-    assertEquals(singlePartitionMetadataManager.getPartitionToSegmentsMap(),
-        ImmutableMap.of(0, Arrays.asList(segment0), 1, Arrays.asList(segment2, segment1)));
-    assertEquals(singlePartitionMetadataManager.getPartitionToFullyReplicatedServersMap(), ImmutableMap.of(0,
-        ImmutableSet.of(SERVER_0, SERVER_1), 1, ImmutableSet.of(SERVER_0, SERVER_1)));
+    tablePartitionInfo = partitionMetadataManager.getTablePartitionInfo();
+    partitionInfoMap = tablePartitionInfo.getPartitionInfoMap();
+    assertEquals(partitionInfoMap[0]._fullyReplicatedServers, ImmutableSet.of(SERVER_0, SERVER_1));
+    assertEquals(partitionInfoMap[0]._segments, Collections.singleton(segment0));
+    assertEquals(partitionInfoMap[1]._fullyReplicatedServers, ImmutableSet.of(SERVER_0, SERVER_1));
+    assertEqualsNoOrder(partitionInfoMap[1]._segments.toArray(), new String[]{segment1, segment2});
+    assertTrue(tablePartitionInfo.getSegmentsWithInvalidPartition().isEmpty());
   }
 
-  private TableConfig getTableConfig(String rawTableName, String[] partitionColumns, String[] partitionFunctions,
-      int[] partitionSizes) {
+  private TableConfig getTableConfig(String[] partitionColumns, String[] partitionFunctions, int[] partitionSizes) {
     Map<String, ColumnPartitionConfig> partitionColumnMetadataMap = new HashMap<>();
     for (int idx = 0; idx < partitionColumns.length; idx++) {
-      partitionColumnMetadataMap.put(partitionColumns[idx], new ColumnPartitionConfig(partitionFunctions[idx],
-          partitionSizes[idx]));
+      partitionColumnMetadataMap.put(partitionColumns[idx],
+          new ColumnPartitionConfig(partitionFunctions[idx], partitionSizes[idx]));
     }
-    return new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName)
-        .setSegmentPartitionConfig(new SegmentPartitionConfig(partitionColumnMetadataMap))
-        .build();
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName(OFFLINE_TABLE_NAME)
+        .setSegmentPartitionConfig(new SegmentPartitionConfig(partitionColumnMetadataMap)).build();
   }
 
-  private void setSegmentZKPartitionMetadata(String tableNameWithType, String segment, String partitionFunction,
-      int numPartitions, int partitionId) {
+  private void setSegmentZKPartitionMetadata(String segment, String partitionFunction, int numPartitions,
+      int partitionId) {
     SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(segment);
     segmentZKMetadata.setPartitionMetadata(new SegmentPartitionMetadata(Collections.singletonMap(PARTITION_COLUMN,
         new ColumnPartitionMetadata(partitionFunction, numPartitions, Collections.singleton(partitionId), null))));
-    ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, tableNameWithType, segmentZKMetadata);
+    ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, OFFLINE_TABLE_NAME, segmentZKMetadata);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -309,6 +309,10 @@ public class CommonConstants {
     public static final String CONFIG_OF_BROKER_RESULT_REWRITER_CLASS_NAMES
         = "pinot.broker.result.rewriter.class.names";
 
+    public static final String CONFIG_OF_ENABLE_PARTITION_METADATA_MANAGER =
+        "pinot.broker.enable.partition.metadata.manager";
+    public static final boolean DEFAULT_ENABLE_PARTITION_METADATA_MANAGER = false;
+
     public static class Request {
       public static final String SQL = "sql";
       public static final String TRACE = "trace";


### PR DESCRIPTION
This is a follow up on #10455 

Previous PR
===
- previous PR #10455 adds `SegmentZkMetadataFetcher` and `SegmentZkMetadataFetcherListener`

This PR
===
- Create `SegmentPartitionMetadataManager` which is similar to `SinglePartitionColumnSegmentPruner` but kept a very different view of the map (contained in a wrapper class `TablePartitionInfo`)
    - Tracks the segments and fully replicated servers for each partition
    - Tracks the segments with invalid partition info

Follow Up
===
due to the complexity of TimeBoundaryManager which needs to coordinate between REALTIME and OFFLINE table loading, we will leaf this one out from SegmentZkMetadataFetcher; to summarize
  - all `SegmentPruners` and `SegmentPartitionMetadataManager` will extend `SegmentZkMetadataFetchListener` and will no longer individually pull and cache from ZK
  - `TimeBoundaryManager` will remain on its own cycle to pull and cache data from ZK