### PR TITLE
Do not serialize metrics in each Operator

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -52,6 +52,7 @@ import org.apache.pinot.query.runtime.executor.OpChainSchedulerService;
 import org.apache.pinot.query.runtime.executor.RoundRobinScheduler;
 import org.apache.pinot.query.runtime.operator.LeafStageTransferableBlockOperator;
 import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
+import org.apache.pinot.query.runtime.operator.MultiStageOperator;
 import org.apache.pinot.query.runtime.operator.OpChain;
 import org.apache.pinot.query.runtime.operator.OpChainId;
 import org.apache.pinot.query.runtime.operator.OpChainStats;
@@ -217,8 +218,10 @@ public class QueryRunner {
               deadlineMs, distributedStagePlan.getMetadataMap());
       OpChainStats opChainStats =
           new OpChainStats(new OpChainId(requestId, _rootServer.virtualId(), sendNode.getStageId()).toString());
-      mailboxSendOperator = new MailboxSendOperator(opChainExecutionContext,
-          new LeafStageTransferableBlockOperator(opChainExecutionContext, serverQueryResults, sendNode.getDataSchema()),
+      MultiStageOperator leafStageOperator =
+          new LeafStageTransferableBlockOperator(opChainExecutionContext, serverQueryResults, sendNode.getDataSchema());
+      leafStageOperator.attachOpChainStats(opChainStats);
+      mailboxSendOperator = new MailboxSendOperator(opChainExecutionContext, leafStageOperator,
           sendNode.getExchangeType(), sendNode.getPartitionKeySelector(), sendNode.getCollationKeys(),
           sendNode.getCollationDirections(), sendNode.isSortOnSender(), sendNode.getStageId(),
           sendNode.getReceiverStageId());

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -53,6 +53,8 @@ import org.apache.pinot.query.runtime.executor.RoundRobinScheduler;
 import org.apache.pinot.query.runtime.operator.LeafStageTransferableBlockOperator;
 import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
 import org.apache.pinot.query.runtime.operator.OpChain;
+import org.apache.pinot.query.runtime.operator.OpChainId;
+import org.apache.pinot.query.runtime.operator.OpChainStats;
 import org.apache.pinot.query.runtime.plan.DistributedStagePlan;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.query.runtime.plan.PhysicalPlanVisitor;
@@ -213,11 +215,14 @@ public class QueryRunner {
       OpChainExecutionContext opChainExecutionContext =
           new OpChainExecutionContext(_mailboxService, requestId, sendNode.getStageId(), _rootServer, deadlineMs,
               deadlineMs, distributedStagePlan.getMetadataMap());
+      OpChainStats opChainStats =
+          new OpChainStats(new OpChainId(requestId, _rootServer.virtualId(), sendNode.getStageId()).toString());
       mailboxSendOperator = new MailboxSendOperator(opChainExecutionContext,
           new LeafStageTransferableBlockOperator(opChainExecutionContext, serverQueryResults, sendNode.getDataSchema()),
           sendNode.getExchangeType(), sendNode.getPartitionKeySelector(), sendNode.getCollationKeys(),
           sendNode.getCollationDirections(), sendNode.isSortOnSender(), sendNode.getStageId(),
           sendNode.getReceiverStageId());
+      mailboxSendOperator.attachOpChainStats(opChainStats);
       int blockCounter = 0;
       while (!TransferableBlockUtils.isEndOfStream(mailboxSendOperator.nextBlock())) {
         LOGGER.debug("Acquired transferable block: {}", blockCounter++);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -54,8 +54,6 @@ import org.apache.pinot.query.runtime.operator.LeafStageTransferableBlockOperato
 import org.apache.pinot.query.runtime.operator.MailboxSendOperator;
 import org.apache.pinot.query.runtime.operator.MultiStageOperator;
 import org.apache.pinot.query.runtime.operator.OpChain;
-import org.apache.pinot.query.runtime.operator.OpChainId;
-import org.apache.pinot.query.runtime.operator.OpChainStats;
 import org.apache.pinot.query.runtime.plan.DistributedStagePlan;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.query.runtime.plan.PhysicalPlanVisitor;
@@ -216,16 +214,12 @@ public class QueryRunner {
       OpChainExecutionContext opChainExecutionContext =
           new OpChainExecutionContext(_mailboxService, requestId, sendNode.getStageId(), _rootServer, deadlineMs,
               deadlineMs, distributedStagePlan.getMetadataMap());
-      OpChainStats opChainStats =
-          new OpChainStats(new OpChainId(requestId, _rootServer.virtualId(), sendNode.getStageId()).toString());
       MultiStageOperator leafStageOperator =
           new LeafStageTransferableBlockOperator(opChainExecutionContext, serverQueryResults, sendNode.getDataSchema());
-      leafStageOperator.attachOpChainStats(opChainStats);
       mailboxSendOperator = new MailboxSendOperator(opChainExecutionContext, leafStageOperator,
           sendNode.getExchangeType(), sendNode.getPartitionKeySelector(), sendNode.getCollationKeys(),
           sendNode.getCollationDirections(), sendNode.isSortOnSender(), sendNode.getStageId(),
           sendNode.getReceiverStageId());
-      mailboxSendOperator.attachOpChainStats(opChainStats);
       int blockCounter = 0;
       while (!TransferableBlockUtils.isEndOfStream(mailboxSendOperator.nextBlock())) {
         LOGGER.debug("Acquired transferable block: {}", blockCounter++);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -111,7 +111,6 @@ public class OpChainSchedulerService extends AbstractExecutionThreadService {
                 LOGGER.error("({}): Completed erroneously {} {}", operatorChain, operatorChain.getStats(),
                     result.getDataBlock().getExceptions());
               } else {
-                operatorChain.getStats().setOperatorStatsMap(result.getResultMetadata());
                 LOGGER.debug("({}): Completed {}", operatorChain, operatorChain.getStats());
               }
             }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -75,7 +75,8 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     _errorBlock = baseResultBlock.stream().filter(e -> !e.getExceptions().isEmpty()).findFirst().orElse(null);
     _currentIndex = 0;
     for (InstanceResponseBlock instanceResponseBlock : baseResultBlock) {
-      _operatorStats.recordExecutionStats(instanceResponseBlock.getResponseMetadata());
+      OperatorStats operatorStats = _opChainStats.getOperatorStats(context, getOperatorId());
+      operatorStats.recordExecutionStats(instanceResponseBlock.getResponseMetadata());
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -43,7 +43,6 @@ import org.apache.pinot.query.routing.VirtualServer;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.operator.utils.OperatorUtils;
 import org.apache.pinot.query.runtime.operator.utils.SortUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.query.service.QueryConfig;
@@ -246,18 +245,10 @@ public class MailboxReceiveOperator extends MultiStageOperator {
     // should be hit first, but is defensive) (2) every mailbox that was opened
     // returned an EOS block. in every other scenario, there are mailboxes that
     // are not yet exhausted and we should wait for more data to be available
-    if (openMailboxCount > 0 && openMailboxCount > eosMailboxCount) {
-      // There are still mailboxes that are not exhausted, so we should wait for more data to be available
-      return TransferableBlockUtils.getNoOpTransferableBlock();
-    } else {
-      // All mailboxes are exhausted, so we should return EOS
-      if (_opChainStats != null) {
-        return TransferableBlockUtils.getEndOfStreamTransferableBlock(
-            OperatorUtils.getMetadataFromOperatorStats(_opChainStats.getOperatorStatsMap()));
-      } else {
-        return TransferableBlockUtils.getEndOfStreamTransferableBlock();
-      }
-    }
+    TransferableBlock block =
+        openMailboxCount > 0 && openMailboxCount > eosMailboxCount ? TransferableBlockUtils.getNoOpTransferableBlock()
+            : TransferableBlockUtils.getEndOfStreamTransferableBlock();
+    return block;
   }
 
   private void cleanUpResourcesOnError() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -43,6 +43,7 @@ import org.apache.pinot.query.routing.VirtualServer;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.operator.utils.OperatorUtils;
 import org.apache.pinot.query.runtime.operator.utils.SortUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.query.service.QueryConfig;
@@ -247,7 +248,8 @@ public class MailboxReceiveOperator extends MultiStageOperator {
     // are not yet exhausted and we should wait for more data to be available
     TransferableBlock block =
         openMailboxCount > 0 && openMailboxCount > eosMailboxCount ? TransferableBlockUtils.getNoOpTransferableBlock()
-            : TransferableBlockUtils.getEndOfStreamTransferableBlock();
+            : TransferableBlockUtils.getEndOfStreamTransferableBlock(
+                OperatorUtils.getMetadataFromOperatorStats(getOperatorStatsMap()));
     return block;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -25,6 +25,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Map;
 import java.util.PriorityQueue;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -216,7 +217,9 @@ public class MailboxReceiveOperator extends MultiStageOperator {
               }
             } else {
               if (_opChainStats != null && !block.getResultMetadata().isEmpty()) {
-                _opChainStats.getOperatorStatsMap().putAll(block.getResultMetadata());
+                for (Map.Entry<String, OperatorStats> entry : block.getResultMetadata().entrySet()) {
+                  _opChainStats.getOperatorStatsMap().compute(entry.getKey(), (_key, _value) -> entry.getValue());
+                }
               }
               eosMailboxCount++;
             }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -154,9 +154,9 @@ public class MailboxSendOperator extends MultiStageOperator {
       while (!transferableBlock.isNoOpBlock()) {
         if (transferableBlock.isEndOfStreamBlock()) {
           if (transferableBlock.isSuccessfulEndOfStreamBlock()) {
-            populateOperatorStatsMap(transferableBlock);
+            populateOpChainStats(this, _opChainStats);
             TransferableBlock eosBlockWithStats = TransferableBlockUtils.getEndOfStreamTransferableBlock(
-                OperatorUtils.getMetadataFromOperatorStats(_operatorStatsMap));
+                OperatorUtils.getMetadataFromOperatorStats(_opChainStats.getOperatorStatsMap()));
             _exchange.send(eosBlockWithStats);
             return eosBlockWithStats;
           } else {
@@ -176,6 +176,13 @@ public class MailboxSendOperator extends MultiStageOperator {
       }
     }
     return transferableBlock;
+  }
+
+  public void populateOpChainStats(MultiStageOperator op, OpChainStats opChainStats) {
+    opChainStats.getOperatorStatsMap().putAll(op.getOperatorStatsMap());
+    for (MultiStageOperator childOp : op.getChildOperators()) {
+      populateOpChainStats(childOp, opChainStats);
+    }
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -159,11 +159,10 @@ public class MailboxSendOperator extends MultiStageOperator {
             TransferableBlock eosBlockWithStats = TransferableBlockUtils.getEndOfStreamTransferableBlock(
                 OperatorUtils.getMetadataFromOperatorStats(_opChainStats.getOperatorStatsMap()));
             _exchange.send(eosBlockWithStats);
-            return transferableBlock;
           } else {
             _exchange.send(transferableBlock);
-            return transferableBlock;
           }
+          return transferableBlock;
         }
         _exchange.send(transferableBlock);
         transferableBlock = _dataTableBlockBaseOperator.nextBlock();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -156,11 +156,10 @@ public class MailboxSendOperator extends MultiStageOperator {
           if (transferableBlock.isSuccessfulEndOfStreamBlock()) {
             //Stats need to be populated here because the block is being sent to the mailbox
             // and the receiving opChain will not be able to access the stats from the previous opChain
-            populateOperatorStatsMap();
             TransferableBlock eosBlockWithStats = TransferableBlockUtils.getEndOfStreamTransferableBlock(
                 OperatorUtils.getMetadataFromOperatorStats(_opChainStats.getOperatorStatsMap()));
             _exchange.send(eosBlockWithStats);
-            return eosBlockWithStats;
+            return transferableBlock;
           } else {
             _exchange.send(transferableBlock);
             return transferableBlock;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -154,6 +154,9 @@ public class MailboxSendOperator extends MultiStageOperator {
       while (!transferableBlock.isNoOpBlock()) {
         if (transferableBlock.isEndOfStreamBlock()) {
           if (transferableBlock.isSuccessfulEndOfStreamBlock()) {
+            //Stats need to be populated here because the block is being sent to the mailbox
+            // and the receiving opChain will not be able to access the stats from the previous opChain
+            populateOperatorStatsMap();
             TransferableBlock eosBlockWithStats = TransferableBlockUtils.getEndOfStreamTransferableBlock(
                 OperatorUtils.getMetadataFromOperatorStats(_opChainStats.getOperatorStatsMap()));
             _exchange.send(eosBlockWithStats);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -154,7 +154,6 @@ public class MailboxSendOperator extends MultiStageOperator {
       while (!transferableBlock.isNoOpBlock()) {
         if (transferableBlock.isEndOfStreamBlock()) {
           if (transferableBlock.isSuccessfulEndOfStreamBlock()) {
-            populateOpChainStats(this, _opChainStats);
             TransferableBlock eosBlockWithStats = TransferableBlockUtils.getEndOfStreamTransferableBlock(
                 OperatorUtils.getMetadataFromOperatorStats(_opChainStats.getOperatorStatsMap()));
             _exchange.send(eosBlockWithStats);
@@ -176,13 +175,6 @@ public class MailboxSendOperator extends MultiStageOperator {
       }
     }
     return transferableBlock;
-  }
-
-  public void populateOpChainStats(MultiStageOperator op, OpChainStats opChainStats) {
-    opChainStats.getOperatorStatsMap().putAll(op.getOperatorStatsMap());
-    for (MultiStageOperator childOp : op.getChildOperators()) {
-      populateOpChainStats(childOp, opChainStats);
-    }
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -60,20 +60,19 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
       _operatorStats.endTimer(nextBlock);
 
       _operatorStats.recordRow(1, nextBlock.getNumRows());
-      if (nextBlock.isEndOfStreamBlock()) {
-        populateOperatorStatsMap(nextBlock);
+      _operatorStats.endTimer(nextBlock);
+      if (nextBlock.isSuccessfulEndOfStreamBlock()) {
+        populateOperatorStatsMap();
       }
       return nextBlock;
     }
   }
 
-  protected void populateOperatorStatsMap(TransferableBlock nextBlock) {
-    if (nextBlock.isSuccessfulEndOfStreamBlock()) {
-      if (!_operatorStats.getExecutionStats().isEmpty()) {
-        _operatorStats.recordSingleStat(DataTable.MetadataKey.OPERATOR_ID.getName(), _operatorId);
-        if (_opChainStats != null) {
-          _opChainStats.getOperatorStatsMap().compute(_operatorId, (_key, _value) -> _operatorStats);
-        }
+  protected void populateOperatorStatsMap() {
+    if (!_operatorStats.getExecutionStats().isEmpty()) {
+      _operatorStats.recordSingleStat(DataTable.MetadataKey.OPERATOR_ID.getName(), _operatorId);
+      if (_opChainStats != null) {
+        _opChainStats.getOperatorStatsMap().compute(_operatorId, (_key, _value) -> _operatorStats);
       }
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -33,11 +33,11 @@ import org.slf4j.LoggerFactory;
 public abstract class MultiStageOperator implements Operator<TransferableBlock>, AutoCloseable {
   private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(MultiStageOperator.class);
 
+  private final String _operatorId;
+  private final OpChainExecutionContext _context;
   // TODO: Move to OperatorContext class.
   protected final OperatorStats _operatorStats;
-  protected final String _operatorId;
-  protected OpChainStats _opChainStats;
-  private final OpChainExecutionContext _context;
+  protected final OpChainStats _opChainStats;
 
   public MultiStageOperator(OpChainExecutionContext context) {
     _context = context;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -72,7 +72,7 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
       if (!_operatorStats.getExecutionStats().isEmpty()) {
         _operatorStats.recordSingleStat(DataTable.MetadataKey.OPERATOR_ID.getName(), _operatorId);
         if (_opChainStats != null) {
-          _opChainStats.getOperatorStatsMap().put(_operatorId, _operatorStats);
+          _opChainStats.getOperatorStatsMap().compute(_operatorId, (_key, _value) -> _operatorStats);
         }
       }
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -53,6 +53,10 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
     _opChainStats = opChainStats;
   }
 
+  public OpChainStats getOpChainStats() {
+    return _opChainStats;
+  }
+
   @Override
   public TransferableBlock nextBlock() {
     if (Tracing.ThreadAccountantOps.isInterrupted()) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -46,15 +46,7 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
     _operatorId =
         Joiner.on("_").join(toExplainString(), _context.getRequestId(), _context.getStageId(), _context.getServer());
     _operatorStats.recordSingleStat(DataTable.MetadataKey.OPERATOR_ID.getName(), _operatorId);
-    _opChainStats = null;
-  }
-
-  public void attachOpChainStats(OpChainStats opChainStats) {
-    _opChainStats = opChainStats;
-  }
-
-  public OpChainStats getOpChainStats() {
-    return _opChainStats;
+    _opChainStats = _context.getStats();
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
@@ -43,11 +43,19 @@ public class OpChain implements AutoCloseable {
     _receivingMailbox = new HashSet<>(receivingMailboxes);
     _id = new OpChainId(requestId, virtualServerId, stageId);
     _stats = new OpChainStats(_id.toString());
-    _root.attachOpChainStats(_stats);
+//    _root.attachOpChainStats(_stats);
+    attachStatsToOperator(_root);
   }
 
   public OpChain(OpChainExecutionContext context, MultiStageOperator root, List<MailboxIdentifier> receivingMailboxes) {
     this(root, receivingMailboxes, context.getServer().virtualId(), context.getRequestId(), context.getStageId());
+  }
+
+  public void attachStatsToOperator(MultiStageOperator op) {
+    op.attachOpChainStats(_stats);
+    for (MultiStageOperator child : op.getChildOperators()) {
+      attachStatsToOperator(child);
+    }
   }
 
   public Operator<TransferableBlock> getRoot() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
@@ -43,6 +43,7 @@ public class OpChain implements AutoCloseable {
     _receivingMailbox = new HashSet<>(receivingMailboxes);
     _id = new OpChainId(requestId, virtualServerId, stageId);
     _stats = new OpChainStats(_id.toString());
+    _root.attachOpChainStats(_stats);
   }
 
   public OpChain(OpChainExecutionContext context, MultiStageOperator root, List<MailboxIdentifier> receivingMailboxes) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChain.java
@@ -37,25 +37,11 @@ public class OpChain implements AutoCloseable {
   private final OpChainStats _stats;
   private final OpChainId _id;
 
-  public OpChain(MultiStageOperator root, List<MailboxIdentifier> receivingMailboxes, int virtualServerId,
-      long requestId, int stageId) {
+  public OpChain(OpChainExecutionContext context, MultiStageOperator root, List<MailboxIdentifier> receivingMailboxes) {
     _root = root;
     _receivingMailbox = new HashSet<>(receivingMailboxes);
-    _id = new OpChainId(requestId, virtualServerId, stageId);
-    _stats = new OpChainStats(_id.toString());
-//    _root.attachOpChainStats(_stats);
-    attachStatsToOperator(_root);
-  }
-
-  public OpChain(OpChainExecutionContext context, MultiStageOperator root, List<MailboxIdentifier> receivingMailboxes) {
-    this(root, receivingMailboxes, context.getServer().virtualId(), context.getRequestId(), context.getStageId());
-  }
-
-  public void attachStatsToOperator(MultiStageOperator op) {
-    op.attachOpChainStats(_stats);
-    for (MultiStageOperator child : op.getChildOperators()) {
-      attachStatsToOperator(child);
-    }
+    _id = context.getId();
+    _stats = context.getStats();
   }
 
   public Operator<TransferableBlock> getRoot() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainStats.java
@@ -84,6 +84,10 @@ public class OpChainStats {
     }
   }
 
+  public long getExecutionTime() {
+    return _executeStopwatch.elapsed(TimeUnit.MILLISECONDS);
+  }
+
   @Override
   public String toString() {
     return String.format("(%s) Queued Count: %s, Executing Time: %sms, Queued Time: %sms", _id, _queuedCount.get(),

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainStats.java
@@ -26,6 +26,8 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.NotThreadSafe;
+import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 
 
@@ -74,6 +76,14 @@ public class OpChainStats {
 
   public ConcurrentHashMap<String, OperatorStats> getOperatorStatsMap() {
     return _operatorStatsMap;
+  }
+
+  public OperatorStats getOperatorStats(OpChainExecutionContext context, String operatorId) {
+    return _operatorStatsMap.computeIfAbsent(operatorId, (id) -> {
+       OperatorStats operatorStats = new OperatorStats(context);
+       operatorStats.recordSingleStat(DataTable.MetadataKey.OPERATOR_ID.getName(), operatorId);
+       return operatorStats;
+     });
   }
 
   private void startExecutionTimer() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OpChainStats.java
@@ -21,8 +21,7 @@ package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.base.Stopwatch;
 import com.google.common.base.Suppliers;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
@@ -50,7 +49,7 @@ public class OpChainStats {
   private final AtomicLong _queuedCount = new AtomicLong();
 
   private final String _id;
-  private Map<String, OperatorStats> _operatorStatsMap = new HashMap<>();
+  private final ConcurrentHashMap<String, OperatorStats> _operatorStatsMap = new ConcurrentHashMap<>();
 
   public OpChainStats(String id) {
     _id = id;
@@ -73,12 +72,8 @@ public class OpChainStats {
     }
   }
 
-  public Map<String, OperatorStats> getOperatorStatsMap() {
+  public ConcurrentHashMap<String, OperatorStats> getOperatorStatsMap() {
     return _operatorStatsMap;
-  }
-
-  public void setOperatorStatsMap(Map<String, OperatorStats> operatorStatsMap) {
-    _operatorStatsMap = operatorStatsMap;
   }
 
   private void startExecutionTimer() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
@@ -38,24 +38,21 @@ public class OperatorStats {
 
   private final VirtualServerAddress _serverAddress;
 
-  private final String _operatorType;
-
   private int _numBlock = 0;
   private int _numRows = 0;
   private long _startTimeMs = -1;
   private final Map<String, String> _executionStats;
   private boolean _processingStarted = false;
 
-  public OperatorStats(OpChainExecutionContext context, String operatorType) {
-    this(context.getRequestId(), context.getStageId(), context.getServer(), operatorType);
+  public OperatorStats(OpChainExecutionContext context) {
+    this(context.getRequestId(), context.getStageId(), context.getServer());
   }
 
   //TODO: remove this constructor after the context constructor can be used in serialization and deserialization
-  public OperatorStats(long requestId, int stageId, VirtualServerAddress serverAddress, String operatorType) {
+  public OperatorStats(long requestId, int stageId, VirtualServerAddress serverAddress) {
     _stageId = stageId;
     _requestId = requestId;
     _serverAddress = serverAddress;
-    _operatorType = operatorType;
     _executionStats = new HashMap<>();
   }
 
@@ -114,10 +111,6 @@ public class OperatorStats {
 
   public VirtualServerAddress getServerAddress() {
     return _serverAddress;
-  }
-
-  public String getOperatorType() {
-    return _operatorType;
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
@@ -35,6 +35,7 @@ public class OperatorStats {
   // TODO: add a operatorId for better tracking purpose.
   private final int _stageId;
   private final long _requestId;
+
   private final VirtualServerAddress _serverAddress;
 
   private final String _operatorType;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/OperatorUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/OperatorUtils.java
@@ -81,7 +81,6 @@ public class OperatorUtils {
       jsonOut.put("requestId", operatorStats.getRequestId());
       jsonOut.put("stageId", operatorStats.getStageId());
       jsonOut.put("serverAddress", operatorStats.getServerAddress().toString());
-      jsonOut.put("operatorType", operatorStats.getOperatorType());
       jsonOut.put("executionStats", operatorStats.getExecutionStats());
       return JsonUtils.objectToString(jsonOut);
     } catch (Exception e) {
@@ -97,10 +96,9 @@ public class OperatorUtils {
       int stageId = operatorStatsNode.get("stageId").asInt();
       String serverAddressStr = operatorStatsNode.get("serverAddress").asText();
       VirtualServerAddress serverAddress = VirtualServerAddress.parse(serverAddressStr);
-      String operatorType = operatorStatsNode.get("operatorType").asText();
 
       OperatorStats operatorStats =
-          new OperatorStats(requestId, stageId, serverAddress, operatorType);
+          new OperatorStats(requestId, stageId, serverAddress);
       operatorStats.recordExecutionStats(
           JsonUtils.jsonNodeToObject(operatorStatsNode.get("executionStats"), new TypeReference<Map<String, String>>() {
           }));

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
@@ -23,6 +23,8 @@ import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.planner.StageMetadata;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.operator.OpChainId;
+import org.apache.pinot.query.runtime.operator.OpChainStats;
 
 
 /**
@@ -38,6 +40,8 @@ public class OpChainExecutionContext {
   private final long _timeoutMs;
   private final long _deadlineMs;
   private final Map<Integer, StageMetadata> _metadataMap;
+  private final OpChainId _id;
+  private final OpChainStats _stats;
 
   public OpChainExecutionContext(MailboxService<TransferableBlock> mailboxService, long requestId, int stageId,
       VirtualServerAddress server, long timeoutMs, long deadlineMs, Map<Integer, StageMetadata> metadataMap) {
@@ -48,6 +52,8 @@ public class OpChainExecutionContext {
     _timeoutMs = timeoutMs;
     _deadlineMs = deadlineMs;
     _metadataMap = metadataMap;
+    _id = new OpChainId(requestId, server.virtualId(), stageId);
+    _stats = new OpChainStats(_id.toString());
   }
 
   public OpChainExecutionContext(PlanRequestContext planRequestContext) {
@@ -82,5 +88,13 @@ public class OpChainExecutionContext {
 
   public Map<Integer, StageMetadata> getMetadataMap() {
     return _metadataMap;
+  }
+
+  public OpChainId getId() {
+    return _id;
+  }
+
+  public OpChainStats getStats() {
+    return _stats;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -55,6 +55,8 @@ import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.MailboxReceiveOperator;
+import org.apache.pinot.query.runtime.operator.OpChainId;
+import org.apache.pinot.query.runtime.operator.OpChainStats;
 import org.apache.pinot.query.runtime.operator.OperatorStats;
 import org.apache.pinot.query.runtime.operator.utils.OperatorUtils;
 import org.apache.pinot.query.runtime.plan.DistributedStagePlan;
@@ -281,10 +283,12 @@ public class QueryDispatcher {
       VirtualServerAddress server, long timeoutMs) {
     OpChainExecutionContext context =
         new OpChainExecutionContext(mailboxService, jobId, stageId, server, timeoutMs, timeoutMs, stageMetadataMap);
+    OpChainStats stats = new OpChainStats(new OpChainId(jobId, server.virtualId(), stageId).toString());
     // timeout is set for reduce stage
     MailboxReceiveOperator mailboxReceiveOperator =
         new MailboxReceiveOperator(context, RelDistribution.Type.RANDOM_DISTRIBUTED, Collections.emptyList(),
             Collections.emptyList(), false, false, dataSchema, stageId, reducerStageId);
+    mailboxReceiveOperator.attachOpChainStats(stats);
     return mailboxReceiveOperator;
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
@@ -24,9 +24,11 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.MultiStageOperator;
 import org.apache.pinot.query.runtime.operator.OpChain;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.stubbing.Answer;
@@ -71,7 +73,9 @@ public class OpChainSchedulerServiceTest {
   }
 
   private OpChain getChain(MultiStageOperator operator) {
-    return new OpChain(operator, ImmutableList.of(), 1, 123, 1);
+    VirtualServerAddress address = new VirtualServerAddress("localhost", 1234, 1);
+    OpChainExecutionContext context = new OpChainExecutionContext(null, 123L, 1, address, 0, 0, null);
+    return new OpChain(context, operator, ImmutableList.of());
   }
 
   @Test

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -34,9 +34,7 @@ import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.exchange.BlockExchange;
-import org.apache.pinot.query.runtime.operator.utils.OperatorUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
-import org.apache.pinot.spi.utils.JsonUtils;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -163,23 +161,15 @@ public class MailboxSendOperatorTest {
             server -> new JsonMailboxIdentifier("123", "0@from:1", "0@to:2", DEFAULT_SENDER_STAGE_ID,
                 DEFAULT_RECEIVER_STAGE_ID), _exchangeFactory, DEFAULT_RECEIVER_STAGE_ID);
 
-    Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
+    TransferableBlock eosBlock = TransferableBlockUtils.getEndOfStreamTransferableBlock();
+    Mockito.when(_input.nextBlock()).thenReturn(eosBlock);
 
     // When:
     TransferableBlock block = operator.nextBlock();
 
     // Then:
-    TransferableBlock eosBlock = TransferableBlockUtils.getEndOfStreamTransferableBlock(
-        OperatorUtils.getMetadataFromOperatorStats(context.getStats().getOperatorStatsMap()));
     Assert.assertTrue(block.isEndOfStreamBlock(), "expected EOS block to propagate");
-    Assert.assertFalse(block.getResultMetadata().isEmpty());
-    Assert.assertTrue(block.getResultMetadata().containsKey(operator.getOperatorId()));
-
-    OperatorStats stats = block.getResultMetadata().get(operator.getOperatorId());
-    Assert.assertEquals(stats.getRequestId(), 1);
-    Assert.assertEquals(stats.getStageId(), DEFAULT_SENDER_STAGE_ID);
-    Assert.assertEquals(JsonUtils.objectToString(block.getResultMetadata()),
-        JsonUtils.objectToString(eosBlock.getResultMetadata()));
+    Assert.assertEquals(block, eosBlock);
   }
 
   @Test

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
@@ -1,0 +1,124 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import java.util.ArrayList;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.MockitoAnnotations;
+import org.testng.Assert;
+import org.testng.annotations.AfterMethod;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class OpChainTest {
+  private AutoCloseable _mocks;
+  @Mock
+  private MultiStageOperator _upstreamOperator;
+
+  @BeforeMethod
+  public void setUp() {
+    _mocks = MockitoAnnotations.openMocks(this);
+  }
+
+  @AfterMethod
+  public void tearDown()
+      throws Exception {
+    _mocks.close();
+  }
+
+  @Test
+  public void testExecutionTimerStats() {
+    Mockito.when(_upstreamOperator.nextBlock()).then(x -> {
+      Thread.sleep(1000);
+      return TransferableBlockUtils.getEndOfStreamTransferableBlock();
+    });
+
+    OpChain opChain = new OpChain(OperatorTestUtil.getDefaultContext(), _upstreamOperator, new ArrayList<>());
+    opChain.getStats().executing();
+    opChain.getRoot().nextBlock();
+    opChain.getStats().queued();
+
+    Assert.assertTrue(opChain.getStats().getExecutionTime() >= 1000);
+
+    Mockito.when(_upstreamOperator.nextBlock()).then(x -> {
+      Thread.sleep(20);
+      return TransferableBlockUtils.getEndOfStreamTransferableBlock();
+    });
+
+    opChain = new OpChain(OperatorTestUtil.getDefaultContext(), _upstreamOperator, new ArrayList<>());
+    opChain.getStats().executing();
+    opChain.getRoot().nextBlock();
+    opChain.getStats().queued();
+
+    Assert.assertTrue(opChain.getStats().getExecutionTime() >= 20);
+    Assert.assertTrue(opChain.getStats().getExecutionTime() < 100);
+  }
+
+  @Test
+  public void testStatsCollection() {
+    OpChainExecutionContext context = OperatorTestUtil.getDefaultContext();
+    DummyMultiStageOperator dummyMultiStageOperator = new DummyMultiStageOperator(context);
+
+    OpChain opChain = new OpChain(context, dummyMultiStageOperator, new ArrayList<>());
+    opChain.getStats().executing();
+    opChain.getRoot().nextBlock();
+    opChain.getStats().queued();
+
+    Assert.assertTrue(opChain.getStats().getExecutionTime() >= 1000);
+    Assert.assertEquals(opChain.getStats().getOperatorStatsMap().size(), 1);
+    Assert.assertTrue(opChain.getStats().getOperatorStatsMap().containsKey(dummyMultiStageOperator.getOperatorId()));
+
+    Map<String, String> executionStats =
+        opChain.getStats().getOperatorStatsMap().get(dummyMultiStageOperator.getOperatorId()).getExecutionStats();
+    Assert.assertTrue(
+        Long.parseLong(executionStats.get(DataTable.MetadataKey.OPERATOR_EXECUTION_TIME_MS.getName())) >= 1000);
+    Assert.assertTrue(
+        Long.parseLong(executionStats.get(DataTable.MetadataKey.OPERATOR_EXECUTION_TIME_MS.getName())) <= 2000);
+  }
+
+  static class DummyMultiStageOperator extends MultiStageOperator {
+    public DummyMultiStageOperator(OpChainExecutionContext context) {
+      super(context);
+    }
+
+    @Override
+    protected TransferableBlock getNextBlock() {
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException e) {
+        // IGNORE
+      }
+      return TransferableBlockUtils.getEndOfStreamTransferableBlock();
+    }
+
+    @Nullable
+    @Override
+    public String toExplainString() {
+      return "DUMMY";
+    }
+  }
+}


### PR DESCRIPTION
There's no need to serialize the metrics unless they are sent or received. We can simply use the OperatorStats objects for rest of the operators.