### PR TITLE
[feature] Add flags to indicate if  FST, H3, and Text indexes are on a segment

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/SegmentMetadataFetcher.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/SegmentMetadataFetcher.java
@@ -55,6 +55,9 @@ public class SegmentMetadataFetcher {
   private static final String NULL_VALUE_VECTOR_READER = "null-value-vector-reader";
   private static final String RANGE_INDEX = "range-index";
   private static final String JSON_INDEX = "json-index";
+  private static final String H3_INDEX = "h3-index";
+  private static final String FST_INDEX = "fst-index";
+  private static final String TEXT_INDEX = "text-index";
 
   private static final String INDEX_NOT_AVAILABLE = "NO";
   private static final String INDEX_AVAILABLE = "YES";
@@ -150,6 +153,24 @@ public class SegmentMetadataFetcher {
       indexStatus.put(JSON_INDEX, INDEX_NOT_AVAILABLE);
     } else {
       indexStatus.put(JSON_INDEX, INDEX_AVAILABLE);
+    }
+
+    if (Objects.isNull(dataSource.getH3Index())) {
+      indexStatus.put(H3_INDEX, INDEX_NOT_AVAILABLE);
+    } else {
+      indexStatus.put(H3_INDEX, INDEX_AVAILABLE);
+    }
+
+    if (Objects.isNull(dataSource.getFSTIndex())) {
+      indexStatus.put(FST_INDEX, INDEX_NOT_AVAILABLE);
+    } else {
+      indexStatus.put(FST_INDEX, INDEX_AVAILABLE);
+    }
+
+    if (Objects.isNull(dataSource.getTextIndex())) {
+      indexStatus.put(TEXT_INDEX, INDEX_NOT_AVAILABLE);
+    } else {
+      indexStatus.put(TEXT_INDEX, INDEX_AVAILABLE);
     }
 
     return indexStatus;

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -171,6 +171,12 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(jsonResponse.get("indexes").size(), 2);
     Assert.assertNotNull(jsonResponse.get("columns").get(0).get("indexSizeMap"));
     Assert.assertNotNull(jsonResponse.get("columns").get(1).get("indexSizeMap"));
+    Assert.assertEquals(jsonResponse.get("indexes").get("column1").get("h3-index").asText(), "NO");
+    Assert.assertEquals(jsonResponse.get("indexes").get("column1").get("fst-index").asText(), "NO");
+    Assert.assertEquals(jsonResponse.get("indexes").get("column1").get("text-index").asText(), "NO");
+    Assert.assertEquals(jsonResponse.get("indexes").get("column2").get("h3-index").asText(), "NO");
+    Assert.assertEquals(jsonResponse.get("indexes").get("column2").get("fst-index").asText(), "NO");
+    Assert.assertEquals(jsonResponse.get("indexes").get("column2").get("text-index").asText(), "NO");
 
     jsonResponse = JsonUtils.stringToJsonNode(
         (_webTarget.path(segmentMetadataPath).queryParam("columns", "*").request().get(String.class)));

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -171,7 +171,6 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(jsonResponse.get("indexes").size(), 2);
     Assert.assertNotNull(jsonResponse.get("columns").get(0).get("indexSizeMap"));
     Assert.assertNotNull(jsonResponse.get("columns").get(1).get("indexSizeMap"));
-    
     Assert.assertEquals(jsonResponse.get("indexes").get("column1").get("h3-index").asText(), "NO");
     Assert.assertEquals(jsonResponse.get("indexes").get("column1").get("fst-index").asText(), "NO");
     Assert.assertEquals(jsonResponse.get("indexes").get("column1").get("text-index").asText(), "NO");

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -171,6 +171,7 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(jsonResponse.get("indexes").size(), 2);
     Assert.assertNotNull(jsonResponse.get("columns").get(0).get("indexSizeMap"));
     Assert.assertNotNull(jsonResponse.get("columns").get(1).get("indexSizeMap"));
+    
     Assert.assertEquals(jsonResponse.get("indexes").get("column1").get("h3-index").asText(), "NO");
     Assert.assertEquals(jsonResponse.get("indexes").get("column1").get("fst-index").asText(), "NO");
     Assert.assertEquals(jsonResponse.get("indexes").get("column1").get("text-index").asText(), "NO");


### PR DESCRIPTION
This PR augments the Segment Metadata returned by the Controller REST API `/segments/{tableName}/{segmentName}/metadata` with flags indicating if columns in a segment have any of the following indexes: H3, FST, and Text. Currently, Pinot has flags for every index but these 3. Without this change, it is not possible to tell if these 3 indexes are on columns in a segment through the metadata returned by the Pinot Controller.