### PR TITLE
wait for full segment commit protocol on force commit

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java
@@ -1170,8 +1170,7 @@ public class SegmentCompletionManager {
      */
     private boolean isWinnerPicked(String preferredInstance, long now, final String stopReason) {
       if ((SegmentCompletionProtocol.REASON_ROW_LIMIT.equals(stopReason)
-          || SegmentCompletionProtocol.REASON_END_OF_PARTITION_GROUP.equals(stopReason)
-          || SegmentCompletionProtocol.REASON_FORCE_COMMIT_MESSAGE_RECEIVED.equals(stopReason))
+          || SegmentCompletionProtocol.REASON_END_OF_PARTITION_GROUP.equals(stopReason))
           && _commitStateMap.size() == 1) {
         _winner = preferredInstance;
         _winningOffset = _commitStateMap.get(preferredInstance);


### PR DESCRIPTION
This closes https://github.com/apache/pinot/issues/10460

This isn't necessarily a bug, but it can lead to unexpected behavior. We observed that picking the first server to respond to force commit led to a case where a server that was several hours behind was chosen as the winner. In the issue, we discussed that the intention was to kick off committing immediately on force commit, but it should generally not be detrimental (extra ~3 seconds) to wait for the typical segment commit protocol.
