### PR TITLE
[multistage] hintable option framework & dynamic broadcast hint

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintOptions.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintOptions.java
@@ -21,7 +21,7 @@ package org.apache.calcite.rel.hint;
 /**
  * {@code PinotHintOptions} specified the supported hint options by Pinot based a particular type of relation node.
  *
- * <p>for each {@link org.apache.calcite.rel.RelNode} type we support a option hint name.</p>
+ * <p>for each {@link org.apache.calcite.rel.RelNode} type we support an option hint name.</p>
  * <p>for each option hint name there's a corresponding {@link RelHint} that supported only key-value option stored
  * in {@link RelHint#kvOptions}</p>
  */
@@ -34,11 +34,11 @@ public class PinotHintOptions {
   }
 
   public static class AggregateOptions {
-    public static final String IS_PARTITIONED_BY_GROUP_BY_KEYS = "partitioned_by_group_by_keys";
+    public static final String IS_PARTITIONED_BY_GROUP_BY_KEYS = "is_partitioned_by_group_by_keys";
   }
 
   public static class JoinHintOptions {
     public static final String JOIN_STRATEGY = "join_strategy";
-    public static final String IS_COLOCATED_BY_JOIN_KEYS = "colocated_by_join_keys";
+    public static final String IS_COLOCATED_BY_JOIN_KEYS = "is_colocated_by_join_keys";
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintOptions.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintOptions.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.calcite.rel.hint;
+
+/**
+ * {@code PinotHintOptions} specified the supported hint options by Pinot based a particular type of relation node.
+ *
+ * <p>for each {@link org.apache.calcite.rel.RelNode} type we support a option hint name.</p>
+ * <p>for each option hint name there's a corresponding {@link RelHint} that supported only key-value option stored
+ * in {@link RelHint#kvOptions}</p>
+ */
+public class PinotHintOptions {
+  public static final String AGGREGATE_HINT_OPTIONS = "aggOptions";
+  public static final String JOIN_HINT_OPTIONS = "joinOptions";
+
+  private PinotHintOptions() {
+    // do not instantiate.
+  }
+
+  public static class AggregateOptions {
+    public static final String IS_PARTITIONED_BY_GROUP_BY_KEYS = "partitioned_by_group_by_keys";
+  }
+
+  public static class JoinHintOptions {
+    public static final String JOIN_STRATEGY = "join_strategy";
+    public static final String IS_COLOCATED_BY_JOIN_KEYS = "colocated_by_join_keys";
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotAggregateExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotAggregateExchangeNodeInsertRule.java
@@ -35,6 +35,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.hint.PinotHintOptions;
 import org.apache.calcite.rel.hint.PinotHintStrategyTable;
 import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.rel.logical.LogicalAggregate;
@@ -51,7 +52,6 @@ import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.ImmutableBitSet;
 import org.apache.calcite.util.ImmutableIntList;
-import org.apache.pinot.query.planner.plannode.AggregateNode;
 
 
 /**
@@ -76,6 +76,10 @@ public class PinotAggregateExchangeNodeInsertRule extends RelOptRule {
       new PinotAggregateExchangeNodeInsertRule(PinotRuleUtils.PINOT_REL_FACTORY);
   private static final Set<SqlKind> SUPPORTED_AGG_KIND = ImmutableSet.of(
       SqlKind.SUM, SqlKind.SUM0, SqlKind.MIN, SqlKind.MAX, SqlKind.COUNT, SqlKind.OTHER_FUNCTION);
+  private static final RelHint FINAL_STAGE_HINT = RelHint.builder(
+      PinotHintStrategyTable.INTERNAL_AGG_FINAL_STAGE).build();
+  private static final RelHint INTERMEDIATE_STAGE_HINT = RelHint.builder(
+      PinotHintStrategyTable.INTERNAL_AGG_INTERMEDIATE_STAGE).build();
 
   public PinotAggregateExchangeNodeInsertRule(RelBuilderFactory factory) {
     super(operand(LogicalAggregate.class, any()), factory, null);
@@ -88,8 +92,11 @@ public class PinotAggregateExchangeNodeInsertRule extends RelOptRule {
     }
     if (call.rel(0) instanceof Aggregate) {
       Aggregate agg = call.rel(0);
-      return !agg.getHints().contains(AggregateNode.INTERMEDIATE_STAGE_HINT)
-          && !agg.getHints().contains(AggregateNode.FINAL_STAGE_HINT);
+      ImmutableList<RelHint> hints = agg.getHints();
+      return !PinotHintStrategyTable.containsHint(hints, PinotHintStrategyTable.INTERNAL_AGG_INTERMEDIATE_STAGE)
+          && !PinotHintStrategyTable.containsHint(hints, PinotHintStrategyTable.INTERNAL_AGG_FINAL_STAGE)
+          && !PinotHintStrategyTable.containsHintOption(hints, PinotHintOptions.AGGREGATE_HINT_OPTIONS,
+          PinotHintOptions.AggregateOptions.IS_PARTITIONED_BY_GROUP_BY_KEYS);
     }
     return false;
   }
@@ -120,7 +127,7 @@ public class PinotAggregateExchangeNodeInsertRule extends RelOptRule {
 
     // 1. attach leaf agg RelHint to original agg.
     ImmutableList<RelHint> newLeafAggHints =
-        new ImmutableList.Builder<RelHint>().addAll(oldHints).add(AggregateNode.INTERMEDIATE_STAGE_HINT).build();
+        new ImmutableList.Builder<RelHint>().addAll(oldHints).add(INTERMEDIATE_STAGE_HINT).build();
     Aggregate newLeafAgg =
         new LogicalAggregate(oldAggRel.getCluster(), oldAggRel.getTraitSet(), newLeafAggHints, oldAggRel.getInput(),
             oldAggRel.getGroupSet(), oldAggRel.getGroupSets(), oldAggRel.getAggCallList());
@@ -167,7 +174,7 @@ public class PinotAggregateExchangeNodeInsertRule extends RelOptRule {
     // create new aggregate relation.
     ImmutableList<RelHint> orgHints = oldAggRel.getHints();
     ImmutableList<RelHint> newIntermediateAggHints =
-        new ImmutableList.Builder<RelHint>().addAll(orgHints).add(AggregateNode.FINAL_STAGE_HINT).build();
+        new ImmutableList.Builder<RelHint>().addAll(orgHints).add(FINAL_STAGE_HINT).build();
     ImmutableBitSet groupSet = groupByList == null ? ImmutableBitSet.range(nGroups) : ImmutableBitSet.of(groupByList);
     relBuilder.aggregate(
         relBuilder.groupKey(groupSet, ImmutableList.of(groupSet)),

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotAggregateToSemiJoinRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotAggregateToSemiJoinRule.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelOptUtil;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinInfo;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.calcite.util.ImmutableBitSet;
+import org.apache.calcite.util.ImmutableIntList;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+
+/**
+ * SemiJoinRule that matches an Aggregate on top of a Join with an Aggregate
+ * as its right child.
+ *
+ * @see CoreRules#PROJECT_TO_SEMI_JOIN
+ */
+public class PinotAggregateToSemiJoinRule extends RelOptRule {
+  public static final PinotAggregateToSemiJoinRule INSTANCE =
+      new PinotAggregateToSemiJoinRule(PinotRuleUtils.PINOT_REL_FACTORY);
+
+  public PinotAggregateToSemiJoinRule(RelBuilderFactory factory) {
+    super(operand(LogicalAggregate.class, any()), factory, null);
+  }
+
+  @Override
+  @SuppressWarnings("rawtypes")
+  public boolean matches(RelOptRuleCall call) {
+    final Aggregate topAgg = call.rel(0);
+    if (!PinotRuleUtils.isJoin(topAgg.getInput())) {
+      return false;
+    }
+    final Join join = (Join) PinotRuleUtils.unboxRel(topAgg.getInput());
+    return PinotRuleUtils.isAggregate(join.getInput(1));
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    final Aggregate topAgg = call.rel(0);
+    final Join join = (Join) PinotRuleUtils.unboxRel(topAgg.getInput());
+    final RelNode left = PinotRuleUtils.unboxRel(join.getInput(0));
+    final Aggregate rightAgg = (Aggregate) PinotRuleUtils.unboxRel(join.getInput(1));
+    perform(call, topAgg, join, left, rightAgg);
+  }
+
+
+  protected void perform(RelOptRuleCall call, @Nullable Aggregate topAgg,
+      Join join, RelNode left, Aggregate rightAgg) {
+    final RelOptCluster cluster = join.getCluster();
+    final RexBuilder rexBuilder = cluster.getRexBuilder();
+    if (topAgg != null) {
+      final ImmutableBitSet aggBits = ImmutableBitSet.of(RelOptUtil.getAllFields(topAgg));
+      final ImmutableBitSet rightBits =
+          ImmutableBitSet.range(left.getRowType().getFieldCount(),
+              join.getRowType().getFieldCount());
+      if (aggBits.intersects(rightBits)) {
+        return;
+      }
+    } else {
+      if (join.getJoinType().projectsRight()
+          && !isEmptyAggregate(rightAgg)) {
+        return;
+      }
+    }
+    final JoinInfo joinInfo = join.analyzeCondition();
+    if (!joinInfo.rightSet().equals(
+        ImmutableBitSet.range(rightAgg.getGroupCount()))) {
+      // Rule requires that aggregate key to be the same as the join key.
+      // By the way, neither a super-set nor a sub-set would work.
+      return;
+    }
+    if (!joinInfo.isEqui()) {
+      return;
+    }
+    final RelBuilder relBuilder = call.builder();
+    relBuilder.push(left);
+    switch (join.getJoinType()) {
+      case SEMI:
+      case INNER:
+        final List<Integer> newRightKeyBuilder = new ArrayList<>();
+        final List<Integer> aggregateKeys = rightAgg.getGroupSet().asList();
+        for (int key : joinInfo.rightKeys) {
+          newRightKeyBuilder.add(aggregateKeys.get(key));
+        }
+        final ImmutableIntList newRightKeys = ImmutableIntList.copyOf(newRightKeyBuilder);
+        relBuilder.push(rightAgg.getInput());
+        final RexNode newCondition =
+            RelOptUtil.createEquiJoinCondition(relBuilder.peek(2, 0),
+                joinInfo.leftKeys, relBuilder.peek(2, 1), newRightKeys,
+                rexBuilder);
+        relBuilder.semiJoin(newCondition).hints(join.getHints());
+        break;
+
+      case LEFT:
+        // The right-hand side produces no more than 1 row (because of the
+        // Aggregate) and no fewer than 1 row (because of LEFT), and therefore
+        // we can eliminate the semi-join.
+        break;
+
+      default:
+        throw new AssertionError(join.getJoinType());
+    }
+    if (topAgg != null) {
+      relBuilder.aggregate(relBuilder.groupKey(topAgg.getGroupSet()), topAgg.getAggCallList());
+    }
+    final RelNode relNode = relBuilder.build();
+    call.transformTo(relNode);
+  }
+
+  private static boolean isEmptyAggregate(Aggregate aggregate) {
+    return aggregate.getRowType().getFieldCount() == 0;
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotJoinToDynamicBroadcastRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotJoinToDynamicBroadcastRule.java
@@ -1,0 +1,170 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Collections;
+import java.util.List;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.hep.HepRelVertex;
+import org.apache.calcite.rel.RelDistributions;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.JoinInfo;
+import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.hint.PinotHintOptions;
+import org.apache.calcite.rel.hint.PinotHintStrategyTable;
+import org.apache.calcite.rel.logical.LogicalExchange;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.tools.RelBuilderFactory;
+import org.apache.zookeeper.common.StringUtils;
+
+
+/**
+ * Special rule for Pinot, this rule transposing an INNER JOIN into dynamic broadcast join for the leaf stage.
+ *
+ * <p>Consider the following INNER JOIN plan
+ *
+ *                  ...                                     ...
+ *                   |                                       |
+ *             [ Transform ]                           [ Transform ]
+ *                   |                                       |
+ *             [ Inner Join ]                     [ Pass-through xChange ]
+ *             /            \                          /
+ *        [xChange]      [xChange]              [Inner Join] <----
+ *           /                \                      /            \
+ *     [ Transform ]     [ Transform ]         [ Transform ]       \
+ *          |                  |                    |               \
+ *     [Proj/Filter]     [Proj/Filter]         [Proj/Filter]  <------\
+ *          |                  |                    |                 \
+ *     [Table Scan ]     [Table Scan ]         [Table Scan ]       [xChange]
+ *                                                                      \
+ *                                                                 [ Transform ]
+ *                                                                       |
+ *                                                                 [Proj/Filter]
+ *                                                                       |
+ *                                                                 [Table Scan ]
+ *
+ * <p> This rule is one part of the overall mechanism and this rule only does the following
+ *
+ *                 ...                                      ...
+ *                  |                                        |
+ *            [ Transform ]                             [ Transform ]
+ *                  |                                       /
+ *            [ Inner Join ]                     [Pass-through xChange]
+ *            /            \                            /
+ *       [xChange]      [xChange]          |----[Dyn. Broadcast]   <-----
+ *          /                \             |           |                 \
+ *    [ Transform ]     [ Transform ]      |----> [ Inner Join ]      [xChange]
+ *         |                  |            |           |                   \
+ *    [Proj/Filter]     [Proj/Filter]      |      [ Transform ]       [ Transform ]
+ *         |                  |            |          |                    |
+ *    [Table Scan ]     [Table Scan ]      |----> [Proj/Filter]       [Proj/Filter]
+ *                                                     |                    |
+ *                                                [Table Scan ]       [Table Scan ]
+ *
+ *
+ *
+ * <p> The next part to extend the Dynamic broadcast into the Proj/Filter operator happens in the runtime.
+ *
+ * <p> This rewrite is only useful if we can ensure that:
+ * <ul>
+ *   <li>new plan can leverage the indexes and fast filtering of the leaf-stage Pinot server processing logic.</li>
+ *   <li>
+ *     data sending over xChange should be relatively small comparing to data would've been selected out if the dynamic
+ *     broadcast is not applied.
+ *   </li>
+ *   <li>
+ *     since leaf-stage operator can only process a typical Pinot V1 engine chain-operator chain. This means the entire
+ *     right-table will be ship over and persist in memory before the dynamic broadcast can occur. memory foot print
+ *     will be high so this rule should be use carefully until we have cost-based optimization.
+ *   </li>
+ *   <li>
+ *     if the dynamic broadcast stage is broadcasting to a left-table that's pre-partitioned with the join key, then the
+ *     right-table will be ship over and persist in memory using hash distribution. memory foot print will be
+ *     relatively low comparing to non-partitioned.
+ *   </li>
+ *   <li>
+ *     if the dynamic broadcast stage operating on a table with the same partition scheme as the left-table, then there
+ *     is not going to be any network shuffling overhead. both memory and latency overhead will be low.
+ *   </li>
+ * </ul>
+ *
+ * TODO #1: Only support SEMI-JOIN, once JOIN operator is supported by leaf-stage we should allow it to match
+ *   @see <a href="https://github.com/apache/pinot/pull/10565/>
+ * TODO #2: Only convert to dynamic broadcast from right-to-left, allow option to specify dynamic broadcast direction.
+ * TODO #3: Only convert to dynamic broadcast if left is leaf stage, allow the option for intermediate stage.
+ * TODO #4: currently adding a pass-through after join, support leaf-stage to chain arbitrary operator(s) next.
+ */
+public class PinotJoinToDynamicBroadcastRule extends RelOptRule {
+  public static final PinotJoinToDynamicBroadcastRule INSTANCE =
+      new PinotJoinToDynamicBroadcastRule(PinotRuleUtils.PINOT_REL_FACTORY);
+  private static final String DYNAMIC_BROADCAST_HINT_OPTION_VALUE = "dynamic_broadcast";
+
+  public PinotJoinToDynamicBroadcastRule(RelBuilderFactory factory) {
+    super(operand(LogicalJoin.class, any()), factory, null);
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    if (call.rels.length < 1 || !(call.rel(0) instanceof Join)) {
+      return false;
+    }
+    Join join = call.rel(0);
+    String joinStrategyString = PinotHintStrategyTable.getHintOption(join.getHints(),
+        PinotHintOptions.JOIN_HINT_OPTIONS, PinotHintOptions.JoinHintOptions.JOIN_STRATEGY);
+    List<String> joinStrategies = joinStrategyString != null ? StringUtils.split(joinStrategyString, ",")
+        : Collections.emptyList();
+    if (!joinStrategies.contains(DYNAMIC_BROADCAST_HINT_OPTION_VALUE)) {
+      return false;
+    }
+    JoinInfo joinInfo = join.analyzeCondition();
+    RelNode left = join.getLeft() instanceof HepRelVertex ? ((HepRelVertex) join.getLeft()).getCurrentRel()
+        : join.getLeft();
+    RelNode right = join.getRight() instanceof HepRelVertex ? ((HepRelVertex) join.getRight()).getCurrentRel()
+        : join.getRight();
+    return left instanceof LogicalExchange && right instanceof LogicalExchange
+        && PinotRuleUtils.noExchangeInSubtree(left.getInput(0))
+        && (join.getJoinType() == JoinRelType.SEMI && joinInfo.nonEquiConditions.isEmpty());
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    Join join = call.rel(0);
+    LogicalExchange left = (LogicalExchange) (join.getLeft() instanceof HepRelVertex
+        ? ((HepRelVertex) join.getLeft()).getCurrentRel() : join.getLeft());
+    LogicalExchange right = (LogicalExchange) (join.getRight() instanceof HepRelVertex
+        ? ((HepRelVertex) join.getRight()).getCurrentRel() : join.getRight());
+
+    boolean isColocatedJoin = PinotHintStrategyTable.containsHintOption(join.getHints(),
+        PinotHintOptions.JOIN_HINT_OPTIONS, PinotHintOptions.JoinHintOptions.IS_COLOCATED_BY_JOIN_KEYS);
+    LogicalExchange dynamicBroadcastExchange = isColocatedJoin
+        ? LogicalExchange.create(right.getInput(), RelDistributions.SINGLETON)
+        : LogicalExchange.create(right.getInput(), RelDistributions.BROADCAST_DISTRIBUTED);
+    Join dynamicFilterJoin =
+        new LogicalJoin(join.getCluster(), join.getTraitSet(), left.getInput(), dynamicBroadcastExchange,
+            join.getCondition(), join.getVariablesSet(), join.getJoinType(), join.isSemiJoinDone(),
+            ImmutableList.copyOf(join.getSystemFieldList()));
+    // adding pass-through exchange after join b/c currently leaf-stage doesn't support chaining operator(s) after JOIN
+    LogicalExchange passThroughAfterJoinExchange =
+        LogicalExchange.create(dynamicFilterJoin, RelDistributions.SINGLETON);
+    call.transformTo(passThroughAfterJoinExchange);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
@@ -123,6 +123,9 @@ public class PinotQueryRuleSets {
       PinotJoinExchangeNodeInsertRule.INSTANCE,
       PinotAggregateExchangeNodeInsertRule.INSTANCE,
       PinotWindowExchangeNodeInsertRule.INSTANCE,
-      PinotSetOpExchangeNodeInsertRule.INSTANCE
+      PinotSetOpExchangeNodeInsertRule.INSTANCE,
+
+      // apply dynamic broadcast rule after exchange is inserted/
+      PinotJoinToDynamicBroadcastRule.INSTANCE
   );
 }

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
@@ -73,6 +73,7 @@ public class PinotQueryRuleSets {
           // join rules
           CoreRules.JOIN_PUSH_EXPRESSIONS,
           CoreRules.PROJECT_TO_SEMI_JOIN,
+          PinotAggregateToSemiJoinRule.INSTANCE,
 
           // convert non-all union into all-union + distinct
           CoreRules.UNION_TO_DISTINCT,

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotRuleUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotRuleUtils.java
@@ -21,7 +21,9 @@ package org.apache.calcite.rel.rules;
 import org.apache.calcite.plan.Contexts;
 import org.apache.calcite.plan.hep.HepRelVertex;
 import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
 import org.apache.calcite.rel.core.Exchange;
+import org.apache.calcite.rel.core.Join;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.RelFactories;
 import org.apache.calcite.rel.logical.LogicalExchange;
@@ -40,20 +42,28 @@ public class PinotRuleUtils {
     // do not instantiate.
   }
 
-  public static boolean isExchange(RelNode rel) {
-    RelNode reference = rel;
-    if (reference instanceof HepRelVertex) {
-      reference = ((HepRelVertex) reference).getCurrentRel();
+  public static RelNode unboxRel(RelNode rel) {
+    if (rel instanceof HepRelVertex) {
+      return ((HepRelVertex) rel).getCurrentRel();
+    } else {
+      return rel;
     }
-    return reference instanceof Exchange;
+  }
+
+  public static boolean isExchange(RelNode rel) {
+    return unboxRel(rel) instanceof Exchange;
   }
 
   public static boolean isProject(RelNode rel) {
-    RelNode reference = rel;
-    if (reference instanceof HepRelVertex) {
-      reference = ((HepRelVertex) reference).getCurrentRel();
-    }
-    return reference instanceof Project;
+    return unboxRel(rel) instanceof Project;
+  }
+
+  public static boolean isJoin(RelNode rel) {
+    return unboxRel(rel) instanceof Join;
+  }
+
+  public static boolean isAggregate(RelNode rel) {
+    return unboxRel(rel) instanceof Aggregate;
   }
 
   // TODO: optimize this part out as it is not efficient to scan the entire subtree for exchanges.

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotRuleUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotRuleUtils.java
@@ -24,6 +24,7 @@ import org.apache.calcite.rel.RelNode;
 import org.apache.calcite.rel.core.Exchange;
 import org.apache.calcite.rel.core.Project;
 import org.apache.calcite.rel.core.RelFactories;
+import org.apache.calcite.rel.logical.LogicalExchange;
 import org.apache.calcite.tools.RelBuilder;
 import org.apache.calcite.tools.RelBuilderFactory;
 
@@ -53,5 +54,21 @@ public class PinotRuleUtils {
       reference = ((HepRelVertex) reference).getCurrentRel();
     }
     return reference instanceof Project;
+  }
+
+  // TODO: optimize this part out as it is not efficient to scan the entire subtree for exchanges.
+  public static boolean noExchangeInSubtree(RelNode relNode) {
+    if (relNode instanceof HepRelVertex) {
+      relNode = ((HepRelVertex) relNode).getCurrentRel();
+    }
+    if (relNode instanceof LogicalExchange) {
+      return false;
+    }
+    for (RelNode child : relNode.getInputs()) {
+      if (!noExchangeInSubtree(child)) {
+        return false;
+      }
+    }
+    return true;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/AggregateNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/AggregateNode.java
@@ -30,11 +30,6 @@ import org.apache.pinot.query.planner.serde.ProtoProperties;
 
 
 public class AggregateNode extends AbstractPlanNode {
-  public static final RelHint FINAL_STAGE_HINT = RelHint.builder(
-      PinotHintStrategyTable.INTERNAL_AGG_FINAL_STAGE).build();
-  public static final RelHint INTERMEDIATE_STAGE_HINT = RelHint.builder(
-      PinotHintStrategyTable.INTERNAL_AGG_INTERMEDIATE_STAGE).build();
-
   private List<RelHint> _relHints;
   @ProtoProperties
   private List<RexExpression> _aggCalls;
@@ -57,11 +52,13 @@ public class AggregateNode extends AbstractPlanNode {
   }
 
   public static boolean isFinalStage(AggregateNode aggNode) {
-    return aggNode.getRelHints().contains(FINAL_STAGE_HINT);
+    return PinotHintStrategyTable.containsHint(aggNode.getRelHints(),
+        PinotHintStrategyTable.INTERNAL_AGG_FINAL_STAGE);
   }
 
   public static boolean isIntermediateStage(AggregateNode aggNode) {
-    return aggNode.getRelHints().contains(INTERMEDIATE_STAGE_HINT);
+    return PinotHintStrategyTable.containsHint(aggNode.getRelHints(),
+        PinotHintStrategyTable.INTERNAL_AGG_INTERMEDIATE_STAGE);
   }
 
   public List<RexExpression> getAggCalls() {

--- a/pinot-query-planner/src/test/resources/queries/PinotHintablePlans.json
+++ b/pinot-query-planner/src/test/resources/queries/PinotHintablePlans.json
@@ -1,0 +1,107 @@
+{
+  "pinot_hint_option_tests": {
+    "queries": [
+      {
+        "description": "semi-join with dynamic_broadcast join strategy",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='dynamic_broadcast,unknown_hint') */ a.col1, a.col2 FROM a WHERE a.col1 IN (SELECT col2 FROM b WHERE b.col3 > 0)",
+        "output": [
+          "Execution Plan",
+          "\nLogicalExchange(distribution=[single])",
+          "\n  LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
+          "\n    LogicalProject(col1=[$0], col2=[$1])",
+          "\n      LogicalTableScan(table=[[a]])",
+          "\n    LogicalExchange(distribution=[broadcast])",
+          "\n      LogicalProject(col2=[$1], col3=[$2])",
+          "\n        LogicalFilter(condition=[>($2, 0)])",
+          "\n          LogicalTableScan(table=[[b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "semi-join with colocated join key",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(colocated_by_join_keys) */ * FROM a WHERE a.col1 IN (SELECT col2 FROM b WHERE b.col3 > 0)",
+        "output": [
+          "Execution Plan",
+          "\nLogicalJoin(condition=[=($0, $5)], joinType=[semi])",
+          "\n  LogicalExchange(distribution=[hash[0]])",
+          "\n    LogicalTableScan(table=[[a]])",
+          "\n  LogicalExchange(distribution=[hash[0]])",
+          "\n    LogicalProject(col2=[$1], col3=[$2])",
+          "\n      LogicalFilter(condition=[>($2, 0)])",
+          "\n        LogicalTableScan(table=[[b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "semi-join with colocated join key and dynamic_broadcast join strategy",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='dynamic_broadcast', colocated_by_join_keys='true') */ a.col1, a.col2 FROM a WHERE a.col1 IN (SELECT col2 FROM b WHERE b.col3 > 0)",
+        "output": [
+          "Execution Plan",
+          "\nLogicalExchange(distribution=[single])",
+          "\n  LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
+          "\n    LogicalProject(col1=[$0], col2=[$1])",
+          "\n      LogicalTableScan(table=[[a]])",
+          "\n    LogicalExchange(distribution=[single])",
+          "\n      LogicalProject(col2=[$1], col3=[$2])",
+          "\n        LogicalFilter(condition=[>($2, 0)])",
+          "\n          LogicalTableScan(table=[[b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "aggregate with skip leaf stage hint, group by aggregate",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ skipLeafStageGroupByAggregation */ a.col2, a.col1, SUM(a.col3) FROM a WHERE a.col3 >= 0 AND a.col1 = 'a' GROUP BY a.col1, a.col2",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col2=[$1], col1=[$0], EXPR$2=[$2])",
+          "\n  LogicalAggregate(group=[{0, 1}], EXPR$2=[$SUM0($2)])",
+          "\n    LogicalExchange(distribution=[hash[0, 1]])",
+          "\n      LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
+          "\n        LogicalFilter(condition=[AND(>=($2, 0), =($0, 'a'))])",
+          "\n          LogicalTableScan(table=[[a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "aggregate with skip leaf stage hint, group by aggregate with having clause",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ skipLeafStageGroupByAggregation */ a.col2, COUNT(*), SUM(a.col3), SUM(a.col1) FROM a WHERE a.col3 >= 0 AND a.col2 = 'a' GROUP BY a.col2 HAVING COUNT(*) > 10 AND MAX(a.col3) >= 0 AND MIN(a.col3) < 20 AND SUM(a.col3) <= 10 AND AVG(a.col3) = 5",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col2=[$0], EXPR$1=[$1], EXPR$2=[$2], EXPR$3=[$3])",
+          "\n  LogicalFilter(condition=[AND(>($1, 10), >=($4, 0), <($5, 20), <=($2, 10), =(/(CAST($2):DOUBLE NOT NULL, $1), 5))])",
+          "\n    LogicalAggregate(group=[{0}], EXPR$1=[COUNT()], EXPR$2=[$SUM0($1)], EXPR$3=[$SUM0($2)], agg#3=[MAX($1)], agg#4=[MIN($1)])",
+          "\n      LogicalExchange(distribution=[hash[0]])",
+          "\n        LogicalProject(col2=[$1], col3=[$2], $f2=[CAST($0):DECIMAL(1000, 500) NOT NULL])",
+          "\n          LogicalFilter(condition=[AND(>=($2, 0), =($1, 'a'))])",
+          "\n            LogicalTableScan(table=[[a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "aggregate with skip intermediate stage hint (via hinting the leaf stage group by as final stage_",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ aggFinalStage */ a.col2, COUNT(*), SUM(a.col3), SUM(a.col1) FROM a WHERE a.col3 >= 0 AND a.col2 = 'a' GROUP BY a.col2 HAVING COUNT(*) > 10",
+        "output": [
+          "Execution Plan",
+          "\nLogicalFilter(condition=[>($1, 10)])",
+          "\n  LogicalAggregate(group=[{0}], EXPR$1=[COUNT()], EXPR$2=[$SUM0($1)], EXPR$3=[$SUM0($2)])",
+          "\n    LogicalProject(col2=[$1], col3=[$2], $f2=[CAST($0):DECIMAL(1000, 500) NOT NULL])",
+          "\n      LogicalFilter(condition=[AND(>=($2, 0), =($1, 'a'))])",
+          "\n        LogicalTableScan(table=[[a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "aggregate with skip leaf stage hint (via hint option partitioned_by_group_by_keys",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ aggOptions(partitioned_by_group_by_keys='true') */ a.col2, COUNT(*), SUM(a.col3), SUM(a.col1) FROM a WHERE a.col3 >= 0 AND a.col2 = 'a' GROUP BY a.col2",
+        "output": [
+          "Execution Plan",
+          "\nLogicalAggregate(group=[{0}], EXPR$1=[COUNT()], EXPR$2=[$SUM0($1)], EXPR$3=[$SUM0($2)])",
+          "\n  LogicalProject(col2=[$1], col3=[$2], $f2=[CAST($0):DECIMAL(1000, 500) NOT NULL])",
+          "\n    LogicalFilter(condition=[AND(>=($2, 0), =($1, 'a'))])",
+          "\n      LogicalTableScan(table=[[a]])",
+          "\n"
+        ]
+      }
+    ]
+  }
+}

--- a/pinot-query-planner/src/test/resources/queries/PinotHintablePlans.json
+++ b/pinot-query-planner/src/test/resources/queries/PinotHintablePlans.json
@@ -3,7 +3,7 @@
     "queries": [
       {
         "description": "semi-join with dynamic_broadcast join strategy",
-        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='dynamic_broadcast,unknown_hint') */ a.col1, a.col2 FROM a WHERE a.col1 IN (SELECT col2 FROM b WHERE b.col3 > 0)",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='dynamic_broadcast',is_colocated_by_join_keys='false') */ a.col1, a.col2 FROM a WHERE a.col1 IN (SELECT col2 FROM b WHERE b.col3 > 0)",
         "output": [
           "Execution Plan",
           "\nLogicalExchange(distribution=[single])",
@@ -19,7 +19,7 @@
       },
       {
         "description": "semi-join with colocated join key",
-        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(colocated_by_join_keys) */ * FROM a WHERE a.col1 IN (SELECT col2 FROM b WHERE b.col3 > 0)",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(is_colocated_by_join_keys) */ * FROM a WHERE a.col1 IN (SELECT col2 FROM b WHERE b.col3 > 0)",
         "output": [
           "Execution Plan",
           "\nLogicalJoin(condition=[=($0, $5)], joinType=[semi])",
@@ -34,7 +34,7 @@
       },
       {
         "description": "semi-join with colocated join key and dynamic_broadcast join strategy",
-        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='dynamic_broadcast', colocated_by_join_keys='true') */ a.col1, a.col2 FROM a WHERE a.col1 IN (SELECT col2 FROM b WHERE b.col3 > 0)",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='dynamic_broadcast', is_colocated_by_join_keys='true') */ a.col1, a.col2 FROM a WHERE a.col1 IN (SELECT col2 FROM b WHERE b.col3 > 0)",
         "output": [
           "Execution Plan",
           "\nLogicalExchange(distribution=[single])",
@@ -53,14 +53,15 @@
         "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='dynamic_broadcast'), aggFinalStage */ a.col1, SUM(a.col3) FROM a WHERE a.col1 IN (SELECT col2 FROM b WHERE b.col3 > 0) GROUP BY 1",
         "output": [
           "Execution Plan",
-          "\nLogicalExchange(distribution=[single])",
-          "\n  LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
-          "\n    LogicalProject(col1=[$0], col2=[$1])",
-          "\n      LogicalTableScan(table=[[a]])",
-          "\n    LogicalExchange(distribution=[broadcast])",
-          "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalFilter(condition=[>($2, 0)])",
-          "\n          LogicalTableScan(table=[[b]])",
+          "\nLogicalAggregate(group=[{0}], EXPR$1=[$SUM0($1)])",
+          "\n  LogicalExchange(distribution=[single])",
+          "\n    LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
+          "\n      LogicalProject(col1=[$0], col3=[$2])",
+          "\n        LogicalTableScan(table=[[a]])",
+          "\n      LogicalExchange(distribution=[broadcast])",
+          "\n        LogicalProject(col2=[$1], col3=[$2])",
+          "\n          LogicalFilter(condition=[>($2, 0)])",
+          "\n            LogicalTableScan(table=[[b]])",
           "\n"
         ]
       },
@@ -69,14 +70,17 @@
         "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='dynamic_broadcast') */ a.col2, SUM(a.col3) FROM a WHERE a.col1 IN (SELECT col2 FROM b WHERE b.col3 > 0) GROUP BY 1",
         "output": [
           "Execution Plan",
-          "\nLogicalExchange(distribution=[single])",
-          "\n  LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
-          "\n    LogicalProject(col1=[$0], col2=[$1])",
-          "\n      LogicalTableScan(table=[[a]])",
-          "\n    LogicalExchange(distribution=[broadcast])",
-          "\n      LogicalProject(col2=[$1], col3=[$2])",
-          "\n        LogicalFilter(condition=[>($2, 0)])",
-          "\n          LogicalTableScan(table=[[b]])",
+          "\nLogicalAggregate(group=[{0}], EXPR$1=[$SUM0($1)])",
+          "\n  LogicalExchange(distribution=[hash[0]])",
+          "\n    LogicalAggregate(group=[{1}], EXPR$1=[$SUM0($2)])",
+          "\n      LogicalExchange(distribution=[single])",
+          "\n        LogicalJoin(condition=[=($0, $3)], joinType=[semi])",
+          "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
+          "\n            LogicalTableScan(table=[[a]])",
+          "\n          LogicalExchange(distribution=[broadcast])",
+          "\n            LogicalProject(col2=[$1], col3=[$2])",
+          "\n              LogicalFilter(condition=[>($2, 0)])",
+          "\n                LogicalTableScan(table=[[b]])",
           "\n"
         ]
       },
@@ -123,8 +127,8 @@
         ]
       },
       {
-        "description": "aggregate with skip leaf stage hint (via hint option partitioned_by_group_by_keys",
-        "sql": "EXPLAIN PLAN FOR SELECT /*+ aggOptions(partitioned_by_group_by_keys='true') */ a.col2, COUNT(*), SUM(a.col3), SUM(a.col1) FROM a WHERE a.col3 >= 0 AND a.col2 = 'a' GROUP BY a.col2",
+        "description": "aggregate with skip leaf stage hint (via hint option is_partitioned_by_group_by_keys",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ aggOptions(is_partitioned_by_group_by_keys='true') */ a.col2, COUNT(*), SUM(a.col3), SUM(a.col1) FROM a WHERE a.col3 >= 0 AND a.col2 = 'a' GROUP BY a.col2",
         "output": [
           "Execution Plan",
           "\nLogicalAggregate(group=[{0}], EXPR$1=[COUNT()], EXPR$2=[$SUM0($1)], EXPR$3=[$SUM0($2)])",

--- a/pinot-query-planner/src/test/resources/queries/PinotHintablePlans.json
+++ b/pinot-query-planner/src/test/resources/queries/PinotHintablePlans.json
@@ -49,6 +49,38 @@
         ]
       },
       {
+        "description": "semi-join with dynamic_broadcast join strategy then group-by on same key",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='dynamic_broadcast'), aggFinalStage */ a.col1, SUM(a.col3) FROM a WHERE a.col1 IN (SELECT col2 FROM b WHERE b.col3 > 0) GROUP BY 1",
+        "output": [
+          "Execution Plan",
+          "\nLogicalExchange(distribution=[single])",
+          "\n  LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
+          "\n    LogicalProject(col1=[$0], col2=[$1])",
+          "\n      LogicalTableScan(table=[[a]])",
+          "\n    LogicalExchange(distribution=[broadcast])",
+          "\n      LogicalProject(col2=[$1], col3=[$2])",
+          "\n        LogicalFilter(condition=[>($2, 0)])",
+          "\n          LogicalTableScan(table=[[b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "semi-join with dynamic_broadcast join strategy then group-by on different key",
+        "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='dynamic_broadcast') */ a.col2, SUM(a.col3) FROM a WHERE a.col1 IN (SELECT col2 FROM b WHERE b.col3 > 0) GROUP BY 1",
+        "output": [
+          "Execution Plan",
+          "\nLogicalExchange(distribution=[single])",
+          "\n  LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
+          "\n    LogicalProject(col1=[$0], col2=[$1])",
+          "\n      LogicalTableScan(table=[[a]])",
+          "\n    LogicalExchange(distribution=[broadcast])",
+          "\n      LogicalProject(col2=[$1], col3=[$2])",
+          "\n        LogicalFilter(condition=[>($2, 0)])",
+          "\n          LogicalTableScan(table=[[b]])",
+          "\n"
+        ]
+      },
+      {
         "description": "aggregate with skip leaf stage hint, group by aggregate",
         "sql": "EXPLAIN PLAN FOR SELECT /*+ skipLeafStageGroupByAggregation */ a.col2, a.col1, SUM(a.col3) FROM a WHERE a.col3 >= 0 AND a.col1 = 'a' GROUP BY a.col1, a.col2",
         "output": [


### PR DESCRIPTION
Details
===
- add hintable option framework
  - indicates the hint applicable node (`aggOptions`, `joinOptions` are added for now)
  - each hint support arbitrary k-v options (e.g. `joinOptions(join_strategy='dynamic_broadcast', colocated_by_join_keys='true')`
- also added the dynamic_broadcast hint and rel optimizer rule 
  - this helps execute queries similar to ([IN_SUBQUERY](https://docs.pinot.apache.org/users/user-guide-query/filtering-with-idset#in_subquery))
- also sanitized agg hint options and tests.
  - also demonstrated that how mixed hint options work (join options and agg options)


Examples
===
- hint with hint name:
```
SELECT /*+ skipLeafStageGroupByAggregation */ 
  a, sum(b) 
FROM tbl 
GROUP BY a
```
- hint with hint options on the specific node
```
SELECT /*+ joinOptions(join_strategy='dynamic_broadcast', colocated_by_join_keys='true') */
  a, b
FROM tbl
WHERE b BETWEEN 10 AND 100
  AND c IN (SELECT d FROM tbl2 WHERE e > 10)
```

Extensibility
===
with this hint strategy framework we can extend easily.

1. adding more hintable node, such as hint on WindowNode
    - we can simply add a `windowOptions` type to `PinotHintOptions` class
2. adding more generic option keyword, such as support `partition_by='col1,col2'` on aggregate and table node. 
    - we can simply add generic k-v option keys to the `PinotHintOptions.aggOptions` sub-class to indicate that a group by should be partitioned by "col1,col2" instead of the group set.
3. adding some completely unknown keyword 
    - the entire options framework is a `Map<String, String>` basis, so we can directly extract the string value, such as on a plugged-in ruleset from some fork. we can simply extract it via String key to get the String value