### PR TITLE
Add required JSON annotation in H3IndexResolution

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/H3IndexResolution.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/H3IndexResolution.java
@@ -20,6 +20,8 @@ package org.apache.pinot.segment.spi.index.reader;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.util.StdConverter;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -31,6 +33,7 @@ import java.util.Objects;
  * To efficiently serialize the resolutions, we use two bytes for encoding th enabled resolutions. The resolution level
  * maps to the corresponding bit.
  */
+@JsonSerialize(converter = H3IndexResolution.ToIntListConverted.class)
 public class H3IndexResolution {
   private short _resolutions;
 
@@ -90,5 +93,12 @@ public class H3IndexResolution {
   @Override
   public int hashCode() {
     return Objects.hash(_resolutions);
+  }
+
+  public static class ToIntListConverted extends StdConverter<H3IndexResolution, List<Integer>> {
+    @Override
+    public List<Integer> convert(H3IndexResolution value) {
+      return value.getResolutions();
+    }
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/H3IndexResolution.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/H3IndexResolution.java
@@ -18,10 +18,17 @@
  */
 package org.apache.pinot.segment.spi.index.reader;
 
-import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonIgnore;
+import com.fasterxml.jackson.core.JsonParseException;
+import com.fasterxml.jackson.core.JsonParser;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.DeserializationContext;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
 import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import com.fasterxml.jackson.databind.deser.std.StdDeserializer;
+import com.fasterxml.jackson.databind.type.CollectionLikeType;
 import com.fasterxml.jackson.databind.util.StdConverter;
+import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Objects;
@@ -34,10 +41,10 @@ import java.util.Objects;
  * maps to the corresponding bit.
  */
 @JsonSerialize(converter = H3IndexResolution.ToIntListConverted.class)
+@JsonDeserialize(using = H3IndexResolution.Deserializator.class)
 public class H3IndexResolution {
   private short _resolutions;
 
-  @JsonCreator
   public H3IndexResolution(List<Integer> resolutions) {
     for (int resolution : resolutions) {
       _resolutions |= 1 << resolution;
@@ -99,6 +106,34 @@ public class H3IndexResolution {
     @Override
     public List<Integer> convert(H3IndexResolution value) {
       return value.getResolutions();
+    }
+  }
+
+  public static class Deserializator extends StdDeserializer<H3IndexResolution> {
+    public Deserializator() {
+      super(H3IndexResolution.class);
+    }
+
+    @Override
+    public H3IndexResolution deserialize(JsonParser p, DeserializationContext ctxt)
+        throws IOException, JsonProcessingException {
+      switch (p.currentToken()) {
+        case VALUE_NUMBER_INT: {
+          long longValue = p.getLongValue();
+          if (longValue > Short.MAX_VALUE || longValue < Short.MIN_VALUE) {
+            throw new JsonParseException(p, "Resolution value is outside the short int range");
+          }
+          return new H3IndexResolution((short) longValue);
+        }
+        case START_ARRAY: {
+          CollectionLikeType arrayType = ctxt.getTypeFactory().constructCollectionLikeType(List.class, Integer.class);
+          List<Integer> resolutions = ctxt.readValue(p, arrayType);
+          return new H3IndexResolution(resolutions);
+        }
+        default: {
+          throw new JsonParseException(p, "Expecting number or array, but found " + p.currentToken());
+        }
+      }
     }
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfigTest.java
@@ -96,4 +96,15 @@ public class H3IndexConfigTest {
     H3IndexConfig readConf = JsonUtils.stringToObject(confAsJson, H3IndexConfig.class);
     Assert.assertEquals(readConf, initialConf, "Unexpected configuration after serialization and deserialization");
   }
+
+  @Test
+  public void deserializeShort()
+      throws JsonProcessingException {
+    H3IndexConfig initialConf = new H3IndexConfig(new H3IndexResolution(Lists.newArrayList(5, 6, 13)));
+
+    String serialized = "{\"resolution\":8288}";
+    H3IndexConfig h3IndexConfig = JsonUtils.stringToObject(serialized, H3IndexConfig.class);
+
+    Assert.assertEquals(h3IndexConfig, initialConf, "Unexpected configuration after reading " + serialized);
+  }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/creator/H3IndexConfigTest.java
@@ -19,11 +19,11 @@
 package org.apache.pinot.segment.spi.index.creator;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.google.common.collect.Lists;
 import org.apache.pinot.segment.spi.index.reader.H3IndexResolution;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
-import org.testng.collections.Lists;
 
 import static org.testng.Assert.*;
 
@@ -83,5 +83,17 @@ public class H3IndexConfigTest {
     Assert.assertEquals(resolution.size(), 3);
     Assert.assertEquals(resolution.getLowestResolution(), 5);
     Assert.assertEquals(resolution.getResolutions(), Lists.newArrayList(5, 6, 13));
+  }
+
+  @Test
+  public void serde()
+      throws JsonProcessingException {
+    H3IndexConfig initialConf = new H3IndexConfig(new H3IndexResolution(Lists.newArrayList(5, 6, 13)));
+
+    String confAsJson = JsonUtils.objectToString(initialConf);
+    Assert.assertEquals(confAsJson, "{\"disabled\":false,\"resolution\":[5,6,13]}");
+
+    H3IndexConfig readConf = JsonUtils.stringToObject(confAsJson, H3IndexConfig.class);
+    Assert.assertEquals(readConf, initialConf, "Unexpected configuration after serialization and deserialization");
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/reader/H3IndexResolutionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/reader/H3IndexResolutionTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.spi.reader;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.pinot.segment.spi.index.reader.H3IndexResolution;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -45,12 +46,40 @@ public class H3IndexResolutionTest {
   }
 
   @Test
-  public void deserialization()
+  public void deserializationList()
       throws JsonProcessingException {
     H3IndexResolution resolution =
         JsonUtils.stringToObject("[5,6,13]", H3IndexResolution.class);
     Assert.assertEquals(resolution.size(), 3);
     Assert.assertEquals(resolution.getLowestResolution(), 5);
     Assert.assertEquals(resolution.getResolutions(), Lists.newArrayList(5, 6, 13));
+  }
+
+  @Test
+  public void deserializationShort()
+      throws JsonProcessingException {
+    H3IndexResolution resolution =
+        JsonUtils.stringToObject("8288", H3IndexResolution.class);
+    Assert.assertEquals(resolution.size(), 3);
+    Assert.assertEquals(resolution.getLowestResolution(), 5);
+    Assert.assertEquals(resolution.getResolutions(), Lists.newArrayList(5, 6, 13));
+  }
+
+  @Test
+  public void deserializationLargeInt() {
+    Assert.assertThrows(JsonParseException.class,
+        () -> JsonUtils.stringToObject(Integer.toString(Integer.MAX_VALUE), H3IndexResolution.class));
+  }
+
+  @Test
+  public void deserializationSmallInt() {
+    Assert.assertThrows(JsonParseException.class,
+        () -> JsonUtils.stringToObject(Integer.toString(Integer.MIN_VALUE), H3IndexResolution.class));
+  }
+
+  @Test
+  public void deserializationObject() {
+    Assert.assertThrows(JsonParseException.class,
+        () -> JsonUtils.stringToObject("{}", H3IndexResolution.class));
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/reader/H3IndexResolutionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/reader/H3IndexResolutionTest.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.segment.spi.reader;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import org.apache.pinot.segment.spi.index.reader.H3IndexResolution;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
@@ -29,6 +31,24 @@ public class H3IndexResolutionTest {
   @Test
   public void testH3IndexResolution() {
     H3IndexResolution resolution = new H3IndexResolution(Lists.newArrayList(13, 5, 6));
+    Assert.assertEquals(resolution.size(), 3);
+    Assert.assertEquals(resolution.getLowestResolution(), 5);
+    Assert.assertEquals(resolution.getResolutions(), Lists.newArrayList(5, 6, 13));
+  }
+
+  @Test
+  public void serialization()
+      throws JsonProcessingException {
+    H3IndexResolution resolution = new H3IndexResolution(Lists.newArrayList(13, 5, 6));
+    String string = JsonUtils.objectToString(resolution);
+    Assert.assertEquals(string, "[5,6,13]");
+  }
+
+  @Test
+  public void deserialization()
+      throws JsonProcessingException {
+    H3IndexResolution resolution =
+        JsonUtils.stringToObject("[5,6,13]", H3IndexResolution.class);
     Assert.assertEquals(resolution.size(), 3);
     Assert.assertEquals(resolution.getLowestResolution(), 5);
     Assert.assertEquals(resolution.getResolutions(), Lists.newArrayList(5, 6, 13));


### PR DESCRIPTION
This is a bugfix.

`H3IndexConfig` objects were not able to be deserialized with Jackson, which was incompatible with the new index configuration syntax.

A couple of tests were added to verify that the new code is working and prevent that error in the future