### PR TITLE
[multistage]: Changes for supporting Json scalar functions.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -205,16 +205,5 @@ public class FunctionRegistry {
     public static boolean jsonMatch(String text, String pattern) {
       throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
     }
-
-    @ScalarFunction(names = {"clpDecode", "clp_decode"}, isPlaceholder = true)
-    public static Object clpDecode(String logtypeFieldName, String dictVarsFieldName, String encodedVarsFieldName) {
-      throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
-    }
-
-    @ScalarFunction(names = {"clpDecode", "clp_decode"}, isPlaceholder = true)
-    public static Object clpDecode(String logtypeFieldName, String dictVarsFieldName, String encodedVarsFieldName,
-        String defaultValue) {
-      throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
-    }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -205,5 +205,16 @@ public class FunctionRegistry {
     public static boolean jsonMatch(String text, String pattern) {
       throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
     }
+
+    @ScalarFunction(names = {"clpDecode", "clp_decode"}, isPlaceholder = true)
+    public static Object clpDecode(String logtypeFieldName, String dictVarsFieldName, String encodedVarsFieldName) {
+      throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
+    }
+
+    @ScalarFunction(names = {"clpDecode", "clp_decode"}, isPlaceholder = true)
+    public static Object clpDecode(String logtypeFieldName, String dictVarsFieldName, String encodedVarsFieldName,
+        String defaultValue) {
+      throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
+    }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -187,7 +187,7 @@ public class FunctionRegistry {
     }
 
     @ScalarFunction(names = {"jsonExtractKey", "json_extract_key"}, isPlaceholder = true)
-    public static String jsonExtractKey(String jsonFieldName, String jsonPath) {
+    public static Object jsonExtractKey(String jsonFieldName, String jsonPath) {
       throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
     }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -239,6 +239,7 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
           + " Column Ordering: " + Arrays.toString(columnIndices));
       return composeColumnIndexedTransferableBlock(responseBlock, adjustedResultSchema, columnIndices);
     } else {
+      handleBytesDataType(desiredDataSchema.getColumnDataTypes(), resultSchema.getColumnDataTypes());
       return composeDirectTransferableBlock(responseBlock, desiredDataSchema);
     }
   }
@@ -345,5 +346,19 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
       }
     }
     return true;
+  }
+
+  /**
+   * This util function handles the ColumnDataType BYTES and set the desiredType as per the result DataSchema.
+   * @param desiredTypes
+   * @param givenTypes
+   */
+  private static void handleBytesDataType(DataSchema.ColumnDataType[] desiredTypes,
+      DataSchema.ColumnDataType[] givenTypes) {
+    for (int i = 0; i < desiredTypes.length; i++) {
+      if (desiredTypes[i] == DataSchema.ColumnDataType.BYTES) {
+        desiredTypes[i] = givenTypes[i];
+      }
+    }
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
@@ -286,7 +286,13 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
               }
             }
           } else {
-            String[] rarray = (String[]) r;
+            String[] rarray;
+            if (r instanceof List) {
+              rarray = ((List<String>) r).toArray(new String[0]);
+            } else {
+              rarray = (String[]) r;
+            }
+
             for (int idx = 0; idx < larray.length; idx++) {
               if (!larray[idx].equals(rarray[idx])) {
                 return -1;

--- a/pinot-query-runtime/src/test/resources/queries/JsonType.json
+++ b/pinot-query-runtime/src/test/resources/queries/JsonType.json
@@ -83,19 +83,19 @@
         ]
       },
       {
-        "sql": "SELECT jsonextractscalar(jsonCol,'$.key1', 'STRING') AS keys FROM {jsonTbl} where stringCol='str1' option(timeoutMs=3600000)",
+        "sql": "SELECT jsonextractscalar(jsonCol,'$.key1', 'STRING') AS keys FROM {jsonTbl} where stringCol='str1'",
         "outputs": [
           ["val1"]
         ]
       },
       {
-        "sql": "SELECT jsonextractscalar(jsonCol,'$.key22', 'STRING', 'dummy') AS keys FROM {jsonTbl} where stringCol='str1' option(timeoutMs=3600000)",
+        "sql": "SELECT jsonextractscalar(jsonCol,'$.key22', 'STRING', 'dummy') AS keys FROM {jsonTbl} where stringCol='str1'",
         "outputs": [
           ["dummy"]
         ]
       },
       {
-        "sql": "SELECT jsonextractscalar(jsonCol,'$.key1111', 'FLOAT') AS keys FROM {jsonTbl} where stringCol='str44' option(timeoutMs=3600000)",
+        "sql": "SELECT jsonextractscalar(jsonCol,'$.key1111', 'FLOAT') AS keys FROM {jsonTbl} where stringCol='str44'",
         "outputs": [
           [22.23]
         ]

--- a/pinot-query-runtime/src/test/resources/queries/JsonType.json
+++ b/pinot-query-runtime/src/test/resources/queries/JsonType.json
@@ -40,6 +40,31 @@
         ]
       },
       {
+        "sql": "SELECT stringCol FROM {jsonTbl} where jsonCol='{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}'",
+        "outputs": [
+          ["str33"]
+        ]
+      },
+      {
+        "description": "Like clause checking specific key.",
+        "sql": "SELECT jsonCol, stringCol FROM {jsonTbl} where jsonCol like '%key111%' OR jsonCol like '%val22%'",
+        "outputs": [
+          ["{\"key11\":\"val11\",\"key22\":\"val22\"}", "str22"],
+          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"],
+          ["{\"key1111\":22.23,\"key2222\":\"val2222\"}", "str44"]
+        ]
+      },
+      {
+        "description": "Like clause is very general, should return all rows.",
+        "sql": "SELECT jsonCol, stringCol FROM {jsonTbl} where jsonCol like '%key%' ",
+        "outputs": [
+          ["{\"key1\":\"val1\",\"key2\":\"val2\"}", "str1"],
+          ["{\"key11\":\"val11\",\"key22\":\"val22\"}", "str22"],
+          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"],
+          ["{\"key1111\":22.23,\"key2222\":\"val2222\"}", "str44"]
+        ]
+      },
+      {
         "sql": "SELECT JSONEXTRACTKEY(jsonCol,'$.*') AS keys FROM {jsonTbl} where stringCol='str33'",
         "outputs": [
           [["$['key111']","$['key222']"]]

--- a/pinot-query-runtime/src/test/resources/queries/JsonType.json
+++ b/pinot-query-runtime/src/test/resources/queries/JsonType.json
@@ -9,7 +9,8 @@
         "inputs": [
           ["{\"key1\":\"val1\",\"key2\":\"val2\"}", "str1"],
           ["{\"key11\":\"val11\",\"key22\":\"val22\"}", "str22"],
-          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"]
+          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"],
+          ["{\"key1111\":22.23,\"key2222\":\"val2222\"}", "str44"]
         ]
       }
     },
@@ -19,7 +20,8 @@
         "outputs": [
           ["{\"key1\":\"val1\",\"key2\":\"val2\"}"],
           ["{\"key11\":\"val11\",\"key22\":\"val22\"}"],
-          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}"]
+          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}"],
+          ["{\"key1111\":22.23,\"key2222\":\"val2222\"}"]
         ]
       },
       {
@@ -27,7 +29,8 @@
         "outputs": [
           ["{\"key1\":\"val1\",\"key2\":\"val2\"}", "str1"],
           ["{\"key11\":\"val11\",\"key22\":\"val22\"}", "str22"],
-          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"]
+          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"],
+          ["{\"key1111\":22.23,\"key2222\":\"val2222\"}", "str44"]
         ]
       },
       {
@@ -37,26 +40,39 @@
         ]
       },
       {
-        "sql": "SELECT stringCol FROM {jsonTbl} where jsonCol='{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}'",
+        "sql": "SELECT JSONEXTRACTKEY(jsonCol,'$.*') AS keys FROM {jsonTbl} where stringCol='str33'",
         "outputs": [
-          ["str33"]
+          [["$['key111']","$['key222']"]]
         ]
       },
       {
-        "description": "Like clause checking specific key.",
-        "sql": "SELECT jsonCol, stringCol FROM {jsonTbl} where jsonCol like '%key111%' OR jsonCol like '%val22%'",
+        "sql": "SELECT JSONEXTRACTKEY(jsonCol,'$.*') AS keys FROM {jsonTbl} where stringCol='str1'",
         "outputs": [
-          ["{\"key11\":\"val11\",\"key22\":\"val22\"}", "str22"],
-          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"]
+          [["$['key1']","$['key2']"]]
         ]
       },
       {
-        "description": "Like clause is very general, should return all rows.",
-        "sql": "SELECT jsonCol, stringCol FROM {jsonTbl} where jsonCol like '%key%' ",
+        "sql": "SELECT jsonextractscalar(jsonCol,'$.key222.key222_a', 'STRING') AS keys FROM {jsonTbl} where stringCol='str33'",
         "outputs": [
-          ["{\"key1\":\"val1\",\"key2\":\"val2\"}", "str1"],
-          ["{\"key11\":\"val11\",\"key22\":\"val22\"}", "str22"],
-          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"]
+          ["val222_a"]
+        ]
+      },
+      {
+        "sql": "SELECT jsonextractscalar(jsonCol,'$.key1', 'STRING') AS keys FROM {jsonTbl} where stringCol='str1' option(timeoutMs=3600000)",
+        "outputs": [
+          ["val1"]
+        ]
+      },
+      {
+        "sql": "SELECT jsonextractscalar(jsonCol,'$.key22', 'STRING', 'dummy') AS keys FROM {jsonTbl} where stringCol='str1' option(timeoutMs=3600000)",
+        "outputs": [
+          ["dummy"]
+        ]
+      },
+      {
+        "sql": "SELECT jsonextractscalar(jsonCol,'$.key1111', 'FLOAT') AS keys FROM {jsonTbl} where stringCol='str44' option(timeoutMs=3600000)",
+        "outputs": [
+          [22.23]
         ]
       }
     ]

--- a/pinot-query-runtime/src/test/resources/queries/StringFunctions.json
+++ b/pinot-query-runtime/src/test/resources/queries/StringFunctions.json
@@ -33,12 +33,7 @@
         "sql": "SELECT concat(strCol, strCol, ',') FROM {stringTbl}"
       },
       { "sql": "SELECT trim(strCol) FROM {stringTbl}" },
-      { "sql": "SELECT lower(strCol), regexp_Replace(strCol, 'e.*o', 'le') FROM {stringTbl}" },
-      {
-        "ignored": true,
-        "comment": "split returns a MV array, we don't yet support that",
-        "sql": "SELECT split(strCol, ' ') FROM {stringTbl}"
-      }
+      { "sql": "SELECT lower(strCol), regexp_Replace(strCol, 'e.*o', 'le') FROM {stringTbl}" }
     ]
   },
   "string_functions_noh2": {
@@ -62,6 +57,12 @@
       }
     },
     "queries": [
+      {
+        "sql": "SELECT split(strCol, ' ') FROM {stringTbl} where strCol like '%wiTH%'",
+        "outputs": [
+          [["wiTH", "Mixed", "CaSe"]]
+        ]
+      },
       {
         "sql": "SELECT strpos(strCol, 'hello') FROM {stringTbl}",
         "outputs": [

--- a/pinot-query-runtime/src/test/resources/queries/StringFunctions.json
+++ b/pinot-query-runtime/src/test/resources/queries/StringFunctions.json
@@ -33,7 +33,12 @@
         "sql": "SELECT concat(strCol, strCol, ',') FROM {stringTbl}"
       },
       { "sql": "SELECT trim(strCol) FROM {stringTbl}" },
-      { "sql": "SELECT lower(strCol), regexp_Replace(strCol, 'e.*o', 'le') FROM {stringTbl}" }
+      { "sql": "SELECT lower(strCol), regexp_Replace(strCol, 'e.*o', 'le') FROM {stringTbl}" },
+      {
+        "ignored": true,
+        "comment": "split returns a MV array, we don't yet support that",
+        "sql": "SELECT split(strCol, ' ') FROM {stringTbl}"
+      }
     ]
   },
   "string_functions_noh2": {
@@ -57,12 +62,6 @@
       }
     },
     "queries": [
-      {
-        "sql": "SELECT split(strCol, ' ') FROM {stringTbl} where strCol like '%wiTH%'",
-        "outputs": [
-          [["wiTH", "Mixed", "CaSe"]]
-        ]
-      },
       {
         "sql": "SELECT strpos(strCol, 'hello') FROM {stringTbl}",
         "outputs": [


### PR DESCRIPTION
- Added support for `json` scalar function(`JSONEXTRACTKEY` , `jsonextractscalar`)
- Changes handle the String `split` function as well.

**Solution approach**
-  [toSql](https://github.com/apache/pinot/blob/master/pinot-query-planner/src/main/java/org/apache/calcite/prepare/PinotCalciteCatalogReader.java#L420) function in class `PinotCalciteCatalogReader` sets columns data type as `SqlTypeName.ANY` if any scalar function return Object class.
- [convertToColumnDataType](https://github.com/apache/pinot/blob/master/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java#L299) function in class `RelToPlanNodeConverter` sets the ColumnDataType as `DataSchema.ColumnDataType.BYTES` because we aren't handling BYTES there.
- Eventually, all such queries based on`DataSchema.ColumnDataType.BYTES` fails with a ClassCastException During the serialization step. However, we get the correct Data Type for the column from SelectionResultsBlock. We can use this right type to propagate the result. Added `handleBytesDataType` function tries to do the same. 

**Note**
- this is the problem with all the scalar functions returning non-primitive data types. 

cc: @walterddr 