### PR TITLE
Change getPrettyName() to default to getId()

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
@@ -61,7 +61,9 @@ public interface IndexType<C extends IndexConfig, IR extends IndexReader, IC ext
 
   Map<String, C> getConfig(TableConfig tableConfig, Schema schema);
 
-  String getPrettyName();
+  default String getPrettyName() {
+    return getId();
+  }
 
   /**
    * Returns the {@link IndexCreator} that can should be used to create an index of this type with the given context


### PR DESCRIPTION
PR #10623 introduced the new index type concept `prettyName` as a new abstract method.

By adding that we break backward compatibility with no reason. Values of `id` and `prettyName` should be the same unless there is some compatibility reason. For example, most indexes created pre `index-spi` used a different name and id in the older `ColumnIndexType` enum. New indexes should be able to have the same `id` and `prettyName`. Therefore this PR changes `getPrettyName` to delegate on `getId` by default