### PR TITLE
Remove "isSorted()" precondition check in the ForwardIndexHandler

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
@@ -302,8 +302,13 @@ public class ForwardIndexHandler extends BaseIndexHandler {
         }
 
         // Note that RAW columns cannot be sorted.
+        // TODO: revisit the the possibility of converting noDictionary -> Dictionary when the column is sorted.
         ColumnMetadata existingColMetadata = _segmentDirectory.getSegmentMetadata().getColumnMetadataFor(column);
-        Preconditions.checkState(!existingColMetadata.isSorted(), "Raw column=" + column + " cannot be sorted.");
+        if (existingColMetadata.isSorted()) {
+          LOGGER.warn("Raw column={} cannot be sorted and the dictionary won't be created. Falling back to use "
+              + "noDictionaryColumn..", column);
+          continue;
+        }
 
         columnOperationsMap.put(column, Collections.singletonList(Operation.ENABLE_DICTIONARY));
       } else if (existingDictColumns.contains(column) && newNoDictColumns.contains(column)) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
@@ -301,15 +301,6 @@ public class ForwardIndexHandler extends BaseIndexHandler {
           continue;
         }
 
-        // Note that RAW columns cannot be sorted.
-        // TODO: revisit the the possibility of converting noDictionary -> Dictionary when the column is sorted.
-        ColumnMetadata existingColMetadata = _segmentDirectory.getSegmentMetadata().getColumnMetadataFor(column);
-        if (existingColMetadata.isSorted()) {
-          LOGGER.warn("Raw column={} cannot be sorted and the dictionary won't be created. Falling back to use "
-              + "noDictionaryColumn..", column);
-          continue;
-        }
-
         columnOperationsMap.put(column, Collections.singletonList(Operation.ENABLE_DICTIONARY));
       } else if (existingDictColumns.contains(column) && newNoDictColumns.contains(column)) {
         // Existing column has dictionary. New config for the column is RAW.


### PR DESCRIPTION
Current code has a precondition check for no-dictionary colums and we fail the load if the no-dictionary columns are sorted when the table config has changed from `no-dict` -> `dict`. This PR unblocks the failure issue.