### PR TITLE
Use genericRow from the caller to update lookup table results

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/MemoryOptimizedDimensionTable.java
@@ -37,7 +37,7 @@ class MemoryOptimizedDimensionTable implements DimensionTable {
   private final Map<PrimaryKey, LookupRecordLocation> _lookupTable;
   private final Schema _tableSchema;
   private final List<String> _primaryKeyColumns;
-  private final GenericRow _reuse = new GenericRow();
+  private final ThreadLocal<GenericRow> _reuse = ThreadLocal.withInitial(GenericRow::new);
   private final List<SegmentDataManager> _segmentDataManagers;
   private final TableDataManager _tableDataManager;
 
@@ -62,7 +62,9 @@ class MemoryOptimizedDimensionTable implements DimensionTable {
     if (lookupRecordLocation == null) {
       return null;
     }
-    return lookupRecordLocation.getRecord(_reuse);
+    GenericRow reuse = _reuse.get();
+    reuse.clear();
+    return lookupRecordLocation.getRecord(reuse);
   }
 
   @Override


### PR DESCRIPTION
Currently we use `_reuse` object in the `MemoryOptimizedDimensionTable` class to update the results.

This however is not thread safe when `.get` function is called from multiple threads.

There are three possible solutions to this - 
1. Use synchronized on the .get method which makes it slow
2. Create a new `GenericRow` object  for every `.get` call which leads to higher memory usage
3. Pass the `GenericRow` object created in the `LookupTransfrom` function. The transform function should create one object per execution ensuring they are not shared.
4. Use ThreadLocal shared `GenericRow`

I have gone with the 4th approach here.