### PR TITLE
Bug Fix: Segment Purger cannot purge old segments after schema evolution

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestClient.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestClient.java
@@ -81,6 +81,16 @@ public class ControllerRequestClient {
     }
   }
 
+  public void updateSchema(Schema schema)
+      throws IOException {
+    String url = _controllerRequestURLBuilder.forSchemaUpdate(schema.getSchemaName());
+    try {
+      HttpClient.wrapAndThrowHttpException(_httpClient.sendMultipartPutRequest(url, schema.toSingleLineJsonString()));
+    } catch (HttpErrorStatusException e) {
+      throw new IOException(e);
+    }
+  }
+
   public void deleteSchema(String schemaName)
       throws IOException {
     String url = _controllerRequestURLBuilder.forSchemaDelete(schemaName);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -622,6 +622,11 @@ public class ControllerTest {
     getControllerRequestClient().addSchema(schema);
   }
 
+  public void updateSchema(Schema schema)
+      throws IOException {
+    getControllerRequestClient().updateSchema(schema);
+  }
+
   public Schema getSchema(String schemaName) {
     Schema schema = _helixResourceManager.getSchema(schemaName);
     assertNotNull(schema);

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
@@ -28,6 +28,7 @@ import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
@@ -45,19 +46,21 @@ public class SegmentPurger {
   private final File _indexDir;
   private final File _workingDir;
   private final TableConfig _tableConfig;
+  private final Schema _schema;
   private final RecordPurger _recordPurger;
   private final RecordModifier _recordModifier;
 
   private int _numRecordsPurged;
   private int _numRecordsModified;
 
-  public SegmentPurger(File indexDir, File workingDir, TableConfig tableConfig, @Nullable RecordPurger recordPurger,
-      @Nullable RecordModifier recordModifier) {
+  public SegmentPurger(File indexDir, File workingDir, TableConfig tableConfig, Schema schema,
+      @Nullable RecordPurger recordPurger, @Nullable RecordModifier recordModifier) {
     Preconditions.checkArgument(recordPurger != null || recordModifier != null,
         "At least one of record purger and modifier should be non-null");
     _indexDir = indexDir;
     _workingDir = workingDir;
     _tableConfig = tableConfig;
+    _schema = schema;
     _recordPurger = recordPurger;
     _recordModifier = recordModifier;
   }
@@ -79,7 +82,7 @@ public class SegmentPurger {
         return null;
       }
 
-      SegmentGeneratorConfig config = new SegmentGeneratorConfig(_tableConfig, segmentMetadata.getSchema());
+      SegmentGeneratorConfig config = new SegmentGeneratorConfig(_tableConfig, _schema);
       config.setOutDir(_workingDir.getPath());
       config.setSegmentName(segmentName);
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/minion/SegmentPurgerTest.java
@@ -67,6 +67,7 @@ public class SegmentPurgerTest {
   private static final String D2 = "d2";
 
   private TableConfig _tableConfig;
+  private Schema _schema;
   private File _originalIndexDir;
   private int _expectedNumRecordsPurged;
   private int _expectedNumRecordsModified;
@@ -79,7 +80,7 @@ public class SegmentPurgerTest {
     _tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setInvertedIndexColumns(Collections.singletonList(D1)).setCreateInvertedIndexDuringSegmentGeneration(true)
         .build();
-    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(D1, FieldSpec.DataType.INT)
+    _schema = new Schema.SchemaBuilder().addSingleValueDimension(D1, FieldSpec.DataType.INT)
         .addSingleValueDimension(D2, FieldSpec.DataType.INT).build();
 
     List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
@@ -98,7 +99,7 @@ public class SegmentPurgerTest {
     }
     GenericRowRecordReader genericRowRecordReader = new GenericRowRecordReader(rows);
 
-    SegmentGeneratorConfig config = new SegmentGeneratorConfig(_tableConfig, schema);
+    SegmentGeneratorConfig config = new SegmentGeneratorConfig(_tableConfig, _schema);
     config.setOutDir(ORIGINAL_SEGMENT_DIR.getPath());
     config.setSegmentName(SEGMENT_NAME);
 
@@ -125,7 +126,7 @@ public class SegmentPurgerTest {
     };
 
     SegmentPurger segmentPurger =
-        new SegmentPurger(_originalIndexDir, PURGED_SEGMENT_DIR, _tableConfig, recordPurger, recordModifier);
+        new SegmentPurger(_originalIndexDir, PURGED_SEGMENT_DIR, _tableConfig, _schema, recordPurger, recordModifier);
     File purgedIndexDir = segmentPurger.purgeSegment();
 
     // Check the purge/modify counter in segment purger

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PurgeMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PurgeMinionClusterIntegrationTest.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.integration.tests;
 
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -34,8 +35,11 @@ import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManag
 import org.apache.pinot.controller.helix.core.minion.PinotTaskManager;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.minion.MinionContext;
+import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
+import org.apache.pinot.spi.data.DimensionFieldSpec;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.util.TestUtils;
@@ -56,25 +60,21 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
   private static final String PURGE_FIRST_RUN_TABLE = "myTable1";
   private static final String PURGE_DELTA_PASSED_TABLE = "myTable2";
   private static final String PURGE_DELTA_NOT_PASSED_TABLE = "myTable3";
+  private static final String PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE = "myTable4";
+
 
   protected PinotHelixTaskResourceManager _helixTaskResourceManager;
   protected PinotTaskManager _taskManager;
   protected PinotHelixResourceManager _pinotHelixResourceManager;
   protected String _tableName;
 
-  protected final File _segmentDir1 = new File(_tempDir, "segmentDir1");
-  protected final File _segmentDir2 = new File(_tempDir, "segmentDir2");
-  protected final File _segmentDir3 = new File(_tempDir, "segmentDir3");
-
-  protected final File _tarDir1 = new File(_tempDir, "tarDir1");
-  protected final File _tarDir2 = new File(_tempDir, "tarDir2");
-  protected final File _tarDir3 = new File(_tempDir, "tarDir3");
+  protected final File _segmentDataDir = new File(_tempDir, "segmentDataDir");
+  protected final File _segmentTarDir = new File(_tempDir, "segmentTarDir");
 
   @BeforeClass
   public void setUp()
       throws Exception {
-    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir1, _tarDir1, _segmentDir2, _tarDir2, _segmentDir3,
-        _tarDir3);
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDataDir, _segmentTarDir);
 
     // Start the Pinot cluster
     startZk();
@@ -85,9 +85,11 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     // Create and upload the schema and table config
     Schema schema = createSchema();
     addSchema(schema);
+
     setTableName(PURGE_DELTA_NOT_PASSED_TABLE);
     TableConfig purgeDeltaNotPassedTableConfig = createOfflineTableConfig();
     purgeDeltaNotPassedTableConfig.setTaskConfig(getPurgeTaskConfig());
+
     setTableName(PURGE_FIRST_RUN_TABLE);
     TableConfig purgeTableConfig = createOfflineTableConfig();
     purgeTableConfig.setTaskConfig(getPurgeTaskConfig());
@@ -96,23 +98,27 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     TableConfig purgeDeltaPassedTableConfig = createOfflineTableConfig();
     purgeDeltaPassedTableConfig.setTaskConfig(getPurgeTaskConfig());
 
+    setTableName(PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE);
+    TableConfig purgeOldSegmentsWithNewIndicesTableConfig = createOfflineTableConfig();
+    purgeOldSegmentsWithNewIndicesTableConfig.setTaskConfig(getPurgeTaskConfig());
+
     addTableConfig(purgeTableConfig);
     addTableConfig(purgeDeltaPassedTableConfig);
     addTableConfig(purgeDeltaNotPassedTableConfig);
+    addTableConfig(purgeOldSegmentsWithNewIndicesTableConfig);
 
     // Unpack the Avro files
     List<File> avroFiles = unpackAvroData(_tempDir);
 
-    // Create and upload segments
-    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, purgeTableConfig, schema, 0, _segmentDir1, _tarDir1);
-    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, purgeDeltaPassedTableConfig, schema, 0, _segmentDir2,
-        _tarDir2);
-    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, purgeDeltaNotPassedTableConfig, schema, 0,
-        _segmentDir3, _tarDir3);
+    // Create segments
+    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, purgeTableConfig, schema, 0, _segmentDataDir,
+        _segmentTarDir);
 
-    uploadSegments(PURGE_FIRST_RUN_TABLE, _tarDir1);
-    uploadSegments(PURGE_DELTA_PASSED_TABLE, _tarDir2);
-    uploadSegments(PURGE_DELTA_NOT_PASSED_TABLE, _tarDir3);
+    // Upload segments
+    uploadSegments(PURGE_FIRST_RUN_TABLE, _segmentTarDir);
+    uploadSegments(PURGE_DELTA_PASSED_TABLE, _segmentTarDir);
+    uploadSegments(PURGE_DELTA_NOT_PASSED_TABLE, _segmentTarDir);
+    uploadSegments(PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE, _segmentTarDir);
 
     startMinion();
     setRecordPurger();
@@ -150,10 +156,14 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
   private void setRecordPurger() {
     MinionContext minionContext = MinionContext.getInstance();
     minionContext.setRecordPurgerFactory(rawTableName -> {
-      List<String> tableNames =
-          Arrays.asList(PURGE_FIRST_RUN_TABLE, PURGE_DELTA_PASSED_TABLE, PURGE_DELTA_NOT_PASSED_TABLE);
+      List<String> tableNames = Arrays.asList(
+          PURGE_FIRST_RUN_TABLE,
+          PURGE_DELTA_PASSED_TABLE,
+          PURGE_DELTA_NOT_PASSED_TABLE,
+          PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE
+      );
       if (tableNames.contains(rawTableName)) {
-        return row -> row.getValue("Quarter").equals(1);
+        return row -> row.getValue("ArrTime").equals(1);
       } else {
         return null;
       }
@@ -173,6 +183,62 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     Map<String, String> tableTaskConfigs = new HashMap<>();
     tableTaskConfigs.put(MinionConstants.PurgeTask.LAST_PURGE_TIME_THREESOLD_PERIOD, "1d");
     return new TableTaskConfig(Collections.singletonMap(MinionConstants.PurgeTask.TASK_TYPE, tableTaskConfigs));
+  }
+
+  /**
+   * Test purge on segments which were built by older schema and table config.
+   * Two new columns are added after segments are built and indices are defined for the new columns in the table config.
+   */
+  @Test
+  public void testPurgeOnOldSegmentsWithIndicesOnNewColumns()
+      throws Exception {
+
+    // add new columns to schema
+    Schema schema = createSchema();
+    schema.addField(new DimensionFieldSpec("ColumnABC", FieldSpec.DataType.INT, true));
+    schema.addField(new DimensionFieldSpec("ColumnXYZ", FieldSpec.DataType.INT, true));
+    updateSchema(schema);
+
+    // add indices to the new columns
+    setTableName(PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE);
+    TableConfig tableConfig = createOfflineTableConfig();
+    tableConfig.setTaskConfig(getPurgeTaskConfig());
+    IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+    List<String> invertedIndices = new ArrayList<>(indexingConfig.getInvertedIndexColumns());
+    invertedIndices.add("ColumnABC");
+    List<String> rangeIndices = new ArrayList<>(indexingConfig.getRangeIndexColumns());
+    rangeIndices.add("ColumnXYZ");
+    indexingConfig.setInvertedIndexColumns(invertedIndices);
+    indexingConfig.setRangeIndexColumns(rangeIndices);
+    updateTableConfig(tableConfig);
+
+    // schedule purge tasks
+    String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE);
+    assertNotNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    assertTrue(_helixTaskResourceManager.getTaskQueues()
+        .contains(PinotHelixTaskResourceManager.getHelixJobQueueName(MinionConstants.PurgeTask.TASK_TYPE)));
+    assertNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
+    waitForTaskToComplete();
+
+    // Check that metadata contains expected values
+    for (SegmentZKMetadata metadata : _pinotHelixResourceManager.getSegmentsZKMetadata(offlineTableName)) {
+      // Check purge time
+      assertTrue(
+          metadata.getCustomMap().containsKey(MinionConstants.PurgeTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX));
+    }
+
+    // 52 rows with ArrTime = 1
+    // 115545 totals rows
+    // Expecting 115545 - 52 = 115493 rows after purging
+    // It might take some time for server to load the purged segments
+    TestUtils.waitForCondition(aVoid -> getCurrentCountStarResult(PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE) == 115493,
+        60_000L, "Failed to get expected purged records");
+
+    // Drop the table
+    dropOfflineTable(PURGE_OLD_SEGMENTS_WITH_NEW_INDICES_TABLE);
+
+    // Check if the task metadata is cleaned up on table deletion
+    verifyTableDelete(offlineTableName);
   }
 
   /**
@@ -205,11 +271,11 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     // Should not generate new purge task as the last time purge is not greater than last + 1day (default purge delay)
     assertNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
 
-    // 28057 rows with quarter = 1
+    // 52 rows with ArrTime = 1
     // 115545 totals rows
-    // Expecting 115545 - 28057 = 87488 rows after purging
+    // Expecting 115545 - 52 = 115493 rows after purging
     // It might take some time for server to load the purged segments
-    TestUtils.waitForCondition(aVoid -> getCurrentCountStarResult(PURGE_FIRST_RUN_TABLE) == 87488, 60_000L,
+    TestUtils.waitForCondition(aVoid -> getCurrentCountStarResult(PURGE_FIRST_RUN_TABLE) == 115493, 60_000L,
         "Failed to get expected purged records");
 
     // Drop the table
@@ -251,11 +317,11 @@ public class PurgeMinionClusterIntegrationTest extends BaseClusterIntegrationTes
     // Should not generate new purge task as the last time purge is not greater than last + 1day (default purge delay)
     assertNull(_taskManager.scheduleTasks(offlineTableName).get(MinionConstants.PurgeTask.TASK_TYPE));
 
-    // 28057 rows with quarter = 1
+    // 52 rows with ArrTime = 1
     // 115545 totals rows
-    // Expecting 115545 - 28057 = 87488 rows after purging
+    // Expecting 115545 - 52 = 115493 rows after purging
     // It might take some time for server to load the purged segments
-    TestUtils.waitForCondition(aVoid -> getCurrentCountStarResult(PURGE_DELTA_PASSED_TABLE) == 87488, 60_000L,
+    TestUtils.waitForCondition(aVoid -> getCurrentCountStarResult(PURGE_DELTA_PASSED_TABLE) == 115493, 60_000L,
         "Failed to get expected purged records");
 
     // Drop the table

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutor.java
@@ -28,6 +28,7 @@ import org.apache.pinot.core.minion.SegmentPurger;
 import org.apache.pinot.plugin.minion.tasks.BaseSingleSegmentConversionExecutor;
 import org.apache.pinot.plugin.minion.tasks.SegmentConversionResult;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 
@@ -44,7 +45,6 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
 
-    TableConfig tableConfig = getTableConfig(tableNameWithType);
     SegmentPurger.RecordPurgerFactory recordPurgerFactory = MINION_CONTEXT.getRecordPurgerFactory();
     SegmentPurger.RecordPurger recordPurger =
         recordPurgerFactory != null ? recordPurgerFactory.getRecordPurger(rawTableName) : null;
@@ -52,8 +52,12 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
     SegmentPurger.RecordModifier recordModifier =
         recordModifierFactory != null ? recordModifierFactory.getRecordModifier(rawTableName) : null;
 
+    TableConfig tableConfig = getTableConfig(tableNameWithType);
+    String schemaName = tableConfig.getValidationConfig().getSchemaName();
+    Schema schema = getSchema(schemaName);
     _eventObserver.notifyProgress(pinotTaskConfig, "Purging segment: " + indexDir);
-    SegmentPurger segmentPurger = new SegmentPurger(indexDir, workingDir, tableConfig, recordPurger, recordModifier);
+    SegmentPurger segmentPurger =
+        new SegmentPurger(indexDir, workingDir, tableConfig, schema, recordPurger, recordModifier);
     File purgedSegmentFile = segmentPurger.purgeSegment();
     if (purgedSegmentFile == null) {
       purgedSegmentFile = indexDir;

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutor.java
@@ -53,8 +53,7 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
         recordModifierFactory != null ? recordModifierFactory.getRecordModifier(rawTableName) : null;
 
     TableConfig tableConfig = getTableConfig(tableNameWithType);
-    String schemaName = tableConfig.getValidationConfig().getSchemaName();
-    Schema schema = getSchema(schemaName);
+    Schema schema = getSchema(rawTableName);
     _eventObserver.notifyProgress(pinotTaskConfig, "Purging segment: " + indexDir);
     SegmentPurger segmentPurger =
         new SegmentPurger(indexDir, workingDir, tableConfig, schema, recordPurger, recordModifier);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutor.java
@@ -53,7 +53,7 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
         recordModifierFactory != null ? recordModifierFactory.getRecordModifier(rawTableName) : null;
 
     TableConfig tableConfig = getTableConfig(tableNameWithType);
-    Schema schema = getSchema(rawTableName);
+    Schema schema = getSchema(tableNameWithType);
     _eventObserver.notifyProgress(pinotTaskConfig, "Purging segment: " + indexDir);
     SegmentPurger segmentPurger =
         new SegmentPurger(indexDir, workingDir, tableConfig, schema, recordPurger, recordModifier);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutorTest.java
@@ -26,6 +26,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.helix.AccessOption;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.utils.SchemaUtils;
 import org.apache.pinot.common.utils.config.TableConfigUtils;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
@@ -95,6 +96,8 @@ public class PurgeTaskExecutorTest {
     ZkHelixPropertyStore<ZNRecord> helixPropertyStore = Mockito.mock(ZkHelixPropertyStore.class);
     Mockito.when(helixPropertyStore.get("/CONFIGS/TABLE/testTable_OFFLINE", null, AccessOption.PERSISTENT))
         .thenReturn(TableConfigUtils.toZNRecord(tableConfig));
+    Mockito.when(helixPropertyStore.get("/SCHEMAS/testTable", null, AccessOption.PERSISTENT))
+        .thenReturn(SchemaUtils.toZNRecord(schema));
     minionContext.setHelixPropertyStore(helixPropertyStore);
     minionContext.setRecordPurgerFactory(rawTableName -> {
       if (rawTableName.equals(TABLE_NAME)) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -128,13 +128,8 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
     for (String columnName : indexConfigs.keySet()) {
       FieldSpec fieldSpec = schema.getFieldSpecFor(columnName);
       if (fieldSpec == null) {
-        // Schema and table configs are normally in sync, and that's enforced by validation put in place in table config
-        // rest endpoint. There's valid scenario in which schema might be different from table config, and that's where
-        // the segment is being regenerated from an old segment, and the schema is taken from the segment file. In this
-        // case, we just ignore the new indices in the latest table config, and build the segment with columns available
-        // in the old schema.
-        LOGGER.warn("Ignoring index creation for column {} because it is not in schema", columnName);
-        continue;
+        Preconditions.checkState(schema.hasColumn(columnName),
+            "Cannot create index for column: %s because it is not in schema", columnName);
       }
       if (fieldSpec.isVirtualColumn()) {
         LOGGER.warn("Ignoring index creation for virtual column " + columnName);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -128,8 +128,13 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
     for (String columnName : indexConfigs.keySet()) {
       FieldSpec fieldSpec = schema.getFieldSpecFor(columnName);
       if (fieldSpec == null) {
-        Preconditions.checkState(schema.hasColumn(columnName),
-            "Cannot create index for column: %s because it is not in schema", columnName);
+        // Schema and table configs are normally in sync, and that's enforced by validation put in place in table config
+        // rest endpoint. There's valid scenario in which schema might be different from table config, and that's where
+        // the segment is being regenerated from an old segment, and the schema is taken from the segment file. In this
+        // case, we just ignore the new indices in the latest table config, and build the segment with columns available
+        // in the old schema.
+        LOGGER.warn("Ignoring index creation for column {} because it is not in schema", columnName);
+        continue;
       }
       if (fieldSpec.isVirtualColumn()) {
         LOGGER.warn("Ignoring index creation for virtual column " + columnName);


### PR DESCRIPTION
Solves the issue https://github.com/apache/pinot/issues/10868

I updated the minion purge integration tests to add a scenario in which the segments are built with old schema. Without the fix that unit test fails.

