### PR TITLE
Allow ValueBlock length to increase in TransformFunction

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunction.java
@@ -88,9 +88,7 @@ public class AdditionTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     if (_resultDataType == DataType.BIG_DECIMAL) {
       BigDecimal[] values = transformToBigDecimalValuesSV(valueBlock);
       ArrayCopyUtils.copy(values, _doubleValuesSV, length);
@@ -109,9 +107,7 @@ public class AdditionTransformFunction extends BaseTransformFunction {
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null) {
-      _bigDecimalValuesSV = new BigDecimal[length];
-    }
+    initBigDecimalValuesSV(length);
     if (_resultDataType == DataType.DOUBLE) {
       double[] values = transformToDoubleValuesSV(valueBlock);
       ArrayCopyUtils.copy(values, _bigDecimalValuesSV, length);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayAverageTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayAverageTransformFunction.java
@@ -70,9 +70,7 @@ public class ArrayAverageTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     switch (_argument.getResultMetadata().getDataType().getStoredType()) {
       case INT:
         int[][] intValuesMV = _argument.transformToIntValuesMV(valueBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLengthTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLengthTransformFunction.java
@@ -67,9 +67,7 @@ public class ArrayLengthTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[length];
-    }
+    initIntValuesSV(length);
     switch (_argument.getResultMetadata().getDataType().getStoredType()) {
       case INT:
         int[][] intValuesMV = _argument.transformToIntValuesMV(valueBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMaxTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMaxTransformFunction.java
@@ -74,9 +74,7 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
       return super.transformToIntValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[length];
-    }
+    initIntValuesSV(length);
     int[][] intValuesMV = _argument.transformToIntValuesMV(valueBlock);
     for (int i = 0; i < length; i++) {
       int maxRes = Integer.MIN_VALUE;
@@ -94,9 +92,7 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
       return super.transformToLongValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[length];
-    }
+    initLongValuesSV(length);
     long[][] longValuesMV = _argument.transformToLongValuesMV(valueBlock);
     for (int i = 0; i < length; i++) {
       long maxRes = Long.MIN_VALUE;
@@ -114,9 +110,7 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
       return super.transformToFloatValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_floatValuesSV == null) {
-      _floatValuesSV = new float[length];
-    }
+    initFloatValuesSV(length);
     float[][] floatValuesMV = _argument.transformToFloatValuesMV(valueBlock);
     for (int i = 0; i < length; i++) {
       float maxRes = Float.NEGATIVE_INFINITY;
@@ -134,9 +128,7 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
       return super.transformToDoubleValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     double[][] doubleValuesMV = _argument.transformToDoubleValuesMV(valueBlock);
     for (int i = 0; i < length; i++) {
       double maxRes = Double.NEGATIVE_INFINITY;
@@ -154,9 +146,7 @@ public class ArrayMaxTransformFunction extends BaseTransformFunction {
       return super.transformToStringValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[length];
-    }
+    initStringValuesSV(length);
     String[][] stringValuesMV = _argument.transformToStringValuesMV(valueBlock);
     for (int i = 0; i < length; i++) {
       String maxRes = null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMinTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayMinTransformFunction.java
@@ -74,9 +74,7 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
       return super.transformToIntValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[length];
-    }
+    initIntValuesSV(length);
     int[][] intValuesMV = _argument.transformToIntValuesMV(valueBlock);
     for (int i = 0; i < length; i++) {
       int minRes = Integer.MAX_VALUE;
@@ -94,9 +92,7 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
       return super.transformToLongValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[length];
-    }
+    initLongValuesSV(length);
     long[][] longValuesMV = _argument.transformToLongValuesMV(valueBlock);
     for (int i = 0; i < length; i++) {
       long minRes = Long.MAX_VALUE;
@@ -114,9 +110,7 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
       return super.transformToFloatValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_floatValuesSV == null) {
-      _floatValuesSV = new float[length];
-    }
+    initFloatValuesSV(length);
     float[][] floatValuesMV = _argument.transformToFloatValuesMV(valueBlock);
     for (int i = 0; i < length; i++) {
       float minRes = Float.POSITIVE_INFINITY;
@@ -134,9 +128,7 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
       return super.transformToDoubleValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     double[][] doubleValuesMV = _argument.transformToDoubleValuesMV(valueBlock);
     for (int i = 0; i < length; i++) {
       double minRes = Double.POSITIVE_INFINITY;
@@ -154,9 +146,7 @@ public class ArrayMinTransformFunction extends BaseTransformFunction {
       return super.transformToStringValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[length];
-    }
+    initStringValuesSV(length);
     String[][] stringValuesMV = _argument.transformToStringValuesMV(valueBlock);
     for (int i = 0; i < length; i++) {
       String minRes = null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArraySumTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArraySumTransformFunction.java
@@ -70,9 +70,7 @@ public class ArraySumTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     double[][] doubleValuesMV = _argument.transformToDoubleValuesMV(valueBlock);
     for (int i = 0; i < length; i++) {
       double sumRes = 0;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
@@ -78,7 +78,6 @@ public abstract class BaseTransformFunction implements TransformFunction {
       new TransformResultMetadata(DataType.STRING, false, false);
   protected static final TransformResultMetadata JSON_MV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.JSON, false, false);
-  // TODO: Support MV BYTES
   protected static final TransformResultMetadata BYTES_MV_NO_DICTIONARY_METADATA =
       new TransformResultMetadata(DataType.BYTES, false, false);
 
@@ -122,12 +121,16 @@ public abstract class BaseTransformFunction implements TransformFunction {
     throw new UnsupportedOperationException();
   }
 
+  protected void initIntValuesSV(int length) {
+    if (_intValuesSV == null || _intValuesSV.length < length) {
+      _intValuesSV = new int[length];
+    }
+  }
+
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[length];
-    }
+    initIntValuesSV(length);
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(valueBlock);
@@ -168,11 +171,10 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return _intValuesSV;
   }
 
+  @Override
   public Pair<int[], RoaringBitmap> transformToIntValuesSVWithNull(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[length];
-    }
+    initIntValuesSV(length);
     RoaringBitmap bitmap;
     DataType resultDataType = getResultMetadata().getDataType();
     switch (resultDataType.getStoredType()) {
@@ -219,12 +221,16 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return ImmutablePair.of(_intValuesSV, bitmap);
   }
 
+  protected void initLongValuesSV(int length) {
+    if (_longValuesSV == null || _longValuesSV.length < length) {
+      _longValuesSV = new long[length];
+    }
+  }
+
   @Override
   public long[] transformToLongValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[length];
-    }
+    initLongValuesSV(length);
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(valueBlock);
@@ -268,9 +274,7 @@ public abstract class BaseTransformFunction implements TransformFunction {
   @Override
   public Pair<long[], RoaringBitmap> transformToLongValuesSVWithNull(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[length];
-    }
+    initLongValuesSV(length);
     RoaringBitmap bitmap;
     DataType resultDataType = getResultMetadata().getDataType();
     switch (resultDataType.getStoredType()) {
@@ -317,12 +321,16 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return ImmutablePair.of(_longValuesSV, bitmap);
   }
 
+  protected void initFloatValuesSV(int length) {
+    if (_floatValuesSV == null || _floatValuesSV.length < length) {
+      _floatValuesSV = new float[length];
+    }
+  }
+
   @Override
   public float[] transformToFloatValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_floatValuesSV == null) {
-      _floatValuesSV = new float[length];
-    }
+    initFloatValuesSV(length);
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(valueBlock);
@@ -366,9 +374,7 @@ public abstract class BaseTransformFunction implements TransformFunction {
   @Override
   public Pair<float[], RoaringBitmap> transformToFloatValuesSVWithNull(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_floatValuesSV == null) {
-      _floatValuesSV = new float[length];
-    }
+    initFloatValuesSV(length);
     RoaringBitmap bitmap;
     DataType resultDataType = getResultMetadata().getDataType();
     switch (resultDataType.getStoredType()) {
@@ -415,12 +421,16 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return ImmutablePair.of(_floatValuesSV, bitmap);
   }
 
+  protected void initDoubleValuesSV(int length) {
+    if (_doubleValuesSV == null || _doubleValuesSV.length < length) {
+      _doubleValuesSV = new double[length];
+    }
+  }
+
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(valueBlock);
@@ -464,9 +474,7 @@ public abstract class BaseTransformFunction implements TransformFunction {
   @Override
   public Pair<double[], RoaringBitmap> transformToDoubleValuesSVWithNull(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     RoaringBitmap bitmap;
     DataType resultDataType = getResultMetadata().getDataType();
     switch (resultDataType.getStoredType()) {
@@ -513,12 +521,16 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return ImmutablePair.of(_doubleValuesSV, bitmap);
   }
 
+  protected void initBigDecimalValuesSV(int length) {
+    if (_bigDecimalValuesSV == null || _bigDecimalValuesSV.length < length) {
+      _bigDecimalValuesSV = new BigDecimal[length];
+    }
+  }
+
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null) {
-      _bigDecimalValuesSV = new BigDecimal[length];
-    }
+    initBigDecimalValuesSV(length);
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(valueBlock);
@@ -563,11 +575,10 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return _bigDecimalValuesSV;
   }
 
+  @Override
   public Pair<BigDecimal[], RoaringBitmap> transformToBigDecimalValuesSVWithNull(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null) {
-      _bigDecimalValuesSV = new BigDecimal[length];
-    }
+    initBigDecimalValuesSV(length);
     RoaringBitmap bitmap;
     DataType resultDataType = getResultMetadata().getDataType();
     switch (resultDataType.getStoredType()) {
@@ -619,12 +630,16 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return ImmutablePair.of(_bigDecimalValuesSV, bitmap);
   }
 
+  protected void initStringValuesSV(int length) {
+    if (_stringValuesSV == null || _stringValuesSV.length < length) {
+      _stringValuesSV = new String[length];
+    }
+  }
+
   @Override
   public String[] transformToStringValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[length];
-    }
+    initStringValuesSV(length);
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(valueBlock);
@@ -669,11 +684,10 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return _stringValuesSV;
   }
 
+  @Override
   public Pair<String[], RoaringBitmap> transformToStringValuesSVWithNull(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[length];
-    }
+    initStringValuesSV(length);
     RoaringBitmap bitmap;
     DataType resultDataType = getResultMetadata().getDataType();
     switch (resultDataType.getStoredType()) {
@@ -725,12 +739,16 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return ImmutablePair.of(_stringValuesSV, bitmap);
   }
 
+  protected void initBytesValuesSV(int length) {
+    if (_bytesValuesSV == null || _bytesValuesSV.length < length) {
+      _bytesValuesSV = new byte[length][];
+    }
+  }
+
   @Override
   public byte[][] transformToBytesValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_bytesValuesSV == null) {
-      _bytesValuesSV = new byte[length][];
-    }
+    initBytesValuesSV(length);
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[] dictIds = transformToDictIdsSV(valueBlock);
@@ -762,9 +780,7 @@ public abstract class BaseTransformFunction implements TransformFunction {
   @Override
   public Pair<byte[][], RoaringBitmap> transformToBytesValuesSVWithNull(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_bytesValuesSV == null) {
-      _bytesValuesSV = new byte[length][];
-    }
+    initBytesValuesSV(length);
     RoaringBitmap bitmap;
     DataType resultDataType = getResultMetadata().getDataType();
     switch (resultDataType.getStoredType()) {
@@ -796,12 +812,16 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return ImmutablePair.of(_bytesValuesSV, bitmap);
   }
 
+  protected void initIntValuesMV(int length) {
+    if (_intValuesMV == null || _intValuesMV.length < length) {
+      _intValuesMV = new int[length][];
+    }
+  }
+
   @Override
   public int[][] transformToIntValuesMV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesMV == null) {
-      _intValuesMV = new int[length][];
-    }
+    initIntValuesMV(length);
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(valueBlock);
@@ -847,9 +867,7 @@ public abstract class BaseTransformFunction implements TransformFunction {
   @Override
   public Pair<int[][], RoaringBitmap> transformToIntValuesMVWithNull(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesMV == null) {
-      _intValuesMV = new int[length][];
-    }
+    initIntValuesMV(length);
     RoaringBitmap bitmap;
     DataType resultDataType = getResultMetadata().getDataType();
     switch (resultDataType.getStoredType()) {
@@ -891,12 +909,16 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return ImmutablePair.of(_intValuesMV, bitmap);
   }
 
+  protected void initLongValuesMV(int length) {
+    if (_longValuesMV == null || _longValuesMV.length < length) {
+      _longValuesMV = new long[length][];
+    }
+  }
+
   @Override
   public long[][] transformToLongValuesMV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_longValuesMV == null) {
-      _longValuesMV = new long[length][];
-    }
+    initLongValuesMV(length);
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(valueBlock);
@@ -942,9 +964,7 @@ public abstract class BaseTransformFunction implements TransformFunction {
   @Override
   public Pair<long[][], RoaringBitmap> transformToLongValuesMVWithNull(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_longValuesMV == null) {
-      _longValuesMV = new long[length][];
-    }
+    initLongValuesMV(length);
     RoaringBitmap bitmap;
     DataType resultDataType = getResultMetadata().getDataType();
     switch (resultDataType.getStoredType()) {
@@ -982,12 +1002,16 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return ImmutablePair.of(_longValuesMV, bitmap);
   }
 
+  protected void initFloatValuesMV(int length) {
+    if (_floatValuesMV == null || _floatValuesMV.length < length) {
+      _floatValuesMV = new float[length][];
+    }
+  }
+
   @Override
   public float[][] transformToFloatValuesMV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_floatValuesMV == null) {
-      _floatValuesMV = new float[length][];
-    }
+    initFloatValuesMV(length);
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(valueBlock);
@@ -1033,9 +1057,7 @@ public abstract class BaseTransformFunction implements TransformFunction {
   @Override
   public Pair<float[][], RoaringBitmap> transformToFloatValuesMVWithNull(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_floatValuesMV == null) {
-      _floatValuesMV = new float[length][];
-    }
+    initFloatValuesMV(length);
     RoaringBitmap bitmap;
     DataType resultDataType = getResultMetadata().getDataType();
     switch (resultDataType.getStoredType()) {
@@ -1077,12 +1099,16 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return ImmutablePair.of(_floatValuesMV, bitmap);
   }
 
+  protected void initDoubleValuesMV(int length) {
+    if (_doubleValuesMV == null || _doubleValuesMV.length < length) {
+      _doubleValuesMV = new double[length][];
+    }
+  }
+
   @Override
   public double[][] transformToDoubleValuesMV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesMV == null) {
-      _doubleValuesMV = new double[length][];
-    }
+    initDoubleValuesMV(length);
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(valueBlock);
@@ -1125,11 +1151,10 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return _doubleValuesMV;
   }
 
+  @Override
   public Pair<double[][], RoaringBitmap> transformToDoubleValuesMVWithNull(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesMV == null) {
-      _doubleValuesMV = new double[length][];
-    }
+    initDoubleValuesMV(length);
     RoaringBitmap bitmap;
     DataType resultDataType = getResultMetadata().getDataType();
     switch (resultDataType.getStoredType()) {
@@ -1171,12 +1196,16 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return ImmutablePair.of(_doubleValuesMV, bitmap);
   }
 
+  protected void initStringValuesMV(int length) {
+    if (_stringValuesMV == null || _stringValuesMV.length < length) {
+      _stringValuesMV = new String[length][];
+    }
+  }
+
   @Override
   public String[][] transformToStringValuesMV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_stringValuesMV == null) {
-      _stringValuesMV = new String[length][];
-    }
+    initStringValuesMV(length);
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(valueBlock);
@@ -1219,11 +1248,10 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return _stringValuesMV;
   }
 
+  @Override
   public Pair<String[][], RoaringBitmap> transformToStringValuesMVWithNull(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_stringValuesMV == null) {
-      _stringValuesMV = new String[length][];
-    }
+    initStringValuesMV(length);
     RoaringBitmap bitmap;
     DataType resultDataType = getResultMetadata().getDataType();
     switch (resultDataType) {
@@ -1265,12 +1293,16 @@ public abstract class BaseTransformFunction implements TransformFunction {
     return ImmutablePair.of(_stringValuesMV, bitmap);
   }
 
+  protected void initBytesValuesMV(int length) {
+    if (_bytesValuesMV == null || _bytesValuesMV.length < length) {
+      _bytesValuesMV = new byte[length][][];
+    }
+  }
+
   @Override
   public byte[][][] transformToBytesValuesMV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_bytesValuesMV == null) {
-      _bytesValuesMV = new byte[length][][];
-    }
+    initBytesValuesMV(length);
     Dictionary dictionary = getDictionary();
     if (dictionary != null) {
       int[][] dictIdsMV = transformToDictIdsMV(valueBlock);
@@ -1292,9 +1324,7 @@ public abstract class BaseTransformFunction implements TransformFunction {
   @Override
   public Pair<byte[][][], RoaringBitmap> transformToBytesValuesMVWithNull(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_bytesValuesMV == null) {
-      _bytesValuesMV = new byte[length][][];
-    }
+    initBytesValuesMV(length);
     RoaringBitmap bitmap;
     DataType resultDataType = getResultMetadata().getDataType();
     switch (resultDataType) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunction.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator.transform.function;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -124,6 +125,14 @@ public abstract class BaseTransformFunction implements TransformFunction {
   protected void initIntValuesSV(int length) {
     if (_intValuesSV == null || _intValuesSV.length < length) {
       _intValuesSV = new int[length];
+    }
+  }
+
+  protected void initZeroFillingIntValuesSV(int length) {
+    if (_intValuesSV == null || _intValuesSV.length < length) {
+      _intValuesSV = new int[length];
+    } else {
+      Arrays.fill(_intValuesSV, 0, length, 0);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/BinaryOperatorTransformFunction.java
@@ -112,9 +112,7 @@ public abstract class BinaryOperatorTransformFunction extends BaseTransformFunct
 
   private void fillResultArray(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[length];
-    }
+    initIntValuesSV(length);
     switch (_leftStoredType) {
       case INT:
         fillResultInt(valueBlock, length);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -282,9 +282,7 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     int[] selected = getSelectedArray(valueBlock);
     int numDocs = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[numDocs];
-    }
+    initIntValuesSV(numDocs);
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
       if (_selections[i]) {
@@ -311,9 +309,7 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     int[] selected = getSelectedArray(valueBlock);
     int numDocs = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[numDocs];
-    }
+    initLongValuesSV(numDocs);
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
       if (_selections[i]) {
@@ -340,9 +336,7 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     int[] selected = getSelectedArray(valueBlock);
     int numDocs = valueBlock.getNumDocs();
-    if (_floatValuesSV == null) {
-      _floatValuesSV = new float[numDocs];
-    }
+    initFloatValuesSV(numDocs);
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
       if (_selections[i]) {
@@ -369,9 +363,7 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     int[] selected = getSelectedArray(valueBlock);
     int numDocs = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[numDocs];
-    }
+    initDoubleValuesSV(numDocs);
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
       if (_selections[i]) {
@@ -398,9 +390,7 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     int[] selected = getSelectedArray(valueBlock);
     int numDocs = valueBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null) {
-      _bigDecimalValuesSV = new BigDecimal[numDocs];
-    }
+    initBigDecimalValuesSV(numDocs);
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
       if (_selections[i]) {
@@ -427,9 +417,7 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     int[] selected = getSelectedArray(valueBlock);
     int numDocs = valueBlock.getNumDocs();
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[numDocs];
-    }
+    initStringValuesSV(numDocs);
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
       if (_selections[i]) {
@@ -456,9 +444,7 @@ public class CaseTransformFunction extends BaseTransformFunction {
     }
     int[] selected = getSelectedArray(valueBlock);
     int numDocs = valueBlock.getNumDocs();
-    if (_bytesValuesSV == null) {
-      _bytesValuesSV = new byte[numDocs][];
-    }
+    initBytesValuesSV(numDocs);
     int numElseThenStatements = _elseThenStatements.size();
     for (int i = 0; i < numElseThenStatements; i++) {
       if (_selections[i]) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CastTransformFunction.java
@@ -118,9 +118,7 @@ public class CastTransformFunction extends BaseTransformFunction {
   // TODO: Add it to the interface
   private int[] transformToBooleanValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[length];
-    }
+    initIntValuesSV(length);
     switch (_sourceDataType.getStoredType()) {
       case INT:
         int[] intValues = _transformFunction.transformToIntValuesSV(valueBlock);
@@ -168,9 +166,7 @@ public class CastTransformFunction extends BaseTransformFunction {
   private long[] transformToTimestampValuesSV(ValueBlock valueBlock) {
     if (_sourceDataType.getStoredType() == DataType.STRING) {
       int length = valueBlock.getNumDocs();
-      if (_longValuesSV == null) {
-        _longValuesSV = new long[length];
-      }
+      initLongValuesSV(length);
       String[] stringValues = _transformFunction.transformToStringValuesSV(valueBlock);
       ArrayCopyUtils.copyToTimestamp(stringValues, _longValuesSV, length);
       return _longValuesSV;
@@ -213,17 +209,13 @@ public class CastTransformFunction extends BaseTransformFunction {
       switch (_sourceDataType) {
         case BOOLEAN:
           int length = valueBlock.getNumDocs();
-          if (_stringValuesSV == null) {
-            _stringValuesSV = new String[length];
-          }
+          initStringValuesSV(length);
           int[] intValues = _transformFunction.transformToIntValuesSV(valueBlock);
           ArrayCopyUtils.copyFromBoolean(intValues, _stringValuesSV, length);
           return _stringValuesSV;
         case TIMESTAMP:
           length = valueBlock.getNumDocs();
-          if (_stringValuesSV == null) {
-            _stringValuesSV = new String[length];
-          }
+          initStringValuesSV(length);
           long[] longValues = _transformFunction.transformToLongValuesSV(valueBlock);
           ArrayCopyUtils.copyFromTimestamp(longValues, _stringValuesSV, length);
           return _stringValuesSV;
@@ -232,9 +224,7 @@ public class CastTransformFunction extends BaseTransformFunction {
       }
     } else {
       int length = valueBlock.getNumDocs();
-      if (_stringValuesSV == null) {
-        _stringValuesSV = new String[length];
-      }
+      initStringValuesSV(length);
       switch (resultDataType) {
         case INT:
           int[] intValues = _transformFunction.transformToIntValuesSV(valueBlock);
@@ -290,9 +280,7 @@ public class CastTransformFunction extends BaseTransformFunction {
   // TODO: Add it to the interface
   private int[][] transformToBooleanValuesMV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesMV == null) {
-      _intValuesMV = new int[length][];
-    }
+    initIntValuesMV(length);
     switch (_sourceDataType.getStoredType()) {
       case INT:
         int[][] intValuesMV = _transformFunction.transformToIntValuesMV(valueBlock);
@@ -336,9 +324,7 @@ public class CastTransformFunction extends BaseTransformFunction {
   private long[][] transformToTimestampValuesMV(ValueBlock valueBlock) {
     if (_sourceDataType.getStoredType() == DataType.STRING) {
       int length = valueBlock.getNumDocs();
-      if (_longValuesMV == null) {
-        _longValuesMV = new long[length][];
-      }
+      initLongValuesMV(length);
       String[][] stringValuesMV = _transformFunction.transformToStringValuesMV(valueBlock);
       ArrayCopyUtils.copyToTimestamp(stringValuesMV, _longValuesMV, length);
       return _longValuesMV;
@@ -372,17 +358,13 @@ public class CastTransformFunction extends BaseTransformFunction {
       switch (_sourceDataType) {
         case BOOLEAN:
           int length = valueBlock.getNumDocs();
-          if (_stringValuesMV == null) {
-            _stringValuesMV = new String[length][];
-          }
+          initStringValuesMV(length);
           int[][] intValuesMV = _transformFunction.transformToIntValuesMV(valueBlock);
           ArrayCopyUtils.copyFromBoolean(intValuesMV, _stringValuesMV, length);
           return _stringValuesMV;
         case TIMESTAMP:
           length = valueBlock.getNumDocs();
-          if (_stringValuesMV == null) {
-            _stringValuesMV = new String[length][];
-          }
+          initStringValuesMV(length);
           long[][] longValuesMV = _transformFunction.transformToLongValuesMV(valueBlock);
           ArrayCopyUtils.copyFromTimestamp(longValuesMV, _stringValuesMV, length);
           return _stringValuesMV;
@@ -391,9 +373,7 @@ public class CastTransformFunction extends BaseTransformFunction {
       }
     } else {
       int length = valueBlock.getNumDocs();
-      if (_stringValuesMV == null) {
-        _stringValuesMV = new String[length][];
-      }
+      initStringValuesMV(length);
       switch (resultDataType) {
         case INT:
           int[][] intValuesMV = _transformFunction.transformToIntValuesMV(valueBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunction.java
@@ -113,9 +113,7 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
    */
   private int[] getIntTransformResults(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[length];
-    }
+    initIntValuesSV(length);
     int width = _transformFunctions.length;
     RoaringBitmap[] nullBitMaps = getNullBitMaps(valueBlock, _transformFunctions);
     int[][] data = new int[width][length];
@@ -147,9 +145,7 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
    */
   private long[] getLongTransformResults(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[length];
-    }
+    initLongValuesSV(length);
     int width = _transformFunctions.length;
     RoaringBitmap[] nullBitMaps = getNullBitMaps(valueBlock, _transformFunctions);
     long[][] data = new long[width][length];
@@ -181,9 +177,7 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
    */
   private float[] getFloatTransformResults(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_floatValuesSV == null) {
-      _floatValuesSV = new float[length];
-    }
+    initFloatValuesSV(length);
     int width = _transformFunctions.length;
     RoaringBitmap[] nullBitMaps = getNullBitMaps(valueBlock, _transformFunctions);
     float[][] data = new float[width][length];
@@ -215,9 +209,7 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
    */
   private double[] getDoubleTransformResults(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     int width = _transformFunctions.length;
     RoaringBitmap[] nullBitMaps = getNullBitMaps(valueBlock, _transformFunctions);
     double[][] data = new double[width][length];
@@ -249,9 +241,7 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
    */
   private BigDecimal[] getBigDecimalTransformResults(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null) {
-      _bigDecimalValuesSV = new BigDecimal[length];
-    }
+    initBigDecimalValuesSV(length);
     int width = _transformFunctions.length;
     RoaringBitmap[] nullBitMaps = getNullBitMaps(valueBlock, _transformFunctions);
     BigDecimal[][] data = new BigDecimal[width][length];
@@ -283,9 +273,7 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
    */
   private String[] getStringTransformResults(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[length];
-    }
+    initStringValuesSV(length);
     int width = _transformFunctions.length;
     RoaringBitmap[] nullBitMaps = getNullBitMaps(valueBlock, _transformFunctions);
     String[][] data = new String[width][length];

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunction.java
@@ -127,9 +127,7 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
       return super.transformToLongValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[length];
-    }
+    initLongValuesSV(length);
     if (_dateTimeTransformer instanceof EpochToEpochTransformer) {
       EpochToEpochTransformer dateTimeTransformer = (EpochToEpochTransformer) _dateTimeTransformer;
       dateTimeTransformer.transform(_mainTransformFunction.transformToLongValuesSV(valueBlock), _longValuesSV,
@@ -148,9 +146,7 @@ public class DateTimeConversionTransformFunction extends BaseTransformFunction {
       return super.transformToStringValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[length];
-    }
+    initStringValuesSV(length);
     if (_dateTimeTransformer instanceof EpochToSDFTransformer) {
       EpochToSDFTransformer dateTimeTransformer = (EpochToSDFTransformer) _dateTimeTransformer;
       dateTimeTransformer.transform(_mainTransformFunction.transformToLongValuesSV(valueBlock), _stringValuesSV,

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTimeTransformFunction.java
@@ -72,9 +72,7 @@ public abstract class DateTimeTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[numDocs];
-    }
+    initIntValuesSV(numDocs);
     long[] timestamps = _timestampsFunction.transformToLongValuesSV(valueBlock);
     convert(timestamps, numDocs, _intValuesSV);
     return _intValuesSV;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunction.java
@@ -129,9 +129,7 @@ public class DateTruncTransformFunction extends BaseTransformFunction {
   @Override
   public long[] transformToLongValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[length];
-    }
+    initLongValuesSV(length);
     long[] input = _mainTransformFunction.transformToLongValuesSV(valueBlock);
     for (int i = 0; i < length; i++) {
       _longValuesSV[i] =

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunction.java
@@ -98,9 +98,7 @@ public class DivisionTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     if (_resultDataType == DataType.BIG_DECIMAL) {
       BigDecimal[] values = transformToBigDecimalValuesSV(valueBlock);
       ArrayCopyUtils.copy(values, _doubleValuesSV, length);
@@ -128,9 +126,7 @@ public class DivisionTransformFunction extends BaseTransformFunction {
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null) {
-      _bigDecimalValuesSV = new BigDecimal[length];
-    }
+    initBigDecimalValuesSV(length);
     if (_resultDataType == DataType.DOUBLE) {
       double[] values = transformToDoubleValuesSV(valueBlock);
       ArrayCopyUtils.copy(values, _bigDecimalValuesSV, length);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunction.java
@@ -61,9 +61,7 @@ public class ExtractTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[numDocs];
-    }
+    initIntValuesSV(numDocs);
     long[] timestamps = _mainTransformFunction.transformToLongValuesSV(valueBlock);
     convert(timestamps, numDocs, _intValuesSV);
     return _intValuesSV;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreatestTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GreatestTransformFunction.java
@@ -32,9 +32,7 @@ public class GreatestTransformFunction extends SelectTupleElementTransformFuncti
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[numDocs];
-    }
+    initIntValuesSV(numDocs);
     int[] values = _arguments.get(0).transformToIntValuesSV(valueBlock);
     System.arraycopy(values, 0, _intValuesSV, 0, numDocs);
     for (int i = 1; i < _arguments.size(); i++) {
@@ -49,9 +47,7 @@ public class GreatestTransformFunction extends SelectTupleElementTransformFuncti
   @Override
   public long[] transformToLongValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[numDocs];
-    }
+    initLongValuesSV(numDocs);
     long[] values = _arguments.get(0).transformToLongValuesSV(valueBlock);
     System.arraycopy(values, 0, _longValuesSV, 0, numDocs);
     for (int i = 1; i < _arguments.size(); i++) {
@@ -66,9 +62,7 @@ public class GreatestTransformFunction extends SelectTupleElementTransformFuncti
   @Override
   public float[] transformToFloatValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_floatValuesSV == null) {
-      _floatValuesSV = new float[numDocs];
-    }
+    initFloatValuesSV(numDocs);
     float[] values = _arguments.get(0).transformToFloatValuesSV(valueBlock);
     System.arraycopy(values, 0, _floatValuesSV, 0, numDocs);
     for (int i = 1; i < _arguments.size(); i++) {
@@ -83,9 +77,7 @@ public class GreatestTransformFunction extends SelectTupleElementTransformFuncti
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[numDocs];
-    }
+    initDoubleValuesSV(numDocs);
     double[] values = _arguments.get(0).transformToDoubleValuesSV(valueBlock);
     System.arraycopy(values, 0, _doubleValuesSV, 0, numDocs);
     for (int i = 1; i < _arguments.size(); i++) {
@@ -100,9 +92,7 @@ public class GreatestTransformFunction extends SelectTupleElementTransformFuncti
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null) {
-      _bigDecimalValuesSV = new BigDecimal[numDocs];
-    }
+    initBigDecimalValuesSV(numDocs);
     BigDecimal[] values = _arguments.get(0).transformToBigDecimalValuesSV(valueBlock);
     System.arraycopy(values, 0, _bigDecimalValuesSV, 0, numDocs);
     for (int i = 1; i < _arguments.size(); i++) {
@@ -117,9 +107,7 @@ public class GreatestTransformFunction extends SelectTupleElementTransformFuncti
   @Override
   public String[] transformToStringValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[numDocs];
-    }
+    initStringValuesSV(numDocs);
     String[] values = _arguments.get(0).transformToStringValuesSV(valueBlock);
     System.arraycopy(values, 0, _stringValuesSV, 0, numDocs);
     for (int i = 1; i < _arguments.size(); i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GroovyTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/GroovyTransformFunction.java
@@ -35,7 +35,6 @@ import org.apache.commons.lang3.EnumUtils;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
-import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.segment.local.function.GroovyFunctionEvaluator;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -222,9 +221,7 @@ public class GroovyTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[length];
-    }
+    initIntValuesSV(length);
     for (int i = 0; i < _numGroovyArgs; i++) {
       _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], valueBlock);
     }
@@ -240,9 +237,7 @@ public class GroovyTransformFunction extends BaseTransformFunction {
   @Override
   public long[] transformToLongValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[length];
-    }
+    initLongValuesSV(length);
     for (int i = 0; i < _numGroovyArgs; i++) {
       _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], valueBlock);
     }
@@ -258,9 +253,7 @@ public class GroovyTransformFunction extends BaseTransformFunction {
   @Override
   public float[] transformToFloatValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_floatValuesSV == null) {
-      _floatValuesSV = new float[length];
-    }
+    initFloatValuesSV(length);
     for (int i = 0; i < _numGroovyArgs; i++) {
       _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], valueBlock);
     }
@@ -275,13 +268,11 @@ public class GroovyTransformFunction extends BaseTransformFunction {
 
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[DocIdSetPlanNode.MAX_DOC_PER_CALL];
-    }
+    int length = valueBlock.getNumDocs();
+    initDoubleValuesSV(length);
     for (int i = 0; i < _numGroovyArgs; i++) {
       _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], valueBlock);
     }
-    int length = valueBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numGroovyArgs; j++) {
         _bindingValues[j] = _fetchElementFunctions[j].apply(_sourceArrays[j], i);
@@ -294,9 +285,7 @@ public class GroovyTransformFunction extends BaseTransformFunction {
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null) {
-      _bigDecimalValuesSV = new BigDecimal[length];
-    }
+    initBigDecimalValuesSV(length);
     for (int i = 0; i < _numGroovyArgs; i++) {
       _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], valueBlock);
     }
@@ -312,9 +301,7 @@ public class GroovyTransformFunction extends BaseTransformFunction {
   @Override
   public String[] transformToStringValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[length];
-    }
+    initStringValuesSV(length);
     for (int i = 0; i < _numGroovyArgs; i++) {
       _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], valueBlock);
     }
@@ -330,9 +317,7 @@ public class GroovyTransformFunction extends BaseTransformFunction {
   @Override
   public int[][] transformToIntValuesMV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesMV == null) {
-      _intValuesMV = new int[length][];
-    }
+    initIntValuesMV(length);
     for (int i = 0; i < _numGroovyArgs; i++) {
       _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], valueBlock);
     }
@@ -355,9 +340,7 @@ public class GroovyTransformFunction extends BaseTransformFunction {
   @Override
   public long[][] transformToLongValuesMV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_longValuesMV == null) {
-      _longValuesMV = new long[length][];
-    }
+    initLongValuesMV(length);
     for (int i = 0; i < _numGroovyArgs; i++) {
       _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], valueBlock);
     }
@@ -380,9 +363,7 @@ public class GroovyTransformFunction extends BaseTransformFunction {
   @Override
   public float[][] transformToFloatValuesMV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_floatValuesMV == null) {
-      _floatValuesMV = new float[length][];
-    }
+    initFloatValuesMV(length);
     for (int i = 0; i < _numGroovyArgs; i++) {
       _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], valueBlock);
     }
@@ -405,9 +386,7 @@ public class GroovyTransformFunction extends BaseTransformFunction {
   @Override
   public double[][] transformToDoubleValuesMV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesMV == null) {
-      _doubleValuesMV = new double[length][];
-    }
+    initDoubleValuesMV(length);
     for (int i = 0; i < _numGroovyArgs; i++) {
       _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], valueBlock);
     }
@@ -429,13 +408,11 @@ public class GroovyTransformFunction extends BaseTransformFunction {
 
   @Override
   public String[][] transformToStringValuesMV(ValueBlock valueBlock) {
-    if (_stringValuesMV == null) {
-      _stringValuesMV = new String[DocIdSetPlanNode.MAX_DOC_PER_CALL][];
-    }
+    int length = valueBlock.getNumDocs();
+    initStringValuesMV(length);
     for (int i = 0; i < _numGroovyArgs; i++) {
       _sourceArrays[i] = _transformToValuesFunctions[i].apply(_groovyArguments[i], valueBlock);
     }
-    int length = valueBlock.getNumDocs();
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numGroovyArgs; j++) {
         _bindingValues[j] = _fetchElementFunctions[j].apply(_sourceArrays[j], i);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InIdSetTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InIdSetTransformFunction.java
@@ -74,9 +74,7 @@ public class InIdSetTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[length];
-    }
+    initIntValuesSV(length);
     DataType storedType = _transformFunction.getResultMetadata().getDataType().getStoredType();
     switch (storedType) {
       case INT:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InTransformFunction.java
@@ -139,11 +139,7 @@ public class InTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null || _intValuesSV.length < length) {
-      _intValuesSV = new int[length];
-    } else {
-      Arrays.fill(_intValuesSV, 0);
-    }
+    initZeroFillingIntValuesSV(length);
     TransformResultMetadata mainFunctionMetadata = _mainFunction.getResultMetadata();
     DataType storedType = mainFunctionMetadata.getDataType().getStoredType();
     if (_valueSet != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/InTransformFunction.java
@@ -139,13 +139,11 @@ public class InTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-
-    if (_intValuesSV == null) {
+    if (_intValuesSV == null || _intValuesSV.length < length) {
       _intValuesSV = new int[length];
     } else {
       Arrays.fill(_intValuesSV, 0);
     }
-
     TransformResultMetadata mainFunctionMetadata = _mainFunction.getResultMetadata();
     DataType storedType = mainFunctionMetadata.getDataType().getStoredType();
     if (_valueSet != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNotNullTransformFunction.java
@@ -64,9 +64,7 @@ public class IsNotNullTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[length];
-    }
+    initIntValuesSV(length);
     Arrays.fill(_intValuesSV, 1);
     int[] docIds = valueBlock.getDocIds();
     assert docIds != null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
@@ -64,10 +64,11 @@ public class IsNullTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
+    if (_intValuesSV == null || _intValuesSV.length < length) {
       _intValuesSV = new int[length];
+    } else {
+      Arrays.fill(_intValuesSV, 0);
     }
-    Arrays.fill(_intValuesSV, 0);
     int[] docIds = valueBlock.getDocIds();
     assert docIds != null;
     if (_nullValueVectorIterator != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IsNullTransformFunction.java
@@ -64,11 +64,7 @@ public class IsNullTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null || _intValuesSV.length < length) {
-      _intValuesSV = new int[length];
-    } else {
-      Arrays.fill(_intValuesSV, 0);
-    }
+    initZeroFillingIntValuesSV(length);
     int[] docIds = valueBlock.getDocIds();
     assert docIds != null;
     if (_nullValueVectorIterator != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractKeyTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractKeyTransformFunction.java
@@ -86,9 +86,7 @@ public class JsonExtractKeyTransformFunction extends BaseTransformFunction {
   @Override
   public String[][] transformToStringValuesMV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_stringValuesMV == null) {
-      _stringValuesMV = new String[length][];
-    }
+    initStringValuesMV(length);
     String[] jsonStrings = _jsonFieldTransformFunction.transformToStringValuesSV(valueBlock);
     for (int i = 0; i < length; i++) {
       List<String> values = JSON_PARSER_CONTEXT.parse(jsonStrings[i]).read(_jsonPath);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractScalarTransformFunction.java
@@ -127,10 +127,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
 
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
-    int numDocs = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[numDocs];
-    }
+    initIntValuesSV(valueBlock.getNumDocs());
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction && valueBlock instanceof ProjectionBlock) {
       ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToIntValuesSV((ProjectionBlock) valueBlock,
           _jsonPathEvaluator, _intValuesSV);
@@ -170,10 +167,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
 
   @Override
   public long[] transformToLongValuesSV(ValueBlock valueBlock) {
-    int numDocs = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[numDocs];
-    }
+    initLongValuesSV(valueBlock.getNumDocs());
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction && valueBlock instanceof ProjectionBlock) {
       ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToLongValuesSV((ProjectionBlock) valueBlock,
           _jsonPathEvaluator, _longValuesSV);
@@ -213,10 +207,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
 
   @Override
   public float[] transformToFloatValuesSV(ValueBlock valueBlock) {
-    int numDocs = valueBlock.getNumDocs();
-    if (_floatValuesSV == null) {
-      _floatValuesSV = new float[numDocs];
-    }
+    initFloatValuesSV(valueBlock.getNumDocs());
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction && valueBlock instanceof ProjectionBlock) {
       ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToFloatValuesSV((ProjectionBlock) valueBlock,
           _jsonPathEvaluator, _floatValuesSV);
@@ -255,10 +246,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
 
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
-    int numDocs = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[numDocs];
-    }
+    initDoubleValuesSV(valueBlock.getNumDocs());
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction && valueBlock instanceof ProjectionBlock) {
       ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToDoubleValuesSV((ProjectionBlock) valueBlock,
           _jsonPathEvaluator, _doubleValuesSV);
@@ -297,10 +285,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
 
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ValueBlock valueBlock) {
-    int numDocs = valueBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null) {
-      _bigDecimalValuesSV = new BigDecimal[numDocs];
-    }
+    initBigDecimalValuesSV(valueBlock.getNumDocs());
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction && valueBlock instanceof ProjectionBlock) {
       ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToBigDecimalValuesSV(
           (ProjectionBlock) valueBlock, _jsonPathEvaluator, _bigDecimalValuesSV);
@@ -339,10 +324,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
 
   @Override
   public String[] transformToStringValuesSV(ValueBlock valueBlock) {
-    int numDocs = valueBlock.getNumDocs();
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[numDocs];
-    }
+    initStringValuesSV(valueBlock.getNumDocs());
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction && valueBlock instanceof ProjectionBlock) {
       ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToStringValuesSV((ProjectionBlock) valueBlock,
           _jsonPathEvaluator, _stringValuesSV);
@@ -381,10 +363,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
 
   @Override
   public int[][] transformToIntValuesMV(ValueBlock valueBlock) {
-    int numDocs = valueBlock.getNumDocs();
-    if (_intValuesMV == null) {
-      _intValuesMV = new int[numDocs][];
-    }
+    initIntValuesMV(valueBlock.getNumDocs());
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction && valueBlock instanceof ProjectionBlock) {
       ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToIntValuesMV((ProjectionBlock) valueBlock,
           _jsonPathEvaluator, _intValuesMV);
@@ -420,10 +399,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
 
   @Override
   public long[][] transformToLongValuesMV(ValueBlock valueBlock) {
-    int numDocs = valueBlock.getNumDocs();
-    if (_longValuesMV == null) {
-      _longValuesMV = new long[numDocs][];
-    }
+    initLongValuesMV(valueBlock.getNumDocs());
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction && valueBlock instanceof ProjectionBlock) {
       ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToLongValuesMV((ProjectionBlock) valueBlock,
           _jsonPathEvaluator, _longValuesMV);
@@ -459,10 +435,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
 
   @Override
   public float[][] transformToFloatValuesMV(ValueBlock valueBlock) {
-    int numDocs = valueBlock.getNumDocs();
-    if (_floatValuesMV == null) {
-      _floatValuesMV = new float[numDocs][];
-    }
+    initFloatValuesMV(valueBlock.getNumDocs());
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction && valueBlock instanceof ProjectionBlock) {
       ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToFloatValuesMV((ProjectionBlock) valueBlock,
           _jsonPathEvaluator, _floatValuesMV);
@@ -498,10 +471,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
 
   @Override
   public double[][] transformToDoubleValuesMV(ValueBlock valueBlock) {
-    int numDocs = valueBlock.getNumDocs();
-    if (_doubleValuesMV == null) {
-      _doubleValuesMV = new double[numDocs][];
-    }
+    initDoubleValuesMV(valueBlock.getNumDocs());
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction && valueBlock instanceof ProjectionBlock) {
       ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToDoubleValuesMV((ProjectionBlock) valueBlock,
           _jsonPathEvaluator, _doubleValuesMV);
@@ -537,10 +507,7 @@ public class JsonExtractScalarTransformFunction extends BaseTransformFunction {
 
   @Override
   public String[][] transformToStringValuesMV(ValueBlock valueBlock) {
-    int numDocs = valueBlock.getNumDocs();
-    if (_stringValuesMV == null || _stringValuesMV.length < numDocs) {
-      _stringValuesMV = new String[numDocs][];
-    }
+    initStringValuesMV(valueBlock.getNumDocs());
     if (_jsonFieldTransformFunction instanceof PushDownTransformFunction && valueBlock instanceof ProjectionBlock) {
       ((PushDownTransformFunction) _jsonFieldTransformFunction).transformToStringValuesMV((ProjectionBlock) valueBlock,
           _jsonPathEvaluator, _stringValuesMV);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LeastTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LeastTransformFunction.java
@@ -32,9 +32,7 @@ public class LeastTransformFunction extends SelectTupleElementTransformFunction 
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[numDocs];
-    }
+    initIntValuesSV(numDocs);
     int[] values = _arguments.get(0).transformToIntValuesSV(valueBlock);
     System.arraycopy(values, 0, _intValuesSV, 0, numDocs);
     for (int i = 1; i < _arguments.size(); i++) {
@@ -49,9 +47,7 @@ public class LeastTransformFunction extends SelectTupleElementTransformFunction 
   @Override
   public long[] transformToLongValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[numDocs];
-    }
+    initLongValuesSV(numDocs);
     long[] values = _arguments.get(0).transformToLongValuesSV(valueBlock);
     System.arraycopy(values, 0, _longValuesSV, 0, numDocs);
     for (int i = 1; i < _arguments.size(); i++) {
@@ -66,9 +62,7 @@ public class LeastTransformFunction extends SelectTupleElementTransformFunction 
   @Override
   public float[] transformToFloatValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_floatValuesSV == null) {
-      _floatValuesSV = new float[numDocs];
-    }
+    initFloatValuesSV(numDocs);
     float[] values = _arguments.get(0).transformToFloatValuesSV(valueBlock);
     System.arraycopy(values, 0, _floatValuesSV, 0, numDocs);
     for (int i = 1; i < _arguments.size(); i++) {
@@ -83,9 +77,7 @@ public class LeastTransformFunction extends SelectTupleElementTransformFunction 
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[numDocs];
-    }
+    initDoubleValuesSV(numDocs);
     double[] values = _arguments.get(0).transformToDoubleValuesSV(valueBlock);
     System.arraycopy(values, 0, _doubleValuesSV, 0, numDocs);
     for (int i = 1; i < _arguments.size(); i++) {
@@ -100,9 +92,7 @@ public class LeastTransformFunction extends SelectTupleElementTransformFunction 
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null) {
-      _bigDecimalValuesSV = new BigDecimal[numDocs];
-    }
+    initBigDecimalValuesSV(numDocs);
     BigDecimal[] values = _arguments.get(0).transformToBigDecimalValuesSV(valueBlock);
     System.arraycopy(values, 0, _bigDecimalValuesSV, 0, numDocs);
     for (int i = 1; i < _arguments.size(); i++) {
@@ -117,9 +107,7 @@ public class LeastTransformFunction extends SelectTupleElementTransformFunction 
   @Override
   public String[] transformToStringValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[numDocs];
-    }
+    initStringValuesSV(numDocs);
     String[] values = _arguments.get(0).transformToStringValuesSV(valueBlock);
     System.arraycopy(values, 0, _stringValuesSV, 0, numDocs);
     for (int i = 1; i < _arguments.size(); i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LogicalOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LogicalOperatorTransformFunction.java
@@ -59,9 +59,7 @@ public abstract class LogicalOperatorTransformFunction extends BaseTransformFunc
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[numDocs];
-    }
+    initIntValuesSV(numDocs);
     System.arraycopy(_arguments.get(0).transformToIntValuesSV(valueBlock), 0, _intValuesSV, 0, numDocs);
     int numArguments = _arguments.size();
     for (int i = 1; i < numArguments; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LookupTransformFunction.java
@@ -229,10 +229,7 @@ public class LookupTransformFunction extends BaseTransformFunction {
     if (_lookupColumnFieldSpec.getDataType().getStoredType() != DataType.INT) {
       return super.transformToIntValuesSV(valueBlock);
     }
-    int numDocs = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[numDocs];
-    }
+    initIntValuesSV(valueBlock.getNumDocs());
     lookup(valueBlock, this::setIntSV);
     return _intValuesSV;
   }
@@ -242,10 +239,7 @@ public class LookupTransformFunction extends BaseTransformFunction {
     if (_lookupColumnFieldSpec.getDataType().getStoredType() != DataType.LONG) {
       return super.transformToLongValuesSV(valueBlock);
     }
-    int numDocs = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[numDocs];
-    }
+    initLongValuesSV(valueBlock.getNumDocs());
     lookup(valueBlock, this::setLongSV);
     return _longValuesSV;
   }
@@ -255,10 +249,7 @@ public class LookupTransformFunction extends BaseTransformFunction {
     if (_lookupColumnFieldSpec.getDataType().getStoredType() != DataType.FLOAT) {
       return super.transformToFloatValuesSV(valueBlock);
     }
-    int numDocs = valueBlock.getNumDocs();
-    if (_floatValuesSV == null) {
-      _floatValuesSV = new float[numDocs];
-    }
+    initFloatValuesSV(valueBlock.getNumDocs());
     lookup(valueBlock, this::setFloatSV);
     return _floatValuesSV;
   }
@@ -268,10 +259,7 @@ public class LookupTransformFunction extends BaseTransformFunction {
     if (_lookupColumnFieldSpec.getDataType().getStoredType() != DataType.DOUBLE) {
       return super.transformToDoubleValuesSV(valueBlock);
     }
-    int numDocs = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[numDocs];
-    }
+    initDoubleValuesSV(valueBlock.getNumDocs());
     lookup(valueBlock, this::setDoubleSV);
     return _doubleValuesSV;
   }
@@ -281,10 +269,7 @@ public class LookupTransformFunction extends BaseTransformFunction {
     if (_lookupColumnFieldSpec.getDataType().getStoredType() != DataType.STRING) {
       return super.transformToStringValuesSV(valueBlock);
     }
-    int numDocs = valueBlock.getNumDocs();
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[numDocs];
-    }
+    initStringValuesSV(valueBlock.getNumDocs());
     lookup(valueBlock, this::setStringSV);
     return _stringValuesSV;
   }
@@ -294,10 +279,7 @@ public class LookupTransformFunction extends BaseTransformFunction {
     if (_lookupColumnFieldSpec.getDataType().getStoredType() != DataType.BYTES) {
       return super.transformToBytesValuesSV(valueBlock);
     }
-    int numDocs = valueBlock.getNumDocs();
-    if (_bytesValuesSV == null) {
-      _bytesValuesSV = new byte[numDocs][];
-    }
+    initBytesValuesSV(valueBlock.getNumDocs());
     lookup(valueBlock, this::setBytesSV);
     return _bytesValuesSV;
   }
@@ -307,10 +289,7 @@ public class LookupTransformFunction extends BaseTransformFunction {
     if (_lookupColumnFieldSpec.getDataType().getStoredType() != DataType.INT) {
       return super.transformToIntValuesMV(valueBlock);
     }
-    int numDocs = valueBlock.getNumDocs();
-    if (_intValuesMV == null) {
-      _intValuesMV = new int[numDocs][];
-    }
+    initIntValuesMV(valueBlock.getNumDocs());
     lookup(valueBlock, this::setIntMV);
     return _intValuesMV;
   }
@@ -320,10 +299,7 @@ public class LookupTransformFunction extends BaseTransformFunction {
     if (_lookupColumnFieldSpec.getDataType().getStoredType() != DataType.LONG) {
       return super.transformToLongValuesMV(valueBlock);
     }
-    int numDocs = valueBlock.getNumDocs();
-    if (_longValuesMV == null) {
-      _longValuesMV = new long[numDocs][];
-    }
+    initLongValuesMV(valueBlock.getNumDocs());
     lookup(valueBlock, this::setLongMV);
     return _longValuesMV;
   }
@@ -333,10 +309,7 @@ public class LookupTransformFunction extends BaseTransformFunction {
     if (_lookupColumnFieldSpec.getDataType().getStoredType() != DataType.FLOAT) {
       return super.transformToFloatValuesMV(valueBlock);
     }
-    int numDocs = valueBlock.getNumDocs();
-    if (_floatValuesMV == null) {
-      _floatValuesMV = new float[numDocs][];
-    }
+    initFloatValuesMV(valueBlock.getNumDocs());
     lookup(valueBlock, this::setFloatMV);
     return _floatValuesMV;
   }
@@ -346,10 +319,7 @@ public class LookupTransformFunction extends BaseTransformFunction {
     if (_lookupColumnFieldSpec.getDataType().getStoredType() != DataType.DOUBLE) {
       return super.transformToDoubleValuesMV(valueBlock);
     }
-    int numDocs = valueBlock.getNumDocs();
-    if (_doubleValuesMV == null) {
-      _doubleValuesMV = new double[numDocs][];
-    }
+    initDoubleValuesMV(valueBlock.getNumDocs());
     lookup(valueBlock, this::setDoubleMV);
     return _doubleValuesMV;
   }
@@ -359,10 +329,7 @@ public class LookupTransformFunction extends BaseTransformFunction {
     if (_lookupColumnFieldSpec.getDataType().getStoredType() != DataType.STRING) {
       return super.transformToStringValuesMV(valueBlock);
     }
-    int numDocs = valueBlock.getNumDocs();
-    if (_stringValuesMV == null) {
-      _stringValuesMV = new String[numDocs][];
-    }
+    initStringValuesMV(valueBlock.getNumDocs());
     lookup(valueBlock, this::setStringMV);
     return _stringValuesMV;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MapValueTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MapValueTransformFunction.java
@@ -97,7 +97,7 @@ public class MapValueTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToDictIdsSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_dictIds == null) {
+    if (_dictIds == null || _dictIds.length < length) {
       _dictIds = new int[length];
     }
     int[][] keyDictIdsMV = _keyColumnFunction.transformToDictIdsMV(valueBlock);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ModuloTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ModuloTransformFunction.java
@@ -75,9 +75,7 @@ public class ModuloTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     if (_firstTransformFunction == null) {
       Arrays.fill(_doubleValuesSV, 0, length, _firstLiteral);
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunction.java
@@ -88,9 +88,7 @@ public class MultiplicationTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     if (_resultDataType == DataType.BIG_DECIMAL) {
       BigDecimal[] values = transformToBigDecimalValuesSV(valueBlock);
       ArrayCopyUtils.copy(values, _doubleValuesSV, length);
@@ -109,9 +107,7 @@ public class MultiplicationTransformFunction extends BaseTransformFunction {
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null) {
-      _bigDecimalValuesSV = new BigDecimal[length];
-    }
+    initBigDecimalValuesSV(length);
     if (_resultDataType == DataType.DOUBLE) {
       double[] values = transformToDoubleValuesSV(valueBlock);
       ArrayCopyUtils.copy(values, _bigDecimalValuesSV, length);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/NotOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/NotOperatorTransformFunction.java
@@ -70,9 +70,7 @@ public class NotOperatorTransformFunction extends BaseTransformFunction {
   @Override
   public int[] transformToIntValuesSV(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[numDocs];
-    }
+    initIntValuesSV(numDocs);
     int[] intValues = _argument.transformToIntValuesSV(valueBlock);
     for (int i = 0; i < numDocs; i++) {
       _intValuesSV[i] = getLogicalNegate(intValues[i]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/PowerTransformFunction.java
@@ -65,9 +65,7 @@ public class PowerTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(valueBlock);
     if (_fixedExponent) {
       for (int i = 0; i < length; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RegexpExtractTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RegexpExtractTransformFunction.java
@@ -97,9 +97,7 @@ public class RegexpExtractTransformFunction extends BaseTransformFunction {
   @Override
   public String[] transformToStringValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[length];
-    }
+    initStringValuesSV(length);
     String[] valuesSV = _valueFunction.transformToStringValuesSV(valueBlock);
     for (int i = 0; i < length; i++) {
       Matcher matcher = _regexp.matcher(valuesSV[i]);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/RoundDecimalTransformFunction.java
@@ -85,9 +85,7 @@ public class RoundDecimalTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(valueBlock);
     if (_fixedScale) {
       for (int i = 0; i < length; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ScalarTransformFunctionWrapper.java
@@ -113,9 +113,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
       return super.transformToIntValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_intValuesSV == null) {
-      _intValuesSV = new int[length];
-    }
+    initIntValuesSV(length);
     getNonLiteralValues(valueBlock);
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
@@ -132,9 +130,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
       return super.transformToLongValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[length];
-    }
+    initLongValuesSV(length);
     getNonLiteralValues(valueBlock);
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
@@ -151,9 +147,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
       return super.transformToFloatValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_floatValuesSV == null) {
-      _floatValuesSV = new float[length];
-    }
+    initFloatValuesSV(length);
     getNonLiteralValues(valueBlock);
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
@@ -170,9 +164,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
       return super.transformToDoubleValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     getNonLiteralValues(valueBlock);
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
@@ -189,9 +181,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
       return super.transformToBigDecimalValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null) {
-      _bigDecimalValuesSV = new BigDecimal[length];
-    }
+    initBigDecimalValuesSV(length);
     getNonLiteralValues(valueBlock);
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
@@ -208,9 +198,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
       return super.transformToStringValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_stringValuesSV == null) {
-      _stringValuesSV = new String[length];
-    }
+    initStringValuesSV(length);
     getNonLiteralValues(valueBlock);
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
@@ -229,9 +217,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
       return super.transformToBytesValuesSV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_bytesValuesSV == null) {
-      _bytesValuesSV = new byte[length][];
-    }
+    initBytesValuesSV(length);
     getNonLiteralValues(valueBlock);
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
@@ -248,9 +234,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
       return super.transformToIntValuesMV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_intValuesMV == null) {
-      _intValuesMV = new int[length][];
-    }
+    initIntValuesMV(length);
     getNonLiteralValues(valueBlock);
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
@@ -267,9 +251,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
       return super.transformToLongValuesMV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_longValuesMV == null) {
-      _longValuesMV = new long[length][];
-    }
+    initLongValuesMV(length);
     getNonLiteralValues(valueBlock);
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
@@ -286,9 +268,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
       return super.transformToFloatValuesMV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_floatValuesMV == null) {
-      _floatValuesMV = new float[length][];
-    }
+    initFloatValuesMV(length);
     getNonLiteralValues(valueBlock);
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
@@ -305,9 +285,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
       return super.transformToDoubleValuesMV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesMV == null) {
-      _doubleValuesMV = new double[length][];
-    }
+    initDoubleValuesMV(length);
     getNonLiteralValues(valueBlock);
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {
@@ -324,9 +302,7 @@ public class ScalarTransformFunctionWrapper extends BaseTransformFunction {
       return super.transformToStringValuesMV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_stringValuesMV == null) {
-      _stringValuesMV = new String[length][];
-    }
+    initStringValuesMV(length);
     getNonLiteralValues(valueBlock);
     for (int i = 0; i < length; i++) {
       for (int j = 0; j < _numNonLiteralArguments; j++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunction.java
@@ -72,9 +72,7 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     if (_resultDataType == DataType.BIG_DECIMAL) {
       BigDecimal[] values = transformToBigDecimalValuesSV(valueBlock);
       ArrayCopyUtils.copy(values, _doubleValuesSV, length);
@@ -88,9 +86,7 @@ public abstract class SingleParamMathTransformFunction extends BaseTransformFunc
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null) {
-      _bigDecimalValuesSV = new BigDecimal[length];
-    }
+    initBigDecimalValuesSV(length);
     if (_resultDataType == DataType.DOUBLE) {
       double[] values = transformToDoubleValuesSV(valueBlock);
       ArrayCopyUtils.copy(values, _bigDecimalValuesSV, length);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunction.java
@@ -97,9 +97,7 @@ public class SubtractionTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     if (_resultDataType == DataType.BIG_DECIMAL) {
       BigDecimal[] values = transformToBigDecimalValuesSV(valueBlock);
       ArrayCopyUtils.copy(values, _doubleValuesSV, length);
@@ -127,9 +125,7 @@ public class SubtractionTransformFunction extends BaseTransformFunction {
   @Override
   public BigDecimal[] transformToBigDecimalValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_bigDecimalValuesSV == null) {
-      _bigDecimalValuesSV = new BigDecimal[length];
-    }
+    initBigDecimalValuesSV(length);
     if (_resultDataType == DataType.DOUBLE) {
       double[] values = transformToDoubleValuesSV(valueBlock);
       ArrayCopyUtils.copy(values, _bigDecimalValuesSV, length);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TimeConversionTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TimeConversionTransformFunction.java
@@ -67,11 +67,8 @@ public class TimeConversionTransformFunction extends BaseTransformFunction {
   @Override
   public long[] transformToLongValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_longValuesSV == null) {
-      _longValuesSV = new long[length];
-    }
-    _timeUnitTransformer.transform(_mainTransformFunction.transformToLongValuesSV(valueBlock), _longValuesSV,
-        length);
+    initLongValuesSV(length);
+    _timeUnitTransformer.transform(_mainTransformFunction.transformToLongValuesSV(valueBlock), _longValuesSV, length);
     return _longValuesSV;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TrigonometricTransformFunctions.java
@@ -59,17 +59,12 @@ public class TrigonometricTransformFunctions {
     @Override
     public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
       int length = valueBlock.getNumDocs();
-
-      if (_doubleValuesSV == null || _doubleValuesSV.length < length) {
-        _doubleValuesSV = new double[length];
-      }
-
+      initDoubleValuesSV(length);
       double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(valueBlock);
       double[] rightValues = _rightTransformFunction.transformToDoubleValuesSV(valueBlock);
       for (int i = 0; i < length; i++) {
         _doubleValuesSV[i] = Math.atan2(leftValues[i], rightValues[i]);
       }
-
       return _doubleValuesSV;
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TruncateDecimalTransformFunction.java
@@ -83,20 +83,17 @@ public class TruncateDecimalTransformFunction extends BaseTransformFunction {
   @Override
   public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
-    if (_doubleValuesSV == null) {
-      _doubleValuesSV = new double[length];
-    }
+    initDoubleValuesSV(length);
     double[] leftValues = _leftTransformFunction.transformToDoubleValuesSV(valueBlock);
     if (_fixedScale) {
       for (int i = 0; i < length; i++) {
-        _doubleValuesSV[i] = BigDecimal.valueOf(leftValues[i])
-            .setScale(_scale, RoundingMode.DOWN).doubleValue();
+        _doubleValuesSV[i] = BigDecimal.valueOf(leftValues[i]).setScale(_scale, RoundingMode.DOWN).doubleValue();
       }
     } else if (_rightTransformFunction != null) {
       int[] rightValues = _rightTransformFunction.transformToIntValuesSV(valueBlock);
       for (int i = 0; i < length; i++) {
-        _doubleValuesSV[i] = BigDecimal.valueOf(leftValues[i])
-            .setScale(rightValues[i], RoundingMode.DOWN).doubleValue();
+        _doubleValuesSV[i] =
+            BigDecimal.valueOf(leftValues[i]).setScale(rightValues[i], RoundingMode.DOWN).doubleValue();
       }
     } else {
       for (int i = 0; i < length; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ValueInTransformFunction.java
@@ -55,7 +55,7 @@ public class ValueInTransformFunction extends BaseTransformFunction {
   private Dictionary _dictionary;
 
   private IntSet _dictIdSet;
-  private int[][] _dictIds;
+  private int[][] _dictIdsMV;
   private IntSet _intValueSet;
   private LongSet _longValueSet;
   private FloatSet _floatValueSet;
@@ -106,6 +106,9 @@ public class ValueInTransformFunction extends BaseTransformFunction {
   @Override
   public int[][] transformToDictIdsMV(ValueBlock valueBlock) {
     int length = valueBlock.getNumDocs();
+    if (_dictIdsMV == null || _dictIdsMV.length < length) {
+      _dictIdsMV = new int[length][];
+    }
     if (_dictIdSet == null) {
       _dictIdSet = new IntOpenHashSet();
       assert _dictionary != null;
@@ -115,15 +118,12 @@ public class ValueInTransformFunction extends BaseTransformFunction {
           _dictIdSet.add(dictId);
         }
       }
-      if (_dictIds == null) {
-        _dictIds = new int[length][];
-      }
     }
     int[][] unFilteredDictIds = _mainTransformFunction.transformToDictIdsMV(valueBlock);
     for (int i = 0; i < length; i++) {
-      _dictIds[i] = filterInts(_dictIdSet, unFilteredDictIds[i]);
+      _dictIdsMV[i] = filterInts(_dictIdSet, unFilteredDictIds[i]);
     }
-    return _dictIds;
+    return _dictIdsMV;
   }
 
   @Override
@@ -132,13 +132,11 @@ public class ValueInTransformFunction extends BaseTransformFunction {
       return super.transformToIntValuesMV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
+    initIntValuesMV(length);
     if (_intValueSet == null) {
       _intValueSet = new IntOpenHashSet();
       for (String inValue : _stringValueSet) {
         _intValueSet.add(Integer.parseInt(inValue));
-      }
-      if (_intValuesMV == null) {
-        _intValuesMV = new int[length][];
       }
     }
     int[][] unFilteredIntValues = _mainTransformFunction.transformToIntValuesMV(valueBlock);
@@ -154,13 +152,11 @@ public class ValueInTransformFunction extends BaseTransformFunction {
       return super.transformToLongValuesMV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
+    initLongValuesMV(length);
     if (_longValueSet == null) {
       _longValueSet = new LongOpenHashSet();
       for (String inValue : _stringValueSet) {
         _longValueSet.add(Long.parseLong(inValue));
-      }
-      if (_longValuesMV == null) {
-        _longValuesMV = new long[length][];
       }
     }
     long[][] unFilteredLongValues = _mainTransformFunction.transformToLongValuesMV(valueBlock);
@@ -176,13 +172,11 @@ public class ValueInTransformFunction extends BaseTransformFunction {
       return super.transformToFloatValuesMV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
+    initFloatValuesMV(length);
     if (_floatValueSet == null) {
       _floatValueSet = new FloatOpenHashSet();
       for (String inValue : _stringValueSet) {
         _floatValueSet.add(Float.parseFloat(inValue));
-      }
-      if (_floatValuesMV == null) {
-        _floatValuesMV = new float[length][];
       }
     }
     float[][] unFilteredFloatValues = _mainTransformFunction.transformToFloatValuesMV(valueBlock);
@@ -198,13 +192,11 @@ public class ValueInTransformFunction extends BaseTransformFunction {
       return super.transformToDoubleValuesMV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
+    initDoubleValuesMV(length);
     if (_doubleValueSet == null) {
       _doubleValueSet = new DoubleOpenHashSet();
       for (String inValue : _stringValueSet) {
         _doubleValueSet.add(Double.parseDouble(inValue));
-      }
-      if (_doubleValuesMV == null) {
-        _doubleValuesMV = new double[length][];
       }
     }
     double[][] unFilteredDoubleValues = _mainTransformFunction.transformToDoubleValuesMV(valueBlock);
@@ -220,9 +212,7 @@ public class ValueInTransformFunction extends BaseTransformFunction {
       return super.transformToStringValuesMV(valueBlock);
     }
     int length = valueBlock.getNumDocs();
-    if (_stringValuesMV == null) {
-      _stringValuesMV = new String[length][];
-    }
+    initStringValuesMV(length);
     String[][] unFilteredStringValues = _mainTransformFunction.transformToStringValuesMV(valueBlock);
     for (int i = 0; i < length; i++) {
       _stringValuesMV[i] = filterStrings(_stringValueSet, unFilteredStringValues[i]);


### PR DESCRIPTION
With chain-able ProjectOperator (introduced in #10405), `ValueBlock` documents might not be fixed. This PR modify all `TransformFunction` to allow different docs in `ValueBlock`