### PR TITLE
Add SSLContext Only Constructor for HttpClient

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -90,6 +90,10 @@ public class HttpClient implements AutoCloseable {
     this(HttpClientConfig.DEFAULT_HTTP_CLIENT_CONFIG, null);
   }
 
+  public HttpClient(@Nullable SSLContext sslContext) {
+    this(HttpClientConfig.DEFAULT_HTTP_CLIENT_CONFIG, sslContext);
+  }
+
   public HttpClient(HttpClientConfig httpClientConfig, @Nullable SSLContext sslContext) {
     SSLContext context = sslContext != null ? sslContext : TlsUtils.getSslContext();
     // Set NoopHostnameVerifier to skip validating hostname when uploading/downloading segments.


### PR DESCRIPTION
See https://github.com/apache/pinot/pull/10487#discussion_r1155085289 for context.

The PR linked above had removed this constructor.

cc: @gortiz 