### PR TITLE
[multistage]: better error messages.

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -172,7 +172,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       LOGGER.info("Caught exception while compiling SQL request {}: {}, {}", requestId, query, e.getMessage());
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.REQUEST_COMPILATION_EXCEPTIONS, 1);
       requestContext.setErrorCode(QueryException.SQL_PARSING_ERROR_CODE);
-      return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR, e));
+      return new BrokerResponseNative(QueryException.getException(QueryException.SQL_PARSING_ERROR, e.getMessage()));
     }
 
     DispatchableSubPlan dispatchableSubPlan = queryPlanResult.getQueryPlan();

--- a/pinot-connectors/pinot-spark-common/src/main/scala/org/apache/pinot/connector/spark/common/PinotDataSourceReadOptions.scala
+++ b/pinot-connectors/pinot-spark-common/src/main/scala/org/apache/pinot/connector/spark/common/PinotDataSourceReadOptions.scala
@@ -18,9 +18,10 @@
  */
 package org.apache.pinot.connector.spark.common
 
+import java.util
+
 import org.apache.pinot.spi.config.table.TableType
 
-import java.util
 import scala.util.Random
 
 /**

--- a/pinot-connectors/pinot-spark-common/src/main/scala/org/apache/pinot/connector/spark/common/PinotDataSourceReadOptions.scala
+++ b/pinot-connectors/pinot-spark-common/src/main/scala/org/apache/pinot/connector/spark/common/PinotDataSourceReadOptions.scala
@@ -18,10 +18,9 @@
  */
 package org.apache.pinot.connector.spark.common
 
-import java.util
-
 import org.apache.pinot.spi.config.table.TableType
 
+import java.util
 import scala.util.Random
 
 /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -109,7 +109,7 @@ public class PinotQueryResource {
       LOGGER.debug("Trace: {}, Running query: {}", traceEnabled, sqlQuery);
       return executeSqlQuery(httpHeaders, sqlQuery, traceEnabled, queryOptions, "/sql");
     } catch (ProcessingException pe) {
-      LOGGER.error("Caught exception while processing get request {}", pe.getMessage());
+      LOGGER.error("Caught exception while processing post request {}", pe.getMessage());
       return pe.getMessage();
     } catch (Exception e) {
       LOGGER.error("Caught exception while processing post request", e);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -69,7 +69,6 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.PinotSqlType;
-import org.apache.pinot.sql.parsers.SqlCompilationException;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -110,8 +109,8 @@ public class PinotQueryResource {
       LOGGER.debug("Trace: {}, Running query: {}", traceEnabled, sqlQuery);
       return executeSqlQuery(httpHeaders, sqlQuery, traceEnabled, queryOptions, "/sql");
     } catch (ProcessingException pe) {
-      LOGGER.error("Caught exception while processing post request", pe);
-      return pe.toString();
+      LOGGER.error("Caught exception while processing get request {}", pe.getMessage());
+      return pe.getMessage();
     } catch (Exception e) {
       LOGGER.error("Caught exception while processing post request", e);
       return QueryException.getException(QueryException.INTERNAL_ERROR, e).toString();
@@ -126,8 +125,8 @@ public class PinotQueryResource {
       LOGGER.debug("Trace: {}, Running query: {}", traceEnabled, sqlQuery);
       return executeSqlQuery(httpHeaders, sqlQuery, traceEnabled, queryOptions, "/sql");
     } catch (ProcessingException pe) {
-      LOGGER.error("Caught exception while processing get request", pe);
-      return pe.toString();
+      LOGGER.error("Caught exception while processing get request {}", pe.getMessage());
+      return pe.getMessage();
     } catch (Exception e) {
       LOGGER.error("Caught exception while processing get request", e);
       return QueryException.getException(QueryException.INTERNAL_ERROR, e).toString();
@@ -141,7 +140,8 @@ public class PinotQueryResource {
     try {
       sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery);
     } catch (Exception ex) {
-      throw QueryException.getException(QueryException.SQL_PARSING_ERROR, new Exception("Unable to parse the SQL"));
+      String errorMessage = String.format("Unable to parse the SQL: '%s'", sqlQuery);
+      throw QueryException.getException(QueryException.SQL_PARSING_ERROR, new Exception(errorMessage));
     }
     Map<String, String> options = sqlNodeAndOptions.getOptions();
     if (queryOptions != null) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -109,6 +109,9 @@ public class PinotQueryResource {
       }
       LOGGER.debug("Trace: {}, Running query: {}", traceEnabled, sqlQuery);
       return executeSqlQuery(httpHeaders, sqlQuery, traceEnabled, queryOptions, "/sql");
+    } catch (ProcessingException pe) {
+      LOGGER.error("Caught exception while processing post request", pe);
+      return pe.toString();
     } catch (Exception e) {
       LOGGER.error("Caught exception while processing post request", e);
       return QueryException.getException(QueryException.INTERNAL_ERROR, e).toString();
@@ -137,7 +140,7 @@ public class PinotQueryResource {
     SqlNodeAndOptions sqlNodeAndOptions;
     try {
       sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery);
-    } catch (SqlCompilationException ex) {
+    } catch (Exception ex) {
       throw QueryException.getException(QueryException.SQL_PARSING_ERROR, new Exception("Unable to parse the SQL"));
     }
     Map<String, String> options = sqlNodeAndOptions.getOptions();

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
@@ -81,7 +81,8 @@ public class TypeFactory extends JavaTypeFactoryImpl {
         return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.DECIMAL)
             : createArrayType(createSqlType(SqlTypeName.DECIMAL), -1);
       case JSON:
-        return createSqlType(SqlTypeName.VARCHAR);
+        // TODO: support JSON, JSON should be supported using a special RelDataType as it is not a simple String,
+        // nor can it be easily parsed as a STRUCT.
       case LIST:
         // TODO: support LIST, MV column should go fall into this category.
       case STRUCT:

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
@@ -81,13 +81,14 @@ public class TypeFactory extends JavaTypeFactoryImpl {
         return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.DECIMAL)
             : createArrayType(createSqlType(SqlTypeName.DECIMAL), -1);
       case JSON:
-        return createSqlType(SqlTypeName.VARBINARY);
+        return createSqlType(SqlTypeName.VARCHAR);
       case LIST:
         // TODO: support LIST, MV column should go fall into this category.
       case STRUCT:
       case MAP:
       default:
-        throw new UnsupportedOperationException("unsupported!");
+        String message = String.format("Unsupported type: %s ", fieldSpec.getDataType().toString());
+        throw new UnsupportedOperationException(message);
     }
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
@@ -81,8 +81,7 @@ public class TypeFactory extends JavaTypeFactoryImpl {
         return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.DECIMAL)
             : createArrayType(createSqlType(SqlTypeName.DECIMAL), -1);
       case JSON:
-        // TODO: support JSON, JSON should be supported using a special RelDataType as it is not a simple String,
-        // nor can it be easily parsed as a STRUCT.
+        return createSqlType(SqlTypeName.VARBINARY);
       case LIST:
         // TODO: support LIST, MV column should go fall into this category.
       case STRUCT:


### PR DESCRIPTION
- handling the `json` data type in a multistage query engine. as per the [comment](https://github.com/apache/pinot/issues/10205#issuecomment-1543278577) 
- returning the meaningful error msg for unsupported type. 
- returning the meaningful error message of SQL parsing errors.

As per the issue https://github.com/apache/pinot/issues/10205

cc @walterddr  