### PR TITLE
use word-break for long names in query console

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Query/QuerySideBar.tsx
+++ b/pinot-controller/src/main/resources/app/components/Query/QuerySideBar.tsx
@@ -66,7 +66,8 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     leftPanel: {
       width: 300,
-      padding: '0 20px'
+      padding: '0 20px',
+      wordBreak: 'break-all',
     },
   }),
 );
@@ -101,6 +102,7 @@ const Sidebar = ({ tableList, fetchSQLData, tableSchema, selectedTable, queryLoa
               cellClickCallback={fetchSQLData}
               isCellClickable
               showSearchBox={true}
+              inAccordionFormat
             />
 
             {!queryLoader && tableSchema.records.length ? (
@@ -109,6 +111,7 @@ const Sidebar = ({ tableList, fetchSQLData, tableSchema, selectedTable, queryLoa
                 data={tableSchema}
                 highlightBackground
                 showSearchBox={true}
+                inAccordionFormat
               />
             ) : null}
           </Grid>


### PR DESCRIPTION
This is a `ui` fixes and closes https://github.com/apache/pinot/issues/10518

This makes the left panel in the query console have a separate line for the search bar. All titles, table names, and column names now use wordbreak instead of overflowing or scrolling

before
![image](https://user-images.githubusercontent.com/4760722/233725122-7fbb481c-ac5b-4132-9526-a20ef5ced138.png)

after
![image](https://user-images.githubusercontent.com/4760722/233725160-46117b1a-54df-4e3d-ba6e-1e7bc0438fd5.png)
