### PR TITLE
Integrate `Obfuscator` for Minion tasks

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/PinotTaskConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/PinotTaskConfig.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 import org.apache.helix.task.TaskConfig;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.spi.utils.EqualityUtils;
+import org.apache.pinot.spi.utils.Obfuscator;
 
 
 public class PinotTaskConfig {
@@ -92,6 +93,6 @@ public class PinotTaskConfig {
 
   @Override
   public String toString() {
-    return "Task Type: " + _taskType + ", Configs: " + _configs;
+    return "Task Type: " + _taskType + ", Configs: " + new Obfuscator().toJsonString(_configs);
   }
 }

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java
@@ -47,6 +47,7 @@ import org.apache.pinot.minion.exception.TaskCancelledException;
 import org.apache.pinot.minion.executor.PinotTaskExecutor;
 import org.apache.pinot.minion.executor.PinotTaskExecutorFactory;
 import org.apache.pinot.minion.executor.TaskExecutorFactoryRegistry;
+import org.apache.pinot.spi.utils.Obfuscator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
@@ -151,7 +152,7 @@ public class TaskFactoryRegistry {
                     MinionMeter.NUMBER_TASKS_EXECUTED, 1L);
               }
               LOGGER.info("Start running {}: {} with configs: {}", pinotTaskConfig.getTaskType(), _taskConfig.getId(),
-                  pinotTaskConfig.getConfigs());
+                  new Obfuscator().toJsonString(pinotTaskConfig.getConfigs()));
 
               try {
                 Object executionResult = _taskExecutor.executeTask(pinotTaskConfig);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
@@ -37,6 +37,7 @@ import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.utils.Obfuscator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -59,7 +60,8 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
     _eventObserver.notifyProgress(pinotTaskConfig, "Converting segments: " + numInputSegments);
     String taskType = pinotTaskConfig.getTaskType();
     Map<String, String> configs = pinotTaskConfig.getConfigs();
-    LOGGER.info("Starting task: {} with configs: {}", taskType, configs);
+    Obfuscator obfuscator = new Obfuscator();
+    LOGGER.info("Starting task: {} with configs: {}", taskType, obfuscator.toJsonString(configs));
     long startMillis = System.currentTimeMillis();
 
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
@@ -112,7 +114,8 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
     }
 
     long endMillis = System.currentTimeMillis();
-    LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms", taskType, configs, (endMillis - startMillis));
+    LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms", taskType, obfuscator.toJsonString(configs),
+        (endMillis - startMillis));
     List<SegmentConversionResult> results = new ArrayList<>();
     for (File outputSegmentDir : outputSegmentDirs) {
       String outputSegmentName = outputSegmentDir.getName();

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -42,6 +42,7 @@ import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.utils.Obfuscator;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -115,7 +116,8 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
     _eventObserver.notifyProgress(pinotTaskConfig, "Converting segments: " + numInputSegments);
     String taskType = pinotTaskConfig.getTaskType();
     Map<String, String> configs = pinotTaskConfig.getConfigs();
-    LOGGER.info("Starting task: {} with configs: {}", taskType, configs);
+    Obfuscator obfuscator = new Obfuscator();
+    LOGGER.info("Starting task: {} with configs: {}", taskType, obfuscator.toJsonString(configs));
     long startMillis = System.currentTimeMillis();
 
     String realtimeTableName = configs.get(MinionConstants.TABLE_NAME_KEY);
@@ -178,7 +180,8 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
     }
 
     long endMillis = System.currentTimeMillis();
-    LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms", taskType, configs, (endMillis - startMillis));
+    LOGGER.info("Finished task: {} with configs: {}. Total time: {}ms", taskType, obfuscator.toJsonString(configs),
+        (endMillis - startMillis));
     List<SegmentConversionResult> results = new ArrayList<>();
     for (File outputSegmentDir : outputSegmentDirs) {
       String outputSegmentName = outputSegmentDir.getName();


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Integrate Obfuscator to hide configs in minion task logs and PinotTaskConfig\.toString

```mermaid
flowchart TD
  N0["PinotTaskConfig#46;toString#40;#41; #40;F1#41;"]:::stModified
  N1["TaskFactoryRegistry#46;runInternal#40;#41; #40;F2#41;"]:::stModified
  N2["MergeRollupTaskExecutor#46;convert#40;#41; #40;F3#41;"]:::stModified
  N3["RealtimeToOfflineSegmentsTaskExecutor#46;convert#40;#41; #40;F4#41;"]:::stModified
  N4["Obfuscator #40;F1#41;"]:::stUnchanged
  N0 -->|"calls new Obfuscator#40;#41;#46;toJsonString"| N4
  N1 -->|"calls new Obfuscator#40;#41;#46;toJsonString"| N4
  N2 -->|"creates Obfuscator instance"| N4
  N3 -->|"creates Obfuscator instance"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/minion/PinotTaskConfig\.java — [before](https://github.com/apache/pinot/blob/d8b78c3fb7d1138edf55a2b60bfd417b1794644f/pinot-core/src/main/java/org/apache/pinot/core/minion/PinotTaskConfig.java) · [after](https://github.com/apache/pinot/blob/cda2b028a0d8f24c40688eb0f057182b74eb4e76/pinot-core/src/main/java/org/apache/pinot/core/minion/PinotTaskConfig.java)
- F2: pinot\-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry\.java — [before](https://github.com/apache/pinot/blob/d8b78c3fb7d1138edf55a2b60bfd417b1794644f/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java) · [after](https://github.com/apache/pinot/blob/cda2b028a0d8f24c40688eb0f057182b74eb4e76/pinot-minion/src/main/java/org/apache/pinot/minion/taskfactory/TaskFactoryRegistry.java)
- F3: pinot\-plugins/pinot\-minion\-tasks/pinot\-minion\-builtin\-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor\.java — [before](https://github.com/apache/pinot/blob/d8b78c3fb7d1138edf55a2b60bfd417b1794644f/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java) · [after](https://github.com/apache/pinot/blob/cda2b028a0d8f24c40688eb0f057182b74eb4e76/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java)
- F4: pinot\-plugins/pinot\-minion\-tasks/pinot\-minion\-builtin\-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor\.java — [before](https://github.com/apache/pinot/blob/d8b78c3fb7d1138edf55a2b60bfd417b1794644f/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java) · [after](https://github.com/apache/pinot/blob/cda2b028a0d8f24c40688eb0f057182b74eb4e76/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImQ4Yjc4YzNmYjdkMTEzOGVkZjU1YTJiNjBiZmQ0MTdiMTc5NDY0NGYiLCJjb250ZXh0X2hhc2giOiIwN2ZkZDQ1ZjRlZDU5ZGNjYjY2ZjExY2VkZjUzY2I1MTA5NDM0MmE1YTI4ZTYyYzk0MzE4NmNhZjU4YTEwYjY4IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MjcwMjkxLCJoZWFkX3NoYSI6ImNkYTJiMDI4YTBkOGYyNGM0MDY4OGViMGYwNTcxODJiNzRlYjRlNzYiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJkOGI3OGMzZmI3ZDExMzhlZGY1NWEyYjYwYmZkNDE3YjE3OTQ2NDRmIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature c16b416f9fcd4604ea0c63ea26343c23e31f85a03274ff74ae05b07a2e1c7cc9 -->
<!-- pinot-pr-flow:end -->

For existing minion task logs, we have not yet
integrated the obfuscator that was added in
https://github.com/apache/pinot/pull/7407

This PR integrates `Obfuscator` for minion logs
that includes `PinotTaskConfig`'s config map.