### PR TITLE
[multistage] improve error message in case of non-existent table queried from controller

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -178,6 +178,14 @@ public class PinotQueryResource {
           new Exception("Unable to find table name from SQL thus cannot dispatch to broker.")).toString();
     }
 
+    for (String tableName : tableNames) {
+      if (!(_pinotHelixResourceManager.hasRealtimeTable(tableName)
+          || _pinotHelixResourceManager.hasOfflineTable(tableName))) {
+        return QueryException.getException(QueryException.BROKER_RESOURCE_MISSING_ERROR, new Exception(String
+            .format("Unable to find table : %s ", tableName))).toString();
+      }
+    }
+
     String brokerTenant = getCommonBrokerTenant(tableNames);
     String serverTenant = getCommonServerTenant(tableNames);
     if (brokerTenant == null || serverTenant == null) {


### PR DESCRIPTION
Follow up to #10336 

As pointed by @walterddr in #10546 that

> the error message for multi-stage query for `select * from non_exist_tbl` will return `cannot find common tenant across all tables: ['non_exist_tbl']`

This PR would search for non-existent tables and the error message will be: `Unable to find table : non_exist_tbl`