### PR TITLE
Fix static DictionaryIndexConfig.DEFAULT_OFFHEAP being actually onheap

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
@@ -259,7 +259,7 @@ public class DictionaryIndexType
       throws IOException {
     PinotDataBuffer dataBuffer =
         segmentReader.getIndexFor(columnMetadata.getColumnName(), StandardIndexes.dictionary());
-    return read(dataBuffer, columnMetadata, DictionaryIndexConfig.DEFAULT_OFFHEAP);
+    return read(dataBuffer, columnMetadata, DictionaryIndexConfig.DEFAULT);
   }
 
   public static Dictionary read(PinotDataBuffer dataBuffer, ColumnMetadata metadata, DictionaryIndexConfig indexConfig)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/bloomfilter/BloomFilterHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/bloomfilter/BloomFilterHandler.java
@@ -300,7 +300,7 @@ public class BloomFilterHandler extends BaseIndexHandler {
       case STRING:
       case BYTES:
         PinotDataBuffer buf = segmentWriter.getIndexFor(columnMetadata.getColumnName(), StandardIndexes.dictionary());
-        return DictionaryIndexType.read(buf, columnMetadata, DictionaryIndexConfig.DEFAULT_OFFHEAP);
+        return DictionaryIndexType.read(buf, columnMetadata, DictionaryIndexConfig.DEFAULT);
       default:
         throw new IllegalStateException(
             "Unsupported data type: " + dataType + " for column: " + columnMetadata.getColumnName());

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java
@@ -29,7 +29,6 @@ import org.apache.pinot.spi.config.table.IndexConfig;
 public class DictionaryIndexConfig extends IndexConfig {
 
   public static final DictionaryIndexConfig DEFAULT = new DictionaryIndexConfig(false, false, false);
-  public static final DictionaryIndexConfig DEFAULT_OFFHEAP = new DictionaryIndexConfig(false, true, false);
   public static final DictionaryIndexConfig DISABLED = new DictionaryIndexConfig(true, false, false);
 
   private final boolean _onHeap;


### PR DESCRIPTION
This is a bugfix. There were two situations where Dictionary reader was loaded offheap before index-spi was merged but loaded onheap after that. All the cases were related to other indexes requiring to have a DictionaryReader to be created, so the issue shouldn't affect queries. The original issue was detected by @jadami10 in https://github.com/apache/pinot/issues/10554#issuecomment-1502462531.

The reason was the static final instance `DictionaryIndexConfig.DEFAULT_OFFHEAP` that was actually configured to load the index onheap. The normal `DictionaryIndexConfig.DEFAULT` is already offheap, so there is no need to have the incorrect static final.
