### PR TITLE
[multisage][perf] do not canonicalize row when schema exactly matches

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseBlock.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.operator.blocks;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -112,7 +111,7 @@ public class InstanceResponseBlock implements Block {
   }
 
   @Nullable
-  public Collection<Object[]> getRows() {
+  public List<Object[]> getRows() {
     return _resultsBlock != null ? _resultsBlock.getRows(_queryContext) : null;
   }
 


### PR DESCRIPTION
we do not need to canonicalize row-by-row when v1 and v2 schema exactly matches (and requires no conversion).

The listed pass-through types are also handled in `DataBlockBuilder` thus it is safe to ignore the canonicalization step in leaf-stage operator; however it doesn't mean the rest of the types requires a conversion 

TODO:
1. verify or optimize type-conversion logic.
2. create alternative solution for type conversion required column data types:
    - BOOL (which stored as INT) 
    - TIMESTAMP (which stored as LONG)
    - ... (any other types verified)
3. possibly create the logic before reaching the leaf-stage such as doing this in COMBINE or even before COMBINE