### PR TITLE
Fix shading in spark2 connector pom file

### DIFF
--- a/pinot-connectors/pinot-spark-2-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-2-connector/pom.xml
@@ -37,6 +37,7 @@
     <paranamer.version>2.8</paranamer.version>
     <scalaxml.version>1.3.0</scalaxml.version>
     <scalatest.version>3.1.1</scalatest.version>
+    <shadeBase>org.apache.pinot.\$internal</shadeBase>
 
     <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
     <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
@@ -119,6 +120,47 @@
       <build>
         <plugins>
           <!-- scala build -->
+          <plugin>
+            <groupId>org.xolstice.maven.plugins</groupId>
+            <artifactId>protobuf-maven-plugin</artifactId>
+            <version>0.6.1</version>
+            <configuration>
+              <protocArtifact>com.google.protobuf:protoc:3.19.2:exe:${os.detected.classifier}</protocArtifact>
+              <pluginId>grpc-java</pluginId>
+              <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.44.1:exe:${os.detected.classifier}</pluginArtifact>
+            </configuration>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>compile</goal>
+                  <goal>compile-custom</goal>
+                </goals>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <artifactId>maven-shade-plugin</artifactId>
+            <executions>
+              <execution>
+                <phase>package</phase>
+                <goals>
+                  <goal>shade</goal>
+                </goals>
+                <configuration>
+                  <relocations>
+                    <relocation>
+                      <pattern>com</pattern>
+                      <shadedPattern>${shadeBase}.com</shadedPattern>
+                      <includes>
+                        <include>com.google.protobuf.**</include>
+                        <include>com.google.common.**</include>
+                      </includes>
+                    </relocation>
+                  </relocations>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
           <plugin>
             <groupId>net.alchim31.maven</groupId>
             <artifactId>scala-maven-plugin</artifactId>

--- a/pinot-connectors/pinot-spark-2-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-2-connector/pom.xml
@@ -121,24 +121,6 @@
         <plugins>
           <!-- scala build -->
           <plugin>
-            <groupId>org.xolstice.maven.plugins</groupId>
-            <artifactId>protobuf-maven-plugin</artifactId>
-            <version>0.6.1</version>
-            <configuration>
-              <protocArtifact>com.google.protobuf:protoc:3.19.2:exe:${os.detected.classifier}</protocArtifact>
-              <pluginId>grpc-java</pluginId>
-              <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.44.1:exe:${os.detected.classifier}</pluginArtifact>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>compile</goal>
-                  <goal>compile-custom</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <artifactId>maven-shade-plugin</artifactId>
             <executions>
               <execution>

--- a/pinot-connectors/pinot-spark-3-connector/pom.xml
+++ b/pinot-connectors/pinot-spark-3-connector/pom.xml
@@ -118,24 +118,6 @@
         <plugins>
           <!-- scala build -->
           <plugin>
-            <groupId>org.xolstice.maven.plugins</groupId>
-            <artifactId>protobuf-maven-plugin</artifactId>
-            <version>0.6.1</version>
-            <configuration>
-              <protocArtifact>com.google.protobuf:protoc:3.19.2:exe:${os.detected.classifier}</protocArtifact>
-              <pluginId>grpc-java</pluginId>
-              <pluginArtifact>io.grpc:protoc-gen-grpc-java:1.44.1:exe:${os.detected.classifier}</pluginArtifact>
-            </configuration>
-            <executions>
-              <execution>
-                <goals>
-                  <goal>compile</goal>
-                  <goal>compile-custom</goal>
-                </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
             <artifactId>maven-shade-plugin</artifactId>
             <executions>
               <execution>

--- a/pinot-connectors/pinot-spark-common/pom.xml
+++ b/pinot-connectors/pinot-spark-common/pom.xml
@@ -37,7 +37,6 @@
     <paranameter.version>2.8</paranameter.version>
     <scalaxml.version>1.3.0</scalaxml.version>
     <scalatest.version>3.1.1</scalatest.version>
-    <shadeBase>org.apache.pinot.\$internal</shadeBase>
 
     <!-- TODO: delete this prop once all the checkstyle warnings are fixed -->
     <checkstyle.fail.on.violation>false</checkstyle.fail.on.violation>
@@ -152,29 +151,6 @@
                   <goal>compile</goal>
                   <goal>compile-custom</goal>
                 </goals>
-              </execution>
-            </executions>
-          </plugin>
-          <plugin>
-            <artifactId>maven-shade-plugin</artifactId>
-            <executions>
-              <execution>
-                <phase>package</phase>
-                <goals>
-                  <goal>shade</goal>
-                </goals>
-                <configuration>
-                  <relocations>
-                    <relocation>
-                      <pattern>com</pattern>
-                      <shadedPattern>${shadeBase}.com</shadedPattern>
-                      <includes>
-                        <include>com.google.protobuf.**</include>
-                        <include>com.google.common.**</include>
-                      </includes>
-                    </relocation>
-                  </relocations>
-                </configuration>
               </execution>
             </executions>
           </plugin>


### PR DESCRIPTION
Adding shading back to the Spark2 Connector pom file for google `common` and `protobuf` libraries, which used to exist but was deleted by mistake in a previous refactoring.
These libraries are common sources of dependency collisions in Spark applications, so it is good to have this.

**Testing**
Tested the change using included integration tests under `ExampleSparkPinotConnectorTest` successfully.

`bugfix` `dependencies`
