### PR TITLE
Fix #10713 by considering tableConfig.indexingConfig.sortedColumns as…

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/column/PhysicalColumnIndexContainer.java
@@ -47,6 +47,9 @@ public final class PhysicalColumnIndexContainer implements ColumnIndexContainer 
     String columnName = metadata.getColumnName();
 
     FieldIndexConfigs fieldIndexConfigs = indexLoadingConfig.getFieldIndexConfig(columnName);
+    if (fieldIndexConfigs == null) {
+      fieldIndexConfigs = FieldIndexConfigs.EMPTY;
+    }
 
     _readersByIndex = new HashMap<>();
     for (IndexType<?, ?, ?> indexType : IndexService.getInstance().getAllIndexes()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
@@ -24,7 +24,6 @@ import com.google.common.collect.Sets;
 import java.io.File;
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
@@ -423,7 +422,7 @@ public class DictionaryIndexType
         ? Lists.newArrayList()
         : tableConfig.getFieldConfigList();
 
-    List<FieldConfig> configsToUpdate = new ArrayList<>();
+    Set<FieldConfig> configsToUpdate = new HashSet<>();
     for (FieldConfig fieldConfig : fieldConfigList) {
       // skip further computation of field configs which already has RAW encodingType
       if (fieldConfig.getEncodingType() == FieldConfig.EncodingType.RAW) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
@@ -402,6 +402,15 @@ public class DictionaryIndexType
           throws IOException, IndexReaderConstraintException {
       return DictionaryIndexType.read(dataBuffer, metadata, indexConfig);
     }
+
+    @Override
+    public Dictionary createIndexReader(SegmentDirectory.Reader segmentReader,
+        FieldIndexConfigs fieldIndexConfigs, ColumnMetadata metadata)
+        throws IOException, IndexReaderConstraintException {
+      //  Contrary to other indexes, Dictionary doesn't really care about its config
+      //  if there is a buffer for this index, it is read even if the config explicitly ask to disable it.
+      return createIndexReader(segmentReader, fieldIndexConfigs, metadata, true);
+    }
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/inverted/InvertedIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/inverted/InvertedIndexType.java
@@ -156,13 +156,15 @@ public class InvertedIndexType
      */
     @Override
     public InvertedIndexReader createIndexReader(SegmentDirectory.Reader segmentReader,
-        FieldIndexConfigs fieldIndexConfigs, ColumnMetadata metadata)
+        FieldIndexConfigs fieldIndexConfigs, ColumnMetadata metadata, boolean prioritizeBuffer)
         throws IOException, IndexReaderConstraintException {
-      if (fieldIndexConfigs == null || !fieldIndexConfigs.getConfig(StandardIndexes.inverted()).isEnabled()) {
+      boolean disabled = fieldIndexConfigs.getConfig(StandardIndexes.inverted()).isDisabled();
+      String columnName = metadata.getColumnName();
+      if (disabled && (!prioritizeBuffer || !segmentReader.hasIndexFor(columnName, StandardIndexes.inverted()))) {
         return null;
       }
       if (!metadata.hasDictionary()) {
-        throw new IllegalStateException("Column " + metadata.getColumnName() + " cannot be indexed by an inverted "
+        throw new IllegalStateException("Column " + columnName + " cannot be indexed by an inverted "
             + "index if it has no dictionary");
       }
       if (metadata.isSorted() && metadata.isSingleValue()) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/DictionaryIndexConfig.java
@@ -67,7 +67,7 @@ public class DictionaryIndexConfig extends IndexConfig {
       return false;
     }
     DictionaryIndexConfig that = (DictionaryIndexConfig) o;
-    return _onHeap == that._onHeap && _useVarLengthDictionary == that._useVarLengthDictionary;
+    return super.equals(that) && _onHeap == that._onHeap && _useVarLengthDictionary == that._useVarLengthDictionary;
   }
 
   @Override


### PR DESCRIPTION
This is a #10713 bugfix. As explained there, the problem occurs when user specifies that the column should not have a dictionary but that column is also included as a sorted column.

In that case, pre `index-spi` we just ignored the `noDictionaryColumns`, but the newer code honored the config.
An alternative is to read the dictionary even if the config says it should be disabled.
But I think is more difficult to make mistakes if we actually introduce this (probably undesired) special case when reading the config in the old syntax.

Therefore this PR modifies the deserializer used by DictionaryIndexType to add the following logic:
- If the user disabled the dictionary using the older config BUT set the same column as the sorted column, the DictionaryConfig for that column is considered enabled.
- If the user disabled the dictionary using the new syntax BUT set the same column as a sorted column, an error is thrown saying that the sorted column must be dictionary encoded.

By doing that we preserve backward compatibility while we encourage people to use a coherent TableConfig once they migrate to the new configuration syntax.

There are still cases where the column can be considered sorted even if it is not specified in the table config. For example, if the schema change and the sorted column is removed but the segments were not reloaded or if by chance a column is sorted in some specific segments (including segments with only 1 row). This PR also changes the way indexes are read. By default, in case the metadata contains a buffer for the index, it will be loaded even if the config says otherwise.