### PR TITLE
[multistage]10732: Fix for tabledoesnotexit error in multistage.

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -182,7 +182,7 @@ public class PinotQueryResource {
     List<TableConfig> tableConfigList = getListTableConfigs(tableNames);
     if (tableConfigList == null || tableConfigList.size() == 0) {
       return QueryException.getException(QueryException.TABLE_DOES_NOT_EXIST_ERROR, new Exception(
-          "Unable to find table in cluster")).toString();
+          "Unable to find table in cluster, table does not exist")).toString();
     }
 
     // When routing a query, there should be at least one common broker tenant for the table. However, the server

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -181,7 +181,7 @@ public class PinotQueryResource {
 
     List<TableConfig> tableConfigList = getListTableConfigs(tableNames);
     if (tableConfigList == null || tableConfigList.size() == 0) {
-      return QueryException.getException(QueryException.BROKER_RESOURCE_MISSING_ERROR, new Exception(
+      return QueryException.getException(QueryException.TABLE_DOES_NOT_EXIST_ERROR, new Exception(
           "Unable to find table in cluster")).toString();
     }
 


### PR DESCRIPTION
- minor fix for `TableDoesNotExistError` in v2 engine.


As per the [issue](https://github.com/apache/pinot/issues/10732) 

cc: @walterddr @ankitsultana 