### PR TITLE
[enhancement] Use string as default compatible type for coalesce

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunction.java
@@ -104,8 +104,7 @@ public class CoalesceTransformFunction extends BaseTransformFunction {
       }
       return DataType.INT;
     }
-    Preconditions.checkState(left == right, "Data type " + left + " is not compatible with ", right);
-    return left;
+    return DataType.STRING;
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CoalesceTransformFunctionTest.java
@@ -453,17 +453,21 @@ public class CoalesceTransformFunctionTest extends BaseTransformFunctionTest {
     testIntTransformFunction(coalesceExpr, expectedResults, _disableNullProjectionBlock, _disableNullDataSourceMap);
   }
 
-  // Test that all arguments have to be same type.
+  // Test that string literal works for coalesce
   @Test
-  public void testDifferentArgumentType()
+  public void testDifferentLiteralArgs()
       throws Exception {
     ExpressionContext coalesceExpr =
-        RequestContextUtils.getExpression(String.format("COALESCE(%s,%s)", INT_SV_COLUMN1, STRING_SV_COLUMN1));
-    Assert.assertThrows(RuntimeException.class, () -> {
-      TransformFunctionFactory.get(coalesceExpr, _enableNullDataSourceMap);
-    });
-    Assert.assertThrows(RuntimeException.class, () -> {
-      TransformFunctionFactory.get(coalesceExpr, _disableNullDataSourceMap);
-    });
+        RequestContextUtils.getExpression(String.format("COALESCE(%s,'%s')", STRING_SV_COLUMN1, 234));
+    String[] expectedResults = new String[NUM_ROWS];
+    for (int i = 0; i < NUM_ROWS; i++) {
+      if (isColumn1Null(i)) {
+        expectedResults[i] = "234";
+      } else {
+        expectedResults[i] = _stringSVValues[i];
+      }
+    }
+    testStringTransformFunction(coalesceExpr, expectedResults, _enableNullProjectionBlock, _enableNullDataSourceMap);
+    testStringTransformFunction(coalesceExpr, expectedResults, _disableNullProjectionBlock, _disableNullDataSourceMap);
   }
 }


### PR DESCRIPTION
Today, we still need to call infer type for literal. So '123' will be inferred as big decimal and we are not table to call coalesce on this because coalesce requires arg types to be same.

This PR changes coalesce to return string type by default so we don't throw exceptions on coalesce (stringCol, '123')