### PR TITLE
SegmentTarPushJobRunner shouldn't fail with missing pushJobSpec

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/BaseSegmentPushJobRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/BaseSegmentPushJobRunner.java
@@ -65,12 +65,11 @@ public abstract class BaseSegmentPushJobRunner implements IngestionJobRunner {
     }
 
     // Read Table config
-    if (_spec.getTableSpec().getTableConfigURI() == null) {
-      throw new RuntimeException("Missing property 'tableConfigURI' in 'tableSpec'");
+    if (_spec.getTableSpec().getTableConfigURI() != null) {
+      _tableConfig =
+          SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), spec.getAuthToken());
+      _consistentPushEnabled = ConsistentDataPushUtils.consistentDataPushEnabled(_tableConfig);
     }
-
-    _tableConfig = SegmentGenerationUtils.getTableConfig(_spec.getTableSpec().getTableConfigURI(), spec.getAuthToken());
-    _consistentPushEnabled = ConsistentDataPushUtils.consistentDataPushEnabled(_tableConfig);
   }
 
   /**


### PR DESCRIPTION
This addresses [#10644](https://github.com/apache/pinot/issues/10644) by having `SegmentTarPushJobRunner` not fail when missing `pushJobSpec`. 