### PR TITLE
fix msal4j dependency version

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -97,7 +97,7 @@
       <dependency>
         <groupId>com.microsoft.azure</groupId>
         <artifactId>msal4j</artifactId>
-        <version>1.8.0</version>
+        <version>1.13.5</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
one msal4j version change was missed in https://github.com/apache/pinot/pull/10495, this PR fixes the issue