### PR TITLE
Enhance the instrumentation for a corner case where the query doesn't go through DocIdSetOp

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedDistinctOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedDistinctOperator.java
@@ -34,6 +34,7 @@ import org.apache.pinot.core.query.distinct.DistinctTable;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.trace.Tracing;
 
 
 /**
@@ -98,23 +99,16 @@ public class DictionaryBasedDistinctOperator extends BaseOperator<DistinctResult
       records = new ArrayList<>(actualLimit);
 
       _numDocsScanned = actualLimit;
-
-      for (int i = 0; i < actualLimit; i++) {
-        records.add(new Record(new Object[]{_dictionary.getInternal(i)}));
-      }
+      iterateOnDictionary(dictLength, actualLimit, records, true);
     } else {
       if (_dictionary.isSorted()) {
         records = new ArrayList<>(actualLimit);
         if (_isAscending) {
           _numDocsScanned = actualLimit;
-          for (int i = 0; i < actualLimit; i++) {
-            records.add(new Record(new Object[]{_dictionary.getInternal(i)}));
-          }
+          iterateOnDictionary(dictLength, actualLimit, records, true);
         } else {
           _numDocsScanned = actualLimit;
-          for (int i = dictLength - 1; i >= (dictLength - actualLimit); i--) {
-            records.add(new Record(new Object[]{_dictionary.getInternal(i)}));
-          }
+          iterateOnDictionary(dictLength, actualLimit, records, false);
         }
       } else {
         // DictionaryBasedDistinctOperator cannot handle nulls.
@@ -132,6 +126,20 @@ public class DictionaryBasedDistinctOperator extends BaseOperator<DistinctResult
     }
 
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
+  }
+
+  private void iterateOnDictionary(int dictLength, int actualLimit, List<Record> records, boolean isAscending) {
+    if (isAscending) {
+      for (int i = 0; i < actualLimit; i++) {
+        Tracing.ThreadAccountantOps.sampleAndCheckInterruptionPeriodically(i);
+        records.add(new Record(new Object[]{_dictionary.getInternal(i)}));
+      }
+    } else {
+      for (int i = dictLength - 1, j = 0; i >= (dictLength - actualLimit); i--, j++) {
+        Tracing.ThreadAccountantOps.sampleAndCheckInterruptionPeriodically(j);
+        records.add(new Record(new Object[]{_dictionary.getInternal(i)}));
+      }
+    }
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedDistinctOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedDistinctOperator.java
@@ -99,16 +99,16 @@ public class DictionaryBasedDistinctOperator extends BaseOperator<DistinctResult
       records = new ArrayList<>(actualLimit);
 
       _numDocsScanned = actualLimit;
-      iterateOnDictionary(dictLength, actualLimit, records, true);
+      iterateOnDictionary(dictLength, actualLimit, records);
     } else {
       if (_dictionary.isSorted()) {
         records = new ArrayList<>(actualLimit);
         if (_isAscending) {
           _numDocsScanned = actualLimit;
-          iterateOnDictionary(dictLength, actualLimit, records, true);
+          iterateOnDictionary(dictLength, actualLimit, records);
         } else {
           _numDocsScanned = actualLimit;
-          iterateOnDictionary(dictLength, actualLimit, records, false);
+          iterateOnDictionaryDesc(dictLength, actualLimit, records);
         }
       } else {
         // DictionaryBasedDistinctOperator cannot handle nulls.
@@ -128,17 +128,17 @@ public class DictionaryBasedDistinctOperator extends BaseOperator<DistinctResult
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 
-  private void iterateOnDictionary(int dictLength, int actualLimit, List<Record> records, boolean isAscending) {
-    if (isAscending) {
-      for (int i = 0; i < actualLimit; i++) {
-        Tracing.ThreadAccountantOps.sampleAndCheckInterruptionPeriodically(i);
-        records.add(new Record(new Object[]{_dictionary.getInternal(i)}));
-      }
-    } else {
-      for (int i = dictLength - 1, j = 0; i >= (dictLength - actualLimit); i--, j++) {
-        Tracing.ThreadAccountantOps.sampleAndCheckInterruptionPeriodically(j);
-        records.add(new Record(new Object[]{_dictionary.getInternal(i)}));
-      }
+  private void iterateOnDictionary(int dictLength, int actualLimit, List<Record> records) {
+    for (int i = 0; i < actualLimit; i++) {
+      Tracing.ThreadAccountantOps.sampleAndCheckInterruptionPeriodically(i);
+      records.add(new Record(new Object[]{_dictionary.getInternal(i)}));
+    }
+  }
+
+  private void iterateOnDictionaryDesc(int dictLength, int actualLimit, List<Record> records) {
+    for (int i = dictLength - 1, j = 0; i >= (dictLength - actualLimit); i--, j++) {
+      Tracing.ThreadAccountantOps.sampleAndCheckInterruptionPeriodically(j);
+      records.add(new Record(new Object[]{_dictionary.getInternal(i)}));
     }
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedServerQueryKilingTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedServerQueryKilingTest.java
@@ -157,7 +157,7 @@ private static final int NUM_DOCS = 3_000_000;
     serverConf.setProperty(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
         + CommonConstants.Accounting.CONFIG_OF_ALARMING_LEVEL_HEAP_USAGE_RATIO, 0.0f);
     serverConf.setProperty(CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "."
-        + CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO, 0.40f);
+        + CommonConstants.Accounting.CONFIG_OF_CRITICAL_LEVEL_HEAP_USAGE_RATIO, 0.25f);
     serverConf.setProperty(
         CommonConstants.PINOT_QUERY_SCHEDULER_PREFIX + "." + CommonConstants.Accounting.CONFIG_OF_FACTORY_NAME,
         "org.apache.pinot.core.accounting.PerQueryCPUMemAccountantFactory");
@@ -225,7 +225,6 @@ private static final int NUM_DOCS = 3_000_000;
       throws Exception {
     JsonNode queryResponse = postQuery(OOM_QUERY_2);
     LOGGER.info("testDigestOOM: {}", queryResponse);
-//    System.out.println(queryResponse.get("exceptions").toString());
     Assert.assertTrue(queryResponse.get("exceptions").toString().contains("QueryCancelledException"));
     Assert.assertTrue(queryResponse.get("exceptions").toString().contains("got killed because"));
   }


### PR DESCRIPTION
Previously when DictionaryBasedDistinctOperator is used the execution path won't go through DocIdSetOperator, which by passes the usage sampling and could cause OOM in production. Fixing this in the PR and added a testcase.