### PR TITLE
Bug fix: Partial upsert default strategy is null

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -49,7 +49,7 @@ public class UpsertConfig extends BaseJsonConfig {
   private Map<String, Strategy> _partialUpsertStrategies;
 
   @JsonPropertyDescription("default upsert strategy for partial mode")
-  private Strategy _defaultPartialUpsertStrategy;
+  private Strategy _defaultPartialUpsertStrategy = Strategy.OVERWRITE;
 
   @JsonPropertyDescription("Columns for upsert comparison, default to time column")
   private List<String> _comparisonColumns;

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/UpsertConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/UpsertConfigTest.java
@@ -46,4 +46,11 @@ public class UpsertConfigTest {
     upsertConfig2.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.OVERWRITE);
     assertEquals(upsertConfig2.getPartialUpsertStrategies(), partialUpsertStratgies);
   }
+
+  @Test
+  public void testUpsertConfigForDefaults() {
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
+    assertEquals(upsertConfig.getHashFunction(), HashFunction.NONE);
+    assertEquals(upsertConfig.getDefaultPartialUpsertStrategy(), UpsertConfig.Strategy.OVERWRITE);
+  }
 }


### PR DESCRIPTION
In the PR #10234 we accidentally removed the `OVERWRITE` method for defaultPartialUpsert strategy. If no default is specified in the table config, it goes as null and breaks down partial upsert.

PartialUpsertQuickstart is also broken because of this issue.