### PR TITLE
Making segment replacement request apis backwards compatible

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/EndReplaceSegmentsRequest.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/EndReplaceSegmentsRequest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.restlet.resources;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.Collections;
 import java.util.List;
@@ -37,6 +38,11 @@ public class EndReplaceSegmentsRequest {
   private final List<String> _segmentsTo;
   private final Map<String, String> _customMap;
 
+  public EndReplaceSegmentsRequest(@JsonProperty("segmentsTo") @Nullable List<String> segmentsTo) {
+    this(segmentsTo, null);
+  }
+
+  @JsonCreator
   public EndReplaceSegmentsRequest(@JsonProperty("segmentsTo") @Nullable List<String> segmentsTo,
       @JsonProperty("customMap") @Nullable Map<String, String> customMap) {
     _segmentsTo = (segmentsTo == null) ? Collections.emptyList() : segmentsTo;

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/StartReplaceSegmentsRequest.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/StartReplaceSegmentsRequest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.restlet.resources;
 
+import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.google.common.base.Preconditions;
 import java.util.Collections;
@@ -39,6 +40,12 @@ public class StartReplaceSegmentsRequest {
   private final List<String> _segmentsTo;
   private final Map<String, String> _customMap;
 
+  public StartReplaceSegmentsRequest(@JsonProperty("segmentsFrom") @Nullable List<String> segmentsFrom,
+      @JsonProperty("segmentsTo") @Nullable List<String> segmentsTo) {
+    this(segmentsFrom, segmentsTo, null);
+  }
+
+  @JsonCreator
   public StartReplaceSegmentsRequest(@JsonProperty("segmentsFrom") @Nullable List<String> segmentsFrom,
       @JsonProperty("segmentsTo") @Nullable List<String> segmentsTo,
       @JsonProperty("customMap") @Nullable Map<String, String> customMap) {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/BaseMultipleSegmentsConversionExecutor.java
@@ -148,7 +148,7 @@ public abstract class BaseMultipleSegmentsConversionExecutor extends BaseTaskExe
               .collect(Collectors.toList());
       String lineageEntryId =
           SegmentConversionUtils.startSegmentReplace(context.getTableNameWithType(), context.getUploadURL(),
-              new StartReplaceSegmentsRequest(segmentsFrom, segmentsTo, null), context.getAuthProvider());
+              new StartReplaceSegmentsRequest(segmentsFrom, segmentsTo), context.getAuthProvider());
       context.setCustomContext(CUSTOM_SEGMENT_UPLOAD_CONTEXT_LINEAGE_ENTRY_ID, lineageEntryId);
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
@@ -120,7 +120,7 @@ public class ConsistentDataPushUtils {
       List<String> segmentsFrom = uriToSegmentsFrom.get(controllerUri);
 
       StartReplaceSegmentsRequest startReplaceSegmentsRequest =
-          new StartReplaceSegmentsRequest(segmentsFrom, segmentsTo, null);
+          new StartReplaceSegmentsRequest(segmentsFrom, segmentsTo);
       DEFAULT_RETRY_POLICY.attempt(() -> {
         try {
           SimpleHttpResponse response =


### PR DESCRIPTION
This [change](https://github.com/apache/pinot/pull/10679) introduced a new parameter to the segment replacement apis, which breaks previous usage. Making StartReplaceSegmentsRequest, EndReplaceSegmentsRequest backwards compatible. 

