### PR TITLE
bugfix: fix #10861: Handle RETAINING state of PartitionConsumer to fix SIGSEGV

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1169,6 +1169,10 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           // Nothing to do. we already built local segment and swapped it with in-memory data.
           _segmentLogger.info("State {}. Nothing to do", _state.toString());
           break;
+        case RETAINING:
+          // Nothing to do. Let PartitionConsumer complete the process of building the segment.
+          _segmentLogger.info("State {}. PartitionConsumer is building segment. Nothing to do", _state.toString());
+          break;
         case DISCARDED:
         case ERROR:
           _segmentLogger.info("State {}. Downloading to replace", _state.toString());


### PR DESCRIPTION
Fixes #10861 

Observing SIGSEGV in pinot-server in following scenario:

- Server gets `KEEP` response from controller, meaning it is not the committer.
- `PartitionConsumer` temporarily changes its state to `RETAINING` and calls buildSegmentAndReplace(). However this ends up taking a long time (more than 10 minutes).
- At the same time, server also receives Helix message to transition (`CONSUMING -> ONLINE`). This path waits for 10 minutes to close the consumer, but fails to do so. Then it goes ahead to download and replace the segment.
- The replace segment flow in Helix handler ends up deleting the segment, whereas partition consumer is still busy indexing rows.

This fix enhances the Helix state transition (`CONSUMING -> ONLINE`) such that if `PartitionConsumer` state is already found to be `RETAINING`, then skip doing anything and let the PartitionConsumer thread complete the process of building the segment.