### PR TITLE
Fixes partial upsert not reflecting multiple comparison column values

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -135,10 +135,17 @@ public class MutableSegmentImplUpsertTest {
       Assert.assertFalse(bitmap.contains(1));
       Assert.assertTrue(bitmap.contains(2));
       Assert.assertFalse(bitmap.contains(3));
+      // Confirm that both comparison column values have made it into the persisted upserted doc
+      Assert.assertEquals(1567205397L, _mutableSegmentImpl.getValue(2, "secondsSinceEpoch"));
+      Assert.assertEquals(1567205395L, _mutableSegmentImpl.getValue(2, "otherComparisonColumn"));
+
       // bb
       Assert.assertFalse(bitmap.contains(4));
       Assert.assertTrue(bitmap.contains(5));
       Assert.assertFalse(bitmap.contains(6));
+      // Confirm that comparison column values have made it into the persisted upserted doc
+      Assert.assertEquals(1567205396L, _mutableSegmentImpl.getValue(5, "secondsSinceEpoch"));
+      Assert.assertEquals(Long.MIN_VALUE, _mutableSegmentImpl.getValue(5, "otherComparisonColumn"));
     }
   }
 }


### PR DESCRIPTION
cc: @KKcorps @Jackie-Jiang 

Without this fix, if using multiple comparison columns it's likely that any server restart will result in an overall different representation of data.  

Presently, comparison columns are skipped in partial upsert handler. This behaviour needs to be changed in order to support merging of any prior comparison column value which is null for the inbound record.