### PR TITLE
Parse nulls last/first.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/OrderByExpressionContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/OrderByExpressionContext.java
@@ -29,10 +29,18 @@ import java.util.Set;
 public class OrderByExpressionContext {
   private final ExpressionContext _expression;
   private final boolean _isAsc;
+  private final Boolean _isNullsLast;
 
   public OrderByExpressionContext(ExpressionContext expression, boolean isAsc) {
     _expression = expression;
     _isAsc = isAsc;
+    _isNullsLast = null;
+  }
+
+  public OrderByExpressionContext(ExpressionContext expression, boolean isAsc, boolean isNullsLast) {
+    _expression = expression;
+    _isAsc = isAsc;
+    _isNullsLast = isNullsLast;
   }
 
   public ExpressionContext getExpression() {
@@ -45,6 +53,16 @@ public class OrderByExpressionContext {
 
   public boolean isDesc() {
     return !_isAsc;
+  }
+
+  public boolean isNullsLast() {
+    // By default, null values sort as if larger than any non-null value; that is, NULLS FIRST is the default for DESC
+    // order, and NULLS LAST otherwise.
+    if (_isNullsLast == null) {
+      return _isAsc;
+    } else {
+      return _isNullsLast;
+    }
   }
 
   /**
@@ -63,16 +81,20 @@ public class OrderByExpressionContext {
       return false;
     }
     OrderByExpressionContext that = (OrderByExpressionContext) o;
-    return _isAsc == that._isAsc && Objects.equals(_expression, that._expression);
+    return Objects.equals(_expression, that._expression) && _isAsc == that._isAsc && _isNullsLast == that._isNullsLast;
   }
 
   @Override
   public int hashCode() {
-    return Objects.hash(_expression, _isAsc);
+    return Objects.hash(_expression, _isAsc, _isNullsLast);
   }
 
   @Override
   public String toString() {
-    return _expression.toString() + (_isAsc ? " ASC" : " DESC");
+    if (_isNullsLast != null) {
+      return _expression.toString() + (_isAsc ? " ASC" : " DESC") + (_isNullsLast ? " NULLS LAST" : " NULLS FIRST");
+    } else {
+      return _expression.toString() + (_isAsc ? " ASC" : " DESC");
+    }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java
@@ -136,17 +136,16 @@ public class QueryContextConverterUtils {
       Set<Expression> seen = new HashSet<>();
       for (Expression orderBy : orderByList) {
         boolean isAsc = isAsc(orderBy);
-        Boolean isNullLast = isNullsLast(orderBy);
-        Expression expressionWithOrderByFunctionsRemoved = removeOrderByFunctions(orderBy);
+        Boolean isNullsLast = isNullsLast(orderBy);
+        Expression orderByFunctionsRemoved = removeOrderByFunctions(orderBy);
         // Deduplicate the order-by expressions
-        if (seen.add(expressionWithOrderByFunctionsRemoved)) {
-          ExpressionContext expressionContextWithOrderByFunctionsRemoved =
-              RequestContextUtils.getExpression(expressionWithOrderByFunctionsRemoved);
-          if (isNullLast != null) {
+        if (seen.add(orderByFunctionsRemoved)) {
+          ExpressionContext expressionContext = RequestContextUtils.getExpression(orderByFunctionsRemoved);
+          if (isNullsLast != null) {
             orderByExpressions.add(
-                new OrderByExpressionContext(expressionContextWithOrderByFunctionsRemoved, isAsc, isNullLast));
+                new OrderByExpressionContext(expressionContext, isAsc, isNullsLast));
           } else {
-            orderByExpressions.add(new OrderByExpressionContext(expressionContextWithOrderByFunctionsRemoved, isAsc));
+            orderByExpressions.add(new OrderByExpressionContext(expressionContext, isAsc));
           }
         }
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java
@@ -18,12 +18,14 @@
  */
 package org.apache.pinot.core.query.request.context.utils;
 
+import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.common.request.DataSource;
 import org.apache.pinot.common.request.Expression;
@@ -39,6 +41,12 @@ import org.apache.pinot.sql.parsers.CalciteSqlParser;
 
 
 public class QueryContextConverterUtils {
+  private static final String ASC = "asc";
+  private static final String DESC = "desc";
+  private static final String NULLS_LAST = "nullslast";
+  private static final String NULLS_FIRST = "nullsfirst";
+  private static final ImmutableSet<String> ORDER_BY_FUNCTIONS = ImmutableSet.of(ASC, DESC, NULLS_LAST, NULLS_FIRST);
+
   private QueryContextConverterUtils() {
   }
 
@@ -124,17 +132,22 @@ public class QueryContextConverterUtils {
     List<OrderByExpressionContext> orderByExpressions = null;
     List<Expression> orderByList = pinotQuery.getOrderByList();
     if (CollectionUtils.isNotEmpty(orderByList)) {
-      // Deduplicate the order-by expressions
       orderByExpressions = new ArrayList<>(orderByList.size());
-      Set<ExpressionContext> expressionSet = new HashSet<>();
+      Set<Expression> seen = new HashSet<>();
       for (Expression orderBy : orderByList) {
-        // NOTE: Order-by is always a Function with the ordering of the Expression
-        Function thriftFunction = orderBy.getFunctionCall();
-        ExpressionContext expression = RequestContextUtils.getExpression(thriftFunction.getOperands().get(0));
-        // Skip duplicate order by expressions, e.g.: SELECT name FROM employees ORDER BY name, name
-        if (expressionSet.add(expression)) {
-          boolean isAsc = thriftFunction.getOperator().equalsIgnoreCase("ASC");
-          orderByExpressions.add(new OrderByExpressionContext(expression, isAsc));
+        boolean isAsc = isAsc(orderBy);
+        Boolean isNullLast = isNullsLast(orderBy);
+        Expression expressionWithOrderByFunctionsRemoved = removeOrderByFunctions(orderBy);
+        // Deduplicate the order-by expressions
+        if (seen.add(expressionWithOrderByFunctionsRemoved)) {
+          ExpressionContext expressionContextWithOrderByFunctionsRemoved =
+              RequestContextUtils.getExpression(expressionWithOrderByFunctionsRemoved);
+          if (isNullLast != null) {
+            orderByExpressions.add(
+                new OrderByExpressionContext(expressionContextWithOrderByFunctionsRemoved, isAsc, isNullLast));
+          } else {
+            orderByExpressions.add(new OrderByExpressionContext(expressionContextWithOrderByFunctionsRemoved, isAsc));
+          }
         }
       }
     }
@@ -162,5 +175,36 @@ public class QueryContextConverterUtils {
         .setHavingFilter(havingFilter).setLimit(pinotQuery.getLimit()).setOffset(pinotQuery.getOffset())
         .setQueryOptions(pinotQuery.getQueryOptions()).setExpressionOverrideHints(expressionContextOverrideHints)
         .setExplain(pinotQuery.isExplain()).build();
+  }
+
+  private static boolean isAsc(Expression expression) {
+    while (expression != null && expression.isSetFunctionCall()) {
+      if (expression.getFunctionCall().getOperator().equals(ASC)) {
+        return true;
+      }
+      expression = expression.getFunctionCall().getOperands().get(0);
+    }
+    return false;
+  }
+
+  @Nullable
+  private static Boolean isNullsLast(Expression expression) {
+    while (expression != null && expression.isSetFunctionCall()) {
+      String operator = expression.getFunctionCall().getOperator();
+      if (operator.equals(NULLS_LAST)) {
+        return true;
+      } else if (operator.equals(NULLS_FIRST)) {
+        return false;
+      }
+      expression = expression.getFunctionCall().getOperands().get(0);
+    }
+    return null;
+  }
+
+  private static Expression removeOrderByFunctions(Expression expression) {
+    while (expression.isSetFunctionCall() && ORDER_BY_FUNCTIONS.contains(expression.getFunctionCall().operator)) {
+      expression = expression.getFunctionCall().getOperands().get(0);
+    }
+    return expression;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java
@@ -142,8 +142,7 @@ public class QueryContextConverterUtils {
         if (seen.add(orderByFunctionsRemoved)) {
           ExpressionContext expressionContext = RequestContextUtils.getExpression(orderByFunctionsRemoved);
           if (isNullsLast != null) {
-            orderByExpressions.add(
-                new OrderByExpressionContext(expressionContext, isAsc, isNullsLast));
+            orderByExpressions.add(new OrderByExpressionContext(expressionContext, isAsc, isNullsLast));
           } else {
             orderByExpressions.add(new OrderByExpressionContext(expressionContext, isAsc));
           }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
@@ -651,12 +651,126 @@ public class BrokerRequestToQueryContextConverterTest {
   }
 
   @Test
-  void testSkipDuplicateOrderByExpressions() {
-    String query = "SELECT name FROM employees ORDER BY name, name";
+  void testDeduplicateOrderByExpressions() {
+    String query = "SELECT name FROM employees ORDER BY name DESC NULLS LAST, name ASC";
 
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
 
     assertNotNull(queryContext.getOrderByExpressions());
     assertEquals(queryContext.getOrderByExpressions().size(), 1);
+  }
+
+  @Test
+  void testRemoveOrderByFunctions() {
+    String query = "SELECT A FROM testTable ORDER BY datetrunc(A) DESC NULLS LAST";
+
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+
+    assertNotNull(queryContext.getOrderByExpressions());
+    List<OrderByExpressionContext> orderByExpressionContexts = queryContext.getOrderByExpressions();
+    assertEquals(orderByExpressionContexts.size(), 1);
+    OrderByExpressionContext orderByExpressionContext = orderByExpressionContexts.get(0);
+    assertTrue(orderByExpressionContext.isDesc());
+    assertTrue(orderByExpressionContext.isNullsLast());
+    assertEquals(orderByExpressionContext.getExpression().getFunction().getFunctionName(), "datetrunc");
+    assertEquals(orderByExpressionContext.getExpression().getFunction().getArguments().get(0).getIdentifier(), "A");
+  }
+
+  @Test
+  void testOrderByDefault() {
+    String query = "SELECT A FROM testTable ORDER BY A";
+
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+
+    assertNotNull(queryContext.getOrderByExpressions());
+    List<OrderByExpressionContext> orderByExpressionContexts = queryContext.getOrderByExpressions();
+    assertEquals(orderByExpressionContexts.size(), 1);
+    OrderByExpressionContext orderByExpressionContext = orderByExpressionContexts.get(0);
+    assertTrue(orderByExpressionContext.isAsc());
+    assertTrue(orderByExpressionContext.isNullsLast());
+  }
+
+  @Test
+  void testOrderByNullsLast() {
+    String query = "SELECT A FROM testTable ORDER BY A NULLS LAST";
+
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+
+    assertNotNull(queryContext.getOrderByExpressions());
+    List<OrderByExpressionContext> orderByExpressionContexts = queryContext.getOrderByExpressions();
+    assertEquals(orderByExpressionContexts.size(), 1);
+    OrderByExpressionContext orderByExpressionContext = orderByExpressionContexts.get(0);
+    assertTrue(orderByExpressionContext.isAsc());
+    assertTrue(orderByExpressionContext.isNullsLast());
+  }
+
+  @Test
+  void testOrderByNullsFirst() {
+    String query = "SELECT A FROM testTable ORDER BY A NULLS FIRST";
+
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+
+    assertNotNull(queryContext.getOrderByExpressions());
+    List<OrderByExpressionContext> orderByExpressionContexts = queryContext.getOrderByExpressions();
+    assertEquals(orderByExpressionContexts.size(), 1);
+    OrderByExpressionContext orderByExpressionContext = orderByExpressionContexts.get(0);
+    assertTrue(orderByExpressionContext.isAsc());
+    assertFalse(orderByExpressionContext.isNullsLast());
+  }
+
+  @Test
+  void testOrderByAscNullsFirst() {
+    String query = "SELECT A FROM testTable ORDER BY A ASC NULLS FIRST";
+
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+
+    assertNotNull(queryContext.getOrderByExpressions());
+    List<OrderByExpressionContext> orderByExpressionContexts = queryContext.getOrderByExpressions();
+    assertEquals(orderByExpressionContexts.size(), 1);
+    OrderByExpressionContext orderByExpressionContext = orderByExpressionContexts.get(0);
+    assertTrue(orderByExpressionContext.isAsc());
+    assertFalse(orderByExpressionContext.isNullsLast());
+  }
+
+  @Test
+  void testOrderByAscNullsLast() {
+    String query = "SELECT A FROM testTable ORDER BY A ASC NULLS LAST";
+
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+
+    assertNotNull(queryContext.getOrderByExpressions());
+    List<OrderByExpressionContext> orderByExpressionContexts = queryContext.getOrderByExpressions();
+    assertEquals(orderByExpressionContexts.size(), 1);
+    OrderByExpressionContext orderByExpressionContext = orderByExpressionContexts.get(0);
+    assertTrue(orderByExpressionContext.isAsc());
+    assertTrue(orderByExpressionContext.isNullsLast());
+  }
+
+  @Test
+  void testOrderByDescNullsFirst() {
+    String query = "SELECT A FROM testTable ORDER BY A DESC NULLS FIRST";
+
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+
+    assertNotNull(queryContext.getOrderByExpressions());
+    List<OrderByExpressionContext> orderByExpressionContexts = queryContext.getOrderByExpressions();
+    assertEquals(orderByExpressionContexts.size(), 1);
+    OrderByExpressionContext orderByExpressionContext = orderByExpressionContexts.get(0);
+    assertTrue(orderByExpressionContext.isDesc());
+    assertFalse(orderByExpressionContext.isNullsLast());
+  }
+
+  @Test
+  void testOrderByDescNullsLast() {
+    String query = "SELECT A FROM testTable ORDER BY A DESC NULLS LAST";
+
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+
+    assertNotNull(queryContext.getOrderByExpressions());
+    List<OrderByExpressionContext> orderByExpressionContexts = queryContext.getOrderByExpressions();
+    assertEquals(orderByExpressionContexts.size(), 1);
+    OrderByExpressionContext orderByExpressionContext = orderByExpressionContexts.get(0);
+    assertTrue(orderByExpressionContext.isDesc());
+    assertTrue(orderByExpressionContext.isNullsLast());
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -299,4 +299,24 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
     assertEquals(rows.size(), 1);
     assertEquals(rows.get(0).get(0).asText(), "null");
   }
+
+  @Test
+  public void testOrderByNullsFirst()
+      throws Exception {
+    String h2Query =
+        "SELECT 1 AS column1 FROM " + getTableName() + " ORDER BY column1 NULLS FIRST";
+    String pinotQuery = h2Query + " option(enableNullHandling=true)";
+
+    testQuery(pinotQuery, h2Query);
+  }
+
+  @Test
+  public void testOrderByNullsLast()
+      throws Exception {
+    String h2Query =
+        "SELECT 1 AS column1 FROM " + getTableName() + " ORDER BY column1 DESC NULLS LAST";
+    String pinotQuery = h2Query + " option(enableNullHandling=true)";
+
+    testQuery(pinotQuery, h2Query);
+  }
 }


### PR DESCRIPTION
Parse nulls last/first in the query and save the order in `OrderByExpressionContext`.

This PR is a no-op. A follow up PR will make use of the nulls last/first in the `OrderByExpressionContext` and apply that to the order by sorting.

Tested in unit tests.