### PR TITLE
[multistage] Make Intermediate Stage Worker Assignment Tenant Aware

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
@@ -771,22 +771,19 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
   }
 
   private void buildTableTenantServerMap(String tableNameWithType, TableConfig tableConfig) {
-    LOGGER.info("buildTableTenantServerMap");
     String serverTag = getServerTagForTable(tableNameWithType, tableConfig);
     List<InstanceConfig> allInstanceConfigs = HelixHelper.getInstanceConfigs(_helixManager);
     List<InstanceConfig> instanceConfigsWithTag = HelixHelper.getInstancesConfigsWithTag(allInstanceConfigs, serverTag);
     Map<String, ServerInstance> serverInstances = new HashMap<>();
     for (InstanceConfig serverInstanceConfig : instanceConfigsWithTag) {
-      LOGGER.info("Building instances. table={}, host={}, instance={}", tableNameWithType,
-          serverInstanceConfig.getHostName(), serverInstanceConfig.getInstanceName());
       serverInstances.put(serverInstanceConfig.getInstanceName(), new ServerInstance(serverInstanceConfig));
     }
     _tableTenantServersMap.put(tableNameWithType, serverInstances);
+    LOGGER.info("Built map for table={} with {} server instances.", tableNameWithType, serverInstances.size());
   }
 
   private void addNewServerToTableTenantServerMap(String instanceId, ServerInstance serverInstance,
       InstanceConfig instanceConfig) {
-    LOGGER.info("addNewServerToTableTenantServerMap");
     List<String> tags = instanceConfig.getTags();
 
     for (Map.Entry<String, Map<String, ServerInstance>> entry : _tableTenantServersMap.entrySet()) {
@@ -796,11 +793,7 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
 
       Map<String, ServerInstance> tenantServerMap = entry.getValue();
 
-      LOGGER.info("Iterating for table={}, tag={}, server_instance_id={}, host={}", tableNameWithType, tableServerTag,
-          instanceId, serverInstance.getHostname());
-
-      if (tags.contains(tableServerTag) && !tenantServerMap.containsKey(instanceId)) {
-        LOGGER.info("Adding instance={}", instanceId);
+      if (!tenantServerMap.containsKey(instanceId) && tags.contains(tableServerTag)) {
         tenantServerMap.put(instanceId, serverInstance);
       }
     }
@@ -816,7 +809,6 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
       serverTag = TagNameUtils.getRealtimeTagForTenant(serverTenantName);
     }
 
-    LOGGER.info("Server tag for table={}, tag={}, servertenant={}", tableNameWithType, serverTag, serverTenantName);
     return serverTag;
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
@@ -57,6 +57,8 @@ import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.HashUtil;
+import org.apache.pinot.common.utils.config.TagNameUtils;
+import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
@@ -102,11 +104,16 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
   private final ServerRoutingStatsManager _serverRoutingStatsManager;
   private final PinotConfiguration _pinotConfig;
 
+  // Map that contains the tableNameWithType as key and the enabled serverInstances that are tagged with the table's
+  // tenant.
+  private final Map<String, Map<String, ServerInstance>> _tableTenantServersMap = new ConcurrentHashMap<>();
+
   private BaseDataAccessor<ZNRecord> _zkDataAccessor;
   private String _externalViewPathPrefix;
   private String _idealStatePathPrefix;
   private String _instanceConfigsPath;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private HelixManager _helixManager;
 
   private Set<String> _routableServers;
 
@@ -125,6 +132,7 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     _idealStatePathPrefix = helixDataAccessor.keyBuilder().idealStates().getPath() + "/";
     _instanceConfigsPath = helixDataAccessor.keyBuilder().instanceConfigs().getPath();
     _propertyStore = helixManager.getHelixPropertyStore();
+    _helixManager = helixManager;
   }
 
   @Override
@@ -244,7 +252,8 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
         enabledServers.add(instanceId);
 
         // Always refresh the server instance with the latest instance config in case it changes
-        ServerInstance serverInstance = new ServerInstance(new InstanceConfig(instanceConfigZNRecord));
+        InstanceConfig instanceConfig = new InstanceConfig(instanceConfigZNRecord);
+        ServerInstance serverInstance = new ServerInstance(instanceConfig);
         if (_enabledServerInstanceMap.put(instanceId, serverInstance) == null) {
           newEnabledServers.add(instanceId);
 
@@ -252,6 +261,8 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
           if (_excludedServers.remove(instanceId)) {
             LOGGER.info("Got excluded server: {} re-enabled, including it into the routing", instanceId);
           }
+
+          addNewServerToTableTenantServerMap(instanceId, serverInstance, instanceConfig);
         }
       }
     }
@@ -259,6 +270,7 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     for (String instance : _enabledServerInstanceMap.keySet()) {
       if (!enabledServers.contains(instance)) {
         newDisabledServers.add(instance);
+        deleteServerFromTableTenantServerMap(instance);
       }
     }
 
@@ -408,6 +420,9 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
     Preconditions.checkState(tableConfig != null, "Failed to find table config for table: %s", tableNameWithType);
 
+    // Build a mapping from the table to the list of servers assigned to the table's tenant.
+    buildTableTenantServerMap(tableNameWithType, tableConfig);
+
     String idealStatePath = getIdealStatePath(tableNameWithType);
     IdealState idealState = getIdealState(idealStatePath);
     Preconditions.checkState(idealState != null, "Failed to find ideal state for table: %s", tableNameWithType);
@@ -545,6 +560,10 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     } else {
       LOGGER.warn("Routing does not exist for table: {}, skipping removing routing", tableNameWithType);
     }
+
+    if (_tableTenantServersMap.remove(tableNameWithType) != null) {
+      LOGGER.info("Removed tenant servers for table: {}", tableNameWithType);
+    }
   }
 
   /**
@@ -601,6 +620,12 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
   @Override
   public Map<String, ServerInstance> getEnabledServerInstanceMap() {
     return _enabledServerInstanceMap;
+  }
+
+  @Override
+  public Map<String, ServerInstance> getEnabledServersForTableTenant(String tableNameWithType) {
+    return _tableTenantServersMap.containsKey(tableNameWithType) ? _tableTenantServersMap.get(tableNameWithType)
+        : new HashMap<String, ServerInstance>();
   }
 
   private String getIdealStatePath(String tableNameWithType) {
@@ -741,6 +766,65 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
         return selectionResult;
       } else {
         return new InstanceSelector.SelectionResult(Collections.emptyMap(), Collections.emptyList(), numPrunedSegments);
+      }
+    }
+  }
+
+  private void buildTableTenantServerMap(String tableNameWithType, TableConfig tableConfig) {
+    LOGGER.info("buildTableTenantServerMap");
+    String serverTag = getServerTagForTable(tableNameWithType, tableConfig);
+    List<InstanceConfig> allInstanceConfigs = HelixHelper.getInstanceConfigs(_helixManager);
+    List<InstanceConfig> instanceConfigsWithTag = HelixHelper.getInstancesConfigsWithTag(allInstanceConfigs, serverTag);
+    Map<String, ServerInstance> serverInstances = new HashMap<>();
+    for (InstanceConfig serverInstanceConfig : instanceConfigsWithTag) {
+      LOGGER.info("Building instances. table={}, host={}, instance={}", tableNameWithType,
+          serverInstanceConfig.getHostName(), serverInstanceConfig.getInstanceName());
+      serverInstances.put(serverInstanceConfig.getInstanceName(), new ServerInstance(serverInstanceConfig));
+    }
+    _tableTenantServersMap.put(tableNameWithType, serverInstances);
+  }
+
+  private void addNewServerToTableTenantServerMap(String instanceId, ServerInstance serverInstance,
+      InstanceConfig instanceConfig) {
+    LOGGER.info("addNewServerToTableTenantServerMap");
+    List<String> tags = instanceConfig.getTags();
+
+    for (Map.Entry<String, Map<String, ServerInstance>> entry : _tableTenantServersMap.entrySet()) {
+      String tableNameWithType = entry.getKey();
+      TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
+      String tableServerTag = getServerTagForTable(tableNameWithType, tableConfig);
+
+      Map<String, ServerInstance> tenantServerMap = entry.getValue();
+
+      LOGGER.info("Iterating for table={}, tag={}, server_instance_id={}, host={}", tableNameWithType, tableServerTag,
+          instanceId, serverInstance.getHostname());
+
+      if (tags.contains(tableServerTag) && !tenantServerMap.containsKey(instanceId)) {
+        LOGGER.info("Adding instance={}", instanceId);
+        tenantServerMap.put(instanceId, serverInstance);
+      }
+    }
+  }
+
+  private String getServerTagForTable(String tableNameWithType, TableConfig tableConfig) {
+    String serverTenantName = tableConfig.getTenantConfig().getServer();
+    String serverTag;
+    if (TableNameBuilder.isOfflineTableResource(tableNameWithType)) {
+      serverTag = TagNameUtils.getOfflineTagForTenant(serverTenantName);
+    } else {
+      // Realtime table
+      serverTag = TagNameUtils.getRealtimeTagForTenant(serverTenantName);
+    }
+
+    LOGGER.info("Server tag for table={}, tag={}, servertenant={}", tableNameWithType, serverTag, serverTenantName);
+    return serverTag;
+  }
+
+
+  private void deleteServerFromTableTenantServerMap(String server) {
+    for (Map.Entry<String, Map<String, ServerInstance>> entry : _tableTenantServersMap.entrySet()) {
+      if (entry.getValue().remove(server) != null) {
+        LOGGER.info("Removing entry for server={}, table={}", server, entry.getKey());
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/RoutingManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/RoutingManager.java
@@ -38,7 +38,7 @@ import org.apache.pinot.spi.annotations.InterfaceStability;
 public interface RoutingManager {
 
   /**
-   * Get all enabled server instances that are available for routing.
+   * Get all enabled server instances in the cluster.
    *
    * @return all currently enabled server instances.
    */
@@ -67,4 +67,12 @@ public interface RoutingManager {
    * @return time boundary info.
    */
   TimeBoundaryInfo getTimeBoundaryInfo(String offlineTableName);
+
+  /**
+   * Returns all enabled server instances for a given table's server tenant.
+   *
+   * @param tableNameWithType name of the table with type
+   * @return all enabled servers for a table's server tenant
+   */
+  Map<String, ServerInstance> getEnabledServersForTableTenant(String tableNameWithType);
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -294,6 +294,8 @@ public class QueryEnvironment {
     Set<String> tableNames = new HashSet<>();
     List<String> qualifiedTableNames = RelOptUtil.findAllTableQualifiedNames(relRoot);
     for (String qualifiedTableName : qualifiedTableNames) {
+      // Calcite encloses table and schema names in square brackets to properly quote and delimit them in SQL
+      // statements, particularly to handle cases when they contain special characters or reserved keywords.
       String tableName = qualifiedTableName.replaceAll("^\\[(.*)\\]$", "$1");
       tableNames.add(tableName);
     }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/StagePlanner.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/StagePlanner.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.planner.logical;
 
 import java.util.List;
+import java.util.Set;
 import org.apache.calcite.rel.RelCollation;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelNode;
@@ -66,7 +67,7 @@ public class StagePlanner {
    * @param relRoot relational plan root.
    * @return dispatchable plan.
    */
-  public QueryPlan makePlan(RelRoot relRoot) {
+  public QueryPlan makePlan(RelRoot relRoot, Set<String> tableNames) {
     RelNode relRootNode = relRoot.rel;
     // Stage ID starts with 1, 0 will be reserved for ROOT stage.
     _stageIdCounter = 1;
@@ -86,7 +87,7 @@ public class StagePlanner {
 
     // perform physical plan conversion and assign workers to each stage.
     DispatchablePlanContext physicalPlanContext = new DispatchablePlanContext(
-        _workerManager, _requestId, _plannerContext, relRoot.fields
+        _workerManager, _requestId, _plannerContext, relRoot.fields, tableNames
     );
     DispatchablePlanVisitor.INSTANCE.constructDispatchablePlan(globalReceiverNode, physicalPlanContext);
     QueryPlan queryPlan = physicalPlanContext.getQueryPlan();

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanContext.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.planner.physical;
 
 import java.util.HashMap;
 import java.util.List;
+import java.util.Set;
 import org.apache.calcite.util.Pair;
 import org.apache.pinot.query.context.PlannerContext;
 import org.apache.pinot.query.planner.QueryPlan;
@@ -31,13 +32,15 @@ public class DispatchablePlanContext {
   private final long _requestId;
   private final PlannerContext _plannerContext;
   private final QueryPlan _queryPlan;
+  private final Set<String> _tableNames;
 
   public DispatchablePlanContext(WorkerManager workerManager, long requestId, PlannerContext plannerContext,
-      List<Pair<Integer, String>> resultFields) {
+      List<Pair<Integer, String>> resultFields, Set<String> tableNames) {
     _workerManager = workerManager;
     _requestId = requestId;
     _plannerContext = plannerContext;
     _queryPlan = new QueryPlan(resultFields, new HashMap<>(), new HashMap<>());
+    _tableNames = tableNames;
   }
 
   public QueryPlan getQueryPlan() {
@@ -54,5 +57,10 @@ public class DispatchablePlanContext {
 
   public PlannerContext getPlannerContext() {
     return _plannerContext;
+  }
+
+  // Returns all the table names.
+  public Set<String> getTableNames() {
+    return _tableNames;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanVisitor.java
@@ -59,7 +59,7 @@ public class DispatchablePlanVisitor implements StageNodeVisitor<Void, Dispatcha
   private void computeWorkerAssignment(StageNode node, DispatchablePlanContext context) {
     int stageId = node.getStageId();
     context.getWorkerManager().assignWorkerToStage(stageId, context.getQueryPlan().getStageMetadataMap().get(stageId),
-        context.getRequestId(), context.getPlannerContext().getOptions());
+        context.getRequestId(), context.getPlannerContext().getOptions(), context.getTableNames());
   }
 
   @Override

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -198,6 +198,8 @@ public class WorkerManager {
         CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM " + tableNameWithType), requestId);
   }
 
+  // TODO: Find a better way to determine whether a stage is leaf stage or intermediary. We could have query plans that
+  //       process table data even in intermediary stages.
   private boolean isLeafStage(StageMetadata stageMetadata) {
     return stageMetadata.getScannedTables().size() == 1;
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -21,11 +21,12 @@ package org.apache.pinot.query.routing;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Lists;
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.RoutingTable;
@@ -62,11 +63,11 @@ public class WorkerManager {
   }
 
   public void assignWorkerToStage(int stageId, StageMetadata stageMetadata, long requestId,
-      Map<String, String> options) {
-    List<String> scannedTables = stageMetadata.getScannedTables();
-    if (scannedTables.size() == 1) {
+      Map<String, String> options, Set<String> tableNames) {
+    if (isLeafStage(stageMetadata)) {
       // --- LEAF STAGE ---
       // table scan stage, need to attach server as well as segment info for each physical table type.
+      List<String> scannedTables = stageMetadata.getScannedTables();
       String logicalTableName = scannedTables.get(0);
       Map<String, RoutingTable> routingTableMap = getRoutingTable(logicalTableName, requestId);
       if (routingTableMap.size() == 0) {
@@ -112,13 +113,26 @@ public class WorkerManager {
           new VirtualServer(new WorkerInstance(_hostName, _port, _port, _port, _port), 0)));
     } else {
       // --- INTERMEDIATE STAGES ---
+      // If the query has more than one table, it is possible that the tables could be hosted on different tenants.
+      // The intermediate stage will be processed on servers randomly picked from the tenants belonging to either or
+      // all of the tables in the query.
       // TODO: actually make assignment strategy decisions for intermediate stages
-      stageMetadata.setServerInstances(assignServers(_routingManager.getEnabledServerInstanceMap().values(),
-          stageMetadata.isRequiresSingletonInstance(), options));
+      Set<ServerInstance> serverInstances = new HashSet<>();
+      if (tableNames.size() == 0) {
+        // This could be the case from queries that don't actually fetch values from the tables. In such cases the
+        // routing need not be tenant aware.
+        // Eg: SELECT 1 AS one FROM select_having_expression_test_test_having HAVING 1 > 2;
+        serverInstances = _routingManager.getEnabledServerInstanceMap().values().stream().collect(Collectors.toSet());
+      } else {
+        serverInstances = fetchServersForIntermediateStage(tableNames);
+      }
+
+      stageMetadata.setServerInstances(
+          assignServers(serverInstances, stageMetadata.isRequiresSingletonInstance(), options));
     }
   }
 
-  private static List<VirtualServer> assignServers(Collection<ServerInstance> servers,
+  private static List<VirtualServer> assignServers(Set<ServerInstance> servers,
       boolean requiresSingletonInstance, Map<String, String> options) {
     int stageParallelism = Integer.parseInt(
         options.getOrDefault(CommonConstants.Broker.Request.QueryOptionKey.STAGE_PARALLELISM, "1"));
@@ -182,5 +196,35 @@ public class WorkerManager {
         TableNameBuilder.extractRawTableName(tableName));
     return _routingManager.getRoutingTable(
         CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM " + tableNameWithType), requestId);
+  }
+
+  private boolean isLeafStage(StageMetadata stageMetadata) {
+    return stageMetadata.getScannedTables().size() == 1;
+  }
+
+  private Set<ServerInstance> fetchServersForIntermediateStage(Set<String> tableNames) {
+    Set<ServerInstance> serverInstances = new HashSet<>();
+
+    for (String table : tableNames) {
+      String rawTableName = TableNameBuilder.extractRawTableName(table);
+      TableType tableType = TableNameBuilder.getTableTypeFromTableName(table);
+      if (tableType == null) {
+        String offlineTable = TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(rawTableName);
+        String realtimeTable = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(rawTableName);
+
+        // Servers in the offline table's tenant.
+        Map<String, ServerInstance> servers = _routingManager.getEnabledServersForTableTenant(offlineTable);
+        serverInstances.addAll(servers.values());
+
+        // Servers in the online table's tenant.
+        servers = _routingManager.getEnabledServersForTableTenant(realtimeTable);
+        serverInstances.addAll(servers.values());
+      } else {
+        Map<String, ServerInstance> servers = _routingManager.getEnabledServersForTableTenant(table);
+        serverInstances.addAll(servers.values());
+      }
+    }
+
+    return serverInstances;
   }
 }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/testutils/MockRoutingManagerFactory.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/testutils/MockRoutingManagerFactory.java
@@ -161,5 +161,10 @@ public class MockRoutingManagerFactory {
       return _hybridTables.contains(rawTableName) ? new TimeBoundaryInfo(TIME_BOUNDARY_COLUMN,
           String.valueOf(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))) : null;
     }
+
+    @Override
+    public Map<String, ServerInstance> getEnabledServersForTableTenant(String tableNameWithType) {
+      return _serverInstances;
+    }
   }
 }


### PR DESCRIPTION
In OSS issue https://github.com/apache/pinot/issues/10605, it was discovered that the worker assignment for Intermediate Stages in a multistage query is not tenant aware. We pick servers from the entire cluster which could mean that the query gets executed on a totally unrelated server tenant. 

This PR addresses above issue. 

**Notes**
1. With this PR, the candidate servers for Intermediate Stage Assignment is the list of all servers belonging to the server tenants from all the tables in the query. Decided to go with this approach because the server tenants for 2 tables could be disjoint. We currently assign all the servers for intermediate stage processing. However, if we decide to implement a smarter strategy for worker assignment in the future, it could be impossible to pick a common tenant belonging to all the tables in the query. 
2. Created a new data structure in BrokerRoutingManager to store the server hosts for each table's tenant.

**Additional changes in the PR**
After discussing with @tibrewalpratik17  and @ankitsultana,  removed the restriction enforced in https://github.com/apache/pinot/pull/10336 where a multistage query should have at least one common server tenant. This restriction might not work when the tables in the query belong to disjoint server tenants. 

**Testing**
I have manually tested the changes on our prod deployment. I'll figure out how to add unit tests as the review is in-progress. 
