### PR TITLE
Add description field to metrics in Pinot

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -93,6 +93,10 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
 
   public interface QueryPhase {
     String getQueryPhaseName();
+
+    default String getDescription() {
+      return "";
+    }
   }
 
   public interface Meter {
@@ -101,6 +105,10 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
     String getUnit();
 
     boolean isGlobal();
+
+    default String getDescription() {
+      return "";
+    }
   }
 
   public interface Gauge {
@@ -109,12 +117,18 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
     String getUnit();
 
     boolean isGlobal();
+    default String getDescription() {
+      return "";
+    }
   }
 
   public interface Timer {
     String getTimerName();
 
     boolean isGlobal();
+    default String getDescription() {
+      return "";
+    }
   }
 
   public void addPhaseTiming(String tableName, QP phase, long duration, TimeUnit timeUnit) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -27,7 +27,7 @@ import org.apache.pinot.common.Utils;
  */
 public enum ServerGauge implements AbstractMetrics.Gauge {
   VERSION("version", true),
-  DOCUMENT_COUNT("documents", false),
+  DOCUMENT_COUNT("documents", false, "Document Count"),
   SEGMENT_COUNT("segments", false),
   LLC_PARTITION_CONSUMING("state", false),
   HIGHEST_STREAM_OFFSET_CONSUMED("messages", false),
@@ -54,10 +54,16 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   private final String _unit;
   private final boolean _global;
 
+  private final String _description;
+
   ServerGauge(String unit, boolean global) {
+    this(unit, global, "");
+  }
+  ServerGauge(String unit, boolean global, String description) {
     _unit = unit;
     _global = global;
     _gaugeName = Utils.toCamelCase(name().toLowerCase());
+    _description = description;
   }
 
   @Override
@@ -78,5 +84,10 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   @Override
   public boolean isGlobal() {
     return _global;
+  }
+
+  @Override
+  public String getDescription() {
+    return _description;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -27,7 +27,7 @@ import org.apache.pinot.common.Utils;
  */
 public enum ServerGauge implements AbstractMetrics.Gauge {
   VERSION("version", true),
-  DOCUMENT_COUNT("documents", false, "Document Count"),
+  DOCUMENT_COUNT("documents", false),
   SEGMENT_COUNT("segments", false),
   LLC_PARTITION_CONSUMING("state", false),
   HIGHEST_STREAM_OFFSET_CONSUMED("messages", false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -59,6 +59,7 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   ServerGauge(String unit, boolean global) {
     this(unit, global, "");
   }
+
   ServerGauge(String unit, boolean global, String description) {
     _unit = unit;
     _global = global;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -85,9 +85,9 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   HEAP_PANIC_LEVEL_EXCEEDED("count", true),
 
   // Netty connection metrics
-  NETTY_CONNECTION_BYTES_RECEIVED("nettyConnection", true),
+  NETTY_CONNECTION_BYTES_RECEIVED("bytes", true),
   NETTY_CONNECTION_RESPONSES_SENT("nettyConnection", true),
-  NETTY_CONNECTION_BYTES_SENT("nettyConnection", true),
+  NETTY_CONNECTION_BYTES_SENT("bytes", true),
 
   // GRPC related metrics
   GRPC_QUERIES("grpcQueries", true),
@@ -101,11 +101,16 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   private final String _meterName;
   private final String _unit;
   private final boolean _global;
+  private final String _description;
 
   ServerMeter(String unit, boolean global) {
+    this(unit, global, "");
+  }
+  ServerMeter(String unit, boolean global, String description) {
     _unit = unit;
     _global = global;
     _meterName = Utils.toCamelCase(name().toLowerCase());
+    _description = description;
   }
 
   @Override
@@ -126,5 +131,10 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   @Override
   public boolean isGlobal() {
     return _global;
+  }
+
+  @Override
+  public String getDescription() {
+    return _description;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -106,6 +106,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   ServerMeter(String unit, boolean global) {
     this(unit, global, "");
   }
+
   ServerMeter(String unit, boolean global, String description) {
     _unit = unit;
     _global = global;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -85,9 +85,9 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   HEAP_PANIC_LEVEL_EXCEEDED("count", true),
 
   // Netty connection metrics
-  NETTY_CONNECTION_BYTES_RECEIVED("bytes", true),
+  NETTY_CONNECTION_BYTES_RECEIVED("nettyConnection", true),
   NETTY_CONNECTION_RESPONSES_SENT("nettyConnection", true),
-  NETTY_CONNECTION_BYTES_SENT("bytes", true),
+  NETTY_CONNECTION_BYTES_SENT("nettyConnection", true),
 
   // GRPC related metrics
   GRPC_QUERIES("grpcQueries", true),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMetrics.java
@@ -79,4 +79,10 @@ public class ServerMetrics extends AbstractMetrics<ServerQueryPhase, ServerMeter
   protected ServerGauge[] getGauges() {
     return ServerGauge.values();
   }
+
+  public static void main(String[] args) {
+    for (ServerMeter meter: ServerMeter.values()) {
+      System.out.println("|" + meter.getMeterName() + "( in " + meter.getUnit() + ") |" + meter.getDescription());
+    }
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMetrics.java
@@ -79,10 +79,4 @@ public class ServerMetrics extends AbstractMetrics<ServerQueryPhase, ServerMeter
   protected ServerGauge[] getGauges() {
     return ServerGauge.values();
   }
-
-  public static void main(String[] args) {
-    for (ServerMeter meter: ServerMeter.values()) {
-      System.out.println("|" + meter.getMeterName() + "( in " + meter.getUnit() + ") |" + meter.getDescription());
-    }
-  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
@@ -47,10 +47,16 @@ public enum ServerTimer implements AbstractMetrics.Timer {
 
   private final String _timerName;
   private final boolean _global;
+  private final String _description;
 
   ServerTimer(String unit, boolean global) {
+    this(unit, global, "");
+  }
+
+  ServerTimer(String unit, boolean global, String description) {
     _global = global;
     _timerName = Utils.toCamelCase(name().toLowerCase());
+    _description = description;
   }
 
   @Override
@@ -66,5 +72,10 @@ public enum ServerTimer implements AbstractMetrics.Timer {
   @Override
   public boolean isGlobal() {
     return _global;
+  }
+
+  @Override
+  public String getDescription() {
+    return _description;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.common.metrics;
 
-import java.util.Arrays;
 import org.apache.pinot.common.Utils;
 
 
@@ -81,5 +80,4 @@ public enum ServerTimer implements AbstractMetrics.Timer {
   public String getDescription() {
     return _description;
   }
-
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
@@ -85,7 +85,7 @@ public enum ServerTimer implements AbstractMetrics.Timer {
   public static void main(String[] args) {
     // Demo
     Arrays.stream(ServerTimer.values()).forEach(m -> {
-      System.out.println(m.getTimerName() + "\t" +  m.getDescription() + "\t" + "Timer");
+      System.out.println(m.getTimerName() + "\t" + m.getDescription() + "\t" + "Timer");
     });
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
@@ -82,10 +82,4 @@ public enum ServerTimer implements AbstractMetrics.Timer {
     return _description;
   }
 
-  public static void main(String[] args) {
-    // Demo
-    Arrays.stream(ServerTimer.values()).forEach(m -> {
-      System.out.println(m.getTimerName() + "\t" + m.getDescription() + "\t" + "Timer");
-    });
-  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.metrics;
 
+import java.util.Arrays;
 import org.apache.pinot.common.Utils;
 
 
@@ -26,24 +27,26 @@ import org.apache.pinot.common.Utils;
  *
  */
 public enum ServerTimer implements AbstractMetrics.Timer {
-  // metric tracking the freshness lag for consuming segments
-  FRESHNESS_LAG_MS("freshnessLagMs", false),
+  FRESHNESS_LAG_MS("freshnessLagMs", false, "Tracks the freshness lag for consuming segments. "
+      + "Computed as the time-period between when the data was last updated in the table and the current time."),
 
-  // The latency of sending the response from server to broker
-  NETTY_CONNECTION_SEND_RESPONSE_LATENCY("nettyConnection", false),
+  NETTY_CONNECTION_SEND_RESPONSE_LATENCY("nettyConnection", false,
+      "Latency of sending the response from server to broker. Computed as the time spent in sending "
+          + "response to brokers after the results are available."),
 
-  // Query cost (execution thread cpu time) for query processing on server
-  EXECUTION_THREAD_CPU_TIME_NS("nanoseconds", false),
+  EXECUTION_THREAD_CPU_TIME_NS("nanoseconds", false, "Query cost (execution thread cpu time) "
+      + "for query processing on server. Computed as time spent by all threads processing query and results "
+      + "(doesn't includes time spent in system activities)"),
 
-  // Query cost (system activities cpu time) for query processing on server
-  SYSTEM_ACTIVITIES_CPU_TIME_NS("nanoseconds", false),
+  SYSTEM_ACTIVITIES_CPU_TIME_NS("nanoseconds", false, "Query cost (system activities cpu time) "
+      + "for query processing on server. Computed as the time spent in processing query on the servers "
+      + "(only counts system acitivities such as GC, OS paging etc.)"),
 
-  // Query cost (response serialization cpu time) for query processing on server
-  RESPONSE_SER_CPU_TIME_NS("nanoseconds", false),
+  RESPONSE_SER_CPU_TIME_NS("nanoseconds", false, "Query cost (response serialization cpu time) "
+      + "for query processing on server. Computed as the time spent in serializing query response on servers"),
 
-  // Total query cost (thread cpu time + system activities cpu time + response serialization cpu time) for query
-  // processing on server
-  TOTAL_CPU_TIME_NS("nanoseconds", false);
+  TOTAL_CPU_TIME_NS("nanoseconds", false, "Total query cost (thread cpu time + system "
+      + "activities cpu time + response serialization cpu time) for query processing on server.");
 
   private final String _timerName;
   private final boolean _global;
@@ -77,5 +80,12 @@ public enum ServerTimer implements AbstractMetrics.Timer {
   @Override
   public String getDescription() {
     return _description;
+  }
+
+  public static void main(String[] args) {
+    // Demo
+    Arrays.stream(ServerTimer.values()).forEach(m -> {
+      System.out.println(m.getTimerName() + "\t" +  m.getDescription() + "\t" + "Timer");
+    });
   }
 }


### PR DESCRIPTION
This PR introduces a new `description` field in Pinot's metric abstraction model. 

* This allows a developer to add metrics related description/documentation directly in the code
* We can further automate metrics documentation generation using a standalone script
 
