### PR TITLE
Adding fields in TableConfigBuilder to enable/disable dictionary optimization for metric columns

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -64,11 +64,12 @@ import static org.testng.Assert.*;
 
 
 public class TableConfigSerDeTest {
-
+  private static final double NO_DICTIONARY_THRESHOLD_RATIO = 0.72;
   @Test
   public void testSerDe()
       throws IOException {
-    TableConfigBuilder tableConfigBuilder = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable");
+    TableConfigBuilder tableConfigBuilder = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTable")
+        .setNoDictionarySizeRatioThreshold(NO_DICTIONARY_THRESHOLD_RATIO).setOptimizeDictionaryForMetrics(true);
     {
       // Default table config
       TableConfig tableConfig = tableConfigBuilder.build();
@@ -367,6 +368,8 @@ public class TableConfigSerDeTest {
     assertNull(tableConfig.getInstanceAssignmentConfigMap());
     assertNull(tableConfig.getSegmentAssignmentConfigMap());
     assertNull(tableConfig.getFieldConfigList());
+    assertEquals(tableConfig.getIndexingConfig().isOptimizeDictionaryForMetrics(), true);
+    assertEquals(tableConfig.getIndexingConfig().getNoDictionarySizeRatioThreshold(), NO_DICTIONARY_THRESHOLD_RATIO);
 
     // Serialize
     ObjectNode tableConfigJson = (ObjectNode) tableConfig.toJsonNode();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/TableConfigBuilder.java
@@ -103,6 +103,10 @@ public class TableConfigBuilder {
   private List<StarTreeIndexConfig> _starTreeIndexConfigs;
   private List<String> _jsonIndexColumns;
   private boolean _aggregateMetrics;
+  private boolean _optimizeDictionaryForMetrics;
+  // This threshold determines if dictionary should be enabled or not for a metric column and is relevant
+  // only when _optimizeDictionaryForMetrics is set to true.
+  private double _noDictionarySizeRatioThreshold;
 
   private TableCustomConfig _customConfig;
   private QuotaConfig _quotaConfig;
@@ -253,6 +257,16 @@ public class TableConfigBuilder {
 
   public TableConfigBuilder setInvertedIndexColumns(List<String> invertedIndexColumns) {
     _invertedIndexColumns = invertedIndexColumns;
+    return this;
+  }
+
+  public TableConfigBuilder setOptimizeDictionaryForMetrics(boolean optimizeDictionaryForMetrics) {
+    _optimizeDictionaryForMetrics = optimizeDictionaryForMetrics;
+    return this;
+  }
+
+  public TableConfigBuilder setNoDictionarySizeRatioThreshold(double noDictionarySizeRatioThreshold) {
+    _noDictionarySizeRatioThreshold = noDictionarySizeRatioThreshold;
     return this;
   }
 
@@ -444,6 +458,8 @@ public class TableConfigBuilder {
     indexingConfig.setStarTreeIndexConfigs(_starTreeIndexConfigs);
     indexingConfig.setJsonIndexColumns(_jsonIndexColumns);
     indexingConfig.setAggregateMetrics(_aggregateMetrics);
+    indexingConfig.setOptimizeDictionaryForMetrics(_optimizeDictionaryForMetrics);
+    indexingConfig.setNoDictionarySizeRatioThreshold(_noDictionarySizeRatioThreshold);
 
     if (_customConfig == null) {
       _customConfig = new TableCustomConfig(null);


### PR DESCRIPTION
This [PR](https://github.com/apache/pinot/pull/8398) introduced index config options to enable/disable dictionary optimization for metrics based on a custom threshold (to enable/disable dictionary for a column) and we want to be able to make use of those options via TableConfigBuilder. 


