### PR TITLE
Add getName() function in LiteralTransformFunction

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/LiteralTransformFunction.java
@@ -40,6 +40,8 @@ import org.roaringbitmap.RoaringBitmap;
  * LITERAL. The data type is inferred from the literal string.
  */
 public class LiteralTransformFunction implements TransformFunction {
+  public static final String FUNCTION_NAME = "literal";
+
   private final Object _literal;
   private final DataType _dataType;
   private final int _intLiteral;
@@ -94,7 +96,7 @@ public class LiteralTransformFunction implements TransformFunction {
 
   @Override
   public String getName() {
-    throw new UnsupportedOperationException();
+    return FUNCTION_NAME;
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/HybridClusterIntegrationTest.java
@@ -211,7 +211,26 @@ public class HybridClusterIntegrationTest extends BaseClusterIntegrationTestSet 
   }
 
   @Test
-  public void testDropResults() throws Exception {
+  public void testQueryTracingWithLiteral()
+      throws Exception {
+    JsonNode jsonNode =
+        postQuery("SET trace = true; SELECT 1, \'test\', ArrDelay FROM " + getTableName() + " LIMIT 10");
+    long countStarResult = 10;
+    Assert.assertEquals(jsonNode.get("resultTable").get("rows").size(), 10);
+    for (int rowId = 0; rowId < 10; rowId++) {
+      Assert.assertEquals(jsonNode.get("resultTable").get("rows").get(rowId).get(0).asLong(), 1);
+      Assert.assertEquals(jsonNode.get("resultTable").get("rows").get(rowId).get(1).asText(), "test");
+    }
+    Assert.assertTrue(jsonNode.get("exceptions").isEmpty());
+    JsonNode traceInfo = jsonNode.get("traceInfo");
+    Assert.assertEquals(traceInfo.size(), 2);
+    Assert.assertTrue(traceInfo.has("localhost_O"));
+    Assert.assertTrue(traceInfo.has("localhost_R"));
+  }
+
+  @Test
+  public void testDropResults()
+      throws Exception {
     final String query = String.format("SELECT * FROM %s limit 10", getTableName());
     final String resultTag = "resultTable";
 


### PR DESCRIPTION
Current query will fail when select literal and tracing enabled.