### PR TITLE
Remove actually unsupported config that selectively enable nullable columns

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
@@ -77,14 +77,11 @@ public class NullValueIndexType extends AbstractIndexType<IndexConfig, NullValue
 
   @Override
   public ColumnConfigDeserializer<IndexConfig> createDeserializer() {
-    return IndexConfigDeserializer.fromIndexes(getPrettyName(), getIndexConfigClass())
-        .withFallbackAlternative(
-            IndexConfigDeserializer.ifIndexingConfig(
-                IndexConfigDeserializer.alwaysCall((TableConfig tableConfig, Schema schema) ->
-                  tableConfig.getIndexingConfig().isNullHandlingEnabled()
-                      ? IndexConfig.ENABLED
-                      : IndexConfig.DISABLED))
-        );
+    return IndexConfigDeserializer.ifIndexingConfig(
+        IndexConfigDeserializer.alwaysCall((TableConfig tableConfig, Schema schema) ->
+            tableConfig.getIndexingConfig().isNullHandlingEnabled()
+                ? IndexConfig.ENABLED
+                : IndexConfig.DISABLED));
   }
 
   public NullValueVectorCreator createIndexCreator(File indexDir, String columnName) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/AbstractIndexType.java
@@ -62,7 +62,11 @@ public abstract class AbstractIndexType<C extends IndexConfig, IR extends IndexR
     if (_deserializer == null) {
       _deserializer = createDeserializer();
     }
-    return _deserializer.deserialize(tableConfig, schema);
+    try {
+      return _deserializer.deserialize(tableConfig, schema);
+    } catch (MergedColumnConfigDeserializer.ConfigDeclaredTwiceException ex) {
+      throw new MergedColumnConfigDeserializer.ConfigDeclaredTwiceException(ex.getColumn(), this, ex);
+    }
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/MergedColumnConfigDeserializer.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/MergedColumnConfigDeserializer.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.spi.index;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 
@@ -60,14 +61,28 @@ public class MergedColumnConfigDeserializer<C> implements ColumnConfigDeserializ
 
   public static class ConfigDeclaredTwiceException extends RuntimeException {
     private final String _column;
+    @Nullable
+    private final IndexType<?, ?, ?> _indexType;
+
+    public ConfigDeclaredTwiceException(String column, IndexType<?, ?, ?> index, Throwable t) {
+      super("Configuration is declared in two different ways for index " + index.getId() + " on column " + column, t);
+      _column = column;
+      _indexType = index;
+    }
 
     public ConfigDeclaredTwiceException(String column) {
       super("Configuration is declared in two different ways for column " + column);
       _column = column;
+      _indexType = null;
     }
 
     public String getColumn() {
       return _column;
+    }
+
+    @Nullable
+    public IndexType<?, ?, ?> getIndexType() {
+      return _indexType;
     }
   }
 


### PR DESCRIPTION
As explained in #10652, nullability is not actually applied per column but to the whole table.

Before this PR, NullValueIndexType followed the same pattern common pattern where first it tries to check if it is configured in `fieldConfigList.indexes` and if it is not, it delegates into the other way to configure them.
In this case, the other way is to set `tableIndexConfg.nullHandlingEnabled` to true.

But even if NullValueIndexType open the possibility of setting nullability per column, the rest of the code is not prepared to do that. I've opened #10652 in order to discuss if we want to add that feature and how to do that, but meanwhile, I think it is better to disable the option of selectively configure nullability per column, given that it is confusing.

The PR also applies a small change in AbstractIndexType in order to improve error messages when indexes are defined using two different syntaxis.