### PR TITLE
Making NormalizedDateSegmentNameGenerator use joda time to keep consistency other time handling

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
@@ -132,14 +132,15 @@ public class NormalizedDateSegmentNameGenerator implements SegmentNameGenerator 
    */
   public String getNormalizedDate(Object timeValue) {
     if (_inputTimeUnit != null) {
-      return new DateTime(_inputTimeUnit.toMillis(Long.parseLong(timeValue.toString()))).toString(_outputSDF.getDateTimeFormatter());
+      return new DateTime(_inputTimeUnit.toMillis(Long.parseLong(timeValue.toString()))).toString(
+          _outputSDF.getDateTimeFormatter());
     } else {
       try {
-        return _inputSDF.getDateTimeFormatter().parseDateTime(timeValue.toString()).toString(_outputSDF.getDateTimeFormatter());
+        return _inputSDF.getDateTimeFormatter().parseDateTime(timeValue.toString())
+            .toString(_outputSDF.getDateTimeFormatter());
       } catch (Exception e) {
-        throw new RuntimeException(String
-            .format("Caught exception while parsing simple date format: %s with value: %s", _inputSDF.getSdfPattern(),
-                timeValue), e);
+        throw new RuntimeException(String.format("Caught exception while parsing simple date format: %s with value: %s",
+            _inputSDF.getSdfPattern(), timeValue), e);
       }
     }
   }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGenerator.java
@@ -19,15 +19,14 @@
 package org.apache.pinot.segment.spi.creator.name;
 
 import com.google.common.base.Preconditions;
-import java.text.ParseException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
-import java.util.TimeZone;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFieldSpec.TimeFormat;
+import org.apache.pinot.spi.data.DateTimeFormatPatternSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
+import org.joda.time.DateTime;
 
 
 /**
@@ -46,11 +45,11 @@ public class NormalizedDateSegmentNameGenerator implements SegmentNameGenerator 
   private final boolean _appendUUIDToSegmentName;
 
   // For APPEND tables
-  private final SimpleDateFormat _outputSDF;
+  private final DateTimeFormatPatternSpec _outputSDF;
   // For EPOCH time format
   private final TimeUnit _inputTimeUnit;
   // For SIMPLE_DATE_FORMAT time format
-  private final SimpleDateFormat _inputSDF;
+  private final DateTimeFormatPatternSpec _inputSDF;
 
   public NormalizedDateSegmentNameGenerator(String tableName, @Nullable String segmentNamePrefix,
       boolean excludeSequenceId, @Nullable String pushType, @Nullable String pushFrequency,
@@ -78,12 +77,13 @@ public class NormalizedDateSegmentNameGenerator implements SegmentNameGenerator 
     // Include time info for APPEND push type
     if (_appendPushType) {
       // For HOURLY push frequency, include hours into output format
+      String sdfPattern;
       if (PUSH_FREQUENCY_HOURLY.equalsIgnoreCase(pushFrequency)) {
-        _outputSDF = new SimpleDateFormat("yyyy-MM-dd-HH");
+        sdfPattern = "yyyy-MM-dd-HH";
       } else {
-        _outputSDF = new SimpleDateFormat("yyyy-MM-dd");
+        sdfPattern = "yyyy-MM-dd";
       }
-      _outputSDF.setTimeZone(TimeZone.getTimeZone("UTC"));
+      _outputSDF = new DateTimeFormatPatternSpec(DateTimeFieldSpec.TimeFormat.SIMPLE_DATE_FORMAT, sdfPattern, "UTC");
 
       // Parse input time format: 'EPOCH'/'TIMESTAMP' or 'SIMPLE_DATE_FORMAT' using pattern
       Preconditions.checkArgument(dateTimeFormatSpec != null,
@@ -99,8 +99,7 @@ public class NormalizedDateSegmentNameGenerator implements SegmentNameGenerator 
             "Must provide pattern for SIMPLE_DATE_FORMAT for NormalizedDateSegmentNameGenerator. Common problem: "
                 + "the format spec in timeColumnName schema is SIMPLE_DATE_FORMAT but pattern is missing");
         _inputTimeUnit = null;
-        _inputSDF = new SimpleDateFormat(dateTimeFormatSpec.getSDFPattern());
-        _inputSDF.setTimeZone(TimeZone.getTimeZone("UTC"));
+        _inputSDF = dateTimeFormatSpec.getDateTimeFormatPattenSpec();
       }
     } else {
       _outputSDF = null;
@@ -133,13 +132,13 @@ public class NormalizedDateSegmentNameGenerator implements SegmentNameGenerator 
    */
   public String getNormalizedDate(Object timeValue) {
     if (_inputTimeUnit != null) {
-      return _outputSDF.format(new Date(_inputTimeUnit.toMillis(Long.parseLong(timeValue.toString()))));
+      return new DateTime(_inputTimeUnit.toMillis(Long.parseLong(timeValue.toString()))).toString(_outputSDF.getDateTimeFormatter());
     } else {
       try {
-        return _outputSDF.format(_inputSDF.parse(timeValue.toString()));
-      } catch (ParseException e) {
+        return _inputSDF.getDateTimeFormatter().parseDateTime(timeValue.toString()).toString(_outputSDF.getDateTimeFormatter());
+      } catch (Exception e) {
         throw new RuntimeException(String
-            .format("Caught exception while parsing simple date format: %s with value: %s", _inputSDF.toPattern(),
+            .format("Caught exception while parsing simple date format: %s with value: %s", _inputSDF.getSdfPattern(),
                 timeValue), e);
       }
     }
@@ -157,13 +156,13 @@ public class NormalizedDateSegmentNameGenerator implements SegmentNameGenerator 
       stringBuilder.append(", excludeSequenceId=true");
     }
     if (_outputSDF != null) {
-      stringBuilder.append(", outputSDF=").append(_outputSDF.toPattern());
+      stringBuilder.append(", outputSDF=").append(_outputSDF.getSdfPattern());
     }
     if (_inputTimeUnit != null) {
       stringBuilder.append(", inputTimeUnit=").append(_inputTimeUnit);
     }
     if (_inputSDF != null) {
-      stringBuilder.append(", inputSDF=").append(_inputSDF.toPattern());
+      stringBuilder.append(", inputSDF=").append(_inputSDF.getSdfPattern());
     }
     return stringBuilder.toString();
   }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGeneratorTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/NormalizedDateSegmentNameGeneratorTest.java
@@ -215,6 +215,13 @@ public class NormalizedDateSegmentNameGeneratorTest {
         "myTable_1970-01-02_1970-01-04");
     assertEquals(segmentNameGenerator.generateSegmentName(VALID_SEQUENCE_ID, "1970-01-02", "1970-01-04"),
         "myTable_1970-01-02_1970-01-04_1");
+
+    // The following date time format will work with Joda time library and not java.text
+    segmentNameGenerator =
+        new NormalizedDateSegmentNameGenerator(TABLE_NAME, null, false, APPEND_PUSH_TYPE, DAILY_PUSH_FREQUENCY,
+            DateTimeFormatSpec.forSimpleDateFormat("yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZ"), null);
+    assertEquals(segmentNameGenerator.generateSegmentName(VALID_SEQUENCE_ID, "2023-01-01T12:00:00.111111111Z",
+        "2023-01-02T12:00:00.111111111Z"), "myTable_2023-01-01_2023-01-02_1");
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatSpec.java
@@ -257,6 +257,10 @@ public class DateTimeFormatSpec {
     return _patternSpec.getDateTimeFormatter();
   }
 
+  public DateTimeFormatPatternSpec getDateTimeFormatPattenSpec() {
+    return _patternSpec;
+  }
+
   /**
    * Converts the time in millis to the date time format.
    * <ul>


### PR DESCRIPTION
**Context**

For a Kafka ingestion use case, the time column was configured with a time format that was working as expected. But when configuring a minion task leveraging the SegmentProcessorFramework, a date format exception was thrown with the same exact time column/format: 
```
Caught exception while parsing simple date format: yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSSZ with value: 2023-03-07T21:18:05.072784135Z at org.apache.pinot.segment.spi.creator.name.NormalizedDateSegmentNameGenerator.getNormalizedDate(NormalizedDateSegmentNameGenerator.java:142)
```

Specifically the realtime ingestion was using `SegmentColumnarIndexCreator`, which uses joda time DateFormatter for parsing time format into epoch millis (See [SegmentColumnarIndexCreator](https://github.com/apache/pinot/blob/master/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java#L446)). 

But the minion task was configured to use the `NormalizedDateSegmentNameGenerator` which failed since it uses another date time format library, `java.text` `SimpleDateFormat`. This library seems to be stricter that the joda time library and if a time column values has literal ‘Z’ in it, the time format must have the `Z` in single quotes. E.g. "2023-01-01T12:00:00.111111111Z" needs a time format of "yyyy-MM-dd'T'HH:mm:ss.SSSSSSSSS’Z’" otherwise it will fail.

**Changes**

This PR makes the `NormalizedDateSegmentNameGenerator` also use the joda date time formatter. Joda is no longer maintained and `java.text` seems to be outdated. This PR aims to unify the time library until we are ready to make the switch to use the newer `java.time` library.

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature`
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
