### PR TITLE
no error metric for queries where all segments are pruned

### DIFF
--- a/pinot-tools/src/main/resources/examples/stream/airlineStats/airlineStats_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/airlineStats/airlineStats_realtime_table_config.json
@@ -12,6 +12,11 @@
     "replication": "1",
     "replicasPerPartition": "1"
   },
+  "routing": {
+    "segmentPrunerTypes": [
+      "time"
+    ]
+  },
   "tenants": {},
   "tableIndexConfig": {
     "loadMode": "MMAP",


### PR DESCRIPTION
this is a small bugfix.

Currently, when all segments are pruned at the broker level, we treat it as if no servers could be found. But we also increment the "no servers found" metric. This isn't actually true in this case, so in this PR we avoid that error log and that metric, and return the broker native response instead. This also fixes the other small bug the `EXPLAIN PLAN FOR` when everything is pruned was also just returning the purely empty response rather than the "broker only explanation".

I tested this by updating the airlineStats table to use time pruning. I left that change in the json because I figured it's nice to have 1 table with time pruning. But happy to revert. Otherwise, I couldn't find any unit tests around this class.