### PR TITLE
Fix flaky test caused by EV check during table creation

### DIFF
--- a/pinot-connectors/pinot-flink-connector/src/test/java/org/apache/pinot/connector/flink/sink/PinotSinkIntegrationTest.java
+++ b/pinot-connectors/pinot-flink-connector/src/test/java/org/apache/pinot/connector/flink/sink/PinotSinkIntegrationTest.java
@@ -107,6 +107,7 @@ public class PinotSinkIntegrationTest extends BaseClusterIntegrationTest {
   public void testPinotSinkWrite()
       throws Exception {
     addSchema(_schema);
+    waitForEVToDisappear(_tableConfig.getTableName());
     addTableConfig(_tableConfig);
 
     StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();
@@ -125,6 +126,7 @@ public class PinotSinkIntegrationTest extends BaseClusterIntegrationTest {
   public void testPinotSinkParallelWrite()
       throws Exception {
     addSchema(_schema);
+    waitForEVToDisappear(_tableConfig.getTableName());
     addTableConfig(_tableConfig);
 
     StreamExecutionEnvironment execEnv = StreamExecutionEnvironment.getExecutionEnvironment();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -239,6 +239,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     TableConfig offlineTableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setBrokerTenant(BROKER_TENANT_NAME)
             .setServerTenant(SERVER_TENANT_NAME).build();
+    waitForEVToDisappear(offlineTableConfig.getTableName());
     _helixResourceManager.addTable(offlineTableConfig);
     checkBrokerResource(taggedBrokers);
 
@@ -279,7 +280,6 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     IdealState brokerResource = HelixHelper.getBrokerIdealStates(_helixAdmin, _clusterName);
     assertTrue(brokerResource.getPartitionSet().isEmpty());
 
-    waitForEVToDisappear(OFFLINE_TABLE_NAME);
     resetBrokerTags();
   }
 
@@ -297,6 +297,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setBrokerTenant(BROKER_TENANT_NAME)
             .setServerTenant(SERVER_TENANT_NAME).build();
+    waitForEVToDisappear(tableConfig.getTableName());
     _helixResourceManager.addTable(tableConfig);
 
     // Untag all Brokers assigned to broker tenant
@@ -323,7 +324,6 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
 
     // Delete the table
     _helixResourceManager.deleteOfflineTable(RAW_TABLE_NAME);
-    waitForEVToDisappear(OFFLINE_TABLE_NAME);
 
     // Reset the brokers
     resetBrokerTags();
@@ -336,6 +336,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setBrokerTenant(BROKER_TENANT_NAME)
             .setServerTenant(SERVER_TENANT_NAME).build();
+    waitForEVToDisappear(tableConfig.getTableName());
     _helixResourceManager.addTable(tableConfig);
     waitForTableOnlineInBrokerResourceEV(OFFLINE_TABLE_NAME);
 
@@ -364,6 +365,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
         new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setBrokerTenant(BROKER_TENANT_NAME)
             .setServerTenant(SERVER_TENANT_NAME)
             .setStreamConfigs(FakeStreamConfigUtils.getDefaultHighLevelStreamConfigs().getStreamConfigsMap()).build();
+    waitForEVToDisappear(tableConfig.getTableName());
     _helixResourceManager.addTable(tableConfig);
     waitForTableOnlineInBrokerResourceEV(REALTIME_TABLE_NAME);
 
@@ -397,9 +399,6 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
       return externalView.getStateMap(OFFLINE_TABLE_NAME) == null
           && externalView.getStateMap(REALTIME_TABLE_NAME) == null;
     }, 60_000L, "Failed to get all brokers DROPPED");
-
-    waitForEVToDisappear(REALTIME_TABLE_NAME);
-    waitForEVToDisappear(OFFLINE_TABLE_NAME);
   }
 
   private void waitForTableOnlineInBrokerResourceEV(String tableNameWithType) {
@@ -736,6 +735,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setBrokerTenant(BROKER_TENANT_NAME)
             .setServerTenant(SERVER_TENANT_NAME).build();
+    waitForEVToDisappear(tableConfig.getTableName());
     _helixResourceManager.addTable(tableConfig);
 
     // Add 5 segments
@@ -993,7 +993,6 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     _helixResourceManager.deleteOfflineTable(RAW_TABLE_NAME);
     segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, OFFLINE_TABLE_NAME);
     assertNull(segmentLineage);
-    waitForEVToDisappear(OFFLINE_TABLE_NAME);
   }
 
   @Test
@@ -1005,6 +1004,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setBrokerTenant(BROKER_TENANT_NAME)
             .setServerTenant(SERVER_TENANT_NAME).setIngestionConfig(ingestionConfig).build();
+    waitForEVToDisappear(tableConfig.getTableName());
     _helixResourceManager.addTable(tableConfig);
 
     // Add 3 segments
@@ -1263,7 +1263,6 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     _helixResourceManager.deleteOfflineTable(RAW_TABLE_NAME);
     segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, OFFLINE_TABLE_NAME);
     assertNull(segmentLineage);
-    waitForEVToDisappear(OFFLINE_TABLE_NAME);
   }
 
   private static void assertSetEquals(Collection<String> actual, String... expected) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManagerStatelessTest.java
@@ -95,6 +95,7 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setTaskConfig(
         new TableTaskConfig(
             ImmutableMap.of("SegmentGenerationAndPushTask", ImmutableMap.of("schedule", "0 * * ? * * *")))).build();
+    waitForEVToDisappear(tableConfig.getTableName());
     addTableConfig(tableConfig);
     waitForJobGroupNames(_controllerStarter.getTaskManager(),
         jgn -> jgn.size() == 1 && jgn.contains(MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE),
@@ -128,6 +129,7 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setTaskConfig(
         new TableTaskConfig(
             ImmutableMap.of("SegmentGenerationAndPushTask", ImmutableMap.of("schedule", "0 */10 * ? * * *")))).build();
+    waitForEVToDisappear(tableConfig.getTableName());
     addTableConfig(tableConfig);
     waitForJobGroupNames(_controllerStarter.getTaskManager(),
         jgn -> jgn.size() == 1 && jgn.contains(MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE),
@@ -193,6 +195,7 @@ public class PinotTaskManagerStatelessTest extends ControllerTest {
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setTaskConfig(
         new TableTaskConfig(
             ImmutableMap.of("SegmentGenerationAndPushTask", ImmutableMap.of("schedule", "0 */10 * ? * * *")))).build();
+    waitForEVToDisappear(tableConfig.getTableName());
     addTableConfig(tableConfig);
     waitForJobGroupNames(_controllerStarter.getTaskManager(),
         jgn -> jgn.size() == 1 && jgn.contains(MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
@@ -115,6 +115,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     Schema schema = createSchema();
     addSchema(schema);
     TableConfig offlineTableConfig = createOfflineTableConfig();
+    waitForEVToDisappear(offlineTableConfig.getTableName());
     addTableConfig(offlineTableConfig);
 
     List<File> avroFiles = getAllAvroFiles();
@@ -214,6 +215,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     Schema schema = createSchema();
     addSchema(schema);
     TableConfig offlineTableConfig = createOfflineTableConfigWithConsistentPush();
+    waitForEVToDisappear(offlineTableConfig.getTableName());
     addTableConfig(offlineTableConfig);
 
     List<File> avroFiles = getAllAvroFiles();
@@ -365,7 +367,6 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
       throws IOException {
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(getTableName());
     dropOfflineTable(offlineTableName);
-    waitForEVToDisappear(offlineTableName);
   }
 
   @AfterClass


### PR DESCRIPTION
Fix the flaky tests caused by #10593. If table is re-created with the same name within the test, make sure EV doesn't exist before creating the table.