### PR TITLE
Trivial fix on a warning detected by static checker

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -363,7 +363,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
 
   private boolean shouldCreateDictionaryWithinThreshold(ColumnIndexCreationInfo info,
       SegmentGeneratorConfig config, FieldSpec spec) {
-    long dictionarySize = info.getDistinctValueCount() * spec.getDataType().size();
+    long dictionarySize = info.getDistinctValueCount() * (long) spec.getDataType().size();
     long forwardIndexSize =
         ((long) info.getTotalNumberOfEntries()
             * PinotDataBitSet.getNumBitsPerValue(info.getDistinctValueCount() - 1) + Byte.SIZE - 1) / Byte.SIZE;


### PR DESCRIPTION
 Trivial fix on a warning detected by static checker
    
Older code was:
    ```
     long dictionarySize = info.getDistinctValueCount() * spec.getDataType().size();
    ```
    
This could produce an overflow if the number of distinct values is close to Integer.MAX_INT / 4, which seems rare, but possible.
    
New code just cast one of the members as long in order to be sure that 64bit product is used.
