### PR TITLE
Clean up temp consuming segment files during server start

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -159,7 +159,7 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         invertedIndexColumns);
 
     _segmentEndTimeThreshold = _start + _streamConfig.getFlushThresholdTimeMillis();
-    _resourceTmpDir = new File(resourceDataDir, "_tmp");
+    _resourceTmpDir = new File(resourceDataDir, RESOURCE_TEMP_DIR_NAME);
     if (!_resourceTmpDir.exists()) {
       _resourceTmpDir.mkdirs();
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1419,7 +1419,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       createPartitionMetadataProvider("Starting");
       setPartitionParameters(realtimeSegmentConfigBuilder, indexingConfig.getSegmentPartitionConfig());
       _realtimeSegment = new MutableSegmentImpl(realtimeSegmentConfigBuilder.build(), serverMetrics);
-      _resourceTmpDir = new File(resourceDataDir, "_tmp");
+      _resourceTmpDir = new File(resourceDataDir, RESOURCE_TEMP_DIR_NAME);
       if (!_resourceTmpDir.exists()) {
         _resourceTmpDir.mkdirs();
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -31,6 +31,7 @@ import org.apache.pinot.spi.utils.CommonConstants.ConsumerState;
 
 
 public abstract class RealtimeSegmentDataManager extends SegmentDataManager {
+  public static final String RESOURCE_TEMP_DIR_NAME = "_tmp";
 
   @Override
   public abstract MutableSegment getSegment();


### PR DESCRIPTION
Fix #10467 

When consuming segment is not properly committed, the temporary segment files will be left on the server disk.
This PR cleans them up during server start, and also clean up the empty table data dirs (table deleted)