### PR TITLE
clean up output files upon exceptions more properly for SegmentProcessorFramework

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
@@ -63,6 +63,7 @@ public class SegmentProcessorFramework {
   private final File _mapperOutputDir;
   private final File _reducerOutputDir;
   private final File _segmentsOutputDir;
+  private Map<String, GenericRowFileManager> _partitionToFileManagerMap;
 
   /**
    * Initializes the SegmentProcessorFramework with record readers, config and working directory.
@@ -91,33 +92,51 @@ public class SegmentProcessorFramework {
    */
   public List<File> process()
       throws Exception {
+    try {
+      return doProcess();
+    } catch (Exception e) {
+      if (_partitionToFileManagerMap != null) {
+        for (GenericRowFileManager fileManager : _partitionToFileManagerMap.values()) {
+          fileManager.cleanUp();
+        }
+      }
+      throw new RuntimeException("Failed to complete process", e);
+    } finally {
+      FileUtils.deleteDirectory(_mapperOutputDir);
+      FileUtils.deleteDirectory(_reducerOutputDir);
+    }
+  }
+
+  private List<File> doProcess()
+      throws Exception {
     // Map phase
     LOGGER.info("Beginning map phase on {} record readers", _recordReaders.size());
     SegmentMapper mapper = new SegmentMapper(_recordReaders, _segmentProcessorConfig, _mapperOutputDir);
-    Map<String, GenericRowFileManager> partitionToFileManagerMap = mapper.map();
+    _partitionToFileManagerMap = mapper.map();
 
     // Check for mapper output files
-    if (partitionToFileManagerMap.isEmpty()) {
+    if (_partitionToFileManagerMap.isEmpty()) {
       LOGGER.info("No partition generated from mapper phase, skipping the reducer phase");
       return Collections.emptyList();
     }
 
     // Reduce phase
-    LOGGER.info("Beginning reduce phase on partitions: {}", partitionToFileManagerMap.keySet());
+    LOGGER.info("Beginning reduce phase on partitions: {}", _partitionToFileManagerMap.keySet());
     Consumer<Object> observer = _segmentProcessorConfig.getProgressObserver();
-    int totalCount = partitionToFileManagerMap.keySet().size();
+    int totalCount = _partitionToFileManagerMap.keySet().size();
     int count = 1;
-    for (Map.Entry<String, GenericRowFileManager> entry : partitionToFileManagerMap.entrySet()) {
+    for (Map.Entry<String, GenericRowFileManager> entry : _partitionToFileManagerMap.entrySet()) {
       String partitionId = entry.getKey();
-      observer.accept(String
-          .format("Doing reduce phase on data from partition: %s (%d out of %d)", partitionId, count++, totalCount));
+      observer.accept(
+          String.format("Doing reduce phase on data from partition: %s (%d out of %d)", partitionId, count++,
+              totalCount));
       GenericRowFileManager fileManager = entry.getValue();
       Reducer reducer = ReducerFactory.getReducer(partitionId, fileManager, _segmentProcessorConfig, _reducerOutputDir);
       entry.setValue(reducer.reduce());
     }
 
     // Segment creation phase
-    LOGGER.info("Beginning segment creation phase on partitions: {}", partitionToFileManagerMap.keySet());
+    LOGGER.info("Beginning segment creation phase on partitions: {}", _partitionToFileManagerMap.keySet());
     List<File> outputSegmentDirs = new ArrayList<>();
     TableConfig tableConfig = _segmentProcessorConfig.getTableConfig();
     Schema schema = _segmentProcessorConfig.getSchema();
@@ -128,9 +147,9 @@ public class SegmentProcessorFramework {
     generatorConfig.setOutDir(_segmentsOutputDir.getPath());
 
     if (tableConfig.getIndexingConfig().getSegmentNameGeneratorType() != null) {
-      generatorConfig.setSegmentNameGenerator(SegmentNameGeneratorFactory
-          .createSegmentNameGenerator(tableConfig, schema, segmentNamePrefix, segmentNamePostfix, fixedSegmentName,
-              false));
+      generatorConfig.setSegmentNameGenerator(
+          SegmentNameGeneratorFactory.createSegmentNameGenerator(tableConfig, schema, segmentNamePrefix,
+              segmentNamePostfix, fixedSegmentName, false));
     } else {
       // SegmentNameGenerator will be inferred by the SegmentGeneratorConfig.
       generatorConfig.setSegmentNamePrefix(segmentNamePrefix);
@@ -139,7 +158,7 @@ public class SegmentProcessorFramework {
 
     int maxNumRecordsPerSegment = _segmentProcessorConfig.getSegmentConfig().getMaxNumRecordsPerSegment();
     int sequenceId = 0;
-    for (Map.Entry<String, GenericRowFileManager> entry : partitionToFileManagerMap.entrySet()) {
+    for (Map.Entry<String, GenericRowFileManager> entry : _partitionToFileManagerMap.entrySet()) {
       String partitionId = entry.getKey();
       GenericRowFileManager fileManager = entry.getValue();
       try {
@@ -168,9 +187,6 @@ public class SegmentProcessorFramework {
         fileManager.cleanUp();
       }
     }
-    FileUtils.deleteDirectory(_mapperOutputDir);
-    FileUtils.deleteDirectory(_reducerOutputDir);
-
     LOGGER.info("Successfully created segments: {}", outputSegmentDirs);
     return outputSegmentDirs;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -108,6 +108,19 @@ public class SegmentMapper {
    */
   public Map<String, GenericRowFileManager> map()
       throws Exception {
+    try {
+      return doMap();
+    } catch (Exception e) {
+      // Cleaning up resources created by the mapper, leaving others to the caller like the input _recordReaders.
+      for (GenericRowFileManager fileManager : _partitionToFileManagerMap.values()) {
+        fileManager.cleanUp();
+      }
+      throw new RuntimeException("Failed to complete map phase", e);
+    }
+  }
+
+  private Map<String, GenericRowFileManager> doMap()
+      throws Exception {
     Consumer<Object> observer = _processorConfig.getProgressObserver();
     int totalCount = _recordReaders.size();
     int count = 1;

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -115,7 +115,7 @@ public class SegmentMapper {
       for (GenericRowFileManager fileManager : _partitionToFileManagerMap.values()) {
         fileManager.cleanUp();
       }
-      throw new RuntimeException("Failed to complete map phase", e);
+      throw e;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/DedupReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/DedupReducer.java
@@ -56,7 +56,7 @@ public class DedupReducer implements Reducer {
       if (_dedupFileManager != null) {
         _dedupFileManager.cleanUp();
       }
-      throw new RuntimeException("Failed to complete dedup reduce", e);
+      throw e;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/DedupReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/DedupReducer.java
@@ -38,6 +38,7 @@ public class DedupReducer implements Reducer {
   private final String _partitionId;
   private final GenericRowFileManager _fileManager;
   private final File _reducerOutputDir;
+  private GenericRowFileManager _dedupFileManager;
 
   public DedupReducer(String partitionId, GenericRowFileManager fileManager, File reducerOutputDir) {
     _partitionId = partitionId;
@@ -47,6 +48,19 @@ public class DedupReducer implements Reducer {
 
   @Override
   public GenericRowFileManager reduce()
+      throws Exception {
+    try {
+      return doReduce();
+    } catch (Exception e) {
+      // Cleaning up resources created by the reducer, leaving others to the caller like the input _fileManager.
+      if (_dedupFileManager != null) {
+        _dedupFileManager.cleanUp();
+      }
+      throw new RuntimeException("Failed to complete dedup reduce", e);
+    }
+  }
+
+  private GenericRowFileManager doReduce()
       throws Exception {
     LOGGER.info("Start reducing on partition: {}", _partitionId);
     long reduceStartTimeMs = System.currentTimeMillis();
@@ -63,10 +77,10 @@ public class DedupReducer implements Reducer {
     FileUtils.forceMkdir(partitionOutputDir);
     LOGGER.info("Start creating dedup file under dir: {}", partitionOutputDir);
     long dedupFileCreationStartTimeMs = System.currentTimeMillis();
-    GenericRowFileManager dedupFileManager =
+    _dedupFileManager =
         new GenericRowFileManager(partitionOutputDir, _fileManager.getFieldSpecs(), _fileManager.isIncludeNullFields(),
             0);
-    GenericRowFileWriter dedupFileWriter = dedupFileManager.getFileWriter();
+    GenericRowFileWriter dedupFileWriter = _dedupFileManager.getFileWriter();
     GenericRow previousRow = new GenericRow();
     recordReader.read(0, previousRow);
     int previousRowId = 0;
@@ -79,11 +93,11 @@ public class DedupReducer implements Reducer {
         dedupFileWriter.write(previousRow);
       }
     }
-    dedupFileManager.closeFileWriter();
+    _dedupFileManager.closeFileWriter();
     LOGGER.info("Finish creating dedup file in {}ms", System.currentTimeMillis() - dedupFileCreationStartTimeMs);
 
     _fileManager.cleanUp();
     LOGGER.info("Finish reducing in {}ms", System.currentTimeMillis() - reduceStartTimeMs);
-    return dedupFileManager;
+    return _dedupFileManager;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/RollupReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/RollupReducer.java
@@ -68,7 +68,7 @@ public class RollupReducer implements Reducer {
       if (_rollupFileManager != null) {
         _rollupFileManager.cleanUp();
       }
-      throw new RuntimeException("Failed to complete rollup reduce", e);
+      throw e;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/RollupReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/reducer/RollupReducer.java
@@ -48,6 +48,7 @@ public class RollupReducer implements Reducer {
   private final GenericRowFileManager _fileManager;
   private final Map<String, AggregationFunctionType> _aggregationTypes;
   private final File _reducerOutputDir;
+  private GenericRowFileManager _rollupFileManager;
 
   public RollupReducer(String partitionId, GenericRowFileManager fileManager,
       Map<String, AggregationFunctionType> aggregationTypes, File reducerOutputDir) {
@@ -59,6 +60,19 @@ public class RollupReducer implements Reducer {
 
   @Override
   public GenericRowFileManager reduce()
+      throws Exception {
+    try {
+      return doReduce();
+    } catch (Exception e) {
+      // Cleaning up resources created by the reducer, leaving others to the caller like the input _fileManager.
+      if (_rollupFileManager != null) {
+        _rollupFileManager.cleanUp();
+      }
+      throw new RuntimeException("Failed to complete rollup reduce", e);
+    }
+  }
+
+  private GenericRowFileManager doReduce()
       throws Exception {
     LOGGER.info("Start reducing on partition: {}", _partitionId);
     long reduceStartTimeMs = System.currentTimeMillis();
@@ -85,9 +99,8 @@ public class RollupReducer implements Reducer {
     FileUtils.forceMkdir(partitionOutputDir);
     LOGGER.info("Start creating rollup file under dir: {}", partitionOutputDir);
     long rollupFileCreationStartTimeMs = System.currentTimeMillis();
-    GenericRowFileManager rollupFileManager =
-        new GenericRowFileManager(partitionOutputDir, fieldSpecs, includeNullFields, 0);
-    GenericRowFileWriter rollupFileWriter = rollupFileManager.getFileWriter();
+    _rollupFileManager = new GenericRowFileManager(partitionOutputDir, fieldSpecs, includeNullFields, 0);
+    GenericRowFileWriter rollupFileWriter = _rollupFileManager.getFileWriter();
     GenericRow previousRow = new GenericRow();
     recordReader.read(0, previousRow);
     int previousRowId = 0;
@@ -122,12 +135,12 @@ public class RollupReducer implements Reducer {
       }
     }
     rollupFileWriter.write(previousRow);
-    rollupFileManager.closeFileWriter();
+    _rollupFileManager.closeFileWriter();
     LOGGER.info("Finish creating rollup file in {}ms", System.currentTimeMillis() - rollupFileCreationStartTimeMs);
 
     _fileManager.cleanUp();
     LOGGER.info("Finish reducing in {}ms", System.currentTimeMillis() - reduceStartTimeMs);
-    return rollupFileManager;
+    return _rollupFileManager;
   }
 
   private static void aggregateWithNullFields(GenericRow aggregatedRow, GenericRow rowToAggregate,

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFrameworkTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFrameworkTest.java
@@ -219,6 +219,8 @@ public class SegmentProcessorFrameworkTest {
     framework = new SegmentProcessorFramework(_singleSegment, config, workingDir);
     outputSegments = framework.process();
     assertEquals(outputSegments.size(), 1);
+    String[] outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     segment = ImmutableSegmentLoader.load(outputSegments.get(0), ReadMode.mmap);
     segmentMetadata = segment.getSegmentMetadata();
     assertEquals(segmentMetadata.getTotalDocs(), 10);
@@ -255,6 +257,8 @@ public class SegmentProcessorFrameworkTest {
     framework = new SegmentProcessorFramework(_singleSegment, config, workingDir);
     outputSegments = framework.process();
     assertEquals(outputSegments.size(), 1);
+    outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     segment = ImmutableSegmentLoader.load(outputSegments.get(0), ReadMode.mmap);
     segmentMetadata = segment.getSegmentMetadata();
     assertEquals(segmentMetadata.getName(), "myTable_segment_0001");
@@ -269,6 +273,8 @@ public class SegmentProcessorFrameworkTest {
     framework = new SegmentProcessorFramework(_singleSegment, config, workingDir);
     outputSegments = framework.process();
     assertEquals(outputSegments.size(), 1);
+    outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     segmentMetadata = new SegmentMetadataImpl(outputSegments.get(0));
     assertEquals(segmentMetadata.getTotalDocs(), 5);
     timeMetadata = segmentMetadata.getColumnMetadataFor("time");
@@ -286,6 +292,8 @@ public class SegmentProcessorFrameworkTest {
     framework = new SegmentProcessorFramework(_singleSegment, config, workingDir);
     outputSegments = framework.process();
     assertEquals(outputSegments.size(), 1);
+    outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     segmentMetadata = new SegmentMetadataImpl(outputSegments.get(0));
     assertEquals(segmentMetadata.getTotalDocs(), 5);
     timeMetadata = segmentMetadata.getColumnMetadataFor("time");
@@ -303,6 +311,8 @@ public class SegmentProcessorFrameworkTest {
     framework = new SegmentProcessorFramework(_singleSegment, config, workingDir);
     outputSegments = framework.process();
     assertTrue(outputSegments.isEmpty());
+    outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     FileUtils.cleanDirectory(workingDir);
     rewindRecordReaders(_singleSegment);
 
@@ -313,6 +323,8 @@ public class SegmentProcessorFrameworkTest {
     framework = new SegmentProcessorFramework(_singleSegment, config, workingDir);
     outputSegments = framework.process();
     assertEquals(outputSegments.size(), 1);
+    outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     segmentMetadata = new SegmentMetadataImpl(outputSegments.get(0));
     assertEquals(segmentMetadata.getTotalDocs(), 10);
     timeMetadata = segmentMetadata.getColumnMetadataFor("time");
@@ -329,6 +341,8 @@ public class SegmentProcessorFrameworkTest {
     framework = new SegmentProcessorFramework(_singleSegment, config, workingDir);
     outputSegments = framework.process();
     assertEquals(outputSegments.size(), 3);
+    outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     outputSegments.sort(null);
     // segment 0
     segmentMetadata = new SegmentMetadataImpl(outputSegments.get(0));
@@ -366,6 +380,8 @@ public class SegmentProcessorFrameworkTest {
     framework = new SegmentProcessorFramework(_singleSegment, config, workingDir);
     outputSegments = framework.process();
     assertEquals(outputSegments.size(), 2);
+    outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     outputSegments.sort(null);
     // segment 0
     segment = ImmutableSegmentLoader.load(outputSegments.get(0), ReadMode.mmap);
@@ -429,6 +445,8 @@ public class SegmentProcessorFrameworkTest {
     framework = new SegmentProcessorFramework(_singleSegment, config, workingDir);
     outputSegments = framework.process();
     assertEquals(outputSegments.size(), 1);
+    outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     segmentMetadata = new SegmentMetadataImpl(outputSegments.get(0));
     assertEquals(segmentMetadata.getTotalDocs(), 8);
     assertEquals(segmentMetadata.getName(), "myTable_1597708800000_1597881600000_0");
@@ -442,6 +460,8 @@ public class SegmentProcessorFrameworkTest {
     framework = new SegmentProcessorFramework(_singleSegment, config, workingDir);
     outputSegments = framework.process();
     assertEquals(outputSegments.size(), 3);
+    outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     outputSegments.sort(null);
     segmentMetadata = new SegmentMetadataImpl(outputSegments.get(0));
     assertEquals(segmentMetadata.getTotalDocs(), 4);
@@ -462,6 +482,8 @@ public class SegmentProcessorFrameworkTest {
     framework = new SegmentProcessorFramework(_singleSegment, config, workingDir);
     outputSegments = framework.process();
     assertEquals(outputSegments.size(), 3);
+    outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     outputSegments.sort(null);
     segmentMetadata = new SegmentMetadataImpl(outputSegments.get(0));
     assertEquals(segmentMetadata.getTotalDocs(), 4);
@@ -488,6 +510,8 @@ public class SegmentProcessorFrameworkTest {
     SegmentProcessorFramework framework = new SegmentProcessorFramework(_multipleSegments, config, workingDir);
     List<File> outputSegments = framework.process();
     assertEquals(outputSegments.size(), 1);
+    String[] outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     SegmentMetadata segmentMetadata = new SegmentMetadataImpl(outputSegments.get(0));
     assertEquals(segmentMetadata.getTotalDocs(), 10);
     assertEquals(segmentMetadata.getName(), "myTable_1597719600000_1597892400000_0");
@@ -501,6 +525,8 @@ public class SegmentProcessorFrameworkTest {
     framework = new SegmentProcessorFramework(_multipleSegments, config, workingDir);
     outputSegments = framework.process();
     assertEquals(outputSegments.size(), 3);
+    outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     outputSegments.sort(null);
     segmentMetadata = new SegmentMetadataImpl(outputSegments.get(0));
     assertEquals(segmentMetadata.getTotalDocs(), 2);
@@ -528,6 +554,8 @@ public class SegmentProcessorFrameworkTest {
     SegmentProcessorFramework framework = new SegmentProcessorFramework(_multiValueSegments, config, workingDir);
     List<File> outputSegments = framework.process();
     assertEquals(outputSegments.size(), 1);
+    String[] outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     ImmutableSegment segment = ImmutableSegmentLoader.load(outputSegments.get(0), ReadMode.mmap);
     SegmentMetadataImpl segmentMetadata = (SegmentMetadataImpl) segment.getSegmentMetadata();
     assertEquals(segmentMetadata.getTotalDocs(), 2);
@@ -562,6 +590,8 @@ public class SegmentProcessorFrameworkTest {
     framework = new SegmentProcessorFramework(_multiValueSegments, config, workingDir);
     outputSegments = framework.process();
     assertEquals(outputSegments.size(), 1);
+    outputDirs = workingDir.list();
+    assertTrue(outputDirs != null && outputDirs.length == 1, Arrays.toString(outputDirs));
     segment = ImmutableSegmentLoader.load(outputSegments.get(0), ReadMode.mmap);
     segmentMetadata = (SegmentMetadataImpl) segment.getSegmentMetadata();
     assertEquals(segmentMetadata.getTotalDocs(), 2);


### PR DESCRIPTION
The previous fix #9797 on leaked files in SegmentProcessorFramework was not enough, as the mapper and reducer may also generate output files and hold on them via mmap, making them leaked upon exceptions thrown from map or reduce phases, e.g. out of disk during mapping phase.