### PR TITLE
[Test] Revert H2 data type mapping from Pinot BIG_DECIMAL to NUMERIC(1200, 600)

### DIFF
--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
@@ -380,7 +380,7 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
       case BOOLEAN:
         return "BOOLEAN";
       case BIG_DECIMAL:
-        return "NUMERIC(65535, 32767)";
+        return "NUMERIC(1200, 600)";
       case BYTES:
         return "BYTEA";
       case TIMESTAMP:


### PR DESCRIPTION
Reduce the precision and scale number of H2 NUMERIC data type to fix the slow tests.
https://github.com/apache/pinot/issues/10482

![image](https://user-images.githubusercontent.com/1202120/228037697-fc45c6f0-65b7-4bde-b5a5-c6f1da9a7747.png)
