### PR TITLE
Exclude woodstox-core from azure-storage-file-datalake in pinot-adls module

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -54,6 +54,10 @@
           <groupId>io.netty</groupId>
           <artifactId>netty-transport-native-kqueue</artifactId>
         </exclusion>
+        <exclusion>
+          <groupId>com.fasterxml.woodstox</groupId>
+          <artifactId>woodstox-core</artifactId>
+        </exclusion>
       </exclusions>
     </dependency>
     <dependency>


### PR DESCRIPTION
This PR excludes woodstox-core from azure-storage-file-datalake in pinot-adls module.

Internally we've seen such failed message on the build:
```
Error:  
Dependency convergence error for com.fasterxml.woodstox:woodstox-core:jar:6.4.0 paths to dependency are:
  +-org.apache.pinot:pinot-adls:jar:0.14.0-SNAPSHOT:compile
    +-com.azure:azure-storage-file-datalake:jar:12.13.3:compile
      +-com.azure:azure-storage-blob:jar:12.20.3:compile
        +-com.azure:azure-storage-common:jar:12.19.3:compile
          +-com.fasterxml.woodstox:woodstox-core:jar:6.4.0:compile
and
  +-org.apache.pinot:pinot-adls:jar:0.14.0-SNAPSHOT:compile
    +-com.azure:azure-storage-file-datalake:jar:12.13.3:compile
      +-com.azure:azure-storage-blob:jar:12.20.3:compile
        +-com.azure:azure-storage-internal-avro:jar:12.5.3:compile
          +-com.fasterxml.woodstox:woodstox-core:jar:6.4.0:compile
and
  +-org.apache.pinot:pinot-adls:jar:0.14.0-SNAPSHOT:compile
    +-com.azure:azure-storage-file-datalake:jar:12.13.3:compile
      +-com.azure:azure-storage-blob:jar:12.20.3:compile
        +-com.fasterxml.woodstox:woodstox-core:jar:6.4.0:compile
and
  +-org.apache.pinot:pinot-adls:jar:0.14.0-SNAPSHOT:compile
    +-com.azure:azure-storage-file-datalake:jar:12.13.3:compile
      +-com.fasterxml.jackson.dataformat:jackson-dataformat-xml:jar:2.12.7:compile
        +-com.fasterxml.woodstox:woodstox-core:jar:6.2.4:compile
and
  +-org.apache.pinot:pinot-adls:jar:0.14.0-SNAPSHOT:compile
    +-com.azure:azure-storage-file-datalake:jar:12.13.3:compile
      +-com.fasterxml.woodstox:woodstox-core:jar:6.4.0:compile
```

Since woodstox-core is already explicitly declared in the pom file, the one inside `azure-storage-file-datalake` can be excluded.