### PR TITLE
Forward auth token for logger APIs from controller to other controllers and brokers

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/AuthQuickstart.java
@@ -74,6 +74,11 @@ public class AuthQuickstart extends Quickstart {
     properties.put("segment.fetcher.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
     properties.put("task.auth.token", "Basic YWRtaW46dmVyeXNlY3JldA==");
 
+    // loggers
+    properties.put("pinot.controller.logger.root.dir", "logs");
+    properties.put("pinot.broker.logger.root.dir", "logs");
+    properties.put("pinot.server.logger.root.dir", "logs");
+    properties.put("pinot.minion.logger.root.dir", "logs");
     return properties;
   }
 


### PR DESCRIPTION
When auth is enabled, the controller logger API cannot directly access controller/broker/minion logger APIs.

Fixed this by forwarding the auth token in request header.