### PR TITLE
[multistage] Table level Access Validation, QPS Quota, Phase Metrics for multistage queries

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
@@ -53,7 +53,7 @@ public interface AccessControl {
    * Fine-grained access control on pinot tables.
    *
    * @param requesterIdentity requester identity
-   * @param tables List of pinot tables used in the query
+   * @param tables Set of pinot tables used in the query. Table name can be with or without tableType.
    *
    * @return {@code true} if authorized, {@code false} otherwise
    */

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/AccessControl.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.broker.api;
 
+import java.util.Set;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
@@ -47,4 +48,14 @@ public interface AccessControl {
    * @return {@code true} if authorized, {@code false} otherwise
    */
   boolean hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest);
+
+  /**
+   * Fine-grained access control on pinot tables.
+   *
+   * @param requesterIdentity requester identity
+   * @param tables List of pinot tables used in the query
+   *
+   * @return {@code true} if authorized, {@code false} otherwise
+   */
+  boolean hasAccess(RequesterIdentity requesterIdentity, Set<String> tables);
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/AllowAllAccessControlFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.broker.broker;
 
+import java.util.Set;
 import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.broker.api.RequesterIdentity;
 import org.apache.pinot.common.request.BrokerRequest;
@@ -41,6 +42,11 @@ public class AllowAllAccessControlFactory extends AccessControlFactory {
   private static class AllowAllAccessControl implements AccessControl {
     @Override
     public boolean hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
+      return true;
+    }
+
+    @Override
+    public boolean hasAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
       return true;
     }
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
@@ -23,6 +23,7 @@ import java.util.Collection;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.broker.api.HttpRequesterIdentity;
@@ -77,18 +78,12 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
 
     @Override
     public boolean hasAccess(RequesterIdentity requesterIdentity) {
-      return hasAccess(requesterIdentity, null);
+      return hasAccess(requesterIdentity, (BrokerRequest) null);
     }
 
     @Override
     public boolean hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
-      Preconditions.checkArgument(requesterIdentity instanceof HttpRequesterIdentity, "HttpRequesterIdentity required");
-      HttpRequesterIdentity identity = (HttpRequesterIdentity) requesterIdentity;
-
-      Collection<String> tokens = identity.getHttpHeaders().get(HEADER_AUTHORIZATION);
-      Optional<BasicAuthPrincipal> principalOpt =
-          tokens.stream().map(BasicAuthUtils::normalizeBase64Token).map(_token2principal::get).filter(Objects::nonNull)
-              .findFirst();
+      Optional<BasicAuthPrincipal> principalOpt = getPrincipalOpt(requesterIdentity);
 
       if (!principalOpt.isPresent()) {
         // no matching token? reject
@@ -103,6 +98,40 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
       }
 
       return principal.hasTable(brokerRequest.getQuerySource().getTableName());
+    }
+
+    @Override
+    public boolean hasAccess(RequesterIdentity requesterIdentity, Set<String> tables) {
+      Optional<BasicAuthPrincipal> principalOpt = getPrincipalOpt(requesterIdentity);
+
+      if (!principalOpt.isPresent()) {
+        // no matching token? reject
+        return false;
+      }
+
+      if (tables == null || tables.size() == 0) {
+        return true;
+      }
+
+      BasicAuthPrincipal principal = principalOpt.get();
+      for (String table : tables) {
+        if (!principal.hasTable(table)) {
+          return false;
+        }
+      }
+
+      return true;
+    }
+
+    private Optional<BasicAuthPrincipal> getPrincipalOpt(RequesterIdentity requesterIdentity) {
+      Preconditions.checkArgument(requesterIdentity instanceof HttpRequesterIdentity, "HttpRequesterIdentity required");
+      HttpRequesterIdentity identity = (HttpRequesterIdentity) requesterIdentity;
+
+      Collection<String> tokens = identity.getHttpHeaders().get(HEADER_AUTHORIZATION);
+      Optional<BasicAuthPrincipal> principalOpt =
+          tokens.stream().map(BasicAuthUtils::normalizeBase64Token).map(_token2principal::get).filter(Objects::nonNull)
+              .findFirst();
+      return principalOpt;
     }
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BasicAuthAccessControlFactory.java
@@ -109,7 +109,7 @@ public class BasicAuthAccessControlFactory extends AccessControlFactory {
         return false;
       }
 
-      if (tables == null || tables.size() == 0) {
+      if (tables == null || tables.isEmpty()) {
         return true;
       }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
@@ -20,6 +20,7 @@ package org.apache.pinot.broker.broker;
 
 import com.google.common.base.Preconditions;
 import java.util.Collection;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
@@ -85,20 +86,13 @@ public class ZkBasicAuthAccessControlFactory extends AccessControlFactory {
 
         @Override
         public boolean hasAccess(RequesterIdentity requesterIdentity, BrokerRequest brokerRequest) {
-            Optional<ZkBasicAuthPrincipal> principalOpt = getPrincipalAuth(requesterIdentity);
-            if (!principalOpt.isPresent()) {
-                // no matching token? reject
-                return false;
-            }
-
-            ZkBasicAuthPrincipal principal = principalOpt.get();
             if (brokerRequest == null || !brokerRequest.isSetQuerySource() || !brokerRequest.getQuerySource()
                 .isSetTableName()) {
                 // no table restrictions? accept
                 return true;
             }
 
-            return principal.hasTable(brokerRequest.getQuerySource().getTableName());
+            return hasAccess(requesterIdentity, Collections.singleton(brokerRequest.getQuerySource().getTableName()));
         }
 
         @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
@@ -108,7 +108,7 @@ public class ZkBasicAuthAccessControlFactory extends AccessControlFactory {
                 // no matching token? reject
                 return false;
             }
-            if (tables == null || tables.size() == 0) {
+            if (tables == null || tables.isEmpty()) {
                 return true;
             }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -55,7 +55,6 @@ import org.apache.pinot.query.catalog.PinotCatalog;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.mailbox.MultiplexingMailboxService;
 import org.apache.pinot.query.planner.QueryPlan;
-import org.apache.pinot.query.planner.StageMetadata;
 import org.apache.pinot.query.routing.WorkerManager;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.service.QueryConfig;

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
@@ -20,8 +20,13 @@ package org.apache.pinot.broker.broker;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import org.apache.pinot.broker.api.AccessControl;
 import org.apache.pinot.broker.api.HttpRequesterIdentity;
 import org.apache.pinot.common.request.BrokerRequest;
@@ -40,13 +45,20 @@ public class BasicAuthAccessControlTest {
 
   private AccessControl _accessControl;
 
+  Set<String> _tableNames;
+
   @BeforeClass
   public void setup() {
     Map<String, Object> config = new HashMap<>();
     config.put("principals", "admin,user");
     config.put("principals.admin.password", "verysecret");
     config.put("principals.user.password", "secret");
-    config.put("principals.user.tables", "lessImportantStuff");
+    config.put("principals.user.tables", "lessImportantStuff,lesserImportantStuff,leastImportantStuff");
+
+    _tableNames = new HashSet<>();
+    _tableNames.add("lessImportantStuff");
+    _tableNames.add("lesserImportantStuff");
+    _tableNames.add("leastImportantStuff");
 
     AccessControlFactory factory = new BasicAuthAccessControlFactory();
     factory.init(new PinotConfiguration(config));
@@ -56,7 +68,7 @@ public class BasicAuthAccessControlTest {
 
   @Test(expectedExceptions = IllegalArgumentException.class)
   public void testNullEntity() {
-    _accessControl.hasAccess(null, null);
+    _accessControl.hasAccess(null, (BrokerRequest) null);
   }
 
   @Test
@@ -66,7 +78,7 @@ public class BasicAuthAccessControlTest {
     HttpRequesterIdentity identity = new HttpRequesterIdentity();
     identity.setHttpHeaders(headers);
 
-    Assert.assertFalse(_accessControl.hasAccess(identity, null));
+    Assert.assertFalse(_accessControl.hasAccess(identity, (BrokerRequest) null));
   }
 
   @Test
@@ -84,6 +96,7 @@ public class BasicAuthAccessControlTest {
     request.setQuerySource(source);
 
     Assert.assertTrue(_accessControl.hasAccess(identity, request));
+    Assert.assertTrue(_accessControl.hasAccess(identity, _tableNames));
   }
 
   @Test
@@ -101,6 +114,14 @@ public class BasicAuthAccessControlTest {
     request.setQuerySource(source);
 
     Assert.assertFalse(_accessControl.hasAccess(identity, request));
+
+    Set<String> tableNames = new HashSet<>();
+    tableNames.add("veryImportantStuff");
+    Assert.assertFalse(_accessControl.hasAccess(identity,tableNames));
+    tableNames.add("lessImportantStuff");
+    Assert.assertFalse(_accessControl.hasAccess(identity,tableNames));
+    tableNames.add("lesserImportantStuff");
+    Assert.assertFalse(_accessControl.hasAccess(identity,tableNames));
   }
 
   @Test
@@ -118,6 +139,13 @@ public class BasicAuthAccessControlTest {
     request.setQuerySource(source);
 
     Assert.assertTrue(_accessControl.hasAccess(identity, request));
+
+    Set<String> tableNames = new HashSet<>();
+    tableNames.add("lessImportantStuff");
+    tableNames.add("veryImportantStuff");
+    tableNames.add("lesserImportantStuff");
+
+    Assert.assertTrue(_accessControl.hasAccess(identity,tableNames));
   }
 
   @Test
@@ -131,6 +159,9 @@ public class BasicAuthAccessControlTest {
     BrokerRequest request = new BrokerRequest();
 
     Assert.assertTrue(_accessControl.hasAccess(identity, request));
+
+    Set<String> tableNames = new HashSet<>();
+    Assert.assertTrue(_accessControl.hasAccess(identity, tableNames));
   }
 
   @Test
@@ -148,5 +179,6 @@ public class BasicAuthAccessControlTest {
     request.setQuerySource(source);
 
     Assert.assertTrue(_accessControl.hasAccess(identity, request));
+    Assert.assertTrue(_accessControl.hasAccess(identity, _tableNames));
   }
 }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BasicAuthAccessControlTest.java
@@ -20,11 +20,8 @@ package org.apache.pinot.broker.broker;
 
 import com.google.common.collect.ArrayListMultimap;
 import com.google.common.collect.Multimap;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.broker.api.AccessControl;
@@ -117,11 +114,11 @@ public class BasicAuthAccessControlTest {
 
     Set<String> tableNames = new HashSet<>();
     tableNames.add("veryImportantStuff");
-    Assert.assertFalse(_accessControl.hasAccess(identity,tableNames));
+    Assert.assertFalse(_accessControl.hasAccess(identity, tableNames));
     tableNames.add("lessImportantStuff");
-    Assert.assertFalse(_accessControl.hasAccess(identity,tableNames));
+    Assert.assertFalse(_accessControl.hasAccess(identity, tableNames));
     tableNames.add("lesserImportantStuff");
-    Assert.assertFalse(_accessControl.hasAccess(identity,tableNames));
+    Assert.assertFalse(_accessControl.hasAccess(identity, tableNames));
   }
 
   @Test
@@ -145,7 +142,7 @@ public class BasicAuthAccessControlTest {
     tableNames.add("veryImportantStuff");
     tableNames.add("lesserImportantStuff");
 
-    Assert.assertTrue(_accessControl.hasAccess(identity,tableNames));
+    Assert.assertTrue(_accessControl.hasAccess(identity, tableNames));
   }
 
   @Test


### PR DESCRIPTION
### Table Level Access Validation
For non-multistage queries, there are two levels of validations:
1. Validation with requesterIdentity
2. Validation with requesterIdentity and BrokerResource (which is typically used to extract table names and perform table level validation)


In MultistageBrokerRequestHandler, we currently only perform (1). This PR adds support for performing table level validations as well. 

### QPS Quota Checker
Added QPS Quota check for all tables involved in a multistage query

### Phase Timers
We have the following phase timers currently:

- REQUEST_COMPILATION
- AUTHORIZATION
- QUERY_ROUTING (This time is included in Compilation when workers are assigned to stages)
- QUERY_EXECUTION
- SCATTER_GATHER (We have stage level stats for Multistage)
- REDUCE (We have stage level stats for Multistage)
- (Not used) REQUEST_CONNECTION_WAIT
- (Not used) DESERIALIZATION

Added phase timers  for REQUEST_COMPILATION, AUTHORIZATION and QUERY_EXECUTION in this PR. T


cc: @siddharthteotia @somandal @walterddr 