### PR TITLE
bugfix: add missing properties when edit instance config

### DIFF
--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -47,6 +47,11 @@ declare module 'Models' {
     hostName: string;
     enabled: boolean;
     port: number;
+    grpcPort: number;
+    adminPort: number;
+    queryServicePort: number;
+    queryMailboxPort: number;
+    queriesDisabled: boolean;
     tags: Array<string>;
     pools?: string;
   };

--- a/pinot-controller/src/main/resources/app/pages/InstanceDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/InstanceDetails.tsx
@@ -120,6 +120,11 @@ const InstanceDetails = ({ match }: RouteComponentProps<Props>) => {
       type: instanceType,
       tags: instanceDetails.tags,
       pools: instanceDetails.pools,
+      grpcPort: instanceDetails.grpcPort,
+      adminPort: instanceDetails.adminPort,
+      queryServicePort: instanceDetails.queryServicePort,
+      queryMailboxPort: instanceDetails.queryMailboxPort,
+      queriesDisabled: instanceDetails.queriesDisabled,
     };
     setState({enabled: instanceDetails.enabled});
     setInstanceDetails(JSON.stringify(instancePutObj, null, 2));


### PR DESCRIPTION
When I tried to edit server instance config, I found that it forget to fetch some properties, such as grpcPort, adminPort, etc. When you save config, you will lost those properties. So I add missing properties when fetchInstanceData. 
Before:
<img width="957" alt="image" src="https://user-images.githubusercontent.com/38196564/236855026-b892c4b4-d044-42f3-bfbb-e500cc1d1f9c.png">
After:
<img width="1176" alt="image" src="https://user-images.githubusercontent.com/38196564/236859823-98891c67-d055-4b21-9c12-220e7a3c253e.png">

