### PR TITLE
Make the TimeUnit in the DATETRUNC function case insensitive.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeFunctions.java
@@ -557,7 +557,8 @@ public class DateTimeFunctions {
    */
   @ScalarFunction
   public static long dateTrunc(String unit, long timeValue) {
-    return dateTrunc(unit, timeValue, TimeUnit.MILLISECONDS, ISOChronology.getInstanceUTC(), TimeUnit.MILLISECONDS);
+    return dateTrunc(unit, timeValue, TimeUnit.MILLISECONDS.name(), ISOChronology.getInstanceUTC(),
+        TimeUnit.MILLISECONDS.name());
   }
 
   /**
@@ -565,12 +566,11 @@ public class DateTimeFunctions {
    *
    * @param unit truncate to unit (millisecond, second, minute, hour, day, week, month, quarter, year)
    * @param timeValue value to truncate
-   * @param inputTimeUnitStr TimeUnit of value, expressed in Java's joda TimeUnit
+   * @param inputTimeUnit TimeUnit of value, expressed in Java's joda TimeUnit
    * @return truncated timeValue in same TimeUnit as the input
    */
   @ScalarFunction
-  public static long dateTrunc(String unit, long timeValue, String inputTimeUnitStr) {
-    TimeUnit inputTimeUnit = TimeUnit.valueOf(inputTimeUnitStr);
+  public static long dateTrunc(String unit, long timeValue, String inputTimeUnit) {
     return dateTrunc(unit, timeValue, inputTimeUnit, ISOChronology.getInstanceUTC(), inputTimeUnit);
   }
 
@@ -579,13 +579,12 @@ public class DateTimeFunctions {
    *
    * @param unit truncate to unit (millisecond, second, minute, hour, day, week, month, quarter, year)
    * @param timeValue value to truncate
-   * @param inputTimeUnitStr TimeUnit of value, expressed in Java's joda TimeUnit
+   * @param inputTimeUnit TimeUnit of value, expressed in Java's joda TimeUnit
    * @param timeZone timezone of the input
    * @return truncated timeValue in same TimeUnit as the input
    */
   @ScalarFunction
-  public static long dateTrunc(String unit, long timeValue, String inputTimeUnitStr, String timeZone) {
-    TimeUnit inputTimeUnit = TimeUnit.valueOf(inputTimeUnitStr);
+  public static long dateTrunc(String unit, long timeValue, String inputTimeUnit, String timeZone) {
     return dateTrunc(unit, timeValue, inputTimeUnit, DateTimeUtils.getChronology(TimeZoneKey.getTimeZoneKey(timeZone)),
         inputTimeUnit);
   }
@@ -595,23 +594,24 @@ public class DateTimeFunctions {
    *
    * @param unit truncate to unit (millisecond, second, minute, hour, day, week, month, quarter, year)
    * @param timeValue value to truncate
-   * @param inputTimeUnitStr TimeUnit of value, expressed in Java's joda TimeUnit
+   * @param inputTimeUnit TimeUnit of value, expressed in Java's joda TimeUnit
    * @param timeZone timezone of the input
-   * @param outputTimeUnitStr TimeUnit to convert the output to
+   * @param outputTimeUnit TimeUnit to convert the output to
    * @return truncated timeValue
    *
    */
   @ScalarFunction
-  public static long dateTrunc(String unit, long timeValue, String inputTimeUnitStr, String timeZone,
-      String outputTimeUnitStr) {
-    return dateTrunc(unit, timeValue, TimeUnit.valueOf(inputTimeUnitStr),
-        DateTimeUtils.getChronology(TimeZoneKey.getTimeZoneKey(timeZone)), TimeUnit.valueOf(outputTimeUnitStr));
+  public static long dateTrunc(String unit, long timeValue, String inputTimeUnit, String timeZone,
+      String outputTimeUnit) {
+    return dateTrunc(unit, timeValue, inputTimeUnit,
+        DateTimeUtils.getChronology(TimeZoneKey.getTimeZoneKey(timeZone)), outputTimeUnit);
   }
 
-  private static long dateTrunc(String unit, long timeValue, TimeUnit inputTimeUnit, ISOChronology chronology,
-      TimeUnit outputTimeUnit) {
-    return outputTimeUnit.convert(DateTimeUtils.getTimestampField(chronology, unit)
-        .roundFloor(TimeUnit.MILLISECONDS.convert(timeValue, inputTimeUnit)), TimeUnit.MILLISECONDS);
+  private static long dateTrunc(String unit, long timeValue, String inputTimeUnit, ISOChronology chronology,
+      String outputTimeUnit) {
+    return TimeUnit.valueOf(outputTimeUnit.toUpperCase()).convert(DateTimeUtils.getTimestampField(chronology, unit)
+            .roundFloor(TimeUnit.MILLISECONDS.convert(timeValue, TimeUnit.valueOf(inputTimeUnit.toUpperCase()))),
+        TimeUnit.MILLISECONDS);
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
@@ -349,7 +349,7 @@ public class DateTimeFunctionsTest {
     // name variations
     testFunction("datetrunc('millisecond', epochMillis, 'MILLISECONDS')", arguments, row, 1612296732123L);
     testFunction("date_trunc('MILLISECOND', epochMillis, 'MILLISECONDS')", arguments, row, 1612296732123L);
-    testFunction("dateTrunc('millisecond', epochMillis, 'MILLISECONDS')", arguments, row, 1612296732123L);
+    testFunction("dateTrunc('millisecond', epochMillis, 'milliseconds')", arguments, row, 1612296732123L);
     testFunction("DATE_TRUNC('SECOND', epochMillis, 'MILLISECONDS')", arguments, row, 1612296732000L);
 
     // MILLISECONDS to various
@@ -399,6 +399,8 @@ public class DateTimeFunctionsTest {
     DateTime result = WEIRD_TIMESTAMP;
     testFunction("datetrunc('millisecond', epochMillis, 'MILLISECONDS', '" + weirdDateTimeZoneid + "')", arguments, row,
         result.getMillis());
+    testFunction("datetrunc('millisecond', epochMillis, 'MILLISECONDS', '" + weirdDateTimeZoneid + "', 'milliseconds')",
+        arguments, row, result.getMillis());
     result = result.withMillisOfSecond(0);
     testFunction("datetrunc('second', epochMillis, 'MILLISECONDS', '" + weirdDateTimeZoneid + "')", arguments, row,
         result.getMillis());


### PR DESCRIPTION
https://github.com/apache/pinot/issues/10749

Currently the `TimeUnit` in the `DateTruncTransformFunction` is [case insensitive](https://github.com/apache/pinot/blob/60ee5eb0e8a2cf8276565ae8b20fb81292315843/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/DateTruncTransformFunction.java#L109) while the `TimeUnit` in the scalar functions is case sensitive. So we only need to modify the scalar functions.

Tested:
- Unit tests
- Local server