### PR TITLE
Add request timeout to java client

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionTimeouts.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionTimeouts.java
@@ -25,18 +25,26 @@ public class ConnectionTimeouts {
     private final int _readTimeoutMs;
     private final int _connectTimeoutMs;
     private final int _handshakeTimeoutMs;
+    private final Integer _requestTimeoutMs;
 
-    private ConnectionTimeouts(int readTimeoutMs, int connectTimeoutMs, int handshakeTimeoutMs) {
+    private ConnectionTimeouts(int readTimeoutMs, int connectTimeoutMs, int handshakeTimeoutMs, int requestTimeoutMs) {
         _readTimeoutMs = readTimeoutMs;
         _connectTimeoutMs = connectTimeoutMs;
         _handshakeTimeoutMs = handshakeTimeoutMs;
+        _requestTimeoutMs = requestTimeoutMs;
     }
 
     public static ConnectionTimeouts create(int readTimeoutMs, int connectTimeoutMs, int handshakeTimeoutMs) {
-        if (readTimeoutMs < 1 || connectTimeoutMs < 1 || handshakeTimeoutMs < 1) {
+        return create(readTimeoutMs, connectTimeoutMs, handshakeTimeoutMs, null);
+    }
+
+    public static ConnectionTimeouts create(int readTimeoutMs, int connectTimeoutMs, int handshakeTimeoutMs,
+        Integer requestTimeoutMs) {
+        if (readTimeoutMs < 1 || connectTimeoutMs < 1 || handshakeTimeoutMs < 1 || (requestTimeoutMs != null
+            && requestTimeoutMs < 1)) {
             throw new IllegalArgumentException("Timeouts must be > 0");
         }
-        return new ConnectionTimeouts(readTimeoutMs, connectTimeoutMs, handshakeTimeoutMs);
+        return new ConnectionTimeouts(readTimeoutMs, connectTimeoutMs, handshakeTimeoutMs, requestTimeoutMs);
     }
 
     public int getReadTimeoutMs() {
@@ -49,5 +57,9 @@ public class ConnectionTimeouts {
 
     public int getHandshakeTimeoutMs() {
         return _handshakeTimeoutMs;
+    }
+
+    public Integer getRequestTimeoutMs() {
+        return _requestTimeoutMs;
     }
 }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -71,7 +72,7 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport {
 
   public JsonAsyncHttpPinotClientTransport(Map<String, String> headers, String scheme, String extraOptionString,
       @Nullable SSLContext sslContext, ConnectionTimeouts connectionTimeouts, TlsProtocols tlsProtocols,
-      @Nullable String appId) {
+      @Nullable String appId, @Nullable String threadPoolName) {
     _brokerReadTimeout = connectionTimeouts.getReadTimeoutMs();
     _headers = headers;
     _scheme = scheme;
@@ -80,6 +81,14 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport {
     Builder builder = Dsl.config();
     if (sslContext != null) {
       builder.setSslContext(new JdkSslContext(sslContext, true, ClientAuth.OPTIONAL));
+    }
+
+    if (threadPoolName != null) {
+      builder.setThreadPoolName(threadPoolName);
+    }
+
+    if (connectionTimeouts.getRequestTimeoutMs() != null) {
+      builder.setRequestTimeout(connectionTimeouts.getRequestTimeoutMs());
     }
 
     builder.setReadTimeout(connectionTimeouts.getReadTimeoutMs())
@@ -92,7 +101,7 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport {
 
   public JsonAsyncHttpPinotClientTransport(Map<String, String> headers, String scheme, String extraOptionStr,
       @Nullable SslContext sslContext, ConnectionTimeouts connectionTimeouts, TlsProtocols tlsProtocols,
-      @Nullable String appId) {
+      @Nullable String appId, @Nullable String threadPoolName) {
     _brokerReadTimeout = connectionTimeouts.getReadTimeoutMs();
     _headers = headers;
     _scheme = scheme;
@@ -101,6 +110,14 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport {
     Builder builder = Dsl.config();
     if (sslContext != null) {
       builder.setSslContext(sslContext);
+    }
+
+    if (threadPoolName != null) {
+      builder.setThreadPoolName(threadPoolName);
+    }
+
+    if (connectionTimeouts.getRequestTimeoutMs() != null) {
+      builder.setRequestTimeout(connectionTimeouts.getRequestTimeoutMs());
     }
 
     builder.setReadTimeout(connectionTimeouts.getReadTimeoutMs())

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Optional;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportFactory.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportFactory.java
@@ -112,9 +112,6 @@ public class JsonAsyncHttpPinotClientTransportFactory implements PinotClientTran
       _threadPoolName = properties.getProperty("threadPoolName");
     }
 
-    _handshakeTimeoutMs =
-        Integer.parseInt(properties.getProperty("brokerHandshakeTimeoutMs", DEFAULT_BROKER_HANDSHAKE_TIMEOUT_MS));
-
     _extraOptionString = properties.getProperty("queryOptions", "");
     return this;
   }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportFactory.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportFactory.java
@@ -43,16 +43,18 @@ public class JsonAsyncHttpPinotClientTransportFactory implements PinotClientTran
   private int _readTimeoutMs = Integer.parseInt(DEFAULT_BROKER_READ_TIMEOUT_MS);
   private int _connectTimeoutMs = Integer.parseInt(DEFAULT_BROKER_READ_TIMEOUT_MS);
   private int _handshakeTimeoutMs = Integer.parseInt(DEFAULT_BROKER_HANDSHAKE_TIMEOUT_MS);
+  private Integer _requestTimeoutMs;
   private String _appId = null;
   private String _extraOptionString;
+  private String _threadPoolName;
 
   @Override
   public PinotClientTransport buildTransport() {
     ConnectionTimeouts connectionTimeouts =
-        ConnectionTimeouts.create(_readTimeoutMs, _connectTimeoutMs, _handshakeTimeoutMs);
+        ConnectionTimeouts.create(_readTimeoutMs, _connectTimeoutMs, _handshakeTimeoutMs, _requestTimeoutMs);
     TlsProtocols tlsProtocols = TlsProtocols.defaultProtocols(_tlsV10Enabled);
     return new JsonAsyncHttpPinotClientTransport(_headers, _scheme, _extraOptionString, _sslContext, connectionTimeouts,
-        tlsProtocols, _appId);
+        tlsProtocols, _appId, _threadPoolName);
   }
 
   public Map<String, String> getHeaders() {
@@ -98,9 +100,20 @@ public class JsonAsyncHttpPinotClientTransportFactory implements PinotClientTran
     _handshakeTimeoutMs =
         Integer.parseInt(properties.getProperty("brokerHandshakeTimeoutMs", DEFAULT_BROKER_HANDSHAKE_TIMEOUT_MS));
     _appId = properties.getProperty("appId");
-    _tlsV10Enabled = Boolean.parseBoolean(properties.getProperty("brokerTlsV10Enabled", DEFAULT_BROKER_TLS_V10_ENABLED))
-        || Boolean.parseBoolean(
-        System.getProperties().getProperty("broker.tlsV10Enabled", DEFAULT_BROKER_TLS_V10_ENABLED));
+    _tlsV10Enabled =
+        Boolean.parseBoolean(properties.getProperty("brokerTlsV10Enabled", DEFAULT_BROKER_TLS_V10_ENABLED)) || Boolean
+            .parseBoolean(System.getProperties().getProperty("broker.tlsV10Enabled", DEFAULT_BROKER_TLS_V10_ENABLED));
+
+    if (properties.containsKey("brokerRequestTimeoutMs")) {
+      _requestTimeoutMs = Integer.parseInt(properties.getProperty("brokerRequestTimeoutMs"));
+    }
+
+    if (properties.containsKey("threadPoolName")) {
+      _threadPoolName = properties.getProperty("threadPoolName");
+    }
+
+    _handshakeTimeoutMs =
+        Integer.parseInt(properties.getProperty("brokerHandshakeTimeoutMs", DEFAULT_BROKER_HANDSHAKE_TIMEOUT_MS));
 
     _extraOptionString = properties.getProperty("queryOptions", "");
     return this;


### PR DESCRIPTION
This PR adds couple of small improvements to pinot java client:
1. Provide the ability to set an optional request timeout along with read, connect and handshake timeouts.
2. Specify custom name for thread pool used by async http client.
3. Cancel the the timed out requests.
