### PR TITLE
(WIP..NOT READY) Adding LazyReader for lazy initialization of record readers.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -136,6 +136,7 @@ public class SegmentMapper {
 
         reuse.clear();
       }
+      recordReader.close();
     }
 
     for (GenericRowFileManager fileManager : _partitionToFileManagerMap.values()) {

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/main/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReader.java
@@ -62,7 +62,8 @@ public class ParquetRecordReader implements RecordReader {
   }
 
   @Override
-  public boolean hasNext() {
+  public boolean hasNext()
+      throws IOException {
     return _internalParquetRecordReader.hasNext();
   }
 

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
@@ -33,6 +33,7 @@ import org.apache.pinot.plugin.inputformat.avro.AvroUtils;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.AbstractRecordReaderTest;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.LazyRecordReader;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -41,8 +42,6 @@ import org.testng.annotations.Test;
 public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
   private final File _testParquetFileWithInt96AndDecimal =
       new File(getClass().getClassLoader().getResource("test-file-with-int96-and-decimal.snappy.parquet").getFile());
-
-  private static final int NUM_RECORDS_TEST_PARQUET_WITH_INT96 = 1965;
 
   @Override
   protected RecordReader createRecordReader(File file)
@@ -83,6 +82,11 @@ public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
     ParquetAvroRecordReader avroRecordReader = new ParquetAvroRecordReader();
     avroRecordReader.init(_dataFile, null, new ParquetRecordReaderConfig());
     testReadParquetFile(avroRecordReader, SAMPLE_RECORDS_SIZE);
+
+    // Test the lazy reader. It should be exactly the same as regular reader
+    RecordReader lazyReader = new LazyRecordReader(avroRecordReader, _dataFile, null,
+        new ParquetRecordReaderConfig());
+    testReadParquetFile(lazyReader, SAMPLE_RECORDS_SIZE);
   }
 
   private void testReadParquetFile(RecordReader reader, int totalRecords)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -123,7 +123,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
             fileFormat);
       }
       return RecordReaderFactory.getRecordReaderByClass(recordReaderClassName, dataFile, sourceFields,
-          segmentGeneratorConfig.getReaderConfig());
+          segmentGeneratorConfig.getReaderConfig(), false);
     }
 
     // NOTE: PinotSegmentRecordReader does not support time conversion (field spec must match)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/LazyRecordReader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/LazyRecordReader.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.data.readers;
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+import javax.annotation.Nullable;
+
+
+/**
+ * Wraps around a RecordReader and does lazy initialization. Initialization of
+ * the reader happens when the reader is used (i.e first call to the iterator)
+ */
+public class LazyRecordReader implements RecordReader {
+  RecordReader _delegate;
+  File _dataFile;
+  Set<String> _fieldsToRead;
+  RecordReaderConfig _recordReaderConfig;
+  boolean _initied;
+
+  public LazyRecordReader(RecordReader delegate, File dataFile, @Nullable Set<String> fieldsToRead,
+      @Nullable RecordReaderConfig recordReaderConfig) {
+    _delegate = delegate;
+    _dataFile = dataFile;
+    _fieldsToRead = fieldsToRead;
+    _recordReaderConfig = recordReaderConfig;
+    _initied = false;
+  }
+
+  @Override
+  public void init(File dataFile, @Nullable Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
+      throws IOException {
+    Preconditions.checkState(!_initied, "RecordReader already initialized");
+    _delegate.init(dataFile, fieldsToRead, recordReaderConfig);
+  }
+
+  @Override
+  public boolean hasNext() throws IOException {
+    checkAndInit();
+    return _delegate.hasNext();
+  }
+
+  public GenericRow next()
+      throws IOException {
+    checkAndInit();
+    return _delegate.next();
+  }
+
+  @Override
+  public GenericRow next(GenericRow reuse)
+      throws IOException {
+    checkAndInit();
+    return _delegate.next(reuse);
+  }
+
+  @Override
+  public void rewind()
+      throws IOException {
+    checkAndInit();
+    _delegate.rewind();
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    _delegate.close();
+  }
+
+  private void checkAndInit() throws IOException {
+    if (!_initied) {
+      init(_dataFile, _fieldsToRead, _recordReaderConfig);
+      _initied = true;
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReader.java
@@ -47,7 +47,8 @@ public interface RecordReader extends Closeable, Serializable {
   /**
    * Return <code>true</code> if more records remain to be read.
    */
-  boolean hasNext();
+  boolean hasNext()
+      throws IOException;
 
   /**
    * Get the next record.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFactory.java
@@ -142,11 +142,21 @@ public class RecordReaderFactory {
    * Constructs and initializes a RecordReader based on the given RecordReader class name and config.
    */
   public static RecordReader getRecordReaderByClass(String recordReaderClassName, File dataFile,
-      Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
+      Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig, boolean lazy)
       throws Exception {
     RecordReader recordReader = PluginManager.get().createInstance(recordReaderClassName);
-    recordReader.init(dataFile, fieldsToRead, recordReaderConfig);
-    return recordReader;
+    if (lazy) {
+      return new LazyRecordReader(recordReader, dataFile, fieldsToRead, recordReaderConfig);
+    } else {
+      recordReader.init(dataFile, fieldsToRead, recordReaderConfig);
+      return recordReader;
+    }
+  }
+
+  public static RecordReader getRecordReaderByClass(String recordReaderClassName, File dataFile,
+      Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
+      throws Exception {
+    return getRecordReaderByClass(recordReaderClassName, dataFile, fieldsToRead, recordReaderConfig, false);
   }
 
   /**
@@ -155,20 +165,20 @@ public class RecordReaderFactory {
   public static RecordReader getRecordReader(FileFormat fileFormat, File dataFile, Set<String> fieldsToRead,
       @Nullable RecordReaderConfig recordReaderConfig)
       throws Exception {
-    return getRecordReader(fileFormat.name(), dataFile, fieldsToRead, recordReaderConfig);
+    return getRecordReader(fileFormat.name(), dataFile, fieldsToRead, recordReaderConfig, false);
   }
 
   /**
    * Constructs and initializes a RecordReader based on the given file format and RecordReader config.
    */
   public static RecordReader getRecordReader(String fileFormat, File dataFile, Set<String> fieldsToRead,
-      @Nullable RecordReaderConfig recordReaderConfig)
+      @Nullable RecordReaderConfig recordReaderConfig, boolean lazy)
       throws Exception {
     String recordReaderClassName = DEFAULT_RECORD_READER_CLASS_MAP.get(fileFormat.toUpperCase());
     if (recordReaderClassName == null) {
       throw new UnsupportedOperationException("No supported RecordReader found for file format - '" + fileFormat + "'");
     }
-    return getRecordReaderByClass(recordReaderClassName, dataFile, fieldsToRead, recordReaderConfig);
+    return getRecordReaderByClass(recordReaderClassName, dataFile, fieldsToRead, recordReaderConfig, lazy);
   }
 
   /**


### PR DESCRIPTION
**Problem:**
RecordReaders are used to iterate over the source/input files, in order to ingest data/create segments. Although we iterate one row at at time from a file, we have readers (like ParquetRecordReader) that allocate a rowGroup (collection of rows) for better read throughput, while reading from Parquet files. This uses up heap memory. The SegmentProcessesorFramework takes in N RecordReaders. Users of this framework allocate N RecordReaders using getRecordReader factory, which also initializes the reader.  Depending on how many readers are created, there's a possibility of running out of heap space due to eager allocation/initialization. 

**Solution**:
Create a decorator (LazyReader) around the RecordReader that initializes the reader only upon invoking the iterator.  This moves the initialization to only when its used/thereby allocating heap space for one reader at at time. 