### PR TITLE
Enable index config by default.

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java
@@ -42,7 +42,7 @@ public class DictionaryIndexConfig extends IndexConfig {
   @JsonCreator
   public DictionaryIndexConfig(@JsonProperty("enabled") Boolean enabled, @JsonProperty("onHeap") Boolean onHeap,
       @JsonProperty("useVarLengthDictionary") @Nullable Boolean useVarLengthDictionary) {
-    super(enabled != null && enabled);
+    super(enabled);
     _onHeap = onHeap != null && onHeap;
     _useVarLengthDictionary = Boolean.TRUE.equals(useVarLengthDictionary);
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/ForwardIndexConfig.java
@@ -46,7 +46,7 @@ public class ForwardIndexConfig extends IndexConfig {
       @Nullable @JsonProperty("chunkCompressionType") ChunkCompressionType chunkCompressionType,
       @JsonProperty("deriveNumDocsPerChunk") Boolean deriveNumDocsPerChunk,
       @JsonProperty("rawIndexWriterVersion") Integer rawIndexWriterVersion) {
-    super(enabled == null || enabled);
+    super(enabled);
     _chunkCompressionType = chunkCompressionType;
     _deriveNumDocsPerChunk = deriveNumDocsPerChunk != null && deriveNumDocsPerChunk;
     _rawIndexWriterVersion = rawIndexWriterVersion == null ? DEFAULT_RAW_WRITER_VERSION : rawIndexWriterVersion;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/FstIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/FstIndexConfig.java
@@ -38,7 +38,7 @@ public class FstIndexConfig extends IndexConfig {
   @JsonCreator
   public FstIndexConfig(@JsonProperty("enabled") @Nullable Boolean enabled,
       @JsonProperty("type") @Nullable FSTType fstType) {
-    super((enabled != null && enabled) || fstType != null);
+    super(enabled);
     _fstType = fstType;
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/RangeIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/RangeIndexConfig.java
@@ -38,7 +38,7 @@ public class RangeIndexConfig extends IndexConfig {
   @JsonCreator
   public RangeIndexConfig(@JsonProperty("enabled") Boolean enabled,
       @JsonProperty("version") @Nullable Integer version) {
-    super(enabled != null && enabled && version != null);
+    super(enabled);
     _version = version != null ? version : 2;
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -50,7 +50,7 @@ public class TextIndexConfig extends IndexConfig {
       @JsonProperty("useANDForMultiTermQueries") boolean useANDForMultiTermQueries,
       @JsonProperty("stopWordsInclude") List<String> stopWordsInclude,
       @JsonProperty("stopWordsExclude") List<String> stopWordsExclude) {
-    super(enabled != null && enabled);
+    super(enabled);
     _fstType = fstType;
     _rawValueForTextIndex = rawValueForTextIndex;
     _enableQueryCache = enableQueryCache;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfig.java
@@ -43,7 +43,7 @@ public class H3IndexConfig extends IndexConfig {
   @JsonCreator
   public H3IndexConfig(@JsonProperty("enabled") @Nullable Boolean enabled,
       @JsonProperty("resolution") H3IndexResolution resolution) {
-    super(enabled != null && enabled);
+    super(enabled);
     _resolution = resolution;
   }
 

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfigTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class DictionaryIndexConfigTest {
+
+  @Test
+  public void withEmptyConf()
+      throws JsonProcessingException {
+    String confStr = "{}";
+    DictionaryIndexConfig config = JsonUtils.stringToObject(confStr, DictionaryIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertFalse(config.isOnHeap(), "Unexpected onHeap");
+    assertFalse(config.getUseVarLengthDictionary(), "Unexpected useVarLengthDictionary");
+  }
+
+  @Test
+  public void withEnabledNull()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": null}";
+    DictionaryIndexConfig config = JsonUtils.stringToObject(confStr, DictionaryIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertFalse(config.isOnHeap(), "Unexpected onHeap");
+    assertFalse(config.getUseVarLengthDictionary(), "Unexpected useVarLengthDictionary");
+  }
+
+  @Test
+  public void withEnabledTrue()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": true}";
+    DictionaryIndexConfig config = JsonUtils.stringToObject(confStr, DictionaryIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertFalse(config.isOnHeap(), "Unexpected onHeap");
+    assertFalse(config.getUseVarLengthDictionary(), "Unexpected useVarLengthDictionary");
+  }
+
+  @Test
+  public void withEnabledFalse()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": false}";
+    DictionaryIndexConfig config = JsonUtils.stringToObject(confStr, DictionaryIndexConfig.class);
+
+    assertFalse(config.isEnabled(), "Unexpected enabled");
+    assertFalse(config.isOnHeap(), "Unexpected onHeap");
+    assertFalse(config.getUseVarLengthDictionary(), "Unexpected useVarLengthDictionary");
+  }
+
+  @Test
+  public void withSomeData()
+      throws JsonProcessingException {
+    String confStr = "{\n"
+        + "  \"onHeap\": true,\n"
+        + "  \"useVarLengthDictionary\": true\n"
+        + "}";
+    DictionaryIndexConfig config = JsonUtils.stringToObject(confStr, DictionaryIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertTrue(config.isOnHeap(), "Unexpected onHeap");
+    assertTrue(config.getUseVarLengthDictionary(), "Unexpected useVarLengthDictionary");
+  }
+}

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigTest.java
@@ -1,0 +1,98 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class ForwardIndexConfigTest {
+
+  @Test
+  public void withEmptyConf()
+      throws JsonProcessingException {
+    String confStr = "{}";
+    ForwardIndexConfig config = JsonUtils.stringToObject(confStr, ForwardIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getChunkCompressionType(), "Unexpected chunkCompressionType");
+    assertFalse(config.isDeriveNumDocsPerChunk(), "Unexpected deriveNumDocsPerChunk");
+    assertEquals(config.getRawIndexWriterVersion(), ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION,
+        "Unexpected rawIndexWriterVersion");
+  }
+
+  @Test
+  public void withEnabledNull()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": null}";
+    ForwardIndexConfig config = JsonUtils.stringToObject(confStr, ForwardIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getChunkCompressionType(), "Unexpected chunkCompressionType");
+    assertFalse(config.isDeriveNumDocsPerChunk(), "Unexpected deriveNumDocsPerChunk");
+    assertEquals(config.getRawIndexWriterVersion(), ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION,
+        "Unexpected rawIndexWriterVersion");
+  }
+
+  @Test
+  public void withEnabledTrue()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": true}";
+    ForwardIndexConfig config = JsonUtils.stringToObject(confStr, ForwardIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getChunkCompressionType(), "Unexpected chunkCompressionType");
+    assertFalse(config.isDeriveNumDocsPerChunk(), "Unexpected deriveNumDocsPerChunk");
+    assertEquals(config.getRawIndexWriterVersion(), ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION,
+        "Unexpected rawIndexWriterVersion");
+  }
+
+  @Test
+  public void withEnabledFalse()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": false}";
+    ForwardIndexConfig config = JsonUtils.stringToObject(confStr, ForwardIndexConfig.class);
+
+    assertFalse(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getChunkCompressionType(), "Unexpected chunkCompressionType");
+    assertFalse(config.isDeriveNumDocsPerChunk(), "Unexpected deriveNumDocsPerChunk");
+    assertEquals(config.getRawIndexWriterVersion(), ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION,
+        "Unexpected rawIndexWriterVersion");
+  }
+
+  @Test
+  public void withSomeData()
+      throws JsonProcessingException {
+    String confStr = "{\n"
+        + "        \"chunkCompressionType\": \"SNAPPY\",\n"
+        + "        \"deriveNumDocsPerChunk\": true,\n"
+        + "        \"rawIndexWriterVersion\": 10\n"
+        + "}";
+    ForwardIndexConfig config = JsonUtils.stringToObject(confStr, ForwardIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertEquals(config.getChunkCompressionType(), ChunkCompressionType.SNAPPY, "Unexpected chunkCompressionType");
+    assertTrue(config.isDeriveNumDocsPerChunk(), "Unexpected deriveNumDocsPerChunk");
+    assertEquals(config.getRawIndexWriterVersion(), 10, "Unexpected rawIndexWriterVersion");
+  }
+}

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/FstIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/FstIndexConfigTest.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.pinot.spi.config.table.FSTType;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class FstIndexConfigTest {
+
+  @Test
+  public void withEmptyConf()
+      throws JsonProcessingException {
+    String confStr = "{}";
+    FstIndexConfig config = JsonUtils.stringToObject(confStr, FstIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getFstType(), "Unexpected type");
+  }
+
+  @Test
+  public void withEnabledNull()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": null}";
+    FstIndexConfig config = JsonUtils.stringToObject(confStr, FstIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getFstType(), "Unexpected type");
+  }
+
+  @Test
+  public void withEnabledTrue()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": true}";
+    FstIndexConfig config = JsonUtils.stringToObject(confStr, FstIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getFstType(), "Unexpected type");
+  }
+
+  @Test
+  public void withEnabledFalse()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": false}";
+    FstIndexConfig config = JsonUtils.stringToObject(confStr, FstIndexConfig.class);
+
+    assertFalse(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getFstType(), "Unexpected type");
+  }
+
+  @Test
+  public void withSomeData()
+      throws JsonProcessingException {
+    String confStr = "{\n"
+        + "        \"type\": \"NATIVE\"\n"
+        + "}";
+    FstIndexConfig config = JsonUtils.stringToObject(confStr, FstIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertEquals(config.getFstType(), FSTType.NATIVE, "Unexpected type");
+  }
+}

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/RangeIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/RangeIndexConfigTest.java
@@ -1,0 +1,81 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class RangeIndexConfigTest {
+
+  @Test
+  public void withEmptyConf()
+      throws JsonProcessingException {
+    String confStr = "{}";
+    RangeIndexConfig config = JsonUtils.stringToObject(confStr, RangeIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertEquals(config.getVersion(), RangeIndexConfig.DEFAULT.getVersion(), "Unexpected version");
+  }
+
+  @Test
+  public void withEnabledNull()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": null}";
+    RangeIndexConfig config = JsonUtils.stringToObject(confStr, RangeIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertEquals(config.getVersion(), RangeIndexConfig.DEFAULT.getVersion(), "Unexpected version");
+  }
+
+  @Test
+  public void withEnabledTrue()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": true}";
+    RangeIndexConfig config = JsonUtils.stringToObject(confStr, RangeIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertEquals(config.getVersion(), RangeIndexConfig.DEFAULT.getVersion(), "Unexpected version");
+  }
+
+  @Test
+  public void withEnabledFalse()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": false}";
+    RangeIndexConfig config = JsonUtils.stringToObject(confStr, RangeIndexConfig.class);
+
+    assertFalse(config.isEnabled(), "Unexpected enabled");
+    assertEquals(config.getVersion(), RangeIndexConfig.DEFAULT.getVersion(), "Unexpected version");
+  }
+
+  @Test
+  public void withSomeData()
+      throws JsonProcessingException {
+    String confStr = "{\n"
+        + "        \"version\": 42\n"
+        + "}";
+    RangeIndexConfig config = JsonUtils.stringToObject(confStr, RangeIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertEquals(config.getVersion(), 42, "Unexpected version");
+  }
+}

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigTest.java
@@ -1,0 +1,112 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.pinot.spi.config.table.FSTType;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+import static org.testng.Assert.*;
+
+
+public class TextIndexConfigTest {
+  @Test
+  public void withEmptyConf()
+      throws JsonProcessingException {
+    String confStr = "{}";
+    TextIndexConfig config = JsonUtils.stringToObject(confStr, TextIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getFstType(), "Unexpected fst");
+    assertNull(config.getRawValueForTextIndex(), "Unexpected rawValue");
+    assertFalse(config.isEnableQueryCache(), "Unexpected queryCache");
+    assertFalse(config.isUseANDForMultiTermQueries(), "Unexpected useANDForMultiTermQueries");
+    assertNull(config.getStopWordsInclude(), "Unexpected stopWordsInclude");
+    assertNull(config.getStopWordsExclude(), "Unexpected stopWordsExclude");
+  }
+
+  @Test
+  public void withEnabledNull()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": null}";
+    TextIndexConfig config = JsonUtils.stringToObject(confStr, TextIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getFstType(), "Unexpected fst");
+    assertNull(config.getRawValueForTextIndex(), "Unexpected rawValue");
+    assertFalse(config.isEnableQueryCache(), "Unexpected queryCache");
+    assertFalse(config.isUseANDForMultiTermQueries(), "Unexpected useANDForMultiTermQueries");
+    assertNull(config.getStopWordsInclude(), "Unexpected stopWordsInclude");
+    assertNull(config.getStopWordsExclude(), "Unexpected stopWordsExclude");
+  }
+
+  @Test
+  public void withEnabledTrue()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": true}";
+    TextIndexConfig config = JsonUtils.stringToObject(confStr, TextIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getFstType(), "Unexpected fst");
+    assertNull(config.getRawValueForTextIndex(), "Unexpected rawValue");
+    assertFalse(config.isEnableQueryCache(), "Unexpected queryCache");
+    assertFalse(config.isUseANDForMultiTermQueries(), "Unexpected useANDForMultiTermQueries");
+    assertNull(config.getStopWordsInclude(), "Unexpected stopWordsInclude");
+    assertNull(config.getStopWordsExclude(), "Unexpected stopWordsExclude");
+  }
+
+  @Test
+  public void withEnabledFalse()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": false}";
+    TextIndexConfig config = JsonUtils.stringToObject(confStr, TextIndexConfig.class);
+
+    assertFalse(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getFstType(), "Unexpected fst");
+    assertNull(config.getRawValueForTextIndex(), "Unexpected rawValue");
+    assertFalse(config.isEnableQueryCache(), "Unexpected queryCache");
+    assertFalse(config.isUseANDForMultiTermQueries(), "Unexpected useANDForMultiTermQueries");
+    assertNull(config.getStopWordsInclude(), "Unexpected stopWordsInclude");
+    assertNull(config.getStopWordsExclude(), "Unexpected stopWordsExclude");
+  }
+
+  @Test
+  public void withSomeData()
+      throws JsonProcessingException {
+    String confStr = "{\n"
+        + "        \"fst\": \"NATIVE\",\n"
+        + "        \"rawValue\": \"fakeValue\",\n"
+        + "        \"queryCache\": true,\n"
+        + "        \"useANDForMultiTermQueries\": true,\n"
+        + "        \"stopWordsInclude\": [\"a\"],\n"
+        + "        \"stopWordsExclude\": [\"b\"]\n"
+        + "}";
+    TextIndexConfig config = JsonUtils.stringToObject(confStr, TextIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertEquals(config.getFstType(), FSTType.NATIVE, "Unexpected fst");
+    assertEquals(config.getRawValueForTextIndex(), "fakeValue", "Unexpected rawValue");
+    assertTrue(config.isEnableQueryCache(), "Unexpected queryCache");
+    assertTrue(config.isUseANDForMultiTermQueries(), "Unexpected useANDForMultiTermQueries");
+    assertEquals(config.getStopWordsInclude(), Lists.newArrayList("a"), "Unexpected stopWordsInclude");
+    assertEquals(config.getStopWordsExclude(), Lists.newArrayList("b"), "Unexpected stopWordsExclude");
+  }
+}

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfigTest.java
@@ -1,0 +1,87 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.index.creator;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.pinot.segment.spi.index.reader.H3IndexResolution;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+import static org.testng.Assert.*;
+
+
+public class H3IndexConfigTest {
+
+  @Test
+  public void withEmptyConf()
+      throws JsonProcessingException {
+    String confStr = "{}";
+    H3IndexConfig config = JsonUtils.stringToObject(confStr, H3IndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getResolution(), "Unexpected resolution");
+  }
+
+  @Test
+  public void withEnabledNull()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": null}";
+    H3IndexConfig config = JsonUtils.stringToObject(confStr, H3IndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getResolution(), "Unexpected resolution");
+  }
+
+  @Test
+  public void withEnabledTrue()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": true}";
+    H3IndexConfig config = JsonUtils.stringToObject(confStr, H3IndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getResolution(), "Unexpected resolution");
+  }
+
+  @Test
+  public void withEnabledFalse()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": false}";
+    H3IndexConfig config = JsonUtils.stringToObject(confStr, H3IndexConfig.class);
+
+    assertFalse(config.isEnabled(), "Unexpected enabled");
+    assertNull(config.getResolution(), "Unexpected resolution");
+  }
+
+  @Test
+  public void withSomeData()
+      throws JsonProcessingException {
+    String confStr = "{\n"
+        + "        \"resolution\": [13, 5, 6]\n"
+        + "}";
+    H3IndexConfig config = JsonUtils.stringToObject(confStr, H3IndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    H3IndexResolution resolution = config.getResolution();
+    Assert.assertEquals(resolution.size(), 3);
+    Assert.assertEquals(resolution.getLowestResolution(), 5);
+    Assert.assertEquals(resolution.getResolutions(), Lists.newArrayList(5, 6, 13));
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/BloomFilterConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/BloomFilterConfig.java
@@ -42,7 +42,7 @@ public class BloomFilterConfig extends IndexConfig {
   public BloomFilterConfig(@JsonProperty("enabled") Boolean enabled, @JsonProperty(value = "fpp") double fpp,
       @JsonProperty(value = "maxSizeInBytes") int maxSizeInBytes,
       @JsonProperty(value = "loadOnHeap") boolean loadOnHeap) {
-    super(enabled != null && enabled);
+    super(enabled);
     if (fpp != 0.0) {
       Preconditions.checkArgument(fpp > 0.0 && fpp < 1.0, "Invalid fpp (false positive probability): %s", fpp);
       _fpp = fpp;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexConfig.java
@@ -35,7 +35,15 @@ public class IndexConfig extends BaseJsonConfig {
   public static final IndexConfig DISABLED = new IndexConfig(false);
   private final boolean _enabled;
 
+  /**
+   * This is used as the default constructor for subclasses. The attribute {@link #_enabled} will be initialized to
+   * {@code enabled == null || enabled}, so it will be false if and only if {@code Boolean.FALSE.equals(enabled)}.
+   */
   @JsonCreator
+  public IndexConfig(@JsonProperty("enabled") Boolean enabled) {
+    this(enabled == null || enabled);
+  }
+
   public IndexConfig(@JsonProperty("enabled") boolean enabled) {
     _enabled = enabled;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/IndexConfig.java
@@ -41,11 +41,7 @@ public class IndexConfig extends BaseJsonConfig {
    */
   @JsonCreator
   public IndexConfig(@JsonProperty("enabled") Boolean enabled) {
-    this(enabled == null || enabled);
-  }
-
-  public IndexConfig(@JsonProperty("enabled") boolean enabled) {
-    _enabled = enabled;
+    _enabled = enabled == null || enabled;
   }
 
   public boolean isEnabled() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/JsonIndexConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/JsonIndexConfig.java
@@ -53,9 +53,24 @@ public class JsonIndexConfig extends IndexConfig {
     super(true);
   }
 
+  public JsonIndexConfig(@JsonProperty("enabled") Boolean enabled) {
+    super(enabled);
+  }
+
   @JsonCreator
-  public JsonIndexConfig(@JsonProperty("enable") @Nullable Boolean enabled) {
-    super(enabled != null && enabled);
+  public JsonIndexConfig(@JsonProperty("enabled") Boolean enabled, @JsonProperty("maxLevels") int maxLevels,
+      @JsonProperty("excludeArray") boolean excludeArray,
+      @JsonProperty("disableCrossArrayUnnest") boolean disableCrossArrayUnnest,
+      @JsonProperty("includePaths") @Nullable Set<String> includePaths,
+      @JsonProperty("excludePaths") @Nullable Set<String> excludePaths,
+      @JsonProperty("excludeFields") @Nullable Set<String> excludeFields) {
+    super(enabled);
+    _maxLevels = maxLevels;
+    _excludeArray = excludeArray;
+    _disableCrossArrayUnnest = disableCrossArrayUnnest;
+    _includePaths = includePaths;
+    _excludePaths = excludePaths;
+    _excludeFields = excludeFields;
   }
 
   public int getMaxLevels() {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/BloomFilterConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/BloomFilterConfigTest.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class BloomFilterConfigTest {
+
+  @Test
+  public void withEmptyConf()
+      throws JsonProcessingException {
+    String confStr = "{}";
+    BloomFilterConfig config = JsonUtils.stringToObject(confStr, BloomFilterConfig.class);
+
+    Assert.assertTrue(config.isEnabled(), "Config should be enabled");
+  }
+
+  @Test
+  public void withEnabledNull()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": null}";
+    BloomFilterConfig config = JsonUtils.stringToObject(confStr, BloomFilterConfig.class);
+
+    Assert.assertTrue(config.isEnabled(), "Config should be enabled");
+  }
+
+  @Test
+  public void withEnabledTrue()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": true}";
+    BloomFilterConfig config = JsonUtils.stringToObject(confStr, BloomFilterConfig.class);
+
+    Assert.assertTrue(config.isEnabled(), "Config should be enabled");
+  }
+
+  @Test
+  public void withEnabledFalse()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": false}";
+    BloomFilterConfig config = JsonUtils.stringToObject(confStr, BloomFilterConfig.class);
+
+    Assert.assertFalse(config.isEnabled(), "Config should be disabled");
+  }
+
+  @Test
+  public void withSomeData()
+      throws JsonProcessingException {
+    String confStr = "{\n"
+        + "  \"fpp\": 0.5,\n"
+        + "  \"maxSizeInBytes\": 1024,\n"
+        + "  \"loadOnHeap\": true"
+        + "}";
+    BloomFilterConfig config = JsonUtils.stringToObject(confStr, BloomFilterConfig.class);
+
+    Assert.assertTrue(config.isEnabled(), "Config should be enabled");
+    Assert.assertEquals(config.getFpp(), 0.5d, "FPP is wrong");
+    Assert.assertEquals(config.getMaxSizeInBytes(), 1024, "maxSizeInBytes is wrong");
+    Assert.assertTrue(config.isLoadOnHeap(), "loadOnHeap is wrong");
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/IndexConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/IndexConfigTest.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
+
+
+public class IndexConfigTest {
+
+  @Test
+  public void withEmptyConf()
+      throws JsonProcessingException {
+    String confStr = "{}";
+    IndexConfig config = JsonUtils.stringToObject(confStr, IndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+  }
+
+  @Test
+  public void withEnabledNull()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": null}";
+    IndexConfig config = JsonUtils.stringToObject(confStr, IndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+  }
+
+  @Test
+  public void withEnabledTrue()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": true}";
+    IndexConfig config = JsonUtils.stringToObject(confStr, IndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+  }
+
+  @Test
+  public void withEnabledFalse()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": false}";
+    IndexConfig config = JsonUtils.stringToObject(confStr, IndexConfig.class);
+
+    assertFalse(config.isEnabled(), "Unexpected enabled");
+  }
+
+  @Test
+  public void withSomeData()
+      throws JsonProcessingException {
+    String confStr = "{\n"
+        + "        \"version\": 42\n"
+        + "}";
+    IndexConfig config = JsonUtils.stringToObject(confStr, IndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+  }
+}

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/JsonIndexConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/JsonIndexConfigTest.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.config.table;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.annotations.Test;
+import org.testng.collections.Lists;
+
+import static org.testng.Assert.*;
+
+
+public class JsonIndexConfigTest {
+
+  @Test
+  public void withEmptyConf()
+      throws JsonProcessingException {
+    String confStr = "{}";
+    JsonIndexConfig config = JsonUtils.stringToObject(confStr, JsonIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertFalse(config.isExcludeArray(), "Unexpected excludeArray");
+    assertFalse(config.isDisableCrossArrayUnnest(), "Unexpected disableCrossArrayUnnest");
+    assertNull(config.getIncludePaths(), "Unexpected includePaths");
+    assertNull(config.getExcludePaths(), "Unexpected excludePaths");
+    assertNull(config.getExcludeFields(), "Unexpected excludeFields");
+  }
+
+  @Test
+  public void withEnabledNull()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": null}";
+    JsonIndexConfig config = JsonUtils.stringToObject(confStr, JsonIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertFalse(config.isExcludeArray(), "Unexpected excludeArray");
+    assertFalse(config.isDisableCrossArrayUnnest(), "Unexpected disableCrossArrayUnnest");
+    assertNull(config.getIncludePaths(), "Unexpected includePaths");
+    assertNull(config.getExcludePaths(), "Unexpected excludePaths");
+    assertNull(config.getExcludeFields(), "Unexpected excludeFields");
+  }
+
+  @Test
+  public void withEnabledTrue()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": true}";
+    JsonIndexConfig config = JsonUtils.stringToObject(confStr, JsonIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertFalse(config.isExcludeArray(), "Unexpected excludeArray");
+    assertFalse(config.isDisableCrossArrayUnnest(), "Unexpected disableCrossArrayUnnest");
+    assertNull(config.getIncludePaths(), "Unexpected includePaths");
+    assertNull(config.getExcludePaths(), "Unexpected excludePaths");
+    assertNull(config.getExcludeFields(), "Unexpected excludeFields");
+  }
+
+  @Test
+  public void withEnabledFalse()
+      throws JsonProcessingException {
+    String confStr = "{\"enabled\": false}";
+    JsonIndexConfig config = JsonUtils.stringToObject(confStr, JsonIndexConfig.class);
+
+    assertFalse(config.isEnabled(), "Unexpected enabled");
+    assertFalse(config.isExcludeArray(), "Unexpected excludeArray");
+    assertFalse(config.isDisableCrossArrayUnnest(), "Unexpected disableCrossArrayUnnest");
+    assertNull(config.getIncludePaths(), "Unexpected includePaths");
+    assertNull(config.getExcludePaths(), "Unexpected excludePaths");
+    assertNull(config.getExcludeFields(), "Unexpected excludeFields");
+  }
+
+  @Test
+  public void withSomeData()
+      throws JsonProcessingException {
+    String confStr = "{\n"
+        + "        \"maxLevels\": 2,\n"
+        + "        \"excludeArray\": true,\n"
+        + "        \"disableCrossArrayUnnest\": true,\n"
+        + "        \"includePaths\": [\"a\"],\n"
+        + "        \"excludePaths\": [\"b\"],\n"
+        + "        \"excludeFields\": [\"c\"]\n"
+        + "}";
+    JsonIndexConfig config = JsonUtils.stringToObject(confStr, JsonIndexConfig.class);
+
+    assertTrue(config.isEnabled(), "Unexpected enabled");
+    assertTrue(config.isExcludeArray(), "Unexpected excludeArray");
+    assertTrue(config.isDisableCrossArrayUnnest(), "Unexpected disableCrossArrayUnnest");
+    assertEquals(config.getIncludePaths(), Lists.newArrayList("a"), "Unexpected includePaths");
+    assertEquals(config.getExcludePaths(), Lists.newArrayList("b"), "Unexpected excludePaths");
+    assertEquals(config.getExcludeFields(), Lists.newArrayList("c"), "Unexpected excludeFields");
+  }
+}


### PR DESCRIPTION
This is a bugfix.

As introduced in #10183, each `IndexConfig` subclass had to manually check for `enabled` nullability in its own way. It is correct that some indexes may request to explicitly ask for `enabled: true` in order to be enabled, but all default indexes should be enabled if their config object is present. 

For example:

```js
{
   bloom: {
       fpp: 0.02,
   }
}
```

Should be considered as a enabled config. Even the empty object should be considered enabled

```js
{
   bloom: {
   }
}
```

In order to explicitly disable an index one must write

```js
{
   bloom: {
       enabled: "false"
   }
}
```

If the index key is not present or set to null, then the default value will be used. In that case, whether the index is enable or not depends on the index type. For example forward index is enabled by default.

Previous code was erroneously initializing some index configs as disabled, as detected in #10554 for bloom filter. Affected indexes were:
- Bloom
- Dictionary
- H3
- FST
- Range
- Text
- Inverted

This PR adds a constructor in `IndexConfig` that contains the default logic, which is the one all default indexes should use. The PR also add unit tests that verify the correct deserialization of indexes for all index types.
