### PR TITLE
Keeps nullness attributes of merged in comparison column values

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ComparisonColumns.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ComparisonColumns.java
@@ -52,7 +52,7 @@ public class ComparisonColumns implements Comparable<ComparisonColumns> {
       Comparable comparisonValue = _values[i];
       Comparable otherComparisonValue = other.getValues()[i];
       if (otherComparisonValue == null) {
-        comparisonResult = 1;
+        continue;
       } else {
         comparisonResult = comparisonValue.compareTo(otherComparisonValue);
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ComparisonColumns.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ComparisonColumns.java
@@ -42,7 +42,9 @@ public class ComparisonColumns implements Comparable<ComparisonColumns> {
       /*
        - iterate over all columns
        - if any value in _values is greater than its counterpart in _other._values, keep _values as-is and return 1
-       - if all values in _values are less than those in _other._values, keep _values as-is and return -1
+       - if any value in _values is less than its counterpart  in _other._values _and_ none are greater than their
+         counterpart in _other._values, keep _values as-is and return -1
+           - i.e. no value in _this_ is greater than its counterpart in _other
        - if all values between the two sets of Comparables are equal (compareTo == 0), keep _values as-is and return 0
        */
     int comparisonResult;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ComparisonColumns.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ComparisonColumns.java
@@ -42,30 +42,31 @@ public class ComparisonColumns implements Comparable<ComparisonColumns> {
       /*
        - iterate over all columns
        - if any value in _values is greater than its counterpart in _other._values, keep _values as-is and return 1
-       - if any value in _values is less than its counterpart  in _other._values _and_ none are greater than their
-         counterpart in _other._values, keep _values as-is and return -1
-           - i.e. no value in _this_ is greater than its counterpart in _other
+       - if any value in _values is less than its counterpart  in _other._values, keep _values as-is and return -1
        - if all values between the two sets of Comparables are equal (compareTo == 0), keep _values as-is and return 0
        */
-    int comparisonResult;
-    int accumResult = 0;
-
     for (int i = 0; i < _values.length; i++) {
       Comparable comparisonValue = _values[i];
       Comparable otherComparisonValue = other.getValues()[i];
-      if (otherComparisonValue == null) {
+      if (comparisonValue == null && otherComparisonValue == null) {
         continue;
-      } else {
-        comparisonResult = comparisonValue.compareTo(otherComparisonValue);
       }
 
-      if (comparisonResult > 0) {
+      // Always keep the record with non-null value, or that with the greater comparisonResult
+      if (comparisonValue == null) {
+        // implies comparisonValue == null && otherComparisonValue != null
+        return -1;
+      } else if (otherComparisonValue == null) {
+        // implies comparisonValue != null && otherComparisonValue == null
         return 1;
       } else {
-        accumResult += comparisonResult;
+        int comparisonResult = comparisonValue.compareTo(otherComparisonValue);
+        if (comparisonResult != 0) {
+          return comparisonResult;
+        }
       }
     }
-    return Math.max(accumResult, -1);
+    return 0;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
@@ -74,7 +74,12 @@ public class PartialUpsertHandler {
             // comparison column values from the previous record, and the sole non-null comparison column value from
             // the new record.
             newRecord.putValue(column, previousRecord.getValue(column));
-            newRecord.removeNullValueField(column);
+            if (!_comparisonColumns.contains(column)) {
+              // Despite wanting to overwrite the values to comparison columns from prior records, we want to
+              // preserve for _this_ record which comparison column was non-null. Doing so will allow us to
+              // re-evaluate the same comparisons when reading a segment and during steady-state stream ingestion
+              newRecord.removeNullValueField(column);
+            }
           } else if (!_comparisonColumns.contains(column)) {
             PartialUpsertMerger merger = _column2Mergers.getOrDefault(column, _defaultPartialUpsertMerger);
             newRecord.putValue(column,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
@@ -74,12 +74,7 @@ public class PartialUpsertHandler {
             // comparison column values from the previous record, and the sole non-null comparison column value from
             // the new record.
             newRecord.putValue(column, previousRecord.getValue(column));
-            if (!_comparisonColumns.contains(column)) {
-              // Despite wanting to overwrite the values to comparison columns from prior records, we want to
-              // preserve for _this_ record which comparison column was non-null. Doing so will allow us to
-              // re-evaluate the same comparisons when reading a segment and during steady-state stream ingestion
-              newRecord.removeNullValueField(column);
-            }
+            newRecord.removeNullValueField(column);
           } else if (!_comparisonColumns.contains(column)) {
             PartialUpsertMerger merger = _column2Mergers.getOrDefault(column, _defaultPartialUpsertMerger);
             newRecord.putValue(column,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertUtils.java
@@ -25,8 +25,6 @@ import java.util.Iterator;
 import java.util.List;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentColumnReader;
 import org.apache.pinot.segment.spi.IndexSegment;
-import org.apache.pinot.segment.spi.datasource.DataSource;
-import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.PeekableIntIterator;
@@ -179,15 +177,11 @@ public class UpsertUtils {
 
   public static class MultiComparisonColumnReader implements UpsertUtils.ComparisonColumnReader {
     private final PinotSegmentColumnReader[] _comparisonColumnReaders;
-    private final NullValueVectorReader[] _comparisonColumnNullReaders;
 
     public MultiComparisonColumnReader(IndexSegment segment, List<String> comparisonColumns) {
       _comparisonColumnReaders = new PinotSegmentColumnReader[comparisonColumns.size()];
-      _comparisonColumnNullReaders = new NullValueVectorReader[comparisonColumns.size()];
 
       for (int i = 0; i < comparisonColumns.size(); i++) {
-        DataSource dataSource = segment.getDataSource(comparisonColumns.get(i));
-        _comparisonColumnNullReaders[i] = dataSource.getNullValueVector();
         _comparisonColumnReaders[i] = new PinotSegmentColumnReader(segment, comparisonColumns.get(i));
       }
     }
@@ -195,19 +189,13 @@ public class UpsertUtils {
     public Comparable getComparisonValue(int docId) {
       Comparable[] comparisonColumns = new Comparable[_comparisonColumnReaders.length];
 
-      int comparisonIndex = -1;
       for (int i = 0; i < _comparisonColumnReaders.length; i++) {
         PinotSegmentColumnReader columnReader = _comparisonColumnReaders[i];
         Comparable comparisonValue = (Comparable) UpsertUtils.getValue(columnReader, docId);
         comparisonColumns[i] = comparisonValue;
-        if (!_comparisonColumnNullReaders[i].isNull(docId)) {
-          comparisonIndex = i;
-        }
       }
 
-      // Note that the comparable index is negative here to indicate that this instance could be the argument to
-      // ComparisonColumns#compareTo, but should never call compareTo itself.
-      return new ComparisonColumns(comparisonColumns, comparisonIndex);
+      return new ComparisonColumns(comparisonColumns, ComparisonColumns.SEALED_SEGMENT_COMPARISON_INDEX);
     }
 
     @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertUtils.java
@@ -191,7 +191,10 @@ public class UpsertUtils {
 
       for (int i = 0; i < _comparisonColumnReaders.length; i++) {
         PinotSegmentColumnReader columnReader = _comparisonColumnReaders[i];
-        Comparable comparisonValue = (Comparable) UpsertUtils.getValue(columnReader, docId);
+        Comparable comparisonValue = null;
+        if (!columnReader.isNull(docId)) {
+          comparisonValue = (Comparable) UpsertUtils.getValue(columnReader, docId);
+        }
         comparisonColumns[i] = comparisonValue;
       }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -76,6 +76,7 @@ public class MutableSegmentImplUpsertTest {
     _schema = Schema.fromFile(new File(schemaResourceUrl.getFile()));
     _tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName("testTable").setUpsertConfig(upsertConfigWithHash)
+            .setNullHandlingEnabled(true)
             .build();
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
@@ -138,6 +139,7 @@ public class MutableSegmentImplUpsertTest {
       // Confirm that both comparison column values have made it into the persisted upserted doc
       Assert.assertEquals(1567205397L, _mutableSegmentImpl.getValue(2, "secondsSinceEpoch"));
       Assert.assertEquals(1567205395L, _mutableSegmentImpl.getValue(2, "otherComparisonColumn"));
+      Assert.assertTrue(_mutableSegmentImpl.getDataSource("secondsSinceEpoch").getNullValueVector().isNull(2));
 
       // bb
       Assert.assertFalse(bitmap.contains(4));
@@ -146,6 +148,7 @@ public class MutableSegmentImplUpsertTest {
       // Confirm that comparison column values have made it into the persisted upserted doc
       Assert.assertEquals(1567205396L, _mutableSegmentImpl.getValue(5, "secondsSinceEpoch"));
       Assert.assertEquals(Long.MIN_VALUE, _mutableSegmentImpl.getValue(5, "otherComparisonColumn"));
+      Assert.assertTrue(_mutableSegmentImpl.getDataSource("otherComparisonColumn").getNullValueVector().isNull(5));
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -76,7 +76,6 @@ public class MutableSegmentImplUpsertTest {
     _schema = Schema.fromFile(new File(schemaResourceUrl.getFile()));
     _tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName("testTable").setUpsertConfig(upsertConfigWithHash)
-            .setNullHandlingEnabled(true)
             .build();
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
@@ -139,7 +138,6 @@ public class MutableSegmentImplUpsertTest {
       // Confirm that both comparison column values have made it into the persisted upserted doc
       Assert.assertEquals(1567205397L, _mutableSegmentImpl.getValue(2, "secondsSinceEpoch"));
       Assert.assertEquals(1567205395L, _mutableSegmentImpl.getValue(2, "otherComparisonColumn"));
-      Assert.assertTrue(_mutableSegmentImpl.getDataSource("secondsSinceEpoch").getNullValueVector().isNull(2));
 
       // bb
       Assert.assertFalse(bitmap.contains(4));
@@ -148,7 +146,6 @@ public class MutableSegmentImplUpsertTest {
       // Confirm that comparison column values have made it into the persisted upserted doc
       Assert.assertEquals(1567205396L, _mutableSegmentImpl.getValue(5, "secondsSinceEpoch"));
       Assert.assertEquals(Long.MIN_VALUE, _mutableSegmentImpl.getValue(5, "otherComparisonColumn"));
-      Assert.assertTrue(_mutableSegmentImpl.getDataSource("otherComparisonColumn").getNullValueVector().isNull(5));
     }
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ComparisonColumnsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ComparisonColumnsTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.segment.local.upsert;
 
 import java.util.Arrays;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ComparisonColumnsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ComparisonColumnsTest.java
@@ -1,0 +1,151 @@
+package org.apache.pinot.segment.local.upsert;
+
+import java.util.Arrays;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class ComparisonColumnsTest {
+  private void nullFill(Comparable[]... comparables) {
+    for (Comparable[] comps : comparables) {
+      Arrays.fill(comps, null);
+    }
+  }
+
+  @Test
+  public void testRealtimeComparison() {
+    int comparisonIndex = 0;
+    Comparable[] newComparables = new Comparable[3];
+    Comparable[] persistedComparables = new Comparable[3];
+    ComparisonColumns alreadyPersisted = new ComparisonColumns(persistedComparables, comparisonIndex);
+    ComparisonColumns toBeIngested = new ComparisonColumns(newComparables, comparisonIndex);
+
+    // reject same col with smaller value
+    newComparables[comparisonIndex] = 1;
+    persistedComparables[comparisonIndex] = 2;
+    int comparisonResult = toBeIngested.compareTo(alreadyPersisted);
+    Assert.assertEquals(comparisonResult, -1);
+
+    // persist same col with equal value
+    nullFill(newComparables, persistedComparables);
+    newComparables[comparisonIndex] = 2;
+    persistedComparables[comparisonIndex] = 2;
+    comparisonResult = toBeIngested.compareTo(alreadyPersisted);
+    Assert.assertEquals(comparisonResult, 0);
+
+    // persist same col with larger value
+    nullFill(newComparables, persistedComparables);
+    newComparables[comparisonIndex] = 2;
+    persistedComparables[comparisonIndex] = 1;
+    comparisonResult = toBeIngested.compareTo(alreadyPersisted);
+    Assert.assertEquals(comparisonResult, 1);
+
+    // persist doc with col which was previously null, even though its value is smaller than the previous non-null col
+    nullFill(newComparables, persistedComparables);
+    comparisonIndex = newComparables.length - 1;
+    toBeIngested = new ComparisonColumns(newComparables, comparisonIndex);
+    newComparables[comparisonIndex] = 1;
+    persistedComparables[0] = 2;
+    comparisonResult = toBeIngested.compareTo(alreadyPersisted);
+    Assert.assertEquals(comparisonResult, 1);
+
+    // persist new doc where existing doc has multiple non-null comparison values
+    nullFill(newComparables, persistedComparables);
+    comparisonIndex = 1;
+    toBeIngested = new ComparisonColumns(newComparables, comparisonIndex);
+    newComparables[comparisonIndex] = 2;
+    Arrays.fill(persistedComparables, 1);
+    comparisonResult = toBeIngested.compareTo(alreadyPersisted);
+    Assert.assertEquals(comparisonResult, 1);
+
+    // reject new doc where existing doc has multiple non-null comparison values
+    nullFill(newComparables, persistedComparables);
+    newComparables[comparisonIndex] = 0;
+    Arrays.fill(persistedComparables, 1);
+    comparisonResult = toBeIngested.compareTo(alreadyPersisted);
+    Assert.assertEquals(comparisonResult, -1);
+  }
+
+  @Test
+  public void testSealedComparison() {
+    // Remember to be cognizant of which scenarios are _actually_ possible in a sealed segment. The way in which docs
+    // are compared during realtime ingestion dictates the possible scenarios of persisted rows. Ex. it is not
+    // possible for 2 docs with the same primary key to have a mutually exclusive set of non-null values; if such a
+    // scenario arose during realtime ingestion, the values would be merged such that the newly persisted doc would
+    // have all non-null comparison values. We should avoid making tests pass for scenarios that are not intended to
+    // be supported.
+    Comparable[] newComparables = new Comparable[3];
+    Comparable[] persistedComparables = new Comparable[3];
+    ComparisonColumns alreadyPersisted =
+        new ComparisonColumns(persistedComparables, ComparisonColumns.SEALED_SEGMENT_COMPARISON_INDEX);
+    ComparisonColumns toBeIngested =
+        new ComparisonColumns(newComparables, ComparisonColumns.SEALED_SEGMENT_COMPARISON_INDEX);
+
+    // reject same col with smaller value
+    newComparables[0] = 1;
+    persistedComparables[0] = 2;
+    int comparisonResult = toBeIngested.compareTo(alreadyPersisted);
+    Assert.assertEquals(comparisonResult, -1);
+
+    // persist same col with equal value
+    nullFill(newComparables, persistedComparables);
+    newComparables[0] = 2;
+    persistedComparables[0] = 2;
+    comparisonResult = toBeIngested.compareTo(alreadyPersisted);
+    Assert.assertEquals(comparisonResult, 0);
+
+    // persist same col with larger value
+    nullFill(newComparables, persistedComparables);
+    newComparables[0] = 2;
+    persistedComparables[0] = 1;
+    comparisonResult = toBeIngested.compareTo(alreadyPersisted);
+    Assert.assertEquals(comparisonResult, 1);
+
+    // reject doc where existing doc has more than one, but not all, non-null comparison values, but _this_ doc has 2
+    // null columns. The presence of null columns in one of the docs implies that it must have come before the doc
+    // with non-null columns.
+    nullFill(newComparables, persistedComparables);
+    newComparables[1] = 1;
+    persistedComparables[0] = 1;
+    persistedComparables[2] = 1;
+    comparisonResult = toBeIngested.compareTo(alreadyPersisted);
+    Assert.assertEquals(comparisonResult, -1);
+
+    // persist doc where existing doc has more than one, but not all, non-null comparison values, but _this_ doc has
+    nullFill(newComparables, persistedComparables);
+    newComparables[0] = 1;
+    newComparables[2] = 2;
+    persistedComparables[0] = 1;
+    persistedComparables[2] = 1;
+    comparisonResult = toBeIngested.compareTo(alreadyPersisted);
+    Assert.assertEquals(comparisonResult, 1);
+
+    // persist doc with non-null value where existing doc had null value in same column previously (but multiple
+    // non-null in other columns)
+    nullFill(newComparables, persistedComparables);
+    newComparables[0] = 1;
+    newComparables[1] = 1;
+    newComparables[2] = 1;
+    persistedComparables[0] = 1;
+    persistedComparables[2] = 1;
+    comparisonResult = toBeIngested.compareTo(alreadyPersisted);
+    Assert.assertEquals(comparisonResult, 1);
+
+    // reject doc where existing doc has all non-null comparison values, but _this_ doc has 2 null values.
+    // The presence of null columns in one of the docs implies that it must have come before the doc with non-null
+    // columns.
+    nullFill(newComparables, persistedComparables);
+    newComparables[1] = 1;
+    Arrays.fill(persistedComparables, 1);
+    comparisonResult = toBeIngested.compareTo(alreadyPersisted);
+    Assert.assertEquals(comparisonResult, -1);
+
+    // Persist doc where existing doc has all non-null comparison values, but _this_ doc has a larger value.
+    nullFill(newComparables, persistedComparables);
+    Arrays.fill(newComparables, 1);
+    Arrays.fill(persistedComparables, 1);
+    newComparables[1] = 2;
+    comparisonResult = toBeIngested.compareTo(alreadyPersisted);
+    Assert.assertEquals(comparisonResult, 1);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ComparisonColumnsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ComparisonColumnsTest.java
@@ -32,53 +32,53 @@ public class ComparisonColumnsTest {
 
   @Test
   public void testRealtimeComparison() {
-    int comparisonIndex = 0;
     Comparable[] newComparables = new Comparable[3];
     Comparable[] persistedComparables = new Comparable[3];
-    ComparisonColumns alreadyPersisted = new ComparisonColumns(persistedComparables, comparisonIndex);
-    ComparisonColumns toBeIngested = new ComparisonColumns(newComparables, comparisonIndex);
+    ComparisonColumns alreadyPersisted = new ComparisonColumns(persistedComparables, 0);
+    ComparisonColumns toBeIngested = new ComparisonColumns(newComparables, 0);
 
     // reject same col with smaller value
-    newComparables[comparisonIndex] = 1;
-    persistedComparables[comparisonIndex] = 2;
+    newComparables[0] = 1;
+    persistedComparables[0] = 2;
     int comparisonResult = toBeIngested.compareTo(alreadyPersisted);
     Assert.assertEquals(comparisonResult, -1);
 
     // persist same col with equal value
     nullFill(newComparables, persistedComparables);
-    newComparables[comparisonIndex] = 2;
-    persistedComparables[comparisonIndex] = 2;
+    newComparables[0] = 2;
+    persistedComparables[0] = 2;
     comparisonResult = toBeIngested.compareTo(alreadyPersisted);
     Assert.assertEquals(comparisonResult, 0);
 
     // persist same col with larger value
     nullFill(newComparables, persistedComparables);
-    newComparables[comparisonIndex] = 2;
-    persistedComparables[comparisonIndex] = 1;
+    newComparables[0] = 2;
+    persistedComparables[0] = 1;
     comparisonResult = toBeIngested.compareTo(alreadyPersisted);
     Assert.assertEquals(comparisonResult, 1);
+    Assert.assertEquals(toBeIngested.getValues(), new Comparable[]{2, null, null});
 
     // persist doc with col which was previously null, even though its value is smaller than the previous non-null col
     nullFill(newComparables, persistedComparables);
-    comparisonIndex = newComparables.length - 1;
-    toBeIngested = new ComparisonColumns(newComparables, comparisonIndex);
-    newComparables[comparisonIndex] = 1;
+    toBeIngested = new ComparisonColumns(newComparables, newComparables.length - 1);
+    newComparables[newComparables.length - 1] = 1;
     persistedComparables[0] = 2;
     comparisonResult = toBeIngested.compareTo(alreadyPersisted);
     Assert.assertEquals(comparisonResult, 1);
+    Assert.assertEquals(toBeIngested.getValues(), new Comparable[]{2, null, 1});
 
     // persist new doc where existing doc has multiple non-null comparison values
     nullFill(newComparables, persistedComparables);
-    comparisonIndex = 1;
-    toBeIngested = new ComparisonColumns(newComparables, comparisonIndex);
-    newComparables[comparisonIndex] = 2;
+    toBeIngested = new ComparisonColumns(newComparables, 1);
+    newComparables[1] = 2;
     Arrays.fill(persistedComparables, 1);
     comparisonResult = toBeIngested.compareTo(alreadyPersisted);
     Assert.assertEquals(comparisonResult, 1);
+    Assert.assertEquals(toBeIngested.getValues(), new Comparable[]{1, 2, 1});
 
     // reject new doc where existing doc has multiple non-null comparison values
     nullFill(newComparables, persistedComparables);
-    newComparables[comparisonIndex] = 0;
+    newComparables[1] = 0;
     Arrays.fill(persistedComparables, 1);
     comparisonResult = toBeIngested.compareTo(alreadyPersisted);
     Assert.assertEquals(comparisonResult, -1);
@@ -111,6 +111,8 @@ public class ComparisonColumnsTest {
     persistedComparables[0] = 2;
     comparisonResult = toBeIngested.compareTo(alreadyPersisted);
     Assert.assertEquals(comparisonResult, 0);
+    // Verify unchanged comparables in the case of SEALED comparison
+    Assert.assertEquals(toBeIngested.getValues(), newComparables);
 
     // persist same col with larger value
     nullFill(newComparables, persistedComparables);


### PR DESCRIPTION
Keeps nullness attributes of merged comparison column values to avoid `IndexOutOfBounds` exception on segment read.