### PR TITLE
[multistage][wip] worker assignment dispatch partition

### DIFF
--- a/pinot-common/src/main/proto/worker.proto
+++ b/pinot-common/src/main/proto/worker.proto
@@ -78,13 +78,17 @@ message StagePlan {
 message StageMetadata {
   repeated string instances = 1;
   repeated string dataSources = 2;
-  map<string, SegmentMap> instanceToSegmentMap = 3;
+  map<string, SegmentPartitionMap> instanceToSegmentMap = 3;
   string timeColumn = 4;
   string timeValue = 5;
 }
 
-message SegmentMap {
-  map<string, SegmentList> tableTypeToSegmentList = 1;
+message SegmentPartitionMap {
+  map<string, PartitionMap> tableTypeToPartitionSegments = 1;
+}
+
+message PartitionMap {
+  map<int32, SegmentList> partitionToSegments = 1;
 }
 
 message SegmentList {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/ExplainPlanStageVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/ExplainPlanStageVisitor.java
@@ -92,9 +92,9 @@ public class ExplainPlanStageVisitor implements StageNodeVisitor<StringBuilder, 
     int stage = node.getStageId();
     context._builder
         .append(context._prefix)
-        .append('[')
+        .append('{')
         .append(stage)
-        .append("]@")
+        .append("}@")
         .append(context._host.getHostname())
         .append(':')
         .append(context._host.getPort())
@@ -138,7 +138,8 @@ public class ExplainPlanStageVisitor implements StageNodeVisitor<StringBuilder, 
     MailboxSendNode sender = (MailboxSendNode) node.getSender();
     int senderStageId = node.getSenderStageId();
     StageMetadata metadata = _queryPlan.getStageMetadataMap().get(senderStageId);
-    Map<ServerInstance, Map<String, List<String>>> segments = metadata.getServerInstanceToSegmentsMap();
+    Map<ServerInstance, Map<String, Map<Integer, List<String>>>> segments =
+        metadata.getServerAndPartitionToSegmentMap();
 
     Iterator<VirtualServer> iterator = metadata.getServerInstances().iterator();
     while (iterator.hasNext()) {
@@ -175,7 +176,7 @@ public class ExplainPlanStageVisitor implements StageNodeVisitor<StringBuilder, 
     context._builder.append("->");
     String receivers = servers.stream()
         .map(VirtualServer::toString)
-        .map(s -> "[" + receiverStageId + "]@" + s)
+        .map(s -> "{" + receiverStageId + "}@" + s)
         .collect(Collectors.joining(",", "{", "}"));
     return context._builder.append(receivers);
   }
@@ -196,7 +197,7 @@ public class ExplainPlanStageVisitor implements StageNodeVisitor<StringBuilder, 
         .append(' ')
         .append(_queryPlan.getStageMetadataMap()
             .get(node.getStageId())
-            .getServerInstanceToSegmentsMap()
+            .getServerAndPartitionToSegmentMap()
             .get(context._host.getServer()))
         .append('\n');
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/StageMetadata.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/StageMetadata.java
@@ -21,8 +21,10 @@ package org.apache.pinot.query.planner;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.query.routing.VirtualServer;
@@ -31,36 +33,81 @@ import org.apache.pinot.query.routing.VirtualServer;
 /**
  * The {@code StageMetadata} info contains the information for dispatching a particular stage.
  *
- * <p>It contains information aboute:
+ * <p>It contains information about:</p>
  * <ul>
- *   <li>the tables it is suppose to scan for</li>
+ *   <li>the tables it is suppose to scan (including real-time and offline portions separately)</li>
  *   <li>the underlying segments a stage requires to execute upon.</li>
  *   <li>the server instances to which this stage should be execute on</li>
+ *   <li>the set of query partition IDs each server instance is responsible for</li>
  * </ul>
+ *
+ * <p>The stage information also contains the receiving stage metadata in order to construct proper bi-directional
+ * metadata to convert {@link org.apache.pinot.query.planner.stage.MailboxSendNode} and
+ * {@link org.apache.pinot.query.planner.stage.MailboxReceiveNode} into proper operators. Here is how:</p>
+ *
+ * <p>The {@code List<VirtualServer>} represents the server instances for the current stage, as well as the associated
+ *   set of partitionIDs for each server instances</p>
+ * <p>The {@code Map<Integer, Map<Integer, List<ServerInstance>>>} represents the receiving stage info</p>
+ * <ul>
+ *   <li>Top level map is keyed by the sending side partitionID.</li>
+ *   <li>Top level map value is another map from receiving side partitionID to receiving side server instance.</li>
+ * </ul>
+ * <p>When mailbox operators are constructed on each server instances. it will
+ * <ul>
+ *   <li>create 1 operator chain per partitionID responsible by each server instances</li>
+ *   <li>for each operator chain that is associated with one particular partitionID, it will used the receiving stage
+ *     info map to lookup the destination partitionID, as well as the list of server instances.</li>
+ *   <li>for each pair of receiving stage partitionID-serverInstance pair, it will create a direct mailbox</li>
+ * </ul>
+ * <p>To summarize the mailboxes created are all uniquely identifiable by:
+ *   [sending_server:sending_partition:receiving_server:receiving_partition]</p>
  */
 public class StageMetadata implements Serializable {
   private List<String> _scannedTables;
 
-  // used for assigning server/worker nodes.
+  /**
+   * This is used for server/worker assignment. {@link VirtualServer} contains information of:
+   *   - {@link ServerInstance} and
+   *   - {@link List<Integer>} as partition IDs associated with this particular serverInstances. partitionIDs are
+   *       globally-indexed.
+   */
   private List<VirtualServer> _serverInstances;
 
-  // used for table scan stage - we use ServerInstance instead of VirtualServer
-  // here because all virtual servers that share a server instance will have the
-  // same segments on them
-  private Map<ServerInstance, Map<String, List<String>>> _serverInstanceToSegmentsMap;
+  /**
+   * Similar to {@link List<VirtualServer>}, this used for server/worker assignment specific to table scan stage.
+   * - For each partition, we will issue a ServerExecutorRequest and generate a result for
+   *     that specific partitionID.
+   */
+  private Map<ServerInstance, Map<String, Map<Integer, List<String>>>> _serverAndPartitionToSegmentMap;
+
+  /**
+   * This is ued for indicating what are the expected receiving servers for the outbound mailbox.
+   *   - top-level map is added to support Spool:
+   *     - key: receiving stage ID, normally there’s only 1 receiving stage.
+   *     - value: inner map indicate partition-ID-to-server mapping.
+   *       - key: receiving-side partitionID (this is different from the sending side partitionID.
+   *       - value: list of receiving server instances
+   * Note for inner map:
+   *   - for partitioned exchanges, the inner map contains multiple entries with a singleton list.
+   *   - for non-partitioned exchanges, the inner map contains 1 entry with a list of all receiving server instances.
+   */
+  private Map<Integer, Map<Integer, List<ServerInstance>>> _receivingServerInstanceMap;
 
   // time boundary info
   private TimeBoundaryInfo _timeBoundaryInfo;
 
   // whether a stage requires singleton instance to execute, e.g. stage contains global reduce (sort/agg) operator.
-  private boolean _requiresSingletonInstance;
+  private transient boolean _requiresSingletonInstance;
+
+  private transient Set<Integer> _inboundStageSet;
 
   public StageMetadata() {
     _scannedTables = new ArrayList<>();
     _serverInstances = new ArrayList<>();
-    _serverInstanceToSegmentsMap = new HashMap<>();
+    _serverAndPartitionToSegmentMap = new HashMap<>();
     _timeBoundaryInfo = null;
     _requiresSingletonInstance = false;
+    _inboundStageSet = new HashSet<>();
   }
 
   public List<String> getScannedTables() {
@@ -75,13 +122,22 @@ public class StageMetadata implements Serializable {
   // attached physical plan context.
   // -----------------------------------------------
 
-  public Map<ServerInstance, Map<String, List<String>>> getServerInstanceToSegmentsMap() {
-    return _serverInstanceToSegmentsMap;
+  public Map<ServerInstance, Map<String, Map<Integer, List<String>>>> getServerAndPartitionToSegmentMap() {
+    return _serverAndPartitionToSegmentMap;
   }
 
-  public void setServerInstanceToSegmentsMap(
-      Map<ServerInstance, Map<String, List<String>>> serverInstanceToSegmentsMap) {
-    _serverInstanceToSegmentsMap = serverInstanceToSegmentsMap;
+  public void setServerAndPartitionToSegmentMap(
+      Map<ServerInstance, Map<String, Map<Integer, List<String>>>> serverAndPartitionToSegmentMap) {
+    _serverAndPartitionToSegmentMap = serverAndPartitionToSegmentMap;
+  }
+
+  public Map<Integer, Map<Integer, List<ServerInstance>>> getReceivingServerInstanceMap() {
+    return _receivingServerInstanceMap;
+  }
+
+  public void setReceivingServerInstanceMap(
+      Map<Integer, Map<Integer, List<ServerInstance>>> receivingServerInstanceMap) {
+    _receivingServerInstanceMap = receivingServerInstanceMap;
   }
 
   public List<VirtualServer> getServerInstances() {
@@ -108,10 +164,18 @@ public class StageMetadata implements Serializable {
     _requiresSingletonInstance = _requiresSingletonInstance || newRequireInstance;
   }
 
+  public Set<Integer> getInboundStageSet() {
+    return _inboundStageSet;
+  }
+
+  public void addInboundStage(int inboundStageId) {
+    _inboundStageSet.add(inboundStageId);
+  }
+
   @Override
   public String toString() {
     return "StageMetadata{" + "_scannedTables=" + _scannedTables + ", _serverInstances=" + _serverInstances
-        + ", _serverInstanceToSegmentsMap=" + _serverInstanceToSegmentsMap + ", _timeBoundaryInfo=" + _timeBoundaryInfo
-        + '}';
+        + ", _serverInstanceToSegmentsMap=" + _serverAndPartitionToSegmentMap + ", _receivingServerInstanceMap="
+        + _receivingServerInstanceMap + ", _timeBoundaryInfo=" + _timeBoundaryInfo + '}';
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.planner.physical;
 
+import java.util.Map;
 import org.apache.pinot.query.planner.StageMetadata;
 import org.apache.pinot.query.planner.stage.AggregateNode;
 import org.apache.pinot.query.planner.stage.FilterNode;
@@ -58,8 +59,9 @@ public class DispatchablePlanVisitor implements StageNodeVisitor<Void, Dispatcha
 
   private void computeWorkerAssignment(StageNode node, DispatchablePlanContext context) {
     int stageId = node.getStageId();
-    context.getWorkerManager().assignWorkerToStage(stageId, context.getQueryPlan().getStageMetadataMap().get(stageId),
-        context.getRequestId(), context.getPlannerContext().getOptions());
+    Map<Integer, StageMetadata> stageMetadataMap = context.getQueryPlan().getStageMetadataMap();
+    context.getWorkerManager().assignWorkerToStage(stageId, stageMetadataMap, context.getRequestId(),
+        context.getPlannerContext().getOptions());
   }
 
   @Override
@@ -99,7 +101,8 @@ public class DispatchablePlanVisitor implements StageNodeVisitor<Void, Dispatcha
   @Override
   public Void visitMailboxReceive(MailboxReceiveNode node, DispatchablePlanContext context) {
     node.getSender().visit(this, context);
-    getStageMetadata(node, context);
+    StageMetadata stageMetadata = getStageMetadata(node, context);
+    stageMetadata.addInboundStage(node.getSender().getStageId());
     return null;
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/VirtualServer.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/VirtualServer.java
@@ -19,10 +19,10 @@
 
 package org.apache.pinot.query.routing;
 
+import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashSet;
+import java.util.List;
 import java.util.Objects;
-import java.util.Set;
 import org.apache.pinot.core.transport.ServerInstance;
 
 
@@ -36,18 +36,18 @@ import org.apache.pinot.core.transport.ServerInstance;
 public class VirtualServer {
 
   private final ServerInstance _server;
-  private final Set<Integer> _partitionIds;
+  private final List<Integer> _partitionIds;
 
   public VirtualServer(ServerInstance server, Collection<Integer> partitionIds) {
     _server = server;
-    _partitionIds = new HashSet<>(partitionIds);
+    _partitionIds = new ArrayList<>(partitionIds);
   }
 
   public ServerInstance getServer() {
     return _server;
   }
 
-  public Set<Integer> getPartitionIds() {
+  public List<Integer> getPartitionIds() {
     return _partitionIds;
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/VirtualServer.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/VirtualServer.java
@@ -19,7 +19,10 @@
 
 package org.apache.pinot.query.routing;
 
+import java.util.Collection;
+import java.util.HashSet;
 import java.util.Objects;
+import java.util.Set;
 import org.apache.pinot.core.transport.ServerInstance;
 
 
@@ -33,19 +36,19 @@ import org.apache.pinot.core.transport.ServerInstance;
 public class VirtualServer {
 
   private final ServerInstance _server;
-  private final int _virtualId;
+  private final Set<Integer> _partitionIds;
 
-  public VirtualServer(ServerInstance server, int virtualId) {
+  public VirtualServer(ServerInstance server, Collection<Integer> partitionIds) {
     _server = server;
-    _virtualId = virtualId;
+    _partitionIds = new HashSet<>(partitionIds);
   }
 
   public ServerInstance getServer() {
     return _server;
   }
 
-  public int getVirtualId() {
-    return _virtualId;
+  public Set<Integer> getPartitionIds() {
+    return _partitionIds;
   }
 
   public String getHostname() {
@@ -77,16 +80,16 @@ public class VirtualServer {
       return false;
     }
     VirtualServer that = (VirtualServer) o;
-    return _virtualId == that._virtualId && Objects.equals(_server, that._server);
+    return _partitionIds.equals(that._partitionIds) && Objects.equals(_server, that._server);
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_server, _virtualId);
+    return Objects.hash(_server, _partitionIds);
   }
 
   @Override
   public String toString() {
-    return _virtualId + "@" + _server.getInstanceId();
+    return _partitionIds + "@" + _server.getInstanceId();
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/VirtualServerAddress.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/VirtualServerAddress.java
@@ -23,14 +23,11 @@ import java.util.Objects;
 
 
 /**
- * Represents the address of a {@link VirtualServer} containing
- * both the ID of the specific virtualized server and the physical
- * internet address in id@hostname:port format.
+ * Represents the address of a {@link VirtualServer} containing both the PartitionID and the physical internet address
+ * in the format of partition_id@hostname:port.
  *
- * <p>This is needed in addition to {@code VirtualServer} because there
- * are some parts of the code that don't have enough information to
- * construct the full {@code VirtualServer} and only require the
- * hostname, port and virtualId.</p>
+ * <p>This is needed in addition to {@code VirtualServer} because there are some parts of the code that works with
+ * single partition (such as mailboxes). </p>
  */
 public class VirtualServerAddress {
 
@@ -42,10 +39,6 @@ public class VirtualServerAddress {
     _hostname = hostname;
     _port = port;
     _virtualId = virtualId;
-  }
-
-  public VirtualServerAddress(VirtualServer server) {
-    this(server.getHostname(), server.getQueryMailboxPort(), server.getVirtualId());
   }
 
   /**

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -20,7 +20,6 @@ package org.apache.pinot.query.routing;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
-import com.google.common.collect.Range;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -29,8 +28,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.stream.Collectors;
-import java.util.stream.IntStream;
-import org.apache.commons.lang.math.IntRange;
+import org.apache.calcite.util.Util;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
@@ -41,8 +39,6 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
-
-import static org.apache.calcite.util.Util.range;
 
 
 /**
@@ -146,7 +142,8 @@ public class WorkerManager {
             && !hostname.startsWith(CommonConstants.Helix.PREFIX_OF_CONTROLLER_INSTANCE)
             && !hostname.startsWith(CommonConstants.Helix.PREFIX_OF_MINION_INSTANCE)) {
           if (matchingIdx == -1) {
-            serverInstances.add(new VirtualServer(server, range(partitionCount, partitionCount + stageParallelism)));
+            serverInstances.add(new VirtualServer(server, Util.range(partitionCount,
+                partitionCount + stageParallelism)));
           } else {
             // for singleton exchange, add 0 as the default parallelism as the requirement of singleton
             serverInstances.add(new VirtualServer(server, Collections.singletonList(0)));

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -120,18 +120,18 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
         // table scan stages; for tableA it should have 2 hosts, for tableB it should have only 1
         Assert.assertEquals(
             e.getValue().getServerInstances().stream().map(VirtualServer::toString).collect(Collectors.toList()),
-            tables.get(0).equals("a") ? ImmutableList.of("0@Server_localhost_2", "0@Server_localhost_1")
-                : ImmutableList.of("0@Server_localhost_1"));
+            tables.get(0).equals("a") ? ImmutableList.of("[0]@Server_localhost_2", "[0]@Server_localhost_1")
+                : ImmutableList.of("[0]@Server_localhost_1"));
       } else if (!PlannerUtils.isRootStage(e.getKey())) {
         // join stage should have both servers used.
         Assert.assertEquals(
             e.getValue().getServerInstances().stream().map(VirtualServer::toString).collect(Collectors.toSet()),
-            ImmutableSet.of("0@Server_localhost_1", "0@Server_localhost_2"));
+            ImmutableSet.of("[0]@Server_localhost_1", "[0]@Server_localhost_2"));
       } else {
         // reduce stage should have the reducer instance.
         Assert.assertEquals(
             e.getValue().getServerInstances().stream().map(VirtualServer::toString).collect(Collectors.toSet()),
-            ImmutableSet.of("0@Server_localhost_3"));
+            ImmutableSet.of("[0]@Server_localhost_3"));
       }
     }
   }
@@ -165,7 +165,7 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
         .filter(stageMetadata -> stageMetadata.getScannedTables().size() != 0).collect(Collectors.toList());
     Assert.assertEquals(tableScanMetadataList.size(), 1);
     Assert.assertEquals(tableScanMetadataList.get(0).getServerInstances().size(), 1);
-    Assert.assertEquals(tableScanMetadataList.get(0).getServerInstances().get(0).toString(), "0@Server_localhost_2");
+    Assert.assertEquals(tableScanMetadataList.get(0).getServerInstances().get(0).toString(), "[0]@Server_localhost_2");
 
     query = "SELECT * FROM d";
     queryPlan = _queryEnvironment.planQuery(query);
@@ -240,12 +240,12 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
         // table scan stages; for tableB it should have only 1
         Assert.assertEquals(e.getValue().getServerInstances().stream()
                 .map(VirtualServer::toString).sorted().collect(Collectors.toList()),
-            ImmutableList.of("0@Server_localhost_1"));
+            ImmutableList.of("[0]@Server_localhost_1"));
       } else if (!PlannerUtils.isRootStage(e.getKey())) {
         // join stage should have both servers used.
         Assert.assertEquals(e.getValue().getServerInstances().stream()
                 .map(VirtualServer::toString).sorted().collect(Collectors.toList()),
-            ImmutableList.of("0@Server_localhost_1", "0@Server_localhost_2"));
+            ImmutableList.of("[0]@Server_localhost_1", "[0]@Server_localhost_2"));
       }
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -173,7 +173,7 @@ public class QueryRunner {
       for (int partitionId : virtualServer.getPartitionIds()) {
         OpChain rootOperator = PhysicalPlanVisitor.build(stageRoot,
             new PlanRequestContext(_mailboxService, requestId, stageRoot.getStageId(), timeoutMs, deadlineMs,
-                new VirtualServerAddress(virtualServer.getHostname(), virtualServer.getPort(), partitionId),
+                new VirtualServerAddress(virtualServer.getHostname(), virtualServer.getQueryMailboxPort(), partitionId),
                 distributedStagePlan.getMetadataMap()));
         _scheduler.register(rootOperator);
       }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -199,10 +199,12 @@ public class MailboxReceiveOperatorTest {
     int server1Port = 123;
     Mockito.when(_server1.getHostname()).thenReturn(serverHost);
     Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+    Mockito.when(_server1.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
-    int server2port = 456;
+    int server2Port = 456;
     Mockito.when(_server2.getHostname()).thenReturn(serverHost);
-    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2port);
+    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+    Mockito.when(_server2.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     int mailboxPort = 789;
     Mockito.when(_mailboxService.getHostname()).thenReturn(serverHost);
@@ -245,12 +247,14 @@ public class MailboxReceiveOperatorTest {
     int server1Port = 123;
     Mockito.when(_server1.getHostname()).thenReturn(serverHost);
     Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+    Mockito.when(_server1.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
-    int server2port = 456;
+    int server2Port = 456;
     Mockito.when(_server2.getHostname()).thenReturn(serverHost);
-    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2port);
+    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+    Mockito.when(_server2.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
-    int mailboxPort = server2port;
+    int mailboxPort = server2Port;
     Mockito.when(_mailboxService.getHostname()).thenReturn(serverHost);
     Mockito.when(_mailboxService.getMailboxPort()).thenReturn(mailboxPort);
 
@@ -261,7 +265,7 @@ public class MailboxReceiveOperatorTest {
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
     JsonMailboxIdentifier expectedMailboxId = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-        new VirtualServerAddress(serverHost, server2port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+        new VirtualServerAddress(serverHost, server2Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(true);
 
@@ -297,12 +301,14 @@ public class MailboxReceiveOperatorTest {
     int server1Port = 123;
     Mockito.when(_server1.getHostname()).thenReturn(serverHost);
     Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+    Mockito.when(_server1.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
-    int server2port = 456;
+    int server2Port = 456;
     Mockito.when(_server2.getHostname()).thenReturn(serverHost);
-    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2port);
+    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+    Mockito.when(_server2.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
-    int mailboxPort = server2port;
+    int mailboxPort = server2Port;
     Mockito.when(_mailboxService.getHostname()).thenReturn(serverHost);
     Mockito.when(_mailboxService.getMailboxPort()).thenReturn(mailboxPort);
 
@@ -313,7 +319,7 @@ public class MailboxReceiveOperatorTest {
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
     JsonMailboxIdentifier expectedMailboxId = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-        new VirtualServerAddress(serverHost, server2port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+        new VirtualServerAddress(serverHost, server2Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(false);
     // Receive null mailbox during timeout.
@@ -350,12 +356,14 @@ public class MailboxReceiveOperatorTest {
     int server1Port = 123;
     Mockito.when(_server1.getHostname()).thenReturn(serverHost);
     Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+    Mockito.when(_server1.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
-    int server2port = 456;
+    int server2Port = 456;
     Mockito.when(_server2.getHostname()).thenReturn(serverHost);
-    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2port);
+    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+    Mockito.when(_server2.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
-    int mailboxPort = server2port;
+    int mailboxPort = server2Port;
     Mockito.when(_mailboxService.getHostname()).thenReturn(serverHost);
     Mockito.when(_mailboxService.getMailboxPort()).thenReturn(mailboxPort);
 
@@ -366,7 +374,7 @@ public class MailboxReceiveOperatorTest {
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
     JsonMailboxIdentifier expectedMailboxId = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-        new VirtualServerAddress(serverHost, server2port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+        new VirtualServerAddress(serverHost, server2Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(false);
     Mockito.when(_mailbox.receive()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -402,12 +410,14 @@ public class MailboxReceiveOperatorTest {
     int server1Port = 123;
     Mockito.when(_server1.getHostname()).thenReturn(serverHost);
     Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+    Mockito.when(_server1.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
-    int server2port = 456;
+    int server2Port = 456;
     Mockito.when(_server2.getHostname()).thenReturn(serverHost);
-    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2port);
+    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+    Mockito.when(_server2.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
-    int mailboxPort = server2port;
+    int mailboxPort = server2Port;
     Mockito.when(_mailboxService.getHostname()).thenReturn(serverHost);
     Mockito.when(_mailboxService.getMailboxPort()).thenReturn(mailboxPort);
 
@@ -418,7 +428,7 @@ public class MailboxReceiveOperatorTest {
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
     JsonMailboxIdentifier expectedMailboxId = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-        new VirtualServerAddress(serverHost, server2port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+        new VirtualServerAddress(serverHost, server2Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(false);
     Object[] expRow = new Object[]{1, 1};
@@ -461,12 +471,14 @@ public class MailboxReceiveOperatorTest {
     int server1Port = 123;
     Mockito.when(_server1.getHostname()).thenReturn(serverHost);
     Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+    Mockito.when(_server1.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
-    int server2port = 456;
+    int server2Port = 456;
     Mockito.when(_server2.getHostname()).thenReturn(serverHost);
-    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2port);
+    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+    Mockito.when(_server2.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
-    int mailboxPort = server2port;
+    int mailboxPort = server2Port;
     Mockito.when(_mailboxService.getHostname()).thenReturn(serverHost);
     Mockito.when(_mailboxService.getMailboxPort()).thenReturn(mailboxPort);
 
@@ -477,7 +489,7 @@ public class MailboxReceiveOperatorTest {
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
     JsonMailboxIdentifier expectedMailboxId = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-        new VirtualServerAddress(serverHost, server2port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+        new VirtualServerAddress(serverHost, server2Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(false);
     Exception e = new Exception("errorBlock");
@@ -515,11 +527,13 @@ public class MailboxReceiveOperatorTest {
     int server1Port = 123;
     Mockito.when(_server1.getHostname()).thenReturn(server1Host);
     Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+    Mockito.when(_server1.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     String server2Host = "hash2";
     int server2Port = 456;
     Mockito.when(_server2.getHostname()).thenReturn(server2Host);
     Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+    Mockito.when(_server2.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     int jobId = 456;
     int stageId = 0;
@@ -575,11 +589,13 @@ public class MailboxReceiveOperatorTest {
     int server1Port = 123;
     Mockito.when(_server1.getHostname()).thenReturn(server1Host);
     Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+    Mockito.when(_server1.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     String server2Host = "hash2";
     int server2Port = 456;
     Mockito.when(_server2.getHostname()).thenReturn(server2Host);
     Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+    Mockito.when(_server2.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     int jobId = 456;
     int stageId = 0;
@@ -636,11 +652,13 @@ public class MailboxReceiveOperatorTest {
     int server1Port = 123;
     Mockito.when(_server1.getHostname()).thenReturn(server1Host);
     Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+    Mockito.when(_server1.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     String server2Host = "hash2";
     int server2Port = 456;
     Mockito.when(_server2.getHostname()).thenReturn(server2Host);
     Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+    Mockito.when(_server2.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     int jobId = 456;
     int stageId = 0;
@@ -698,11 +716,13 @@ public class MailboxReceiveOperatorTest {
     int server1Port = 123;
     Mockito.when(_server1.getHostname()).thenReturn(server1Host);
     Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+    Mockito.when(_server1.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     String server2Host = "hash2";
     int server2Port = 456;
     Mockito.when(_server2.getHostname()).thenReturn(server2Host);
     Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+    Mockito.when(_server2.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     int jobId = 456;
     int stageId = 0;
@@ -757,11 +777,13 @@ public class MailboxReceiveOperatorTest {
     int server1Port = 123;
     Mockito.when(_server1.getHostname()).thenReturn(server1Host);
     Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+    Mockito.when(_server1.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     String server2Host = "hash2";
     int server2Port = 456;
     Mockito.when(_server2.getHostname()).thenReturn(server2Host);
     Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+    Mockito.when(_server2.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     int jobId = 456;
     int stageId = 0;
@@ -812,11 +834,13 @@ public class MailboxReceiveOperatorTest {
     int server1Port = 123;
     Mockito.when(_server1.getHostname()).thenReturn(server1Host);
     Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+    Mockito.when(_server1.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     String server2Host = "hash2";
     int server2Port = 456;
     Mockito.when(_server2.getHostname()).thenReturn(server2Host);
     Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+    Mockito.when(_server2.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     int jobId = 456;
     int stageId = 0;
@@ -893,11 +917,13 @@ public class MailboxReceiveOperatorTest {
     int server1Port = 123;
     Mockito.when(_server1.getHostname()).thenReturn(server1Host);
     Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+    Mockito.when(_server1.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     String server2Host = "hash2";
     int server2Port = 456;
     Mockito.when(_server2.getHostname()).thenReturn(server2Host);
     Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+    Mockito.when(_server2.getPartitionIds()).thenReturn(Collections.singletonList(0));
 
     int jobId = 456;
     int stageId = 0;

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -73,7 +73,7 @@ public class MailboxSendOperatorTest {
 
     Mockito.when(_server.getHostname()).thenReturn("mock");
     Mockito.when(_server.getQueryMailboxPort()).thenReturn(0);
-    Mockito.when(_server.getVirtualId()).thenReturn(0);
+    Mockito.when(_server.getPartitionIds()).thenReturn(Collections.singletonList(0));
   }
 
   @AfterMethod
@@ -205,8 +205,8 @@ public class MailboxSendOperatorTest {
     stageMetadata.setServerInstances(ImmutableList.of(_server));
     Map<Integer, StageMetadata> stageMetadataMap = Collections.singletonMap(DEFAULT_RECEIVER_STAGE_ID, stageMetadata);
     OpChainExecutionContext context =
-        new OpChainExecutionContext(_mailboxService, 1, DEFAULT_SENDER_STAGE_ID, new VirtualServerAddress(_server),
-            deadlineMs, deadlineMs, stageMetadataMap);
+        new OpChainExecutionContext(_mailboxService, 1, DEFAULT_SENDER_STAGE_ID, new VirtualServerAddress(
+            _server.getHostname(), _server.getQueryMailboxPort(), 0), deadlineMs, deadlineMs, stageMetadataMap);
     return context;
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/serde/QueryPlanSerDeUtilsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/serde/QueryPlanSerDeUtilsTest.java
@@ -19,12 +19,11 @@
 
 package org.apache.pinot.query.runtime.plan.serde;
 
+import java.util.Arrays;
 import org.apache.pinot.query.routing.VirtualServer;
 import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-
-import static org.testng.Assert.*;
 
 
 public class QueryPlanSerDeUtilsTest {
@@ -33,7 +32,7 @@ public class QueryPlanSerDeUtilsTest {
   public void shouldSerializeServer() {
     // Given:
     VirtualServer server = Mockito.mock(VirtualServer.class);
-    Mockito.when(server.getVirtualId()).thenReturn(1);
+    Mockito.when(server.getPartitionIds()).thenReturn(Arrays.asList(0, 1));
     Mockito.when(server.getHostname()).thenReturn("Server_192.987.1.123");
     Mockito.when(server.getPort()).thenReturn(80);
     Mockito.when(server.getGrpcPort()).thenReturn(10);
@@ -44,19 +43,19 @@ public class QueryPlanSerDeUtilsTest {
     String serialized = QueryPlanSerDeUtils.instanceToString(server);
 
     // Then:
-    Assert.assertEquals(serialized, "1@Server_192.987.1.123:80(10:20:30)");
+    Assert.assertEquals(serialized, "[0,1]@Server_192.987.1.123:80(10:20:30)");
   }
 
   @Test
   public void shouldDeserializeServerString() {
     // Given:
-    String serverString = "1@Server_192.987.1.123:80(10:20:30)";
+    String serverString = "[0,1]@Server_192.987.1.123:80(10:20:30)";
 
     // When:
     VirtualServer server = QueryPlanSerDeUtils.stringToInstance(serverString);
 
     // Then:
-    Assert.assertEquals(server.getVirtualId(), 1);
+    Assert.assertEquals(server.getPartitionIds(), Arrays.asList(0, 1));
     Assert.assertEquals(server.getHostname(), "Server_192.987.1.123");
     Assert.assertEquals(server.getPort(), 80);
     Assert.assertEquals(server.getGrpcPort(), 10);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/QueryServerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/QueryServerTest.java
@@ -145,7 +145,7 @@ public class QueryServerTest extends QueryTestSet {
 
   private static boolean isMetadataMapsEqual(StageMetadata left, StageMetadata right) {
     return left.getServerInstances().equals(right.getServerInstances())
-        && left.getServerInstanceToSegmentsMap().equals(right.getServerInstanceToSegmentsMap())
+        && left.getServerAndPartitionToSegmentMap().equals(right.getServerAndPartitionToSegmentMap())
         && left.getScannedTables().equals(right.getScannedTables());
   }
 


### PR DESCRIPTION
previously with https://github.com/apache/pinot/pull/10157 we dispatch 1 request per virtual server. this causes lots of issues when parallelism is high --> as broker becomes the bottleneck creating dispatch payloads

Details
==
This PR makes VirutalServer containing 
- physical `ServerInstance`
- list of `partitionIds`
and makes QueryDispatcher to
- dispatch and generate 1 request per single physical server with all partitions associated
- partitions are globally indexed

TODO list
==
- [x] change VirtualServer interface
- [x] change dispatch mechanism (backward-incompatible)
- [ ] add tests

relates to #9611 