### PR TITLE
Bug fix to get EndReplaceSegmentsRequest correctly

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -1075,7 +1075,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
   EndReplaceSegmentsRequest endReplaceSegmentsRequest, @Nullable AuthProvider authProvider)
       throws IOException, HttpErrorStatusException {
     String jsonBody = (endReplaceSegmentsRequest == null) ? null
-        : JsonUtils.objectToString(endReplaceSegmentsRequest.getSegmentsTo());
+        : JsonUtils.objectToString(endReplaceSegmentsRequest);
     return HttpClient.wrapAndThrowHttpException(
         _httpClient.sendRequest(getEndReplaceSegmentsRequest(uri, jsonBody, socketTimeoutMs, authProvider)));
   }


### PR DESCRIPTION
This bug was introduced by [PR](https://github.com/apache/pinot/pull/10630). EndReplaceSegmentsRequest is a new parameter, not used yet. 