### PR TITLE
Remove the validation of ReplicaGroupStrategyConfig and ReplicaGroupPartitionConfig cannot co-exist

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -142,7 +142,6 @@ public final class TableConfigUtils {
       validateIndexingConfig(tableConfig.getIndexingConfig(), schema);
       validateFieldConfigList(tableConfig.getFieldConfigList(), tableConfig.getIndexingConfig(), schema);
       validateInstancePartitionsTypeMapConfig(tableConfig);
-      validatePartitionedReplicaGroupInstance(tableConfig);
       if (!skipTypes.contains(ValidationType.UPSERT)) {
         validateUpsertAndDedupConfig(tableConfig, schema);
         validatePartialUpsertStrategies(tableConfig, schema);
@@ -604,24 +603,6 @@ public final class TableConfigUtils {
           !tableConfig.getInstanceAssignmentConfigMap().containsKey(instancePartitionsType.toString()),
           String.format("Both InstanceAssignmentConfigMap and InstancePartitionsMap set for %s",
               instancePartitionsType));
-    }
-  }
-
-  /**
-   * Detects whether both replicaGroupStrategyConfig and replicaGroupPartitionConfig are set for a given
-   * table. Validation fails because the table would ignore replicaGroupStrategyConfig
-   * when the replicaGroupPartitionConfig is already set.
-   */
-  @VisibleForTesting
-  static void validatePartitionedReplicaGroupInstance(TableConfig tableConfig) {
-    if (tableConfig.getValidationConfig().getReplicaGroupStrategyConfig() == null
-        || MapUtils.isEmpty(tableConfig.getInstanceAssignmentConfigMap())) {
-      return;
-    }
-    for (Map.Entry<String, InstanceAssignmentConfig> entry: tableConfig.getInstanceAssignmentConfigMap().entrySet()) {
-      boolean isNullReplicaGroupPartitionConfig = entry.getValue().getReplicaGroupPartitionConfig() == null;
-      Preconditions.checkState(isNullReplicaGroupPartitionConfig,
-          "Both replicaGroupStrategyConfig and replicaGroupPartitionConfig is provided");
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -32,7 +32,6 @@ import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.HashFunction;
-import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
 import org.apache.pinot.spi.config.table.RoutingConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
@@ -43,7 +42,6 @@ import org.apache.pinot.spi.config.table.TierConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.config.table.assignment.InstanceAssignmentConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
-import org.apache.pinot.spi.config.table.assignment.InstanceReplicaGroupPartitionConfig;
 import org.apache.pinot.spi.config.table.ingestion.AggregationConfig;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.config.table.ingestion.ComplexTypeConfig;
@@ -1747,46 +1745,6 @@ public class TableConfigUtilsTest {
       // Call validate with instance partitions and config set for the same type
       TableConfigUtils.validateInstancePartitionsTypeMapConfig(invalidTableConfig);
       Assert.fail("Validation should have failed since both instancePartitionsMap and config are set");
-    } catch (IllegalStateException ignored) {
-    }
-  }
-
-  @Test
-  public void testValidatePartitionedReplicaGroupInstance() {
-    String partitionColumn = "testPartitionCol";
-    ReplicaGroupStrategyConfig replicaGroupStrategyConfig =
-        new ReplicaGroupStrategyConfig(partitionColumn, 2);
-
-    TableConfig tableConfigWithoutReplicaGroupStrategyConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
-            .build();
-    // Call validate with a table-config without replicaGroupStrategyConfig or replicaGroupPartitionConfig.
-    TableConfigUtils.validatePartitionedReplicaGroupInstance(tableConfigWithoutReplicaGroupStrategyConfig);
-
-    TableConfig tableConfigWithReplicaGroupStrategyConfig =
-        new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
-    tableConfigWithReplicaGroupStrategyConfig.getValidationConfig()
-        .setReplicaGroupStrategyConfig(replicaGroupStrategyConfig);
-
-    // Call validate with a table-config with replicaGroupStrategyConfig and without replicaGroupPartitionConfig.
-    TableConfigUtils.validatePartitionedReplicaGroupInstance(tableConfigWithReplicaGroupStrategyConfig);
-
-    InstanceAssignmentConfig instanceAssignmentConfig = Mockito.mock(InstanceAssignmentConfig.class);
-    InstanceReplicaGroupPartitionConfig instanceReplicaGroupPartitionConfig =
-        new InstanceReplicaGroupPartitionConfig(true, 0, 0, 0, 2, 0, false, partitionColumn);
-    Mockito.doReturn(instanceReplicaGroupPartitionConfig)
-        .when(instanceAssignmentConfig).getReplicaGroupPartitionConfig();
-
-    TableConfig invalidTableConfig = new TableConfigBuilder(TableType.OFFLINE)
-        .setTableName(TABLE_NAME).setInstanceAssignmentConfigMap(
-            ImmutableMap.of(TableType.OFFLINE.toString(), instanceAssignmentConfig)).build();
-    invalidTableConfig.getValidationConfig().setReplicaGroupStrategyConfig(replicaGroupStrategyConfig);
-
-    try {
-      // Call validate with a table-config with replicaGroupStrategyConfig and replicaGroupPartitionConfig.
-      TableConfigUtils.validatePartitionedReplicaGroupInstance(invalidTableConfig);
-      Assert.fail("Validation should have failed since both replicaGroupStrategyConfig "
-          + "and replicaGroupPartitionConfig are set");
     } catch (IllegalStateException ignored) {
     }
   }


### PR DESCRIPTION
This validation is backward incompatible. We used to get the partition column name from the `ReplicaGroupStrategyConfig`, which can co-exist with `ReplicaGroupPartitionConfig`.