### PR TITLE
Minor Pinot Deepstore Upload Retry Task Improvements

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/SimpleHttpErrorInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/SimpleHttpErrorInfo.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.common.utils;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 
@@ -30,6 +31,7 @@ public class SimpleHttpErrorInfo {
   private String _error;
 
   @JsonCreator
+  @JsonIgnoreProperties(ignoreUnknown = true)
   public SimpleHttpErrorInfo(@JsonProperty("code") int code, @JsonProperty("error") String message) {
     _code = code;
     _error = message;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -209,6 +209,8 @@ public class ControllerConf extends PinotConfiguration {
     // Default value is false.
     public static final String ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT =
         "controller.realtime.segment.deepStoreUploadRetryEnabled";
+    public static final String DEEP_STORE_RETRY_UPLOAD_TIMEOUT_MS =
+        "controller.realtime.segment.deepStoreUploadRetry.timeoutMs";
 
     public static final int MIN_INITIAL_DELAY_IN_SECONDS = 120;
     public static final int MAX_INITIAL_DELAY_IN_SECONDS = 300;
@@ -897,6 +899,10 @@ public class ControllerConf extends PinotConfiguration {
 
   public boolean isDeepStoreRetryUploadLLCSegmentEnabled() {
     return getProperty(ControllerPeriodicTasksConf.ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT, false);
+  }
+
+  public int getDeepStoreRetryUploadTimeoutMs() {
+    return getProperty(ControllerPeriodicTasksConf.DEEP_STORE_RETRY_UPLOAD_TIMEOUT_MS, -1);
   }
 
   public long getPinotTaskManagerInitialDelaySeconds() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1567,10 +1567,14 @@ public class PinotLLCRealtimeSegmentManager {
   String moveSegmentFile(String rawTableName, String segmentName, String segmentLocation, PinotFS pinotFS)
       throws IOException {
     URI segmentFileURI = URIUtils.getUri(segmentLocation);
-    URI uriToMoveTo = URIUtils.getUri(_controllerConf.getDataDir(), rawTableName, URIUtils.encode(segmentName));
+    URI uriToMoveTo = createSegmentPath(rawTableName, segmentName);
     Preconditions.checkState(pinotFS.move(segmentFileURI, uriToMoveTo, true),
         "Failed to move segment file for segment: %s from: %s to: %s", segmentName, segmentLocation, uriToMoveTo);
     return uriToMoveTo.toString();
+  }
+
+  URI createSegmentPath(String rawTableName, String segmentName) {
+    return URIUtils.getUri(_controllerConf.getDataDir(), rawTableName, URIUtils.encode(segmentName));
   }
 
   private PinotFS createPinotFS(String rawTableName) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -484,8 +484,8 @@ public class PinotLLCRealtimeSegmentManager {
       return;
     }
 
-    URI tableDirURI = getTableDirURI(rawTableName);
-    PinotFS pinotFS = createPinotFS(rawTableName);
+    URI tableDirURI = URIUtils.getUri(_controllerConf.getDataDir(), rawTableName);
+    PinotFS pinotFS = PinotFSFactory.create(tableDirURI.getScheme());
     String uriToMoveTo = moveSegmentFile(rawTableName, segmentName, segmentLocation, pinotFS);
 
     // Cleans up tmp segment files under table dir.
@@ -1405,7 +1405,7 @@ public class PinotLLCRealtimeSegmentManager {
           retentionMs - MIN_TIME_BEFORE_SEGMENT_EXPIRATION_FOR_FIXING_DEEP_STORE_COPY_MILLIS);
     }
 
-    PinotFS pinotFS = createPinotFS(rawTableName);
+    PinotFS pinotFS = PinotFSFactory.create(URIUtils.getUri(_controllerConf.getDataDir()).getScheme());
 
     // Iterate through LLC segments and upload missing deep store copy by following steps:
     //  1. Ask servers which have online segment replica to upload to deep store.
@@ -1573,16 +1573,8 @@ public class PinotLLCRealtimeSegmentManager {
     return uriToMoveTo.toString();
   }
 
+  @VisibleForTesting
   URI createSegmentPath(String rawTableName, String segmentName) {
     return URIUtils.getUri(_controllerConf.getDataDir(), rawTableName, URIUtils.encode(segmentName));
-  }
-
-  private PinotFS createPinotFS(String rawTableName) {
-    URI tableDirURI = getTableDirURI(rawTableName);
-    return PinotFSFactory.create(tableDirURI.getScheme());
-  }
-
-  private URI getTableDirURI(String rawTableName) {
-    return URIUtils.getUri(_controllerConf.getDataDir(), rawTableName);
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.TreeMap;
+import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
@@ -81,7 +82,6 @@ import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.zookeeper.data.Stat;
 import org.joda.time.Interval;
-import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -90,7 +90,12 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-import static org.testng.Assert.*;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertNotNull;
+import static org.testng.Assert.assertNull;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
 
 
 public class PinotLLCRealtimeSegmentManagerTest {
@@ -949,6 +954,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
     ControllerConf controllerConfig = new ControllerConf();
     controllerConfig.setProperty(
         ControllerConf.ControllerPeriodicTasksConf.ENABLE_DEEP_STORE_RETRY_UPLOAD_LLC_SEGMENT, true);
+    controllerConfig.setDataDir(TEMP_DIR.toString());
     FakePinotLLCRealtimeSegmentManager segmentManager =
         new FakePinotLLCRealtimeSegmentManager(pinotHelixResourceManager, controllerConfig);
     Assert.assertTrue(segmentManager.isDeepStoreLLCSegmentUploadRetryEnabled());
@@ -992,10 +998,16 @@ public class PinotLLCRealtimeSegmentManagerTest {
             REALTIME_TABLE_NAME,
             segmentsZKMetadata.get(0).getSegmentName(),
             "upload") + "?uploadTimeoutMs=-1";
-    String segmentDownloadUrl0 = String.format("segmentDownloadUr_%s", segmentsZKMetadata.get(0)
-        .getSegmentName());
+    // tempSegmentFileLocation is the location where the segment uploader will upload the segment. This usually ends
+    // with a random UUID
+    File tempSegmentFileLocation = new File(TEMP_DIR, segmentsZKMetadata.get(0).getSegmentName() + UUID.randomUUID());
+    FileUtils.write(tempSegmentFileLocation, "test");
+    // After the deep-store retry task gets the segment location returned by Pinot server, it will move the segment to
+    // its final location. This is the expected segment location.
+    String expectedSegmentLocation = segmentManager.createSegmentPath(RAW_TABLE_NAME,
+        segmentsZKMetadata.get(0).getSegmentName()).toString();
     when(segmentManager._mockedFileUploadDownloadClient
-        .uploadToSegmentStore(serverUploadRequestUrl0)).thenReturn(segmentDownloadUrl0);
+        .uploadToSegmentStore(serverUploadRequestUrl0)).thenReturn(tempSegmentFileLocation.getPath());
 
     // Change 2nd segment status to be DONE, but with default peer download url.
     // Verify later the download url isn't fixed after upload failure.
@@ -1043,14 +1055,14 @@ public class PinotLLCRealtimeSegmentManagerTest {
         .thenReturn(segmentManager._tableConfig);
 
 
-    segmentManager = Mockito.spy(segmentManager);
-    Mockito.doAnswer(answer -> answer.getArgument(2))
-        .when(segmentManager).moveSegmentFile(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
     // Verify the result
     segmentManager.uploadToDeepStoreIfMissing(segmentManager._tableConfig, segmentsZKMetadata);
     assertEquals(
         segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentNames.get(0), null).getDownloadUrl(),
-        segmentDownloadUrl0);
+        expectedSegmentLocation);
+    assertFalse(tempSegmentFileLocation.exists(),
+        "Deep-store retry task should move the file from temp location to permanent location");
+
     assertEquals(
         segmentManager.getSegmentZKMetadata(REALTIME_TABLE_NAME, segmentNames.get(1), null).getDownloadUrl(),
         CommonConstants.Segment.METADATA_URI_FOR_PEER_DOWNLOAD);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -65,7 +65,6 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.env.PinotConfiguration;
-import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
@@ -82,6 +81,7 @@ import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.zookeeper.data.Stat;
 import org.joda.time.Interval;
+import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.Test;
@@ -1042,6 +1042,10 @@ public class PinotLLCRealtimeSegmentManagerTest {
     when(pinotHelixResourceManager.getTableConfig(REALTIME_TABLE_NAME))
         .thenReturn(segmentManager._tableConfig);
 
+
+    segmentManager = Mockito.spy(segmentManager);
+    Mockito.doAnswer(answer -> answer.getArgument(2))
+        .when(segmentManager).moveSegmentFile(Mockito.any(), Mockito.any(), Mockito.any(), Mockito.any());
     // Verify the result
     segmentManager.uploadToDeepStoreIfMissing(segmentManager._tableConfig, segmentsZKMetadata);
     assertEquals(
@@ -1207,12 +1211,6 @@ public class PinotLLCRealtimeSegmentManagerTest {
     long getCurrentTimeMs() {
       return CURRENT_TIME_MS;
     }
-
-    @Override
-    String moveSegmentFile(String rawTableName, String segmentName, String segmentLocation, PinotFS pinotFS)
-        throws IOException {
-      return segmentLocation;
-    }
   }
 
   private static class FakePinotLLCRealtimeSegmentManagerII extends FakePinotLLCRealtimeSegmentManager {
@@ -1245,12 +1243,6 @@ public class PinotLLCRealtimeSegmentManagerTest {
           break;
       }
       return segmentZKMetadata;
-    }
-
-    @Override
-    String moveSegmentFile(String rawTableName, String segmentName, String segmentLocation, PinotFS pinotFS)
-        throws IOException {
-      return segmentLocation;
     }
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -65,6 +65,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
@@ -990,7 +991,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
             "segments",
             REALTIME_TABLE_NAME,
             segmentsZKMetadata.get(0).getSegmentName(),
-            "upload");
+            "upload") + "?uploadTimeoutMs=-1";
     String segmentDownloadUrl0 = String.format("segmentDownloadUr_%s", segmentsZKMetadata.get(0)
         .getSegmentName());
     when(segmentManager._mockedFileUploadDownloadClient
@@ -1013,7 +1014,7 @@ public class PinotLLCRealtimeSegmentManagerTest {
             "segments",
             REALTIME_TABLE_NAME,
             segmentsZKMetadata.get(1).getSegmentName(),
-            "upload");
+            "upload") + "?uploadTimeoutMs=-1";
     when(segmentManager._mockedFileUploadDownloadClient
         .uploadToSegmentStore(serverUploadRequestUrl1))
         .thenThrow(new HttpErrorStatusException(
@@ -1206,6 +1207,12 @@ public class PinotLLCRealtimeSegmentManagerTest {
     long getCurrentTimeMs() {
       return CURRENT_TIME_MS;
     }
+
+    @Override
+    String moveSegmentFile(String rawTableName, String segmentName, String segmentLocation, PinotFS pinotFS)
+        throws IOException {
+      return segmentLocation;
+    }
   }
 
   private static class FakePinotLLCRealtimeSegmentManagerII extends FakePinotLLCRealtimeSegmentManager {
@@ -1238,6 +1245,12 @@ public class PinotLLCRealtimeSegmentManagerTest {
           break;
       }
       return segmentZKMetadata;
+    }
+
+    @Override
+    String moveSegmentFile(String rawTableName, String segmentName, String segmentLocation, PinotFS pinotFS)
+        throws IOException {
+      return segmentLocation;
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/PinotFSSegmentUploader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/PinotFSSegmentUploader.java
@@ -59,7 +59,13 @@ public class PinotFSSegmentUploader implements SegmentUploader {
     _serverMetrics = serverMetrics;
   }
 
+  @Override
   public URI uploadSegment(File segmentFile, LLCSegmentName segmentName) {
+    return uploadSegment(segmentFile, segmentName, _timeoutInMs);
+  }
+
+  @Override
+  public URI uploadSegment(File segmentFile, LLCSegmentName segmentName, int timeoutInMillis) {
     if (_segmentStoreUriStr == null || _segmentStoreUriStr.isEmpty()) {
       LOGGER.error("Missing segment store uri. Failed to upload segment file {} for {}.", segmentFile.getName(),
           segmentName.getSegmentName());
@@ -89,7 +95,7 @@ public class PinotFSSegmentUploader implements SegmentUploader {
     };
     Future<URI> future = _executorService.submit(uploadTask);
     try {
-      URI segmentLocation = future.get(_timeoutInMs, TimeUnit.MILLISECONDS);
+      URI segmentLocation = future.get(timeoutInMillis, TimeUnit.MILLISECONDS);
       LOGGER.info("Successfully upload segment {} to {}.", segmentName, segmentLocation);
       _serverMetrics.addMeteredTableValue(rawTableName,
           segmentLocation == null ? ServerMeter.SEGMENT_UPLOAD_FAILURE : ServerMeter.SEGMENT_UPLOAD_SUCCESS, 1);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentUploader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentUploader.java
@@ -25,5 +25,15 @@ import org.apache.pinot.common.utils.LLCSegmentName;
 
 public interface SegmentUploader {
   // Returns the URI of the uploaded segment. null if the upload fails.
+
+  /**
+   * Uploads the given segmentFile to the deep-store. The upload to deep-store involve calling another Pinot component.
+   */
   URI uploadSegment(File segmentFile, LLCSegmentName segmentName);
+
+  /**
+   * Same as {@link SegmentUploader#uploadSegment(File, LLCSegmentName)}, but allows users to provide a call
+   * specific timeout.
+   */
+  URI uploadSegment(File segmentFile, LLCSegmentName segmentName, int timeoutInMillis);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentUploader.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentUploader.java
@@ -24,16 +24,15 @@ import org.apache.pinot.common.utils.LLCSegmentName;
 
 
 public interface SegmentUploader {
-  // Returns the URI of the uploaded segment. null if the upload fails.
 
   /**
-   * Uploads the given segmentFile to the deep-store. The upload to deep-store involve calling another Pinot component.
+   * Uploads the given segmentFile to the deep-store. Returns the URI where the segment is uploaded.
    */
   URI uploadSegment(File segmentFile, LLCSegmentName segmentName);
 
   /**
-   * Same as {@link SegmentUploader#uploadSegment(File, LLCSegmentName)}, but allows users to provide a call
-   * specific timeout.
+   * Uploads the given segmentFile to the deep-store. Returns the URI where the segment is uploaded. The upload will
+   * wait for the specified timeout.
    */
   URI uploadSegment(File segmentFile, LLCSegmentName segmentName, int timeoutInMillis);
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -468,9 +468,15 @@ public class TablesResource {
    * Upload a low level consumer segment to segment store and return the segment download url. This endpoint is used
    * when segment store copy is unavailable for committed low level consumer segments.
    * Please note that invocation of this endpoint may cause query performance to suffer, since we tar up the segment
-   * to upload it. There's a query parameter to configure how long the segment-uploader should wait for the upload to
-   * deep-store to finish.
-   * @see <a>href="https://tinyurl.com/f63ru4sb</a>
+   * to upload it.
+   *
+   * @see <a href="https://tinyurl.com/f63ru4sb></a>
+   * @param realtimeTableName table name with type.
+   * @param segmentName name of the segment to be uploaded
+   * @param timeoutMs timeout for the segment upload to the deep-store. If this is negative, the default timeout
+   *                  would be used.
+   * @return full url where the segment is uploaded
+   * @throws Exception if an error occurred during the segment upload.
    */
   @POST
   @Path("/segments/{realtimeTableName}/{segmentName}/upload")
@@ -531,6 +537,7 @@ public class TablesResource {
       SegmentUploader segmentUploader = _serverInstance.getInstanceDataManager().getSegmentUploader();
       URI segmentDownloadUrl;
       if (timeoutMs <= 0) {
+        // Use default timeout if passed timeout is not positive
         segmentDownloadUrl = segmentUploader.uploadSegment(segmentTarFile, new LLCSegmentName(segmentName));
       } else {
         segmentDownloadUrl = segmentUploader.uploadSegment(segmentTarFile, new LLCSegmentName(segmentName), timeoutMs);


### PR DESCRIPTION
**Context:** Deepstore upload retry task is used to fix realtime segments with missing download url links. To fix such segments, it finds a server which has a copy of the segment, and issues a upload request via the API: `/segments/{realtimeTableName}/{segmentName}/upload`.

The server then uploads the segment to HDFS using the `PinotFSSegmentUploader`. Now, the `PinotFSSegmentUploader` copies the segment to a deep-store path which ends in a UUID `/path/to/table/segment_name<uuid>`.

So, if a segment is fixed by the upload retry task, it ends up with a UUID based path in its segment metadata.

**What this PR does**

1. For the deep-store upload retry task, the path returned by the API call to the server is considered a tmp path, and the segment is moved to its final location using the same logic used by realtime segment commit flow. This ensures path names are consistent with regular realtime segments.
2. The timeout for `PinotFSSegmentUploader` when called from the realtime segment commit flow cannot be kept too high, since it may cause significant ingestion lag. However, when the segment is uploaded using the retry task, we can keep a relatively higher timeout. So we have added support for configuring the timeout on a per call basis for uploadSegment. The timeout to be used by the retry task is also configurable using a new config. 

**Test Plan**

Tested on internal cluster.

fixes #10751