### PR TITLE
Add a pre-shutdown method to make deleting tables faster

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -182,6 +182,15 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected abstract void doStart();
 
   @Override
+  public void preShutDown() {
+    _logger.info("Initiating preShutDown routine for table: {}", _tableNameWithType);
+    doPreShutDown();
+    _logger.info("Completed preShutDown routine for table: {}", _tableNameWithType);
+  }
+
+  protected abstract void doPreShutDown();
+
+  @Override
   public void shutDown() {
     _logger.info("Shutting down table data manager for table: {}", _tableNameWithType);
     _shutDown = true;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineTableDataManager.java
@@ -37,6 +37,10 @@ public class OfflineTableDataManager extends BaseTableDataManager {
   }
 
   @Override
+  protected void doPreShutDown() {
+  }
+
+  @Override
   protected void doShutdown() {
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -244,10 +244,16 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   }
 
   @Override
-  protected void doShutdown() {
+  protected void doPreShutDown() {
     if (_tableUpsertMetadataManager != null) {
       // Stop the upsert metadata manager first to prevent removing metadata when destroying segments
       _tableUpsertMetadataManager.stop();
+    }
+  }
+
+  @Override
+  protected void doShutdown() {
+    if (_tableUpsertMetadataManager != null) {
       for (SegmentDataManager segmentDataManager : _segmentDataManagerMap.values()) {
         segmentDataManager.destroy();
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -57,6 +57,12 @@ public interface TableDataManager {
   void start();
 
   /**
+   * Should be called only once before shutting down the table data manager.
+   * We can use this method to do some pre-shutdown work, e.g. stop the upsert metadata manager
+   */
+  void preShutDown();
+
+  /**
    * Shuts down the table data manager. Should be called only once. After calling shut down, no other method should be
    * called.
    */

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -234,17 +234,17 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   @Override
   public void deleteTable(String tableNameWithType)
       throws Exception {
-    // Wait externalview to converge
     long endTimeMs = System.currentTimeMillis() + _externalViewDroppedMaxWaitMs;
-    _tableDataManagerMap.compute(tableNameWithType, (k, v) -> {
-      if (v != null) {
-        v.preShutDown();
-        LOGGER.info("Completed pre shutdown routine for table: {}", tableNameWithType);
-      } else {
-        LOGGER.warn("Failed to find table data manager for table: {}, skip shutting down the table", tableNameWithType);
-      }
-      return null;
-    });
+    TableDataManager tableDataManager = _tableDataManagerMap.get(tableNameWithType);
+    if (tableDataManager != null) {
+      tableDataManager.preShutDown();
+      LOGGER.info("Completed pre shutdown routine for table: {}", tableNameWithType);
+    } else {
+      LOGGER.warn("Failed to find table data manager for table: {}, skip shutting down the table", tableNameWithType);
+      return;
+    }
+
+    // Wait externalview to converge
     do {
       ExternalView externalView = _helixManager.getHelixDataAccessor()
           .getProperty(_helixManager.getHelixDataAccessor().keyBuilder().externalView(tableNameWithType));


### PR DESCRIPTION
Currently, when a table is deleted we wait for EV to converge and then trigger the shutdown.

However, this leads to performance bottlenecks primarily being that during EV convergence, segments are removed from upsert metadata and their valid doc ids snapshots are taken.

This can be avoided if we simply add a preShutDown method and stop the upsert metadata manager in that call. When upsert metadata manager is stopped, we simply skip the segment removal and directly return null.

The call to this method can be made before shutdown. 

In future, we can also add other calls to this method.