### PR TITLE
Allow configuring helix timeouts for EV dropped in Instance manager

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -131,14 +131,14 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   // Check if the external view is dropped for a table, and if so, wait for the external view to
   // be updated for a maximum of this time.
   private static final String EXTERNAL_VIEW_DROPPED_MAX_WAIT_MS = "external.view.dropped.max.wait.ms";
-  private static final String EXTERNAL_VIEW_CHECK_INTERVAL_MS = "external.view.check.interval.ms";
+  private static final String EXTERNAL_VIEW_DROPPED_CHECK_INTERVAL_MS = "external.view.dropped.check.interval.ms";
 
   private final static String[] REQUIRED_KEYS = {INSTANCE_ID};
   private static final long DEFAULT_ERROR_CACHE_SIZE = 100L;
   private static final int DEFAULT_DELETED_SEGMENTS_CACHE_SIZE = 10_000;
   private static final int DEFAULT_DELETED_SEGMENTS_CACHE_TTL_MINUTES = 2;
   public static final long DEFAULT_EXTERNAL_VIEW_DROPPED_MAX_WAIT_MS = 20 * 60_000L;
-  public static final long DEFAULT_EXTERNAL_VIEW_CHECK_INTERVAL_MS = 1_000L;
+  public static final long DEFAULT_EXTERNAL_VIEW_DROPPED_CHECK_INTERVAL_MS = 1_000L;
 
   private final PinotConfiguration _instanceDataManagerConfiguration;
 
@@ -297,9 +297,9 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   }
 
   @Override
-  public long getExternalViewCheckIntervalMs() {
-    return _instanceDataManagerConfiguration.getProperty(EXTERNAL_VIEW_CHECK_INTERVAL_MS,
-        DEFAULT_EXTERNAL_VIEW_CHECK_INTERVAL_MS);
+  public long getExternalViewDroppedCheckIntervalMs() {
+    return _instanceDataManagerConfiguration.getProperty(EXTERNAL_VIEW_DROPPED_CHECK_INTERVAL_MS,
+        DEFAULT_EXTERNAL_VIEW_DROPPED_CHECK_INTERVAL_MS);
   }
 
   @Override

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -128,10 +128,17 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   private static final String DELETED_SEGMENTS_CACHE_TTL_MINUTES = "table.deleted.segments.cache.ttl.minutes";
   private static final String PEER_DOWNLOAD_SCHEME = "peer.download.scheme";
 
+  // Check if the external view is dropped for a table, and if so, wait for the external view to
+  // be updated for a maximum of this time.
+  private static final String EXTERNAL_VIEW_DROPPED_MAX_WAIT_MS = "external.view.dropped.max.wait.ms";
+  private static final String EXTERNAL_VIEW_CHECK_INTERVAL_MS = "external.view.check.interval.ms";
+
   private final static String[] REQUIRED_KEYS = {INSTANCE_ID};
   private static final long DEFAULT_ERROR_CACHE_SIZE = 100L;
   private static final int DEFAULT_DELETED_SEGMENTS_CACHE_SIZE = 10_000;
   private static final int DEFAULT_DELETED_SEGMENTS_CACHE_TTL_MINUTES = 2;
+  public static final long DEFAULT_EXTERNAL_VIEW_DROPPED_MAX_WAIT_MS = 20 * 60_000L;
+  public static final long DEFAULT_EXTERNAL_VIEW_CHECK_INTERVAL_MS = 1_000L;
 
   private final PinotConfiguration _instanceDataManagerConfiguration;
 
@@ -281,6 +288,18 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   @Override
   public String getSegmentPeerDownloadScheme() {
     return _instanceDataManagerConfiguration.getProperty(PEER_DOWNLOAD_SCHEME);
+  }
+
+  @Override
+  public long getExternalViewDroppedMaxWaitMs() {
+    return _instanceDataManagerConfiguration.getProperty(EXTERNAL_VIEW_DROPPED_MAX_WAIT_MS,
+        DEFAULT_EXTERNAL_VIEW_DROPPED_MAX_WAIT_MS);
+  }
+
+  @Override
+  public long getExternalViewCheckIntervalMs() {
+    return _instanceDataManagerConfiguration.getProperty(EXTERNAL_VIEW_CHECK_INTERVAL_MS,
+        DEFAULT_EXTERNAL_VIEW_CHECK_INTERVAL_MS);
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -68,4 +68,8 @@ public interface InstanceDataManagerConfig {
   int getDeletedSegmentsCacheTtlMinutes();
 
   String getSegmentPeerDownloadScheme();
+
+  long getExternalViewDroppedMaxWaitMs();
+
+  long getExternalViewCheckIntervalMs();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -71,5 +71,5 @@ public interface InstanceDataManagerConfig {
 
   long getExternalViewDroppedMaxWaitMs();
 
-  long getExternalViewCheckIntervalMs();
+  long getExternalViewDroppedCheckIntervalMs();
 }


### PR DESCRIPTION
We can set the following configs to configure the timeout

`external.view.dropped.max.wait.ms` - The duration of time in milliseconds to wait for the external view to be dropped. Default - 20 minutes.

`external.view.check.interval.ms` - The period in milliseconds in which to ping ZK for latest EV state.
