### PR TITLE
Add testng on verifier

### DIFF
--- a/pinot-compatibility-verifier/pom.xml
+++ b/pinot-compatibility-verifier/pom.xml
@@ -93,6 +93,11 @@
       <type>test-jar</type>
     </dependency>
     <dependency>
+      <groupId>org.testng</groupId>
+      <artifactId>testng</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-controller</artifactId>
       <version>${project.version}</version>

--- a/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/StreamOp.java
+++ b/pinot-compatibility-verifier/src/main/java/org/apache/pinot/compat/StreamOp.java
@@ -21,8 +21,8 @@ package org.apache.pinot.compat;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import com.google.common.base.Function;
 import java.io.File;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -30,7 +30,6 @@ import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import java.util.UUID;
-import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.kafka.clients.admin.AdminClient;
 import org.apache.kafka.clients.admin.AdminClientConfig;
@@ -304,16 +303,8 @@ public class StreamOp extends BaseOp {
 
   private void waitForDocsLoaded(String tableName, long targetDocs, long timeoutMs) {
     LOGGER.info("Wait Doc to load ...");
-    TestUtils.waitForCondition(new Function<Void, Boolean>() {
-      @Nullable
-      @Override
-      public Boolean apply(@Nullable Void aVoid) {
-        try {
-          return fetchExistingTotalDocs(tableName) == targetDocs;
-        } catch (Exception e) {
-          return null;
-        }
-      }
-    }, 100L, timeoutMs, "Failed to load " + targetDocs + " documents", true);
+    TestUtils.waitForCondition(
+        () -> fetchExistingTotalDocs(tableName) == targetDocs, 100L, timeoutMs,
+        "Failed to load " + targetDocs + " documents", true, Duration.ofSeconds(1));
   }
 }


### PR DESCRIPTION
This PR include a couple of small changes that were included in #10184 but can be merged alone in order to merge it earlier and simplify the other PR.

First, this PR adds a runtime dependency to testng in `pinot-compability-verifier`. That dependency was used but not declared. I discovered this when one of the test failed, which throws a testng assertion error. The funny thing is that the assertion error class wasn't in the classpath, so the error I'd got was a class not found exception. Once I added this dependency, the error message I had was the actual error that I had to solve.

It also adds a a new method `TestUtils.waitForCondition` that accepts a `SupplierWithException`. If the supplier throws, then the error is caught and retried until. This will repeated until the supplier doesn't fail or there is a timeout.