### PR TITLE
[multistage][cleanup] clean up opChain wake up call API

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/MailboxService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/MailboxService.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import java.util.function.Consumer;
 import org.apache.pinot.query.mailbox.channel.ChannelManager;
 import org.apache.pinot.query.mailbox.channel.GrpcMailboxServer;
+import org.apache.pinot.query.runtime.operator.OpChainId;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -55,12 +56,12 @@ public class MailboxService {
   private final String _hostname;
   private final int _port;
   private final PinotConfiguration _config;
-  private final Consumer<String> _receiveMailCallback;
+  private final Consumer<OpChainId> _receiveMailCallback;
   private final ChannelManager _channelManager = new ChannelManager();
 
   private GrpcMailboxServer _grpcMailboxServer;
 
-  public MailboxService(String hostname, int port, PinotConfiguration config, Consumer<String> receiveMailCallback) {
+  public MailboxService(String hostname, int port, PinotConfiguration config, Consumer<OpChainId> receiveMailCallback) {
     _hostname = hostname;
     _port = port;
     _config = config;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainScheduler.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainScheduler.java
@@ -22,6 +22,7 @@ import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.query.runtime.operator.OpChain;
+import org.apache.pinot.query.runtime.operator.OpChainId;
 
 
 /**
@@ -52,12 +53,12 @@ public interface OpChainScheduler {
   void yield(OpChain opChain);
 
   /**
-   * A callback called whenever data is received for the given mailbox. This can be used by the scheduler
+   * A callback called whenever data is received for the given opChain. This can be used by the scheduler
    * implementations to re-scheduled suspended OpChains. This method may be called for an OpChain that has not yet
    * been scheduled, or an OpChain that has already been de-registered.
-   * @param mailboxId the mailbox ID
+   * @param opChainId the {@link OpChain} ID
    */
-  void onDataAvailable(String mailboxId);
+  void onDataAvailable(OpChainId opChainId);
 
   /**
    * Returns an OpChain that is ready to be run by {@link OpChainSchedulerService}, waiting for the given time if

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -26,6 +26,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pinot.core.util.trace.TraceRunnable;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.operator.OpChain;
+import org.apache.pinot.query.runtime.operator.OpChainId;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -152,14 +153,13 @@ public class OpChainSchedulerService extends AbstractExecutionThreadService {
   }
 
   /**
-   * This method should be called whenever data is available in a given mailbox.
-   * Implementations of this method should be idempotent, it may be called in the
-   * scenario that no mail is available.
+   * This method should be called whenever data is available for an {@link OpChain} to consume.
+   * Implementations of this method should be idempotent, it may be called in the scenario that no data is available.
    *
-   * @param mailboxId the identifier of the mailbox that now has data
+   * @param opChainId the identifier of the operator chain
    */
-  public final void onDataAvailable(String mailboxId) {
-    _scheduler.onDataAvailable(mailboxId);
+  public final void onDataAvailable(OpChainId opChainId) {
+    _scheduler.onDataAvailable(opChainId);
   }
 
   // TODO: remove this method after we pipe down the proper executor pool to the v1 engine

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/RoundRobinScheduler.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/RoundRobinScheduler.java
@@ -35,7 +35,6 @@ import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.pinot.query.mailbox.MailboxIdUtils;
 import org.apache.pinot.query.runtime.operator.OpChain;
 import org.apache.pinot.query.runtime.operator.OpChainId;
 import org.slf4j.Logger;
@@ -191,12 +190,11 @@ public class RoundRobinScheduler implements OpChainScheduler {
   }
 
   @Override
-  public void onDataAvailable(String mailboxId) {
-    OpChainId opChainId = MailboxIdUtils.toOpChainId(mailboxId);
+  public void onDataAvailable(OpChainId opChainId) {
     // If this chain isn't alive as per the scheduler, don't do anything. If the OpChain is registered after this, it
     // will anyways be scheduled to run since new OpChains are run immediately.
     if (!_aliveChains.containsKey(opChainId)) {
-      trace("got mail, but the OpChain is not registered so ignoring the event " + mailboxId);
+      trace("woken up but the OpChain is not registered so ignoring the event: " + opChainId);
       return;
     }
     _lock.lock();
@@ -217,7 +215,7 @@ public class RoundRobinScheduler implements OpChainScheduler {
     } finally {
       _lock.unlock();
     }
-    trace("got mail for " + mailboxId);
+    trace("got data for " + opChainId);
   }
 
   @Override

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/MailboxServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/mailbox/MailboxServiceTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.query.runtime.operator.OpChainId;
 import org.apache.pinot.query.runtime.operator.OperatorTestUtil;
 import org.apache.pinot.query.service.QueryConfig;
 import org.apache.pinot.query.testutils.QueryTestUtils;
@@ -46,7 +47,7 @@ public class MailboxServiceTest {
   private static final DataSchema DATA_SCHEMA =
       new DataSchema(new String[]{"testColumn"}, new ColumnDataType[]{ColumnDataType.INT});
 
-  private final AtomicReference<Consumer<String>> _receiveMailCallback1 = new AtomicReference<>();
+  private final AtomicReference<Consumer<OpChainId>> _receiveMailCallback1 = new AtomicReference<>();
 
   private MailboxService _mailboxService1;
   private MailboxService _mailboxService2;
@@ -58,7 +59,7 @@ public class MailboxServiceTest {
     PinotConfiguration config = new PinotConfiguration(
         Collections.singletonMap(QueryConfig.KEY_OF_MAX_INBOUND_QUERY_DATA_BLOCK_SIZE_BYTES, 4_000_000));
     _mailboxService1 = new MailboxService("localhost", QueryTestUtils.getAvailablePort(), config,
-        mailboxId -> _receiveMailCallback1.get().accept(mailboxId));
+        opChainId -> _receiveMailCallback1.get().accept(opChainId));
     _mailboxService1.start();
     _mailboxService2 = new MailboxService("localhost", QueryTestUtils.getAvailablePort(), config, mailboxId -> {
     });

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/RoundRobinSchedulerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/RoundRobinSchedulerTest.java
@@ -88,7 +88,7 @@ public class RoundRobinSchedulerTest {
     // When Op-Chain is done executing, yield is called
     _scheduler.yield(chain);
     // When data is received, callback is called
-    _scheduler.onDataAvailable(MAILBOX_1);
+    _scheduler.onDataAvailable(MailboxIdUtils.toOpChainId(MAILBOX_1));
     // next should return the OpChain immediately after the callback
     Assert.assertEquals(_scheduler.next(DEFAULT_POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS), chain);
     // Say the OpChain is done, then a de-register will be called
@@ -160,9 +160,9 @@ public class RoundRobinSchedulerTest {
     _scheduler.yield(chain3);
     _scheduler.yield(chain2);
     // Data may be received in arbitrary order
-    _scheduler.onDataAvailable(MAILBOX_2);
-    _scheduler.onDataAvailable(MAILBOX_3);
-    _scheduler.onDataAvailable(MAILBOX_1);
+    _scheduler.onDataAvailable(MailboxIdUtils.toOpChainId(MAILBOX_2));
+    _scheduler.onDataAvailable(MailboxIdUtils.toOpChainId(MAILBOX_3));
+    _scheduler.onDataAvailable(MailboxIdUtils.toOpChainId(MAILBOX_1));
     // Subsequent polls would be in the order the callback was processed. A callback here is said to be "processed"
     // if it has successfully returned.
     Assert.assertEquals(_scheduler.next(DEFAULT_POLL_TIMEOUT_MS, TimeUnit.MILLISECONDS), chain2);


### PR DESCRIPTION
Summary
===
OpChainSchedulerService now accepts OpChain ID for onDataAvailable
- decouple Mailbox concept from OpChain
- MailboxService use callback method that accepts directly OpChainID instead of MailboxID

TODO
===
- we should decouple MailboxService callback into --> mailboxID --> opChainID lookup method and onDataAvailable callback method 
- allow non-mailbox based wake up of OpChain for example local subquery result using pipeline breaker operator