### PR TITLE
[Multi-stage] Support ordering null values

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
@@ -49,7 +49,7 @@ public final class DataBlockUtils {
   }
 
   private static String extractErrorMsg(Throwable t) {
-    while (t.getMessage() == null) {
+    while (t.getCause() != null && t.getMessage() == null) {
       t = t.getCause();
     }
     return t.getMessage() + "\n" + QueryException.getTruncatedStackTrace(t);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -56,16 +56,18 @@ public class SortOperator extends MultiStageOperator {
   private TransferableBlock _upstreamErrorBlock;
 
   public SortOperator(OpChainExecutionContext context, MultiStageOperator upstreamOperator,
-      List<RexExpression> collationKeys, List<RelFieldCollation.Direction> collationDirections, int fetch, int offset,
-      DataSchema dataSchema, boolean isInputSorted) {
-    this(context, upstreamOperator, collationKeys, collationDirections, fetch, offset, dataSchema, isInputSorted,
-        SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY,
+      List<RexExpression> collationKeys, List<RelFieldCollation.Direction> collationDirections,
+      List<RelFieldCollation.NullDirection> collationNullDirections, int fetch, int offset, DataSchema dataSchema,
+      boolean isInputSorted) {
+    this(context, upstreamOperator, collationKeys, collationDirections, collationNullDirections, fetch, offset,
+        dataSchema, isInputSorted, SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY,
         CommonConstants.Broker.DEFAULT_BROKER_QUERY_RESPONSE_LIMIT);
   }
 
   @VisibleForTesting
   SortOperator(OpChainExecutionContext context, MultiStageOperator upstreamOperator, List<RexExpression> collationKeys,
-      List<RelFieldCollation.Direction> collationDirections, int fetch, int offset, DataSchema dataSchema,
+      List<RelFieldCollation.Direction> collationDirections,
+      List<RelFieldCollation.NullDirection> collationNullDirections, int fetch, int offset, DataSchema dataSchema,
       boolean isInputSorted, int defaultHolderCapacity, int defaultResponseLimit) {
     super(context);
     _upstreamOperator = upstreamOperator;
@@ -87,7 +89,7 @@ public class SortOperator extends MultiStageOperator {
       // Use the opposite direction as specified by the collation directions since we need the PriorityQueue to decide
       // which elements to keep and which to remove based on the limits.
       _priorityQueue = new PriorityQueue<>(Math.min(defaultHolderCapacity, _numRowsToKeep),
-          new SortUtils.SortComparator(collationKeys, collationDirections, dataSchema, false, true));
+          new SortUtils.SortComparator(collationKeys, collationDirections, collationNullDirections, dataSchema, true));
       _rows = null;
     }
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -72,8 +72,8 @@ public class PhysicalPlanVisitor implements PlanNodeVisitor<MultiStageOperator, 
     if (node.isSortOnReceiver()) {
       SortedMailboxReceiveOperator sortedMailboxReceiveOperator =
           new SortedMailboxReceiveOperator(context.getOpChainExecutionContext(), node.getExchangeType(),
-              node.getDataSchema(), node.getCollationKeys(), node.getCollationDirections(), node.isSortOnSender(),
-              node.getSenderStageId());
+              node.getDataSchema(), node.getCollationKeys(), node.getCollationDirections(),
+              node.getCollationNullDirections(), node.isSortOnSender(), node.getSenderStageId());
       context.addReceivingMailboxIds(sortedMailboxReceiveOperator.getMailboxIds());
       return sortedMailboxReceiveOperator;
     } else {
@@ -167,7 +167,8 @@ public class PhysicalPlanVisitor implements PlanNodeVisitor<MultiStageOperator, 
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
     boolean isInputSorted = nextOperator instanceof SortedMailboxReceiveOperator;
     return new SortOperator(context.getOpChainExecutionContext(), nextOperator, node.getCollationKeys(),
-        node.getCollationDirections(), node.getFetch(), node.getOffset(), node.getDataSchema(), isInputSorted);
+        node.getCollationDirections(), node.getCollationNullDirections(), node.getFetch(), node.getOffset(),
+        node.getDataSchema(), isInputSorted);
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/ServerRequestPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/ServerRequestPlanVisitor.java
@@ -108,8 +108,7 @@ public class ServerRequestPlanVisitor implements PlanNodeVisitor<Void, ServerPla
     pinotQuery.setExplain(false);
     ServerPlanRequestContext context =
         new ServerPlanRequestContext(mailboxService, requestId, stagePlan.getStageId(), timeoutMs, deadlineMs,
-            stagePlan.getServer(), stagePlan.getStageMetadata(), pinotQuery, tableType, timeBoundaryInfo,
-            traceEnabled);
+            stagePlan.getServer(), stagePlan.getStageMetadata(), pinotQuery, tableType, timeBoundaryInfo, traceEnabled);
 
     // visit the plan and create query physical plan.
     ServerRequestPlanVisitor.walkStageNode(stagePlan.getStageRoot(), context);
@@ -232,16 +231,15 @@ public class ServerRequestPlanVisitor implements PlanNodeVisitor<Void, ServerPla
   @Override
   public Void visitSort(SortNode node, ServerPlanRequestContext context) {
     visitChildren(node, context);
+    PinotQuery pinotQuery = context.getPinotQuery();
     if (node.getCollationKeys().size() > 0) {
-      context.getPinotQuery().setOrderByList(
-          CalciteRexExpressionParser.convertOrderByList(node.getCollationKeys(), node.getCollationDirections(),
-              context.getPinotQuery()));
+      pinotQuery.setOrderByList(CalciteRexExpressionParser.convertOrderByList(node, pinotQuery));
     }
     if (node.getFetch() > 0) {
-      context.getPinotQuery().setLimit(node.getFetch());
+      pinotQuery.setLimit(node.getFetch());
     }
     if (node.getOffset() > 0) {
-      context.getPinotQuery().setOffset(node.getOffset());
+      pinotQuery.setOffset(node.getOffset());
     }
     return null;
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.calcite.rel.RelFieldCollation.Direction;
+import org.apache.calcite.rel.RelFieldCollation.NullDirection;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
@@ -68,9 +69,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema, false);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(TransferableBlockUtils.getErrorTransferableBlock(new Exception("foo!")));
@@ -87,9 +90,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema, false);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
 
     Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getNoOpTransferableBlock());
 
@@ -105,9 +110,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema, false);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
 
     Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
@@ -123,9 +130,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema, false);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -146,9 +155,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0,
-        schema, true);
+    SortOperator op =
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, true);
 
     // Purposefully setting input as unsorted order for validation but 'isInputSorted' should only be true if actually
     // sorted
@@ -171,9 +182,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(1);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"ignored", "sort"}, new DataSchema.ColumnDataType[]{INT, INT});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema, false);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{1, 2}, new Object[]{2, 1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -194,9 +207,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{STRING});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema, false);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{"b"}, new Object[]{"a"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -217,9 +232,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.DESCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema, false);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -240,9 +257,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 1, schema, false);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 1,
+            schema, false);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -263,9 +282,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 1,
-        schema, true);
+    SortOperator op =
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 1,
+            schema, true);
 
     // Set input rows as sorted since input is expected to be sorted
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{1}, new Object[]{2}, new Object[]{3}))
@@ -287,9 +308,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 1, 1, schema, false);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 1, 1,
+            schema, false);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -309,9 +332,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 1, 1,
-        schema, true);
+    SortOperator op =
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 1, 1,
+            schema, true);
 
     // Set input rows as sorted since input is expected to be sorted
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{1}, new Object[]{2}, new Object[]{3}))
@@ -332,10 +357,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 0, 0, schema, false, 10,
-            1);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 0, 0,
+            schema, false, 10, 1);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -355,9 +381,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, -1, 0, schema, false);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, -1, 0,
+            schema, false);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -376,9 +404,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema, false);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}))
         .thenReturn(block(schema, new Object[]{1}))
@@ -400,9 +430,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0,
-        schema, true);
+    SortOperator op =
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, true);
 
     // Set input rows as sorted since input is expected to be sorted
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{1}))
@@ -425,9 +457,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0, 1);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING, Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST, NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"first", "second"}, new DataSchema.ColumnDataType[]{INT, INT});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema, false);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{1, 2}, new Object[]{1, 1}, new Object[]{1, 3}))
@@ -450,9 +484,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0, 1);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING, Direction.DESCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST, NullDirection.FIRST);
     DataSchema schema = new DataSchema(new String[]{"first", "second"}, new DataSchema.ColumnDataType[]{INT, INT});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema, false);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
 
     Mockito.when(_input.nextBlock())
         .thenReturn(block(schema, new Object[]{1, 2}, new Object[]{1, 1}, new Object[]{1, 3}))
@@ -475,9 +511,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
     SortOperator op =
-        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0, schema, false);
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
 
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}))
         .thenReturn(TransferableBlockUtils.getNoOpTransferableBlock()).thenReturn(block(schema, new Object[]{1}))
@@ -500,9 +538,11 @@ public class SortOperatorTest {
     // Given:
     List<RexExpression> collation = collation(0);
     List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
     DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
-    SortOperator op = new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, 10, 0,
-        schema, true);
+    SortOperator op =
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, true);
 
     // Set input rows as sorted since input is expected to be sorted
     Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{1}))
@@ -518,6 +558,85 @@ public class SortOperatorTest {
     Assert.assertEquals(block.getNumRows(), 2);
     Assert.assertEquals(block.getContainer().get(0), new Object[]{1});
     Assert.assertEquals(block.getContainer().get(1), new Object[]{2});
+    Assert.assertTrue(block2.isEndOfStreamBlock(), "expected EOS block to propagate");
+  }
+
+  @Test
+  public void shouldHaveNullAtLast() {
+    // Given:
+    List<RexExpression> collation = collation(0);
+    List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
+    DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
+    SortOperator op =
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
+
+    Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{null}))
+        .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
+
+    // When:
+    TransferableBlock block = op.nextBlock(); // construct
+    TransferableBlock block2 = op.nextBlock(); // eos
+
+    // Then:
+    Assert.assertEquals(block.getNumRows(), 3);
+    Assert.assertEquals(block.getContainer().get(0), new Object[]{1});
+    Assert.assertEquals(block.getContainer().get(1), new Object[]{2});
+    Assert.assertEquals(block.getContainer().get(2), new Object[]{null});
+    Assert.assertTrue(block2.isEndOfStreamBlock(), "expected EOS block to propagate");
+  }
+
+  @Test
+  public void shouldHaveNullAtFirst() {
+    // Given:
+    List<RexExpression> collation = collation(0);
+    List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.FIRST);
+    DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
+    SortOperator op =
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
+
+    Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{2}, new Object[]{1}, new Object[]{null}))
+        .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
+
+    // When:
+    TransferableBlock block = op.nextBlock(); // construct
+    TransferableBlock block2 = op.nextBlock(); // eos
+
+    // Then:
+    Assert.assertEquals(block.getNumRows(), 3);
+    Assert.assertEquals(block.getContainer().get(0), new Object[]{null});
+    Assert.assertEquals(block.getContainer().get(1), new Object[]{1});
+    Assert.assertEquals(block.getContainer().get(2), new Object[]{2});
+    Assert.assertTrue(block2.isEndOfStreamBlock(), "expected EOS block to propagate");
+  }
+
+  @Test
+  public void shouldHandleMultipleCollationKeysWithNulls() {
+    // Given:
+    List<RexExpression> collation = collation(0, 1);
+    List<Direction> directions = ImmutableList.of(Direction.ASCENDING, Direction.DESCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.FIRST, NullDirection.LAST);
+    DataSchema schema = new DataSchema(new String[]{"first", "second"}, new DataSchema.ColumnDataType[]{INT, INT});
+    SortOperator op =
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
+
+    Mockito.when(_input.nextBlock())
+        .thenReturn(block(schema, new Object[]{1, 1}, new Object[]{1, null}, new Object[]{null, 1}))
+        .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
+
+    // When:
+    TransferableBlock block = op.nextBlock(); // construct
+    TransferableBlock block2 = op.nextBlock(); // eos
+
+    // Then:
+    Assert.assertEquals(block.getNumRows(), 3);
+    Assert.assertEquals(block.getContainer().get(0), new Object[]{null, 1});
+    Assert.assertEquals(block.getContainer().get(1), new Object[]{1, 1});
+    Assert.assertEquals(block.getContainer().get(2), new Object[]{1, null});
     Assert.assertTrue(block2.isEndOfStreamBlock(), "expected EOS block to propagate");
   }
 

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -45,6 +45,16 @@
       {
         "description": "LEFT JOIN and GROUP BY with AGGREGATE",
         "sql": "SELECT {tbl1}.strCol2, COUNT({tbl2}.intCol1), MIN({tbl2}.intCol1), MAX({tbl2}.doubleCol1), SUM({tbl2}.doubleCol1) FROM {tbl1} LEFT OUTER JOIN {tbl2} ON {tbl1}.strCol1 = {tbl2}.strCol1 GROUP BY {tbl1}.strCol2"
+      },
+      {
+        "description": "LEFT JOIN and SORT (by default, H2 treats null as the smallest value, which is different from Postgres, thus we don't test the default ordering)",
+        "sql": "SELECT {tbl2}.doubleCol1 AS col FROM {tbl1} LEFT OUTER JOIN {tbl2} ON {tbl1}.strCol1 = {tbl2}.strCol1 ORDER BY col NULLS FIRST",
+        "keepOutputRowOrder": true
+      },
+      {
+        "description": "LEFT JOIN and GROUP BY with AGGREGATE AND SORT",
+        "sql": "SELECT {tbl1}.strCol2, COUNT({tbl2}.intCol1), MIN({tbl2}.intCol1) AS minCol, MAX({tbl2}.doubleCol1) AS maxCol, SUM({tbl2}.doubleCol1) FROM {tbl1} LEFT OUTER JOIN {tbl2} ON {tbl1}.strCol1 = {tbl2}.strCol1 GROUP BY {tbl1}.strCol2 ORDER BY minCol DESC NULLS LAST, maxCol ASC NULLS LAST",
+        "keepOutputRowOrder": true
       }
     ]
   }


### PR DESCRIPTION
Following the Postgres behavior:
- By default, treat null as the largest value
- Support `NULLS FIRST` and `NULLS LAST`