### PR TITLE
Fix a bug in SELECT DISTINCT ORDER BY.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -20,6 +20,7 @@ package org.apache.pinot.sql.parsers;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import com.google.common.collect.ImmutableSet;
 import java.io.StringReader;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -80,6 +81,11 @@ public class CalciteSqlParser {
   private CalciteSqlParser() {
   }
 
+  public static final String ASC = "asc";
+  public static final String DESC = "desc";
+  public static final String NULLS_LAST = "nullslast";
+  public static final String NULLS_FIRST = "nullsfirst";
+  public static final ImmutableSet<String> ORDER_BY_FUNCTIONS = ImmutableSet.of(ASC, DESC, NULLS_LAST, NULLS_FIRST);
   public static final List<QueryRewriter> QUERY_REWRITERS = new ArrayList<>(QueryRewriterFactory.getQueryRewriters());
   private static final Logger LOGGER = LoggerFactory.getLogger(CalciteSqlParser.class);
 
@@ -316,7 +322,7 @@ public class CalciteSqlParser {
           List<Expression> distinctExpressions = getAliasLeftExpressionsFromDistinctExpression(function);
           for (Expression orderByExpression : orderByList) {
             // NOTE: Order-by is always a Function with the ordering of the Expression
-            if (!distinctExpressions.contains(orderByExpression.getFunctionCall().getOperands().get(0))) {
+            if (!distinctExpressions.contains(removeOrderByFunctions(orderByExpression))) {
               throw new IllegalStateException("ORDER-BY columns should be included in the DISTINCT columns");
             }
           }
@@ -641,18 +647,18 @@ public class CalciteSqlParser {
     Expression expression;
     if (node.getKind() == SqlKind.NULLS_LAST) {
       SqlBasicCall basicCall = (SqlBasicCall) node;
-      expression = RequestUtils.getFunctionExpression("nullslast");
+      expression = RequestUtils.getFunctionExpression(NULLS_LAST);
       expression.getFunctionCall().addToOperands(convertOrderBy(basicCall.getOperandList().get(0), true));
     } else if (node.getKind() == SqlKind.NULLS_FIRST) {
       SqlBasicCall basicCall = (SqlBasicCall) node;
-      expression = RequestUtils.getFunctionExpression("nullsfirst");
+      expression = RequestUtils.getFunctionExpression(NULLS_FIRST);
       expression.getFunctionCall().addToOperands(convertOrderBy(basicCall.getOperandList().get(0), true));
     } else if (node.getKind() == SqlKind.DESCENDING) {
       SqlBasicCall basicCall = (SqlBasicCall) node;
-      expression = RequestUtils.getFunctionExpression("desc");
+      expression = RequestUtils.getFunctionExpression(DESC);
       expression.getFunctionCall().addToOperands(convertOrderBy(basicCall.getOperandList().get(0), false));
     } else if (createAscExpression) {
-      expression = RequestUtils.getFunctionExpression("asc");
+      expression = RequestUtils.getFunctionExpression(ASC);
       expression.getFunctionCall().addToOperands(toExpression(node));
     } else {
       return toExpression(node);
@@ -992,5 +998,12 @@ public class CalciteSqlParser {
       return false;
     }
     return false;
+  }
+
+  public static Expression removeOrderByFunctions(Expression expression) {
+    while (expression.isSetFunctionCall() && ORDER_BY_FUNCTIONS.contains(expression.getFunctionCall().operator)) {
+      expression = expression.getFunctionCall().getOperands().get(0);
+    }
+    return expression;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
@@ -776,7 +776,7 @@ public class BrokerRequestToQueryContextConverterTest {
 
   @Test
   void testDistinctOrderByNullsLast() {
-    String query = "SELECT A FROM testTable ORDER BY A NULLS LAST";
+    String query = "SELECT DISTINCT A FROM testTable ORDER BY A NULLS LAST";
 
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
@@ -773,4 +773,18 @@ public class BrokerRequestToQueryContextConverterTest {
     assertTrue(orderByExpressionContext.isDesc());
     assertTrue(orderByExpressionContext.isNullsLast());
   }
+
+  @Test
+  void testDistinctOrderByNullsLast() {
+    String query = "SELECT A FROM testTable ORDER BY A NULLS LAST";
+
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
+
+    assertNotNull(queryContext.getOrderByExpressions());
+    List<OrderByExpressionContext> orderByExpressionContexts = queryContext.getOrderByExpressions();
+    assertEquals(orderByExpressionContexts.size(), 1);
+    OrderByExpressionContext orderByExpressionContext = orderByExpressionContexts.get(0);
+    assertFalse(orderByExpressionContext.isDesc());
+    assertTrue(orderByExpressionContext.isNullsLast());
+  }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -319,7 +319,7 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
   }
 
   @Test
-  public void testDistinctDescNullsLast()
+  public void testDistinctOrderByNullsLast()
       throws Exception {
     String h2Query = "SELECT distinct salary FROM " + getTableName() + " ORDER BY salary DESC NULLS LAST";
     String pinotQuery = h2Query + " option(enableNullHandling=true)";

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -303,8 +303,7 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
   @Test
   public void testOrderByNullsFirst()
       throws Exception {
-    String h2Query =
-        "SELECT 1 AS column1 FROM " + getTableName() + " ORDER BY column1 NULLS FIRST";
+    String h2Query = "SELECT salary FROM " + getTableName() + " ORDER BY salary NULLS FIRST";
     String pinotQuery = h2Query + " option(enableNullHandling=true)";
 
     testQuery(pinotQuery, h2Query);
@@ -313,8 +312,16 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
   @Test
   public void testOrderByNullsLast()
       throws Exception {
-    String h2Query =
-        "SELECT 1 AS column1 FROM " + getTableName() + " ORDER BY column1 DESC NULLS LAST";
+    String h2Query = "SELECT salary FROM " + getTableName() + " ORDER BY salary DESC NULLS LAST";
+    String pinotQuery = h2Query + " option(enableNullHandling=true)";
+
+    testQuery(pinotQuery, h2Query);
+  }
+
+  @Test
+  public void testDistinctDescNullsLast()
+      throws Exception {
+    String h2Query = "SELECT distinct salary FROM " + getTableName() + " ORDER BY salary DESC NULLS LAST";
     String pinotQuery = h2Query + " option(enableNullHandling=true)";
 
     testQuery(pinotQuery, h2Query);


### PR DESCRIPTION
Currently if the query is `SELECT DISTINCT column1 FROM testTable ORDER BY column1 NULLS LAST`, we get an error: `ORDER-BY columns should be included in the DISTINCT columns`.

Tested in unit tests and local server.