### PR TITLE
Changing LIKE behaviour to case-sensitive and adding support for ILIKE

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -752,14 +752,40 @@ public class StringFunctions {
   }
 
   @ScalarFunction(names = {"regexpLike", "regexp_like"})
+  public static boolean regexpLike(String inputStr, String regexPatternStr, String flag) {
+    Integer patternFlag;
+    switch (flag) {
+      case "i":
+        patternFlag = Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE;
+        break;
+      default:
+        patternFlag = null;
+        break;
+    }
+
+    Pattern p;
+    if (patternFlag != null) {
+      p = Pattern.compile(regexPatternStr, patternFlag);
+    } else {
+      p = Pattern.compile(regexPatternStr);
+    }
+    return p.matcher(inputStr).find();
+  }
+
+  @ScalarFunction(names = {"regexpLike", "regexp_like"})
   public static boolean regexpLike(String inputStr, String regexPatternStr) {
-    Pattern pattern = Pattern.compile(regexPatternStr, Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
-    return pattern.matcher(inputStr).find();
+    return regexpLike(inputStr, regexPatternStr, "i");
   }
 
   @ScalarFunction
   public static boolean like(String inputStr, String likePatternStr) {
     String regexPatternStr = RegexpPatternConverterUtils.likeToRegexpLike(likePatternStr);
-    return regexpLike(inputStr, regexPatternStr);
+    return regexpLike(inputStr, regexPatternStr, "");
+  }
+
+  @ScalarFunction
+  public static boolean ilike(String inputStr, String likePatternStr) {
+    String regexPatternStr = RegexpPatternConverterUtils.likeToRegexpLike(likePatternStr);
+    return regexpLike(inputStr, regexPatternStr, "i");
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
@@ -205,7 +205,7 @@ public class RequestContextUtils {
       case LIKE:
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new RegexpLikePredicate(getExpression(operands.get(0)),
-                RegexpPatternConverterUtils.likeToRegexpLike(getStringValue(operands.get(1)))));
+                RegexpPatternConverterUtils.likeToRegexpLike(getStringValue(operands.get(1))), ""));
       case TEXT_CONTAINS:
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new TextContainsPredicate(getExpression(operands.get(0)), getStringValue(operands.get(1))));
@@ -336,7 +336,7 @@ public class RequestContextUtils {
             new RegexpLikePredicate(operands.get(0), getStringValue(operands.get(1))));
       case LIKE:
         return new FilterContext(FilterContext.Type.PREDICATE, null, new RegexpLikePredicate(operands.get(0),
-            RegexpPatternConverterUtils.likeToRegexpLike(getStringValue(operands.get(1)))));
+            RegexpPatternConverterUtils.likeToRegexpLike(getStringValue(operands.get(1))), ""));
       case TEXT_CONTAINS:
         return new FilterContext(FilterContext.Type.PREDICATE, null,
             new TextContainsPredicate(operands.get(0), getStringValue(operands.get(1))));

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/RegexpLikePredicate.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/RegexpLikePredicate.java
@@ -35,6 +35,19 @@ public class RegexpLikePredicate extends BasePredicate {
     _value = value;
   }
 
+  public RegexpLikePredicate(ExpressionContext lhs, String value, String flag) {
+    super(lhs);
+    _value = value;
+    switch (flag) {
+      case "i":
+        _pattern = Pattern.compile(_value, Pattern.UNICODE_CASE | Pattern.CASE_INSENSITIVE);
+        break;
+      default:
+        _pattern = Pattern.compile(_value);
+        break;
+    }
+  }
+
   @Override
   public Type getType() {
     return Type.REGEXP_LIKE;


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

LIKE changed to case\-sensitive; ILIKE added for case\-insensitive; both delegate to regexpLike with appropriate flags\.

```mermaid
flowchart TD
  N0["like#40;String#44;String#41; #40;F1#41;"]:::stModified
  N1["regexpLike#40;String#44;String#44;String#41; #40;F1#41;"]:::stAdded
  N2["ilike#40;String#44;String#41; #40;F1#41;"]:::stAdded
  N3["RegexpLikePredicate#40;#46;#46;#46;#44;String#44;flag#41; #40;F3#41;"]:::stModified
  N4["RequestContextUtils#46;getFilter#40;LIKE#41; #40;F2#41;"]:::stModified
  N0 -->|"calls"| N1
  N2 -->|"calls"| N1
  N4 -->|"creates"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions\.java — [before](https://github.com/apache/pinot/blob/8dab8034cf588be5d4d6c92db55dbbf3ebc51f7f/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java) · [after](https://github.com/apache/pinot/blob/5434e1127340d0d4f35372b18b69b56cf9761f27/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java)
- F2: pinot\-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils\.java — [before](https://github.com/apache/pinot/blob/8dab8034cf588be5d4d6c92db55dbbf3ebc51f7f/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java) · [after](https://github.com/apache/pinot/blob/5434e1127340d0d4f35372b18b69b56cf9761f27/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java)
- F3: pinot\-common/src/main/java/org/apache/pinot/common/request/context/predicate/RegexpLikePredicate\.java — [before](https://github.com/apache/pinot/blob/8dab8034cf588be5d4d6c92db55dbbf3ebc51f7f/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/RegexpLikePredicate.java) · [after](https://github.com/apache/pinot/blob/5434e1127340d0d4f35372b18b69b56cf9761f27/pinot-common/src/main/java/org/apache/pinot/common/request/context/predicate/RegexpLikePredicate.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjhkYWI4MDM0Y2Y1ODhiZTVkNGQ2YzkyZGI1NWRiYmYzZWJjNTFmN2YiLCJjb250ZXh0X2hhc2giOiI4N2VmZjI3MmVkMGJiOGEyMTQ3MDcyMDVlZmJmNWE2NTBjNGIyZDk3ZGE5YTgxYmFlYTdhMDEwM2RmN2FjN2VjIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MjcwMjY4LCJoZWFkX3NoYSI6IjU0MzRlMTEyNzM0MGQwZDRmMzUzNzJiMThiNjliNTZjZjk3NjFmMjciLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJmMmFmZTIxYjk5NjJhMGQ2NzZhNzg4N2VkYzk5OWJjYmVlNmM0NDFkIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 2323473473c615e46a57a880f736db13fa7bbf3026396fa3889386370197ec24 -->
<!-- pinot-pr-flow:end -->

Labels: `backward-incompatible` 

As discussed in #10609, changing the behaviour of `LIKE` function to case-senstiive rather than the present case-insensitive nature. Also introduced a new function `ILIKE` which is equivalent to case-insensitive `LIKE`.