### PR TITLE
Add server metrics to capture gRPC activity

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -89,6 +89,11 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   NETTY_CONNECTION_RESPONSES_SENT("nettyConnection", true),
   NETTY_CONNECTION_BYTES_SENT("nettyConnection", true),
 
+  // GRPC related metrics
+  GRPC_QUERIES("grpcQueries", true),
+  GRPC_BYTES_RECEIVED("grpcBytesReceived", true),
+  GRPC_BYTES_SENT("grpcBytesSent", true),
+
   NUM_SEGMENTS_PRUNED_INVALID("numSegmentsPrunedInvalid", false),
   NUM_SEGMENTS_PRUNED_BY_LIMIT("numSegmentsPrunedByLimit", false),
   NUM_SEGMENTS_PRUNED_BY_VALUE("numSegmentsPrunedByValue", false),;

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
@@ -118,6 +118,9 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
 
   @Override
   public void submit(ServerRequest request, StreamObserver<ServerResponse> responseObserver) {
+    _serverMetrics.addMeteredGlobalValue(ServerMeter.GRPC_QUERIES, 1);
+    _serverMetrics.addMeteredGlobalValue(ServerMeter.GRPC_BYTES_RECEIVED, request.getSerializedSize());
+
     // Deserialize the request
     ServerQueryRequest queryRequest;
     try {
@@ -168,6 +171,7 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
       return;
     }
     responseObserver.onNext(serverResponse);
+    _serverMetrics.addMeteredGlobalValue(ServerMeter.GRPC_BYTES_SENT, serverResponse.getSerializedSize());
     responseObserver.onCompleted();
   }
 }


### PR DESCRIPTION
Can be used to:
- distinguish gRPC queries from Netty based ones
- track migrations from HTTP to gRPC
- etc.

`observability`