### PR TITLE
Allow configurable socket timeout during segment downloads.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -1165,6 +1165,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
    * Download a file.
    *
    * @param uri URI
+   * @param socketTimeoutMs socketTimeoutMs
    * @param dest File destination
    * @param authProvider auth provider
    * @param httpHeaders http headers

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -1131,6 +1131,22 @@ public class FileUploadDownloadClient implements AutoCloseable {
   }
 
   /**
+   * Download a file with a configurable timeout
+   *
+   * @param uri URI
+   * @param dest File destination
+   * @param authProvider auth provider
+   * @param socketTimeoutMs connection socket timeout ms
+   * @return Response status code
+   * @throws IOException
+   * @throws HttpErrorStatusException
+   */
+  public int downloadFile(URI uri, File dest, AuthProvider authProvider, int socketTimeoutMs)
+      throws IOException, HttpErrorStatusException {
+    return _httpClient.downloadFile(uri, socketTimeoutMs, dest, authProvider, null);
+  }
+
+  /**
    * Download a file.
    *
    * @param uri URI
@@ -1156,9 +1172,9 @@ public class FileUploadDownloadClient implements AutoCloseable {
    * @throws IOException
    * @throws HttpErrorStatusException
    */
-  public int downloadFile(URI uri, File dest, AuthProvider authProvider, List<Header> httpHeaders)
+  public int downloadFile(URI uri, int socketTimeoutMs, File dest, AuthProvider authProvider, List<Header> httpHeaders)
       throws IOException, HttpErrorStatusException {
-    return _httpClient.downloadFile(uri, HttpClient.DEFAULT_SOCKET_TIMEOUT_MS, dest, authProvider, httpHeaders);
+    return _httpClient.downloadFile(uri, socketTimeoutMs, dest, authProvider, httpHeaders);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
@@ -23,6 +23,7 @@ import java.net.URI;
 import java.util.List;
 import java.util.Random;
 import org.apache.pinot.common.auth.AuthProviderUtils;
+import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -38,15 +39,18 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
   public static final String RETRY_COUNT_CONFIG_KEY = "retry.count";
   public static final String RETRY_WAIT_MS_CONFIG_KEY = "retry.wait.ms";
   public static final String RETRY_DELAY_SCALE_FACTOR_CONFIG_KEY = "retry.delay.scale.factor";
+  public static final String CONNECTION_SOCKET_TIMEOUT_MS = "socket.timeout.ms";
   public static final int DEFAULT_RETRY_COUNT = 3;
   public static final int DEFAULT_RETRY_WAIT_MS = 100;
   public static final int DEFAULT_RETRY_DELAY_SCALE_FACTOR = 5;
+  public static final int DEFAULT_SOCKET_TIMEOUT_MS = HttpClient.DEFAULT_SOCKET_TIMEOUT_MS;
 
   protected final Logger _logger = LoggerFactory.getLogger(getClass().getSimpleName());
 
   protected int _retryCount;
   protected int _retryWaitMs;
   protected int _retryDelayScaleFactor;
+  protected int _socketTimeoutMs;
   protected AuthProvider _authProvider;
 
   @Override
@@ -54,11 +58,11 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
     _retryCount = config.getProperty(RETRY_COUNT_CONFIG_KEY, DEFAULT_RETRY_COUNT);
     _retryWaitMs = config.getProperty(RETRY_WAIT_MS_CONFIG_KEY, DEFAULT_RETRY_WAIT_MS);
     _retryDelayScaleFactor = config.getProperty(RETRY_DELAY_SCALE_FACTOR_CONFIG_KEY, DEFAULT_RETRY_DELAY_SCALE_FACTOR);
+    _socketTimeoutMs = config.getProperty(CONNECTION_SOCKET_TIMEOUT_MS, DEFAULT_SOCKET_TIMEOUT_MS);
     _authProvider = AuthProviderUtils.extractAuthProvider(config, CommonConstants.KEY_OF_AUTH);
     doInit(config);
-    _logger
-        .info("Initialized with retryCount: {}, retryWaitMs: {}, retryDelayScaleFactor: {}", _retryCount, _retryWaitMs,
-            _retryDelayScaleFactor);
+    _logger.info("Initialized with retryCount: {}, retryWaitMs: {}, retryDelayScaleFactor: {}, sockeTimeoutMs: {}",
+        _retryCount, _retryWaitMs, _retryDelayScaleFactor, _socketTimeoutMs);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -68,7 +68,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
         if (!InetAddresses.isInetAddress(hostName)) {
           httpHeaders.add(new BasicHeader(HttpHeaders.HOST, hostName + ":" + port));
         }
-        int statusCode = _httpClient.downloadFile(uri, dest, _authProvider, httpHeaders);
+        int statusCode = _httpClient.downloadFile(uri, _socketTimeoutMs, dest, _authProvider, httpHeaders);
         _logger
             .info("Downloaded segment from: {} to: {} of size: {}; Response status code: {}", uri, dest, dest.length(),
                 statusCode);
@@ -151,7 +151,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
   public void fetchSegmentToLocalWithoutRetry(URI uri, File dest)
       throws Exception {
     try {
-      int statusCode = _httpClient.downloadFile(uri, dest, _authProvider);
+      int statusCode = _httpClient.downloadFile(uri, dest, _authProvider, _socketTimeoutMs);
       _logger.info("Downloaded segment from: {} to: {} of size: {}; Response status code: {}", uri, dest, dest.length(),
           statusCode);
     } catch (Exception e) {


### PR DESCRIPTION
Today the socket timeout during segment download is hardcoded to be 10mins. In some large use cases this timeout is too long and result in connection pool exhaustion. This PR makes the timeout configurable.