### PR TITLE
[CI] Reduce timeout for codecov and not fail the job in any case

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -108,6 +108,8 @@ jobs:
         run: .github/workflows/scripts/.pinot_test.sh
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        continue-on-error: true
+        timeout-minutes: 5
         with:
           flags: unittests${{ matrix.testset }}
           name: codecov-unit-tests
@@ -154,6 +156,8 @@ jobs:
         run: .github/workflows/scripts/.pinot_test.sh
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@v3
+        continue-on-error: true
+        timeout-minutes: 5
         with:
           flags: integration${{ matrix.testset }}
           name: codecov-integration-tests


### PR DESCRIPTION
Observed some tests are succeed, but codecov upload process timeout in 6 hours then failed the CI job.
So change the plugin timeout to 5mins and continue on error to make sure the checks can go through.