### PR TITLE
Fix an error introduced in index-spi that ignores the createInvertedI…

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -138,7 +138,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   private static final String COLUMN_LENGTH_MAP_KEY = "columnLengthMap";
   private static final String COLUMN_CARDINALITY_MAP_KEY = "columnCardinalityMap";
   private static final String MAX_NUM_MULTI_VALUES_MAP_KEY = "maxNumMultiValuesMap";
-  private static final int DISK_SIZE_IN_BYTES = 20797370;
+  private static final int DISK_SIZE_IN_BYTES = 20797324;
   private static final int NUM_ROWS = 115545;
 
   private final List<ServiceStatus.ServiceStatusCallback> _serviceStatusCallbacks =

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -223,9 +223,10 @@ public class SegmentGeneratorConfig implements Serializable {
       // TODO 2: Decide what to do with this. Index-spi is based on the idea that TableConfig is the source of truth
       if (indexingConfig.getInvertedIndexColumns() != null) {
         Map<String, String> customConfigs = tableConfig.getCustomConfig().getCustomConfigs();
-        boolean shouldSkipInvertedIndex = !indexingConfig.isCreateInvertedIndexDuringSegmentGeneration()
-            && (customConfigs == null || !Boolean.parseBoolean(customConfigs.get(GENERATE_INV_BEFORE_PUSH_DEPREC_PROP)));
-        if (shouldSkipInvertedIndex) {
+        boolean customConfigEnabled =
+            customConfigs != null && Boolean.parseBoolean(customConfigs.get(GENERATE_INV_BEFORE_PUSH_DEPREC_PROP));
+        boolean indexingConfigEnable = indexingConfig.isCreateInvertedIndexDuringSegmentGeneration();
+        if (!customConfigEnabled && !indexingConfigEnable) {
           setIndexOn(StandardIndexes.inverted(), IndexConfig.DISABLED, indexingConfig.getInvertedIndexColumns());
         }
       }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -224,7 +224,7 @@ public class SegmentGeneratorConfig implements Serializable {
       if (indexingConfig.getInvertedIndexColumns() != null) {
         Map<String, String> customConfigs = tableConfig.getCustomConfig().getCustomConfigs();
         boolean shouldSkipInvertedIndex = !indexingConfig.isCreateInvertedIndexDuringSegmentGeneration()
-            && (customConfigs == null || Boolean.parseBoolean(customConfigs.get(GENERATE_INV_BEFORE_PUSH_DEPREC_PROP)));
+            && (customConfigs == null || !Boolean.parseBoolean(customConfigs.get(GENERATE_INV_BEFORE_PUSH_DEPREC_PROP)));
         if (shouldSkipInvertedIndex) {
           setIndexOn(StandardIndexes.inverted(), IndexConfig.DISABLED, indexingConfig.getInvertedIndexColumns());
         }


### PR DESCRIPTION
This commit fixes a problem introduced in https://github.com/apache/pinot/pull/10184, which ignores the createInvertedIndexDuringSegmentGeneration property in IndexLoadingConfig.