### PR TITLE
Fix withDissabledTrue typo

### DIFF
--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfigTest.java
@@ -61,7 +61,7 @@ public class DictionaryIndexConfigTest {
   }
 
   @Test
-  public void withDissabledTrue()
+  public void withDisabledTrue()
       throws JsonProcessingException {
     String confStr = "{\"disabled\": true}";
     DictionaryIndexConfig config = JsonUtils.stringToObject(confStr, DictionaryIndexConfig.class);

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/ForwardIndexConfigTest.java
@@ -68,7 +68,7 @@ public class ForwardIndexConfigTest {
   }
 
   @Test
-  public void withDissabledTrue()
+  public void withDisabledTrue()
       throws JsonProcessingException {
     String confStr = "{\"disabled\": true}";
     ForwardIndexConfig config = JsonUtils.stringToObject(confStr, ForwardIndexConfig.class);

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfigTest.java
@@ -61,7 +61,7 @@ public class H3IndexConfigTest {
   }
 
   @Test
-  public void withDissabledTrue()
+  public void withDisabledTrue()
       throws JsonProcessingException {
     String confStr = "{\"disabled\": true}";
     H3IndexConfig config = JsonUtils.stringToObject(confStr, H3IndexConfig.class);

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/JsonIndexConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/table/JsonIndexConfigTest.java
@@ -71,7 +71,7 @@ public class JsonIndexConfigTest {
   }
 
   @Test
-  public void withDissabledTrue()
+  public void withDisabledTrue()
       throws JsonProcessingException {
     String confStr = "{\"disabled\": true}";
     JsonIndexConfig config = JsonUtils.stringToObject(confStr, JsonIndexConfig.class);


### PR DESCRIPTION
This PR fixes a typo in indexes introduced last week that were named as `withDissabledTrue`