### PR TITLE
bug fix: to keep QueryParser thread safe when handling many read requests on class RealtimeLuceneTextIndex

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
@@ -45,10 +45,9 @@ import org.slf4j.LoggerFactory;
  */
 public class RealtimeLuceneTextIndex implements MutableTextIndex {
   private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(RealtimeLuceneTextIndex.class);
-
-  private final QueryParser _queryParser;
   private final LuceneTextIndexCreator _indexCreator;
   private SearcherManager _searcherManager;
+  private final StandardAnalyzer _analyzer = new StandardAnalyzer();
   private final String _column;
   private final String _segmentName;
 
@@ -84,8 +83,6 @@ public class RealtimeLuceneTextIndex implements MutableTextIndex {
           e.getMessage());
       throw new RuntimeException(e);
     }
-    StandardAnalyzer analyzer = new StandardAnalyzer();
-    _queryParser = new QueryParser(column, analyzer);
   }
 
   /**
@@ -107,7 +104,7 @@ public class RealtimeLuceneTextIndex implements MutableTextIndex {
     Collector docIDCollector = new RealtimeLuceneDocIdCollector(docIDs);
     IndexSearcher indexSearcher = null;
     try {
-      Query query = _queryParser.parse(searchQuery);
+      Query query = new QueryParser(_column, _analyzer).parse(searchQuery);
       indexSearcher = _searcherManager.acquire();
       indexSearcher.search(query, docIDCollector);
       return getPinotDocIds(indexSearcher, docIDs);


### PR DESCRIPTION
bugfix: Add write and read lock on RealtimeLuceneTextIndex to keep t…

Our team create an Text Index for one column. When the amount of concurrency is small, there is no problem with the query. However as the amount of concurrency increases, various problems caused by concurrency will now pop up. Then we will add write/read lock to LuceneTextIndex.
