### PR TITLE
UI: fix sql query options seperator

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -271,18 +271,18 @@ const QueryPage = () => {
     setQueryLoader(true);
     queryExecuted.current = true;
     let params;
-    let queryOptions = '';
+    let queryOptions = [];
     if(queryTimeout){
-      queryOptions += `timeoutMs=${queryTimeout}`;
+      queryOptions.push(`timeoutMs=${queryTimeout}`);
     }
     if(checked.useMSE){
-      queryOptions += `useMultistageEngine=true`;
+      queryOptions.push(`useMultistageEngine=true`);
     }
     const finalQuery = `${query || inputQuery.trim()}`;
     params = JSON.stringify({
       sql: `${finalQuery}`,
       trace: checked.tracing,
-      queryOptions: `${queryOptions}`,
+      queryOptions: `${queryOptions.join(";")}`,
     });
 
     if(finalQuery !== ''){


### PR DESCRIPTION
This PR is `ui` `bugfix`

### Issue
- In the SQL editor If there were multiple query options, then queryOptions passed to payload were incorrect.
- Backend expects `;` as a separator between multiple queryOptions 

### Fix 
- Separate query options by `;`

<hr>

Payload before
```json
{
  "sql": "select * from baseballStats limit 10",
  "trace": true,
  "queryOptions": "timeoutMs=1000useMultistageEngine=true"
}
```


Payload After
 ```json
{
  "sql": "select * from baseballStats limit 10",
  "trace": true,
  "queryOptions": "timeoutMs=1000;useMultistageEngine=true"
}
```
