### PR TITLE
[multistage] 10736: Fix for self join table names extraction in multistage

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -172,7 +172,11 @@ public class CalciteSqlParser {
     } else if (sqlNode instanceof SqlBasicCall) {
       if (((SqlBasicCall) sqlNode).getOperator() instanceof SqlAsOperator) {
         SqlNode firstOperand = ((SqlBasicCall) sqlNode).getOperandList().get(0);
-        tableNames.addAll(((SqlIdentifier) firstOperand).names);
+        if (firstOperand instanceof SqlSelect) {
+          tableNames.addAll(extractTableNamesFromNode(firstOperand));
+        } else {
+          tableNames.addAll(((SqlIdentifier) firstOperand).names);
+        }
       } else {
         for (SqlNode node : ((SqlBasicCall) sqlNode).getOperandList()) {
           tableNames.addAll(extractTableNamesFromNode(node));

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -3232,6 +3232,7 @@ public class CalciteSqlCompilerTest {
         CalciteSqlParser.compileToPinotQuery("SELECT key, COUNT(*) AS b FROM T3 JOIN T4 GROUP BY key"));
     Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = T2.key"));
 
+    // test for self join queries
     query = "SELECT T1.a FROM T1 JOIN(SELECT key FROM T1) as self ON T1.key=self.key";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     dataSource = pinotQuery.getDataSource();

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -3232,7 +3232,7 @@ public class CalciteSqlCompilerTest {
         CalciteSqlParser.compileToPinotQuery("SELECT key, COUNT(*) AS b FROM T3 JOIN T4 GROUP BY key"));
     Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = T2.key"));
 
-    // test for self join queries
+    // test for self join queries.
     query = "SELECT T1.a FROM T1 JOIN(SELECT key FROM T1) as self ON T1.key=self.key";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     dataSource = pinotQuery.getDataSource();

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -3138,6 +3138,14 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(tableNames.get(1), "tbl2");
     Assert.assertEquals(tableNames.get(2), "tbl3");
     Assert.assertEquals(tableNames.get(3), "tbl4");
+
+    // test for self join queries
+    query = "SELECT tbl1.a FROM tbl1 JOIN(SELECT a FROM tbl1) as self ON tbl1.a=self.a ";
+    sqlNodeAndOptions = RequestUtils.parseQuery(query);
+    tableNames = CalciteSqlParser.extractTableNamesFromNode(sqlNodeAndOptions.getSqlNode());
+    Assert.assertEquals(tableNames.size(), 2);
+    Assert.assertEquals(tableNames.get(0), "tbl1");
+    Assert.assertEquals(tableNames.get(1), "tbl1");
   }
 
   @Test
@@ -3223,5 +3231,21 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(rightSubquery,
         CalciteSqlParser.compileToPinotQuery("SELECT key, COUNT(*) AS b FROM T3 JOIN T4 GROUP BY key"));
     Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = T2.key"));
+
+    query = "SELECT T1.a FROM T1 JOIN(SELECT key FROM T1) as self ON T1.key=self.key";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    dataSource = pinotQuery.getDataSource();
+    Assert.assertNull(dataSource.getTableName());
+    Assert.assertNull(dataSource.getSubquery());
+    Assert.assertNotNull(dataSource.getJoin());
+    join = dataSource.getJoin();
+    Assert.assertEquals(join.getType(), JoinType.INNER);
+    Assert.assertEquals(join.getLeft().getTableName(), "T1");
+    right = join.getRight();
+    Assert.assertEquals(right.getTableName(), "self");
+    rightSubquery = right.getSubquery();
+    Assert.assertEquals(rightSubquery,
+        CalciteSqlParser.compileToPinotQuery("SELECT key FROM T1"));
+    Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = self.key"));
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -3248,5 +3248,21 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(rightSubquery,
         CalciteSqlParser.compileToPinotQuery("SELECT key FROM T1"));
     Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = self.key"));
+
+    query = "SELECT T1.a FROM T1 JOIN(SELECT key FROM T2) as self ON T1.key=self.key";
+    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    dataSource = pinotQuery.getDataSource();
+    Assert.assertNull(dataSource.getTableName());
+    Assert.assertNull(dataSource.getSubquery());
+    Assert.assertNotNull(dataSource.getJoin());
+    join = dataSource.getJoin();
+    Assert.assertEquals(join.getType(), JoinType.INNER);
+    Assert.assertEquals(join.getLeft().getTableName(), "T1");
+    right = join.getRight();
+    Assert.assertEquals(right.getTableName(), "self");
+    rightSubquery = right.getSubquery();
+    Assert.assertEquals(rightSubquery,
+        CalciteSqlParser.compileToPinotQuery("SELECT key FROM T2"));
+    Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = self.key"));
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -3248,22 +3248,5 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(rightSubquery,
         CalciteSqlParser.compileToPinotQuery("SELECT key FROM T1"));
     Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = self.key"));
-
-    // test for join queries with 'as' alias.
-    query = "SELECT T1.a FROM T1 JOIN(SELECT key FROM T2) as self ON T1.key=self.key";
-    pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    dataSource = pinotQuery.getDataSource();
-    Assert.assertNull(dataSource.getTableName());
-    Assert.assertNull(dataSource.getSubquery());
-    Assert.assertNotNull(dataSource.getJoin());
-    join = dataSource.getJoin();
-    Assert.assertEquals(join.getType(), JoinType.INNER);
-    Assert.assertEquals(join.getLeft().getTableName(), "T1");
-    right = join.getRight();
-    Assert.assertEquals(right.getTableName(), "self");
-    rightSubquery = right.getSubquery();
-    Assert.assertEquals(rightSubquery,
-        CalciteSqlParser.compileToPinotQuery("SELECT key FROM T2"));
-    Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = self.key"));
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -3249,7 +3249,7 @@ public class CalciteSqlCompilerTest {
         CalciteSqlParser.compileToPinotQuery("SELECT key FROM T1"));
     Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = self.key"));
 
-    // test for join queries with 'as' alias
+    // test for join queries with 'as' alias.
     query = "SELECT T1.a FROM T1 JOIN(SELECT key FROM T2) as self ON T1.key=self.key";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     dataSource = pinotQuery.getDataSource();

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -3249,6 +3249,7 @@ public class CalciteSqlCompilerTest {
         CalciteSqlParser.compileToPinotQuery("SELECT key FROM T1"));
     Assert.assertEquals(join.getCondition(), CalciteSqlParser.compileToExpression("T1.key = self.key"));
 
+    // test for join queries with 'as' alias
     query = "SELECT T1.a FROM T1 JOIN(SELECT key FROM T2) as self ON T1.key=self.key";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     dataSource = pinotQuery.getDataSource();


### PR DESCRIPTION
- Fix for extracting the table names in case of Self Join queries.
- Added test cases for Self Join queries.

As per the [issue](https://github.com/apache/pinot/issues/10736) 

cc: @walterddr @ankitsultana @xiangfu0 