### PR TITLE
Use min of (retry count, number of controller addresses) as retry count when fetch segment

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -100,8 +100,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
 
   private int getRetryCount(RoundRobinURIProvider uriProvider) {
     // Use the minimal value of configured retry count and number of IP addresses.
-    int retryCount = Math.min(_retryCount, uriProvider.numAddresses());
-    return retryCount;
+    return Math.min(_retryCount, uriProvider.numAddresses());
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -106,7 +106,10 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
     // Create a RoundRobinURIProvider to round robin IP addresses when retry uploading. Otherwise, may always try to
     // download from a same broken host as: 1) DNS may not RR the IP addresses 2) OS cache the DNS resolution result.
     RoundRobinURIProvider uriProvider = new RoundRobinURIProvider(downloadURI);
-    int retryCount = Math.max(_retryCount, uriProvider.numAddresses());
+
+    // Use the minimal value of configured retry count and number of IP addresses.
+    int retryCount = Math.min(_retryCount, uriProvider.numAddresses());
+
     AtomicReference<File> ret = new AtomicReference<>(); // return the untared segment directory
     _logger.info("Retry downloading for {} times. retryCount from pinot server config: {}, number of IP addresses for "
         + "download URI: {}", retryCount, _retryCount, uriProvider.numAddresses());

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -55,8 +55,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
     // download from a same broken host as: 1) DNS may not RR the IP addresses 2) OS cache the DNS resolution result.
     RoundRobinURIProvider uriProvider = new RoundRobinURIProvider(downloadURI);
 
-    // Use the minimal value of configured retry count and number of IP addresses.
-    int retryCount = Math.min(_retryCount, uriProvider.numAddresses());
+    int retryCount = getRetryCount(uriProvider);
 
     _logger.info("Retry downloading for {} times. retryCount from pinot server config: {}, number of IP addresses for "
         + "download URI: {}", retryCount, _retryCount, uriProvider.numAddresses());
@@ -99,6 +98,12 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
     });
   }
 
+  private int getRetryCount(RoundRobinURIProvider uriProvider) {
+    // Use the minimal value of configured retry count and number of IP addresses.
+    int retryCount = Math.min(_retryCount, uriProvider.numAddresses());
+    return retryCount;
+  }
+
   @Override
   public File fetchUntarSegmentToLocalStreamed(URI downloadURI, File dest, long maxStreamRateInByte,
       AtomicInteger attempts)
@@ -107,8 +112,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
     // download from a same broken host as: 1) DNS may not RR the IP addresses 2) OS cache the DNS resolution result.
     RoundRobinURIProvider uriProvider = new RoundRobinURIProvider(downloadURI);
 
-    // Use the minimal value of configured retry count and number of IP addresses.
-    int retryCount = Math.min(_retryCount, uriProvider.numAddresses());
+    int retryCount = getRetryCount(uriProvider);
 
     AtomicReference<File> ret = new AtomicReference<>(); // return the untared segment directory
     _logger.info("Retry downloading for {} times. retryCount from pinot server config: {}, number of IP addresses for "


### PR DESCRIPTION
Thanks @mcvsubbu for rc-ing this
see [PR#8845](https://github.com/apache/pinot/pull/8845)