### PR TITLE
Add the support for filling the default header if the header is missing

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVDefaultHeaderUtil.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVDefaultHeaderUtil.java
@@ -1,0 +1,191 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.csv;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.csv.CSVFormat;
+import org.apache.commons.csv.CSVParser;
+import org.apache.commons.csv.CSVRecord;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.commons.lang3.math.NumberUtils;
+import org.apache.pinot.spi.data.readers.RecordReaderUtils;
+
+
+public class CSVDefaultHeaderUtil {
+
+  private CSVDefaultHeaderUtil() {
+  }
+
+  private static final String DEFAULT_CSV_COLUMN_PREFIX = "col_";
+  private static final int MAX_CSV_SAMPLE_ROWS = 100;
+
+  static class ColumnValueAttributes {
+    private Type _dataType;
+    private int _length;
+
+    enum Type {
+      STRING, NUMBER, ARRAY
+    }
+
+    ColumnValueAttributes(Object value, Character multiValueDelimiter) {
+      _dataType = Type.STRING;
+      if (multiValueDelimiter != null && value.toString().contains(String.valueOf(multiValueDelimiter))) {
+        _dataType = Type.ARRAY;
+        return;
+      } else if (NumberUtils.isParsable(value.toString())) {
+        _dataType = Type.NUMBER;
+      }
+      _length = value.toString().length();
+    }
+
+    public Type getDataType() {
+      return _dataType;
+    }
+
+    public int getLength() {
+      return _length;
+    }
+  }
+
+  /**
+   * Detects the types for each column based on the row values. If any column is of a single type (e.g. number), except
+   * for the first row, then the first row is presumed to be a header. If the type of the column is assumed to
+   * be a string, the length of the strings within the body is the determining factor. Specifically, if all the rows
+   * except the first are the same length, it's a header.
+   *
+   * If no header is detected, then the header property within the CSVRecordReaderConfig will be set with the following
+   * e.g. {col_0, col_1, col_2, ..}. If a header is detected within the file, then the header property will not
+   * be set and will default to use the first row of the file.
+   *
+   * Motivation for this logic is taken from: https://github.com/python/cpython/blob/main/Lib/csv.py
+   *
+   * Returns the default header when no header is detected. If the header is detected, then returns null.
+   */
+  public static String getDefaultHeader(File csvFile, CSVFormat format, Character delimiter,
+      Character multiValueDelimiter)
+      throws IOException {
+    // Assume there is no header and the default header based on number of columns. We need the default header or
+    // else the CSVRecordReader may not read the values correctly when there are columns with the same values.
+    int numColumns = 0;
+    int rowCounter = 0;
+    List<CSVRecord> records = new ArrayList<>();
+    String[] originalHeader = format.getHeader();
+    try (BufferedReader bufferedReader = RecordReaderUtils.getBufferedReader(csvFile)) {
+      format.withHeader(null);
+      CSVParser parser = format.parse(bufferedReader);
+      Iterator<CSVRecord> iterator = parser.iterator();
+      while (iterator.hasNext() && rowCounter < MAX_CSV_SAMPLE_ROWS + 1) {
+        CSVRecord row = iterator.next();
+        records.add(row);
+        int curNumColumns = row.size();
+        if (curNumColumns > numColumns) {
+          numColumns = curNumColumns;
+        }
+        rowCounter++;
+      }
+    }
+
+    if (records.size() == 0) {
+      throw new IllegalStateException("CSV file is empty. csvFile=" + csvFile.getAbsolutePath());
+    }
+
+    String[] defaultColumnNames = new String[numColumns];
+    for (int i = 0; i < numColumns; i++) {
+      defaultColumnNames[i] = DEFAULT_CSV_COLUMN_PREFIX + i;
+    }
+
+    HashMap<String, ColumnValueAttributes> csvHeaderAttributes = new HashMap<>(numColumns);
+    HashMap<String, ColumnValueAttributes> csvBodyAttributes = new HashMap<>(numColumns);
+    Iterator<CSVRecord> iterator = records.iterator();
+    CSVRecord header = iterator.next();
+    for (int i = 0; i < header.size(); i++) {
+      csvHeaderAttributes.put(defaultColumnNames[i], new ColumnValueAttributes(header.get(i), multiValueDelimiter));
+      // Initialize the body attributes with null values at first
+      csvBodyAttributes.put(defaultColumnNames[i], null);
+    }
+
+    while (iterator.hasNext() && rowCounter < MAX_CSV_SAMPLE_ROWS) {
+      CSVRecord row = iterator.next();
+      // Skip rows that have irregular number of columns
+      if (row.size() != numColumns) {
+        continue;
+      }
+      for (int i = 0; i < row.size(); i++) {
+        String fieldName = DEFAULT_CSV_COLUMN_PREFIX + i;
+        String columnValue = row.get(i);
+
+        if (!csvBodyAttributes.containsKey(fieldName) || columnValue == null) {
+          continue;
+        }
+        ColumnValueAttributes csvBodyAttribute = csvBodyAttributes.get(fieldName);
+        ColumnValueAttributes curColumnAttributes = new ColumnValueAttributes(columnValue, multiValueDelimiter);
+        if (csvBodyAttribute == null) {
+          csvBodyAttributes.put(fieldName, curColumnAttributes);
+        } else {
+          // If column type is String and length does not match, remove from consideration
+          if (csvBodyAttribute.getDataType().equals(ColumnValueAttributes.Type.STRING)
+              && csvBodyAttribute.getLength() != curColumnAttributes.getLength()) {
+            csvBodyAttributes.remove(fieldName);
+          } else {
+            // If data type does not match, remove from consideration
+            if (!csvBodyAttribute.getDataType().equals(curColumnAttributes.getDataType())) {
+              csvBodyAttributes.remove(fieldName);
+            }
+          }
+        }
+      }
+    }
+
+    // Compare first row with the rest of the values and vote on whether it's a header.
+    int hasHeader = 0;
+    for (Map.Entry<String, ColumnValueAttributes> entry : csvBodyAttributes.entrySet()) {
+      ColumnValueAttributes headerAttributes = csvHeaderAttributes.get(entry.getKey());
+      if (entry.getValue().getDataType().equals(ColumnValueAttributes.Type.STRING)) {
+        // Compare lengths for String case
+        if (headerAttributes.getLength() != entry.getValue().getLength()) {
+          hasHeader++;
+        } else {
+          hasHeader--;
+        }
+      } else {
+        // Compare types
+        if (!headerAttributes.getDataType().equals(entry.getValue().getDataType())) {
+          hasHeader++;
+        } else {
+          hasHeader--;
+        }
+      }
+    }
+
+    if (hasHeader > 0) {
+      // reset the csv format to the original header.
+      format.withHeader(originalHeader);
+      return null;
+    } else {
+      return StringUtils.join(defaultColumnNames, delimiter);
+    }
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReader.java
@@ -83,15 +83,6 @@ public class CSVRecordReader implements RecordReader {
       }
       char delimiter = config.getDelimiter();
       format = format.withDelimiter(delimiter);
-      String csvHeader = config.getHeader();
-      if (csvHeader == null) {
-        format = format.withHeader();
-      } else {
-        //validate header for the delimiter before splitting
-        validateHeaderForDelimiter(delimiter, csvHeader, format);
-        format = format.withHeader(StringUtils.split(csvHeader, delimiter));
-      }
-
       format = format.withCommentMarker(config.getCommentMarker());
       format = format.withEscape(config.getEscapeCharacter());
       format = format.withIgnoreEmptyLines(config.isIgnoreEmptyLines());
@@ -110,6 +101,19 @@ public class CSVRecordReader implements RecordReader {
       String nullString = config.getNullStringValue();
       if (nullString != null) {
         format = format.withNullString(nullString);
+      }
+
+      String csvHeader = config.getHeader();
+      if (csvHeader == null && config.fillDefaultHeaderWhenMissing()) {
+        csvHeader = CSVDefaultHeaderUtil.getDefaultHeader(dataFile, format, delimiter, multiValueDelimiter);
+      }
+
+      if (csvHeader != null) {
+        // validate header for the delimiter before splitting
+        validateHeaderForDelimiter(delimiter, csvHeader, format);
+        format = format.withHeader(StringUtils.split(csvHeader, delimiter));
+      } else {
+        format = format.withHeader();
       }
 
       _format = format;

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/main/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderConfig.java
@@ -30,6 +30,15 @@ public class CSVRecordReaderConfig implements RecordReaderConfig {
 
   private String _fileFormat;
   private String _header;
+
+  // When true, record reader would fill the default header (e.g. "col_0", "col_1" ...) when the source is detected not
+  // to include the header. If the header is explicitly set (setHeader()), this configuration is ignored.
+  //
+  // WARNING: CSV header detection is based on a heuristic (the logic is motivated by Python's csv library -
+  // https://github.com/python/cpython/blob/main/Lib/csv.py) and it doesn't guarantee the 100% accuracy.
+  // In some edge cases, we may have a false negative and override the header to the default one. In this case, the
+  // user should either turn off the configuration or explicitly pass the header config using setHeader().
+  private boolean _fillDefaultHeaderWhenMissing;
   private char _delimiter = DEFAULT_DELIMITER;
   private char _multiValueDelimiter = DEFAULT_MULTI_VALUE_DELIMITER;
   private boolean _multiValueDelimiterEnabled = true; // when false, skip parsing for multiple values
@@ -42,7 +51,6 @@ public class CSVRecordReaderConfig implements RecordReaderConfig {
   private Character _quoteCharacter = '"';
   private String _quoteMode;
   private String _recordSeparator;
-
 
   public String getFileFormat() {
     return _fileFormat;
@@ -58,6 +66,14 @@ public class CSVRecordReaderConfig implements RecordReaderConfig {
 
   public void setHeader(String header) {
     _header = header;
+  }
+
+  public boolean fillDefaultHeaderWhenMissing() {
+    return _fillDefaultHeaderWhenMissing;
+  }
+
+  public void setFillDefaultHeaderWhenMissing(boolean fillDefaultHeaderWhenMissing) {
+    _fillDefaultHeaderWhenMissing = fillDefaultHeaderWhenMissing;
   }
 
   public char getDelimiter() {

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderDefaultHeaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/java/org/apache/pinot/plugin/inputformat/csv/CSVRecordReaderDefaultHeaderTest.java
@@ -1,0 +1,153 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.inputformat.csv;
+
+import java.io.BufferedWriter;
+import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.testng.Assert;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+
+public class CSVRecordReaderDefaultHeaderTest {
+  protected final File _tempDir = new File(FileUtils.getTempDirectory(), "CSVRecordReaderDefaultHeaderTest");
+
+  @BeforeClass
+  public void setup()
+      throws IOException {
+    FileUtils.forceMkdir(_tempDir);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws Exception {
+    FileUtils.forceDelete(_tempDir);
+  }
+
+  @Test
+  public void testFillDefaultHeader()
+      throws IOException {
+    File csvWithHeader = new File(_tempDir, "withHeader.csv");
+    List<String> csvWithHeaderContents = Arrays.asList("a,b,c", "1,2,3", "4,5,6");
+    writeContentsToFile(csvWithHeader, csvWithHeaderContents);
+
+    CSVRecordReader csvRecordReader = getCSVRecordReader(csvWithHeader, true, null, null);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().size(), 3);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().keySet(), new HashSet<>(Arrays.asList("a", "b", "c")));
+
+    csvRecordReader = getCSVRecordReader(csvWithHeader, false, null, null);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().size(), 3);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().keySet(), new HashSet<>(Arrays.asList("a", "b", "c")));
+
+    File csvNoHeader = new File(_tempDir, "noHeader.csv");
+    List<String> csvNoHeaderContents = Arrays.asList("1,2,3", "4,5,6");
+    writeContentsToFile(csvNoHeader, csvNoHeaderContents);
+
+    csvRecordReader = getCSVRecordReader(csvNoHeader, true, null, null);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().size(), 3);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().keySet(),
+        new HashSet<>(Arrays.asList("col_0", "col_1", "col_2")));
+
+    csvRecordReader = getCSVRecordReader(csvNoHeader, false, null, null);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().size(), 3);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().keySet(), new HashSet<>(Arrays.asList("1", "2", "3")));
+
+    File csvNoHeaderWithRepeating = new File(_tempDir, "noHeaderWithRepeating.csv");
+    List<String> csvNoHeaderWithRepeatingContents = Arrays.asList("1,2,1", "4,5,6");
+    writeContentsToFile(csvNoHeaderWithRepeating, csvNoHeaderWithRepeatingContents);
+
+    csvRecordReader = getCSVRecordReader(csvNoHeaderWithRepeating, true, null, null);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().size(), 3);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().keySet(),
+        new HashSet<>(Arrays.asList("col_0", "col_1", "col_2")));
+
+    try {
+      getCSVRecordReader(csvNoHeaderWithRepeating, false, null, null);
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    File csvNoHeaderAllStrWithRepeating = new File(_tempDir, "noHeaderAllStrWithRepeating.csv");
+    List<String> csvNoHeaderAllStrWithRepeatingContents = Arrays.asList("a,a,b", "b,c,d");
+    writeContentsToFile(csvNoHeaderAllStrWithRepeating, csvNoHeaderAllStrWithRepeatingContents);
+
+    csvRecordReader = getCSVRecordReader(csvNoHeaderAllStrWithRepeating, true, null, null);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().size(), 3);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().keySet(),
+        new HashSet<>(Arrays.asList("col_0", "col_1", "col_2")));
+
+    try {
+      getCSVRecordReader(csvNoHeaderAllStrWithRepeating, false, null, null);
+    } catch (IllegalArgumentException e) {
+      // expected
+    }
+
+    File csvNoHeaderComplex = new File(_tempDir, "noHeaderComplex.csv");
+    List<String> csvNoHeaderComplexContents =
+        Arrays.asList("205,Natalie,Jones,Female,22 Baker St,History;Geography,music;pingpong,3.8;2.9,1571900400000",
+            "205,,Jones,Female,22 Baker St,History;Geography,music;pingpong,3.8;2.9,1571900400000");
+    writeContentsToFile(csvNoHeaderComplex, csvNoHeaderComplexContents);
+
+    csvRecordReader = getCSVRecordReader(csvNoHeaderComplex, true, null, null);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().size(), 9);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().keySet(),
+        new HashSet<>(Arrays.asList("col_0", "col_1", "col_2", "col_3", "col_4", "col_5", "col_6", "col_7", "col_8")));
+
+    csvRecordReader = getCSVRecordReader(csvNoHeaderComplex, false, null, null);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().size(), 9);
+    Assert.assertEquals(csvRecordReader.getCSVHeaderMap().keySet(), new HashSet<>(
+        Arrays.asList("205", "Natalie", "Jones", "Female", "22 Baker St", "History;Geography", "music;pingpong",
+            "3.8;2.9", "1571900400000")));
+  }
+
+  private CSVRecordReader getCSVRecordReader(File csvFile, boolean setFillDefaultHeaderWhenMissing, Character delimiter,
+      Character multiValueDelimiter)
+      throws IOException {
+    CSVRecordReaderConfig csvRecordReaderConfig = new CSVRecordReaderConfig();
+    csvRecordReaderConfig.setFillDefaultHeaderWhenMissing(setFillDefaultHeaderWhenMissing);
+    if (delimiter != null) {
+      csvRecordReaderConfig.setDelimiter(delimiter);
+    }
+    if (multiValueDelimiter != null) {
+      csvRecordReaderConfig.setMultiValueDelimiter(multiValueDelimiter);
+    }
+    CSVRecordReader csvRecordReader = new CSVRecordReader();
+    csvRecordReader.init(csvFile, null, csvRecordReaderConfig);
+    return csvRecordReader;
+  }
+
+  private void writeContentsToFile(File file, List<String> contents)
+      throws IOException {
+    try (BufferedWriter writer = new BufferedWriter(new FileWriter(file))) {
+      for (int i = 0; i < contents.size(); i++) {
+        writer.write(contents.get(i));
+        if (i < contents.size() - 1) {
+          writer.newLine();
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
- Currently, csv record reader makes the assumption that the first row will be the header.
- The PR adds a new configuration `fillDefaultHeaderWhenMissing`, which will fill the default header when the header is missing from the file.
- default header will follow the pattern: `col_0, col_1, col_2...`