### PR TITLE
[multistage] Avoid Busy Waiting in Broker

### DIFF
--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -183,7 +183,8 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
    * Test compares against its desired exceptions.
    */
   @Test(dataProvider = "testDataWithSqlExecutionExceptions")
-  public void testSqlWithExceptionMsgChecker(String sql, String exceptionMsg) {
+  public void testSqlWithExceptionMsgChecker(String sql, String exceptionMsg)
+      throws InterruptedException {
     long requestId = RANDOM_REQUEST_ID_GEN.nextLong();
     DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(sql);
     Map<String, String> requestMetadataMap =

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
@@ -91,7 +91,8 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
    * Dispatch query to each pinot-server. The logic should mimic QueryDispatcher.submit() but does not actually make
    * ser/de dispatches.
    */
-  protected List<Object[]> queryRunner(String sql, Map<Integer, ExecutionStatsAggregator> executionStatsAggregatorMap) {
+  protected List<Object[]> queryRunner(String sql, Map<Integer, ExecutionStatsAggregator> executionStatsAggregatorMap)
+      throws InterruptedException {
     long requestId = RANDOM_REQUEST_ID_GEN.nextLong();
     SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sql);
     QueryEnvironment.QueryPlannerResult queryPlannerResult =

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -292,7 +292,8 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
   }
 
   private Optional<List<Object[]>> runQuery(String sql, final String except,
-      Map<Integer, ExecutionStatsAggregator> executionStatsAggregatorMap) {
+      Map<Integer, ExecutionStatsAggregator> executionStatsAggregatorMap)
+      throws InterruptedException {
     try {
       // query pinot
       List<Object[]> resultRows = queryRunner(sql, executionStatsAggregatorMap);


### PR DESCRIPTION
At present the broker can run into a busy waiting loop if all the receiving mailbox are initialized but there's at least one mailbox which hasn't returned EOS yet.

This leads to that query hogging one entire CPU core which leads to obvious issues.

I guess long-term we would want to use a scheduler for the broker as well (or get rid of polling and use an event based approach), but meanwhile I think it might be good to fix this issue. We saw this in our prod clusters once recently.

We have known about this issue for a while now so thinking it's best to put a fix in: https://github.com/apache/pinot/issues/10131

cc: @walterddr 