### PR TITLE
[multistage] Split MailboxReceiveOperator into sorted and non-sorted versions

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotSortExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotSortExchangeNodeInsertRule.java
@@ -70,7 +70,7 @@ public class PinotSortExchangeNodeInsertRule extends RelOptRule {
         RelDistributions.hash(Collections.emptyList()),
         sort.getCollation(),
         false,
-        true);
+        !sort.getCollation().getKeys().isEmpty());
     call.transformTo(LogicalSort.create(exchange, sort.getCollation(), sort.offset, sort.fetch));
   }
 }

--- a/pinot-query-planner/src/test/resources/queries/BasicQueryPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/BasicQueryPlans.json
@@ -39,7 +39,7 @@
           "Execution Plan",
           "\nLogicalProject(EXPR$0=[dateTrunc('DAY', $4)])",
           "\n  LogicalSort(offset=[0], fetch=[10])",
-          "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[true])",
+          "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n      LogicalSort(fetch=[10])",
           "\n        LogicalTableScan(table=[[a]])",
           "\n"
@@ -52,7 +52,7 @@
           "Execution Plan",
           "\nLogicalProject(day=[dateTrunc('DAY', $4)])",
           "\n  LogicalSort(offset=[0], fetch=[10])",
-          "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[true])",
+          "\n    PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n      LogicalSort(fetch=[10])",
           "\n        LogicalTableScan(table=[[a]])",
           "\n"

--- a/pinot-query-planner/src/test/resources/queries/WindowFunctionPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/WindowFunctionPlans.json
@@ -77,7 +77,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalSort(offset=[0], fetch=[10])",
-          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[true])",
+          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[10])",
           "\n      LogicalProject(col1=[$0], $1=[$2])",
           "\n        LogicalWindow(window#0=[window(aggs [SUM($1)])])",
@@ -300,7 +300,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalSort(offset=[0], fetch=[100])",
-          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[true])",
+          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[100])",
           "\n      LogicalProject(col1=[$0], $1=[$3], $2=[$4])",
           "\n        LogicalWindow(window#0=[window(aggs [SUM($2), COUNT($1)])])",
@@ -536,7 +536,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalSort(offset=[0], fetch=[10])",
-          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[true])",
+          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[10])",
           "\n      LogicalProject(col1=[$0], EXPR$1=[/(CAST($3):DOUBLE NOT NULL, $4)])",
           "\n        LogicalWindow(window#0=[window(partition {1} aggs [SUM($2), COUNT($2)])])",
@@ -785,7 +785,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalSort(offset=[0], fetch=[10])",
-          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[true])",
+          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[10])",
           "\n      LogicalProject(col1=[$0], EXPR$1=[/(CAST($2):DOUBLE NOT NULL, $3)], EXPR$2=[$4])",
           "\n        LogicalWindow(window#0=[window(partition {0} aggs [SUM($1), COUNT($1), MIN($1)])])",
@@ -1097,7 +1097,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalSort(offset=[0], fetch=[10])",
-          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[true])",
+          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[10])",
           "\n      LogicalProject(col1=[$0], EXPR$1=[/(CAST($3):DOUBLE NOT NULL, $4)])",
           "\n        LogicalWindow(window#0=[window(order by [1] aggs [SUM($2), COUNT($2)])])",
@@ -1265,7 +1265,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalSort(offset=[0], fetch=[10])",
-          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[true])",
+          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[10])",
           "\n      LogicalProject(col1=[$0], EXPR$1=[/(CAST($2):DOUBLE NOT NULL, $3)], EXPR$2=[$4])",
           "\n        LogicalWindow(window#0=[window(order by [0] aggs [SUM($1), COUNT($1), MIN($1)])])",
@@ -1433,7 +1433,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalSort(offset=[0], fetch=[10])",
-          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[true])",
+          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[10])",
           "\n      LogicalProject(col1=[$0], EXPR$1=[/(CAST($3):DOUBLE NOT NULL, $4)])",
           "\n        LogicalWindow(window#0=[window(partition {1} order by [1] aggs [SUM($2), COUNT($2)])])",
@@ -1640,7 +1640,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalSort(offset=[0], fetch=[10])",
-          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[true])",
+          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[10])",
           "\n      LogicalProject(col1=[$0], EXPR$1=[/(CAST($2):DOUBLE NOT NULL, $3)], EXPR$2=[$4])",
           "\n        LogicalWindow(window#0=[window(partition {0} order by [0] aggs [SUM($1), COUNT($1), MIN($1)])])",
@@ -1846,7 +1846,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalSort(offset=[0], fetch=[10])",
-          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[true])",
+          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[10])",
           "\n      LogicalProject(col1=[$0], EXPR$1=[/(CAST($3):DOUBLE NOT NULL, $4)])",
           "\n        LogicalWindow(window#0=[window(partition {1} order by [0] aggs [SUM($2), COUNT($2)])])",
@@ -2014,7 +2014,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalSort(offset=[0], fetch=[10])",
-          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[true])",
+          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
           "\n    LogicalSort(fetch=[10])",
           "\n      LogicalProject(col1=[$0], EXPR$1=[/(CAST($3):DOUBLE NOT NULL, $4)], EXPR$2=[$5])",
           "\n        LogicalWindow(window#0=[window(partition {0} order by [1] aggs [SUM($2), COUNT($2), MIN($2)])])",

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
@@ -1,0 +1,136 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableSet;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Set;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.pinot.query.mailbox.JsonMailboxIdentifier;
+import org.apache.pinot.query.mailbox.MailboxIdentifier;
+import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.routing.VirtualServer;
+import org.apache.pinot.query.routing.VirtualServerAddress;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.query.service.QueryConfig;
+
+
+/**
+ * Base class to be used by the various MailboxReceiveOperators such as the sorted and non-sorted versions. This
+ * class contains the common logic needed for MailboxReceive
+ *
+ * BaseMailboxReceiveOperator receives mailbox from mailboxService from sendingStageInstances.
+ * We use sendingStageInstance to deduce mailboxId and fetch the content from mailboxService.
+ * When exchangeType is Singleton, we find the mapping mailbox for the mailboxService. If not found, use empty list.
+ * When exchangeType is non-Singleton, we pull from each instance in round-robin way to get matched mailbox content.
+ */
+public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
+
+  // TODO: Unify SUPPORTED_EXCHANGE_TYPES with MailboxSendOperator.
+  protected static final Set<RelDistribution.Type> SUPPORTED_EXCHANGE_TYPES =
+      ImmutableSet.of(RelDistribution.Type.BROADCAST_DISTRIBUTED, RelDistribution.Type.HASH_DISTRIBUTED,
+          RelDistribution.Type.SINGLETON, RelDistribution.Type.RANDOM_DISTRIBUTED);
+
+  protected final MailboxService<TransferableBlock> _mailboxService;
+  protected final RelDistribution.Type _exchangeType;
+  protected final List<MailboxIdentifier> _sendingMailbox;
+  protected final long _deadlineTimestampNano;
+  protected int _serverIdx;
+  protected TransferableBlock _upstreamErrorBlock;
+
+  protected static MailboxIdentifier toMailboxId(VirtualServer sender, long jobId, int senderStageId,
+      int receiverStageId, VirtualServerAddress receiver) {
+    return new JsonMailboxIdentifier(
+        String.format("%s_%s", jobId, senderStageId),
+        new VirtualServerAddress(sender),
+        receiver,
+        senderStageId,
+        receiverStageId);
+  }
+
+  public BaseMailboxReceiveOperator(OpChainExecutionContext context, List<VirtualServer> sendingStageInstances,
+      RelDistribution.Type exchangeType, int senderStageId, int receiverStageId, Long timeoutMs) {
+    super(context);
+    _mailboxService = context.getMailboxService();
+    VirtualServerAddress receiver = context.getServer();
+    long jobId = context.getRequestId();
+    Preconditions.checkState(SUPPORTED_EXCHANGE_TYPES.contains(exchangeType),
+        "Exchange/Distribution type: " + exchangeType + " is not supported!");
+    long timeoutNano = (timeoutMs != null ? timeoutMs : QueryConfig.DEFAULT_MAILBOX_TIMEOUT_MS) * 1_000_000L;
+    _deadlineTimestampNano = timeoutNano + System.nanoTime();
+
+    _exchangeType = exchangeType;
+    if (_exchangeType == RelDistribution.Type.SINGLETON) {
+      VirtualServer singletonInstance = null;
+      for (VirtualServer serverInstance : sendingStageInstances) {
+        if (serverInstance.getHostname().equals(_mailboxService.getHostname())
+            && serverInstance.getQueryMailboxPort() == _mailboxService.getMailboxPort()) {
+          Preconditions.checkState(singletonInstance == null, "multiple instance found for singleton exchange type!");
+          singletonInstance = serverInstance;
+        }
+      }
+
+      if (singletonInstance == null) {
+        // TODO: fix WorkerManager assignment, this should not happen if we properly assign workers.
+        // see: https://github.com/apache/pinot/issues/9611
+        _sendingMailbox = Collections.emptyList();
+      } else {
+        _sendingMailbox =
+            Collections.singletonList(toMailboxId(singletonInstance, jobId, senderStageId, receiverStageId, receiver));
+      }
+    } else {
+      _sendingMailbox = new ArrayList<>(sendingStageInstances.size());
+      for (VirtualServer instance : sendingStageInstances) {
+        _sendingMailbox.add(toMailboxId(instance, jobId, senderStageId, receiverStageId, receiver));
+      }
+    }
+    _upstreamErrorBlock = null;
+    _serverIdx = 0;
+  }
+
+  public List<MailboxIdentifier> getSendingMailbox() {
+    return _sendingMailbox;
+  }
+
+  @Override
+  public List<MultiStageOperator> getChildOperators() {
+    return ImmutableList.of();
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    for (MailboxIdentifier sendingMailbox : _sendingMailbox) {
+      _mailboxService.releaseReceivingMailbox(sendingMailbox);
+    }
+  }
+
+  @Override
+  public void cancel(Throwable t) {
+    super.cancel(t);
+    for (MailboxIdentifier sendingMailbox : _sendingMailbox) {
+      _mailboxService.releaseReceivingMailbox(sendingMailbox);
+    }
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -18,35 +18,17 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
-import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableSet;
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
-import java.util.PriorityQueue;
-import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
-import org.apache.calcite.rel.RelFieldCollation;
-import org.apache.commons.collections.CollectionUtils;
-import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.exception.QueryException;
-import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.query.mailbox.JsonMailboxIdentifier;
 import org.apache.pinot.query.mailbox.MailboxIdentifier;
-import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.mailbox.ReceivingMailbox;
-import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.routing.VirtualServer;
-import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.operator.utils.SortUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
-import org.apache.pinot.query.service.QueryConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -54,119 +36,22 @@ import org.slf4j.LoggerFactory;
 /**
  * This {@code MailboxReceiveOperator} receives data from a {@link ReceivingMailbox} and serve it out from the
  * {@link MultiStageOperator#getNextBlock()}()} API.
- *
- *  MailboxReceiveOperator receives mailbox from mailboxService from sendingStageInstances.
- *  We use sendingStageInstance to deduce mailboxId and fetch the content from mailboxService.
- *  When exchangeType is Singleton, we find the mapping mailbox for the mailboxService. If not found, use empty list.
- *  When exchangeType is non-Singleton, we pull from each instance in round-robin way to get matched mailbox content.
- *
- *  TODO: Once sorting on the {@code MailboxSendOperator} is available, modify this to use a k-way merge instead of
- *        resorting via the PriorityQueue.
  */
-public class MailboxReceiveOperator extends MultiStageOperator {
+public class MailboxReceiveOperator extends BaseMailboxReceiveOperator {
   private static final Logger LOGGER = LoggerFactory.getLogger(MailboxReceiveOperator.class);
   private static final String EXPLAIN_NAME = "MAILBOX_RECEIVE";
 
-  // TODO: Unify SUPPORTED_EXCHANGE_TYPES with MailboxSendOperator.
-  private static final Set<RelDistribution.Type> SUPPORTED_EXCHANGE_TYPES =
-      ImmutableSet.of(RelDistribution.Type.BROADCAST_DISTRIBUTED, RelDistribution.Type.HASH_DISTRIBUTED,
-          RelDistribution.Type.SINGLETON, RelDistribution.Type.RANDOM_DISTRIBUTED);
-
-  private final MailboxService<TransferableBlock> _mailboxService;
-  private final RelDistribution.Type _exchangeType;
-  private final List<RexExpression> _collationKeys;
-  private final List<RelFieldCollation.Direction> _collationDirections;
-  private final boolean _isSortOnSender;
-  private final boolean _isSortOnReceiver;
-  private final DataSchema _dataSchema;
-  private final List<MailboxIdentifier> _sendingMailbox;
-  private final long _deadlineTimestampNano;
-  private final PriorityQueue<Object[]> _priorityQueue;
-  private int _serverIdx;
-  private TransferableBlock _upstreamErrorBlock;
-  private boolean _isSortedBlockConstructed;
-
-  private static MailboxIdentifier toMailboxId(VirtualServer sender, long jobId, int senderStageId,
-      int receiverStageId, VirtualServerAddress receiver) {
-    return new JsonMailboxIdentifier(
-        String.format("%s_%s", jobId, senderStageId),
-        new VirtualServerAddress(sender),
-        receiver,
-        senderStageId,
-        receiverStageId);
-  }
-
-  public MailboxReceiveOperator(OpChainExecutionContext context, RelDistribution.Type exchangeType,
-      List<RexExpression> collationKeys, List<RelFieldCollation.Direction> collationDirections, boolean isSortOnSender,
-      boolean isSortOnReceiver, DataSchema dataSchema, int senderStageId, int receiverStageId) {
-    this(context, context.getMetadataMap().get(senderStageId).getServerInstances(), exchangeType, collationKeys,
-        collationDirections, isSortOnSender, isSortOnReceiver, dataSchema, senderStageId,
+  public MailboxReceiveOperator(OpChainExecutionContext context, RelDistribution.Type exchangeType, int senderStageId,
+      int receiverStageId) {
+    this(context, context.getMetadataMap().get(senderStageId).getServerInstances(), exchangeType, senderStageId,
         receiverStageId, context.getTimeoutMs());
   }
 
   // TODO: Move deadlineInNanoSeconds to OperatorContext.
   // TODO: Remove boxed timeoutMs value from here and use long deadlineMs from context.
   public MailboxReceiveOperator(OpChainExecutionContext context, List<VirtualServer> sendingStageInstances,
-      RelDistribution.Type exchangeType, List<RexExpression> collationKeys,
-      List<RelFieldCollation.Direction> collationDirections, boolean isSortOnSender, boolean isSortOnReceiver,
-      DataSchema dataSchema, int senderStageId, int receiverStageId, Long timeoutMs) {
-    super(context);
-    _mailboxService = context.getMailboxService();
-    VirtualServerAddress receiver = context.getServer();
-    long jobId = context.getRequestId();
-    Preconditions.checkState(SUPPORTED_EXCHANGE_TYPES.contains(exchangeType),
-        "Exchange/Distribution type: " + exchangeType + " is not supported!");
-    long timeoutNano = (timeoutMs != null ? timeoutMs : QueryConfig.DEFAULT_MAILBOX_TIMEOUT_MS) * 1_000_000L;
-    _deadlineTimestampNano = timeoutNano + System.nanoTime();
-
-    _exchangeType = exchangeType;
-    if (_exchangeType == RelDistribution.Type.SINGLETON) {
-      VirtualServer singletonInstance = null;
-      for (VirtualServer serverInstance : sendingStageInstances) {
-        if (serverInstance.getHostname().equals(_mailboxService.getHostname())
-            && serverInstance.getQueryMailboxPort() == _mailboxService.getMailboxPort()) {
-          Preconditions.checkState(singletonInstance == null, "multiple instance found for singleton exchange type!");
-          singletonInstance = serverInstance;
-        }
-      }
-
-      if (singletonInstance == null) {
-        // TODO: fix WorkerManager assignment, this should not happen if we properly assign workers.
-        // see: https://github.com/apache/pinot/issues/9611
-        _sendingMailbox = Collections.emptyList();
-      } else {
-        _sendingMailbox =
-            Collections.singletonList(toMailboxId(singletonInstance, jobId, senderStageId, receiverStageId, receiver));
-      }
-    } else {
-      _sendingMailbox = new ArrayList<>(sendingStageInstances.size());
-      for (VirtualServer instance : sendingStageInstances) {
-        _sendingMailbox.add(toMailboxId(instance, jobId, senderStageId, receiverStageId, receiver));
-      }
-    }
-    _collationKeys = collationKeys;
-    _collationDirections = collationDirections;
-    _isSortOnSender = isSortOnSender;
-    _isSortOnReceiver = isSortOnReceiver;
-    _dataSchema = dataSchema;
-    if (CollectionUtils.isEmpty(collationKeys) || !_isSortOnReceiver) {
-      _priorityQueue = null;
-    } else {
-      _priorityQueue = new PriorityQueue<>(new SortUtils.SortComparator(collationKeys, collationDirections,
-          dataSchema, false));
-    }
-    _upstreamErrorBlock = null;
-    _serverIdx = 0;
-    _isSortedBlockConstructed = false;
-  }
-
-  public List<MailboxIdentifier> getSendingMailbox() {
-    return _sendingMailbox;
-  }
-
-  @Override
-  public List<MultiStageOperator> getChildOperators() {
-    return ImmutableList.of();
+      RelDistribution.Type exchangeType, int senderStageId, int receiverStageId, Long timeoutMs) {
+    super(context, sendingStageInstances, exchangeType, senderStageId, receiverStageId, timeoutMs);
   }
 
   @Nullable
@@ -178,7 +63,6 @@ public class MailboxReceiveOperator extends MultiStageOperator {
   @Override
   protected TransferableBlock getNextBlock() {
     if (_upstreamErrorBlock != null) {
-      cleanUpResourcesOnError();
       return _upstreamErrorBlock;
     } else if (System.nanoTime() >= _deadlineTimestampNano) {
       return TransferableBlockUtils.getErrorTransferableBlock(QueryException.EXECUTION_TIMEOUT_ERROR);
@@ -201,20 +85,12 @@ public class MailboxReceiveOperator extends MultiStageOperator {
           // Get null block when pulling times out from mailbox.
           if (block != null) {
             if (block.isErrorBlock()) {
-              cleanUpResourcesOnError();
               _upstreamErrorBlock =
                   TransferableBlockUtils.getErrorTransferableBlock(block.getDataBlock().getExceptions());
               return _upstreamErrorBlock;
             }
             if (!block.isEndOfStreamBlock()) {
-              if (_priorityQueue != null) {
-                // Ordering is enabled, add rows to the PriorityQueue
-                List<Object[]> container = block.getContainer();
-                _priorityQueue.addAll(container);
-              } else {
-                // Ordering is not enabled, return the input block as is
-                return block;
-              }
+              return block;
             } else {
               if (_opChainStats != null && !block.getResultMetadata().isEmpty()) {
                 for (Map.Entry<String, OperatorStats> entry : block.getResultMetadata().entrySet()) {
@@ -231,18 +107,6 @@ public class MailboxReceiveOperator extends MultiStageOperator {
       }
     }
 
-    if (((openMailboxCount == 0) || (openMailboxCount <= eosMailboxCount))
-        && (!CollectionUtils.isEmpty(_priorityQueue)) && !_isSortedBlockConstructed) {
-      // Some data is present in the PriorityQueue, these need to be sent upstream
-      LinkedList<Object[]> rows = new LinkedList<>();
-      while (_priorityQueue.size() > 0) {
-        Object[] row = _priorityQueue.poll();
-        rows.addFirst(row);
-      }
-      _isSortedBlockConstructed = true;
-      return new TransferableBlock(rows, _dataSchema, DataBlock.Type.ROW);
-    }
-
     // there are two conditions in which we should return EOS: (1) there were
     // no mailboxes to open (this shouldn't happen because the second condition
     // should be hit first, but is defensive) (2) every mailbox that was opened
@@ -252,31 +116,5 @@ public class MailboxReceiveOperator extends MultiStageOperator {
         openMailboxCount > 0 && openMailboxCount > eosMailboxCount ? TransferableBlockUtils.getNoOpTransferableBlock()
             : TransferableBlockUtils.getEndOfStreamTransferableBlock();
     return block;
-  }
-
-  private void cleanUpResourcesOnError() {
-    if (_priorityQueue != null) {
-      _priorityQueue.clear();
-    }
-  }
-
-  public boolean hasCollationKeys() {
-    return !CollectionUtils.isEmpty(_collationKeys);
-  }
-
-  @Override
-  public void close() {
-    super.close();
-    for (MailboxIdentifier sendingMailbox : _sendingMailbox) {
-      _mailboxService.releaseReceivingMailbox(sendingMailbox);
-    }
-  }
-
-  @Override
-  public void cancel(Throwable t) {
-    super.cancel(t);
-    for (MailboxIdentifier sendingMailbox : _sendingMailbox) {
-      _mailboxService.releaseReceivingMailbox(sendingMailbox);
-    }
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -80,8 +80,10 @@ public class SortOperator extends MultiStageOperator {
       _priorityQueue = null;
       _rows = new ArrayList<>();
     } else {
+      // Use the opposite direction as specified by the collation directions since we need the PriorityQueue to decide
+      // which elements to keep and which to remove based on the limits.
       _priorityQueue = new PriorityQueue<>(_numRowsToKeep,
-          new SortUtils.SortComparator(collationKeys, collationDirections, dataSchema, false));
+          new SortUtils.SortComparator(collationKeys, collationDirections, dataSchema, false, true));
       _rows = null;
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperator.java
@@ -195,8 +195,6 @@ public class SortedMailboxReceiveOperator extends BaseMailboxReceiveOperator {
   @Override
   public void cancel(Throwable t) {
     super.cancel(t);
-    if (_upstreamErrorBlock != null) {
-      cleanUpResources();
-    }
+    cleanUpResources();
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperator.java
@@ -1,0 +1,189 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator;
+
+import com.google.common.base.Preconditions;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import java.util.PriorityQueue;
+import javax.annotation.Nullable;
+import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelFieldCollation;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.pinot.common.datablock.DataBlock;
+import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.mailbox.MailboxIdentifier;
+import org.apache.pinot.query.mailbox.ReceivingMailbox;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.routing.VirtualServer;
+import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.operator.utils.SortUtils;
+import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * This {@code SortedMailboxReceiveOperator} receives data from a {@link ReceivingMailbox} and serve it out from the
+ * {@link MultiStageOperator#getNextBlock()}()} API in a sorted manner.
+ *
+ *  TODO: Once sorting on the {@code MailboxSendOperator} is available, modify this to use a k-way merge instead of
+ *        resorting via the PriorityQueue.
+ */
+public class SortedMailboxReceiveOperator extends BaseMailboxReceiveOperator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(SortedMailboxReceiveOperator.class);
+  private static final String EXPLAIN_NAME = "SORTED_MAILBOX_RECEIVE";
+
+  private final List<RexExpression> _collationKeys;
+  private final List<RelFieldCollation.Direction> _collationDirections;
+  private final boolean _isSortOnSender;
+  private final boolean _isSortOnReceiver;
+  private final DataSchema _dataSchema;
+  private final PriorityQueue<Object[]> _priorityQueue;
+  private boolean _isSortedBlockConstructed;
+
+  public SortedMailboxReceiveOperator(OpChainExecutionContext context, RelDistribution.Type exchangeType,
+      List<RexExpression> collationKeys, List<RelFieldCollation.Direction> collationDirections, boolean isSortOnSender,
+      boolean isSortOnReceiver, DataSchema dataSchema, int senderStageId, int receiverStageId) {
+    this(context, context.getMetadataMap().get(senderStageId).getServerInstances(), exchangeType, collationKeys,
+        collationDirections, isSortOnSender, isSortOnReceiver, dataSchema, senderStageId,
+        receiverStageId, context.getTimeoutMs());
+  }
+
+  // TODO: Move deadlineInNanoSeconds to OperatorContext.
+  // TODO: Remove boxed timeoutMs value from here and use long deadlineMs from context.
+  public SortedMailboxReceiveOperator(OpChainExecutionContext context, List<VirtualServer> sendingStageInstances,
+      RelDistribution.Type exchangeType, List<RexExpression> collationKeys,
+      List<RelFieldCollation.Direction> collationDirections, boolean isSortOnSender, boolean isSortOnReceiver,
+      DataSchema dataSchema, int senderStageId, int receiverStageId, Long timeoutMs) {
+    super(context, sendingStageInstances, exchangeType, senderStageId, receiverStageId, timeoutMs);
+    _collationKeys = collationKeys;
+    _collationDirections = collationDirections;
+    _isSortOnSender = isSortOnSender;
+    _isSortOnReceiver = isSortOnReceiver;
+    _dataSchema = dataSchema;
+    Preconditions.checkState(!CollectionUtils.isEmpty(collationKeys) && isSortOnReceiver,
+        "Collation keys should exist and sorting must be enabled otherwise use non-sorted MailboxReceiveOperator");
+    _priorityQueue = new PriorityQueue<>(new SortUtils.SortComparator(collationKeys, collationDirections,
+        dataSchema, false));
+    _isSortedBlockConstructed = false;
+  }
+
+  @Nullable
+  @Override
+  public String toExplainString() {
+    return EXPLAIN_NAME;
+  }
+
+  @Override
+  protected TransferableBlock getNextBlock() {
+    if (_upstreamErrorBlock != null) {
+      cleanUpResourcesOnError();
+      return _upstreamErrorBlock;
+    } else if (System.nanoTime() >= _deadlineTimestampNano) {
+      return TransferableBlockUtils.getErrorTransferableBlock(QueryException.EXECUTION_TIMEOUT_ERROR);
+    }
+
+    int startingIdx = _serverIdx;
+    int openMailboxCount = 0;
+    int eosMailboxCount = 0;
+    boolean foundNonNullTransferableBlock;
+    // For all non-singleton distribution, we poll from every instance to check mailbox content.
+    // Since this operator needs to wait for all incoming data before it can send the data to the
+    // upstream operators, this operator will keep trying to poll from all mailboxes until it only
+    // receives null blocks or EOS for all mailboxes. This operator does not need to yield itself
+    // for backpressure at the moment but once support is added for k-way merge when input data is
+    // sorted this operator will have to return some data blocks without waiting for all the data.
+    // TODO: Fix wasted CPU cycles on waiting for servers that are not supposed to give content.
+    do {
+      // Reset the following for each loop
+      foundNonNullTransferableBlock = false;
+      openMailboxCount = 0;
+      eosMailboxCount = 0;
+      for (int i = 0; i < _sendingMailbox.size(); i++) {
+        // this implements a round-robin mailbox iterator, so we don't starve any mailboxes
+        _serverIdx = (startingIdx + i) % _sendingMailbox.size();
+        MailboxIdentifier mailboxId = _sendingMailbox.get(_serverIdx);
+        try {
+          ReceivingMailbox<TransferableBlock> mailbox = _mailboxService.getReceivingMailbox(mailboxId);
+          if (!mailbox.isClosed()) {
+            openMailboxCount++;
+            TransferableBlock block = mailbox.receive();
+            // Get null block when pulling times out from mailbox.
+            if (block != null) {
+              foundNonNullTransferableBlock = true;
+              if (block.isErrorBlock()) {
+                cleanUpResourcesOnError();
+                _upstreamErrorBlock =
+                    TransferableBlockUtils.getErrorTransferableBlock(block.getDataBlock().getExceptions());
+                return _upstreamErrorBlock;
+              }
+              if (!block.isEndOfStreamBlock()) {
+                // Add rows to the PriorityQueue to order them
+                List<Object[]> container = block.getContainer();
+                _priorityQueue.addAll(container);
+              } else {
+                if (_opChainStats != null && !block.getResultMetadata().isEmpty()) {
+                  for (Map.Entry<String, OperatorStats> entry : block.getResultMetadata().entrySet()) {
+                    _opChainStats.getOperatorStatsMap().compute(entry.getKey(), (_key, _value) -> entry.getValue());
+                  }
+                }
+                eosMailboxCount++;
+              }
+            }
+          }
+        } catch (Exception e) {
+          return TransferableBlockUtils.getErrorTransferableBlock(
+              new RuntimeException(String.format("Error polling mailbox=%s", mailboxId), e));
+        }
+      }
+    } while (foundNonNullTransferableBlock && ((openMailboxCount > 0) && (openMailboxCount > eosMailboxCount)));
+
+    if (((openMailboxCount == 0) || (openMailboxCount <= eosMailboxCount))
+        && (!CollectionUtils.isEmpty(_priorityQueue)) && !_isSortedBlockConstructed) {
+      // Some data is present in the PriorityQueue, these need to be sent upstream
+      LinkedList<Object[]> rows = new LinkedList<>();
+      while (_priorityQueue.size() > 0) {
+        Object[] row = _priorityQueue.poll();
+        rows.addFirst(row);
+      }
+      _isSortedBlockConstructed = true;
+      return new TransferableBlock(rows, _dataSchema, DataBlock.Type.ROW);
+    }
+
+    // there are two conditions in which we should return EOS: (1) there were
+    // no mailboxes to open (this shouldn't happen because the second condition
+    // should be hit first, but is defensive) (2) every mailbox that was opened
+    // returned an EOS block. in every other scenario, there are mailboxes that
+    // are not yet exhausted and we should wait for more data to be available
+    TransferableBlock block =
+        openMailboxCount > 0 && openMailboxCount > eosMailboxCount ? TransferableBlockUtils.getNoOpTransferableBlock()
+            : TransferableBlockUtils.getEndOfStreamTransferableBlock();
+    return block;
+  }
+
+  private void cleanUpResourcesOnError() {
+    if (_priorityQueue != null) {
+      _priorityQueue.clear();
+    }
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/SortUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/SortUtils.java
@@ -36,8 +36,16 @@ public class SortUtils {
     private final int[] _multipliers;
     private final boolean[] _useDoubleComparison;
 
+    /**
+     * Sort comparator for use with priority queues
+     * @param collationKeys collation keys to sort on
+     * @param collationDirections collation direction for each collation key to sort on
+     * @param dataSchema data schema to use
+     * @param isNullHandlingEnabled 'true' if null handling is enabled. Not supported yet
+     * @param switchDirections 'true' if the opposite sort direction should be used as what is specified
+     */
     public SortComparator(List<RexExpression> collationKeys, List<RelFieldCollation.Direction> collationDirections,
-        DataSchema dataSchema, boolean isNullHandlingEnabled) {
+        DataSchema dataSchema, boolean isNullHandlingEnabled, boolean switchDirections) {
       DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
       _size = collationKeys.size();
       _valueIndices = new int[_size];
@@ -45,7 +53,8 @@ public class SortUtils {
       _useDoubleComparison = new boolean[_size];
       for (int i = 0; i < _size; i++) {
         _valueIndices[i] = ((RexExpression.InputRef) collationKeys.get(i)).getIndex();
-        _multipliers[i] = collationDirections.get(i).isDescending() ? 1 : -1;
+        _multipliers[i] = switchDirections ? (collationDirections.get(i).isDescending() ? 1 : -1)
+            : (collationDirections.get(i).isDescending() ? -1 : 1);
         _useDoubleComparison[i] = columnDataTypes[_valueIndices[i]].isNumber();
       }
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.query.runtime.plan;
 
-import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.query.planner.stage.AggregateNode;
 import org.apache.pinot.query.planner.stage.FilterNode;
 import org.apache.pinot.query.planner.stage.JoinNode;
@@ -63,7 +62,7 @@ public class PhysicalPlanVisitor implements StageNodeVisitor<MultiStageOperator,
 
   @Override
   public MultiStageOperator visitMailboxReceive(MailboxReceiveNode node, PlanRequestContext context) {
-    if (!CollectionUtils.isEmpty(node.getCollationKeys()) && node.isSortOnReceiver()) {
+    if (node.isSortOnReceiver()) {
       SortedMailboxReceiveOperator sortedMailboxReceiveOperator =
           new SortedMailboxReceiveOperator(context.getOpChainExecutionContext(), node.getExchangeType(),
               node.getCollationKeys(), node.getCollationDirections(), node.isSortOnSender(), node.isSortOnReceiver(),

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -21,7 +21,6 @@ package org.apache.pinot.query.service.dispatch;
 import com.google.common.annotations.VisibleForTesting;
 import io.grpc.Deadline;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -286,8 +285,7 @@ public class QueryDispatcher {
       DataSchema dataSchema, OpChainExecutionContext context) {
     // timeout is set for reduce stage
     MailboxReceiveOperator mailboxReceiveOperator =
-        new MailboxReceiveOperator(context, RelDistribution.Type.RANDOM_DISTRIBUTED, Collections.emptyList(),
-            Collections.emptyList(), false, false, dataSchema, stageId, reducerStageId);
+        new MailboxReceiveOperator(context, RelDistribution.Type.RANDOM_DISTRIBUTED, stageId, reducerStageId);
     return mailboxReceiveOperator;
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
@@ -20,16 +20,20 @@ package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Random;
 import org.apache.calcite.rel.RelDistribution;
+import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.JsonMailboxIdentifier;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.mailbox.ReceivingMailbox;
+import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.routing.VirtualServer;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
@@ -44,9 +48,10 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.INT;
+import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.STRING;
 
 
-public class MailboxReceiveOperatorTest {
+public class SortedMailboxReceiveOperatorTest {
 
   private static final int DEFAULT_RECEIVER_STAGE_ID = 10;
 
@@ -83,12 +88,19 @@ public class MailboxReceiveOperatorTest {
   @Test
   public void shouldTimeoutOnExtraLongSleep()
       throws InterruptedException {
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+    collationKeys.add(new RexExpression.InputRef(0));
+    collationDirections.add(RelFieldCollation.Direction.ASCENDING);
+
     // shorter timeoutMs should result in error.
+    DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, 10L, 10L,
             new HashMap<>());
-    MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, 10L);
+    SortedMailboxReceiveOperator receiveOp =
+        new SortedMailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON, collationKeys,
+            collationDirections, false, true, inSchema, 456, 789, 10L);
     Thread.sleep(200L);
     TransferableBlock mailbox = receiveOp.nextBlock();
     Assert.assertTrue(mailbox.isErrorBlock());
@@ -98,13 +110,15 @@ public class MailboxReceiveOperatorTest {
     // longer timeout or default timeout (10s) doesn't result in error.
     context = new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, 2000L, 2000L,
         new HashMap<>());
-    receiveOp = new MailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, 2000L);
+    receiveOp = new SortedMailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON,
+        collationKeys, collationDirections, false, true, inSchema, 456, 789, 2000L);
     Thread.sleep(200L);
     mailbox = receiveOp.nextBlock();
     Assert.assertFalse(mailbox.isErrorBlock());
     context = new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
         Long.MAX_VALUE, new HashMap<>());
-    receiveOp = new MailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON, 456, 789, null);
+    receiveOp = new SortedMailboxReceiveOperator(context, new ArrayList<>(), RelDistribution.Type.SINGLETON,
+        collationKeys, collationDirections, false, true, inSchema, 456, 789, null);
     Thread.sleep(200L);
     mailbox = receiveOp.nextBlock();
     Assert.assertFalse(mailbox.isErrorBlock());
@@ -123,12 +137,19 @@ public class MailboxReceiveOperatorTest {
     Mockito.when(_server2.getHostname()).thenReturn("singleton");
     Mockito.when(_server2.getQueryMailboxPort()).thenReturn(123);
 
+    DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
+
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+    collationKeys.add(new RexExpression.InputRef(0));
+    collationDirections.add(RelFieldCollation.Direction.ASCENDING);
+
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
-    MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
-            456, 789, null);
+    SortedMailboxReceiveOperator receiveOp =
+        new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
+            collationKeys, collationDirections, false, true, inSchema, 456, 789, null);
   }
 
   @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*RANGE_DISTRIBUTED.*")
@@ -142,11 +163,19 @@ public class MailboxReceiveOperatorTest {
     Mockito.when(_server2.getHostname()).thenReturn("singleton");
     Mockito.when(_server2.getQueryMailboxPort()).thenReturn(123);
 
+    DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
+
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+    collationKeys.add(new RexExpression.InputRef(0));
+    collationDirections.add(RelFieldCollation.Direction.ASCENDING);
+
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, 1, DEFAULT_RECEIVER_STAGE_ID, _testAddr, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
-    MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
-        RelDistribution.Type.RANGE_DISTRIBUTED, 456, 789, null);
+    SortedMailboxReceiveOperator receiveOp = new SortedMailboxReceiveOperator(context,
+        ImmutableList.of(_server1, _server2), RelDistribution.Type.RANGE_DISTRIBUTED, collationKeys,
+        collationDirections, false, true, inSchema, 456, 789, null);
   }
 
   @Test
@@ -170,13 +199,21 @@ public class MailboxReceiveOperatorTest {
     String toHost = "toHost";
     VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
 
+    DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
+
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+    collationKeys.add(new RexExpression.InputRef(0));
+    collationDirections.add(RelFieldCollation.Direction.ASCENDING);
+
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
 
-    MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
-            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    SortedMailboxReceiveOperator receiveOp =
+        new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
+            collationKeys, collationDirections, false, true, inSchema, stageId, DEFAULT_RECEIVER_STAGE_ID,
+            null);
 
     // Receive end of stream block directly when there is no match.
     Assert.assertTrue(receiveOp.nextBlock().isEndOfStreamBlock());
@@ -208,13 +245,21 @@ public class MailboxReceiveOperatorTest {
     Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId)).thenReturn(_mailbox);
     Mockito.when(_mailbox.isClosed()).thenReturn(true);
 
+    DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
+
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+    collationKeys.add(new RexExpression.InputRef(0));
+    collationDirections.add(RelFieldCollation.Direction.ASCENDING);
+
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
 
-    MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
-            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    SortedMailboxReceiveOperator receiveOp =
+        new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
+            collationKeys, collationDirections, false, true, inSchema, stageId, DEFAULT_RECEIVER_STAGE_ID,
+            null);
 
     // Receive end of stream block directly when mailbox is close.
     Assert.assertTrue(receiveOp.nextBlock().isEndOfStreamBlock());
@@ -249,13 +294,21 @@ public class MailboxReceiveOperatorTest {
     // Receive null mailbox during timeout.
     Mockito.when(_mailbox.receive()).thenReturn(null);
 
+    DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
+
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+    collationKeys.add(new RexExpression.InputRef(0));
+    collationDirections.add(RelFieldCollation.Direction.ASCENDING);
+
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
 
-    MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
-            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    SortedMailboxReceiveOperator receiveOp =
+        new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
+            collationKeys, collationDirections, false, true, inSchema, stageId, DEFAULT_RECEIVER_STAGE_ID,
+            null);
     // Receive NoOpBlock.
     Assert.assertTrue(receiveOp.nextBlock().isNoOpBlock());
   }
@@ -288,13 +341,21 @@ public class MailboxReceiveOperatorTest {
     Mockito.when(_mailbox.isClosed()).thenReturn(false);
     Mockito.when(_mailbox.receive()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
+    DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
+
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+    collationKeys.add(new RexExpression.InputRef(0));
+    collationDirections.add(RelFieldCollation.Direction.ASCENDING);
+
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
 
-    MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
-            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    SortedMailboxReceiveOperator receiveOp =
+        new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
+            collationKeys, collationDirections, false, true, inSchema, stageId, DEFAULT_RECEIVER_STAGE_ID,
+            null);
     // Receive EosBloc.
     Assert.assertTrue(receiveOp.nextBlock().isEndOfStreamBlock());
   }
@@ -330,13 +391,19 @@ public class MailboxReceiveOperatorTest {
     Mockito.when(_mailbox.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow),
         TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+    collationKeys.add(new RexExpression.InputRef(0));
+    collationDirections.add(RelFieldCollation.Direction.ASCENDING);
+
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
 
-    MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
-            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    SortedMailboxReceiveOperator receiveOp =
+        new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
+            collationKeys, collationDirections, false, true, inSchema, stageId, DEFAULT_RECEIVER_STAGE_ID,
+            null);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     while (receivedBlock.isNoOpBlock()) {
       receivedBlock = receiveOp.nextBlock();
@@ -376,17 +443,95 @@ public class MailboxReceiveOperatorTest {
     DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
     Mockito.when(_mailbox.receive()).thenReturn(TransferableBlockUtils.getErrorTransferableBlock(e));
 
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+    collationKeys.add(new RexExpression.InputRef(0));
+    collationDirections.add(RelFieldCollation.Direction.ASCENDING);
+
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
 
-    MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
-            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    SortedMailboxReceiveOperator receiveOp =
+        new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.SINGLETON,
+            collationKeys, collationDirections, false, true, inSchema, stageId, DEFAULT_RECEIVER_STAGE_ID,
+            null);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     Assert.assertTrue(receivedBlock.isErrorBlock());
     MetadataBlock error = (MetadataBlock) receivedBlock.getDataBlock();
     Assert.assertTrue(error.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("errorBlock"));
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class,
+      expectedExceptionsMessageRegExp = ".*Collation keys should exist.*")
+  public void shouldThrowOnEmptyCollationKey()
+      throws Exception {
+    String server1Host = "hash1";
+    int server1Port = 123;
+    Mockito.when(_server1.getHostname()).thenReturn(server1Host);
+    Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+
+    String server2Host = "hash2";
+    int server2Port = 456;
+    Mockito.when(_server2.getHostname()).thenReturn(server2Host);
+    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+
+    int jobId = 456;
+    int stageId = 0;
+    int toPort = 8888;
+    String toHost = "toHost";
+    VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
+
+    DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
+
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    SortedMailboxReceiveOperator receiveOp =
+        new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
+            RelDistribution.Type.HASH_DISTRIBUTED, collationKeys, collationDirections, false, true, inSchema, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, null);
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class,
+      expectedExceptionsMessageRegExp = ".*sorting must be enabled.*")
+  public void shouldThrowOnShouldSortOnReceiverFalse()
+      throws Exception {
+    String server1Host = "hash1";
+    int server1Port = 123;
+    Mockito.when(_server1.getHostname()).thenReturn(server1Host);
+    Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+
+    String server2Host = "hash2";
+    int server2Port = 456;
+    Mockito.when(_server2.getHostname()).thenReturn(server2Host);
+    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+
+    int jobId = 456;
+    int stageId = 0;
+    int toPort = 8888;
+    String toHost = "toHost";
+    VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
+
+    DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
+
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+    collationKeys.add(new RexExpression.InputRef(0));
+    collationDirections.add(RelFieldCollation.Direction.ASCENDING);
+
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    SortedMailboxReceiveOperator receiveOp =
+        new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
+            RelDistribution.Type.HASH_DISTRIBUTED, collationKeys, collationDirections, false, false, inSchema, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, null);
   }
 
   @Test
@@ -422,13 +567,19 @@ public class MailboxReceiveOperatorTest {
     Mockito.when(_mailbox2.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow),
         TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+    collationKeys.add(new RexExpression.InputRef(0));
+    collationDirections.add(RelFieldCollation.Direction.ASCENDING);
+
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
 
-    MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,
-            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    SortedMailboxReceiveOperator receiveOp =
+        new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
+            RelDistribution.Type.HASH_DISTRIBUTED, collationKeys, collationDirections, false, true, inSchema, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, null);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     while (receivedBlock.isNoOpBlock()) {
       receivedBlock = receiveOp.nextBlock();
@@ -472,13 +623,19 @@ public class MailboxReceiveOperatorTest {
     Mockito.when(_mailbox2.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow),
         TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+    collationKeys.add(new RexExpression.InputRef(0));
+    collationDirections.add(RelFieldCollation.Direction.ASCENDING);
+
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
 
-    MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,
-            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    SortedMailboxReceiveOperator receiveOp =
+        new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
+            RelDistribution.Type.HASH_DISTRIBUTED, collationKeys, collationDirections, false, true, inSchema, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, null);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     while (receivedBlock.isNoOpBlock()) {
       receivedBlock = receiveOp.nextBlock();
@@ -486,67 +643,6 @@ public class MailboxReceiveOperatorTest {
     List<Object[]> resultRows = receivedBlock.getContainer();
     Assert.assertEquals(resultRows.size(), 1);
     Assert.assertEquals(resultRows.get(0), expRow);
-  }
-
-  @Test
-  public void shouldReceiveMailboxFromTwoServers()
-      throws Exception {
-    String server1Host = "hash1";
-    int server1Port = 123;
-    Mockito.when(_server1.getHostname()).thenReturn(server1Host);
-    Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
-
-    String server2Host = "hash2";
-    int server2Port = 456;
-    Mockito.when(_server2.getHostname()).thenReturn(server2Host);
-    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
-
-    int jobId = 456;
-    int stageId = 0;
-    int toPort = 8888;
-    String toHost = "toHost";
-    VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
-
-    DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
-    JsonMailboxIdentifier expectedMailboxId1 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-        new VirtualServerAddress(server1Host, server1Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
-    Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId1)).thenReturn(_mailbox);
-    Mockito.when(_mailbox.isClosed()).thenReturn(false);
-    Object[] expRow1 = new Object[]{1, 1};
-    Object[] expRow2 = new Object[]{2, 2};
-    Mockito.when(_mailbox.receive())
-        .thenReturn(OperatorTestUtil.block(inSchema, expRow1), OperatorTestUtil.block(inSchema, expRow2),
-            TransferableBlockUtils.getEndOfStreamTransferableBlock());
-
-    Object[] expRow3 = new Object[]{3, 3};
-    JsonMailboxIdentifier expectedMailboxId2 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
-        new VirtualServerAddress(server2Host, server2Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
-    Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId2)).thenReturn(_mailbox2);
-    Mockito.when(_mailbox2.isClosed()).thenReturn(false);
-    Mockito.when(_mailbox2.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow3));
-    OpChainExecutionContext context =
-        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
-            Long.MAX_VALUE, new HashMap<>());
-
-    MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,
-            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
-    // Receive first block from first server.
-    TransferableBlock receivedBlock = receiveOp.nextBlock();
-    List<Object[]> resultRows = receivedBlock.getContainer();
-    Assert.assertEquals(resultRows.size(), 1);
-    Assert.assertEquals(resultRows.get(0), expRow1);
-    // Receive second block from first server.
-    receivedBlock = receiveOp.nextBlock();
-    resultRows = receivedBlock.getContainer();
-    Assert.assertEquals(resultRows.size(), 1);
-    Assert.assertEquals(resultRows.get(0), expRow2);
-
-    // Receive from second server.
-    receivedBlock = receiveOp.nextBlock();
-    resultRows = receivedBlock.getContainer();
-    Assert.assertEquals(resultRows.size(), 1);
-    Assert.assertEquals(resultRows.get(0), expRow3);
   }
 
   @Test
@@ -583,13 +679,19 @@ public class MailboxReceiveOperatorTest {
     Mockito.when(_mailbox2.isClosed()).thenReturn(false);
     Mockito.when(_mailbox2.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow3));
 
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+    collationKeys.add(new RexExpression.InputRef(0));
+    collationDirections.add(RelFieldCollation.Direction.ASCENDING);
+
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
 
-    MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,
-            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    SortedMailboxReceiveOperator receiveOp =
+        new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
+            RelDistribution.Type.HASH_DISTRIBUTED, collationKeys, collationDirections, false, true, inSchema, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, null);
     // Receive error block from first server.
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     Assert.assertTrue(receivedBlock.isErrorBlock());
@@ -630,14 +732,185 @@ public class MailboxReceiveOperatorTest {
     Mockito.when(_mailbox2.isClosed()).thenReturn(false);
     Mockito.when(_mailbox2.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow3));
 
+    List<RexExpression> collationKeys = new ArrayList<>();
+    List<RelFieldCollation.Direction> collationDirections = new ArrayList<>();
+    collationKeys.add(new RexExpression.InputRef(0));
+    collationDirections.add(RelFieldCollation.Direction.ASCENDING);
+
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
             Long.MAX_VALUE, new HashMap<>());
 
-    MailboxReceiveOperator receiveOp =
-        new MailboxReceiveOperator(context, ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED,
-            stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+    SortedMailboxReceiveOperator receiveOp =
+        new SortedMailboxReceiveOperator(context, ImmutableList.of(_server1, _server2),
+            RelDistribution.Type.HASH_DISTRIBUTED, collationKeys, collationDirections, false, true, inSchema, stageId,
+            DEFAULT_RECEIVER_STAGE_ID, null);
     TransferableBlock receivedBlock = receiveOp.nextBlock();
     Assert.assertTrue(receivedBlock.isErrorBlock(), "server-1 should have returned an error-block");
+  }
+
+  @Test
+  public void shouldReceiveMailboxFromTwoServersWithCollationKey()
+      throws Exception {
+    String server1Host = "hash1";
+    int server1Port = 123;
+    Mockito.when(_server1.getHostname()).thenReturn(server1Host);
+    Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+
+    String server2Host = "hash2";
+    int server2Port = 456;
+    Mockito.when(_server2.getHostname()).thenReturn(server2Host);
+    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+
+    int jobId = 456;
+    int stageId = 0;
+    int toPort = 8888;
+    String toHost = "toHost";
+    VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
+
+    DataSchema inSchema = new DataSchema(new String[]{"col1", "col2"}, new DataSchema.ColumnDataType[]{INT, INT});
+    JsonMailboxIdentifier expectedMailboxId1 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(server1Host, server1Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId1)).thenReturn(_mailbox);
+    Mockito.when(_mailbox.isClosed()).thenReturn(false);
+    Object[] expRow1 = new Object[]{3, 3};
+    Object[] expRow2 = new Object[]{1, 1};
+    Mockito.when(_mailbox.receive())
+        .thenReturn(OperatorTestUtil.block(inSchema, expRow1), OperatorTestUtil.block(inSchema, expRow2),
+            TransferableBlockUtils.getEndOfStreamTransferableBlock());
+
+    Object[] expRow3 = new Object[]{4, 2};
+    Object[] expRow4 = new Object[]{2, 4};
+    Object[] expRow5 = new Object[]{-1, 95};
+    JsonMailboxIdentifier expectedMailboxId2 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(server2Host, server2Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId2)).thenReturn(_mailbox2);
+    Mockito.when(_mailbox2.isClosed()).thenReturn(false);
+    Mockito.when(_mailbox2.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow3),
+        OperatorTestUtil.block(inSchema, expRow4), OperatorTestUtil.block(inSchema, expRow5),
+        TransferableBlockUtils.getEndOfStreamTransferableBlock());
+
+    // Setup the collation key and direction
+    List<RexExpression> collationKeys = new ArrayList<>(Collections.singletonList(new RexExpression.InputRef(0)));
+    RelFieldCollation.Direction direction = _random.nextBoolean() ? RelFieldCollation.Direction.ASCENDING
+        : RelFieldCollation.Direction.DESCENDING;
+    List<RelFieldCollation.Direction> collationDirection = new ArrayList<>(Collections.singletonList(direction));
+
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    SortedMailboxReceiveOperator receiveOp = new SortedMailboxReceiveOperator(context,
+        ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, collationKeys, collationDirection,
+        false, true, inSchema, stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+
+    // Receive a set of no-op blocks and skip over them
+    TransferableBlock receivedBlock = receiveOp.nextBlock();
+    while (receivedBlock.isNoOpBlock()) {
+      receivedBlock = receiveOp.nextBlock();
+    }
+    List<Object[]> resultRows = receivedBlock.getContainer();
+    // All blocks should be returned together since ordering was required
+    Assert.assertEquals(resultRows.size(), 5);
+    if (direction == RelFieldCollation.Direction.ASCENDING) {
+      Assert.assertEquals(resultRows.get(0), expRow5);
+      Assert.assertEquals(resultRows.get(1), expRow2);
+      Assert.assertEquals(resultRows.get(2), expRow4);
+      Assert.assertEquals(resultRows.get(3), expRow1);
+      Assert.assertEquals(resultRows.get(4), expRow3);
+    } else {
+      Assert.assertEquals(resultRows.get(0), expRow3);
+      Assert.assertEquals(resultRows.get(1), expRow1);
+      Assert.assertEquals(resultRows.get(2), expRow4);
+      Assert.assertEquals(resultRows.get(3), expRow2);
+      Assert.assertEquals(resultRows.get(4), expRow5);
+    }
+
+    receivedBlock = receiveOp.nextBlock();
+    Assert.assertTrue(receivedBlock.isEndOfStreamBlock());
+  }
+
+  @Test
+  public void shouldReceiveMailboxFromTwoServersWithCollationKeyTwoColumns()
+      throws Exception {
+    String server1Host = "hash1";
+    int server1Port = 123;
+    Mockito.when(_server1.getHostname()).thenReturn(server1Host);
+    Mockito.when(_server1.getQueryMailboxPort()).thenReturn(server1Port);
+
+    String server2Host = "hash2";
+    int server2Port = 456;
+    Mockito.when(_server2.getHostname()).thenReturn(server2Host);
+    Mockito.when(_server2.getQueryMailboxPort()).thenReturn(server2Port);
+
+    int jobId = 456;
+    int stageId = 0;
+    int toPort = 8888;
+    String toHost = "toHost";
+    VirtualServerAddress toAddress = new VirtualServerAddress(toHost, toPort, 0);
+
+    DataSchema inSchema = new DataSchema(new String[]{"col1", "col2", "col3"},
+        new DataSchema.ColumnDataType[]{INT, INT, STRING});
+    JsonMailboxIdentifier expectedMailboxId1 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(server1Host, server1Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId1)).thenReturn(_mailbox);
+    Mockito.when(_mailbox.isClosed()).thenReturn(false);
+    Object[] expRow1 = new Object[]{3, 3, "queen"};
+    Object[] expRow2 = new Object[]{1, 1, "pink floyd"};
+    Mockito.when(_mailbox.receive())
+        .thenReturn(OperatorTestUtil.block(inSchema, expRow1), OperatorTestUtil.block(inSchema, expRow2),
+            TransferableBlockUtils.getEndOfStreamTransferableBlock());
+
+    Object[] expRow3 = new Object[]{42, 2, "pink floyd"};
+    Object[] expRow4 = new Object[]{2, 4, "aerosmith"};
+    Object[] expRow5 = new Object[]{-1, 95, "foo fighters"};
+    JsonMailboxIdentifier expectedMailboxId2 = new JsonMailboxIdentifier(String.format("%s_%s", jobId, stageId),
+        new VirtualServerAddress(server2Host, server2Port, 0), toAddress, stageId, DEFAULT_RECEIVER_STAGE_ID);
+    Mockito.when(_mailboxService.getReceivingMailbox(expectedMailboxId2)).thenReturn(_mailbox2);
+    Mockito.when(_mailbox2.isClosed()).thenReturn(false);
+    Mockito.when(_mailbox2.receive()).thenReturn(OperatorTestUtil.block(inSchema, expRow3),
+        OperatorTestUtil.block(inSchema, expRow4), OperatorTestUtil.block(inSchema, expRow5),
+        TransferableBlockUtils.getEndOfStreamTransferableBlock());
+
+    // Setup the collation key and direction
+    List<RexExpression> collationKeys = new ArrayList<>(Arrays.asList(new RexExpression.InputRef(2),
+        new RexExpression.InputRef(0)));
+    RelFieldCollation.Direction direction1 = _random.nextBoolean() ? RelFieldCollation.Direction.ASCENDING
+        : RelFieldCollation.Direction.DESCENDING;
+    RelFieldCollation.Direction direction2 = RelFieldCollation.Direction.ASCENDING;
+    List<RelFieldCollation.Direction> collationDirection = new ArrayList<>(Arrays.asList(direction1, direction2));
+
+    OpChainExecutionContext context =
+        new OpChainExecutionContext(_mailboxService, jobId, DEFAULT_RECEIVER_STAGE_ID, toAddress, Long.MAX_VALUE,
+            Long.MAX_VALUE, new HashMap<>());
+
+    SortedMailboxReceiveOperator receiveOp = new SortedMailboxReceiveOperator(context,
+        ImmutableList.of(_server1, _server2), RelDistribution.Type.HASH_DISTRIBUTED, collationKeys, collationDirection,
+        false, true, inSchema, stageId, DEFAULT_RECEIVER_STAGE_ID, null);
+
+    // Receive a set of no-op blocks and skip over them
+    TransferableBlock receivedBlock = receiveOp.nextBlock();
+    while (receivedBlock.isNoOpBlock()) {
+      receivedBlock = receiveOp.nextBlock();
+    }
+    List<Object[]> resultRows = receivedBlock.getContainer();
+    // All blocks should be returned together since ordering was required
+    Assert.assertEquals(resultRows.size(), 5);
+    if (direction1 == RelFieldCollation.Direction.ASCENDING) {
+      Assert.assertEquals(resultRows.get(0), expRow4);
+      Assert.assertEquals(resultRows.get(1), expRow5);
+      Assert.assertEquals(resultRows.get(2), expRow2);
+      Assert.assertEquals(resultRows.get(3), expRow3);
+      Assert.assertEquals(resultRows.get(4), expRow1);
+    } else {
+      Assert.assertEquals(resultRows.get(0), expRow1);
+      Assert.assertEquals(resultRows.get(1), expRow2);
+      Assert.assertEquals(resultRows.get(2), expRow3);
+      Assert.assertEquals(resultRows.get(3), expRow5);
+      Assert.assertEquals(resultRows.get(4), expRow4);
+    }
+
+    receivedBlock = receiveOp.nextBlock();
+    Assert.assertTrue(receivedBlock.isEndOfStreamBlock());
   }
 }


### PR DESCRIPTION
This PR addresses the issue found in: https://github.com/apache/pinot/issues/10555

Issue summary:
The logic added as part of PR https://github.com/apache/pinot/pull/10408 added support to order as part of the `MailboxReceiveOperator` which essentially stored all the rows in a `PriorityQueue` instead of returning them right away. Due to this we got into a situation where the blocks were added to the `PriorityQueue` but we never re-polled immediately to check for `EOS` and instead returned a no-op block. No-op puts the opChain back into the scheduler wait queue. Since the SendMailbox had already sent out the `EOS` earlier there was no new blocks sent out. Due to this, since no new blocks were sent the `_seenMail` was never set and the operator had to be reawakened and rescheduled after the default timeout.

Fix:
This PR fixes the above by splitting the MailboxReceiveOperator into a `MailboxReceiveOperator` and a `SortedMailboxReceiveOperator`. The sorted version keeps polling for data from all the mailboxes until it gets only 'null' blocks or gets EOS from all mailboxes. The `MailboxReceiveOperator` does not perform any sorting and will behave the same way it did prior to the PR https://github.com/apache/pinot/pull/10408.

Testing done:
- Unit tests in multi-stage planning and runtime modules
- MultiStageEngineIntegrationTest - to ensure that this fixes the increase in runtime from 30s to 500s (and fixes the regression in ORDER BY queries)
- MultiStageEngineCustomTenantIntegrationTest

cc @walterddr @ankitsultana @siddharthteotia @vvivekiyer 