### PR TITLE
Redefine the semantics of SEGMENT_STREAMED_DOWNLOAD_UNTAR_FAILURES metric to count individual segment fetch failures.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -70,6 +70,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   REFRESH_FAILURES("segments", false),
   UNTAR_FAILURES("segments", false),
   SEGMENT_STREAMED_DOWNLOAD_UNTAR_FAILURES("segments", false),
+  SEGMENT_TOTAL_STREAMED_DOWNLOAD_UNTAR_FAILURES("segments", false),
   SEGMENT_DIR_MOVEMENT_FAILURES("segments", false),
   SEGMENT_DOWNLOAD_FAILURES("segments", false),
   SEGMENT_DOWNLOAD_FROM_REMOTE_FAILURES("segments", false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -69,8 +69,8 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   RELOAD_FAILURES("segments", false),
   REFRESH_FAILURES("segments", false),
   UNTAR_FAILURES("segments", false),
-  SEGMENT_STREAMED_DOWNLOAD_UNTAR_FAILURES("segments", false),
-  SEGMENT_TOTAL_STREAMED_DOWNLOAD_UNTAR_FAILURES("segments", false),
+  SEGMENT_STREAMED_DOWNLOAD_UNTAR_FAILURES("segments", false, "Counts the number of segment "
+      + "fetch failures"),
   SEGMENT_DIR_MOVEMENT_FAILURES("segments", false),
   SEGMENT_DOWNLOAD_FAILURES("segments", false),
   SEGMENT_DOWNLOAD_FROM_REMOTE_FAILURES("segments", false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
@@ -50,7 +50,6 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
   protected int _retryDelayScaleFactor;
   protected AuthProvider _authProvider;
 
-
   @Override
   public void init(PinotConfiguration config) {
     _retryCount = config.getProperty(RETRY_COUNT_CONFIG_KEY, DEFAULT_RETRY_COUNT);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.net.URI;
 import java.util.List;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -48,6 +49,7 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
   protected int _retryWaitMs;
   protected int _retryDelayScaleFactor;
   protected AuthProvider _authProvider;
+
 
   @Override
   public void init(PinotConfiguration config) {
@@ -102,7 +104,8 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
     });
   }
 
-  public File fetchUntarSegmentToLocalStreamed(URI uri, File dest, long rateLimit)
+  public File fetchUntarSegmentToLocalStreamed(URI uri, File dest, long rateLimit,
+      AtomicInteger attempts)
       throws Exception {
     throw new UnsupportedOperationException();
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -35,6 +35,8 @@ import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.RoundRobinURIProvider;
 import org.apache.pinot.common.utils.http.HttpClientConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.retry.AttemptsExceededException;
+import org.apache.pinot.spi.utils.retry.RetriableOperationException;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 
 
@@ -101,53 +103,63 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
   public File fetchUntarSegmentToLocalStreamed(URI downloadURI, File dest, long maxStreamRateInByte,
       AtomicInteger attempts)
       throws Exception {
-    // Create a RoundRobinURIProvider to round robin IP addresses when retry uploading. Otherwise may always try to
+    // Create a RoundRobinURIProvider to round robin IP addresses when retry uploading. Otherwise, may always try to
     // download from a same broken host as: 1) DNS may not RR the IP addresses 2) OS cache the DNS resolution result.
     RoundRobinURIProvider uriProvider = new RoundRobinURIProvider(downloadURI);
     int retryCount = Math.max(_retryCount, uriProvider.numAddresses());
     AtomicReference<File> ret = new AtomicReference<>(); // return the untared segment directory
     _logger.info("Retry downloading for {} times. retryCount from pinot server config: {}, number of IP addresses for "
         + "download URI: {}", retryCount, _retryCount, uriProvider.numAddresses());
-    int tries = RetryPolicies.exponentialBackoffRetryPolicy(retryCount, _retryWaitMs,
-        _retryDelayScaleFactor).attempt(() -> {
-      URI uri = uriProvider.next();
-      try {
-        String hostName = downloadURI.getHost();
-        int port = downloadURI.getPort();
-        // If the original download address is specified as host name, need add a "HOST" HTTP header to the HTTP
-        // request. Otherwise, if the download address is a LB address, when the LB be configured as "disallow direct
-        // access by IP address", downloading will fail.
-        List<Header> httpHeaders = new LinkedList<>();
-        if (!InetAddresses.isInetAddress(hostName)) {
-          httpHeaders.add(new BasicHeader(HttpHeaders.HOST, hostName + ":" + port));
-        }
-        ret.set(_httpClient.downloadUntarFileStreamed(uri, dest, _authProvider, httpHeaders, maxStreamRateInByte));
+    int tries = 0;
+    try {
+      tries = RetryPolicies.exponentialBackoffRetryPolicy(retryCount, _retryWaitMs, _retryDelayScaleFactor).attempt(
+          () -> {
+        URI uri = uriProvider.next();
+        try {
+          String hostName = downloadURI.getHost();
+          int port = downloadURI.getPort();
+          // If the original download address is specified as host name, need add a "HOST" HTTP header to the HTTP
+          // request. Otherwise, if the download address is a LB address, when the LB be configured as "disallow direct
+          // access by IP address", downloading will fail.
+          List<Header> httpHeaders = new LinkedList<>();
+          if (!InetAddresses.isInetAddress(hostName)) {
+            httpHeaders.add(new BasicHeader(HttpHeaders.HOST, hostName + ":" + port));
+          }
+          ret.set(_httpClient.downloadUntarFileStreamed(uri, dest, _authProvider, httpHeaders, maxStreamRateInByte));
 
-        return true;
-      } catch (HttpErrorStatusException e) {
-        int statusCode = e.getStatusCode();
-        if (statusCode == HttpStatus.SC_NOT_FOUND || statusCode >= 500) {
-          // Temporary exception
-          // 404 is treated as a temporary exception, as the downloadURI may be backed by multiple hosts,
-          // if singe host is down, can retry with another host.
-          _logger.warn("Got temporary error status code: {} while downloading segment from: {} to: {}", statusCode, uri,
+          return true;
+        } catch (HttpErrorStatusException e) {
+          int statusCode = e.getStatusCode();
+          if (statusCode == HttpStatus.SC_NOT_FOUND || statusCode >= 500) {
+            // Temporary exception
+            // 404 is treated as a temporary exception, as the downloadURI may be backed by multiple hosts,
+            // if singe host is down, can retry with another host.
+            _logger.warn("Got temporary error status code: {} while downloading segment from: {} to: {}", statusCode,
+                uri,
+                dest, e);
+            return false;
+          } else {
+            // Permanent exception
+            _logger.error("Got permanent error status code: {} while downloading segment from: {} to: {}, won't retry",
+                statusCode, uri, dest, e);
+            throw e;
+          }
+        } catch (IOException e) {
+          _logger.warn("Caught IOException while stream download-untarring segment from: {} to: {}, retrying", uri,
               dest, e);
           return false;
-        } else {
-          // Permanent exception
-          _logger.error("Got permanent error status code: {} while downloading segment from: {} to: {}, won't retry",
-              statusCode, uri, dest, e);
-          throw e;
+        } catch (Exception e) {
+          _logger.warn("Caught exception while downloading segment from: {} to: {}", uri, dest, e);
+          return false;
         }
-      } catch (IOException e) {
-        _logger.warn("Caught IOException while stream download-untarring segment from: {} to: {}, retrying",
-            uri, dest, e);
-        return false;
-      } catch (Exception e) {
-        _logger.warn("Caught exception while downloading segment from: {} to: {}", uri, dest, e);
-        return false;
-      }
-    });
+      });
+    } catch (AttemptsExceededException e) {
+      attempts.set(e.getAttempts());
+      throw e;
+    } catch (RetriableOperationException e) {
+      attempts.set(e.getAttempts());
+      throw e;
+    }
     attempts.set(tries);
     return ret.get();
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -110,7 +110,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
     AtomicReference<File> ret = new AtomicReference<>(); // return the untared segment directory
     _logger.info("Retry downloading for {} times. retryCount from pinot server config: {}, number of IP addresses for "
         + "download URI: {}", retryCount, _retryCount, uriProvider.numAddresses());
-    int tries = 0;
+    int tries;
     try {
       tries = RetryPolicies.exponentialBackoffRetryPolicy(retryCount, _retryWaitMs, _retryDelayScaleFactor).attempt(
           () -> {
@@ -135,8 +135,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
             // 404 is treated as a temporary exception, as the downloadURI may be backed by multiple hosts,
             // if singe host is down, can retry with another host.
             _logger.warn("Got temporary error status code: {} while downloading segment from: {} to: {}", statusCode,
-                uri,
-                dest, e);
+                uri, dest, e);
             return false;
           } else {
             // Permanent exception

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcher.java
@@ -21,6 +21,7 @@ package org.apache.pinot.common.utils.fetcher;
 import java.io.File;
 import java.net.URI;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
 
@@ -40,7 +41,7 @@ public interface SegmentFetcher {
   /**
    * Fetches a segment from URI location and untar to local in a streamed manner
    */
-  File fetchUntarSegmentToLocalStreamed(URI uri, File dest, long rateLimit)
+  File fetchUntarSegmentToLocalStreamed(URI uri, File dest, long rateLimit, AtomicInteger attempts)
       throws Exception;
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactory.java
@@ -26,6 +26,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pinot.common.auth.AuthConfig;
 import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.spi.crypt.PinotCrypter;
@@ -166,14 +167,17 @@ public class SegmentFetcherFactory {
    * @return the untared directory
    * @throws Exception
    */
-  public static File fetchAndStreamUntarToLocal(String uri, File tempRootDir, long maxStreamRateInByte)
+  public static File fetchAndStreamUntarToLocal(String uri, File tempRootDir,
+      long maxStreamRateInByte, AtomicInteger attempts)
       throws Exception {
-    return getInstance().fetchAndStreamUntarToLocalInternal(new URI(uri), tempRootDir, maxStreamRateInByte);
+    return getInstance().fetchAndStreamUntarToLocalInternal(new URI(uri), tempRootDir, maxStreamRateInByte, attempts);
   }
 
-  private File fetchAndStreamUntarToLocalInternal(URI uri, File tempRootDir, long maxStreamRateInByte)
+  private File fetchAndStreamUntarToLocalInternal(URI uri, File tempRootDir,
+      long maxStreamRateInByte, AtomicInteger attempts)
       throws Exception {
-    return getSegmentFetcher(uri.getScheme()).fetchUntarSegmentToLocalStreamed(uri, tempRootDir, maxStreamRateInByte);
+    return getSegmentFetcher(uri.getScheme()).fetchUntarSegmentToLocalStreamed(uri, tempRootDir, maxStreamRateInByte,
+        attempts);
   }
 
   /**

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactoryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/fetcher/SegmentFetcherFactoryTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.pinot.spi.crypt.PinotCrypter;
 import org.apache.pinot.spi.crypt.PinotCrypterFactory;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -115,10 +116,11 @@ public class SegmentFetcherFactoryTest {
     }
 
     @Override
-    public File fetchUntarSegmentToLocalStreamed(URI uri, File dest, long rateLimit)
+    public File fetchUntarSegmentToLocalStreamed(URI uri, File dest, long rateLimit, AtomicInteger attempts)
         throws Exception {
       assertEquals(uri, new URI(TEST_URI));
       _fetchFileToLocalCalled++;
+      attempts.set(0);
       return new File("fakeSegmentIndexFile");
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -628,9 +628,15 @@ public abstract class BaseTableDataManager implements TableDataManager {
         maxStreamRateInByte);
     String uri = zkMetadata.getDownloadUrl();
     try {
-      File ret = SegmentFetcherFactory.fetchAndStreamUntarToLocal(uri, tempRootDir, maxStreamRateInByte);
-      LOGGER.info("Download and untarred segment: {} for table: {} from: {}", segmentName, _tableNameWithType, uri);
-      return ret;
+      try {
+        File ret = SegmentFetcherFactory.fetchAndStreamUntarToLocal(uri, tempRootDir, maxStreamRateInByte);
+        LOGGER.info("Download and untarred segment: {} for table: {} from: {}", segmentName, _tableNameWithType, uri);
+        return ret;
+      } catch (Exception e) {
+        _serverMetrics.addMeteredTableValue(_tableNameWithType,
+            ServerMeter.SEGMENT_TOTAL_STREAMED_DOWNLOAD_UNTAR_FAILURES, 1L);
+        throw e;
+      }
     } catch (AttemptsExceededException e) {
       LOGGER.error("Attempts exceeded when stream download-untarring segment: {} for table: {} from: {} to: {}",
           segmentName, _tableNameWithType, uri, tempRootDir);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -628,19 +628,16 @@ public abstract class BaseTableDataManager implements TableDataManager {
         maxStreamRateInByte);
     String uri = zkMetadata.getDownloadUrl();
     try {
-      try {
         File ret = SegmentFetcherFactory.fetchAndStreamUntarToLocal(uri, tempRootDir, maxStreamRateInByte);
-        LOGGER.info("Download and untarred segment: {} for table: {} from: {}", segmentName, _tableNameWithType, uri);
+        LOGGER.info("Downloaded and untarred segment: {} for table: {} from: {}", segmentName, _tableNameWithType, uri);
         return ret;
-      } catch (Exception e) {
-        _serverMetrics.addMeteredTableValue(_tableNameWithType,
-            ServerMeter.SEGMENT_TOTAL_STREAMED_DOWNLOAD_UNTAR_FAILURES, 1L);
-        throw e;
+    } catch (Exception e) {
+      _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.SEGMENT_STREAMED_DOWNLOAD_UNTAR_FAILURES,
+          1L);
+      if (e instanceof AttemptsExceededException) {
+        LOGGER.error("Attempts exceeded when stream download-untarring segment: {} for table: {} from: {} to: {}",
+            segmentName, _tableNameWithType, uri, tempRootDir);
       }
-    } catch (AttemptsExceededException e) {
-      LOGGER.error("Attempts exceeded when stream download-untarring segment: {} for table: {} from: {} to: {}",
-          segmentName, _tableNameWithType, uri, tempRootDir);
-      _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.SEGMENT_STREAMED_DOWNLOAD_UNTAR_FAILURES, 1L);
       throw e;
     } finally {
       if (_segmentDownloadSemaphore != null) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/AttemptsExceededException.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/AttemptsExceededException.java
@@ -24,7 +24,18 @@ package org.apache.pinot.spi.utils.retry;
  */
 public class AttemptsExceededException extends AttemptFailureException {
 
+  private int _attempts = 0;
+
   public AttemptsExceededException(String message) {
     super(message);
+  }
+
+  public AttemptsExceededException(String message, int attempts) {
+    super(message);
+    _attempts = attempts;
+  }
+
+  public int getAttempts() {
+    return _attempts;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/BaseRetryPolicy.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/BaseRetryPolicy.java
@@ -60,8 +60,8 @@ public abstract class BaseRetryPolicy implements RetryPolicy {
         return attempt;
       }
     } catch (Exception e) {
-      throw new RetriableOperationException(e);
+      throw new RetriableOperationException(e, attempt + 1);
     }
-    throw new AttemptsExceededException("Operation failed after " + _maxNumAttempts + " attempts");
+    throw new AttemptsExceededException("Operation failed after " + _maxNumAttempts + " attempts", attempt);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/BaseRetryPolicy.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/BaseRetryPolicy.java
@@ -62,6 +62,6 @@ public abstract class BaseRetryPolicy implements RetryPolicy {
     } catch (Exception e) {
       throw new RetriableOperationException(e, attempt + 1);
     }
-    throw new AttemptsExceededException("Operation failed after " + _maxNumAttempts + " attempts", attempt);
+    throw new AttemptsExceededException("Operation failed after " + _maxNumAttempts + " attempts", _maxNumAttempts);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/BaseRetryPolicy.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/BaseRetryPolicy.java
@@ -42,14 +42,14 @@ public abstract class BaseRetryPolicy implements RetryPolicy {
   protected abstract long getDelayMs(int currentAttempt);
 
   @Override
-  public void attempt(Callable<Boolean> operation)
+  public int attempt(Callable<Boolean> operation)
       throws AttemptsExceededException, RetriableOperationException {
     int attempt = 0;
     try {
       while (attempt < _maxNumAttempts - 1) {
         if (Boolean.TRUE.equals(operation.call())) {
           // Succeeded
-          return;
+          return attempt;
         } else {
           // Failed
           Thread.sleep(getDelayMs(attempt++));
@@ -57,7 +57,7 @@ public abstract class BaseRetryPolicy implements RetryPolicy {
       }
       if (_maxNumAttempts > 0 && Boolean.TRUE.equals(operation.call())) {
         // Succeeded
-        return;
+        return attempt;
       }
     } catch (Exception e) {
       throw new RetriableOperationException(e);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/RetriableOperationException.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/RetriableOperationException.java
@@ -23,7 +23,18 @@ package org.apache.pinot.spi.utils.retry;
  */
 public class RetriableOperationException extends AttemptFailureException {
 
+  private int _attempts = 0;
+
+  public int getAttempts() {
+    return _attempts;
+  }
+
   public RetriableOperationException(Throwable cause) {
     super(cause);
+  }
+
+  public RetriableOperationException(Throwable cause, int attempts) {
+    super(cause);
+    _attempts = attempts;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/RetryPolicy.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/retry/RetryPolicy.java
@@ -33,7 +33,8 @@ public interface RetryPolicy {
    * @param operation The operation to attempt, which returns true on success and false on failure.
    * @throws AttemptsExceededException
    * @throws RetriableOperationException
+   * @return the number of attempts used for the operation. 0 means the first try was successful.
    */
-  void attempt(Callable<Boolean> operation)
+  int attempt(Callable<Boolean> operation)
       throws AttemptsExceededException, RetriableOperationException;
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/retry/RetryPolicyTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/retry/RetryPolicyTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.spi.utils.retry;
 
+import java.util.concurrent.atomic.AtomicInteger;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -105,6 +106,7 @@ public class RetryPolicyTest {
         Assert.fail();
       } catch (AttemptsExceededException e) {
         // Expected
+        Assert.assertEquals(e.getAttempts(), MAX_NUM_ATTEMPTS - 1);
       }
 
       try {
@@ -112,6 +114,7 @@ public class RetryPolicyTest {
         Assert.fail();
       } catch (AttemptsExceededException e) {
         // Expected
+        Assert.assertEquals(e.getAttempts(), MAX_NUM_ATTEMPTS - 1);
       }
 
       try {
@@ -121,7 +124,17 @@ public class RetryPolicyTest {
         Assert.fail();
       } catch (RetriableOperationException e) {
         // Expected
+        Assert.assertEquals(e.getAttempts(), 1);
       }
+
+      // Function returns false MAX_NUM_ATTEMPTS - 2 times and does not throw, make sure
+      // we return the correct value of attempts.
+      // Use MAX_NUM_ATTEMPTS - 1 to make sure we do not throw and return attempts
+      AtomicInteger atomicInteger = new AtomicInteger(MAX_NUM_ATTEMPTS - 1);
+      int retries = retryPolicy.attempt(() -> {
+          return (atomicInteger.decrementAndGet() <= 0);
+      });
+      Assert.assertEquals(retries, MAX_NUM_ATTEMPTS - 2);
     }
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/retry/RetryPolicyTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/retry/RetryPolicyTest.java
@@ -106,7 +106,7 @@ public class RetryPolicyTest {
         Assert.fail();
       } catch (AttemptsExceededException e) {
         // Expected
-        Assert.assertEquals(e.getAttempts(), MAX_NUM_ATTEMPTS - 1);
+        Assert.assertEquals(e.getAttempts(), MAX_NUM_ATTEMPTS);
       }
 
       try {
@@ -114,7 +114,7 @@ public class RetryPolicyTest {
         Assert.fail();
       } catch (AttemptsExceededException e) {
         // Expected
-        Assert.assertEquals(e.getAttempts(), MAX_NUM_ATTEMPTS - 1);
+        Assert.assertEquals(e.getAttempts(), MAX_NUM_ATTEMPTS);
       }
 
       try {


### PR DESCRIPTION
Current metric for failures ticks only after 3 consecutive failures and that almost never happens, I am redefining the metric so we can track individual failures in segment fetcher.


