### PR TITLE
Track Number of Segments Fixed by Deepstore Retry Task

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -56,6 +56,7 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   NUMBER_REVERT_REPLACE_FAILURE("NumRevertReplaceFailure", false),
   CRON_SCHEDULER_JOB_TRIGGERED("cronSchedulerJobTriggered", false),
   CRON_SCHEDULER_JOB_SKIPPED("cronSchedulerJobSkipped", false),
+  LLC_SEGMENTS_DEEP_STORE_UPLOAD_RETRY_SUCCESS("LLCSegmentDeepStoreUploadRetrySuccess", false),
   LLC_SEGMENTS_DEEP_STORE_UPLOAD_RETRY_ERROR("LLCSegmentDeepStoreUploadRetryError", false),
   SEGMENT_MISSING_DEEP_STORE_LINK("RealtimeSegmentMissingDeepStoreLink", false),
   NUMBER_ADHOC_TASKS_SUBMITTED("adhocTasks", false);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1455,6 +1455,8 @@ public class PinotLLCRealtimeSegmentManager {
         persistSegmentZKMetadata(realtimeTableName, segmentZKMetadata, -1);
         LOGGER.info("Successfully uploaded LLC segment {} to deep store with download url: {}", segmentName,
             segmentDownloadUrl);
+        _controllerMetrics.addMeteredTableValue(realtimeTableName,
+            ControllerMeter.LLC_SEGMENTS_DEEP_STORE_UPLOAD_RETRY_SUCCESS, 1L);
       } catch (Exception e) {
         _controllerMetrics.addMeteredTableValue(realtimeTableName,
             ControllerMeter.LLC_SEGMENTS_DEEP_STORE_UPLOAD_RETRY_ERROR, 1L);


### PR DESCRIPTION
Missed this in: https://github.com/apache/pinot/pull/10752