### PR TITLE
LOCAL_JOIN Operator

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.SqlNumericLiteral;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.request.DataSource;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
@@ -266,10 +267,20 @@ public class RequestUtils {
   }
 
   public static String getTableName(PinotQuery pinotQuery) {
-    while (pinotQuery.getDataSource().getSubquery() != null) {
-      pinotQuery = pinotQuery.getDataSource().getSubquery();
+    return getTableName(pinotQuery.getDataSource());
+  }
+
+  public static String getTableName(DataSource dataSource) {
+    if (dataSource.getSubquery() != null) {
+      return getTableName(dataSource.getSubquery());
     }
-    return pinotQuery.getDataSource().getTableName();
+    if (dataSource.getTableName() != null) {
+      return dataSource.getTableName();
+    }
+    if (dataSource.getJoin() != null) {
+      return getTableName(dataSource.getJoin().getLeft());
+    }
+    throw new IllegalArgumentException("Failed to find table name");
   }
 
   public static Map<String, String> getOptionsFromJson(JsonNode request, String optionsKey) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/ColumnContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/ColumnContext.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator;
 
 import javax.annotation.Nullable;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
 import org.apache.pinot.segment.spi.datasource.DataSource;
@@ -69,5 +70,50 @@ public class ColumnContext {
     TransformResultMetadata resultMetadata = transformFunction.getResultMetadata();
     return new ColumnContext(resultMetadata.getDataType(), resultMetadata.isSingleValue(),
         transformFunction.getDictionary(), null);
+  }
+
+  public static ColumnContext fromColumnDataType(ColumnDataType columnDataType) {
+    switch (columnDataType) {
+      case INT:
+        return new ColumnContext(DataType.INT, true, null, null);
+      case LONG:
+        return new ColumnContext(DataType.LONG, true, null, null);
+      case FLOAT:
+        return new ColumnContext(DataType.FLOAT, true, null, null);
+      case DOUBLE:
+        return new ColumnContext(DataType.DOUBLE, true, null, null);
+      case BIG_DECIMAL:
+        return new ColumnContext(DataType.BIG_DECIMAL, true, null, null);
+      case BOOLEAN:
+        return new ColumnContext(DataType.BOOLEAN, true, null, null);
+      case TIMESTAMP:
+        return new ColumnContext(DataType.TIMESTAMP, true, null, null);
+      case STRING:
+        return new ColumnContext(DataType.STRING, true, null, null);
+      case JSON:
+        return new ColumnContext(DataType.JSON, true, null, null);
+      case BYTES:
+        return new ColumnContext(DataType.BYTES, true, null, null);
+      case INT_ARRAY:
+        return new ColumnContext(DataType.INT, false, null, null);
+      case LONG_ARRAY:
+        return new ColumnContext(DataType.LONG, false, null, null);
+      case FLOAT_ARRAY:
+        return new ColumnContext(DataType.FLOAT, false, null, null);
+      case DOUBLE_ARRAY:
+        return new ColumnContext(DataType.DOUBLE, false, null, null);
+      case BOOLEAN_ARRAY:
+        return new ColumnContext(DataType.BOOLEAN, false, null, null);
+      case TIMESTAMP_ARRAY:
+        return new ColumnContext(DataType.TIMESTAMP, false, null, null);
+      case STRING_ARRAY:
+        return new ColumnContext(DataType.STRING, false, null, null);
+      case BYTES_ARRAY:
+        return new ColumnContext(DataType.BYTES, false, null, null);
+      case UNKNOWN:
+        return new ColumnContext(DataType.UNKNOWN, true, null, null);
+      default:
+        throw new IllegalStateException("Unsupported column data type: " + columnDataType);
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/LocalJoinOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/LocalJoinOperator.java
@@ -1,0 +1,296 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator;
+
+import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Base64;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.datatable.DataTableFactory;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.common.utils.HashUtil;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.operator.blocks.RowBasedValueBlock;
+import org.apache.pinot.core.operator.blocks.RowBlock;
+import org.apache.pinot.core.operator.blocks.ValueBlock;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.SharedValueKey;
+
+
+// TODO: Support null handling
+// TODO: Support extra filter condition
+public class LocalJoinOperator extends BaseProjectOperator<RowBasedValueBlock> {
+  private static final String EXPLAIN_NAME = "LOCAL_JOIN";
+
+  private final QueryContext _queryContext;
+  private final BaseProjectOperator<?> _leftProjectOperator;
+  private final LookUpContext _context;
+
+  public LocalJoinOperator(QueryContext queryContext, BaseProjectOperator<?> leftProjectOperator, String leftTableName,
+      String rightTableName, ExpressionContext leftJoinKey, String rightJoinKey, String[] projectColumns) {
+    _queryContext = queryContext;
+    _leftProjectOperator = leftProjectOperator;
+    _context = queryContext.getOrComputeSharedValue(LookUpContext.class, rightTableName,
+        k -> initContext(leftTableName, rightTableName, leftJoinKey, rightJoinKey, projectColumns));
+  }
+
+  private LookUpContext initContext(String leftTableName, String rightTableName, ExpressionContext leftJoinKey,
+      String rightJoinKey, String[] projectColumns) {
+    LookUpContext context = new LookUpContext();
+
+    String rightTableKey = SharedValueKey.LOCAL_JOIN_RIGHT_TABLE_PREFIX + rightTableName;
+    String serializedRightDataTable = _queryContext.getQueryOptions().get(rightTableKey);
+    RowBlock rightTable = _queryContext.getSharedValue(RowBlock.class, rightTableKey);
+
+    // Compute the right column to index map
+    DataTable rightDataTable = null;
+    DataSchema rightDataSchema;
+    if (rightTable == null) {
+      Preconditions.checkState(serializedRightDataTable != null, "Cannot find right table: %s", rightTableName);
+      try {
+        rightDataTable = DataTableFactory.getDataTable(Base64.getDecoder().decode(serializedRightDataTable));
+        rightDataSchema = rightDataTable.getDataSchema();
+      } catch (IOException e) {
+        throw new RuntimeException("Caught exception while deserializing the right table: " + rightTableName);
+      }
+    } else {
+      rightDataSchema = rightTable.getDataSchema();
+    }
+    String[] rightRawColumns = rightDataSchema.getColumnNames();
+    ColumnDataType[] rightColumnDataTypes = rightDataSchema.getColumnDataTypes();
+    Object2IntMap<String> rightRawColumnToIndexMap = new Object2IntOpenHashMap<>(rightRawColumns.length);
+    rightRawColumnToIndexMap.defaultReturnValue(-1);
+    for (int i = 0; i < rightRawColumns.length; i++) {
+      rightRawColumnToIndexMap.put(rightRawColumns[i], i);
+    }
+
+    // Construct the look-up table
+    int rightJoinColumnIndex = rightRawColumnToIndexMap.getInt(rightJoinKey);
+    Preconditions.checkArgument(rightJoinColumnIndex != -1, "Failed to find right join column: %s", rightJoinKey);
+    Map<Object, List<Object[]>> lookupTable = new HashMap<>();
+    if (rightTable == null) {
+      int numRows = rightDataTable.getNumberOfRows();
+      for (int i = 0; i < numRows; i++) {
+        Object[] row = SelectionOperatorUtils.extractRowFromDataTable(rightDataTable, i);
+        Object key = row[rightJoinColumnIndex];
+        lookupTable.computeIfAbsent(key, k1 -> new ArrayList<>()).add(row);
+      }
+    } else {
+      List<Object[]> rows = rightTable.getRows();
+      for (Object[] row : rows) {
+        Object key = row[rightJoinColumnIndex];
+        lookupTable.computeIfAbsent(key, k1 -> new ArrayList<>()).add(row);
+      }
+    }
+    context._lookupTable = lookupTable;
+
+    Object2IntMap<ExpressionContext> leftRawColumnToIndexMap = new Object2IntOpenHashMap<>();
+    leftRawColumnToIndexMap.defaultReturnValue(-1);
+    List<ExpressionContext> leftRawColumns = new ArrayList<>();
+    leftRawColumnToIndexMap.put(leftJoinKey, 0);
+    leftRawColumns.add(leftJoinKey);
+
+    // Compute the project column indexes and types
+    String leftTableColumnPrefix = leftTableName + ".";
+    int leftPrefixLength = leftTableColumnPrefix.length();
+    String rightTableColumnPrefix = rightTableName + ".";
+    int rightPrefixLength = rightTableColumnPrefix.length();
+    int numProjectColumns = projectColumns.length;
+    boolean[] projectColumnInLeftTable = new boolean[numProjectColumns];
+    int[] projectColumnIndexes = new int[numProjectColumns];
+    ColumnDataType[] projectColumnTypes = new ColumnDataType[numProjectColumns];
+    Map<String, ColumnContext> columnContextMap = new HashMap<>(HashUtil.getHashMapCapacity(numProjectColumns));
+    for (int i = 0; i < numProjectColumns; i++) {
+      String projectColumn = projectColumns[i];
+      ColumnDataType columnDataType;
+      if (projectColumn.startsWith(leftTableColumnPrefix)) {
+        projectColumnInLeftTable[i] = true;
+        ExpressionContext leftRawColumn = ExpressionContext.forIdentifier(projectColumn.substring(leftPrefixLength));
+        int index = leftRawColumnToIndexMap.computeIntIfAbsent(leftRawColumn, k1 -> {
+          leftRawColumns.add(k1);
+          return leftRawColumnToIndexMap.size();
+        });
+        projectColumnIndexes[i] = index;
+        ColumnContext columnContext = _leftProjectOperator.getResultColumnContext(leftRawColumn);
+        columnDataType = ColumnDataType.fromDataType(columnContext.getDataType(), columnContext.isSingleValue());
+      } else {
+        Preconditions.checkArgument(projectColumn.startsWith(rightTableColumnPrefix),
+            "Illegal project column: %s (no table prefix)", projectColumn);
+        String rightRawColumn = projectColumn.substring(rightPrefixLength);
+        int index = rightRawColumnToIndexMap.getInt(rightRawColumn);
+        Preconditions.checkArgument(index != -1, "Failed to find right project column: %s", rightRawColumn);
+        projectColumnIndexes[i] = index;
+        columnDataType = rightColumnDataTypes[index];
+      }
+      projectColumnTypes[i] = columnDataType;
+      columnContextMap.put(projectColumn, ColumnContext.fromColumnDataType(columnDataType));
+    }
+
+    context._leftRawColumns = leftRawColumns.toArray(new ExpressionContext[0]);
+    context._projectColumnInLeftTable = projectColumnInLeftTable;
+    context._projectColumnIndexes = projectColumnIndexes;
+    context._columnContextMap = columnContextMap;
+    context._resultDataSchema = new DataSchema(projectColumns, projectColumnTypes);
+    return context;
+  }
+
+  @Override
+  public Map<String, ColumnContext> getSourceColumnContextMap() {
+    return _context._columnContextMap;
+  }
+
+  @Override
+  public ColumnContext getResultColumnContext(ExpressionContext expression) {
+    assert expression.getType() == ExpressionContext.Type.IDENTIFIER;
+    return _context._columnContextMap.get(expression.getIdentifier());
+  }
+
+  @Override
+  protected RowBasedValueBlock getNextBlock() {
+    ValueBlock valueBlock = _leftProjectOperator.nextBlock();
+    if (valueBlock == null) {
+      return null;
+    }
+    List<Object[]> rows = new ArrayList<>();
+    int numLeftColumns = _context._leftRawColumns.length;
+    Object[][] leftColumnValues = new Object[numLeftColumns][];
+    int numDocs = valueBlock.getNumDocs();
+    for (int i = 0; i < numLeftColumns; i++) {
+      ExpressionContext leftColumn = _context._leftRawColumns[i];
+      BlockValSet valueSet = valueBlock.getBlockValueSet(leftColumn);
+      switch (valueSet.getValueType().getStoredType()) {
+        case INT: {
+          Object[] values = leftColumnValues[i];
+          if (values == null || values.length < numDocs) {
+            values = new Object[numDocs];
+            leftColumnValues[i] = values;
+          }
+          int[] intValuesSV = valueSet.getIntValuesSV();
+          for (int j = 0; j < numDocs; j++) {
+            values[j] = intValuesSV[j];
+          }
+          break;
+        }
+        case LONG: {
+          Object[] values = leftColumnValues[i];
+          if (values == null || values.length < numDocs) {
+            values = new Object[numDocs];
+            leftColumnValues[i] = values;
+          }
+          long[] longValuesSV = valueSet.getLongValuesSV();
+          for (int j = 0; j < numDocs; j++) {
+            values[j] = longValuesSV[j];
+          }
+          break;
+        }
+        case FLOAT: {
+          Object[] values = leftColumnValues[i];
+          if (values == null || values.length < numDocs) {
+            values = new Object[numDocs];
+            leftColumnValues[i] = values;
+          }
+          float[] floatValuesSV = valueSet.getFloatValuesSV();
+          for (int j = 0; j < numDocs; j++) {
+            values[j] = floatValuesSV[j];
+          }
+          break;
+        }
+        case DOUBLE: {
+          Object[] values = leftColumnValues[i];
+          if (values == null || values.length < numDocs) {
+            values = new Object[numDocs];
+            leftColumnValues[i] = values;
+          }
+          double[] doubleValuesSV = valueSet.getDoubleValuesSV();
+          for (int j = 0; j < numDocs; j++) {
+            values[j] = doubleValuesSV[j];
+          }
+          break;
+        }
+        case BIG_DECIMAL:
+          leftColumnValues[i] = valueSet.getBigDecimalValuesSV();
+          break;
+        case STRING:
+          leftColumnValues[i] = valueSet.getStringValuesSV();
+          break;
+        case BYTES:
+          leftColumnValues[i] = valueSet.getBytesValuesSV();
+          break;
+        default:
+          throw new IllegalStateException("Unsupported value type: " + valueSet.getValueType().getStoredType());
+      }
+    }
+    int numProjectColumns = _context._projectColumnIndexes.length;
+    for (int i = 0; i < numDocs; i++) {
+      Object key = leftColumnValues[0][i];
+      List<Object[]> rightRows = _context._lookupTable.get(key);
+      if (rightRows != null) {
+        for (Object[] rightRow : rightRows) {
+          Object[] row = new Object[numProjectColumns];
+          for (int j = 0; j < numProjectColumns; j++) {
+            int columnIndex = _context._projectColumnIndexes[j];
+            if (_context._projectColumnInLeftTable[j]) {
+              row[j] = leftColumnValues[columnIndex][i];
+            } else {
+              row[j] = rightRow[columnIndex];
+            }
+          }
+          rows.add(row);
+        }
+      }
+    }
+
+    return new RowBasedValueBlock(_context._resultDataSchema, rows);
+  }
+
+  @Override
+  public List<BaseProjectOperator<?>> getChildOperators() {
+    return Collections.singletonList(_leftProjectOperator);
+  }
+
+  @Override
+  public String toExplainString() {
+    return EXPLAIN_NAME;
+  }
+
+  @Override
+  public ExecutionStatistics getExecutionStatistics() {
+    return _leftProjectOperator.getExecutionStatistics();
+  }
+
+  public static class LookUpContext {
+    // TODO: Consider adding a single value lookup table when all the lists are single element
+    public Map<Object, List<Object[]>> _lookupTable;
+    public ExpressionContext[] _leftRawColumns;
+    public boolean[] _projectColumnInLeftTable;
+    public int[] _projectColumnIndexes;
+    public Map<String, ColumnContext> _columnContextMap;
+    public DataSchema _resultDataSchema;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/RowBasedValueBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/RowBasedValueBlock.java
@@ -1,0 +1,64 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.blocks;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.ArrayUtils;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.core.query.reduce.RowBasedBlockValSet;
+
+
+public class RowBasedValueBlock extends RowBlock implements ValueBlock {
+
+  public RowBasedValueBlock(DataSchema dataSchema, List<Object[]> rows) {
+    super(dataSchema, rows);
+  }
+
+  @Override
+  public int getNumDocs() {
+    return _rows.size();
+  }
+
+  @Nullable
+  @Override
+  public int[] getDocIds() {
+    return null;
+  }
+
+  @Override
+  public BlockValSet getBlockValueSet(ExpressionContext expression) {
+    Preconditions.checkState(expression.getType() == ExpressionContext.Type.IDENTIFIER,
+        "Only support reading column (IDENTIFIER) from RowBlock, got: %s", expression.getType());
+    return getBlockValueSet(expression.getIdentifier());
+  }
+
+  @Override
+  public BlockValSet getBlockValueSet(String column) {
+    // TODO: Consider caching the RowBasedBlockValSet and reuse the column major value array
+    int index = ArrayUtils.indexOf(_dataSchema.getColumnNames(), column);
+    Preconditions.checkState(index >= 0, "Failed to find column: %s", column);
+    DataSchema.ColumnDataType columnDataType = _dataSchema.getColumnDataTypes()[index];
+    Preconditions.checkState(!columnDataType.isArray(), "Do not support ARRAY type: %s", columnDataType);
+    return new RowBasedBlockValSet(columnDataType, _rows, index);
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/RowBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/RowBlock.java
@@ -1,0 +1,42 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.blocks;
+
+import java.util.List;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.Block;
+
+
+public class RowBlock implements Block {
+  protected final DataSchema _dataSchema;
+  protected final List<Object[]> _rows;
+
+  public RowBlock(DataSchema dataSchema, List<Object[]> rows) {
+    _dataSchema = dataSchema;
+    _rows = rows;
+  }
+
+  public DataSchema getDataSchema() {
+    return _dataSchema;
+  }
+
+  public List<Object[]> getRows() {
+    return _rows;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -97,6 +97,15 @@ public class AggregationPlanNode implements PlanNode {
     int numTotalDocs = _indexSegment.getSegmentMetadata().getTotalDocs();
     AggregationFunction[] aggregationFunctions = _queryContext.getAggregationFunctions();
 
+    // DO NOT use optimized operator for JOIN queries because column might be from the right table
+    if (_queryContext.hasJoin()) {
+      Set<ExpressionContext> expressionsToTransform =
+          AggregationFunctionUtils.collectExpressionsToTransform(aggregationFunctions, null);
+      BaseProjectOperator<?> projectOperator = new ProjectPlanNode(_indexSegment, _queryContext, expressionsToTransform,
+          DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
+      return new AggregationOperator(aggregationFunctions, projectOperator, numTotalDocs, false);
+    }
+
     FilterPlanNode filterPlanNode = new FilterPlanNode(_indexSegment, _queryContext);
     BaseFilterOperator filterOperator = filterPlanNode.run();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/CombinePlanNode.java
@@ -217,7 +217,8 @@ public class CombinePlanNode implements PlanNode {
           // Selection order-by
           List<OrderByExpressionContext> orderByExpressions = _queryContext.getOrderByExpressions();
           assert orderByExpressions != null;
-          if (orderByExpressions.get(0).getExpression().getType() == ExpressionContext.Type.IDENTIFIER) {
+          if (orderByExpressions.get(0).getExpression().getType() == ExpressionContext.Type.IDENTIFIER
+              && !_queryContext.hasJoin()) {
             return new MinMaxValueBasedSelectionOrderByCombineOperator(operators, _queryContext, _executorService);
           } else {
             return new SelectionOrderByCombineOperator(operators, _queryContext, _executorService);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
@@ -18,9 +18,11 @@
  */
 package org.apache.pinot.core.plan;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -28,9 +30,11 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.operator.BaseProjectOperator;
 import org.apache.pinot.core.operator.DocIdSetOperator;
+import org.apache.pinot.core.operator.LocalJoinOperator;
 import org.apache.pinot.core.operator.ProjectionOperator;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.operator.transform.TransformOperator;
+import org.apache.pinot.core.query.request.context.JoinContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
@@ -62,6 +66,10 @@ public class ProjectPlanNode implements PlanNode {
 
   @Override
   public BaseProjectOperator<?> run() {
+    return _queryContext.hasJoin() ? createProjectOperatorWithJoin() : createProjectOperatorWithoutJoin();
+  }
+
+  private BaseProjectOperator<?> createProjectOperatorWithoutJoin() {
     Set<String> projectionColumns = new HashSet<>();
     boolean hasNonIdentifierExpression = false;
     for (ExpressionContext expression : _expressions) {
@@ -70,14 +78,65 @@ public class ProjectPlanNode implements PlanNode {
         hasNonIdentifierExpression = true;
       }
     }
+    ProjectionOperator projectionOperator = createProjectionOperator(projectionColumns);
+    return hasNonIdentifierExpression ? new TransformOperator(_queryContext, projectionOperator, _expressions)
+        : projectionOperator;
+  }
+
+  private BaseProjectOperator<?> createProjectOperatorWithJoin() {
+    Set<String> joinProjectColumns = new HashSet<>();
+    boolean hasNonIdentifierExpressionAfterJoin = false;
+    for (ExpressionContext expression : _expressions) {
+      expression.getColumns(joinProjectColumns);
+      if (expression.getType() != ExpressionContext.Type.IDENTIFIER) {
+        hasNonIdentifierExpressionAfterJoin = true;
+      }
+    }
+
+    JoinContext join = _queryContext.getDataSource().getJoin();
+    String columnPrefix = join.getRawLeftTableName() + ".";
+    int prefixLength = columnPrefix.length();
+    Set<String> projectionColumns = new HashSet<>();
+    for (String column : joinProjectColumns) {
+      if (column.startsWith(columnPrefix)) {
+        projectionColumns.add(column.substring(prefixLength));
+      }
+    }
+
+    BaseProjectOperator<?> projectOperatorBeforeJoin;
+    ExpressionContext leftJoinKey = join.getLeftJoinKey();
+    if (leftJoinKey.getType() == ExpressionContext.Type.IDENTIFIER) {
+      // No transform before JOIN
+      projectionColumns.add(leftJoinKey.getIdentifier());
+      projectOperatorBeforeJoin = createProjectionOperator(projectionColumns);
+    } else {
+      // Need transform before JOIN
+      List<ExpressionContext> expressionsBeforeJoin = new ArrayList<>(projectionColumns.size() + 1);
+      expressionsBeforeJoin.add(leftJoinKey);
+      for (String column : projectionColumns) {
+        expressionsBeforeJoin.add(ExpressionContext.forIdentifier(column));
+      }
+      leftJoinKey.getColumns(projectionColumns);
+      ProjectionOperator projectionOperator = createProjectionOperator(projectionColumns);
+      projectOperatorBeforeJoin = new TransformOperator(_queryContext, projectionOperator, expressionsBeforeJoin);
+    }
+
+    LocalJoinOperator localJoinOperator =
+        new LocalJoinOperator(_queryContext, projectOperatorBeforeJoin, join.getRawLeftTableName(),
+            join.getRightTableName(), leftJoinKey, join.getRightJoinKey(), joinProjectColumns.toArray(new String[0]));
+    return hasNonIdentifierExpressionAfterJoin ? new TransformOperator(_queryContext, localJoinOperator, _expressions)
+        : localJoinOperator;
+  }
+
+  private ProjectionOperator createProjectionOperator(Set<String> projectionColumns) {
     Map<String, DataSource> dataSourceMap = new HashMap<>(HashUtil.getHashMapCapacity(projectionColumns.size()));
-    projectionColumns.forEach(column -> dataSourceMap.put(column, _indexSegment.getDataSource(column)));
+    for (String column : projectionColumns) {
+      dataSourceMap.put(column, _indexSegment.getDataSource(column));
+    }
     // NOTE: Skip creating DocIdSetOperator when maxDocsPerCall is 0 (for selection query with LIMIT 0)
     DocIdSetOperator docIdSetOperator =
         _maxDocsPerCall > 0 ? new DocIdSetPlanNode(_indexSegment, _queryContext, _maxDocsPerCall, _filterOperator).run()
             : null;
-    ProjectionOperator projectionOperator = new ProjectionOperator(dataSourceMap, docIdSetOperator);
-    return hasNonIdentifierExpression ? new TransformOperator(_queryContext, projectionOperator, _expressions)
-        : projectionOperator;
+    return new ProjectionOperator(dataSourceMap, docIdSetOperator);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SelectionQuerySegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/SelectionQuerySegmentPruner.java
@@ -53,8 +53,8 @@ public class SelectionQuerySegmentPruner implements SegmentPruner {
   public boolean isApplicableTo(QueryContext query) {
     // Only prune selection queries
     // If LIMIT is not 0, only prune segments for selection queries without filter
-    return QueryContextUtils.isSelectionQuery(query)
-        && (query.getFilter() == null || query.getLimit() == 0);
+    return QueryContextUtils.isSelectionQuery(query) && ((query.getFilter() == null && !query.hasJoin())
+        || query.getLimit() == 0);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/DataSourceContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/DataSourceContext.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.request.context;
+
+public class DataSourceContext {
+  private final String _tableName;
+  private final QueryContext _subquery;
+  private final JoinContext _join;
+
+  public DataSourceContext(String tableName, QueryContext subquery, JoinContext join) {
+    _tableName = tableName;
+    _subquery = subquery;
+    _join = join;
+  }
+
+  public String getTableName() {
+    return _tableName;
+  }
+
+  public QueryContext getSubquery() {
+    return _subquery;
+  }
+
+  public JoinContext getJoin() {
+    return _join;
+  }
+
+  @Override
+  public String toString() {
+    return "DataSourceContext{" + "_tableName='" + _tableName + '\'' + ", _subquery=" + _subquery + ", _join=" + _join
+        + '}';
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/JoinContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/JoinContext.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.request.context;
+
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+
+
+public class JoinContext {
+  private final String _leftTableName;
+  private final String _rawLeftTableName;
+  private final String _rightTableName;
+  private final ExpressionContext _leftJoinKey;
+  private final String _rightJoinKey;
+
+  public JoinContext(String leftTableName, String rightTableName, ExpressionContext leftJoinKey, String rightJoinKey) {
+    _leftTableName = leftTableName;
+    _rawLeftTableName = TableNameBuilder.extractRawTableName(leftTableName);
+    _rightTableName = rightTableName;
+    _leftJoinKey = leftJoinKey;
+    _rightJoinKey = rightJoinKey;
+  }
+
+  public String getLeftTableName() {
+    return _leftTableName;
+  }
+
+  public String getRawLeftTableName() {
+    return _rawLeftTableName;
+  }
+
+  public String getRightTableName() {
+    return _rightTableName;
+  }
+
+  public ExpressionContext getLeftJoinKey() {
+    return _leftJoinKey;
+  }
+
+  public String getRightJoinKey() {
+    return _rightJoinKey;
+  }
+
+  @Override
+  public String toString() {
+    return "JoinContext{" + "_leftTableName='" + _leftTableName + '\'' + ", _rightTableName='" + _rightTableName + '\''
+        + ", _leftJoinKey=" + _leftJoinKey + ", _rightJoinKey='" + _rightJoinKey + '\'' + '}';
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.request.context.utils;
 
+import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -29,11 +30,16 @@ import org.apache.pinot.common.request.DataSource;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.ExpressionType;
 import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Join;
+import org.apache.pinot.common.request.JoinType;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FilterContext;
+import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.core.query.request.context.DataSourceContext;
+import org.apache.pinot.core.query.request.context.JoinContext;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 
@@ -54,13 +60,7 @@ public class QueryContextConverterUtils {
    */
   public static QueryContext getQueryContext(PinotQuery pinotQuery) {
     // FROM
-    String tableName;
-    DataSource dataSource = pinotQuery.getDataSource();
-    tableName = dataSource.getTableName();
-    QueryContext subquery = null;
-    if (dataSource.getSubquery() != null) {
-      subquery = getQueryContext(dataSource.getSubquery());
-    }
+    DataSourceContext dataSource = getDataSourceContext(pinotQuery.getDataSource());
 
     // SELECT
     List<ExpressionContext> selectExpressions;
@@ -107,7 +107,9 @@ public class QueryContextConverterUtils {
     FilterContext filter = null;
     Expression filterExpression = pinotQuery.getFilterExpression();
     if (filterExpression != null) {
-      filter = RequestContextUtils.getFilter(filterExpression);
+      JoinContext join = dataSource.getJoin();
+      String columnPrefix = join != null ? join.getRawLeftTableName() + "." : null;
+      filter = RequestContextUtils.getFilter(filterExpression, columnPrefix);
     }
 
     // GROUP BY
@@ -155,11 +157,91 @@ public class QueryContextConverterUtils {
       }
     }
 
-    return new QueryContext.Builder().setTableName(tableName).setSubquery(subquery)
-        .setSelectExpressions(selectExpressions).setAliasList(aliasList).setFilter(filter)
-        .setGroupByExpressions(groupByExpressions).setOrderByExpressions(orderByExpressions)
-        .setHavingFilter(havingFilter).setLimit(pinotQuery.getLimit()).setOffset(pinotQuery.getOffset())
-        .setQueryOptions(pinotQuery.getQueryOptions()).setExpressionOverrideHints(expressionContextOverrideHints)
-        .setExplain(pinotQuery.isExplain()).build();
+    return new QueryContext.Builder().setDataSource(dataSource).setSelectExpressions(selectExpressions)
+        .setAliasList(aliasList).setFilter(filter).setGroupByExpressions(groupByExpressions)
+        .setOrderByExpressions(orderByExpressions).setHavingFilter(havingFilter).setLimit(pinotQuery.getLimit())
+        .setOffset(pinotQuery.getOffset()).setQueryOptions(pinotQuery.getQueryOptions())
+        .setExpressionOverrideHints(expressionContextOverrideHints).setExplain(pinotQuery.isExplain()).build();
+  }
+
+  private static DataSourceContext getDataSourceContext(DataSource dataSource) {
+    String tableName = dataSource.getTableName();
+    QueryContext subquery = null;
+    if (dataSource.getSubquery() != null) {
+      subquery = getQueryContext(dataSource.getSubquery());
+    }
+    JoinContext joinContext = null;
+    if (dataSource.getJoin() != null) {
+      Join join = dataSource.getJoin();
+      Preconditions.checkArgument(join.getType() == JoinType.INNER, "Only INNER JOIN is supported");
+
+      DataSourceContext leftDataSource = getDataSourceContext(join.getLeft());
+      Preconditions.checkArgument(isSimpleTable(leftDataSource), "Left side of JOIN must be a table, got: %s",
+          leftDataSource);
+      String leftTableName = leftDataSource.getTableName();
+      String leftTableColumnPrefix = leftTableName + ".";
+
+      DataSourceContext rightDataSource = getDataSourceContext(join.getRight());
+      Preconditions.checkArgument(isSimpleTable(rightDataSource), "Right side of JOIN must be a table, got: %s",
+          rightDataSource);
+      String rightTableName = rightDataSource.getTableName();
+      String rightTableColumnPrefix = rightTableName + ".";
+
+      Expression condition = join.getCondition();
+      Preconditions.checkArgument(condition != null, "JOIN condition must be specified");
+      Function function = condition.getFunctionCall();
+      Preconditions.checkArgument(function != null && function.getOperator().equals("EQUALS"),
+          "Only EQ JOIN condition is supported, got: %s", condition);
+      List<Expression> operands = function.getOperands();
+      ExpressionContext firstJoinKey = RequestContextUtils.getExpression(operands.get(0));
+      ExpressionContext secondJoinKey = RequestContextUtils.getExpression(operands.get(1));
+      ExpressionContext leftJoinKey;
+      String rightJoinKey;
+      if (isRightTableColumn(secondJoinKey, rightTableColumnPrefix)) {
+        leftJoinKey = getLeftJoinKey(firstJoinKey, leftTableColumnPrefix);
+        rightJoinKey = getRightJoinKey(secondJoinKey, rightTableColumnPrefix);
+      } else {
+        Preconditions.checkArgument(isRightTableColumn(firstJoinKey, rightTableColumnPrefix),
+            "Failed to find JOIN key for right table");
+        leftJoinKey = getLeftJoinKey(secondJoinKey, leftTableColumnPrefix);
+        rightJoinKey = getRightJoinKey(firstJoinKey, rightTableColumnPrefix);
+      }
+      joinContext = new JoinContext(leftTableName, rightTableName, leftJoinKey, rightJoinKey);
+    }
+    return new DataSourceContext(tableName, subquery, joinContext);
+  }
+
+  private static boolean isSimpleTable(DataSourceContext dataSource) {
+    return dataSource.getTableName() != null && dataSource.getSubquery() == null && dataSource.getJoin() == null;
+  }
+
+  private static boolean isRightTableColumn(ExpressionContext expression, String rightTableColumnPrefix) {
+    return expression.getIdentifier() != null && expression.getIdentifier().startsWith(rightTableColumnPrefix);
+  }
+
+  private static ExpressionContext getLeftJoinKey(ExpressionContext expression, String leftTableColumnPrefix) {
+    switch (expression.getType()) {
+      case LITERAL:
+        return expression;
+      case IDENTIFIER:
+        String identifier = expression.getIdentifier();
+        if (identifier.equals("*")) {
+          return expression;
+        } else {
+          Preconditions.checkArgument(identifier.startsWith(leftTableColumnPrefix),
+              "Column: %s does not have left table prefix: %s", identifier, leftTableColumnPrefix);
+          return ExpressionContext.forIdentifier(identifier.substring(leftTableColumnPrefix.length()));
+        }
+      case FUNCTION:
+        FunctionContext function = expression.getFunction();
+        function.getArguments().replaceAll(argument -> getLeftJoinKey(argument, leftTableColumnPrefix));
+        return expression;
+      default:
+        throw new IllegalStateException();
+    }
+  }
+
+  private static String getRightJoinKey(ExpressionContext expressionContext, String rightTableColumnPrefix) {
+    return expressionContext.getIdentifier().substring(rightTableColumnPrefix.length());
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -66,6 +66,7 @@ import org.apache.pinot.sql.parsers.CalciteSqlParser;
 /**
  * Base class for queries tests.
  */
+@SuppressWarnings("unchecked")
 public abstract class BaseQueriesTest {
   protected static final PlanMaker PLAN_MAKER = new InstancePlanMakerImplV2();
   protected static final QueryOptimizer OPTIMIZER = new QueryOptimizer();
@@ -86,11 +87,14 @@ public abstract class BaseQueriesTest {
    * Run query on single index segment.
    * <p>Use this to test a single operator.
    */
-  @SuppressWarnings({"rawtypes", "unchecked"})
-  protected <T extends Operator> T getOperator(String query) {
+  protected <T extends Operator<?>> T getOperator(String query) {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     PinotQuery serverPinotQuery = GapfillUtils.stripGapfill(pinotQuery);
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(serverPinotQuery);
+    return getOperator(queryContext);
+  }
+
+  protected <T extends Operator<?>> T getOperator(QueryContext queryContext) {
     return (T) PLAN_MAKER.makeSegmentPlanNode(getIndexSegment(), queryContext).run();
   }
 
@@ -98,8 +102,7 @@ public abstract class BaseQueriesTest {
    * Run query with hard-coded filter on single index segment.
    * <p>Use this to test a single operator.
    */
-  @SuppressWarnings("rawtypes")
-  protected <T extends Operator> T getOperatorWithFilter(String query) {
+  protected <T extends Operator<?>> T getOperatorWithFilter(String query) {
     return getOperator(query + getFilter());
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/LocalJoinQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/LocalJoinQueriesTest.java
@@ -1,0 +1,689 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.queries;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.common.datatable.DataTableBuilder;
+import org.apache.pinot.core.common.datatable.DataTableBuilderV4;
+import org.apache.pinot.core.data.table.Record;
+import org.apache.pinot.core.operator.blocks.RowBlock;
+import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
+import org.apache.pinot.core.operator.blocks.results.DistinctResultsBlock;
+import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
+import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
+import org.apache.pinot.core.query.aggregation.groupby.AggregationGroupByResult;
+import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
+import org.apache.pinot.core.query.distinct.DistinctTable;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.SharedValueKey;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class LocalJoinQueriesTest extends BaseQueriesTest {
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "LocalJoinQueriesTest");
+  private static final String RAW_LEFT_TABLE_NAME = "T1";
+  private static final String RIGHT_TABLE_NAME = "T2";
+  private static final String SEGMENT_NAME = "testSegment";
+
+  private static final int NUM_ROWS_LEFT = 1000;
+  private static final int NUM_ROWS_RIGHT = 200;
+  private static final int NUM_UNIQUE_ROWS = 100;
+
+  private IndexSegment _indexSegment;
+  private List<IndexSegment> _indexSegments;
+  private String _serializedRightDataTable;
+  private RowBlock _rightTable;
+
+  @Override
+  protected String getFilter() {
+    return null;
+  }
+
+  @Override
+  protected IndexSegment getIndexSegment() {
+    return _indexSegment;
+  }
+
+  @Override
+  protected List<IndexSegment> getIndexSegments() {
+    return _indexSegments;
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteDirectory(INDEX_DIR);
+    setUpSegment();
+    setUpRightTable();
+  }
+
+  /**
+   * T1.a T1.b T1.c
+   *    0    1    2
+   *    1    2    3
+   *    2    3    4
+   * ...
+   *   99  100  101
+   * (repeat 10 times)
+   */
+  private void setUpSegment()
+      throws Exception {
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_LEFT_TABLE_NAME).build();
+    Schema schema =
+        new Schema.SchemaBuilder().setSchemaName(RAW_LEFT_TABLE_NAME).addSingleValueDimension("a", DataType.INT)
+            .addSingleValueDimension("b", DataType.LONG).addSingleValueDimension("c", DataType.STRING).build();
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
+    config.setSegmentName(SEGMENT_NAME);
+    config.setOutDir(INDEX_DIR.getAbsolutePath());
+
+    List<GenericRow> rows = new ArrayList<>(NUM_ROWS_LEFT);
+    for (int i = 0; i < NUM_ROWS_LEFT; i++) {
+      GenericRow row = new GenericRow();
+      int value = i % NUM_UNIQUE_ROWS;
+      row.putValue("a", value);
+      row.putValue("b", value + 1);
+      row.putValue("c", value + 2);
+      rows.add(row);
+    }
+
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    driver.init(config, new GenericRowRecordReader(rows));
+    driver.build();
+
+    ImmutableSegment immutableSegment =
+        ImmutableSegmentLoader.load(new File(INDEX_DIR, driver.getSegmentName()), ReadMode.mmap);
+    _indexSegment = immutableSegment;
+    _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+  }
+
+  /**
+   * T2.a T2.b T2.c
+   *    0    2    4
+   *    1    3    5
+   *    2    4    6
+   * ...
+   *   99  101  103
+   * (repeat 2 times)
+   */
+  private void setUpRightTable()
+      throws IOException {
+    DataSchema dataSchema = new DataSchema(new String[]{"a", "b", "c"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.STRING
+    });
+    DataTableBuilder dataTableBuilder = new DataTableBuilderV4(dataSchema);
+    List<Object[]> rows = new ArrayList<>(NUM_ROWS_RIGHT);
+    for (int i = 0; i < NUM_ROWS_RIGHT; i++) {
+      int value = i % NUM_UNIQUE_ROWS;
+      dataTableBuilder.startRow();
+      dataTableBuilder.setColumn(0, value);
+      dataTableBuilder.setColumn(1, (long) (value + 2));
+      dataTableBuilder.setColumn(2, Integer.toString(value + 4));
+      dataTableBuilder.finishRow();
+      rows.add(new Object[]{value, (long) (value + 2), Integer.toString(value + 4)});
+    }
+    _serializedRightDataTable = Base64.getEncoder().encodeToString(dataTableBuilder.build().toBytes());
+    _rightTable = new RowBlock(dataSchema, rows);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(INDEX_DIR);
+  }
+
+  @Test
+  public void testJoinSelectOnly() {
+    /*
+      T1.a T1.b T1.c T2.a T2.b T2.c
+         0    1    2    0    2    4
+         0    1    2    0    2    4
+         1    2    3    1    3    5
+         1    2    3    1    3    5
+         2    3    4    2    4    6
+         2    3    4    2    4    6
+      ...
+        99  100  101   99  101  103
+        99  100  101   99  101  103
+      (repeat 10 times)
+     */
+    String query = "SELECT T1.a, T1.b, T1.c, T2.a, T2.b, T2.c FROM T1 JOIN T2 ON T1.a = T2.a LIMIT 10000";
+    SelectionResultsBlock resultsBlock1 = (SelectionResultsBlock) getOperator(getQuery(query)).nextBlock();
+    SelectionResultsBlock resultsBlock2 = (SelectionResultsBlock) getOperator(getQueryContext(query)).nextBlock();
+    for (SelectionResultsBlock resultsBlock : Arrays.asList(resultsBlock1, resultsBlock2)) {
+      DataSchema dataSchema = resultsBlock.getDataSchema();
+      assertEquals(dataSchema.getColumnNames(), new String[]{"T1.a", "T1.b", "T1.c", "T2.a", "T2.b", "T2.c"});
+      assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+          ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.LONG,
+          ColumnDataType.STRING
+      });
+      List<Object[]> rows = resultsBlock.getRows();
+      assertEquals(rows.size(), 2000);
+      for (int i = 0; i < 2000; i++) {
+        int keyValue = (i / 2) % NUM_UNIQUE_ROWS;
+        Object[] row = rows.get(i);
+        assertEquals(row[0], keyValue);
+        assertEquals(row[1], (long) (keyValue + 1));
+        assertEquals(row[2], Integer.toString(keyValue + 2));
+        assertEquals(row[3], keyValue);
+        assertEquals(row[4], (long) (keyValue + 2));
+        assertEquals(row[5], Integer.toString(keyValue + 4));
+      }
+    }
+    BrokerResponseNative brokerResponse = getBrokerResponse(getQuery(query));
+    List<Object[]> brokerResults = brokerResponse.getResultTable().getRows();
+    assertEquals(brokerResults.size(), 8000);
+    assertEquals(brokerResults.get(0), new Object[]{0, 1L, "2", 0, 2L, "4"});
+
+    /*
+      T1.b T1.c T2.c T1.a
+         2    3    4    1
+         2    3    4    1
+         3    4    5    2
+         3    4    5    2
+         4    5    6    3
+         4    5    6    3
+      ...
+       100  101  102   99
+       100  101  102   99
+      (repeat 10 times)
+     */
+    query = "SELECT T1.c, T2.c, T1.a FROM T1 JOIN T2 ON T2.b = T1.b LIMIT 10000";
+    resultsBlock1 = (SelectionResultsBlock) getOperator(getQuery(query)).nextBlock();
+    resultsBlock2 = (SelectionResultsBlock) getOperator(getQueryContext(query)).nextBlock();
+    for (SelectionResultsBlock resultsBlock : Arrays.asList(resultsBlock1, resultsBlock2)) {
+      DataSchema dataSchema = resultsBlock.getDataSchema();
+      assertEquals(dataSchema.getColumnNames(), new String[]{"T1.c", "T2.c", "T1.a"});
+      assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+          ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.INT
+      });
+      List<Object[]> rows = resultsBlock.getRows();
+      assertEquals(rows.size(), 1980);
+      for (int i = 0; i < 1980; i++) {
+        int keyValue = (i / 2) % 99 + 2;
+        Object[] row = rows.get(i);
+        assertEquals(row[0], Integer.toString(keyValue + 1));
+        assertEquals(row[1], Integer.toString(keyValue + 2));
+        assertEquals(row[2], keyValue - 1);
+      }
+    }
+    brokerResponse = getBrokerResponse(getQuery(query));
+    brokerResults = brokerResponse.getResultTable().getRows();
+    assertEquals(brokerResults.size(), 7920);
+    assertEquals(brokerResults.get(0), new Object[]{"3", "4", 1});
+
+    /*
+      T1.c T2.a T1.b T2.c
+         4    0    3    4
+         4    0    3    4
+         5    1    4    5
+         5    1    4    5
+         6    2    5    6
+         6    2    5    6
+      ...
+       101   97  100  101
+       101   97  100  101
+      (repeat 10 times)
+     */
+    query = "SELECT T2.a, T1.b, T2.c FROM T1 JOIN T2 ON T1.c = T2.c LIMIT 10000";
+    resultsBlock1 = (SelectionResultsBlock) getOperator(getQuery(query)).nextBlock();
+    resultsBlock2 = (SelectionResultsBlock) getOperator(getQueryContext(query)).nextBlock();
+    for (SelectionResultsBlock resultsBlock : Arrays.asList(resultsBlock1, resultsBlock2)) {
+      DataSchema dataSchema = resultsBlock.getDataSchema();
+      assertEquals(dataSchema.getColumnNames(), new String[]{"T2.a", "T1.b", "T2.c"});
+      assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+          ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.STRING
+      });
+      List<Object[]> rows = resultsBlock.getRows();
+      assertEquals(rows.size(), 1960);
+      for (int i = 0; i < 1960; i++) {
+        int keyValue = (i / 2) % 98 + 4;
+        Object[] row = rows.get(i);
+        assertEquals(row[0], keyValue - 4);
+        assertEquals(row[1], (long) (keyValue - 1));
+        assertEquals(row[2], Integer.toString(keyValue));
+      }
+    }
+    brokerResponse = getBrokerResponse(getQuery(query));
+    brokerResults = brokerResponse.getResultTable().getRows();
+    assertEquals(brokerResults.size(), 7840);
+    assertEquals(brokerResults.get(0), new Object[]{0, 3L, "4"});
+  }
+
+  @Test
+  public void testJoinSelectOrderBy() {
+    /*
+      Before ordering:
+      T1.a T1.b T1.c T2.a T2.b T2.c
+         0    1    2    0    2    4
+         0    1    2    0    2    4
+         1    2    3    1    3    5
+         1    2    3    1    3    5
+         2    3    4    2    4    6
+         2    3    4    2    4    6
+      ...
+        99  100  101   99  101  103
+        99  100  101   99  101  103
+      (repeat 10 times)
+
+      After ordering:
+      T1.a T1.b T1.c T2.a T2.b T2.c
+        99  100  101   99  101  103
+        99  100  101   99  101  103
+      ...
+      (repeat 20 times)
+        98   99  100   98  100  102
+      ...
+     */
+    String query =
+        "SELECT T1.a, T1.b, T1.c, T2.a, T2.b, T2.c FROM T1 JOIN T2 ON T1.a = T2.a ORDER BY T1.a DESC LIMIT 10000";
+    SelectionResultsBlock resultsBlock1 = (SelectionResultsBlock) getOperator(getQuery(query)).nextBlock();
+    SelectionResultsBlock resultsBlock2 = (SelectionResultsBlock) getOperator(getQueryContext(query)).nextBlock();
+    for (SelectionResultsBlock resultsBlock : Arrays.asList(resultsBlock1, resultsBlock2)) {
+      DataSchema dataSchema = resultsBlock.getDataSchema();
+      assertEquals(dataSchema.getColumnNames(), new String[]{"T1.a", "T1.b", "T1.c", "T2.a", "T2.b", "T2.c"});
+      assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+          ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.LONG,
+          ColumnDataType.STRING
+      });
+      List<Object[]> rows = resultsBlock.getRows();
+      assertEquals(rows.size(), 2000);
+      for (int i = 0; i < 2000; i++) {
+        int keyValue = 99 - i / 20;
+        Object[] row = rows.get(i);
+        assertEquals(row[0], keyValue);
+        assertEquals(row[1], (long) (keyValue + 1));
+        assertEquals(row[2], Integer.toString(keyValue + 2));
+        assertEquals(row[3], keyValue);
+        assertEquals(row[4], (long) (keyValue + 2));
+        assertEquals(row[5], Integer.toString(keyValue + 4));
+      }
+    }
+    BrokerResponseNative brokerResponse = getBrokerResponse(getQuery(query));
+    List<Object[]> brokerResults = brokerResponse.getResultTable().getRows();
+    assertEquals(brokerResults.size(), 8000);
+    assertEquals(brokerResults.get(0), new Object[]{99, 100L, "101", 99, 101L, "103"});
+
+    /*
+      Before ordering:
+      T1.b T1.c T2.c T1.a
+         2    3    4    1
+         2    3    4    1
+         3    4    5    2
+         3    4    5    2
+         4    5    6    3
+         4    5    6    3
+      ...
+       100  101  102   99
+       100  101  102   99
+      (repeat 10 times)
+
+      After ordering:
+      T2.c T1.c T1.a
+        10    9    7
+        10    9    7
+      ...
+      (repeat 20 times)
+       100   99   97
+      ...
+     */
+    query = "SELECT T1.c, T2.c, T1.a FROM T1 JOIN T2 ON T2.b = T1.b ORDER BY T2.c LIMIT 10000";
+    resultsBlock1 = (SelectionResultsBlock) getOperator(getQuery(query)).nextBlock();
+    resultsBlock2 = (SelectionResultsBlock) getOperator(getQueryContext(query)).nextBlock();
+    for (SelectionResultsBlock resultsBlock : Arrays.asList(resultsBlock1, resultsBlock2)) {
+      DataSchema dataSchema = resultsBlock.getDataSchema();
+      assertEquals(dataSchema.getColumnNames(), new String[]{"T2.c", "T1.c", "T1.a"});
+      assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+          ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.INT
+      });
+      List<Object[]> rows = resultsBlock.getRows();
+      assertEquals(rows.size(), 1980);
+      for (int i = 0; i < 20; i++) {
+        Object[] row = rows.get(i);
+        assertEquals(row[0], "10");
+        assertEquals(row[1], "9");
+        assertEquals(row[2], 7);
+      }
+      for (int i = 20; i < 40; i++) {
+        Object[] row = rows.get(i);
+        assertEquals(row[0], "100");
+        assertEquals(row[1], "99");
+        assertEquals(row[2], 97);
+      }
+    }
+    brokerResponse = getBrokerResponse(getQuery(query));
+    brokerResults = brokerResponse.getResultTable().getRows();
+    assertEquals(brokerResults.size(), 7920);
+    assertEquals(brokerResults.get(0), new Object[]{"9", "10", 7});
+  }
+
+  @Test
+  public void testJoinSelectWithTransform() {
+    /*
+      T2.a T1.a T1.b T2.c
+         1    0    1    5
+         1    0    1    5
+         3    1    2    7
+         3    1    2    7
+         5    2    3    9
+         5    2    3    9
+      ...
+        99   49   50  103
+        99   49   50  103
+      (repeat 10 times)
+     */
+    String query = "SELECT T1.a, T1.b, T2.c FROM T1 JOIN T2 ON CAST(T1.a + T1.b AS INT) = T2.a LIMIT 10000";
+    SelectionResultsBlock resultsBlock1 = (SelectionResultsBlock) getOperator(getQuery(query)).nextBlock();
+    SelectionResultsBlock resultsBlock2 = (SelectionResultsBlock) getOperator(getQueryContext(query)).nextBlock();
+    for (SelectionResultsBlock resultsBlock : Arrays.asList(resultsBlock1, resultsBlock2)) {
+      DataSchema dataSchema = resultsBlock.getDataSchema();
+      assertEquals(dataSchema.getColumnNames(), new String[]{"T1.a", "T1.b", "T2.c"});
+      assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+          ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.STRING
+      });
+      List<Object[]> rows = resultsBlock.getRows();
+      assertEquals(rows.size(), 1000);
+      for (int i = 0; i < 1000; i++) {
+        int keyValue = ((i / 2) % 50) * 2 + 1;
+        Object[] row = rows.get(i);
+        assertEquals(row[0], (keyValue - 1) / 2);
+        assertEquals(row[1], (long) ((keyValue + 1) / 2));
+        assertEquals(row[2], Integer.toString(keyValue + 4));
+      }
+    }
+    BrokerResponseNative brokerResponse = getBrokerResponse(getQuery(query));
+    List<Object[]> brokerResults = brokerResponse.getResultTable().getRows();
+    assertEquals(brokerResults.size(), 4000);
+    assertEquals(brokerResults.get(0), new Object[]{0, 1L, "5"});
+
+    /*
+      T2.b T1.a T1.b T2.c
+         3    1    2    5
+         3    1    2    5
+         5    2    3    7
+         5    2    3    7
+      ...
+       101   50   51  103
+       101   50   51  103
+      (repeat 10 times)
+     */
+    query = "SELECT T1.a, T1.b + T2.c FROM T1 JOIN T2 ON CAST(T1.a + T1.b AS LONG) = T2.b LIMIT 10000";
+    resultsBlock1 = (SelectionResultsBlock) getOperator(getQuery(query)).nextBlock();
+    resultsBlock2 = (SelectionResultsBlock) getOperator(getQueryContext(query)).nextBlock();
+    for (SelectionResultsBlock resultsBlock : Arrays.asList(resultsBlock1, resultsBlock2)) {
+      DataSchema dataSchema = resultsBlock.getDataSchema();
+      assertEquals(dataSchema.getColumnNames(), new String[]{"T1.a", "plus(T1.b,T2.c)"});
+      assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+          ColumnDataType.INT, ColumnDataType.DOUBLE
+      });
+      List<Object[]> rows = resultsBlock.getRows();
+      assertEquals(rows.size(), 1000);
+      for (int i = 0; i < 1000; i++) {
+        int keyValue = ((i / 2) % 50) * 2 + 3;
+        Object[] row = rows.get(i);
+        assertEquals(row[0], (keyValue - 1) / 2);
+        assertEquals(row[1], (3 * keyValue + 5) / 2.0);
+      }
+    }
+    brokerResponse = getBrokerResponse(getQuery(query));
+    brokerResults = brokerResponse.getResultTable().getRows();
+    assertEquals(brokerResults.size(), 4000);
+    assertEquals(brokerResults.get(0), new Object[]{1, 7.0});
+  }
+
+  @Test
+  public void testJoinSelectWithFilter() {
+    /*
+      T1.a T1.b T1.c T2.a T2.b T2.c
+        50   51   52   50   52   54
+        50   51   52   50   52   54
+        51   52   53   51   53   55
+        51   52   53   51   53   55
+        52   53   54   52   54   56
+        52   53   54   52   54   56
+      ...
+        99  100  101   99  101  103
+        99  100  101   99  101  103
+      (repeat 10 times)
+     */
+    String query =
+        "SELECT T1.a, T1.b, T1.c, T2.a, T2.b, T2.c FROM T1 JOIN T2 ON T1.a = T2.a WHERE T1.a >= 50 LIMIT 10000";
+    SelectionResultsBlock resultsBlock1 = (SelectionResultsBlock) getOperator(getQuery(query)).nextBlock();
+    SelectionResultsBlock resultsBlock2 = (SelectionResultsBlock) getOperator(getQueryContext(query)).nextBlock();
+    for (SelectionResultsBlock resultsBlock : Arrays.asList(resultsBlock1, resultsBlock2)) {
+      DataSchema dataSchema = resultsBlock.getDataSchema();
+      assertEquals(dataSchema.getColumnNames(), new String[]{"T1.a", "T1.b", "T1.c", "T2.a", "T2.b", "T2.c"});
+      assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+          ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.LONG,
+          ColumnDataType.STRING
+      });
+      List<Object[]> rows = resultsBlock.getRows();
+      assertEquals(rows.size(), 1000);
+      for (int i = 0; i < 1000; i++) {
+        int keyValue = (i / 2) % 50 + 50;
+        Object[] row = rows.get(i);
+        assertEquals(row[0], keyValue);
+        assertEquals(row[1], (long) (keyValue + 1));
+        assertEquals(row[2], Integer.toString(keyValue + 2));
+        assertEquals(row[3], keyValue);
+        assertEquals(row[4], (long) (keyValue + 2));
+        assertEquals(row[5], Integer.toString(keyValue + 4));
+      }
+    }
+    BrokerResponseNative brokerResponse = getBrokerResponse(getQuery(query));
+    List<Object[]> brokerResults = brokerResponse.getResultTable().getRows();
+    assertEquals(brokerResults.size(), 4000);
+    assertEquals(brokerResults.get(0), new Object[]{50, 51L, "52", 50, 52L, "54"});
+
+    /*
+      T1.b T1.c T2.c T1.a
+         2    3    4    1
+         2    3    4    1
+         3    4    5    2
+         3    4    5    2
+         4    5    6    3
+         4    5    6    3
+      ...
+        24   25   26   23
+        24   25   26   23
+      (repeat 10 times)
+     */
+    query = "SELECT T1.c, T2.c, T1.a FROM T1 JOIN T2 ON T2.b = T1.b WHERE T1.b + T1.c < 50 LIMIT 10000";
+    resultsBlock1 = (SelectionResultsBlock) getOperator(getQuery(query)).nextBlock();
+    resultsBlock2 = (SelectionResultsBlock) getOperator(getQueryContext(query)).nextBlock();
+    for (SelectionResultsBlock resultsBlock : Arrays.asList(resultsBlock1, resultsBlock2)) {
+      DataSchema dataSchema = resultsBlock.getDataSchema();
+      assertEquals(dataSchema.getColumnNames(), new String[]{"T1.c", "T2.c", "T1.a"});
+      assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+          ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.INT
+      });
+      List<Object[]> rows = resultsBlock.getRows();
+      assertEquals(rows.size(), 460);
+      for (int i = 0; i < 460; i++) {
+        int keyValue = (i / 2) % 23 + 2;
+        Object[] row = rows.get(i);
+        assertEquals(row[0], Integer.toString(keyValue + 1));
+        assertEquals(row[1], Integer.toString(keyValue + 2));
+        assertEquals(row[2], keyValue - 1);
+      }
+    }
+    brokerResponse = getBrokerResponse(getQuery(query));
+    brokerResults = brokerResponse.getResultTable().getRows();
+    assertEquals(brokerResults.size(), 1840);
+    assertEquals(brokerResults.get(0), new Object[]{"3", "4", 1});
+  }
+
+  @Test
+  public void testJoinDistinct() {
+    String query =
+        "SELECT DISTINCT T1.a, T1.b, T1.c, T2.a, T2.b, T2.c FROM T1 JOIN T2 ON T1.a = T2.a ORDER BY T1.a LIMIT 10000";
+    DistinctResultsBlock resultsBlock1 = (DistinctResultsBlock) getOperator(getQuery(query)).nextBlock();
+    DistinctResultsBlock resultsBlock2 = (DistinctResultsBlock) getOperator(getQueryContext(query)).nextBlock();
+    for (DistinctResultsBlock resultsBlock : Arrays.asList(resultsBlock1, resultsBlock2)) {
+      DistinctTable distinctTable = resultsBlock.getDistinctTable();
+      DataSchema dataSchema = distinctTable.getDataSchema();
+      assertEquals(dataSchema.getColumnNames(), new String[]{"T1.a", "T1.b", "T1.c", "T2.a", "T2.b", "T2.c"});
+      assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+          ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.LONG,
+          ColumnDataType.STRING
+      });
+      Collection<Record> records = distinctTable.getRecords();
+      assertEquals(records.size(), 100);
+      for (Record record : records) {
+        Object[] values = record.getValues();
+        int keyValue = (int) values[0];
+        assertEquals(values[1], (long) (keyValue + 1));
+        assertEquals(values[2], Integer.toString(keyValue + 2));
+        assertEquals(values[3], keyValue);
+        assertEquals(values[4], (long) (keyValue + 2));
+        assertEquals(values[5], Integer.toString(keyValue + 4));
+      }
+    }
+    BrokerResponseNative brokerResponse = getBrokerResponse(getQuery(query));
+    List<Object[]> brokerResults = brokerResponse.getResultTable().getRows();
+    assertEquals(brokerResults.size(), 100);
+    assertEquals(brokerResults.get(0), new Object[]{0, 1L, "2", 0, 2L, "4"});
+  }
+
+  @Test
+  public void testJoinAggregation() {
+    String query = "SELECT COUNT(*), SUM(T1.a), MAX(T1.b), MIN(T1.c + T2.a) FROM T1 JOIN T2 ON T1.a = T2.a";
+    AggregationResultsBlock resultsBlock1 = (AggregationResultsBlock) getOperator(getQuery(query)).nextBlock();
+    AggregationResultsBlock resultsBlock2 = (AggregationResultsBlock) getOperator(getQueryContext(query)).nextBlock();
+    for (AggregationResultsBlock resultsBlock : Arrays.asList(resultsBlock1, resultsBlock2)) {
+      List<Object> results = resultsBlock.getResults();
+      assertEquals(results, Arrays.asList(2000L, 99000.0, 100.0, 2.0));
+    }
+    BrokerResponseNative brokerResponse = getBrokerResponse(getQuery(query));
+    List<Object[]> brokerResults = brokerResponse.getResultTable().getRows();
+    assertEquals(brokerResults.size(), 1);
+    assertEquals(brokerResults.get(0), new Object[]{8000L, 396000.0, 100.0, 2.0});
+  }
+
+  @Test
+  public void testJoinGroupBy() {
+    String query =
+        "SELECT T1.c, COUNT(*), SUM(T1.a), MAX(T1.b), MIN(T1.c + T2.a) FROM T1 JOIN T2 ON T1.a = T2.a GROUP BY T1.c "
+            + "ORDER BY MIN(T1.c + T2.a) LIMIT 10000";
+    GroupByResultsBlock resultsBlock1 = (GroupByResultsBlock) getOperator(getQuery(query)).nextBlock();
+    GroupByResultsBlock resultsBlock2 = (GroupByResultsBlock) getOperator(getQueryContext(query)).nextBlock();
+    for (GroupByResultsBlock resultsBlock : Arrays.asList(resultsBlock1, resultsBlock2)) {
+      DataSchema dataSchema = resultsBlock.getDataSchema();
+      assertEquals(dataSchema.getColumnNames(),
+          new String[]{"T1.c", "count(*)", "sum(T1.a)", "max(T1.b)", "min(plus(T1.c,T2.a))"});
+      assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
+          ColumnDataType.STRING, ColumnDataType.LONG, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE,
+          ColumnDataType.DOUBLE
+      });
+      AggregationGroupByResult groupByResult = resultsBlock.getAggregationGroupByResult();
+      Iterator<GroupKeyGenerator.GroupKey> groupKeyIterator = groupByResult.getGroupKeyIterator();
+      while (groupKeyIterator.hasNext()) {
+        GroupKeyGenerator.GroupKey groupKey = groupKeyIterator.next();
+        int keyValue = Integer.parseInt((String) groupKey._keys[0]) - 2;
+        assertEquals(groupByResult.getResultForGroupId(0, groupKey._groupId), 20L);
+        assertEquals(groupByResult.getResultForGroupId(1, groupKey._groupId), keyValue * 20.0);
+        assertEquals(groupByResult.getResultForGroupId(2, groupKey._groupId), keyValue + 1.0);
+        assertEquals(groupByResult.getResultForGroupId(3, groupKey._groupId), 2 * keyValue + 2.0);
+      }
+    }
+    BrokerResponseNative brokerResponse = getBrokerResponse(getQuery(query));
+    List<Object[]> brokerResults = brokerResponse.getResultTable().getRows();
+    assertEquals(brokerResults.size(), 100);
+    assertEquals(brokerResults.get(0), new Object[]{"2", 80L, 0.0, 1.0, 2.0});
+  }
+
+  @Test(dataProvider = "testInvalidQueriesDataProvider", expectedExceptions = {
+      IllegalArgumentException.class, IllegalStateException.class
+  })
+  public void testInvalidQueries(String query) {
+    getOperator(getQuery(query));
+  }
+
+  @DataProvider
+  public static Object[][] testInvalidQueriesDataProvider() {
+    //@formatter:off
+    return new Object[][]{
+        new Object[]{"SELECT T1.a FROM T1 JOIN T2"},                // Missing ON
+        new Object[]{"SELECT T1.a FROM T1 JOIN T2 ON T1.a > T2.a"}, // Missing EQ
+        new Object[]{"SELECT T1.a FROM T2 JOIN T1 ON T1.a = T2.a"}, // Right table not in query option
+        // Missing prefix
+        new Object[]{"SELECT a FROM T1 JOIN T2 ON T1.a = T2.a"},
+        new Object[]{"SELECT T1.a FROM T1 JOIN T2 ON a = T2.a"},
+        new Object[]{"SELECT T1.a FROM T1 JOIN T2 ON T1.a = T2.a WHERE a > 0"},
+        new Object[]{"SELECT T1.a FROM T1 JOIN T2 ON T1.a = T2.a ORDER BY a"},
+        // Invalid column
+        new Object[]{"SELECT T1.d FROM T1 JOIN T2 ON T1.a = T2.a"},
+        new Object[]{"SELECT T2.d FROM T1 JOIN T2 ON T1.a = T2.a"},
+        new Object[]{"SELECT T1.a FROM T1 JOIN T2 ON T1.d = T2.a"},
+        new Object[]{"SELECT T1.a FROM T1 JOIN T2 ON T1.a = T2.d"},
+        new Object[]{"SELECT T1.a FROM T1 JOIN T2 ON T1.a = T2.a WHERE T1.d > 0"},
+        new Object[]{"SELECT T1.a FROM T1 JOIN T2 ON T1.a = T2.a ORDER BY T1.d"},
+        // Do not support SELECT *
+        new Object[]{"SELECT * FROM T1 JOIN T2 ON T1.a = T2.a"},
+        // Do not support extra filter on right table
+        new Object[]{"SELECT T1.a FROM T1 JOIN T2 ON T1.a = T2.a AND T1.b > T2.b"},
+        new Object[]{"SELECT T1.a FROM T1 JOIN T2 ON T1.a = T2.a WHERE T1.b > T2.b"},
+        new Object[]{"SELECT T1.a FROM T1 JOIN T2 ON T1.a = T2.a WHERE T2.b > 0"},
+        // Do not support filtered aggregations
+        new Object[]{"SELECT COUNT(*) FILTER(WHERE T1.b > 10) FROM T1 JOIN T2 ON T1.a = T2.a"}
+    };
+    //@formatter:on
+  }
+
+  private String getQuery(String query) {
+    String rightTableKey = SharedValueKey.LOCAL_JOIN_RIGHT_TABLE_PREFIX + RIGHT_TABLE_NAME;
+    return String.format("SET %s = '%s'; %s", rightTableKey, _serializedRightDataTable, query);
+  }
+
+  private QueryContext getQueryContext(String query) {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+    String rightTableKey = SharedValueKey.LOCAL_JOIN_RIGHT_TABLE_PREFIX + RIGHT_TABLE_NAME;
+    queryContext.putSharedValue(RowBlock.class, rightTableKey, _rightTable);
+    return queryContext;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -212,7 +212,7 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
   @Override
   public DataSource getDataSource(String column) {
     DataSource result = _dataSources.get(column);
-    Preconditions.checkNotNull(result,
+    Preconditions.checkState(result != null,
         "DataSource for %s should not be null. Potentially invalid column name specified.", column);
     return result;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -20,7 +20,6 @@ package org.apache.pinot.segment.local.indexsegment.immutable;
 
 import com.google.common.base.Preconditions;
 import java.io.File;
-import java.net.URI;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -167,13 +166,6 @@ public class ImmutableSegmentLoader {
       }
     } else {
       indexLoadingConfig.addKnownColumns(columnMetadataMap.keySet());
-    }
-
-    URI indexDirURI = segmentDirectory.getIndexDir();
-    String scheme = indexDirURI.getScheme();
-    File localIndexDir = null;
-    if (scheme != null && scheme.equalsIgnoreCase("file")) {
-      localIndexDir = new File(indexDirURI);
     }
 
     SegmentDirectory.Reader segmentReader = segmentDirectory.createReader();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -332,6 +332,10 @@ public class CommonConstants {
         public static final String ROUTING_FORCE_HLC = "FORCE_HLC";
         public static final String DEFAULT_IN_PREDICATE_SORT_THRESHOLD = "1000";
       }
+
+      public static class SharedValueKey {
+        public static final String LOCAL_JOIN_RIGHT_TABLE_PREFIX = "localJoinRightTable_";
+      }
     }
 
     public static class FailureDetector {


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Illustrates the addition of LOCAL\_JOIN operator: from query parsing through plan construction to block production and join\-aware operators\.

```mermaid
flowchart TD
  N0["QueryContextConverterUtils#46;getQueryContext #40;F18#41;"]:::stAdded
  N1["QueryContext #40;F17#41;"]:::stModified
  N2["ProjectPlanNode#46;run#40;#41; #40;F12#41;"]:::stModified
  N3["LocalJoinOperator #40;F4#41;"]:::stAdded
  N4["RowBasedValueBlock #40;F5#41;"]:::stAdded
  N5["AggregationPlanNode#46;buildNonFilteredAggOperator#40;#41; #40;F8#41;"]:::stModified
  N6["SelectionOrderByOperator#46;getNextBlock#40;#41; #40;F7#41;"]:::stModified
  N0 -->|"creates"| N1
  N2 -->|"reads hasJoin #47; getDataSource"| N1
  N2 -->|"instantiates"| N3
  N3 -->|"returns RowBasedValueBlock"| N4
  N5 -->|"uses ProjectPlanNode output"| N2
  N6 -->|"checks hasJoin"| N1
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

Partial evidence: 0 file patches omitted; 1 truncated.

<details>
<summary>Diff evidence</summary>

- F4: pinot\-core/src/main/java/org/apache/pinot/core/operator/LocalJoinOperator\.java — [after](https://github.com/apache/pinot/blob/4ccb6e11808b0a0f841d6e0fbef37986c18086ae/pinot-core/src/main/java/org/apache/pinot/core/operator/LocalJoinOperator.java)
- F5: pinot\-core/src/main/java/org/apache/pinot/core/operator/blocks/RowBasedValueBlock\.java — [after](https://github.com/apache/pinot/blob/4ccb6e11808b0a0f841d6e0fbef37986c18086ae/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/RowBasedValueBlock.java)
- F7: pinot\-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator\.java — [before](https://github.com/apache/pinot/blob/586c937114fd21ad910781b3b7e0bdc92f87e497/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java) · [after](https://github.com/apache/pinot/blob/4ccb6e11808b0a0f841d6e0fbef37986c18086ae/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java)
- F8: pinot\-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode\.java — [before](https://github.com/apache/pinot/blob/586c937114fd21ad910781b3b7e0bdc92f87e497/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java) · [after](https://github.com/apache/pinot/blob/4ccb6e11808b0a0f841d6e0fbef37986c18086ae/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java)
- F12: pinot\-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode\.java — [before](https://github.com/apache/pinot/blob/586c937114fd21ad910781b3b7e0bdc92f87e497/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java) · [after](https://github.com/apache/pinot/blob/4ccb6e11808b0a0f841d6e0fbef37986c18086ae/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java)
- F17: pinot\-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext\.java — [before](https://github.com/apache/pinot/blob/586c937114fd21ad910781b3b7e0bdc92f87e497/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java) · [after](https://github.com/apache/pinot/blob/4ccb6e11808b0a0f841d6e0fbef37986c18086ae/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/QueryContext.java)
- F18: pinot\-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils\.java — [before](https://github.com/apache/pinot/blob/586c937114fd21ad910781b3b7e0bdc92f87e497/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java) · [after](https://github.com/apache/pinot/blob/4ccb6e11808b0a0f841d6e0fbef37986c18086ae/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjU4NmM5MzcxMTRmZDIxYWQ5MTA3ODFiM2I3ZTBiZGM5MmY4N2U0OTciLCJjb250ZXh0X2hhc2giOiI2MjM1YjgzMDdmN2RkMzg0MzE2MTQxNTNkNTI3Yjc0YTdiNTgwZTk5MzI3MTA3MzU4MzYyMDA1MzUxZTI4ODM3IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MjAyMDk2LCJoZWFkX3NoYSI6IjRjY2I2ZTExODA4YjBhMGY4NDFkNmUwZmJlZjM3OTg2YzE4MDg2YWUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI1ODZjOTM3MTE0ZmQyMWFkOTEwNzgxYjNiN2UwYmRjOTJmODdlNDk3IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 92aa6d49b7fb51634e33b30cca2ff8371d4c0ed1feddd09f6145ae3df99ad493 -->
<!-- pinot-pr-flow:end -->

Add `LOCAL_JOIN` operator as a project operator, which can be chained with `TransformOperator`, and consumed by the top level select/distinct/aggregate/group-by operator.

Currently it can support equality JOIN with an in-memory right table (either passed by query option or set as the shared object in the `QueryContext`.

Supported queries:
`SELECT T1.c, T2.c, T1.a FROM T1 JOIN T2 ON T2.b = T1.b ORDER BY T2.c LIMIT 10000`
`SELECT T1.a, T1.b + T2.c FROM T1 JOIN T2 ON CAST(T1.a + T1.b AS LONG) = T2.b LIMIT 10000`
`SELECT T1.c, T2.c, T1.a FROM T1 JOIN T2 ON T2.b = T1.b WHERE T1.b + T1.c < 50 LIMIT 10000`
`SELECT DISTINCT T1.a, T1.b, T2.c FROM T1 JOIN T2 ON T1.a = T2.a ORDER BY T1.a LIMIT 10000`
`SELECT COUNT(*), SUM(T1.a), MAX(T1.b), MIN(T1.c + T2.a) FROM T1 JOIN T2 ON T1.a = T2.a`
`SELECT T1.c, COUNT(*), SUM(T1.a), MAX(T1.b), MIN(T1.c + T2.a) FROM T1 JOIN T2 ON T1.a = T2.a GROUP BY T1.c ORDER BY MIN(T1.c + T2.a) LIMIT 10000`

See `LocalJoinQueriesTest` for more query examples.