### PR TITLE
Refactor usage of WorkerMetadata and StageMetadata

### DIFF
--- a/pinot-common/src/main/proto/worker.proto
+++ b/pinot-common/src/main/proto/worker.proto
@@ -73,10 +73,10 @@ message StagePlan {
   string virtualAddress = 2;
   StageNode stageRoot = 3;
   StageMetadata stageMetadata = 4;
+  WorkerMetadata workerMetadata = 5;
 }
 
 message StageMetadata {
-  repeated WorkerMetadata workerMetadata = 1;
   map<string, string> customProperty = 2;
 }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/DispatchablePlanFragment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/DispatchablePlanFragment.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.query.routing.QueryServerInstance;
-import org.apache.pinot.query.routing.StageMetadata;
 import org.apache.pinot.query.routing.WorkerMetadata;
 
 
@@ -106,10 +105,6 @@ public class DispatchablePlanFragment {
   public void setWorkerMetadataList(List<WorkerMetadata> workerMetadataList) {
     _workerMetadataList.clear();
     _workerMetadataList.addAll(workerMetadataList);
-  }
-
-  public StageMetadata toStageMetadata() {
-    return new StageMetadata(_workerMetadataList, _customProperties);
   }
 
   public void setServerInstanceToWorkerIdMap(Map<QueryServerInstance, List<Integer>> serverInstanceToWorkerIdMap) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
@@ -57,9 +57,8 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
     _exchangeType = exchangeType;
 
     long requestId = context.getRequestId();
-    int workerId = context.getServer().workerId();
     MailboxMetadata senderMailBoxMetadatas =
-        context.getStageMetadata().getWorkerMetadataList().get(workerId).getMailBoxInfosMap().get(senderStageId);
+        context.getWorkerMetadata().getMailBoxInfosMap().get(senderStageId);
     Preconditions.checkState(senderMailBoxMetadatas != null && !senderMailBoxMetadatas.getMailBoxIdList().isEmpty(),
         "Failed to find mailbox for stage: %s",
         senderStageId);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -91,9 +91,8 @@ public class MailboxSendOperator extends MultiStageOperator {
     long requestId = context.getRequestId();
     long deadlineMs = context.getDeadlineMs();
 
-    int workerId = context.getServer().workerId();
     MailboxMetadata receiverMailboxMetadatas =
-        context.getStageMetadata().getWorkerMetadataList().get(workerId).getMailBoxInfosMap().get(receiverStageId);
+        context.getWorkerMetadata().getMailBoxInfosMap().get(receiverStageId);
     if (exchangeType == RelDistribution.Type.SINGLETON) {
       Preconditions.checkState(receiverMailboxMetadatas.getMailBoxIdList().size() == 1,
           "Multiple instances found for SINGLETON exchange type");

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/DistributedStagePlan.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/DistributedStagePlan.java
@@ -33,6 +33,8 @@ public class DistributedStagePlan {
   private int _stageId;
   private VirtualServerAddress _server;
   private PlanNode _stageRoot;
+  private WorkerMetadata _workerMetadata;
+
   private StageMetadata _stageMetadata;
 
   public DistributedStagePlan(int stageId) {
@@ -40,11 +42,12 @@ public class DistributedStagePlan {
   }
 
   public DistributedStagePlan(int stageId, VirtualServerAddress server, PlanNode stageRoot,
-      StageMetadata stageMetadata) {
+      StageMetadata stageMetadata, WorkerMetadata workerMetadata) {
     _stageId = stageId;
     _server = server;
     _stageRoot = stageRoot;
     _stageMetadata = stageMetadata;
+    _workerMetadata = workerMetadata;
   }
 
   public int getStageId() {
@@ -63,6 +66,10 @@ public class DistributedStagePlan {
     return _stageMetadata;
   }
 
+  public WorkerMetadata getWorkerMetadata() {
+    return _workerMetadata;
+  }
+
   public void setServer(VirtualServerAddress serverAddress) {
     _server = serverAddress;
   }
@@ -75,7 +82,7 @@ public class DistributedStagePlan {
     _stageMetadata = stageMetadata;
   }
 
-  public WorkerMetadata getCurrentWorkerMetadata() {
-    return _stageMetadata.getWorkerMetadataList().get(_server.workerId());
+  public void setWorkerMetadata(WorkerMetadata workerMetadata) {
+    _workerMetadata = workerMetadata;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/DistributedStagePlan.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/DistributedStagePlan.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.query.runtime.plan;
 
 import org.apache.pinot.query.planner.plannode.PlanNode;
-import org.apache.pinot.query.routing.StageMetadata;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.routing.WorkerMetadata;
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
@@ -19,8 +19,8 @@
 package org.apache.pinot.query.runtime.plan;
 
 import org.apache.pinot.query.mailbox.MailboxService;
-import org.apache.pinot.query.routing.StageMetadata;
 import org.apache.pinot.query.routing.VirtualServerAddress;
+import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.operator.OpChainId;
 import org.apache.pinot.query.runtime.operator.OpChainStats;
 
@@ -37,30 +37,29 @@ public class OpChainExecutionContext {
   private final VirtualServerAddress _server;
   private final long _timeoutMs;
   private final long _deadlineMs;
-  private final StageMetadata _stageMetadata;
+  private final WorkerMetadata _workerMetadata;
   private final OpChainId _id;
   private final OpChainStats _stats;
   private final boolean _traceEnabled;
 
-  public OpChainExecutionContext(MailboxService mailboxService, long requestId, int stageId,
-      VirtualServerAddress server, long timeoutMs, long deadlineMs, StageMetadata stageMetadata,
-      boolean traceEnabled) {
+  public OpChainExecutionContext(MailboxService mailboxService, long requestId, int stageId, long timeoutMs,
+      long deadlineMs, WorkerMetadata workerMetadata, boolean traceEnabled) {
     _mailboxService = mailboxService;
     _requestId = requestId;
     _stageId = stageId;
-    _server = server;
+    _server = workerMetadata.getVirtualServerAddress();
     _timeoutMs = timeoutMs;
     _deadlineMs = deadlineMs;
-    _stageMetadata = stageMetadata;
-    _id = new OpChainId(requestId, server.workerId(), stageId);
+    _workerMetadata = workerMetadata;
+    _id = new OpChainId(requestId, _server.workerId(), stageId);
     _stats = new OpChainStats(_id.toString());
     _traceEnabled = traceEnabled;
   }
 
   public OpChainExecutionContext(PlanRequestContext planRequestContext) {
     this(planRequestContext.getMailboxService(), planRequestContext.getRequestId(), planRequestContext.getStageId(),
-        planRequestContext.getServer(), planRequestContext.getTimeoutMs(), planRequestContext.getDeadlineMs(),
-        planRequestContext.getStageMetadata(), planRequestContext.isTraceEnabled());
+        planRequestContext.getTimeoutMs(), planRequestContext.getDeadlineMs(), planRequestContext.getWorkerMetadata(),
+        planRequestContext.isTraceEnabled());
   }
 
   public MailboxService getMailboxService() {
@@ -87,8 +86,8 @@ public class OpChainExecutionContext {
     return _deadlineMs;
   }
 
-  public StageMetadata getStageMetadata() {
-    return _stageMetadata;
+  public WorkerMetadata getWorkerMetadata() {
+    return _workerMetadata;
   }
 
   public OpChainId getId() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanRequestContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanRequestContext.java
@@ -21,7 +21,6 @@ package org.apache.pinot.query.runtime.plan;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.query.mailbox.MailboxService;
-import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.routing.WorkerMetadata;
 
 
@@ -32,20 +31,18 @@ public class PlanRequestContext {
   // TODO: Timeout is not needed since deadline is already present.
   private final long _timeoutMs;
   private final long _deadlineMs;
-  protected final VirtualServerAddress _server;
   protected final WorkerMetadata _workerMetadata;
   protected final List<String> _receivingMailboxIds = new ArrayList<>();
   private final OpChainExecutionContext _opChainExecutionContext;
   private final boolean _traceEnabled;
 
   public PlanRequestContext(MailboxService mailboxService, long requestId, int stageId, long timeoutMs, long deadlineMs,
-      VirtualServerAddress server, WorkerMetadata workerMetadata, boolean traceEnabled) {
+      WorkerMetadata workerMetadata, boolean traceEnabled) {
     _mailboxService = mailboxService;
     _requestId = requestId;
     _stageId = stageId;
     _timeoutMs = timeoutMs;
     _deadlineMs = deadlineMs;
-    _server = server;
     _workerMetadata = workerMetadata;
     _traceEnabled = traceEnabled;
     _opChainExecutionContext = new OpChainExecutionContext(this);
@@ -65,10 +62,6 @@ public class PlanRequestContext {
 
   public long getDeadlineMs() {
     return _deadlineMs;
-  }
-
-  public VirtualServerAddress getServer() {
-    return _server;
   }
 
   public WorkerMetadata getWorkerMetadata() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanRequestContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PlanRequestContext.java
@@ -21,8 +21,8 @@ package org.apache.pinot.query.runtime.plan;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.pinot.query.mailbox.MailboxService;
-import org.apache.pinot.query.routing.StageMetadata;
 import org.apache.pinot.query.routing.VirtualServerAddress;
+import org.apache.pinot.query.routing.WorkerMetadata;
 
 
 public class PlanRequestContext {
@@ -33,20 +33,20 @@ public class PlanRequestContext {
   private final long _timeoutMs;
   private final long _deadlineMs;
   protected final VirtualServerAddress _server;
-  protected final StageMetadata _stageMetadata;
+  protected final WorkerMetadata _workerMetadata;
   protected final List<String> _receivingMailboxIds = new ArrayList<>();
   private final OpChainExecutionContext _opChainExecutionContext;
   private final boolean _traceEnabled;
 
   public PlanRequestContext(MailboxService mailboxService, long requestId, int stageId, long timeoutMs, long deadlineMs,
-      VirtualServerAddress server, StageMetadata stageMetadata, boolean traceEnabled) {
+      VirtualServerAddress server, WorkerMetadata workerMetadata, boolean traceEnabled) {
     _mailboxService = mailboxService;
     _requestId = requestId;
     _stageId = stageId;
     _timeoutMs = timeoutMs;
     _deadlineMs = deadlineMs;
     _server = server;
-    _stageMetadata = stageMetadata;
+    _workerMetadata = workerMetadata;
     _traceEnabled = traceEnabled;
     _opChainExecutionContext = new OpChainExecutionContext(this);
   }
@@ -71,8 +71,8 @@ public class PlanRequestContext {
     return _server;
   }
 
-  public StageMetadata getStageMetadata() {
-    return _stageMetadata;
+  public WorkerMetadata getWorkerMetadata() {
+    return _workerMetadata;
   }
 
   public MailboxService getMailboxService() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/ServerRequestPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/ServerRequestPlanVisitor.java
@@ -108,8 +108,9 @@ public class ServerRequestPlanVisitor implements PlanNodeVisitor<Void, ServerPla
     pinotQuery.setExplain(false);
     ServerPlanRequestContext context =
         new ServerPlanRequestContext(mailboxService, requestId, stagePlan.getStageId(), timeoutMs, deadlineMs,
-            stagePlan.getServer(), stagePlan.getStageMetadata(), pinotQuery, tableType, timeBoundaryInfo,
-            traceEnabled);
+            stagePlan.getServer(),
+            stagePlan.getStageMetadata().getWorkerMetadataList().get(stagePlan.getServer().workerId()), pinotQuery,
+            tableType, timeBoundaryInfo, traceEnabled);
 
     // visit the plan and create query physical plan.
     ServerRequestPlanVisitor.walkStageNode(stagePlan.getStageRoot(), context);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/ServerRequestPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/ServerRequestPlanVisitor.java
@@ -108,9 +108,7 @@ public class ServerRequestPlanVisitor implements PlanNodeVisitor<Void, ServerPla
     pinotQuery.setExplain(false);
     ServerPlanRequestContext context =
         new ServerPlanRequestContext(mailboxService, requestId, stagePlan.getStageId(), timeoutMs, deadlineMs,
-            stagePlan.getServer(),
-            stagePlan.getStageMetadata().getWorkerMetadataList().get(stagePlan.getServer().workerId()), pinotQuery,
-            tableType, timeBoundaryInfo, traceEnabled);
+            stagePlan.getWorkerMetadata(), pinotQuery, tableType, timeBoundaryInfo, traceEnabled);
 
     // visit the plan and create query physical plan.
     ServerRequestPlanVisitor.walkStageNode(stagePlan.getStageRoot(), context);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/StageMetadata.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/StageMetadata.java
@@ -16,12 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.query.routing;
+package org.apache.pinot.query.runtime.plan;
 
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
+import org.apache.pinot.query.planner.DispatchablePlanFragment;
+import org.apache.pinot.query.routing.WorkerMetadata;
 
 
 /**
@@ -34,6 +36,11 @@ public class StageMetadata {
   public StageMetadata(List<WorkerMetadata> workerMetadataList, Map<String, String> customProperties) {
     _workerMetadataList = workerMetadataList;
     _customProperties = customProperties;
+  }
+
+  public static StageMetadata from(DispatchablePlanFragment dispatchablePlanFragment) {
+    return new StageMetadata(dispatchablePlanFragment.getWorkerMetadataList(),
+        dispatchablePlanFragment.getCustomProperties());
   }
 
   public List<WorkerMetadata> getWorkerMetadataList() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/StageMetadata.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/StageMetadata.java
@@ -19,32 +19,23 @@
 package org.apache.pinot.query.runtime.plan;
 
 import java.util.HashMap;
-import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.query.planner.DispatchablePlanFragment;
-import org.apache.pinot.query.routing.WorkerMetadata;
 
 
 /**
  * {@code StageMetadata} is used to send plan fragment-level info about how to execute a stage physically.
  */
 public class StageMetadata {
-  private final List<WorkerMetadata> _workerMetadataList;
   private final Map<String, String> _customProperties;
 
-  public StageMetadata(List<WorkerMetadata> workerMetadataList, Map<String, String> customProperties) {
-    _workerMetadataList = workerMetadataList;
+  public StageMetadata(Map<String, String> customProperties) {
     _customProperties = customProperties;
   }
 
   public static StageMetadata from(DispatchablePlanFragment dispatchablePlanFragment) {
-    return new StageMetadata(dispatchablePlanFragment.getWorkerMetadataList(),
-        dispatchablePlanFragment.getCustomProperties());
-  }
-
-  public List<WorkerMetadata> getWorkerMetadataList() {
-    return _workerMetadataList;
+    return new StageMetadata(dispatchablePlanFragment.getCustomProperties());
   }
 
   public Map<String, String> getCustomProperties() {
@@ -55,16 +46,10 @@ public class StageMetadata {
     public static final String TABLE_NAME_KEY = "tableName";
     public static final String TIME_BOUNDARY_COLUMN_KEY = "timeBoundaryInfo.timeColumn";
     public static final String TIME_BOUNDARY_VALUE_KEY = "timeBoundaryInfo.timeValue";
-    private List<WorkerMetadata> _workerMetadataList;
     private Map<String, String> _customProperties;
 
     public Builder() {
       _customProperties = new HashMap<>();
-    }
-
-    public Builder setWorkerMetadataList(List<WorkerMetadata> workerMetadataList) {
-      _workerMetadataList = workerMetadataList;
-      return this;
     }
 
     public Builder addTableName(String tableName) {
@@ -79,7 +64,7 @@ public class StageMetadata {
     }
 
     public StageMetadata build() {
-      return new StageMetadata(_workerMetadataList, _customProperties);
+      return new StageMetadata(_customProperties);
     }
 
     public void putAllCustomProperties(Map<String, String> customPropertyMap) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/serde/QueryPlanSerDeUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/serde/QueryPlanSerDeUtils.java
@@ -28,10 +28,10 @@ import org.apache.pinot.common.proto.Worker;
 import org.apache.pinot.query.planner.plannode.AbstractPlanNode;
 import org.apache.pinot.query.planner.plannode.StageNodeSerDeUtils;
 import org.apache.pinot.query.routing.MailboxMetadata;
-import org.apache.pinot.query.routing.StageMetadata;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.plan.DistributedStagePlan;
+import org.apache.pinot.query.runtime.plan.StageMetadata;
 
 
 /**

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/serde/QueryPlanSerDeUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/serde/QueryPlanSerDeUtils.java
@@ -48,6 +48,7 @@ public class QueryPlanSerDeUtils {
     distributedStagePlan.setServer(protoToAddress(stagePlan.getVirtualAddress()));
     distributedStagePlan.setStageRoot(StageNodeSerDeUtils.deserializeStageNode(stagePlan.getStageRoot()));
     distributedStagePlan.setStageMetadata(fromProtoStageMetadata(stagePlan.getStageMetadata()));
+    distributedStagePlan.setWorkerMetadata(fromProtoWorkerMetadata(stagePlan.getWorkerMetadata()));
     return distributedStagePlan;
   }
 
@@ -56,7 +57,9 @@ public class QueryPlanSerDeUtils {
         .setStageId(distributedStagePlan.getStageId())
         .setVirtualAddress(addressToProto(distributedStagePlan.getServer()))
         .setStageRoot(StageNodeSerDeUtils.serializeStageNode((AbstractPlanNode) distributedStagePlan.getStageRoot()))
-        .setStageMetadata(toProtoStageMetadata(distributedStagePlan.getStageMetadata())).build();
+        .setStageMetadata(toProtoStageMetadata(distributedStagePlan.getStageMetadata()))
+        .setWorkerMetadata(toProtoWorkerMetadata(distributedStagePlan.getWorkerMetadata()))
+        .build();
   }
 
   private static final Pattern VIRTUAL_SERVER_PATTERN = Pattern.compile(
@@ -81,11 +84,6 @@ public class QueryPlanSerDeUtils {
 
   private static StageMetadata fromProtoStageMetadata(Worker.StageMetadata protoStageMetadata) {
     StageMetadata.Builder builder = new StageMetadata.Builder();
-    List<WorkerMetadata> workerMetadataList = new ArrayList<>();
-    for (Worker.WorkerMetadata protoWorkerMetadata : protoStageMetadata.getWorkerMetadataList()) {
-      workerMetadataList.add(fromProtoWorkerMetadata(protoWorkerMetadata));
-    }
-    builder.setWorkerMetadataList(workerMetadataList);
     builder.putAllCustomProperties(protoStageMetadata.getCustomPropertyMap());
     return builder.build();
   }
@@ -121,9 +119,6 @@ public class QueryPlanSerDeUtils {
 
   private static Worker.StageMetadata toProtoStageMetadata(StageMetadata stageMetadata) {
     Worker.StageMetadata.Builder builder = Worker.StageMetadata.newBuilder();
-    for (WorkerMetadata workerMetadata : stageMetadata.getWorkerMetadataList()) {
-      builder.addWorkerMetadata(toProtoWorkerMetadata(workerMetadata));
-    }
     builder.putAllCustomProperty(stageMetadata.getCustomProperties());
     return builder.build();
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestContext.java
@@ -22,8 +22,8 @@ import org.apache.pinot.common.request.InstanceRequest;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.query.mailbox.MailboxService;
-import org.apache.pinot.query.routing.StageMetadata;
 import org.apache.pinot.query.routing.VirtualServerAddress;
+import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.apache.pinot.spi.config.table.TableType;
 
@@ -40,9 +40,9 @@ public class ServerPlanRequestContext extends PlanRequestContext {
   protected InstanceRequest _instanceRequest;
 
   public ServerPlanRequestContext(MailboxService mailboxService, long requestId, int stageId, long timeoutMs,
-      long deadlineMs, VirtualServerAddress server, StageMetadata stageMetadata, PinotQuery pinotQuery,
+      long deadlineMs, VirtualServerAddress server, WorkerMetadata workerMetadata, PinotQuery pinotQuery,
       TableType tableType, TimeBoundaryInfo timeBoundaryInfo, boolean traceEnabled) {
-    super(mailboxService, requestId, stageId, timeoutMs, deadlineMs, server, stageMetadata, traceEnabled);
+    super(mailboxService, requestId, stageId, timeoutMs, deadlineMs, server, workerMetadata, traceEnabled);
     _pinotQuery = pinotQuery;
     _tableType = tableType;
     _timeBoundaryInfo = timeBoundaryInfo;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestContext.java
@@ -22,7 +22,6 @@ import org.apache.pinot.common.request.InstanceRequest;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.query.mailbox.MailboxService;
-import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.plan.PlanRequestContext;
 import org.apache.pinot.spi.config.table.TableType;
@@ -40,9 +39,9 @@ public class ServerPlanRequestContext extends PlanRequestContext {
   protected InstanceRequest _instanceRequest;
 
   public ServerPlanRequestContext(MailboxService mailboxService, long requestId, int stageId, long timeoutMs,
-      long deadlineMs, VirtualServerAddress server, WorkerMetadata workerMetadata, PinotQuery pinotQuery,
+      long deadlineMs, WorkerMetadata workerMetadata, PinotQuery pinotQuery,
       TableType tableType, TimeBoundaryInfo timeBoundaryInfo, boolean traceEnabled) {
-    super(mailboxService, requestId, stageId, timeoutMs, deadlineMs, server, workerMetadata, traceEnabled);
+    super(mailboxService, requestId, stageId, timeoutMs, deadlineMs, workerMetadata, traceEnabled);
     _pinotQuery = pinotQuery;
     _tableType = tableType;
     _timeBoundaryInfo = timeBoundaryInfo;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -195,9 +195,9 @@ public class QueryDispatcher {
         (MailboxReceiveNode) dispatchableSubPlan.getQueryStageList().get(reduceStageId).getPlanFragment()
             .getFragmentRoot();
     VirtualServerAddress server = new VirtualServerAddress(mailboxService.getHostname(), mailboxService.getPort(), 0);
-    StageMetadata stageMetadata = StageMetadata.from(dispatchableSubPlan.getQueryStageList().get(reduceStageId));
     OpChainExecutionContext context = new OpChainExecutionContext(mailboxService, requestId, reduceStageId, timeoutMs,
-        System.currentTimeMillis() + timeoutMs, stageMetadata.getWorkerMetadataList().get(server.workerId()),
+        System.currentTimeMillis() + timeoutMs,
+        dispatchableSubPlan.getQueryStageList().get(reduceStageId).getWorkerMetadataList().get(server.workerId()),
         traceEnabled);
     MailboxReceiveOperator mailboxReceiveOperator = createReduceStageOperator(context, reduceNode.getSenderStageId());
     List<DataBlock> resultDataBlocks =
@@ -212,7 +212,8 @@ public class QueryDispatcher {
       int stageId, VirtualServerAddress serverAddress) {
     return new DistributedStagePlan(stageId, serverAddress,
         dispatchableSubPlan.getQueryStageList().get(stageId).getPlanFragment().getFragmentRoot(),
-        StageMetadata.from(dispatchableSubPlan.getQueryStageList().get(stageId)));
+        StageMetadata.from(dispatchableSubPlan.getQueryStageList().get(stageId)),
+        dispatchableSubPlan.getQueryStageList().get(stageId).getWorkerMetadataList().get(serverAddress.workerId()));
   }
 
   private static List<DataBlock> reduceMailboxReceive(MailboxReceiveOperator mailboxReceiveOperator, long timeoutMs,

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerServiceTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.pinot.query.routing.VirtualServerAddress;
+import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.MultiStageOperator;
 import org.apache.pinot.query.runtime.operator.OpChain;
@@ -74,7 +75,8 @@ public class OpChainSchedulerServiceTest {
 
   private OpChain getChain(MultiStageOperator operator) {
     VirtualServerAddress address = new VirtualServerAddress("localhost", 1234, 1);
-    OpChainExecutionContext context = new OpChainExecutionContext(null, 123L, 1, address, 0, 0, null, true);
+    OpChainExecutionContext context = new OpChainExecutionContext(null, 123L, 1, 0, 0,
+        new WorkerMetadata.Builder().setVirtualServerAddress(address).build(), true);
     return new OpChain(context, operator, ImmutableList.of());
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/RoundRobinSchedulerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/executor/RoundRobinSchedulerTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.query.mailbox.MailboxIdUtils;
 import org.apache.pinot.query.routing.VirtualServerAddress;
+import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.operator.MultiStageOperator;
 import org.apache.pinot.query.runtime.operator.OpChain;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
@@ -179,7 +180,8 @@ public class RoundRobinSchedulerTest {
   }
 
   private OpChainExecutionContext getOpChainExecutionContext(long requestId, int stageId, int virtualServerId) {
-    return new OpChainExecutionContext(null, requestId, stageId,
-        new VirtualServerAddress("localhost", 1234, virtualServerId), 0, 0, null, true);
+    return new OpChainExecutionContext(null, requestId, stageId, 0, 0,
+        new WorkerMetadata.Builder().setVirtualServerAddress(
+            new VirtualServerAddress("localhost", 1234, virtualServerId)).build(), true);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -36,7 +36,6 @@ import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
-import org.apache.pinot.query.runtime.plan.StageMetadata;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
@@ -118,12 +117,8 @@ public class MailboxReceiveOperatorTest {
   public void shouldThrowSingletonNoMatchMailboxServer() {
     VirtualServerAddress server1 = new VirtualServerAddress("localhost", 456, 0);
     VirtualServerAddress server2 = new VirtualServerAddress("localhost", 789, 1);
-    StageMetadata stageMetadata = new StageMetadata.Builder()
-        .setWorkerMetadataList(Stream.of(server1, server2).map(
-            s -> new WorkerMetadata.Builder().setVirtualServerAddress(s).build()).collect(Collectors.toList()))
-        .build();
     OpChainExecutionContext context = new OpChainExecutionContext(_mailboxService, 0, 0, Long.MAX_VALUE, Long.MAX_VALUE,
-        stageMetadata.getWorkerMetadataList().get(0), false);
+        new WorkerMetadata.Builder().setVirtualServerAddress(server1).build(), false);
     //noinspection resource
     new MailboxReceiveOperator(context, RelDistribution.Type.SINGLETON, 1);
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -18,12 +18,10 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.MailboxService;
-import org.apache.pinot.query.routing.StageMetadata;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
@@ -171,12 +169,9 @@ public class MailboxSendOperatorTest {
   }
 
   private MailboxSendOperator getMailboxSendOperator() {
-    StageMetadata stageMetadata = new StageMetadata.Builder()
-        .setWorkerMetadataList(Collections.singletonList(
-            new WorkerMetadata.Builder().setVirtualServerAddress(_server).build())).build();
     OpChainExecutionContext context =
-        new OpChainExecutionContext(_mailboxService, 0, SENDER_STAGE_ID, _server, Long.MAX_VALUE, Long.MAX_VALUE,
-            stageMetadata, false);
+        new OpChainExecutionContext(_mailboxService, 0, SENDER_STAGE_ID, Long.MAX_VALUE, Long.MAX_VALUE,
+            new WorkerMetadata.Builder().setVirtualServerAddress(_server).build(), false);
     return new MailboxSendOperator(context, _sourceOperator, _exchange, null, null, false);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
@@ -42,13 +42,13 @@ import org.apache.pinot.query.mailbox.ReceivingMailbox;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.physical.MailboxIdUtils;
 import org.apache.pinot.query.routing.MailboxMetadata;
-import org.apache.pinot.query.routing.StageMetadata;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.exchange.BlockExchange;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.query.runtime.plan.StageMetadata;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -198,8 +198,8 @@ public class OpChainTest {
     int receivedStageId = 2;
     int senderStageId = 1;
     OpChainExecutionContext context =
-        new OpChainExecutionContext(_mailboxService1, 1, senderStageId, _serverAddress, 1000,
-            System.currentTimeMillis() + 1000, _receivingStageMetadata, true);
+        new OpChainExecutionContext(_mailboxService1, 1, senderStageId, 1000, System.currentTimeMillis() + 1000,
+            _receivingStageMetadata.getWorkerMetadataList().get(_serverAddress.workerId()), true);
 
     Stack<MultiStageOperator> operators =
         getFullOpchain(receivedStageId, senderStageId, context, dummyOperatorWaitTime);
@@ -212,8 +212,8 @@ public class OpChainTest {
     opChain.getStats().queued();
 
     OpChainExecutionContext secondStageContext =
-        new OpChainExecutionContext(_mailboxService2, 1, senderStageId + 1, _serverAddress, 1000,
-            System.currentTimeMillis() + 1000, _receivingStageMetadata, true);
+        new OpChainExecutionContext(_mailboxService2, 1, senderStageId + 1, 1000, System.currentTimeMillis() + 1000,
+            _receivingStageMetadata.getWorkerMetadataList().get(_serverAddress.workerId()), true);
 
     MailboxReceiveOperator secondStageReceiveOp =
         new MailboxReceiveOperator(secondStageContext, RelDistribution.Type.BROADCAST_DISTRIBUTED, senderStageId + 1);
@@ -238,8 +238,8 @@ public class OpChainTest {
     int receivedStageId = 2;
     int senderStageId = 1;
     OpChainExecutionContext context =
-        new OpChainExecutionContext(_mailboxService1, 1, senderStageId, _serverAddress, 1000,
-            System.currentTimeMillis() + 1000, _receivingStageMetadata, false);
+        new OpChainExecutionContext(_mailboxService1, 1, senderStageId, 1000, System.currentTimeMillis() + 1000,
+            _receivingStageMetadata.getWorkerMetadataList().get(_serverAddress.workerId()), false);
 
     Stack<MultiStageOperator> operators =
         getFullOpchain(receivedStageId, senderStageId, context, dummyOperatorWaitTime);
@@ -250,8 +250,8 @@ public class OpChainTest {
     opChain.getStats().queued();
 
     OpChainExecutionContext secondStageContext =
-        new OpChainExecutionContext(_mailboxService2, 1, senderStageId + 1, _serverAddress, 1000,
-            System.currentTimeMillis() + 1000, _receivingStageMetadata, false);
+        new OpChainExecutionContext(_mailboxService2, 1, senderStageId + 1, 1000, System.currentTimeMillis() + 1000,
+            _receivingStageMetadata.getWorkerMetadataList().get(_serverAddress.workerId()), false);
     MailboxReceiveOperator secondStageReceiveOp =
         new MailboxReceiveOperator(secondStageContext, RelDistribution.Type.BROADCAST_DISTRIBUTED, senderStageId);
 
@@ -289,8 +289,8 @@ public class OpChainTest {
     List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
         new SelectionResultsBlock(upStreamSchema, Arrays.asList(new Object[]{1}, new Object[]{2})), queryContext));
     LeafStageTransferableBlockOperator leafOp = new LeafStageTransferableBlockOperator(context,
-            LeafStageTransferableBlockOperatorTest.getStaticBlockProcessor(resultsBlockList),
-            Collections.singletonList(mock(ServerQueryRequest.class)), upStreamSchema);
+        LeafStageTransferableBlockOperatorTest.getStaticBlockProcessor(resultsBlockList),
+        Collections.singletonList(mock(ServerQueryRequest.class)), upStreamSchema);
 
     //Transform operator
     RexExpression.InputRef ref0 = new RexExpression.InputRef(0);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OperatorTestUtil.java
@@ -23,9 +23,11 @@ import java.util.List;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.routing.VirtualServerAddress;
+import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.query.testutils.MockDataBlockOperatorFactory;
+
 
 public class OperatorTestUtil {
   // simple key-value collision schema/data test set: "Aa" and "BB" have same hash code in java.
@@ -63,19 +65,19 @@ public class OperatorTestUtil {
 
   public static OpChainExecutionContext getDefaultContext() {
     VirtualServerAddress virtualServerAddress = new VirtualServerAddress("mock", 80, 0);
-    return new OpChainExecutionContext(null, 1, 2, virtualServerAddress, Long.MAX_VALUE, Long.MAX_VALUE,
-        null, true);
+    return new OpChainExecutionContext(null, 1, 2, Long.MAX_VALUE, Long.MAX_VALUE,
+        new WorkerMetadata.Builder().setVirtualServerAddress(virtualServerAddress).build(), true);
   }
 
   public static OpChainExecutionContext getDefaultContextWithTracingDisabled() {
     VirtualServerAddress virtualServerAddress = new VirtualServerAddress("mock", 80, 0);
-    return new OpChainExecutionContext(null, 1, 2, virtualServerAddress, Long.MAX_VALUE, Long.MAX_VALUE,
-        null, false);
+    return new OpChainExecutionContext(null, 1, 2, Long.MAX_VALUE, Long.MAX_VALUE,
+        new WorkerMetadata.Builder().setVirtualServerAddress(virtualServerAddress).build(), false);
   }
 
   public static OpChainExecutionContext getContext(long requestId, int stageId,
       VirtualServerAddress virtualServerAddress) {
-    return new OpChainExecutionContext(null, requestId, stageId, virtualServerAddress, Long.MAX_VALUE, Long.MAX_VALUE,
-        null, true);
+    return new OpChainExecutionContext(null, requestId, stageId, Long.MAX_VALUE, Long.MAX_VALUE,
+        new WorkerMetadata.Builder().setVirtualServerAddress(virtualServerAddress).build(), true);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
@@ -40,7 +40,6 @@ import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
-import org.apache.pinot.query.runtime.plan.StageMetadata;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.testng.annotations.AfterMethod;
@@ -126,13 +125,9 @@ public class SortedMailboxReceiveOperatorTest {
   public void shouldThrowSingletonNoMatchMailboxServer() {
     VirtualServerAddress server1 = new VirtualServerAddress("localhost", 456, 0);
     VirtualServerAddress server2 = new VirtualServerAddress("localhost", 789, 1);
-    StageMetadata stageMetadata = new StageMetadata.Builder()
-        .setWorkerMetadataList(Stream.of(server1, server2).map(
-            s -> new WorkerMetadata.Builder().setVirtualServerAddress(s).build()).collect(Collectors.toList()))
-        .build();
     OpChainExecutionContext context =
         new OpChainExecutionContext(_mailboxService, 0, 0, Long.MAX_VALUE, Long.MAX_VALUE,
-            stageMetadata.getWorkerMetadataList().get(0), false);
+            new WorkerMetadata.Builder().setVirtualServerAddress(server1).build(), false);
     //noinspection resource
     new SortedMailboxReceiveOperator(context, RelDistribution.Type.SINGLETON, DATA_SCHEMA, COLLATION_KEYS,
         COLLATION_DIRECTIONS, false, 1);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/QueryServerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/QueryServerTest.java
@@ -40,10 +40,10 @@ import org.apache.pinot.query.planner.DispatchablePlanFragment;
 import org.apache.pinot.query.planner.DispatchableSubPlan;
 import org.apache.pinot.query.planner.plannode.PlanNode;
 import org.apache.pinot.query.routing.QueryServerInstance;
-import org.apache.pinot.query.routing.StageMetadata;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.QueryRunner;
+import org.apache.pinot.query.runtime.plan.StageMetadata;
 import org.apache.pinot.query.runtime.plan.serde.QueryPlanSerDeUtils;
 import org.apache.pinot.query.service.dispatch.QueryDispatcher;
 import org.apache.pinot.query.testutils.QueryTestUtils;
@@ -124,7 +124,7 @@ public class QueryServerTest extends QueryTestSet {
 
         DispatchablePlanFragment dispatchablePlanFragment = dispatchableSubPlan.getQueryStageList().get(stageId);
 
-        StageMetadata stageMetadata = dispatchablePlanFragment.toStageMetadata();
+        StageMetadata stageMetadata = StageMetadata.from(dispatchablePlanFragment);
 
         // ensure mock query runner received correctly deserialized payload.
         QueryRunner mockRunner =

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/QueryServerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/QueryServerTest.java
@@ -121,10 +121,9 @@ public class QueryServerTest extends QueryTestSet {
 
         // submit the request for testing.
         submitRequest(queryRequest);
-
         DispatchablePlanFragment dispatchablePlanFragment = dispatchableSubPlan.getQueryStageList().get(stageId);
-
         StageMetadata stageMetadata = StageMetadata.from(dispatchablePlanFragment);
+        WorkerMetadata workerMetadata = dispatchablePlanFragment.getWorkerMetadataList().get(0);
 
         // ensure mock query runner received correctly deserialized payload.
         QueryRunner mockRunner =
@@ -139,7 +138,8 @@ public class QueryServerTest extends QueryTestSet {
               PlanNode planNode =
                   dispatchableSubPlan.getQueryStageList().get(finalStageId).getPlanFragment().getFragmentRoot();
               return isStageNodesEqual(planNode, distributedStagePlan.getStageRoot()) && isStageMetadataEqual(
-                  stageMetadata, distributedStagePlan.getStageMetadata());
+                  stageMetadata, distributedStagePlan.getStageMetadata()) && isWorkerMetadataEqual(workerMetadata,
+                  distributedStagePlan.getWorkerMetadata());
             }), Mockito.argThat(requestMetadataMap -> requestIdStr.equals(
                 requestMetadataMap.get(QueryConfig.KEY_OF_BROKER_REQUEST_ID))));
             return true;
@@ -170,16 +170,6 @@ public class QueryServerTest extends QueryTestSet {
             || !EqualityUtils.isEqual(expectedTimeBoundaryInfo.getTimeValue(),
             actualTimeBoundaryInfo.getTimeValue()))) {
       return false;
-    }
-    List<WorkerMetadata> expectedWorkerMetadataList = expected.getWorkerMetadataList();
-    List<WorkerMetadata> actualWorkerMetadataList = actual.getWorkerMetadataList();
-    if (expectedWorkerMetadataList.size() != actualWorkerMetadataList.size()) {
-      return false;
-    }
-    for (int i = 0; i < expectedWorkerMetadataList.size(); i++) {
-      if (!isWorkerMetadataEqual(expectedWorkerMetadataList.get(i), actualWorkerMetadataList.get(i))) {
-        return false;
-      }
     }
     return true;
   }


### PR DESCRIPTION
- Refactor StageMetadata from `pinot-query-planner` to `pinot-query-runtime` package
- Only set necessary `WorkerMetadata` for `OpChainExecutionContext`
- Move `WorkerMetadata` out from `StageMetadata` to `DistributedStagePlan`