### PR TITLE
[bugfix] Make pinot-controller apply webpack production mode when bin-dist pro…

### DIFF
--- a/pinot-controller/pom.xml
+++ b/pinot-controller/pom.xml
@@ -277,4 +277,13 @@
       </plugin>
     </plugins>
   </build>
+
+  <profiles>
+    <profile>
+      <id>bin-dist</id>
+      <properties>
+        <npm.script>build</npm.script>
+      </properties>
+    </profile>
+  </profiles>
 </project>


### PR DESCRIPTION
Previous PR #10221 improved the build performance on developer machines without affecting the docker image, but other build methods where affected, including the webpack development mode instead of production mode, as indicated by @jadami10 [here](https://github.com/apache/pinot/pull/10221/files#r1155387697).

This PR does not rollback to the previous behavior by default, but does so when Maven profile `bin-dist` is used. That profile is the one that is used in `pinot-distribution` to create the shaded jar and Pinot documentation indicates to enable it in order build Pinot (for example, in the README.md in this repo).

In my local machine `mvn generate-resources` requires 23s go run `pinot-controller` while `mvn generate-resources -Pbin-dist` takes 47s

