### PR TITLE
Upsert snapshot should be taken before new a consuming segment created

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -686,7 +686,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
               //noinspection BusyWait
               Thread.sleep(RealtimeTableDataManager.READY_TO_CONSUME_DATA_CHECK_INTERVAL_MS);
             } while (allSegmentsForPartition.stream().anyMatch(
-                segmentDataManager -> !segmentDataManager.getSegment().getSegmentMetadata().isMutableSegment()));
+                segmentDataManager -> segmentDataManager.getSegment().getSegmentMetadata().isMutableSegment()));
           }
           // Persist snapshot and release all the segments for this partition, they should be immutableSegments.
           for (SegmentDataManager segmentDataManager: allSegmentsForPartition) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1476,6 +1476,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         // block ingestion for new consuming segments
         _isReadyToConsumeData = () -> false;
         // persist snapshot for all sealed segments
+        // TODO: Use a semaphore to guarantee all the segments are sealed before peristing snapshot.
         List<SegmentDataManager> allSegments = _realtimeTableDataManager.acquireAllSegments();
         for (SegmentDataManager segmentDataManager: allSegments) {
           if (segmentDataManager.getSegment() instanceof ImmutableSegment) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -689,13 +689,16 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
                 mutableSegmentsForPartition.add(segmentDataManager);
               }
             }
+            int numMutableSegmentLeft = mutableSegmentsForPartition.size();
             // wait if all segments (except the new consuming segment) for this partition not sealed completely.
-            while (mutableSegmentsForPartition.size() > 0) {
+            while (numMutableSegmentLeft > 0) {
+              numMutableSegmentLeft = 0;
               Thread.sleep(RealtimeTableDataManager.READY_TO_CONSUME_DATA_CHECK_INTERVAL_MS);
               for (SegmentDataManager segmentDataManager : mutableSegmentsForPartition) {
-                if (!segmentDataManager.getSegment().getSegmentMetadata().isMutableSegment()) {
+                if (segmentDataManager.getSegment().getSegmentMetadata().isMutableSegment()) {
+                  numMutableSegmentLeft += 1;
+                } else {
                   _realtimeTableDataManager.releaseSegment(segmentDataManager);
-                  mutableSegmentsForPartition.remove(segmentDataManager);
                 }
               }
             }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -670,7 +670,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           // Persist snapshot for sealed segments. We need to guarantee the previous segment is already replaced with
           // the immutable segment, so the snapshot might not be persisted for the previous consuming segment.
           List<SegmentDataManager> allSegments = _realtimeTableDataManager.acquireAllSegments();
-          List<SegmentDataManager> allSegmentsForPartition = _realtimeTableDataManager.acquireAllSegments();
+          List<SegmentDataManager> allSegmentsForPartition = new ArrayList<>();
           for (SegmentDataManager segmentDataManager: allSegments) {
             // release segments not this partition
             if (_partitionGroupId == new LLCSegmentName(segmentDataManager.getSegmentName()).getPartitionGroupId()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -208,8 +208,39 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       _tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(tableConfig, schema, this, _serverMetrics);
     }
 
-    // For dedup and partial-upsert, need to wait for all segments loaded before starting consuming data
-    if (isDedupEnabled() || isPartialUpsertEnabled()) {
+    if (tableConfig.getUpsertConfig() != null && tableConfig.getUpsertConfig().isEnableSnapshot()
+        && isPartialUpsertEnabled()) {
+      // For partial-upsert, need to wait for all segments loaded before starting consuming data
+      // For snapshot enabled, we need to make sure the snapshots are persisted for all sealed segments
+      _isTableReadyToConsumeData = new BooleanSupplier() {
+        volatile boolean _allSnapshotPersisted;
+        volatile boolean _allSegmentsLoaded;
+        long _lastCheckTimeMs;
+
+        @Override
+        public boolean getAsBoolean() {
+          if (_allSnapshotPersisted && _allSegmentsLoaded) {
+            return true;
+          } else {
+            synchronized (this) {
+              if (_allSnapshotPersisted && _allSegmentsLoaded) {
+                return true;
+              }
+              long currentTimeMs = System.currentTimeMillis();
+              if (currentTimeMs - _lastCheckTimeMs
+                  <= RealtimeTableDataManager.READY_TO_CONSUME_DATA_CHECK_INTERVAL_MS) {
+                return false;
+              }
+              _lastCheckTimeMs = currentTimeMs;
+              _allSnapshotPersisted = checkAllSnapshotPersisted();
+              _allSegmentsLoaded = TableStateUtils.isAllSegmentsLoaded(_helixManager, _tableNameWithType);
+              return _allSnapshotPersisted && _allSegmentsLoaded;
+            }
+          }
+        }
+      };
+    } else if (isDedupEnabled() || isPartialUpsertEnabled()) {
+      // For dedup and partial-upsert, need to wait for all segments loaded before starting consuming data
       _isTableReadyToConsumeData = new BooleanSupplier() {
         volatile boolean _allSegmentsLoaded;
         long _lastCheckTimeMs;
@@ -234,9 +265,49 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
           }
         }
       };
+    } else if (tableConfig.getUpsertConfig() != null && tableConfig.getUpsertConfig().isEnableSnapshot()) {
+      // For snapshot enabled, we need to make sure the snapshots are persisted for all sealed segments
+      _isTableReadyToConsumeData = new BooleanSupplier() {
+        volatile boolean _allSnapshotPersisted;
+        long _lastCheckTimeMs;
+
+        @Override
+        public boolean getAsBoolean() {
+          if (_allSnapshotPersisted) {
+            return true;
+          } else {
+            synchronized (this) {
+              if (_allSnapshotPersisted) {
+                return true;
+              }
+              long currentTimeMs = System.currentTimeMillis();
+              if (currentTimeMs - _lastCheckTimeMs
+                  <= RealtimeTableDataManager.READY_TO_CONSUME_DATA_CHECK_INTERVAL_MS) {
+                return false;
+              }
+              _lastCheckTimeMs = currentTimeMs;
+              _allSnapshotPersisted = checkAllSnapshotPersisted();
+              return _allSnapshotPersisted;
+            }
+          }
+        }
+      };
     } else {
       _isTableReadyToConsumeData = () -> true;
     }
+  }
+
+  private boolean checkAllSnapshotPersisted() {
+    List<SegmentDataManager> allSegments = acquireAllSegments();
+    for (SegmentDataManager segmentDataManager : allSegments) {
+      if (segmentDataManager.getSegment() instanceof ImmutableSegment) {
+        File file = ((ImmutableSegmentImpl) segmentDataManager.getSegment()).getValidDocIdsSnapshotFile();
+        if (!file.exists()) {
+          return false;
+        }
+      }
+    }
+    return true;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -444,7 +444,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       segmentDataManager =
           new LLRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, this, _indexDir.getAbsolutePath(),
               indexLoadingConfig, schema, llcSegmentName, semaphore, _serverMetrics, partitionUpsertMetadataManager,
-              partitionDedupMetadataManager, _isTableReadyToConsumeData);
+              partitionDedupMetadataManager, _isTableReadyToConsumeData, _helixManager);
     } else {
       InstanceZKMetadata instanceZKMetadata = ZKMetadataProvider.getInstanceZKMetadata(_propertyStore, _instanceId);
       segmentDataManager = new HLRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, instanceZKMetadata, this,

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -1002,7 +1002,7 @@ public class LLRealtimeSegmentDataManagerTest {
         throws Exception {
       super(segmentZKMetadata, tableConfig, realtimeTableDataManager, resourceDataDir,
           new IndexLoadingConfig(makeInstanceDataManagerConfig(), tableConfig), schema, llcSegmentName,
-          semaphoreMap.get(llcSegmentName.getPartitionGroupId()), serverMetrics, null, null, () -> true);
+          semaphoreMap.get(llcSegmentName.getPartitionGroupId()), serverMetrics, null, null, () -> true, null);
       _state = LLRealtimeSegmentDataManager.class.getDeclaredField("_state");
       _state.setAccessible(true);
       _shouldStop = LLRealtimeSegmentDataManager.class.getDeclaredField("_shouldStop");

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -159,7 +159,7 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     }
   }
 
-  public File getValidDocIdsSnapshotFile() {
+  private File getValidDocIdsSnapshotFile() {
     return new File(SegmentDirectoryPaths.findSegmentDirectory(_segmentMetadata.getIndexDir()),
         V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentImpl.java
@@ -159,7 +159,7 @@ public class ImmutableSegmentImpl implements ImmutableSegment {
     }
   }
 
-  private File getValidDocIdsSnapshotFile() {
+  public File getValidDocIdsSnapshotFile() {
     return new File(SegmentDirectoryPaths.findSegmentDirectory(_segmentMetadata.getIndexDir()),
         V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -306,9 +306,6 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     // Allow persisting valid doc ids snapshot after metadata manager is stopped
     MutableRoaringBitmap validDocIds =
         segment.getValidDocIds() != null ? segment.getValidDocIds().getMutableRoaringBitmap() : null;
-    if (_enableSnapshot && segment instanceof ImmutableSegmentImpl) {
-      ((ImmutableSegmentImpl) segment).persistValidDocIdsSnapshot(validDocIds);
-    }
     if (validDocIds == null || validDocIds.isEmpty()) {
       _logger.info("Skip removing segment without valid docs: {}", segmentName);
       return;


### PR DESCRIPTION
Bug fix for #10800 

The current behavior of Upsert ValidDocIds Snapshot is, we took snapshot when removeSegments.
However there might be PKs (e.g. pk1) that marked as invalid because same PK appears in the new consuming segment.
When it happens, the snapshot will be persisted with invalid pk1.

When restart, the new consuimg segment will be discard and re-ingested, then it will cause inconsistency because we will load ValidDocIds Snapshot instead of build ValidDocsIndexes. 


`bugfix`

