### PR TITLE
[feature] Consider tierConfigs when assigning new offline segment

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -76,6 +76,9 @@ public class ControllerConf extends PinotConfiguration {
   public static final String CONTROLLER_RESOURCE_PACKAGES = "controller.restlet.api.resource.packages";
   public static final String DEFAULT_CONTROLLER_RESOURCE_PACKAGES = "org.apache.pinot.controller.api.resources";
 
+  // Consider tierConfigs when assigning new offline segment
+  public static final String CONTROLLER_ENABLE_TIERED_SEGMENT_ASSIGNMENT = "controller.segment.enableTieredAssignment";
+
   public enum ControllerMode {
     DUAL, PINOT_ONLY, HELIX_ONLY
   }
@@ -669,6 +672,14 @@ public class ControllerConf extends PinotConfiguration {
   public void setSegmentRelocatorFrequencyInSeconds(int segmentRelocatorFrequencyInSeconds) {
     setProperty(ControllerPeriodicTasksConf.DEPRECATED_SEGMENT_RELOCATOR_FREQUENCY_IN_SECONDS,
         Integer.toString(segmentRelocatorFrequencyInSeconds));
+  }
+
+  public boolean tieredSegmentAssignmentEnabled() {
+    return getProperty(CONTROLLER_ENABLE_TIERED_SEGMENT_ASSIGNMENT, false);
+  }
+
+  public void setTieredSegmentAssignmentEnabled(boolean enabled) {
+    setProperty(CONTROLLER_ENABLE_TIERED_SEGMENT_ASSIGNMENT, enabled);
   }
 
   public boolean tenantIsolationEnabled() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -114,6 +114,7 @@ import org.apache.pinot.common.minion.MinionTaskMetadataUtils;
 import org.apache.pinot.common.restlet.resources.EndReplaceSegmentsRequest;
 import org.apache.pinot.common.restlet.resources.RevertReplaceSegmentsRequest;
 import org.apache.pinot.common.tier.Tier;
+import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.common.tier.TierSegmentSelector;
 import org.apache.pinot.common.utils.BcryptUtils;
 import org.apache.pinot.common.utils.HashUtil;
@@ -217,6 +218,7 @@ public class PinotHelixResourceManager {
   private final boolean _enableBatchMessageMode;
   private final boolean _allowHLCTables;
   private final int _deletedSegmentsRetentionInDays;
+  private final boolean _enableTieredSegmentAssignment;
 
   private HelixManager _helixZkManager;
   private HelixAdmin _helixAdmin;
@@ -230,7 +232,7 @@ public class PinotHelixResourceManager {
 
   public PinotHelixResourceManager(String zkURL, String helixClusterName, @Nullable String dataDir,
       boolean isSingleTenantCluster, boolean enableBatchMessageMode, boolean allowHLCTables,
-      int deletedSegmentsRetentionInDays, LineageManager lineageManager) {
+      int deletedSegmentsRetentionInDays, boolean enableTieredSegmentAssignment, LineageManager lineageManager) {
     _helixZkURL = HelixConfig.getAbsoluteZkPathForHelix(zkURL);
     _helixClusterName = helixClusterName;
     _dataDir = dataDir;
@@ -238,6 +240,7 @@ public class PinotHelixResourceManager {
     _enableBatchMessageMode = enableBatchMessageMode;
     _deletedSegmentsRetentionInDays = deletedSegmentsRetentionInDays;
     _allowHLCTables = allowHLCTables;
+    _enableTieredSegmentAssignment = enableTieredSegmentAssignment;
     _instanceAdminEndpointCache =
         CacheBuilder.newBuilder().expireAfterWrite(CACHE_ENTRY_EXPIRE_TIME_HOURS, TimeUnit.HOURS)
             .build(new CacheLoader<String, String>() {
@@ -259,7 +262,7 @@ public class PinotHelixResourceManager {
     this(controllerConf.getZkStr(), controllerConf.getHelixClusterName(), controllerConf.getDataDir(),
         controllerConf.tenantIsolationEnabled(), controllerConf.getEnableBatchMessageMode(),
         controllerConf.getHLCTablesAllowed(), controllerConf.getDeletedSegmentsRetentionInDays(),
-        LineageManagerFactory.create(controllerConf));
+        controllerConf.tieredSegmentAssignmentEnabled(), LineageManagerFactory.create(controllerConf));
   }
 
   /**
@@ -2268,10 +2271,28 @@ public class PinotHelixResourceManager {
     try {
       TableConfig tableConfig = getTableConfig(tableNameWithType);
       Preconditions.checkState(tableConfig != null, "Failed to find table config for table: " + tableNameWithType);
+
+      List<Tier> sortedTiers = null;
+      Map<String, InstancePartitions> tierToInstancePartitionsMap = null;
+
+      // Initialize tier information only in case direct tier assignment is configured
+      if (_enableTieredSegmentAssignment && CollectionUtils.isNotEmpty(tableConfig.getTierConfigsList())) {
+        sortedTiers = TierConfigUtils.getSortedTiersForStorageType(tableConfig.getTierConfigsList(),
+            TierFactory.PINOT_SERVER_STORAGE_TYPE, _helixZkManager);
+        tierToInstancePartitionsMap =
+            TierConfigUtils.getTierToInstancePartitionsMap(tableNameWithType, sortedTiers, _helixZkManager);
+
+        // Update segment tier to support direct assignment for multiple data directories
+        updateSegmentTargetTier(tableNameWithType, segmentName, sortedTiers);
+      }
+
       Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap =
           fetchOrComputeInstancePartitions(tableNameWithType, tableConfig);
       SegmentAssignment segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(_helixZkManager, tableConfig);
       synchronized (getTableUpdaterLock(tableNameWithType)) {
+        final List<Tier> finalSortedTiers = sortedTiers;
+        final Map<String, InstancePartitions> finalTierToInstancePartitionsMap = tierToInstancePartitionsMap;
+
         HelixHelper.updateIdealState(_helixZkManager, tableNameWithType, idealState -> {
           assert idealState != null;
           Map<String, Map<String, String>> currentAssignment = idealState.getRecord().getMapFields();
@@ -2280,7 +2301,8 @@ public class PinotHelixResourceManager {
                 tableNameWithType);
           } else {
             List<String> assignedInstances =
-                segmentAssignment.assignSegment(segmentName, currentAssignment, instancePartitionsMap);
+                segmentAssignment.assignSegment(segmentName, currentAssignment, instancePartitionsMap,
+                    finalSortedTiers, finalTierToInstancePartitionsMap);
             LOGGER.info("Assigning segment: {} to instances: {} for table: {}", segmentName, assignedInstances,
                 tableNameWithType);
             currentAssignment.put(segmentName,

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineSegmentAssignment.java
@@ -32,19 +32,63 @@ import org.apache.pinot.controller.helix.core.assignment.segment.strategy.Segmen
 import org.apache.pinot.controller.helix.core.assignment.segment.strategy.SegmentAssignmentStrategyFactory;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.utils.RebalanceConfigConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
  * Segment assignment for offline table.
  */
 public class OfflineSegmentAssignment extends BaseSegmentAssignment {
+  private final Logger _logger = LoggerFactory.getLogger(getClass());
 
   @Override
   public List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
       Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap) {
+    // Fallback to default assignment
     InstancePartitions instancePartitions = instancePartitionsMap.get(InstancePartitionsType.OFFLINE);
     Preconditions.checkState(instancePartitions != null, "Failed to find OFFLINE instance partitions for table: %s",
         _tableNameWithType);
+    return doAssignSegment(segmentName, currentAssignment, instancePartitions);
+  }
+
+  @Override
+  public List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
+      Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap, @Nullable List<Tier> sortedTiers,
+      @Nullable Map<String, InstancePartitions> tierInstancePartitionsMap) {
+
+    _logger.info("Assigning segment: {} based on tier configuration for table: {}", segmentName, _tableNameWithType);
+
+    // Check if a new segment is eligible for any tier already
+    final Tier tier = SegmentAssignmentUtils.findTierForNewSegment(_tableNameWithType, sortedTiers, segmentName);
+    if (tier != null && tierInstancePartitionsMap.containsKey(tier.getName())) {
+      _logger.info("Segment: {} qualifies for tier: {}", segmentName, tier.getName());
+
+      // Finally delegate assignment to regular code
+      final InstancePartitions tierInstancePartitions = tierInstancePartitionsMap.get(tier.getName());
+      _logger.info("Assigning segment: {} with tier instance partitions: {} for table: {}", segmentName,
+          tierInstancePartitions, _tableNameWithType);
+
+      final List<String> instancesAssigned = doAssignSegment(segmentName, currentAssignment, tierInstancePartitions);
+      _logger.info("Assigned segment: {} to tier instances: {} for table: {}", segmentName, instancesAssigned,
+          _tableNameWithType);
+      return instancesAssigned;
+    }
+
+    // Fallback to default assignment
+    return assignSegment(segmentName, currentAssignment, instancePartitionsMap);
+  }
+
+  /**
+   * Assign segment to the specified instance partitions
+   *
+   * @param segmentName Name of the segment
+   * @param currentAssignment Current segment assignment of the table (map from segment name to instance state map)
+   * @param instancePartitions Instance partitions for the table
+   * @return
+   */
+  protected List<String> doAssignSegment(String segmentName,
+      Map<String, Map<String, String>> currentAssignment, InstancePartitions instancePartitions) {
     // Gets Segment assignment strategy for instance partitions
     SegmentAssignmentStrategy segmentAssignmentStrategy = SegmentAssignmentStrategyFactory
         .getSegmentAssignmentStrategy(_helixManager, _tableConfig, InstancePartitionsType.OFFLINE.toString(),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
@@ -34,6 +34,8 @@ import org.apache.pinot.controller.helix.core.assignment.segment.strategy.Segmen
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.apache.pinot.spi.utils.RebalanceConfigConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -72,6 +74,7 @@ import org.apache.pinot.spi.utils.RebalanceConfigConstants;
  * </ul>
  */
 public class RealtimeSegmentAssignment extends BaseSegmentAssignment {
+  private final Logger _logger = LoggerFactory.getLogger(getClass());
 
   @Override
   public List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
@@ -100,6 +103,14 @@ public class RealtimeSegmentAssignment extends BaseSegmentAssignment {
     _logger.info("Assigned segment: {} to instances: {} for table: {}", segmentName, instancesAssigned,
         _tableNameWithType);
     return instancesAssigned;
+  }
+
+  @Override
+  public List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
+      Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap, @Nullable List<Tier> unusedSortedTiers,
+      @Nullable Map<String, InstancePartitions> unusedTierInstancePartitionsMap) {
+    _logger.warn("Tiered assignment of CONSUMING segments is not supported, switching to default assignment");
+    return assignSegment(segmentName, currentAssignment, instancePartitionsMap);
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignment.java
@@ -53,6 +53,20 @@ public interface SegmentAssignment {
       Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap);
 
   /**
+   * Assigns segment to instances. Consider tier configuration if the latter is provided.
+   *
+   * @param segmentName Name of the segment to be assigned
+   * @param currentAssignment Current segment assignment of the table (map from segment name to instance state map)
+   * @param instancePartitionsMap Map from type (OFFLINE|CONSUMING|COMPLETED) to instance partitions
+   * @param sortedTiers List of Tiers sorted as per priority
+   * @param tierInstancePartitionsMap Map from tierName to instance partitions
+   * @return List of instances to assign the segment to
+   */
+  List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
+      Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap, @Nullable List<Tier> sortedTiers,
+      @Nullable Map<String, InstancePartitions> tierInstancePartitionsMap);
+
+  /**
    * Rebalances the segment assignment for a table.
    *
    * @param currentAssignment Current segment assignment of the table (map from segment name to instance state map)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
@@ -30,6 +30,7 @@ import java.util.PriorityQueue;
 import java.util.Set;
 import java.util.TreeMap;
 import javax.annotation.Nullable;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
 import org.apache.pinot.common.assignment.InstancePartitions;
@@ -406,6 +407,25 @@ public class SegmentAssignmentUtils {
     public Map<String, Map<String, String>> getNonTierSegmentAssignment() {
       return _nonTierSegmentAssignment;
     }
+  }
+
+  /**
+   * Checks tiers one-by-one to return the first one for which a newly registered segment qualifies
+   * @param tableNameWithType table to which the segment assignment belongs
+   * @param sortedTiers list of tiers, pre-sorted as per desired order by caller
+   * @param segmentName name of the new segment
+   * @return tier for which the segment qualifies, or null if segment doesn't belong to any tier
+   */
+  public static Tier findTierForNewSegment(String tableNameWithType, @Nullable List<Tier> sortedTiers,
+      String segmentName) {
+    if (CollectionUtils.isNotEmpty(sortedTiers)) {
+      for (Tier tier : sortedTiers) {
+        if (tier.getSegmentSelector().selectSegment(tableNameWithType, segmentName)) {
+          return tier;
+        }
+      }
+    }
+    return null;
   }
 
   /**

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerAssignmentTest.java
@@ -1,0 +1,134 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core;
+
+import static org.testng.Assert.assertEquals;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.tier.TierFactory;
+import org.apache.pinot.controller.ControllerConf;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.controller.utils.SegmentMetadataMockUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TierConfig;
+import org.apache.pinot.spi.config.tenant.Tenant;
+import org.apache.pinot.spi.config.tenant.TenantRole;
+import org.apache.pinot.spi.utils.CommonConstants.Helix;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+@Test(groups = "assignment")
+public class PinotHelixResourceManagerAssignmentTest extends ControllerTest {
+  private static final int NUM_BROKER_INSTANCES = 3;
+  private static final int NUM_OFFLINE_SERVER_INSTANCES = 2;
+  private static final int NUM_REALTIME_SERVER_INSTANCES = 2;
+  private static final int NUM_SERVER_INSTANCES = NUM_OFFLINE_SERVER_INSTANCES + NUM_REALTIME_SERVER_INSTANCES;
+  private static final String BROKER_TENANT_NAME = "brokerTenant";
+  private static final String SERVER_TENANT_NAME = "serverTenant";
+
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME);
+  private static final String REALTIME_TABLE_NAME = TableNameBuilder.REALTIME.tableNameWithType(RAW_TABLE_NAME);
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    startZk();
+
+    Map<String, Object> properties = getDefaultControllerConfiguration();
+    properties.put(ControllerConf.CONTROLLER_ENABLE_TIERED_SEGMENT_ASSIGNMENT, true);
+    properties.put(ControllerConf.CLUSTER_TENANT_ISOLATION_ENABLE, false);
+    startController(properties);
+
+    addFakeBrokerInstancesToAutoJoinHelixCluster(NUM_BROKER_INSTANCES, false);
+    addFakeServerInstancesToAutoJoinHelixCluster(NUM_SERVER_INSTANCES, false);
+
+    resetBrokerTags();
+    resetServerTags();
+  }
+
+  private void untagBrokers() {
+    for (String brokerInstance : _helixResourceManager.getAllInstancesForBrokerTenant(BROKER_TENANT_NAME)) {
+      _helixResourceManager.updateInstanceTags(brokerInstance, Helix.UNTAGGED_BROKER_INSTANCE, false);
+    }
+  }
+
+  private void resetBrokerTags() {
+    untagBrokers();
+    assertEquals(_helixResourceManager.getOnlineUnTaggedBrokerInstanceList().size(), NUM_BROKER_INSTANCES);
+    Tenant brokerTenant = new Tenant(TenantRole.BROKER, BROKER_TENANT_NAME, NUM_BROKER_INSTANCES, 0, 0);
+    _helixResourceManager.createBrokerTenant(brokerTenant);
+    assertEquals(_helixResourceManager.getOnlineUnTaggedBrokerInstanceList().size(), 0);
+  }
+
+  private void untagServers() {
+    for (String serverInstance : _helixResourceManager.getAllInstancesForServerTenant(SERVER_TENANT_NAME)) {
+      _helixResourceManager.updateInstanceTags(serverInstance, Helix.UNTAGGED_SERVER_INSTANCE, false);
+    }
+  }
+
+  private void resetServerTags() {
+    untagServers();
+    assertEquals(_helixResourceManager.getOnlineUnTaggedServerInstanceList().size(), NUM_SERVER_INSTANCES);
+    Tenant serverTenant =
+        new Tenant(TenantRole.SERVER, SERVER_TENANT_NAME, NUM_SERVER_INSTANCES, NUM_OFFLINE_SERVER_INSTANCES,
+            NUM_REALTIME_SERVER_INSTANCES);
+    _helixResourceManager.createServerTenant(serverTenant);
+    assertEquals(_helixResourceManager.getOnlineUnTaggedServerInstanceList().size(), 0);
+  }
+
+  @Test
+  public void testAssignTargetTier()
+      throws Exception {
+    TierConfig tierConfig =
+        new TierConfig("tier1", TierFactory.FIXED_SEGMENT_SELECTOR_TYPE, null, Collections.singletonList("testSegment"),
+            TierFactory.PINOT_SERVER_STORAGE_TYPE, SERVER_TENANT_NAME + "_OFFLINE", null, null);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setBrokerTenant(BROKER_TENANT_NAME)
+            .setTierConfigList(Collections.singletonList(tierConfig)).setServerTenant(SERVER_TENANT_NAME).build();
+    waitForEVToDisappear(tableConfig.getTableName());
+    _helixResourceManager.addTable(tableConfig);
+
+    String segmentName = "testSegment";
+    ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, OFFLINE_TABLE_NAME, new SegmentZKMetadata(segmentName));
+    _helixResourceManager.addNewSegment(OFFLINE_TABLE_NAME,
+        SegmentMetadataMockUtils.mockSegmentMetadata(OFFLINE_TABLE_NAME, "testSegment"), "downloadUrl");
+
+    List<SegmentZKMetadata> retrievedSegmentsZKMetadata =
+        _helixResourceManager.getSegmentsZKMetadata(OFFLINE_TABLE_NAME);
+    SegmentZKMetadata retrievedSegmentZKMetadata = retrievedSegmentsZKMetadata.get(0);
+    assertEquals(retrievedSegmentZKMetadata.getTier(), "tier1");
+  }
+
+  @AfterClass
+  public void tearDown() {
+    stopFakeInstances();
+    stopController();
+    stopZk();
+  }
+}


### PR DESCRIPTION
**Context**

Upon registering (pushing) metadata for offline segment the latter is unconditionally assigned to servers defined by `tenants.server` property, without considering `tierConfigs`. Only on rebalance (triggered by SegmentRelocator job) it will be "moved" to a proper tenant/tier. 

This behavior is not really convenient when table is refilled regularly as segments will initially end up in default "warm" tier, while preferably they shall be properly distributed from the very start. This change, controlled by a flag, fixes this behaviour and allows the segment to reside in a proper tenant/tier upon assignment.

**Changes**
1. Introduce new controller setting `controller.segment.enableTieredAssignment` that enables direct tenant/tier assignment.
2. Change interface of `SegmentAssigner.assignSegment` method to become similar to `rebalanceTable` one. Only implementation for OFFLINE segments has been customized. REALTIME segments are assigned as before.
3. Implemented a couple of unit tests to validate the behaviour.

cc: @klsince 

