### PR TITLE
Make broker's rest resource packages configurable

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -55,10 +55,10 @@ import org.slf4j.LoggerFactory;
 
 public class BrokerAdminApiApplication extends ResourceConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(BrokerAdminApiApplication.class);
-  private static final String RESOURCE_PACKAGE = "org.apache.pinot.broker.api.resources";
   public static final String PINOT_CONFIGURATION = "pinotConfiguration";
   public static final String BROKER_INSTANCE_ID = "brokerInstanceId";
 
+  private final String _brokerResourcePackages;
   private final boolean _useHttps;
   private final boolean _swaggerBrokerEnabled;
   private final ExecutorService _executorService;
@@ -68,7 +68,10 @@ public class BrokerAdminApiApplication extends ResourceConfig {
   public BrokerAdminApiApplication(BrokerRoutingManager routingManager, BrokerRequestHandler brokerRequestHandler,
       BrokerMetrics brokerMetrics, PinotConfiguration brokerConf, SqlQueryExecutor sqlQueryExecutor,
       ServerRoutingStatsManager serverRoutingStatsManager, AccessControlFactory accessFactory) {
-    packages(RESOURCE_PACKAGE);
+    _brokerResourcePackages = brokerConf.getProperty(CommonConstants.Broker.BROKER_RESOURCE_PACKAGES,
+        CommonConstants.Broker.DEFAULT_BROKER_RESOURCE_PACKAGES);
+    String[] pkgs = _brokerResourcePackages.split(",");
+    packages(pkgs);
     property(PINOT_CONFIGURATION, brokerConf);
     _useHttps = Boolean.parseBoolean(brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_SWAGGER_USE_HTTPS));
     _swaggerBrokerEnabled = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_SWAGGER_BROKER_ENABLED,
@@ -137,7 +140,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
       beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
     }
     beanConfig.setBasePath("/");
-    beanConfig.setResourcePackage(RESOURCE_PACKAGE);
+    beanConfig.setResourcePackage(_brokerResourcePackages);
     beanConfig.setScan(true);
 
     HttpHandler httpHandler = new CLStaticHttpHandler(BrokerAdminApiApplication.class.getClassLoader(), "/api/");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -225,6 +225,10 @@ public class CommonConstants {
     public static final String CONFIG_OF_BROKER_ID = "pinot.broker.instance.id";
     public static final String CONFIG_OF_BROKER_HOSTNAME = "pinot.broker.hostname";
     public static final String CONFIG_OF_SWAGGER_USE_HTTPS = "pinot.broker.swagger.use.https";
+    // Comma separated list of packages that contains javax service resources.
+    public static final String BROKER_RESOURCE_PACKAGES = "broker.restlet.api.resource.packages";
+    public static final String DEFAULT_BROKER_RESOURCE_PACKAGES = "org.apache.pinot.broker.api.resources";
+
     // Configuration to consider the broker ServiceStatus as being STARTED if the percent of resources (tables) that
     // are ONLINE for this this broker has crossed the threshold percentage of the total number of tables
     // that it is expected to serve.
@@ -259,6 +263,7 @@ public class CommonConstants {
 
     public static final String DISABLE_GROOVY = "pinot.broker.disable.query.groovy";
     public static final boolean DEFAULT_DISABLE_GROOVY = true;
+    public static final String DEFAULT_BROKER_RESOURCE_PACKAGE = "org.apache.pinot.broker.api.resources";
 
     // Rewrite potential expensive functions to their approximation counterparts
     // - DISTINCT_COUNT -> DISTINCT_COUNT_SMART_HLL

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -230,7 +230,7 @@ public class CommonConstants {
     public static final String DEFAULT_BROKER_RESOURCE_PACKAGES = "org.apache.pinot.broker.api.resources";
 
     // Configuration to consider the broker ServiceStatus as being STARTED if the percent of resources (tables) that
-    // are ONLINE for this this broker has crossed the threshold percentage of the total number of tables
+    // are ONLINE for this broker has crossed the threshold percentage of the total number of tables
     // that it is expected to serve.
     public static final String CONFIG_OF_BROKER_MIN_RESOURCE_PERCENT_FOR_START =
         "pinot.broker.startup.minResourcePercent";
@@ -263,8 +263,6 @@ public class CommonConstants {
 
     public static final String DISABLE_GROOVY = "pinot.broker.disable.query.groovy";
     public static final boolean DEFAULT_DISABLE_GROOVY = true;
-    public static final String DEFAULT_BROKER_RESOURCE_PACKAGE = "org.apache.pinot.broker.api.resources";
-
     // Rewrite potential expensive functions to their approximation counterparts
     // - DISTINCT_COUNT -> DISTINCT_COUNT_SMART_HLL
     // - PERCENTILE -> PERCENTILE_SMART_TDIGEST

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
@@ -67,6 +67,7 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
       // TODO: support forbids = {"-brokerHost", "-brokerPort"})
   private String _configFileName;
 
+  @CommandLine.Option(names = {"-configOverrides"}, required = false, description = "Proxy config overrides")
   private Map<String, Object> _configOverrides = new HashMap<>();
 
   public boolean getHelp() {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
@@ -67,7 +67,8 @@ public class StartBrokerCommand extends AbstractBaseAdminCommand implements Comm
       // TODO: support forbids = {"-brokerHost", "-brokerPort"})
   private String _configFileName;
 
-  @CommandLine.Option(names = {"-configOverrides"}, required = false, description = "Proxy config overrides")
+  @CommandLine.Option(names = {"-configOverrides"}, required = false, split = ",",
+      description = "Proxy config overrides")
   private Map<String, Object> _configOverrides = new HashMap<>();
 
   public boolean getHelp() {


### PR DESCRIPTION
* Rest resources to be included in the broker is configurable now 
* Added -configOverride to StartBrokerCommand

Labels: `feature` , `release-notes` 

## Release Notes

* New configuration to control the rest resources in a broker application:
  * `broker.restlet.api.resource.packages` - Comma separate list of package namespaces; **Default**: `org.apache.pinot.broker.api.resources`
* `StartBrokerCommand` can now accept `-configOverrides` as a command line option. 
  