### PR TITLE
API to expose the contract/rules imposed by pinot on tableConfig

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -68,6 +68,7 @@ import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.auth.ManualAuthorization;
 import org.apache.pinot.segment.local.utils.SchemaUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -328,6 +329,22 @@ public class PinotSchemaRestletResource {
       return JsonUtils.objectToPrettyString(response);
     } catch (JsonProcessingException e) {
       throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Gets the metadata on the valid {@link org.apache.pinot.spi.data.FieldSpec.DataType} for each
+   * {@link org.apache.pinot.spi.data.FieldSpec.FieldType} and the default null values for each combination
+   */
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/schemas/fieldSpec")
+  @ApiOperation(value = "Get fieldSpec metadata", notes = "Get fieldSpec metadata")
+  public String getFieldSpecMetadata() {
+    try {
+      return JsonUtils.objectToString(FieldSpec.FIELD_SPEC_METADATA);
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -133,8 +133,7 @@ public class TableConfigsRestletResource {
    */
   @GET
   @Produces(MediaType.APPLICATION_JSON)
-  @Path("/tableConfigs/metadata")
-  @Authenticate(AccessType.READ)
+  @Path("/tableConfigs/specMetadata")
   @ApiOperation(value = "Get TableConfig metadata", notes = "Get TableConfig metadata")
   public String getFieldSpecMetadata() {
     try {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -66,6 +66,7 @@ import org.apache.pinot.segment.local.utils.SchemaUtils;
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.spi.config.TableConfigs;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -121,6 +122,23 @@ public class TableConfigsRestletResource {
         configsList.add(rawTableName);
       }
       return configsList.toString();
+    } catch (Exception e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
+    }
+  }
+
+  /**
+   * Gets the metadata on the valid {@link org.apache.pinot.spi.data.FieldSpec.DataType} for each
+   * {@link org.apache.pinot.spi.data.FieldSpec.FieldType} and the default null values for each combination
+   */
+  @GET
+  @Produces(MediaType.APPLICATION_JSON)
+  @Path("/tableConfigs/metadata")
+  @Authenticate(AccessType.READ)
+  @ApiOperation(value = "Get TableConfig metadata", notes = "Get TableConfig metadata")
+  public String getFieldSpecMetadata() {
+    try {
+      return JsonUtils.objectToString(FieldSpec.fieldSpecMetadata);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -138,7 +138,7 @@ public class TableConfigsRestletResource {
   @ApiOperation(value = "Get TableConfig metadata", notes = "Get TableConfig metadata")
   public String getFieldSpecMetadata() {
     try {
-      return JsonUtils.objectToString(FieldSpec.fieldSpecMetadata);
+      return JsonUtils.objectToString(FieldSpec.FIELD_SPEC_METADATA);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/TableConfigsRestletResource.java
@@ -66,7 +66,6 @@ import org.apache.pinot.segment.local.utils.SchemaUtils;
 import org.apache.pinot.segment.local.utils.TableConfigUtils;
 import org.apache.pinot.spi.config.TableConfigs;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -122,22 +121,6 @@ public class TableConfigsRestletResource {
         configsList.add(rawTableName);
       }
       return configsList.toString();
-    } catch (Exception e) {
-      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
-    }
-  }
-
-  /**
-   * Gets the metadata on the valid {@link org.apache.pinot.spi.data.FieldSpec.DataType} for each
-   * {@link org.apache.pinot.spi.data.FieldSpec.FieldType} and the default null values for each combination
-   */
-  @GET
-  @Produces(MediaType.APPLICATION_JSON)
-  @Path("/tableConfigs/specMetadata")
-  @ApiOperation(value = "Get TableConfig metadata", notes = "Get TableConfig metadata")
-  public String getFieldSpecMetadata() {
-    try {
-      return JsonUtils.objectToString(FieldSpec.FIELD_SPEC_METADATA);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.INTERNAL_SERVER_ERROR, e);
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -92,7 +92,6 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
       }
       FIELD_SPEC_METADATA.put(fieldType, fieldTypeMetadata);
     }
-    System.out.println(FIELD_SPEC_METADATA);
   }
 
   protected String _name;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -104,6 +104,56 @@ public final class Schema implements Serializable {
     return JsonUtils.inputStreamToObject(schemaInputStream, Schema.class);
   }
 
+  public static void validate(FieldType fieldType, DataType dataType) {
+    switch (fieldType) {
+      case DIMENSION:
+      case TIME:
+      case DATE_TIME:
+        switch (dataType) {
+          case INT:
+          case LONG:
+          case FLOAT:
+          case DOUBLE:
+          case BIG_DECIMAL:
+          case BOOLEAN:
+          case TIMESTAMP:
+          case STRING:
+          case JSON:
+          case BYTES:
+            break;
+          default:
+            throw new IllegalStateException(
+                "Unsupported data type: " + dataType + " in DIMENSION/TIME field");
+        }
+        break;
+      case METRIC:
+        switch (dataType) {
+          case INT:
+          case LONG:
+          case FLOAT:
+          case DOUBLE:
+          case BIG_DECIMAL:
+          case BYTES:
+            break;
+          default:
+            throw new IllegalStateException("Unsupported data type: " + dataType + " in METRIC field");
+        }
+        break;
+      case COMPLEX:
+        switch (dataType) {
+          case STRUCT:
+          case MAP:
+          case LIST:
+            break;
+          default:
+            throw new IllegalStateException("Unsupported data type: " + dataType + " in COMPLEX field");
+        }
+        break;
+      default:
+        throw new IllegalStateException("Unsupported data type: " + dataType + " for field");
+    }
+  }
+
   /**
    * NOTE: schema name could be null in tests
    */
@@ -450,52 +500,10 @@ public final class Schema implements Serializable {
       FieldType fieldType = fieldSpec.getFieldType();
       DataType dataType = fieldSpec.getDataType();
       String fieldName = fieldSpec.getName();
-      switch (fieldType) {
-        case DIMENSION:
-        case TIME:
-        case DATE_TIME:
-          switch (dataType) {
-            case INT:
-            case LONG:
-            case FLOAT:
-            case DOUBLE:
-            case BIG_DECIMAL:
-            case BOOLEAN:
-            case TIMESTAMP:
-            case STRING:
-            case JSON:
-            case BYTES:
-              break;
-            default:
-              throw new IllegalStateException(
-                  "Unsupported data type: " + dataType + " in DIMENSION/TIME field: " + fieldName);
-          }
-          break;
-        case METRIC:
-          switch (dataType) {
-            case INT:
-            case LONG:
-            case FLOAT:
-            case DOUBLE:
-            case BIG_DECIMAL:
-            case BYTES:
-              break;
-            default:
-              throw new IllegalStateException("Unsupported data type: " + dataType + " in METRIC field: " + fieldName);
-          }
-          break;
-        case COMPLEX:
-          switch (dataType) {
-            case STRUCT:
-            case MAP:
-            case LIST:
-              break;
-            default:
-              throw new IllegalStateException("Unsupported data type: " + dataType + " in COMPLEX field: " + fieldName);
-          }
-          break;
-        default:
-          throw new IllegalStateException("Unsupported data type: " + dataType + " for field: " + fieldName);
+      try {
+        validate(fieldType, dataType);
+      } catch (IllegalStateException e) {
+        throw new IllegalStateException(e.getMessage() + ": " + fieldName);
       }
     }
   }


### PR DESCRIPTION
This PR tries to address the items mention in [issue #10647](https://github.com/apache/pinot/issues/10647)

Changes : 

1. Moved the switch case logic from `Schema.validate()` to `Schema.validate(FieldType fieldType, DataType dataType)` so that the code can be reused to just validate if a DataType is allowed by a FieldType.
2. Created `FieldSpec.FIELD_SPEC_METADATA` to hold the spec metadata.
3. Created a wrapper to hold the spec metadata. Currently is just has the valid (fieldType, dataType) pairs along with the respective default null values.
```
{
  "fieldTypes": {
    "METRIC": {
      "allowedDataTypes": {
        "INT": {
            "nullDefault": 0
        },
        "STRING": {
          "nullDefault": "null"
        },
        .
        .
        .
      ]
    },
    "DIMENSION": {
      "allowedDataTypes": [
        "INT": {
          "nullDefault": -2147483648
        },
        "STRING": {
          "nullDefault": "null"
        },
        .
        .
        .
      }
    },
    .
    .
    .
  },
  "dataTypes": {
    "INT": {
      "storedType": "INT",
      "size": 4,
      "sortable": true,
      "numeric": true
    },
    "UNKNOWN": {
      "storedType": "UNKNOWN",
      "size": -1,
      "sortable": true,
      "numeric": false
    },
    .
    .
    .
}
```
4. Expose the metadata from a new API endpoint at `/schemas/fieldSpec`