### PR TITLE
Upgraded joda-time library version from 2.10.5 to 2.11.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -529,7 +529,7 @@
       <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
-        <version>2.10.5</version>
+        <version>2.11.2</version>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
Previously, the following query would throw an error.

```
select FromDateTime('2023-03-22', 'yyyy-MM-dd', 'Asia/Tehran') AS epochMillis
FROM ignoreMe
```

Error Gist:
```
Caused by: org.joda.time.IllegalInstantException: Cannot parse "2023-03-22": Illegal instant due to time zone offset transition (Asia/Tehran)
```


The joda-time library upgrade fixes this issue. Verified that the query works post the library version update.

For additional context see [this](https://github.com/JodaOrg/joda-time/blob/7858bb0035c05335bb2cab208f3367e5ccd7105e/src/changes/changes.xml#L56-L74) and [this](https://github.com/JodaOrg/global-tz/blame/8fa527c233c75dedb5d2857fbb96c2a40b3bcad6/asia#L1599-L1600).