### PR TITLE
[bugfix] Pinot config env substitution

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -119,7 +119,7 @@ public abstract class CommonsConfigurationUtils {
   }
 
   private static Object mapValue(String key, Configuration configuration) {
-    return Optional.of(configuration.getStringArray(key)).filter(values -> values.length > 1).<Object>map(
+    return Optional.of(configuration.getStringArray(key)).filter(values -> values.length > 0).<Object>map(
         values -> Arrays.stream(values).collect(Collectors.joining(",")))
         .orElseGet(() -> configuration.getProperty(key));
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.spi.env;
 
-import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -32,7 +31,6 @@ import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.MapConfiguration;
 import org.apache.commons.configuration.PropertiesConfiguration;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.utils.Obfuscator;
 
@@ -356,15 +354,10 @@ public class PinotConfiguration {
    * @return the property String value. Fallback to default value if missing.
    */
   public String getProperty(String name, String defaultValue) {
-    Object rawProperty = getRawProperty(name, defaultValue);
-    if (rawProperty instanceof List) {
-      return StringUtils.join(((ArrayList) rawProperty).toArray(), ',');
-    } else {
-      if (rawProperty == null) {
-        return null;
-      }
-      return rawProperty.toString();
+    if (!_configuration.containsKey(relaxPropertyName(name))) {
+      return defaultValue;
     }
+    return getProperty(name, _configuration);
   }
 
   private <T> T getProperty(String name, T defaultValue, Class<T> returnType) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
@@ -354,10 +354,7 @@ public class PinotConfiguration {
    * @return the property String value. Fallback to default value if missing.
    */
   public String getProperty(String name, String defaultValue) {
-    if (!_configuration.containsKey(relaxPropertyName(name))) {
-      return defaultValue;
-    }
-    return getProperty(name, _configuration);
+    return _configuration.getString(relaxPropertyName(name), defaultValue);
   }
 
   private <T> T getProperty(String name, T defaultValue, Class<T> returnType) {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java
@@ -207,6 +207,21 @@ public class PinotConfigurationTest {
     new PinotConfiguration(new PinotFSSpec());
   }
 
+  @Test
+  public void assertPropertyInterpolation() {
+    Map<String, Object> configs = new HashMap<>();
+    configs.put("config.property.1", "${sys:PINOT_CONFIGURATION_TEST_VAR}");
+
+    PinotConfiguration pinotConfiguration = new PinotConfiguration(configs);
+
+    System.setProperty("PINOT_CONFIGURATION_TEST_VAR", "val1");
+
+    Assert.assertEquals(pinotConfiguration.getProperty("config.property.1"), "val1");
+    Assert.assertEquals(pinotConfiguration.getProperty("config.property.1", "defaultVal"), "val1");
+
+    System.clearProperty("PINOT_CONFIGURATION_TEST_VAR");
+  }
+
   private void copyClasspathResource(String classpathResource, String target)
       throws IOException {
     try (InputStream inputStream = PinotConfigurationTest.class.getResourceAsStream(classpathResource)) {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java
@@ -218,6 +218,8 @@ public class PinotConfigurationTest {
 
     Assert.assertEquals(pinotConfiguration.getProperty("config.property.1"), "val1");
     Assert.assertEquals(pinotConfiguration.getProperty("config.property.1", "defaultVal"), "val1");
+    Map<String, Object> properties = pinotConfiguration.toMap();
+    Assert.assertEquals(properties.get("config.property.1"), "val1");
 
     System.clearProperty("PINOT_CONFIGURATION_TEST_VAR");
   }


### PR DESCRIPTION
Fix environment variable substitution for specific configs in #10719 

  - Fix `access.control.init.password` in controller config
  - Fix `controller.segment.fetcher.auth.token` in controller config
  - Fix `pinot.server.segment.fetcher.auth.token`, `pinot.server.segment.uploader.auth.token`, and `pinot.server.instance.auth.token` in server config

Changes

- Change `String PinotConfiguration.getProperty(String name, String defaultValue)` to call `String CompositeConfiguration.getProperty(String name, String defaultValue)` (which performs interpolation)
  - This will fix `access.control.init.password` since it uses this function
  - https://github.com/dd-willgan/pinot/blob/ea75326da28ef8c4176b463296a5067b6cac2261/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java#L827-L829
- Change `Object CommonConfigurationUtils mapValue(String key, Configuration configuration)` to utilize the output of `CompositeConfiguration.getStringArray` for greater than 0 outputs instead of greater than 1
  - This will fix all the `auth.token` configs, which are parsed by the AuthProviderUtils class https://github.com/dd-willgan/pinot/blob/ea75326da28ef8c4176b463296a5067b6cac2261/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthProviderUtils.java#L54
  - `toMap` eventually calls the `mapValue` function in question. As long as there 1 element in the output of `getStringArray` we can take the result and join with commas.

Tested

- Added a test case checking the behavior with system properties (also interpolated but easier to mock than environment variables)
- Built Pinot Docker image / deployed with Helm
  - Verified that environment variable substitution was working for `access.control.init.password` as default user when using ZK-based controller auth was working, previously it wasn't
  - Verified that the environment variable substitution was working for the auth tokens by creating a table, uploading a test segment to controller, and verifying that server was able to download the segment. Previously it wasn't since it didn't pass the right credentials when trying to download the segment from the controller