### PR TITLE
Change shell to bash

### DIFF
--- a/pinot-tools/src/main/resources/appAssemblerScriptTemplate
+++ b/pinot-tools/src/main/resources/appAssemblerScriptTemplate
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Licensed to the Apache Software Foundation (ASF) under one
 # or more contributor license agreements.  See the NOTICE file


### PR DESCRIPTION
### Problem
We are seeing errors in logs while launching pinot:
```
[2023-03-07 13:36:31.903103] /pay/deploy/pinot-sandbox/current/bin/pinot-admin.sh: 119: [[: not found
[2023-03-07 13:36:31.903133] /pay/deploy/pinot-sandbox/current/bin/pinot-admin.sh: 131: [[: not found
[2023-03-07 13:36:31.912766] /pay/deploy/pinot-sandbox/current/bin/pinot-admin.sh: 131: [[: not found 
```

### Solution
Sh doesn't support `[[` construct, so change launcher to use bash explicitly. Error comes from this section:
```
      if [ -n "$PLUGINS_INCLUDE" ] ; then
        if [[ "$PLUGINS_INCLUDE" = *,* ]]
        then
            echo "\$PLUGINS_INCLUDE should use ; as the delimiter"
            exit 1
        fi
```

Leaving `#!/bin/sh` works on some systems that have set default shell to be bash, but most of the Debian based distributives use dash as default, since it is lighter to run.

### Testing
- Bash is fully sh compatible
- Run `./pinot-tools-pkg/bin/pinot-admin.sh` on ubuntu verify
- Run `./pinot-tools-pkg/bin/quick-start-batch.sh` on mac to verify 
