### PR TITLE
[multistage] Avoid Broker Request Id Collision

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -330,26 +330,26 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
    * requestId generator addresses that by:
    * <ol>
    *   <li>
-   *     Using a mask computed using the hash-code of the broker-id to ensure two brokers don't come to the same
-   *     requestId. This mask is applied to the most significant 32 bits.
+   *     Using a mask computed using the hash-code of the broker-id to ensure two brokers don't arrive at the same
+   *     requestId. This mask becomes the most significant 9 digits (in base-10).
    *   </li>
    *   <li>
-   *     Using a auto-incrementing counter for the least significant 32 bits. This should make debugging a bit easier
-   *     (it's possible to infer from two requestIds which one came first).
+   *     Using a auto-incrementing counter for the least significant 9 digits (in base-10).
    *   </li>
    * </ol>
    */
   static class MultiStageRequestIdGenerator {
+    private static final long OFFSET = 1_000_000_000L;
     private final long _mask;
     private final AtomicLong _incrementingId = new AtomicLong(0);
 
     public MultiStageRequestIdGenerator(String brokerId) {
-      _mask = ((long) (brokerId.hashCode() & Integer.MAX_VALUE)) << 32;
+      _mask = ((long) (brokerId.hashCode() & Integer.MAX_VALUE)) * OFFSET;
     }
 
     public long get() {
-      long normalized = (_incrementingId.getAndIncrement() & ((1L << 32) - 1));
-      return _mask | normalized;
+      long normalized = (_incrementingId.getAndIncrement() & Long.MAX_VALUE) % OFFSET;
+      return _mask + normalized;
     }
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -23,8 +23,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.apache.calcite.jdbc.CalciteSchemaBuilder;
 import org.apache.commons.lang3.StringUtils;
@@ -69,6 +71,7 @@ import org.slf4j.LoggerFactory;
 
 public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(MultiStageBrokerRequestHandler.class);
+  private final Random RANDOM = new Random();
   private final String _reducerHostname;
   private final int _reducerPort;
   private final long _defaultBrokerTimeoutMs;
@@ -76,6 +79,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   private final MailboxService _mailboxService;
   private final QueryEnvironment _queryEnvironment;
   private final QueryDispatcher _queryDispatcher;
+  private final Supplier<Long> _multistageRequestIdGenerator = () -> RANDOM.nextLong() & Long.MAX_VALUE;
 
   public MultiStageBrokerRequestHandler(PinotConfiguration config, String brokerIdFromConfig,
       BrokerRoutingManager routingManager, AccessControlFactory accessControlFactory,
@@ -115,7 +119,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   public BrokerResponse handleRequest(JsonNode request, @Nullable SqlNodeAndOptions sqlNodeAndOptions,
       @Nullable RequesterIdentity requesterIdentity, RequestContext requestContext)
       throws Exception {
-    long requestId = _requestIdGenerator.incrementAndGet();
+    long requestId = _multistageRequestIdGenerator.get();
     requestContext.setRequestId(requestId);
     requestContext.setRequestArrivalTimeMillis(System.currentTimeMillis());
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -71,7 +71,7 @@ import org.slf4j.LoggerFactory;
 
 public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   private static final Logger LOGGER = LoggerFactory.getLogger(MultiStageBrokerRequestHandler.class);
-  private final Random RANDOM = new Random();
+  private final Random _random = new Random();
   private final String _reducerHostname;
   private final int _reducerPort;
   private final long _defaultBrokerTimeoutMs;
@@ -79,7 +79,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
   private final MailboxService _mailboxService;
   private final QueryEnvironment _queryEnvironment;
   private final QueryDispatcher _queryDispatcher;
-  private final Supplier<Long> _multistageRequestIdGenerator = () -> RANDOM.nextLong() & Long.MAX_VALUE;
+  private final Supplier<Long> _multistageRequestIdGenerator = () -> _random.nextLong() & Long.MAX_VALUE;
 
   public MultiStageBrokerRequestHandler(PinotConfiguration config, String brokerIdFromConfig,
       BrokerRoutingManager routingManager, AccessControlFactory accessControlFactory,

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandlerTest.java
@@ -92,6 +92,7 @@ public class MultiStageBrokerRequestHandlerTest {
     Assert.assertEquals(10, requestIds.stream().distinct().count(), "Request Id should be unique");
     Assert.assertEquals(1, requestIds.stream().map(x -> (x >> 32)).distinct().count(),
         "Request Id should have a broker-id specific mask for the 32 MSB");
+    Assert.assertTrue(requestIds.stream().noneMatch(x -> x < 0), "Request Id should not be negative");
   }
 
   @AfterClass


### PR DESCRIPTION
cc: @walterddr 

request id collisions across brokers can cause weird query failures (we are seeing this in our production).

Later we should switch to string based request-id. For now going with RNG to avoid having to deal with broker response changes and b/w incompatibility issues.