### PR TITLE
Fix Bug in Reporting Timer Value for Min Consuming Freshness

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -279,7 +279,7 @@ public abstract class QueryScheduler {
         _numDroppedLogCounter.incrementAndGet();
       }
 
-      if (minConsumingFreshnessMs > -1) {
+      if (minConsumingFreshnessMs > -1 && minConsumingFreshnessMs != Long.MAX_VALUE) {
         _serverMetrics.addTimedTableValue(tableNameWithType, ServerTimer.FRESHNESS_LAG_MS,
             (System.currentTimeMillis() - minConsumingFreshnessMs), TimeUnit.MILLISECONDS);
       }


### PR DESCRIPTION
Saw this in our prod cluster. minConsumingFreshnessMs is sometimes returned as Long.MAX_VALUE, which leads to an overflow.

```
2023-04-26 21:56:55.217 [pqr-5] INFO  org.apache.pinot.core.query.scheduler.QueryScheduler  - Processed requestId=58,table=<redacted>segments(queried/processed/matc
hed/consumingQueried/consumingProcessed/consumingMatched/invalid/limit/value)=2/0/0/2/0/0/0/0/0,schedulerWaitMs=1,reqDeserMs=0,totalExecMs=0,resSerMs=0,totalTimeMs=1,minConsumingFreshnessM
s=9223372036854775807,broker=<redacted>,numDocsScanned=0,scanInFilter=0,scanPostFilter=0<redacted>
```