### PR TITLE
[New Feature] Add new configuration options which allows broker to use a bounded Jersey ThreadPool

### DIFF
--- a/pinot-broker/pom.xml
+++ b/pinot-broker/pom.xml
@@ -80,6 +80,10 @@
       <artifactId>jersey-media-json-jackson</artifactId>
     </dependency>
     <dependency>
+      <groupId>org.glassfish.jersey.core</groupId>
+      <artifactId>jersey-common</artifactId>
+    </dependency>
+    <dependency>
       <groupId>io.swagger</groupId>
       <artifactId>swagger-jaxrs</artifactId>
       <exclusions>

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -109,13 +109,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
             .getProperty(CommonConstants.Broker.CONFIG_OF_ENABLE_BOUNDED_THREAD_POOL,
                     CommonConstants.Broker.DEFAULT_ENABLE_BOUNDED_THREAD_POOL);
     if (enableBoundedThreadPool) {
-      int maximumPoolSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_MAX_POOL_SIZE,
-              CommonConstants.Broker.DEFAULT_MAX_POOL_SIZE);
-      int corePoolSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_CORE_POOL_SIZE,
-              CommonConstants.Broker.DEFAULT_CORE_POOL_SIZE);
-      int queueSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_QUEUE_SIZE,
-              CommonConstants.Broker.DEFAULT_QUEUE_SIZE);
-      register(new BrokerManagedAsyncExecutorProvider(brokerMetrics, maximumPoolSize, corePoolSize, queueSize));
+      register(buildBrokerManagedAsyncExecutorProvider(brokerConf, brokerMetrics));
     }
     register(JacksonFeature.class);
     registerClasses(io.swagger.jaxrs.listing.ApiListingResource.class);
@@ -163,6 +157,17 @@ public class BrokerAdminApiApplication extends ResourceConfig {
         BrokerAdminApiApplication.class.getClassLoader().getResource("META-INF/resources/webjars/swagger-ui/3.23.11/");
     CLStaticHttpHandler swaggerDist = new CLStaticHttpHandler(new URLClassLoader(new URL[]{swaggerDistLocation}));
     _httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
+  }
+
+  private BrokerManagedAsyncExecutorProvider buildBrokerManagedAsyncExecutorProvider(
+          PinotConfiguration brokerConf, BrokerMetrics brokerMetrics) {
+    int corePoolSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_CORE_POOL_SIZE,
+            CommonConstants.Broker.DEFAULT_CORE_POOL_SIZE);
+    int maximumPoolSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_MAX_POOL_SIZE,
+            CommonConstants.Broker.DEFAULT_MAX_POOL_SIZE);
+    int queueSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_QUEUE_SIZE,
+            CommonConstants.Broker.DEFAULT_QUEUE_SIZE);
+    return new BrokerManagedAsyncExecutorProvider(corePoolSize, maximumPoolSize, queueSize, brokerMetrics);
   }
 
   public void stop() {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -105,6 +105,18 @@ public class BrokerAdminApiApplication extends ResourceConfig {
         bind(accessFactory).to(AccessControlFactory.class);
       }
     });
+    boolean enableBoundedThreadPool = brokerConf
+            .getProperty(CommonConstants.Broker.CONFIG_OF_ENABLE_BOUNDED_THREAD_POOL,
+                    CommonConstants.Broker.DEFAULT_ENABLE_BOUNDED_THREAD_POOL);
+    if (enableBoundedThreadPool) {
+      int maximumPoolSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_MAX_POOL_SIZE,
+              CommonConstants.Broker.DEFAULT_MAX_POOL_SIZE);
+      int corePoolSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_CORE_POOL_SIZE,
+              CommonConstants.Broker.DEFAULT_CORE_POOL_SIZE);
+      int queueSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_QUEUE_SIZE,
+              CommonConstants.Broker.DEFAULT_QUEUE_SIZE);
+      register(new BrokerManagedAsyncExecutorProvider(brokerMetrics, maximumPoolSize, corePoolSize, queueSize));
+    }
     register(JacksonFeature.class);
     registerClasses(io.swagger.jaxrs.listing.ApiListingResource.class);
     registerClasses(io.swagger.jaxrs.listing.SwaggerSerializers.class);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -105,10 +105,10 @@ public class BrokerAdminApiApplication extends ResourceConfig {
         bind(accessFactory).to(AccessControlFactory.class);
       }
     });
-    boolean enableBoundedThreadPool = brokerConf
-            .getProperty(CommonConstants.Broker.CONFIG_OF_ENABLE_BOUNDED_THREAD_POOL,
-                    CommonConstants.Broker.DEFAULT_ENABLE_BOUNDED_THREAD_POOL);
-    if (enableBoundedThreadPool) {
+    boolean enableBoundedJerseyThreadPoolExecutor = brokerConf
+        .getProperty(CommonConstants.Broker.CONFIG_OF_ENABLE_BOUNDED_JERSEY_THREADPOOL_EXECUTOR,
+            CommonConstants.Broker.DEFAULT_ENABLE_BOUNDED_JERSEY_THREADPOOL_EXECUTOR);
+    if (enableBoundedJerseyThreadPoolExecutor) {
       register(buildBrokerManagedAsyncExecutorProvider(brokerConf, brokerMetrics));
     }
     register(JacksonFeature.class);
@@ -159,14 +159,16 @@ public class BrokerAdminApiApplication extends ResourceConfig {
     _httpServer.getServerConfiguration().addHttpHandler(swaggerDist, "/swaggerui-dist/");
   }
 
-  private BrokerManagedAsyncExecutorProvider buildBrokerManagedAsyncExecutorProvider(
-          PinotConfiguration brokerConf, BrokerMetrics brokerMetrics) {
-    int corePoolSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_CORE_POOL_SIZE,
-            CommonConstants.Broker.DEFAULT_CORE_POOL_SIZE);
-    int maximumPoolSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_MAX_POOL_SIZE,
-            CommonConstants.Broker.DEFAULT_MAX_POOL_SIZE);
-    int queueSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_QUEUE_SIZE,
-            CommonConstants.Broker.DEFAULT_QUEUE_SIZE);
+  private BrokerManagedAsyncExecutorProvider buildBrokerManagedAsyncExecutorProvider(PinotConfiguration brokerConf,
+      BrokerMetrics brokerMetrics) {
+    int corePoolSize = brokerConf
+        .getProperty(CommonConstants.Broker.CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_CORE_POOL_SIZE,
+            CommonConstants.Broker.DEFAULT_JERSEY_THREADPOOL_EXECUTOR_CORE_POOL_SIZE);
+    int maximumPoolSize = brokerConf
+        .getProperty(CommonConstants.Broker.CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_MAX_POOL_SIZE,
+            CommonConstants.Broker.DEFAULT_JERSEY_THREADPOOL_EXECUTOR_MAX_POOL_SIZE);
+    int queueSize = brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_QUEUE_SIZE,
+        CommonConstants.Broker.DEFAULT_JERSEY_THREADPOOL_EXECUTOR_QUEUE_SIZE);
     return new BrokerManagedAsyncExecutorProvider(corePoolSize, maximumPoolSize, queueSize, brokerMetrics);
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProvider.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProvider.java
@@ -48,15 +48,15 @@ public class BrokerManagedAsyncExecutorProvider extends ThreadPoolExecutorProvid
     private final int _queueSize;
 
     public BrokerManagedAsyncExecutorProvider(
-            BrokerMetrics brokerMetrics,
-            int maximumPoolSize,
             int corePoolSize,
-            int queueSize) {
+            int maximumPoolSize,
+            int queueSize,
+            BrokerMetrics brokerMetrics) {
         super(NAME);
-        _brokerMetrics = brokerMetrics;
-        _maximumPoolSize = maximumPoolSize;
         _corePoolSize = corePoolSize;
+        _maximumPoolSize = maximumPoolSize;
         _queueSize = queueSize;
+        _brokerMetrics = brokerMetrics;
     }
 
     @Override

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProvider.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProvider.java
@@ -1,0 +1,109 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.broker;
+
+
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import javax.ws.rs.ServiceUnavailableException;
+import javax.ws.rs.core.Response;
+import org.apache.pinot.common.metrics.BrokerMeter;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.glassfish.jersey.server.ManagedAsyncExecutor;
+import org.glassfish.jersey.spi.ThreadPoolExecutorProvider;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * BrokerManagedAsyncExecutorProvider provides a bounded thread pool.
+ */
+@ManagedAsyncExecutor
+public class BrokerManagedAsyncExecutorProvider extends ThreadPoolExecutorProvider {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BrokerManagedAsyncExecutorProvider.class);
+
+    private static final String NAME = "broker-managed-async-executor";
+
+    private final BrokerMetrics _brokerMetrics;
+
+    private final int _maximumPoolSize;
+    private final int _corePoolSize;
+    private final int _queueSize;
+
+    public BrokerManagedAsyncExecutorProvider(
+            BrokerMetrics brokerMetrics,
+            int maximumPoolSize,
+            int corePoolSize,
+            int queueSize) {
+        super(NAME);
+        _brokerMetrics = brokerMetrics;
+        _maximumPoolSize = maximumPoolSize;
+        _corePoolSize = corePoolSize;
+        _queueSize = queueSize;
+    }
+
+    @Override
+    protected int getMaximumPoolSize() {
+        return _maximumPoolSize;
+    }
+
+    @Override
+    protected int getCorePoolSize() {
+        return _corePoolSize;
+    }
+
+    @Override
+    protected BlockingQueue<Runnable> getWorkQueue() {
+        return new ArrayBlockingQueue(_queueSize);
+    }
+
+    @Override
+    protected RejectedExecutionHandler getRejectedExecutionHandler() {
+        return new BrokerThreadPoolRejectExecutionHandler(_brokerMetrics);
+    }
+
+    static class BrokerThreadPoolRejectExecutionHandler implements RejectedExecutionHandler {
+        private final BrokerMetrics _brokerMetrics;
+
+        public BrokerThreadPoolRejectExecutionHandler(BrokerMetrics brokerMetrics) {
+            _brokerMetrics = brokerMetrics;
+        }
+
+        /**
+         * Reject the runnable if it can’t be accommodated by the thread pool.
+         *
+         * <p> Response returned will have SERVICE_UNAVAILABLE(503) error code with error msg.
+         *
+         * @param r Runnable
+         * @param executor ThreadPoolExecutor
+         */
+        @Override
+        public void rejectedExecution(Runnable r, ThreadPoolExecutor executor) {
+            _brokerMetrics.addMeteredGlobalValue(BrokerMeter.QUERY_REJECTION_EXCEPTIONS, 1L);
+            LOGGER.error("Task " + r + " rejected from " + executor);
+
+            throw new ServiceUnavailableException(Response.status(Response.Status.SERVICE_UNAVAILABLE)
+                    .entity("Pinot Broker thread pool can not accommodate more requests now. "
+                            + "Request is rejected from "
+                            + executor)
+                    .build());
+        }
+    }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProvider.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProvider.java
@@ -20,6 +20,7 @@ package org.apache.pinot.broker.broker;
 
 import java.util.concurrent.ArrayBlockingQueue;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.RejectedExecutionHandler;
 import java.util.concurrent.ThreadPoolExecutor;
 import javax.ws.rs.ServiceUnavailableException;
@@ -68,6 +69,9 @@ public class BrokerManagedAsyncExecutorProvider extends ThreadPoolExecutorProvid
 
   @Override
   protected BlockingQueue<Runnable> getWorkQueue() {
+    if (_queueSize == Integer.MAX_VALUE) {
+      return new LinkedBlockingQueue();
+    }
     return new ArrayBlockingQueue(_queueSize);
   }
 

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProviderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProviderTest.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.broker;
+
+import java.util.Collections;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import javax.ws.rs.ServiceUnavailableException;
+import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.spi.metrics.PinotMetricUtils;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertTrue;
+
+public class BrokerManagedAsyncExecutorProviderTest {
+
+    public static BrokerMetrics _brokerMetrics;
+
+    @BeforeClass
+    public void setUp() {
+        _brokerMetrics = new BrokerMetrics(
+                CommonConstants.Broker.DEFAULT_METRICS_NAME_PREFIX,
+                PinotMetricUtils.getPinotMetricsRegistry(null),
+                CommonConstants.Broker.DEFAULT_ENABLE_TABLE_LEVEL_METRICS,
+                Collections.emptyList());
+    }
+
+    @Test
+    public void testExecutorService() throws InterruptedException, ExecutionException {
+        // create a new instance of the executor provider
+        BrokerManagedAsyncExecutorProvider provider = new BrokerManagedAsyncExecutorProvider(_brokerMetrics, 2, 2, 2);
+
+        // get the executor service
+        ThreadPoolExecutor executor = (ThreadPoolExecutor) provider.getExecutorService();
+
+        // submit a task to the executor service and wait for it to complete
+        Future<Integer> futureResult = executor.submit(() -> 1 + 1);
+        Integer result = futureResult.get();
+
+        // verify that the task was executed and returned the expected result
+        assertNotNull(result);
+        assertEquals((int) result, 2);
+
+        // wait for the executor service to shutdown
+        executor.shutdown();
+        executor.awaitTermination(1, TimeUnit.SECONDS);
+    }
+
+    @Test
+    public void testGet() {
+        BrokerManagedAsyncExecutorProvider provider = new BrokerManagedAsyncExecutorProvider(_brokerMetrics, 1, 1, 1);
+        ExecutorService executorService = provider.getExecutorService();
+
+        // verify that the executor has the expected properties
+        assertNotNull(executorService);
+        assertTrue(executorService instanceof ThreadPoolExecutor);
+
+        ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executorService;
+
+        assertEquals(1, threadPoolExecutor.getCorePoolSize());
+        assertEquals(1, threadPoolExecutor.getMaximumPoolSize());
+
+        BlockingQueue<Runnable> blockingQueue = threadPoolExecutor.getQueue();
+        assertNotNull(blockingQueue);
+        assertTrue(blockingQueue instanceof ArrayBlockingQueue);
+        assertEquals(0, blockingQueue.size());
+        assertEquals(1, blockingQueue.remainingCapacity());
+
+        RejectedExecutionHandler rejectedExecutionHandler = threadPoolExecutor.getRejectedExecutionHandler();
+        assertNotNull(rejectedExecutionHandler);
+        assertTrue(rejectedExecutionHandler
+                instanceof BrokerManagedAsyncExecutorProvider.BrokerThreadPoolRejectExecutionHandler);
+
+        // test that the executor actually executes tasks
+        AtomicInteger counter = new AtomicInteger();
+        for (int i = 0; i < 1; i++) {
+            threadPoolExecutor.execute(() -> counter.incrementAndGet());
+        }
+        assertEquals(counter.get(), 0);
+    }
+
+    @Test(expectedExceptions = ServiceUnavailableException.class)
+    public void testRejectHandler() {
+        BrokerManagedAsyncExecutorProvider provider = new BrokerManagedAsyncExecutorProvider(_brokerMetrics, 1, 1, 1);
+        ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) provider.getExecutorService();
+
+        // test the rejection policy
+        AtomicInteger counter = new AtomicInteger();
+        for (int i = 0; i < 10; i++) {
+            threadPoolExecutor.execute(() -> counter.incrementAndGet());
+        }
+    }
+}

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProviderTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/BrokerManagedAsyncExecutorProviderTest.java
@@ -41,92 +41,94 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
+
 public class BrokerManagedAsyncExecutorProviderTest {
 
-    public static BrokerMetrics _brokerMetrics;
+  public static BrokerMetrics _brokerMetrics;
 
-    @BeforeClass
-    public void setUp() {
-        _brokerMetrics = new BrokerMetrics(
-                CommonConstants.Broker.DEFAULT_METRICS_NAME_PREFIX,
-                PinotMetricUtils.getPinotMetricsRegistry(new PinotConfiguration()),
-                CommonConstants.Broker.DEFAULT_ENABLE_TABLE_LEVEL_METRICS,
-                Collections.emptyList());
+  @BeforeClass
+  public void setUp() {
+    _brokerMetrics = new BrokerMetrics(CommonConstants.Broker.DEFAULT_METRICS_NAME_PREFIX,
+        PinotMetricUtils.getPinotMetricsRegistry(new PinotConfiguration()),
+        CommonConstants.Broker.DEFAULT_ENABLE_TABLE_LEVEL_METRICS, Collections.emptyList());
+  }
+
+  @Test
+  public void testExecutorService()
+      throws InterruptedException, ExecutionException {
+    // create a new instance of the executor provider
+    BrokerManagedAsyncExecutorProvider provider = new BrokerManagedAsyncExecutorProvider(2, 2, 2, _brokerMetrics);
+
+    // get the executor service
+    ThreadPoolExecutor executor = (ThreadPoolExecutor) provider.getExecutorService();
+
+    // submit a task to the executor service and wait for it to complete
+    Future<Integer> futureResult = executor.submit(() -> 1 + 1);
+    Integer result = futureResult.get();
+
+    // verify that the task was executed and returned the expected result
+    assertNotNull(result);
+    assertEquals((int) result, 2);
+
+    // wait for the executor service to shutdown
+    executor.shutdown();
+    executor.awaitTermination(1, TimeUnit.SECONDS);
+  }
+
+  @Test
+  public void testGet()
+      throws InterruptedException {
+    BrokerManagedAsyncExecutorProvider provider = new BrokerManagedAsyncExecutorProvider(1, 1, 1, _brokerMetrics);
+    ExecutorService executorService = provider.getExecutorService();
+
+    // verify that the executor has the expected properties
+    assertNotNull(executorService);
+    assertTrue(executorService instanceof ThreadPoolExecutor);
+
+    ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executorService;
+
+    assertEquals(1, threadPoolExecutor.getCorePoolSize());
+    assertEquals(1, threadPoolExecutor.getMaximumPoolSize());
+
+    BlockingQueue<Runnable> blockingQueue = threadPoolExecutor.getQueue();
+    assertNotNull(blockingQueue);
+    assertTrue(blockingQueue instanceof ArrayBlockingQueue);
+    assertEquals(0, blockingQueue.size());
+    assertEquals(1, blockingQueue.remainingCapacity());
+
+    RejectedExecutionHandler rejectedExecutionHandler = threadPoolExecutor.getRejectedExecutionHandler();
+    assertNotNull(rejectedExecutionHandler);
+    assertTrue(
+        rejectedExecutionHandler instanceof BrokerManagedAsyncExecutorProvider.BrokerThreadPoolRejectExecutionHandler);
+
+    // test that the executor actually executes tasks
+    AtomicInteger counter = new AtomicInteger();
+    CountDownLatch latch = new CountDownLatch(1);
+    for (int i = 0; i < 1; i++) {
+      threadPoolExecutor.execute(() -> {
+        counter.incrementAndGet();
+        latch.countDown();
+      });
     }
+    latch.await();
+    assertEquals(counter.get(), 1);
+  }
 
-    @Test
-    public void testExecutorService() throws InterruptedException, ExecutionException {
-        // create a new instance of the executor provider
-        BrokerManagedAsyncExecutorProvider provider = new BrokerManagedAsyncExecutorProvider(2, 2, 2, _brokerMetrics);
+  @Test(expectedExceptions = ServiceUnavailableException.class)
+  public void testRejectHandler()
+      throws InterruptedException {
+    BrokerManagedAsyncExecutorProvider provider = new BrokerManagedAsyncExecutorProvider(1, 1, 1, _brokerMetrics);
+    ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) provider.getExecutorService();
 
-        // get the executor service
-        ThreadPoolExecutor executor = (ThreadPoolExecutor) provider.getExecutorService();
-
-        // submit a task to the executor service and wait for it to complete
-        Future<Integer> futureResult = executor.submit(() -> 1 + 1);
-        Integer result = futureResult.get();
-
-        // verify that the task was executed and returned the expected result
-        assertNotNull(result);
-        assertEquals((int) result, 2);
-
-        // wait for the executor service to shutdown
-        executor.shutdown();
-        executor.awaitTermination(1, TimeUnit.SECONDS);
+    // test the rejection policy
+    AtomicInteger counter = new AtomicInteger();
+    CountDownLatch latch = new CountDownLatch(10);
+    for (int i = 0; i < 10; i++) {
+      threadPoolExecutor.execute(() -> {
+        counter.incrementAndGet();
+        latch.countDown();
+      });
     }
-
-    @Test
-    public void testGet() throws InterruptedException {
-        BrokerManagedAsyncExecutorProvider provider = new BrokerManagedAsyncExecutorProvider(1, 1, 1, _brokerMetrics);
-        ExecutorService executorService = provider.getExecutorService();
-
-        // verify that the executor has the expected properties
-        assertNotNull(executorService);
-        assertTrue(executorService instanceof ThreadPoolExecutor);
-
-        ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) executorService;
-
-        assertEquals(1, threadPoolExecutor.getCorePoolSize());
-        assertEquals(1, threadPoolExecutor.getMaximumPoolSize());
-
-        BlockingQueue<Runnable> blockingQueue = threadPoolExecutor.getQueue();
-        assertNotNull(blockingQueue);
-        assertTrue(blockingQueue instanceof ArrayBlockingQueue);
-        assertEquals(0, blockingQueue.size());
-        assertEquals(1, blockingQueue.remainingCapacity());
-
-        RejectedExecutionHandler rejectedExecutionHandler = threadPoolExecutor.getRejectedExecutionHandler();
-        assertNotNull(rejectedExecutionHandler);
-        assertTrue(rejectedExecutionHandler
-                instanceof BrokerManagedAsyncExecutorProvider.BrokerThreadPoolRejectExecutionHandler);
-
-        // test that the executor actually executes tasks
-        AtomicInteger counter = new AtomicInteger();
-        CountDownLatch latch = new CountDownLatch(1);
-        for (int i = 0; i < 1; i++) {
-            threadPoolExecutor.execute(() -> {
-                counter.incrementAndGet();
-                latch.countDown();
-            });
-        }
-        latch.await();
-        assertEquals(counter.get(), 1);
-    }
-
-    @Test(expectedExceptions = ServiceUnavailableException.class)
-    public void testRejectHandler() throws InterruptedException {
-        BrokerManagedAsyncExecutorProvider provider = new BrokerManagedAsyncExecutorProvider(1, 1, 1, _brokerMetrics);
-        ThreadPoolExecutor threadPoolExecutor = (ThreadPoolExecutor) provider.getExecutorService();
-
-        // test the rejection policy
-        AtomicInteger counter = new AtomicInteger();
-        CountDownLatch latch = new CountDownLatch(10);
-        for (int i = 0; i < 10; i++) {
-            threadPoolExecutor.execute(() -> {
-                counter.incrementAndGet();
-                latch.countDown();
-            });
-        }
-        latch.await();
-    }
+    latch.await();
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -32,8 +32,8 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   QUERIES("queries", false),
 
   // These metrics track the exceptions caught during query execution in broker side.
-  // Query rejected by Jersey thread pool
-  QUERY_REJECTION_EXCEPTIONS("exceptions", true),
+  // Query rejected by Jersey thread pool executor
+  QUERY_REJECTED_EXCEPTIONS("exceptions", true),
   // Query compile phase.
   REQUEST_COMPILATION_EXCEPTIONS("exceptions", true),
   // Get resource phase.

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -32,6 +32,8 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   QUERIES("queries", false),
 
   // These metrics track the exceptions caught during query execution in broker side.
+  // Query rejected by Jersey thread pool
+  QUERY_REJECTION_EXCEPTIONS("exceptions", true),
   // Query compile phase.
   REQUEST_COMPILATION_EXCEPTIONS("exceptions", true),
   // Get resource phase.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -246,16 +246,22 @@ public class CommonConstants {
     // Config for Jersey ThreadPoolExecutorProvider.
     // By default, Jersey uses the default unbounded thread pool to process queries.
     // By enabling it, BrokerManagedAsyncExecutorProvider will be used to create a bounded thread pool.
-    public static final String CONFIG_OF_ENABLE_BOUNDED_THREAD_POOL = "pinot.broker.enable.bounded.threadPool";
-    public static final boolean DEFAULT_ENABLE_BOUNDED_THREAD_POOL = false;
+    public static final String CONFIG_OF_ENABLE_BOUNDED_JERSEY_THREADPOOL_EXECUTOR =
+            "pinot.broker.enable.bounded.jersey.threadpool.executor";
+    public static final boolean DEFAULT_ENABLE_BOUNDED_JERSEY_THREADPOOL_EXECUTOR = false;
     // Default capacities for the bounded thread pool
-    public static final String CONFIG_OF_MAX_POOL_SIZE = "pinot.broker.max.pool.size";
-    public static final int DEFAULT_MAX_POOL_SIZE = Runtime.getRuntime().availableProcessors() * 2;
-    public static final String CONFIG_OF_CORE_POOL_SIZE = "pinot.broker.core.pool.size";
-    public static final int DEFAULT_CORE_POOL_SIZE = Runtime.getRuntime().availableProcessors() * 2;
-    public static final String CONFIG_OF_QUEUE_SIZE = "pinot.broker.queue.size";
-    public static final int DEFAULT_QUEUE_SIZE = Runtime.getRuntime().availableProcessors() * 2;
-
+    public static final String CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_MAX_POOL_SIZE =
+            "pinot.broker.jersey.threadpool.executor.max.pool.size";
+    public static final int DEFAULT_JERSEY_THREADPOOL_EXECUTOR_MAX_POOL_SIZE =
+            Runtime.getRuntime().availableProcessors() * 2;
+    public static final String CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_CORE_POOL_SIZE =
+            "pinot.broker.jersey.threadpool.executor.core.pool.size";
+    public static final int DEFAULT_JERSEY_THREADPOOL_EXECUTOR_CORE_POOL_SIZE =
+            Runtime.getRuntime().availableProcessors() * 2;
+    public static final String CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_QUEUE_SIZE =
+            "pinot.broker.jersey.threadpool.executor.queue.size";
+    public static final int DEFAULT_JERSEY_THREADPOOL_EXECUTOR_QUEUE_SIZE =
+        Runtime.getRuntime().availableProcessors() * 2;
 
     // used for SQL GROUP BY during broker reduce
     public static final String CONFIG_OF_BROKER_GROUPBY_TRIM_THRESHOLD = "pinot.broker.groupby.trim.threshold";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -243,6 +243,20 @@ public class CommonConstants {
         Math.max(1, Math.min(10, Runtime.getRuntime().availableProcessors() / 2));
     // Same logic as CombineOperatorUtils
 
+    // Config for Jersey ThreadPoolExecutorProvider.
+    // By default, Jersey uses the default unbounded thread pool to process queries.
+    // By enabling it, BrokerManagedAsyncExecutorProvider will be used to create a bounded thread pool.
+    public static final String CONFIG_OF_ENABLE_BOUNDED_THREAD_POOL = "pinot.broker.enable.bounded.threadPool";
+    public static final boolean DEFAULT_ENABLE_BOUNDED_THREAD_POOL = false;
+    // Default capacities for the bounded thread pool
+    public static final String CONFIG_OF_MAX_POOL_SIZE = "pinot.broker.max.pool.size";
+    public static final int DEFAULT_MAX_POOL_SIZE = Runtime.getRuntime().availableProcessors() * 2;
+    public static final String CONFIG_OF_CORE_POOL_SIZE = "pinot.broker.core.pool.size";
+    public static final int DEFAULT_CORE_POOL_SIZE = Runtime.getRuntime().availableProcessors() * 2;
+    public static final String CONFIG_OF_QUEUE_SIZE = "pinot.broker.queue.size";
+    public static final int DEFAULT_QUEUE_SIZE = Runtime.getRuntime().availableProcessors() * 2;
+
+
     // used for SQL GROUP BY during broker reduce
     public static final String CONFIG_OF_BROKER_GROUPBY_TRIM_THRESHOLD = "pinot.broker.groupby.trim.threshold";
     public static final int DEFAULT_BROKER_GROUPBY_TRIM_THRESHOLD = 1_000_000;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -260,8 +260,7 @@ public class CommonConstants {
             Runtime.getRuntime().availableProcessors() * 2;
     public static final String CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_QUEUE_SIZE =
             "pinot.broker.jersey.threadpool.executor.queue.size";
-    public static final int DEFAULT_JERSEY_THREADPOOL_EXECUTOR_QUEUE_SIZE =
-        Runtime.getRuntime().availableProcessors() * 2;
+    public static final int DEFAULT_JERSEY_THREADPOOL_EXECUTOR_QUEUE_SIZE = Integer.MAX_VALUE;
 
     // used for SQL GROUP BY during broker reduce
     public static final String CONFIG_OF_BROKER_GROUPBY_TRIM_THRESHOLD = "pinot.broker.groupby.trim.threshold";


### PR DESCRIPTION
### [New Feature] Add new configuration options which allows broker to use a bounded Jersey ThreadPool

Currently Broker uses Jersey default unbounded thread pool to process async requests and it uses No-Op RejectedExecutionHandler. 

When a broker is serving very high QPS, a significant amount of threads will be accumulated on the broker. We have seen ~25k threads accumulated in a short time because of this and brokers were taken down very quickly. This is also the root cause of #9019.

This PR 
(1) Implements a custom provider `BrokerManagedAsyncExecutorProvider` by extending `ThreadPoolExecutorProvider`, which will be automatically picked by Jersey. When async requests can not be accommodated, they will get rejected and  customers will receive ERROR code 503 (Service Unavailable). 

(2) Add new configuration options below which allow us to use the bounded thread pool and allocate capacities for it. By default, it is disabled. 
`pinot.broker.enable.bounded.http.async.executor`
`pinot.broker.http.async.executor.max.pool.size`
`pinot.broker.http.async.executor.core.pool.size`
`pinot.broker.http.async.executor.queue.size`

By enabling the new configs, endpoints POST /query/sql and GET /query/sql will be impacted. 


### Test 
Tested locally, one example response for a rejected request is
```
HTTP/1.1 503 Service Unavailable
Content-Type: application/json
Connection: close
Content-Length: 220

Pinot Broker thread pool can not accommodate more requests now. Request is rejected from java.util.concurrent.ThreadPoolExecutor@79c8b52f[Running, pool size = 1, active threads = 1, queued tasks = 1, completed tasks = 6]
```

The error log emitted by BrokerManagedAsyncExecutorProvider is:
`2023/04/14 16:47:26.146 ERROR [BrokerManagedAsyncExecutorProvider] [grizzly-http-server-15] Task java.util.concurrent.FutureTask@dafa6aa[Not completed, task = java.util.concurrent.Executors$RunnableAdapter@74af7b05[Wrapped task = org.glassfish.jersey.server.ServerRuntime$AsyncResponder$2@58e4de25]] rejected from java.util.concurrent.ThreadPoolExecutor@1bebdf0b[Running, pool size = 1, active threads = 1, queued tasks = 1, completed tasks = 6]`

