### PR TITLE
Make table deletion idempotent

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/messages/TableDeletionControllerMessage.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/messages/TableDeletionControllerMessage.java
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.messages;
+
+import com.google.common.base.Preconditions;
+import java.util.UUID;
+import javax.annotation.Nonnull;
+import org.apache.helix.model.Message;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.spi.config.table.TableType;
+
+/**
+ * This Helix message is sent from the controller to the servers to remove TableDataManager when the table is deleted.
+ */
+public class TableDeletionControllerMessage extends Message {
+  public static final String DELETE_TABLE_MSG_SUB_TYPE = "DELETE_TABLE";
+  public static final String TABLE_NAME_WITH_TYPE_KEY = "tableNameWithType";
+  public static final String TABLE_TYPE_KEY = "tableType";
+  public static final String RETENTION_PERIOD_KEY = "retentionPeriod";
+
+  public TableDeletionControllerMessage(@Nonnull String tableNameWithType, TableType tableType,
+      String retentionPeriod) {
+    super(MessageType.USER_DEFINE_MSG, UUID.randomUUID().toString());
+    setMsgSubType(DELETE_TABLE_MSG_SUB_TYPE);
+    ZNRecord znRecord = getRecord();
+    znRecord.setSimpleField(TABLE_NAME_WITH_TYPE_KEY, tableNameWithType);
+    if (tableType != null) {
+      znRecord.setSimpleField(TABLE_TYPE_KEY, tableType.toString());
+    }
+    if (retentionPeriod != null) {
+      znRecord.setSimpleField(RETENTION_PERIOD_KEY, retentionPeriod);
+    }
+
+    // Give it infinite time to process the message, as long as session is alive
+    setExecutionTimeout(-1);
+  }
+
+  public TableDeletionControllerMessage(Message message) {
+    super(message.getRecord());
+    String msgSubType = message.getMsgSubType();
+    Preconditions.checkArgument(msgSubType.equals(DELETE_TABLE_MSG_SUB_TYPE),
+        "Invalid message sub type: " + msgSubType + " for TableDeletionMessage");
+  }
+
+  public String getTableNameWithType() {
+    return getRecord().getSimpleField(TABLE_NAME_WITH_TYPE_KEY);
+  }
+
+  public TableType getTableType() {
+    if (getRecord().getSimpleFields().containsKey(TABLE_TYPE_KEY)) {
+      return TableType.valueOf(getRecord().getSimpleField(TABLE_TYPE_KEY));
+    } else {
+      return null;
+    }
+  }
+
+  public String getRetentionPeriod() {
+    return getRecord().getSimpleField(RETENTION_PERIOD_KEY);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/controllerjob/ControllerJobType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/controllerjob/ControllerJobType.java
@@ -19,5 +19,5 @@
 package org.apache.pinot.common.metadata.controllerjob;
 
 public enum ControllerJobType {
-  RELOAD_SEGMENT, FORCE_COMMIT, TABLE_REBALANCE
+  RELOAD_SEGMENT, FORCE_COMMIT, TABLE_REBALANCE, TABLE_DELETE
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -448,7 +448,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     // Register message handler for incoming user-defined helix messages.
     _helixParticipantManager.getMessagingService()
         .registerMessageHandlerFactory(Message.MessageType.USER_DEFINE_MSG.toString(),
-            new ControllerUserDefinedMessageHandlerFactory(_periodicTaskScheduler));
+            new ControllerUserDefinedMessageHandlerFactory(_periodicTaskScheduler, _helixResourceManager));
 
     String accessControlFactoryClass = _config.getAccessControlFactoryClass();
     LOGGER.info("Use class: {} as the AccessControlFactory", accessControlFactoryClass);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerUserDefinedMessageHandlerFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerUserDefinedMessageHandlerFactory.java
@@ -22,6 +22,7 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
+import javax.ws.rs.core.Response;
 import org.apache.helix.NotificationContext;
 import org.apache.helix.messaging.handling.HelixTaskResult;
 import org.apache.helix.messaging.handling.MessageHandler;
@@ -29,6 +30,7 @@ import org.apache.helix.messaging.handling.MessageHandlerFactory;
 import org.apache.helix.model.Message;
 import org.apache.pinot.common.messages.RunPeriodicTaskMessage;
 import org.apache.pinot.common.messages.TableDeletionControllerMessage;
+import org.apache.pinot.controller.api.exception.ControllerApplicationException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.periodictask.PeriodicTask;
 import org.apache.pinot.core.periodictask.PeriodicTaskScheduler;
@@ -174,6 +176,7 @@ public class ControllerUserDefinedMessageHandlerFactory implements MessageHandle
     public HelixTaskResult handleMessage() {
       LOGGER.info("Handling deletion for table {}: Start", _tableNameWithType);
 
+      //TODO: some of this validation logic is duplicate and can be removed
       List<String> tablesDeleted = new LinkedList<>();
       HelixTaskResult result = new HelixTaskResult();
       try {
@@ -206,9 +209,8 @@ public class ControllerUserDefinedMessageHandlerFactory implements MessageHandle
         return result;
       }
 
-      //TODO: fix this, should be warning or error
-      result.setSuccess(true);
-      result.setMessage("Following tables deleted: " + tablesDeleted);
+      result.setException(new ControllerApplicationException(LOGGER, "Table " + _tableNameWithType + " does not exist",
+          Response.Status.NOT_FOUND));
       return result;
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerUserDefinedMessageHandlerFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerUserDefinedMessageHandlerFactory.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.controller;
 
+import java.util.LinkedList;
+import java.util.List;
 import java.util.Map;
 import java.util.Properties;
 import org.apache.helix.NotificationContext;
@@ -26,8 +28,12 @@ import org.apache.helix.messaging.handling.MessageHandler;
 import org.apache.helix.messaging.handling.MessageHandlerFactory;
 import org.apache.helix.model.Message;
 import org.apache.pinot.common.messages.RunPeriodicTaskMessage;
+import org.apache.pinot.common.messages.TableDeletionControllerMessage;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.periodictask.PeriodicTask;
 import org.apache.pinot.core.periodictask.PeriodicTaskScheduler;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,9 +44,12 @@ public class ControllerUserDefinedMessageHandlerFactory implements MessageHandle
   private static final String USER_DEFINED_MSG_STRING = Message.MessageType.USER_DEFINE_MSG.toString();
 
   private final PeriodicTaskScheduler _periodicTaskScheduler;
+  private final PinotHelixResourceManager _pinotHelixResourceManager;
 
-  public ControllerUserDefinedMessageHandlerFactory(PeriodicTaskScheduler periodicTaskScheduler) {
+  public ControllerUserDefinedMessageHandlerFactory(PeriodicTaskScheduler periodicTaskScheduler,
+      PinotHelixResourceManager pinotHelixResourceManager) {
     _periodicTaskScheduler = periodicTaskScheduler;
+    _pinotHelixResourceManager = pinotHelixResourceManager;
   }
 
   @Override
@@ -49,6 +58,11 @@ public class ControllerUserDefinedMessageHandlerFactory implements MessageHandle
     if (messageType.equals(RunPeriodicTaskMessage.RUN_PERIODIC_TASK_MSG_SUB_TYPE)) {
       return new RunPeriodicTaskMessageHandler(new RunPeriodicTaskMessage(message), notificationContext,
           _periodicTaskScheduler);
+    }
+
+    if (messageType.equals(TableDeletionControllerMessage.DELETE_TABLE_MSG_SUB_TYPE)) {
+      return new TableDeletionControllerMessageHandler(new TableDeletionControllerMessage(message), notificationContext,
+          _pinotHelixResourceManager);
     }
 
     // Log a warning and return no-op message handler for unsupported message sub-types. This can happen when
@@ -138,6 +152,77 @@ public class ControllerUserDefinedMessageHandlerFactory implements MessageHandle
     @Override
     public void onError(Exception e, ErrorCode code, ErrorType type) {
       LOGGER.error("Got error for no-op message handling (error code: {}, error type: {})", code, type, e);
+    }
+  }
+
+  private static class TableDeletionControllerMessageHandler extends MessageHandler {
+    private final String _tableNameWithType;
+    private final TableType _tableType;
+    private final String _retentionPeriod;
+    private final PinotHelixResourceManager _helixResourceManager;
+
+    TableDeletionControllerMessageHandler(TableDeletionControllerMessage message, NotificationContext context,
+        PinotHelixResourceManager helixResourceManager) {
+      super(message, context);
+      _tableNameWithType = message.getTableNameWithType();
+      _tableType = message.getTableType();
+      _retentionPeriod = message.getRetentionPeriod();
+      _helixResourceManager = helixResourceManager;
+    }
+
+    @Override
+    public HelixTaskResult handleMessage() {
+      LOGGER.info("Handling deletion for table {}: Start", _tableNameWithType);
+
+      List<String> tablesDeleted = new LinkedList<>();
+      HelixTaskResult result = new HelixTaskResult();
+      try {
+        boolean tableExist = false;
+        if (verifyTableType(_tableNameWithType, _tableType, TableType.OFFLINE)) {
+          tableExist = _helixResourceManager.hasOfflineTable(_tableNameWithType);
+          // Even the table name does not exist, still go on to delete remaining table metadata
+          // in case a previous delete did not complete.
+          _helixResourceManager.deleteOfflineTableBlocking(_tableNameWithType, _retentionPeriod);
+          if (tableExist) {
+            tablesDeleted.add(TableNameBuilder.OFFLINE.tableNameWithType(_tableNameWithType));
+          }
+        }
+        if (verifyTableType(_tableNameWithType, _tableType, TableType.REALTIME)) {
+          tableExist = _helixResourceManager.hasRealtimeTable(_tableNameWithType);
+          // Even the table name does not exist, still go on to delete remaining table metadata
+          // in case a previous delete did not complete.
+          _helixResourceManager.deleteRealtimeTableTableBlocking(_tableNameWithType, _retentionPeriod);
+          if (tableExist) {
+            tablesDeleted.add(TableNameBuilder.REALTIME.tableNameWithType(_tableNameWithType));
+          }
+        }
+        if (!tablesDeleted.isEmpty()) {
+          result.setSuccess(true);
+          result.setMessage("Following tables deleted: " + tablesDeleted);
+          return result;
+        }
+      } catch (Exception e) {
+        result.setException(e);
+        return result;
+      }
+
+      //TODO: fix this, should be warning or error
+      result.setSuccess(true);
+      result.setMessage("Following tables deleted: " + tablesDeleted);
+      return result;
+    }
+
+    private boolean verifyTableType(String tableName, TableType tableType, TableType expectedType) {
+      if (tableType != null && tableType != expectedType) {
+        return false;
+      }
+      TableType typeFromTableName = TableNameBuilder.getTableTypeFromTableName(tableName);
+      return typeFromTableName == null || typeFromTableName == expectedType;
+    }
+
+    @Override
+    public void onError(Exception e, ErrorCode code, ErrorType type) {
+      LOGGER.error("Got error for table deletion message handling (error code: {}, error type: {})", code, type, e);
     }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -69,6 +69,7 @@ import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.AccessOption;
+import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -425,7 +426,6 @@ public class PinotTableRestletResource {
   @Authenticate(AccessType.DELETE)
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Deletes a table", notes = "Deletes a table")
-  //TODO: Add an optional `async` parameter, new flow is triggered only when `async` is set to `true`
   public SuccessResponse deleteTable(
       @ApiParam(value = "Name of the table to delete", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "realtime|offline") @QueryParam("type") String tableTypeStr,
@@ -436,47 +436,120 @@ public class PinotTableRestletResource {
       @QueryParam("async") @DefaultValue("false") boolean async) {
     TableType tableType = Constants.validateTableType(tableTypeStr);
 
+    boolean isOfflineTable = verifyTableType(tableName, tableType, TableType.OFFLINE);
+    boolean isRealtimeTable = verifyTableType(tableName, tableType, TableType.REALTIME);
+
+    boolean offlineTableExists =
+        isOfflineTable && _pinotHelixResourceManager.hasOfflineTable(
+            tableName);
+
+    boolean realtimeTableExists =
+        isRealtimeTable && _pinotHelixResourceManager.hasRealtimeTable(
+            tableName);
+
+    if (!offlineTableExists && !realtimeTableExists) {
+      throw new ControllerApplicationException(LOGGER,
+          "Table '" + tableName + "' with type " + tableType + " does not exist", Response.Status.NOT_FOUND);
+    }
+
     if (async) {
-      String messageId = _pinotHelixResourceManager.deleteTableAsync(tableName, tableType, retentionPeriod);
+      Pair<Integer, String> msgInfo =
+          _pinotHelixResourceManager.deleteTableAsync(tableName, tableType, retentionPeriod);
 
       //TODO: change this error message for correct exception handling
-      if (messageId == null) {
+      if (msgInfo.getLeft() == 0) {
         throw new ControllerApplicationException(LOGGER, "Table '" + tableName + "' does not exist",
             Response.Status.BAD_REQUEST);
       }
 
-      return new SuccessResponse("Tables deletion triggered for table: " + tableName + ", job id: " + messageId);
+      Map<String, String> tableDeleteMeta = new HashMap<>();
+      tableDeleteMeta.put("numMessagesSent", String.valueOf(msgInfo.getLeft()));
+      tableDeleteMeta.put("deleteTableJobId", msgInfo.getRight());
+      // Store in ZK
+      try {
+        if (_pinotHelixResourceManager.addTableDeleteJob(tableName, msgInfo.getRight(), msgInfo.getLeft())) {
+          tableDeleteMeta.put("tableDeleteJobMetaZKStorageStatus", "SUCCESS");
+        } else {
+          tableDeleteMeta.put("tableDeleteMetaZKStorageStatus", "FAILED");
+          LOGGER.error("Failed to add delete table job metadata into zookeeper for table: {}", tableName);
+        }
+      } catch (Exception e) {
+        tableDeleteMeta.put("tableDeleteMetaZKStorageStatus", "FAILED");
+        LOGGER.error("Failed to add delete table job metadata  into zookeeper for table: {}", tableName, e);
+      }
+      try {
+        tableDeleteMeta.put("message", "Table deletion triggered");
+        tableDeleteMeta.put("table", tableName);
+        return new SuccessResponse(JsonUtils.objectToString(tableDeleteMeta));
+      } catch (JsonProcessingException e) {
+        throw new ControllerApplicationException(LOGGER, "Failed to serialize response",
+            Response.Status.INTERNAL_SERVER_ERROR, e);
+      }
     } else {
       List<String> tablesDeleted = new LinkedList<>();
       try {
-        boolean tableExist = false;
-        if (verifyTableType(tableName, tableType, TableType.OFFLINE)) {
-          tableExist = _pinotHelixResourceManager.hasOfflineTable(tableName);
+        if (isOfflineTable) {
           // Even the table name does not exist, still go on to delete remaining table metadata
           // in case a previous delete did not complete.
           _pinotHelixResourceManager.deleteOfflineTable(tableName, retentionPeriod);
-          if (tableExist) {
+
+          if (offlineTableExists) {
             tablesDeleted.add(TableNameBuilder.OFFLINE.tableNameWithType(tableName));
           }
         }
-        if (verifyTableType(tableName, tableType, TableType.REALTIME)) {
-          tableExist = _pinotHelixResourceManager.hasRealtimeTable(tableName);
+        if (isRealtimeTable) {
           // Even the table name does not exist, still go on to delete remaining table metadata
           // in case a previous delete did not complete.
           _pinotHelixResourceManager.deleteRealtimeTable(tableName, retentionPeriod);
-          if (tableExist) {
+
+          if (realtimeTableExists) {
             tablesDeleted.add(TableNameBuilder.REALTIME.tableNameWithType(tableName));
           }
         }
-        if (!tablesDeleted.isEmpty()) {
-          return new SuccessResponse("Tables: " + tablesDeleted + " deleted");
-        }
+
+        return new SuccessResponse("Tables: " + tablesDeleted + " deleted");
       } catch (Exception e) {
         throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
       }
-      throw new ControllerApplicationException(LOGGER,
-          "Table '" + tableName + "' with type " + tableType + " does not exist", Response.Status.NOT_FOUND);
     }
+  }
+
+  @GET
+  @Path("/tables/deleteTableStatus/{jobId}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get status for a submitted force commit operation",
+      notes = "Get status for a submitted force commit operation")
+  public JsonNode getDeleteTableJobStatus(
+      @ApiParam(value = "Delete table job id", required = true) @PathParam("jobId") String deleteTableJobId)
+      throws Exception {
+    Map<String, String> controllerJobZKMetadata =
+        _pinotHelixResourceManager.getControllerJobZKMetadata(deleteTableJobId,
+            ControllerJobType.TABLE_DELETE);
+    if (controllerJobZKMetadata == null) {
+      throw new ControllerApplicationException(LOGGER, "Failed to find controller job id: " + deleteTableJobId,
+          Response.Status.NOT_FOUND);
+    }
+    String tableNameWithType = controllerJobZKMetadata.get(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE);
+
+    ExternalView externalView =
+        _pinotHelixResourceManager.getTableExternalView(tableNameWithType);
+    Map<String, Object> result = new HashMap<>(controllerJobZKMetadata);
+
+    if (externalView != null) {
+      result.put("segmentsPendingDeletion", externalView.getPartitionSet());
+      result.put("segmentsPendingDeletionCount", externalView.getPartitionSet().size());
+    } else {
+      result.put("segmentsPendingDeletion", Collections.emptyList());
+      result.put("segmentsPendingDeletionCount", 0);
+    }
+
+    TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
+    if (tableConfig != null) {
+      result.put("tableConfigDeleted", false);
+    } else {
+      result.put("tableConfigDeleted", true);
+    }
+    return JsonUtils.objectToJsonNode(result);
   }
 
   //   Return true iff the table is of the expectedType based on the given tableName and tableType. The truth table:

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -105,6 +105,7 @@ import org.apache.pinot.common.messages.RunPeriodicTaskMessage;
 import org.apache.pinot.common.messages.SegmentRefreshMessage;
 import org.apache.pinot.common.messages.SegmentReloadMessage;
 import org.apache.pinot.common.messages.TableConfigRefreshMessage;
+import org.apache.pinot.common.messages.TableDeletionControllerMessage;
 import org.apache.pinot.common.messages.TableDeletionMessage;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.controllerjob.ControllerJobType;
@@ -1918,6 +1919,51 @@ public class PinotHelixResourceManager {
       LOGGER.info("Deleting table {}: Removed helix table resource", offlineTableName);
     }
 
+    deleteSegmentPartitionsForOfflineTable(retentionPeriod, offlineTableName);
+  }
+
+  public void deleteOfflineTableBlocking(String tableName, @Nullable String retentionPeriod) {
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
+    LOGGER.info("Deleting table {}: Start", offlineTableName);
+
+    // Remove the table from brokerResource
+    HelixHelper.removeResourceFromBrokerIdealState(_helixZkManager, offlineTableName);
+    LOGGER.info("Deleting table {}: Removed from broker resource", offlineTableName);
+
+    // Delete the table on servers
+    deleteTableOnServer(offlineTableName);
+
+    // Drop the table
+    if (_helixAdmin.getResourcesInCluster(_helixClusterName).contains(offlineTableName)) {
+      _helixAdmin.dropResource(_helixClusterName, offlineTableName);
+      LOGGER.info("Deleting table {}: Removed helix table resource", offlineTableName);
+    }
+
+    // Wait for external view to converge
+    long externalViewDroppedMaxWaitMs = 20 * 60 * 1000L; //TODO: make this configurable
+    long externalViewDroppedCheckInternalMs = 1000L; //TODO: make this configurable
+    long endTimeMs = System.currentTimeMillis() + externalViewDroppedMaxWaitMs;
+    do {
+      try {
+        ExternalView externalView = _helixZkManager.getHelixDataAccessor()
+            .getProperty(_helixZkManager.getHelixDataAccessor().keyBuilder().externalView(offlineTableName));
+
+        if (externalView == null) {
+          LOGGER.info("ExternalView converged for the table to delete: {}", offlineTableName);
+          break;
+        }
+        Thread.sleep(externalViewDroppedCheckInternalMs);
+      } catch (InterruptedException e) {
+        LOGGER.warn("Interrupted while waiting for external view to converge for table: {}. Deletion failed.",
+            offlineTableName, e);
+        return;
+      }
+    } while (System.currentTimeMillis() < endTimeMs);
+
+    deleteSegmentPartitionsForOfflineTable(retentionPeriod, offlineTableName);
+  }
+
+  private void deleteSegmentPartitionsForOfflineTable(String retentionPeriod, String offlineTableName) {
     // Remove all stored segments for the table
     Long retentionPeriodMs = retentionPeriod != null ? TimeUtils.convertPeriodToMillis(retentionPeriod) : null;
     _segmentDeletionManager.removeSegmentsFromStore(offlineTableName, getSegmentsFromPropertyStore(offlineTableName),
@@ -1952,11 +1998,7 @@ public class PinotHelixResourceManager {
     LOGGER.info("Deleting table {}: Finish", offlineTableName);
   }
 
-  public void deleteRealtimeTable(String tableName) {
-    deleteRealtimeTable(tableName, null);
-  }
-
-  public void deleteRealtimeTable(String tableName, @Nullable String retentionPeriod) {
+  public void deleteRealtimeTableTableBlocking(String tableName, @Nullable String retentionPeriod) {
     String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     LOGGER.info("Deleting table {}: Start", realtimeTableName);
 
@@ -1964,9 +2006,8 @@ public class PinotHelixResourceManager {
     HelixHelper.removeResourceFromBrokerIdealState(_helixZkManager, realtimeTableName);
     LOGGER.info("Deleting table {}: Removed from broker resource", realtimeTableName);
 
-    // Drop the table on servers
-    // TODO: Make this api idempotent and blocking by waiting for externalview to converge on controllers
-    //      instead of servers. Follow the same steps for offline tables.
+    // Delete the table on servers, sending this after EV convergence doesn't work
+    // as Helix sender throws exception EV not found
     deleteTableOnServer(realtimeTableName);
 
     // Cache the state and drop the table
@@ -1977,6 +2018,32 @@ public class PinotHelixResourceManager {
       LOGGER.info("Deleting table {}: Removed helix table resource", realtimeTableName);
     }
 
+    // Wait for external view to converge
+    long externalViewDroppedMaxWaitMs = 20 * 60 * 1000L; //TODO: make this configurable
+    long externalViewDroppedCheckInternalMs = 1000L; //TODO: make this configurable
+    long endTimeMs = System.currentTimeMillis() + externalViewDroppedMaxWaitMs;
+    do {
+      try {
+      ExternalView externalView = _helixZkManager.getHelixDataAccessor()
+          .getProperty(_helixZkManager.getHelixDataAccessor().keyBuilder().externalView(realtimeTableName));
+
+      if (externalView == null) {
+        LOGGER.info("ExternalView converged for the table to delete: {}", realtimeTableName);
+        break;
+      }
+      Thread.sleep(externalViewDroppedCheckInternalMs);
+      } catch (InterruptedException e) {
+        LOGGER.warn("Interrupted while waiting for external view to converge for table: {}. Deletion failed.",
+            realtimeTableName, e);
+        return;
+      }
+    } while (System.currentTimeMillis() < endTimeMs);
+
+    deleteSegmentPartitionsForRealtimeTable(tableName, retentionPeriod, realtimeTableName, instancesForTable);
+  }
+
+  private void deleteSegmentPartitionsForRealtimeTable(String tableName, String retentionPeriod,
+      String realtimeTableName, Set<String> instancesForTable) {
     // Remove all stored segments for the table
     Long retentionPeriodMs = retentionPeriod != null ? TimeUtils.convertPeriodToMillis(retentionPeriod) : null;
     _segmentDeletionManager.removeSegmentsFromStore(realtimeTableName, getSegmentsFromPropertyStore(realtimeTableName),
@@ -2024,6 +2091,34 @@ public class PinotHelixResourceManager {
     LOGGER.info("Deleting table {}: Removed table config", realtimeTableName);
 
     LOGGER.info("Deleting table {}: Finish", realtimeTableName);
+  }
+
+  public void deleteRealtimeTable(String tableName) {
+    deleteRealtimeTable(tableName, null);
+  }
+
+  public void deleteRealtimeTable(String tableName, @Nullable String retentionPeriod) {
+    String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
+    LOGGER.info("Deleting table {}: Start", realtimeTableName);
+
+    // Remove the table from brokerResource
+    HelixHelper.removeResourceFromBrokerIdealState(_helixZkManager, realtimeTableName);
+    LOGGER.info("Deleting table {}: Removed from broker resource", realtimeTableName);
+
+    // Drop the table on servers
+    // TODO: Make this api idempotent and blocking by waiting for externalview to converge on controllers
+    //      instead of servers. Follow the same steps for offline tables.
+    deleteTableOnServer(realtimeTableName);
+
+    // Cache the state and drop the table
+    Set<String> instancesForTable = null;
+    if (_helixAdmin.getResourcesInCluster(_helixClusterName).contains(realtimeTableName)) {
+      instancesForTable = getAllInstancesForTable(realtimeTableName);
+      _helixAdmin.dropResource(_helixClusterName, realtimeTableName);
+      LOGGER.info("Deleting table {}: Removed helix table resource", realtimeTableName);
+    }
+
+    deleteSegmentPartitionsForRealtimeTable(tableName, retentionPeriod, realtimeTableName, instancesForTable);
   }
 
   /**
@@ -2332,6 +2427,41 @@ public class PinotHelixResourceManager {
   /**
    * Delete the table on servers by sending table deletion message
    */
+  public String deleteTableAsync(String tableNameWithType, TableType tableType, String retentionPeriod) {
+    LOGGER.info("Sending delete table message for table: {}", tableNameWithType);
+
+    Criteria recipientCriteria = new Criteria();
+    recipientCriteria.setRecipientInstanceType(InstanceType.PARTICIPANT);
+    recipientCriteria.setInstanceName("%");
+    recipientCriteria.setResource(CommonConstants.Helix.LEAD_CONTROLLER_RESOURCE_NAME);
+    recipientCriteria.setSessionSpecific(true);
+    recipientCriteria.setSelfExcluded(false);
+    TableDeletionControllerMessage tableDeletionMessage =
+        new TableDeletionControllerMessage(tableNameWithType, tableType, retentionPeriod);
+    ClusterMessagingService messagingService = _helixZkManager.getMessagingService();
+
+    // Externalview can be null for newly created table, skip sending the message
+    if (_helixZkManager.getHelixDataAccessor()
+        .getProperty(_helixZkManager.getHelixDataAccessor().keyBuilder().externalView(tableNameWithType)) == null) {
+      LOGGER.warn("No delete table message sent for newly created table: {} as the externalview is null.",
+          tableNameWithType);
+      return null;
+    }
+    // Infinite timeout on the recipient
+    int timeoutMs = -1;
+    int numMessagesSent = messagingService.send(recipientCriteria, tableDeletionMessage, null, timeoutMs);
+    if (numMessagesSent > 0) {
+      LOGGER.info("Sent {} delete table messages for table: {}", numMessagesSent, tableNameWithType);
+    } else {
+      LOGGER.warn("No delete table message sent for table: {}", tableNameWithType);
+    }
+
+    return tableDeletionMessage.getId();
+  }
+
+  /**
+   * Delete the table on servers by sending table deletion message
+   */
   private void deleteTableOnServer(String tableNameWithType) {
     LOGGER.info("Sending delete table message for table: {}", tableNameWithType);
     Criteria recipientCriteria = new Criteria();
@@ -2342,13 +2472,6 @@ public class PinotHelixResourceManager {
     TableDeletionMessage tableDeletionMessage = new TableDeletionMessage(tableNameWithType);
     ClusterMessagingService messagingService = _helixZkManager.getMessagingService();
 
-    // Externalview can be null for newly created table, skip sending the message
-    if (_helixZkManager.getHelixDataAccessor()
-        .getProperty(_helixZkManager.getHelixDataAccessor().keyBuilder().externalView(tableNameWithType)) == null) {
-      LOGGER.warn("No delete table message sent for newly created table: {} as the externalview is null.",
-          tableNameWithType);
-      return;
-    }
     // Infinite timeout on the recipient
     int timeoutMs = -1;
     int numMessagesSent = messagingService.send(recipientCriteria, tableDeletionMessage, null, timeoutMs);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -48,6 +48,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.spi.utils.JsonUtils.stringToJsonNode;
 import static org.testng.Assert.*;
 
 
@@ -292,7 +293,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
   private TableConfig getTableConfig(String tableName, String tableType)
       throws Exception {
     String tableConfigString = sendGetRequest(DEFAULT_INSTANCE.getControllerRequestURLBuilder().forTableGet(tableName));
-    return JsonUtils.jsonNodeToObject(JsonUtils.stringToJsonNode(tableConfigString).get(tableType), TableConfig.class);
+    return JsonUtils.jsonNodeToObject(stringToJsonNode(tableConfigString).get(tableType), TableConfig.class);
   }
 
   @Test
@@ -309,7 +310,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     tableConfig.getValidationConfig().setRetentionTimeUnit("HOURS");
     tableConfig.getValidationConfig().setRetentionTimeValue("10");
 
-    JsonNode jsonResponse = JsonUtils.stringToJsonNode(
+    JsonNode jsonResponse = stringToJsonNode(
         sendPutRequest(DEFAULT_INSTANCE.getControllerRequestURLBuilder().forUpdateTableConfig(tableName),
             tableConfig.toJsonString()));
     assertTrue(jsonResponse.has("status"));
@@ -408,14 +409,14 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     Map<String, Map<String, String>> taskTypeMap = new HashMap<>();
     taskTypeMap.put(MinionConstants.MergeRollupTask.TASK_TYPE, new HashMap<>());
     offlineTableConfig2.setTaskConfig(new TableTaskConfig(taskTypeMap));
-    JsonUtils.stringToJsonNode(
+    stringToJsonNode(
         sendPutRequest(DEFAULT_INSTANCE.getControllerRequestURLBuilder().forUpdateTableConfig(rawTableName2),
             offlineTableConfig2.toJsonString()));
     // update for pqr_REALTIME
     taskTypeMap = new HashMap<>();
     taskTypeMap.put(MinionConstants.RealtimeToOfflineSegmentsTask.TASK_TYPE, new HashMap<>());
     realtimeTableConfig1.setTaskConfig(new TableTaskConfig(taskTypeMap));
-    JsonUtils.stringToJsonNode(
+    stringToJsonNode(
         sendPutRequest(DEFAULT_INSTANCE.getControllerRequestURLBuilder().forUpdateTableConfig(rawTableName1),
             realtimeTableConfig1.toJsonString()));
 
@@ -435,7 +436,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     taskTypeMap = new HashMap<>();
     taskTypeMap.put(MinionConstants.MergeRollupTask.TASK_TYPE, new HashMap<>());
     offlineTableConfig1.setTaskConfig(new TableTaskConfig(taskTypeMap));
-    JsonUtils.stringToJsonNode(
+    stringToJsonNode(
         sendPutRequest(DEFAULT_INSTANCE.getControllerRequestURLBuilder().forUpdateTableConfig(rawTableName1),
             offlineTableConfig1.toJsonString()));
 
@@ -450,7 +451,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
 
   private List<String> getTableNames(String url)
       throws IOException {
-    JsonNode tablesJson = JsonUtils.stringToJsonNode(sendGetRequest(url)).get("tables");
+    JsonNode tablesJson = stringToJsonNode(sendGetRequest(url)).get("tables");
     return JsonUtils.jsonNodeToObject(tablesJson, new TypeReference<List<String>>() {
     });
   }
@@ -570,6 +571,136 @@ public class PinotTableRestletResourceTest extends ControllerTest {
     deleteResponse = sendDeleteRequest(
         StringUtil.join("/", DEFAULT_INSTANCE.getControllerBaseApiUrl(), "tables", "table3_OFFLINE?type=offline"));
     assertEquals(deleteResponse, "{\"status\":\"Tables: [table3_OFFLINE] deleted\"}");
+  }
+
+  @Test
+  public void testDeleteTableAsync()
+      throws IOException {
+    // Case 1: Create a REALTIME table and delete it directly w/o using query param.
+    TableConfig realtimeTableConfig = _realtimeBuilder.setTableName("table0").build();
+    String creationResponse = sendPostRequest(_createTableUrl, realtimeTableConfig.toJsonString());
+    assertEquals(creationResponse,
+        "{\"unrecognizedProperties\":{},\"status\":\"Table table0_REALTIME successfully added\"}");
+
+    // Delete realtime table using REALTIME suffix.
+    String deleteResponse = sendDeleteRequest(
+        StringUtil.join("/", DEFAULT_INSTANCE.getControllerBaseApiUrl(), "tables", "table0_REALTIME?async=true"));
+//    assertEquals(deleteResponse, "{\"status\":\"Tables: [table0_REALTIME] deleted\"}");
+    waitForTableDeletion("table0_REALTIME", deleteResponse);
+
+    // Case 2: Create a OFFLINE table and delete it directly w/o using query param.
+    TableConfig offlineTableConfig = _offlineBuilder.setTableName("table0").build();
+    creationResponse = sendPostRequest(_createTableUrl, offlineTableConfig.toJsonString());
+    assertEquals(creationResponse,
+        "{\"unrecognizedProperties\":{},\"status\":\"Table table0_OFFLINE successfully added\"}");
+
+    // Delete offline table using OFFLINE suffix.
+    deleteResponse = sendDeleteRequest(
+        StringUtil.join("/", DEFAULT_INSTANCE.getControllerBaseApiUrl(), "tables", "table0_OFFLINE?async=true"));
+    waitForTableDeletion("table0_OFFLINE", deleteResponse);
+
+    // Case 3: Create REALTIME and OFFLINE tables and delete both of them.
+    TableConfig rtConfig1 = _realtimeBuilder.setTableName("table1").build();
+    creationResponse = sendPostRequest(_createTableUrl, rtConfig1.toJsonString());
+    assertEquals(creationResponse,
+        "{\"unrecognizedProperties\":{},\"status\":\"Table table1_REALTIME successfully added\"}");
+
+    TableConfig offlineConfig1 = _offlineBuilder.setTableName("table1").build();
+    creationResponse = sendPostRequest(_createTableUrl, offlineConfig1.toJsonString());
+    assertEquals(creationResponse,
+        "{\"unrecognizedProperties\":{},\"status\":\"Table table1_OFFLINE successfully added\"}");
+
+    deleteResponse = sendDeleteRequest(
+        StringUtil.join("/", DEFAULT_INSTANCE.getControllerBaseApiUrl(), "tables", "table1?async=true"));
+    waitForTableDeletion("table1_OFFLINE", deleteResponse);
+    waitForTableDeletion("table1_REALTIME", deleteResponse);
+
+    // Case 4: Create REALTIME and OFFLINE tables and delete the realtime/offline table using query params.
+    TableConfig rtConfig2 = _realtimeBuilder.setTableName("table2").build();
+    creationResponse = sendPostRequest(_createTableUrl, rtConfig2.toJsonString());
+    assertEquals(creationResponse,
+        "{\"unrecognizedProperties\":{},\"status\":\"Table table2_REALTIME successfully added\"}");
+
+    TableConfig offlineConfig2 = _offlineBuilder.setTableName("table2").build();
+    creationResponse = sendPostRequest(_createTableUrl, offlineConfig2.toJsonString());
+    assertEquals(creationResponse,
+        "{\"unrecognizedProperties\":{},\"status\":\"Table table2_OFFLINE successfully added\"}");
+
+    // The conflict between param type and table name suffix causes no table being deleted.
+    try {
+      sendDeleteRequest(StringUtil.join("/", DEFAULT_INSTANCE.getControllerBaseApiUrl(), "tables",
+          "table2_OFFLINE?type=realtime&async=true"));
+      fail("Deleting a realtime table with OFFLINE suffix.");
+    } catch (Exception e) {
+      assertTrue(e instanceof IOException);
+    }
+
+    deleteResponse = sendDeleteRequest(
+        StringUtil.join("/", DEFAULT_INSTANCE.getControllerBaseApiUrl(), "tables", "table2?type=realtime&async=true"));
+    waitForTableDeletion("table2_REALTIME", deleteResponse);
+
+    deleteResponse = sendDeleteRequest(
+        StringUtil.join("/", DEFAULT_INSTANCE.getControllerBaseApiUrl(), "tables", "table2?type=offline&async=true"));
+    waitForTableDeletion("table2_OFFLINE", deleteResponse);
+
+    // Case 5: Delete a non-existent table and expect a bad request expection.
+    try {
+      deleteResponse = sendDeleteRequest(StringUtil.join("/", DEFAULT_INSTANCE.getControllerBaseApiUrl(), "tables",
+          "no_such_table_OFFLINE?async=true"));
+      fail("Deleting a non-existing table should fail.");
+    } catch (Exception e) {
+      assertTrue(e instanceof IOException);
+    }
+
+    // Case 6: Create REALTIME and OFFLINE tables and delete the realtime/offline table using query params and suffixes.
+    TableConfig rtConfig3 = _realtimeBuilder.setTableName("table3").build();
+    creationResponse = sendPostRequest(_createTableUrl, rtConfig3.toJsonString());
+    assertEquals(creationResponse,
+        "{\"unrecognizedProperties\":{},\"status\":\"Table table3_REALTIME successfully added\"}");
+
+    TableConfig offlineConfig3 = _offlineBuilder.setTableName("table3").build();
+    creationResponse = sendPostRequest(_createTableUrl, offlineConfig3.toJsonString());
+    assertEquals(creationResponse,
+        "{\"unrecognizedProperties\":{},\"status\":\"Table table3_OFFLINE successfully added\"}");
+
+    deleteResponse = sendDeleteRequest(StringUtil.join("/", DEFAULT_INSTANCE.getControllerBaseApiUrl(), "tables",
+        "table3_REALTIME?type=realtime&async=true"));
+    waitForTableDeletion("table3_REALTIME", deleteResponse);
+
+    deleteResponse = sendDeleteRequest(StringUtil.join("/", DEFAULT_INSTANCE.getControllerBaseApiUrl(), "tables",
+        "table3_OFFLINE?type=offline&async=true"));
+    waitForTableDeletion("table3_OFFLINE", deleteResponse);
+  }
+
+  private boolean isTableDeleted(String tableName, String jobId)
+      throws Exception {
+    String response = sendGetRequest(
+        StringUtil.join("/", DEFAULT_INSTANCE.getControllerBaseApiUrl(), "tables/deleteTableStatus", jobId));
+    JsonNode jsonResponse = JsonUtils.stringToJsonNode(response);
+    int segmentsPendingDeletion = jsonResponse.get("segmentsPendingDeletionCount").intValue();
+    boolean tableConfigDeleted = jsonResponse.get("tableConfigDeleted").booleanValue();
+    return segmentsPendingDeletion == 0 && tableConfigDeleted;
+  }
+
+  private void waitForTableDeletion(String tableName, String deleteResponse) {
+    int numAttempts = 0;
+    while (numAttempts < 10) {
+      try {
+        JsonNode jsonResponse = JsonUtils.stringToJsonNode(deleteResponse);
+        String status = jsonResponse.get("status").textValue();
+        JsonNode statusJson = JsonUtils.stringToJsonNode(status);
+        String jobId = statusJson.get("deleteTableJobId").textValue();
+
+        if (isTableDeleted(tableName, jobId)) {
+          return;
+        }
+        Thread.sleep(1000);
+        numAttempts++;
+      } catch (Exception e) {
+        fail("Caught exception while waiting for table deletion: " + e.getMessage());
+      }
+    }
+    fail("Table " + tableName + " was not deleted within 10 seconds");
   }
 
   @Test


### PR DESCRIPTION
This PR aims to solve the issue describe in #10603 

A new flag `async` is added to the table request.

When set, we trigger table deletion via a background job and only return a job id. The table deletion then proceeds in background via a message handler on controller. The controller now waits for EV to converge and only then triggers deletion for segments and configs.


Also added a new API `/tables/deleteTableStatus/{jobId}` to track the progress of deletion.

It returns the response in the following format

```json
 {
     "jobId":"01fe31f4-39ac-44f8-baaa-33289cf818cf",
     "segmentsPendingDeletion":[],
     "segmentsPendingDeletionCount":0,
     "messageCount":"1",
     "submissionTimeMs":"1681943216398",
     "jobType":"TABLE_DELETE",
     "tableName":"table0_REALTIME",
     "tableConfigDeleted":false
}
```