### PR TITLE
Select distinct multi-column NULL support.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/DistinctExecutorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/DistinctExecutorFactory.java
@@ -130,7 +130,8 @@ public class DistinctExecutorFactory {
             limit);
       } else {
         // Raw value based
-        return new RawMultiColumnDistinctExecutor(expressions, hasMVExpression, dataTypes, null, limit);
+        return new RawMultiColumnDistinctExecutor(expressions, hasMVExpression, dataTypes, null, nullHandlingEnabled,
+            limit);
       }
     }
   }
@@ -202,13 +203,14 @@ public class DistinctExecutorFactory {
           }
         }
       }
-      if (dictionaryBased) {
+      if (dictionaryBased && !nullHandlingEnabled) {
         // Dictionary based
         return new DictionaryBasedMultiColumnDistinctOrderByExecutor(expressions, hasMVExpression, dictionaries,
             dataTypes, orderByExpressions, limit);
       } else {
         // Raw value based
-        return new RawMultiColumnDistinctExecutor(expressions, hasMVExpression, dataTypes, orderByExpressions, limit);
+        return new RawMultiColumnDistinctExecutor(expressions, hasMVExpression, dataTypes, orderByExpressions,
+            nullHandlingEnabled, limit);
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawMultiColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawMultiColumnDistinctExecutor.java
@@ -34,6 +34,7 @@ import org.apache.pinot.core.query.distinct.DistinctExecutorUtils;
 import org.apache.pinot.core.query.distinct.DistinctTable;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.roaringbitmap.RoaringBitmap;
 
 
 /**
@@ -43,11 +44,14 @@ public class RawMultiColumnDistinctExecutor implements DistinctExecutor {
   private final List<ExpressionContext> _expressions;
   private final boolean _hasMVExpression;
   private final DistinctTable _distinctTable;
+  private final boolean _nullHandlingEnabled;
 
   public RawMultiColumnDistinctExecutor(List<ExpressionContext> expressions, boolean hasMVExpression,
-      List<DataType> dataTypes, @Nullable List<OrderByExpressionContext> orderByExpressions, int limit) {
+      List<DataType> dataTypes, @Nullable List<OrderByExpressionContext> orderByExpressions,
+      boolean nullHandlingEnabled, int limit) {
     _expressions = expressions;
     _hasMVExpression = hasMVExpression;
+    _nullHandlingEnabled = nullHandlingEnabled;
 
     int numExpressions = expressions.size();
     String[] columnNames = new String[numExpressions];
@@ -57,7 +61,7 @@ public class RawMultiColumnDistinctExecutor implements DistinctExecutor {
       columnDataTypes[i] = ColumnDataType.fromDataTypeSV(dataTypes.get(i));
     }
     DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);
-    _distinctTable = new DistinctTable(dataSchema, orderByExpressions, limit, false);
+    _distinctTable = new DistinctTable(dataSchema, orderByExpressions, limit, _nullHandlingEnabled);
   }
 
   @Override
@@ -69,15 +73,25 @@ public class RawMultiColumnDistinctExecutor implements DistinctExecutor {
       for (int i = 0; i < numExpressions; i++) {
         blockValSets[i] = valueBlock.getBlockValueSet(_expressions.get(i));
       }
-      RowBasedBlockValueFetcher valueFetcher = new RowBasedBlockValueFetcher(blockValSets);
-      if (_distinctTable.hasOrderBy()) {
-        for (int i = 0; i < numDocs; i++) {
-          Record record = new Record(valueFetcher.getRow(i));
-          _distinctTable.addWithOrderBy(record);
+      RoaringBitmap[] nullBitmaps = new RoaringBitmap[numExpressions];
+      if (_nullHandlingEnabled) {
+        for (int i = 0; i < numExpressions; i++) {
+          nullBitmaps[i] = blockValSets[i].getNullBitmap();
         }
-      } else {
-        for (int i = 0; i < numDocs; i++) {
-          Record record = new Record(valueFetcher.getRow(i));
+      }
+      RowBasedBlockValueFetcher valueFetcher = new RowBasedBlockValueFetcher(blockValSets);
+      for (int docId = 0; docId < numDocs; docId++) {
+        Record record = new Record(valueFetcher.getRow(docId));
+        if (_nullHandlingEnabled) {
+          for (int i = 0; i < numExpressions; i++) {
+            if (nullBitmaps[i] != null && nullBitmaps[i].contains(docId)) {
+              record.getValues()[i] = null;
+            }
+          }
+        }
+        if (_distinctTable.hasOrderBy()) {
+          _distinctTable.addWithOrderBy(record);
+        } else {
           if (_distinctTable.addWithoutOrderBy(record)) {
             return true;
           }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawMultiColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawMultiColumnDistinctExecutor.java
@@ -98,6 +98,7 @@ public class RawMultiColumnDistinctExecutor implements DistinctExecutor {
         }
       }
     } else {
+      // TODO(https://github.com/apache/pinot/issues/10882): support NULL for multi-value
       Object[][] svValues = new Object[numExpressions][];
       Object[][][] mvValues = new Object[numExpressions][][];
       for (int i = 0; i < numExpressions; i++) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.queries;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
@@ -26,6 +27,7 @@ import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
+import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
@@ -41,6 +43,7 @@ import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.Test;
 
+import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 
@@ -50,7 +53,10 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   private static final String RAW_TABLE_NAME = "testTable";
   private static final String SEGMENT_NAME = "testSegment";
   private static final String COLUMN1 = "column1";
+  private static final String COLUMN2 = "column2";
+  private static final int NULL_PLACEHOLDER = (int) DataSchema.ColumnDataType.INT.getNullPlaceholder();
 
+  private List<GenericRow> _rows;
   private IndexSegment _indexSegment;
   private List<IndexSegment> _indexSegments;
 
@@ -69,10 +75,11 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     return _indexSegments;
   }
 
-  private void setUp(TableConfig tableConfig, List<GenericRow> records)
+  private void setUpSegments(TableConfig tableConfig, List<GenericRow> records)
       throws Exception {
     FileUtils.deleteDirectory(INDEX_DIR);
-    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT).build();
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT)
+        .addSingleValueDimension(COLUMN2, FieldSpec.DataType.INT).build();
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
     segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
@@ -88,17 +95,22 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
   }
 
+  private void insertRow(Integer column1Value, Integer column2Value) {
+    GenericRow row = new GenericRow();
+    row.putValue(COLUMN1, column1Value);
+    row.putValue(COLUMN2, column2Value);
+    _rows.add(row);
+  }
+
   @Test
   public void testSelectDistinctOrderByNullsFirst()
       throws Exception {
     FileUtils.deleteDirectory(INDEX_DIR);
-    GenericRow nonNullRow = new GenericRow();
-    nonNullRow.putValue(COLUMN1, 1);
-    GenericRow nullRow = new GenericRow();
-    nullRow.putValue(COLUMN1, null);
-    List<GenericRow> rows = Arrays.asList(nonNullRow, nullRow);
+    _rows = new ArrayList<>();
+    insertRow(1, null);
+    insertRow(null, null);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
-    setUp(tableConfig, rows);
+    setUpSegments(tableConfig, _rows);
     Map<String, String> queryOptions = new HashMap<>();
     queryOptions.put("enableNullHandling", "true");
     String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s NULLS FIRST", COLUMN1, COLUMN1);
@@ -114,13 +126,11 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   public void testSelectDistinctOrderByNullsLast()
       throws Exception {
     FileUtils.deleteDirectory(INDEX_DIR);
-    GenericRow nonNullRow = new GenericRow();
-    nonNullRow.putValue(COLUMN1, 1);
-    GenericRow nullRow = new GenericRow();
-    nullRow.putValue(COLUMN1, null);
-    List<GenericRow> rows = Arrays.asList(nonNullRow, nullRow);
+    _rows = new ArrayList<>();
+    insertRow(1, null);
+    insertRow(null, null);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
-    setUp(tableConfig, rows);
+    setUpSegments(tableConfig, _rows);
     Map<String, String> queryOptions = new HashMap<>();
     queryOptions.put("enableNullHandling", "true");
     String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s NULLS LAST", COLUMN1, COLUMN1);
@@ -130,5 +140,74 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     ResultTable resultTable = brokerResponse.getResultTable();
     assertNotNull(resultTable.getRows().get(0)[0]);
     assertNull(resultTable.getRows().get(1)[0]);
+  }
+
+  @Test
+  public void testSelectDistinctNullPlaceholderDiffersFromNull()
+      throws Exception {
+    FileUtils.deleteDirectory(INDEX_DIR);
+    _rows = new ArrayList<>();
+    insertRow(1, null);
+    insertRow(NULL_PLACEHOLDER, null);
+    insertRow(null, null);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    setUpSegments(tableConfig, _rows);
+    Map<String, String> queryOptions = new HashMap<>();
+    queryOptions.put("enableNullHandling", "true");
+    String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s NULLS LAST", COLUMN1, COLUMN1);
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+
+    ResultTable resultTable = brokerResponse.getResultTable();
+    assertEquals(resultTable.getRows().size(), 3);
+  }
+
+  @Test
+  public void testSelectDistinctMultiColumn()
+      throws Exception {
+    _rows = new ArrayList<>();
+    insertRow(1, 1);
+    insertRow(1, 1);
+    insertRow(null, 1);
+    insertRow(null, 1);
+    insertRow(null, 2);
+    insertRow(null, null);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    setUpSegments(tableConfig, _rows);
+    Map<String, String> queryOptions = new HashMap<>();
+    queryOptions.put("enableNullHandling", "true");
+    String query =
+        String.format("SELECT DISTINCT %s,%s FROM testTable ORDER BY %s,%s", COLUMN1, COLUMN2, COLUMN1, COLUMN2);
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+
+    ResultTable resultTable = brokerResponse.getResultTable();
+    assertEquals(resultTable.getRows().size(), 4);
+  }
+
+  @Test
+  public void testSelectDistinctOrderByMultiColumn()
+      throws Exception {
+    _rows = new ArrayList<>();
+    insertRow(null, 1);
+    insertRow(null, 2);
+    insertRow(null, 2);
+    insertRow(1, 1);
+    insertRow(null, null);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    setUpSegments(tableConfig, _rows);
+    Map<String, String> queryOptions = new HashMap<>();
+    queryOptions.put("enableNullHandling", "true");
+    String query =
+        String.format("SELECT DISTINCT %s,%s FROM testTable ORDER BY %s,%s", COLUMN1, COLUMN2, COLUMN1, COLUMN2);
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+
+    ResultTable resultTable = brokerResponse.getResultTable();
+    assertEquals(resultTable.getRows().size(), 4);
+    assertEquals(resultTable.getRows().get(0), new Object[]{1, 1});
+    assertEquals(resultTable.getRows().get(1), new Object[]{null, 1});
+    assertEquals(resultTable.getRows().get(2), new Object[]{null, 2});
+    assertEquals(resultTable.getRows().get(3), new Object[]{null, null});
   }
 }


### PR DESCRIPTION
This PR enables NULL support for queries like `SELECT DISTINCT col1, col2 from testTable ORDER BY col1, col2`.

Tested in unit tests.