### PR TITLE
Fix a bug in star-tree filter operator which can incorrecly filter documents

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/operator/StarTreeFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/operator/StarTreeFilterOperator.java
@@ -203,12 +203,16 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
   @Nullable
   private StarTreeResult traverseStarTree() {
     MutableRoaringBitmap matchingDocIds = new MutableRoaringBitmap();
-    Set<String> globalRemainingPredicateColumns = Collections.emptySet();
-    boolean globalRemainingPredicateColumnsSet = false;
+    Set<String> globalRemainingPredicateColumns = null;
 
     StarTree starTree = _starTreeV2.getStarTree();
     List<String> dimensionNames = starTree.getDimensionNames();
     StarTreeNode starTreeRootNode = starTree.getRoot();
+
+    // Track whether we have found a leaf node added to the queue. If we have found a leaf node, and traversed to the
+    // level of the leave node, we can set globalRemainingPredicateColumns if not already set because we know the leaf
+    // node won't split further on other predicate columns.
+    boolean findLeafNode = starTreeRootNode.isLeaf();
 
     // Use BFS to traverse the star tree
     Queue<StarTreeNode> queue = new ArrayDeque<>();
@@ -216,6 +220,9 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
     int currentDimensionId = -1;
     Set<String> remainingPredicateColumns = new HashSet<>(_predicateEvaluatorsMap.keySet());
     Set<String> remainingGroupByColumns = new HashSet<>(_groupByColumns);
+    if (findLeafNode) {
+      globalRemainingPredicateColumns = new HashSet<>(remainingPredicateColumns);
+    }
     IntSet matchingDictIds = null;
     StarTreeNode starTreeNode;
     while ((starTreeNode = queue.poll()) != null) {
@@ -225,6 +232,9 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
         String dimension = dimensionNames.get(dimensionId);
         remainingPredicateColumns.remove(dimension);
         remainingGroupByColumns.remove(dimension);
+        if (findLeafNode && globalRemainingPredicateColumns == null) {
+          globalRemainingPredicateColumns = new HashSet<>(remainingPredicateColumns);
+        }
         matchingDictIds = null;
         currentDimensionId = dimensionId;
       }
@@ -240,14 +250,6 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
       // remaining predicate columns for this node
       if (starTreeNode.isLeaf()) {
         matchingDocIds.add((long) starTreeNode.getStartDocId(), starTreeNode.getEndDocId());
-        // Only set the global remaining predicate columns once because we traverse the tree with BFS, so the first leaf
-        // node always have all the remaining predicate columns
-        if (!globalRemainingPredicateColumnsSet) {
-          if (!remainingPredicateColumns.isEmpty()) {
-            globalRemainingPredicateColumns = new HashSet<>(remainingPredicateColumns);
-          }
-          globalRemainingPredicateColumnsSet = true;
-        }
         continue;
       }
 
@@ -257,8 +259,8 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
       // Only read star-node when the dimension is not in the global remaining predicate columns or group-by columns
       // because we cannot use star-node in such cases
       StarTreeNode starNode = null;
-      if (!globalRemainingPredicateColumns.contains(childDimension) && !remainingGroupByColumns.contains(
-          childDimension)) {
+      if ((globalRemainingPredicateColumns == null || !globalRemainingPredicateColumns.contains(childDimension))
+          && !remainingGroupByColumns.contains(childDimension)) {
         starNode = starTreeNode.getChildForDimensionValue(StarTreeNode.ALL);
       }
 
@@ -287,18 +289,22 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
           // star-node if so
           if (starNode != null && numMatchingDictIds >= numChildren - 1) {
             List<StarTreeNode> matchingChildNodes = new ArrayList<>();
+            boolean findLeafChildNode = false;
             while (childrenIterator.hasNext()) {
               StarTreeNode childNode = childrenIterator.next();
               if (matchingDictIds.contains(childNode.getDimensionValue())) {
                 matchingChildNodes.add(childNode);
+                findLeafChildNode |= childNode.isLeaf();
               }
             }
             if (matchingChildNodes.size() == numChildren - 1) {
               // All the child nodes (except for the star-node) match the predicate, use the star-node
               queue.add(starNode);
+              findLeafNode |= starNode.isLeaf();
             } else {
               // Some child nodes do not match the predicate, use the matching child nodes
               queue.addAll(matchingChildNodes);
+              findLeafNode |= findLeafChildNode;
             }
           } else {
             // Cannot use the star-node, use the matching child nodes
@@ -306,6 +312,7 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
               StarTreeNode childNode = childrenIterator.next();
               if (matchingDictIds.contains(childNode.getDimensionValue())) {
                 queue.add(childNode);
+                findLeafNode |= childNode.isLeaf();
               }
             }
           }
@@ -318,6 +325,7 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
             // Child node might be null because the matching dictionary id might not exist under this branch
             if (childNode != null) {
               queue.add(childNode);
+              findLeafNode |= childNode.isLeaf();
             }
           }
         }
@@ -327,6 +335,7 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
         if (starNode != null) {
           // Star-node exists, use it
           queue.add(starNode);
+          findLeafNode |= starNode.isLeaf();
         } else {
           // Star-node does not exist or cannot be used, add all non-star nodes to the queue
           Iterator<? extends StarTreeNode> childrenIterator = starTreeNode.getChildrenIterator();
@@ -334,13 +343,15 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
             StarTreeNode childNode = childrenIterator.next();
             if (childNode.getDimensionValue() != StarTreeNode.ALL) {
               queue.add(childNode);
+              findLeafNode |= childNode.isLeaf();
             }
           }
         }
       }
     }
 
-    return new StarTreeResult(matchingDocIds, globalRemainingPredicateColumns);
+    return new StarTreeResult(matchingDocIds,
+        globalRemainingPredicateColumns != null ? globalRemainingPredicateColumns : Collections.emptySet());
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/BaseSingleTreeBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/BaseSingleTreeBuilder.java
@@ -380,12 +380,12 @@ abstract class BaseSingleTreeBuilder implements SingleTreeBuilder {
         nodeDimensionValue = dimensionValue;
       }
     }
-    TreeNode laseNode = getNewNode();
-    laseNode._dimensionId = dimensionId;
-    laseNode._dimensionValue = nodeDimensionValue;
-    laseNode._startDocId = nodeStartDocId;
-    laseNode._endDocId = endDocId;
-    nodes.put(nodeDimensionValue, laseNode);
+    TreeNode lastNode = getNewNode();
+    lastNode._dimensionId = dimensionId;
+    lastNode._dimensionValue = nodeDimensionValue;
+    lastNode._startDocId = nodeStartDocId;
+    lastNode._endDocId = endDocId;
+    nodes.put(nodeDimensionValue, lastNode);
     return nodes;
   }
 


### PR DESCRIPTION
This bug was introduced in #9667

When the predicate matches all the non-star nodes under a branch, we can use the star-node if it exists and the dimension is not included in the remaining predicate and group-by. In the existing code we update the global remaining predicate too late, and the branches before the update can mistakenly use the star-node even though the dimension is included in the remaining predicate.

This PR fixes that behavior by tracking whether we have added leaf node into the queue, so that we can update the global remaining predicate before traversing any child of that dimension.

Added a hard-coded query in `StarTreeClusterIntegrationTest` to test this behavior. Also print the random seed when test fails to make it much easier to reproduce.

This also fixes #9945 