### PR TITLE
Remove Multiget stack trace from table size logs

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ServerTableSizeReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ServerTableSizeReader.java
@@ -66,7 +66,8 @@ public class ServerTableSizeReader {
     CompletionServiceHelper completionServiceHelper =
         new CompletionServiceHelper(_executor, _connectionManager, endpointsToServers);
     CompletionServiceHelper.CompletionServiceResponse serviceResponse =
-        completionServiceHelper.doMultiGetRequest(serverUrls, tableNameWithType, false, timeoutMs);
+        completionServiceHelper.doMultiGetRequest(serverUrls, tableNameWithType, false, timeoutMs,
+            "get segment size info from servers");
     Map<String, List<SegmentSizeInfo>> serverToSegmentSizeInfoListMap = new HashMap<>();
     int failedParses = 0;
     for (Map.Entry<String, String> streamResponse : serviceResponse._httpResponses.entrySet()) {


### PR DESCRIPTION
The segment status checker periodically checks the size of the table, which involves retrieving information from multiple servers that host replicas of the segment. If one or more of these servers are temporarily down, error messages related to connection errors can clutter the logs with unnecessary stack traces. To address this issue, we've updated the logging process to only display the error message, along with a log indicating that the error occurred while attempting to retrieve the segment size from the affected servers.