### PR TITLE
Fix the double destroy of segment data manager during server shutdown

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/ImmutableSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/ImmutableSegmentDataManager.java
@@ -44,7 +44,7 @@ public class ImmutableSegmentDataManager extends SegmentDataManager {
   }
 
   @Override
-  public void destroy() {
+  protected void doDestroy() {
     _immutableSegment.destroy();
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -469,7 +469,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   }
 
   @Override
-  public void destroy() {
+  protected void doDestroy() {
     LOGGER.info("Trying to shutdown RealtimeSegmentDataManager : {}!", _segmentName);
     _isShuttingDown = true;
     try {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1238,7 +1238,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     return true;
   }
 
-  public void destroy() {
+  protected void doDestroy() {
     try {
       stop();
     } catch (InterruptedException e) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/SegmentDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/SegmentDataManager.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.data.manager;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.pinot.segment.spi.IndexSegment;
 
 
@@ -27,6 +28,7 @@ import org.apache.pinot.segment.spi.IndexSegment;
  */
 public abstract class SegmentDataManager {
   private final long _loadTimeMs = System.currentTimeMillis();
+  private final AtomicBoolean _destroyed = new AtomicBoolean();
   private int _referenceCount = 1;
 
   public long getLoadTimeMs() {
@@ -71,5 +73,15 @@ public abstract class SegmentDataManager {
 
   public abstract IndexSegment getSegment();
 
-  public abstract void destroy();
+  /**
+   * Destroys the data manager and releases all the resources allocated.
+   * The data manager can only be destroyed once.
+   */
+  public void destroy() {
+    if (_destroyed.compareAndSet(false, true)) {
+      doDestroy();
+    }
+  }
+
+  protected abstract void doDestroy();
 }


### PR DESCRIPTION
When server is shutting down, the segment data manager might be destroyed twice, which leads to unexpected exceptions (e.g. NPE, multiple releases of buffer, or even crash):
- Once from reference count reaching 0 because segments are offloaded
- Once from shutting down the `RealtimeTableDataManager`