### PR TITLE
Fix a bug in the order by comparator.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/utils/OrderByComparatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/utils/OrderByComparatorFactory.java
@@ -78,8 +78,10 @@ public class OrderByComparatorFactory {
         for (int i = from; i < to; i++) {
           Comparable v1 = (Comparable) o1[i];
           Comparable v2 = (Comparable) o2[i];
-          if (v1 == null) {
-            return v2 == null ? 0 : nullsMultipliers[i];
+          if (v1 == null && v2 == null) {
+            continue;
+          } else if (v1 == null) {
+            return nullsMultipliers[i];
           } else if (v2 == null) {
             return -nullsMultipliers[i];
           }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/utils/OrderByComparatorFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/utils/OrderByComparatorFactoryTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -37,56 +36,73 @@ public class OrderByComparatorFactoryTest {
   private static final boolean DESC = false;
   private static final boolean NULLS_LAST = true;
   private static final boolean NULLS_FIRST = false;
-  private static final ExpressionContext EXPRESSION_CONTEXT = ExpressionContext.forIdentifier("Column1");
+  private static final ExpressionContext COLUMN1 = ExpressionContext.forIdentifier("Column1");
+  private static final ExpressionContext COLUMN2 = ExpressionContext.forIdentifier("Column2");
+  private static final int COLUMN1_INDEX = 0;
+  private static final int COLUMN2_INDEX = 1;
 
   private List<Object[]> _rows;
 
-  @BeforeTest
-  public void setUp() {
+  public void setUpSingleColumnRows() {
     _rows = Arrays.asList(new Object[]{1}, new Object[]{2}, new Object[]{null});
   }
 
-  private List<Object> extractColumn(List<Object[]> rows) {
-    return rows.stream().map(row -> row[0]).collect(Collectors.toList());
+  private List<Object> extractColumn(List<Object[]> rows, int columnIndex) {
+    return rows.stream().map(row -> row[columnIndex]).collect(Collectors.toList());
   }
 
   @Test
   public void testAscNullsLast() {
     List<OrderByExpressionContext> orderBys =
-        Collections.singletonList(new OrderByExpressionContext(EXPRESSION_CONTEXT, ASC, NULLS_LAST));
+        Collections.singletonList(new OrderByExpressionContext(COLUMN1, ASC, NULLS_LAST));
+    setUpSingleColumnRows();
 
     _rows.sort(OrderByComparatorFactory.getComparator(orderBys, ENABLE_NULL_HANDLING));
 
-    assertEquals(extractColumn(_rows), Arrays.asList(1, 2, null));
+    assertEquals(extractColumn(_rows, COLUMN1_INDEX), Arrays.asList(1, 2, null));
   }
 
   @Test
   public void testAscNullsFirst() {
     List<OrderByExpressionContext> orderBys =
-        Collections.singletonList(new OrderByExpressionContext(EXPRESSION_CONTEXT, ASC, NULLS_FIRST));
+        Collections.singletonList(new OrderByExpressionContext(COLUMN1, ASC, NULLS_FIRST));
+    setUpSingleColumnRows();
 
     _rows.sort(OrderByComparatorFactory.getComparator(orderBys, ENABLE_NULL_HANDLING));
 
-    assertEquals(extractColumn(_rows), Arrays.asList(null, 1, 2));
+    assertEquals(extractColumn(_rows, COLUMN1_INDEX), Arrays.asList(null, 1, 2));
   }
 
   @Test
   public void testDescNullsLast() {
     List<OrderByExpressionContext> orderBys =
-        Collections.singletonList(new OrderByExpressionContext(EXPRESSION_CONTEXT, DESC, NULLS_LAST));
+        Collections.singletonList(new OrderByExpressionContext(COLUMN1, DESC, NULLS_LAST));
+    setUpSingleColumnRows();
 
     _rows.sort(OrderByComparatorFactory.getComparator(orderBys, ENABLE_NULL_HANDLING));
 
-    assertEquals(extractColumn(_rows), Arrays.asList(2, 1, null));
+    assertEquals(extractColumn(_rows, COLUMN1_INDEX), Arrays.asList(2, 1, null));
   }
 
   @Test
   public void testDescNullsFirst() {
     List<OrderByExpressionContext> orderBys =
-        Collections.singletonList(new OrderByExpressionContext(EXPRESSION_CONTEXT, DESC, NULLS_FIRST));
+        Collections.singletonList(new OrderByExpressionContext(COLUMN1, DESC, NULLS_FIRST));
+    setUpSingleColumnRows();
 
     _rows.sort(OrderByComparatorFactory.getComparator(orderBys, ENABLE_NULL_HANDLING));
 
-    assertEquals(extractColumn(_rows), Arrays.asList(null, 2, 1));
+    assertEquals(extractColumn(_rows, COLUMN1_INDEX), Arrays.asList(null, 2, 1));
+  }
+
+  @Test
+  public void testTwoNullsCompareNextColumn() {
+    List<OrderByExpressionContext> orderBys = Arrays.asList(new OrderByExpressionContext(COLUMN1, ASC, NULLS_LAST),
+        new OrderByExpressionContext(COLUMN2, ASC, NULLS_LAST));
+    _rows = Arrays.asList(new Object[]{null, 2}, new Object[]{null, 3}, new Object[]{1, 1});
+
+    _rows.sort(OrderByComparatorFactory.getComparator(orderBys, ENABLE_NULL_HANDLING));
+
+    assertEquals(extractColumn(_rows, COLUMN2_INDEX), Arrays.asList(1, 2, 3));
   }
 }


### PR DESCRIPTION
If both values are null in the current column, we should compare the next column.

Tested in unit tests.