### PR TITLE
[multistage] Run ExpandSearch Rule After All Filter Pushdown Rules

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
@@ -86,11 +86,7 @@ public class PinotQueryRuleSets {
 
           // reduce aggregate functions like AVG, STDDEV_POP etc.
           PinotReduceAggregateFunctionsRule.INSTANCE,
-          CoreRules.AGGREGATE_REDUCE_FUNCTIONS,
-
-          // Expand all SEARCH nodes to simplified filter nodes. SEARCH nodes get created for queries with range
-          // predicates, in-clauses, etc.
-          PinotFilterExpandSearchRule.INSTANCE
+          CoreRules.AGGREGATE_REDUCE_FUNCTIONS
           );
 
   // Filter pushdown rules run using a RuleCollection since we want to push down a filter as much as possible in a
@@ -114,6 +110,9 @@ public class PinotQueryRuleSets {
 
   // Pinot specific rules that should be run after all other rules
   public static final Collection<RelOptRule> PINOT_POST_RULES = ImmutableList.of(
+      // Expand all SEARCH nodes to simplified filter nodes. SEARCH nodes get created for queries with range
+      // predicates, in-clauses, etc.
+      PinotFilterExpandSearchRule.INSTANCE,
       // add an extra exchange for sort
       PinotSortExchangeNodeInsertRule.INSTANCE,
       // copy exchanges down, this must be done after SortExchangeNodeInsertRule

--- a/pinot-query-runtime/src/test/resources/queries/FromExpressions.json
+++ b/pinot-query-runtime/src/test/resources/queries/FromExpressions.json
@@ -138,6 +138,11 @@
       },
       {
         "psql": "7.2.1.3",
+        "description": "sub-query to multiple anti semi-join queries with star results, using NOT IN clause",
+        "sql": "SELECT * FROM {tbl1} WHERE (num > -10 and num < 10) AND (name NOT IN (SELECT val FROM {tbl2} WHERE num = 3)) AND (name NOT IN (SELECT val from {tbl2} WHERE num = 4))"
+      },
+      {
+        "psql": "7.2.1.3",
         "description": "sub-query to semi-join syntax with star results, using single val predicate clause",
         "sql": "SELECT * FROM {tbl1} WHERE num < (SELECT SUM(num) FROM {tbl2})"
       },

--- a/pinot-query-runtime/src/test/resources/queries/FromExpressions.json
+++ b/pinot-query-runtime/src/test/resources/queries/FromExpressions.json
@@ -143,6 +143,26 @@
       },
       {
         "psql": "7.2.1.3",
+        "description": "sub-query with range predicates",
+        "sql": "SELECT * FROM {tbl1} WHERE (num > -10 and num < 10) AND (name NOT IN (SELECT val FROM {tbl2} WHERE num > -100 and num < 5))"
+      },
+      {
+        "psql": "7.2.1.3",
+        "description": "join with range predicates on both sides of the join",
+        "sql": "SELECT * FROM {tbl1} AS A, {tbl2} AS B WHERE (A.num > 10 AND B.num < 20)"
+      },
+      {
+        "psql": "7.2.1.3",
+        "description": "join with range predicate disjunction",
+        "sql": "SELECT * FROM {tbl1} AS A, {tbl2} AS B WHERE A.num > 10 OR B.num < 20"
+      },
+      {
+        "psql": "7.2.1.3",
+        "description": "join query with mix of range predicate disjunction/conjunction",
+        "sql": "SELECT * FROM {tbl1} AS A, {tbl2} AS B WHERE (A.num > 10 AND B.num < 20) OR (A.num < 10 AND B.num < 10)"
+      },
+      {
+        "psql": "7.2.1.3",
         "description": "sub-query to semi-join syntax with star results, using single val predicate clause",
         "sql": "SELECT * FROM {tbl1} WHERE num < (SELECT SUM(num) FROM {tbl2})"
       },


### PR DESCRIPTION
In #10409 I had added support for properly supporting predicate pushdown. However it introduced a bug where we could get "Range is not implemented yet" error because the filter pushdown rules could create a Sarg of their own.

This can be reproduced using the COLOCATED_JOIN Quickstart with the following query. It can also be reproduced using the unit-test case I have added.

```
select count(*) from userAttributes_OFFLINE 
  WHERE deviceOS NOT IN ('macos') 
  AND daysSinceFirstTrip > -4294967296 and daysSinceFirstTrip <= 10 
  AND (userUUID NOT IN (select userUUID FROM userGroups_OFFLINE WHERE groupUUID = 'group-1')) AND (userUUID NOT IN (SELECT userUUID FROM userGroups_OFFLINE WHERE groupUUID = 'group-2'))
```

cc: @walterddr 