### PR TITLE
[multistage] Handle Integer.MIN_VALUE in FieldSelectionKeySelector

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/partitioning/FieldSelectionKeySelector.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/partitioning/FieldSelectionKeySelector.java
@@ -89,7 +89,7 @@ public class FieldSelectionKeySelector implements KeySelector<Object[], Object[]
     }
 
     // return a positive number because this is used directly to modulo-index
-    return Math.abs(hashCode);
+    return hashCode & Integer.MAX_VALUE;
   }
 
   @Override


### PR DESCRIPTION
Saw this in our production where one of the inputs hashes to `Integer.MIN_VALUE`.

`Math.abs` returns negation of the input number if the input number is negative. So for `Integer.MIN_VALUE`, it returns the same value. This is also documented in the docs for `Math.abs`.

In other places like `MurmurPartitionFunction`, `HashCodePartitionFunction`, etc. we seem to be already doing this so looks like it's a known thing.