### PR TITLE
update segment target tier before table rebalance

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -645,7 +645,9 @@ public class PinotTableRestletResource {
       value = "How often to check if external view converges with ideal states") @DefaultValue("1000")
   @QueryParam("externalViewCheckIntervalInMs") long externalViewCheckIntervalInMs,
       @ApiParam(value = "How long to wait till external view converges with ideal states") @DefaultValue("3600000")
-      @QueryParam("externalViewStabilizationTimeoutInMs") long externalViewStabilizationTimeoutInMs) {
+      @QueryParam("externalViewStabilizationTimeoutInMs") long externalViewStabilizationTimeoutInMs,
+      @ApiParam(value = "Whether to update segment target tier as part of the rebalance") @DefaultValue("false")
+      @QueryParam("updateTargetTier") boolean updateTargetTier) {
 
     String tableNameWithType = constructTableNameWithType(tableName, tableTypeStr);
 
@@ -661,8 +663,8 @@ public class PinotTableRestletResource {
         externalViewCheckIntervalInMs);
     rebalanceConfig.addProperty(RebalanceConfigConstants.EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS,
         externalViewStabilizationTimeoutInMs);
-    rebalanceConfig.addProperty(RebalanceConfigConstants.JOB_ID,
-        TableRebalancer.createUniqueRebalanceJobIdentifier());
+    rebalanceConfig.addProperty(RebalanceConfigConstants.UPDATE_TARGET_TIER, updateTargetTier);
+    rebalanceConfig.addProperty(RebalanceConfigConstants.JOB_ID, TableRebalancer.createUniqueRebalanceJobIdentifier());
 
     try {
       if (dryRun || downtime) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -21,10 +21,8 @@ package org.apache.pinot.controller.helix.core.relocation;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.BlockingQueue;
@@ -38,13 +36,9 @@ import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.helix.ClusterMessagingService;
 import org.apache.helix.Criteria;
 import org.apache.helix.InstanceType;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.assignment.InstanceAssignmentConfigUtils;
 import org.apache.pinot.common.messages.SegmentReloadMessage;
-import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerMetrics;
-import org.apache.pinot.common.tier.Tier;
-import org.apache.pinot.common.tier.TierSegmentSelector;
 import org.apache.pinot.common.utils.config.TierConfigUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
@@ -54,7 +48,6 @@ import org.apache.pinot.controller.helix.core.rebalance.RebalanceResult;
 import org.apache.pinot.controller.helix.core.rebalance.TableRebalancer;
 import org.apache.pinot.controller.util.TableTierReader;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.RebalanceConfigConstants;
@@ -187,24 +180,17 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
         _externalViewCheckIntervalInMs);
     rebalanceConfig.addProperty(RebalanceConfigConstants.EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS,
         _externalViewStabilizationTimeoutInMs);
-    rebalanceConfig.addProperty(RebalanceConfigConstants.JOB_ID,
-        TableRebalancer.createUniqueRebalanceJobIdentifier());
+    rebalanceConfig.addProperty(RebalanceConfigConstants.UPDATE_TARGET_TIER,
+        TierConfigUtils.shouldRelocateToTiers(tableConfig));
+    rebalanceConfig.addProperty(RebalanceConfigConstants.JOB_ID, TableRebalancer.createUniqueRebalanceJobIdentifier());
 
     try {
       // Relocating segments to new tiers needs two sequential actions: table rebalance and local tier migration.
       // Table rebalance moves segments to the new ideal servers, which can change for a segment when its target
       // tier is updated. New servers can put segments onto the right tier when loading the segments. After that,
       // all segments are put on the right servers. If any segments are not on their target tier, the server local
-      // tier migration is triggered for them, basically asking the hosting servers to reload them.
-      //
-      // We assume segment target tier is not changed between the two actions, so update target tier here as well,
-      // instead of using a separate task.
-      // TODO: can add some sanity checks on the server side when reloading segments to be more defensive, e.g. only
-      //       migrating segment to new tier when the hosting server is in the server pool configured for that tier.
-      if (TierConfigUtils.shouldRelocateToTiers(tableConfig)) {
-        updateTargetTier(tableNameWithType, tableConfig);
-      }
-
+      // tier migration is triggered for them, basically asking the hosting servers to reload them. The segment
+      // target tier may get changed between the two sequential actions, but cluster states converge eventually.
       RebalanceResult rebalance = _pinotHelixResourceManager.rebalanceTable(tableNameWithType, rebalanceConfig, false);
       switch (rebalance.getStatus()) {
         case NO_OP:
@@ -221,20 +207,6 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
       }
     } catch (Throwable t) {
       LOGGER.error("Caught exception/error while rebalancing table: {}", tableNameWithType, t);
-    }
-  }
-
-  /**
-   * Calculate the target tier the segment belongs to and set it in segment ZK metadata as goal state, which can be
-   * checked by servers when loading the segment to put it onto the target storage tier.
-   */
-  private void updateTargetTier(String tableNameWithType, TableConfig tableConfig) {
-    List<TierConfig> tierCfgs = tableConfig.getTierConfigsList();
-    List<Tier> sortedTiers = tierCfgs == null ? Collections.emptyList()
-        : TierConfigUtils.getSortedTiers(tierCfgs, _pinotHelixResourceManager.getHelixZkManager());
-    LOGGER.info("Updating target tiers for segments of table: {} with tierConfigs: {}", tableNameWithType, sortedTiers);
-    for (String segmentName : _pinotHelixResourceManager.getSegmentsFor(tableNameWithType, true)) {
-      updateSegmentTargetTier(tableNameWithType, segmentName, sortedTiers, _pinotHelixResourceManager);
     }
   }
 
@@ -259,46 +231,6 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
     } catch (Exception e) {
       LOGGER.error("Failed to migrate segments of table: {} to new tiers on hosting servers", tableNameWithType, e);
     }
-  }
-
-  @VisibleForTesting
-  static void updateSegmentTargetTier(String tableNameWithType, String segmentName, List<Tier> sortedTiers,
-      PinotHelixResourceManager pinotHelixResourceManager) {
-    ZNRecord segmentMetadataZNRecord =
-        pinotHelixResourceManager.getSegmentMetadataZnRecord(tableNameWithType, segmentName);
-    if (segmentMetadataZNRecord == null) {
-      LOGGER.debug("No ZK metadata for segment: {} of table: {}", segmentName, tableNameWithType);
-      return;
-    }
-    Tier targetTier = null;
-    for (Tier tier : sortedTiers) {
-      TierSegmentSelector tierSegmentSelector = tier.getSegmentSelector();
-      if (tierSegmentSelector.selectSegment(tableNameWithType, segmentName)) {
-        targetTier = tier;
-        break;
-      }
-    }
-    SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(segmentMetadataZNRecord);
-    String targetTierName = null;
-    if (targetTier == null) {
-      if (segmentZKMetadata.getTier() == null) {
-        LOGGER.debug("Segment: {} of table: {} is already set to go to default tier", segmentName, tableNameWithType);
-        return;
-      }
-      LOGGER.info("Segment: {} of table: {} is put back on default tier", segmentName, tableNameWithType);
-    } else {
-      targetTierName = targetTier.getName();
-      if (targetTierName.equals(segmentZKMetadata.getTier())) {
-        LOGGER.debug("Segment: {} of table: {} is already set to go to target tier: {}", segmentName, tableNameWithType,
-            targetTierName);
-        return;
-      }
-      LOGGER.info("Segment: {} of table: {} is put onto new tier: {}", segmentName, tableNameWithType, targetTierName);
-    }
-    // Update the tier in segment ZK metadata and write it back to ZK.
-    segmentZKMetadata.setTier(targetTierName);
-    pinotHelixResourceManager.updateZkMetadata(tableNameWithType, segmentZKMetadata,
-        segmentMetadataZNRecord.getVersion());
   }
 
   @VisibleForTesting

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/RebalanceConfigConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/RebalanceConfigConstants.java
@@ -71,4 +71,6 @@ public class RebalanceConfigConstants {
   public static final long DEFAULT_EXTERNAL_VIEW_CHECK_INTERVAL_IN_MS = 1_000L; // 1 second
   public static final String EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS = "externalViewStabilizationTimeoutInMs";
   public static final long DEFAULT_EXTERNAL_VIEW_STABILIZATION_TIMEOUT_IN_MS = 60 * 60_000L; // 1 hour
+  public static final String UPDATE_TARGET_TIER = "updateTargetTier";
+  public static final boolean DEFAULT_UPDATE_TARGET_TIER = false;
 }


### PR DESCRIPTION
This PR tries to make index config tier overwriting #10553 more robust.

Turns out the fix in #10642 is not enough, e.g. if one updates tierConfigs in table config and calls rebalance API to move segments around and it happens before SegmentRelocator task kicks in to update the segment target tiers, it's still possible that segments are loaded on the new servers without using the tier specific index configs. So moving the logic that updates segment target tier into `rebalanceTable` method to be shared by both table rebalance API and SegmentRelocator periodic task.