### PR TITLE
Upgrade to Apache Datasketches 4.0.0

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgValueIntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgValueIntegerTupleSketchAggregationFunction.java
@@ -20,7 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import org.apache.datasketches.tuple.CompactSketch;
-import org.apache.datasketches.tuple.SketchIterator;
+import org.apache.datasketches.tuple.TupleSketchIterator;
 import org.apache.datasketches.tuple.Union;
 import org.apache.datasketches.tuple.aninteger.IntegerSummary;
 import org.apache.pinot.common.request.context.ExpressionContext;
@@ -56,7 +56,7 @@ public class AvgValueIntegerTupleSketchAggregationFunction
     integerSummarySketches.forEach(union::union);
     double retainedTotal = 0L;
     CompactSketch<IntegerSummary> result = union.getResult();
-    SketchIterator<IntegerSummary> summaries = result.iterator();
+    TupleSketchIterator<IntegerSummary> summaries = result.iterator();
     while (summaries.next()) {
       retainedTotal += summaries.getSummary().getValue();
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -25,7 +25,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.datasketches.Util;
 import org.apache.datasketches.memory.Memory;
 import org.apache.datasketches.theta.AnotB;
 import org.apache.datasketches.theta.Intersection;
@@ -34,6 +33,7 @@ import org.apache.datasketches.theta.Sketch;
 import org.apache.datasketches.theta.Union;
 import org.apache.datasketches.theta.UpdateSketch;
 import org.apache.datasketches.theta.UpdateSketchBuilder;
+import org.apache.datasketches.thetacommon.ThetaUtil;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FilterContext;
@@ -1305,7 +1305,7 @@ public class DistinctCountThetaSketchAggregationFunction
     private static final char PARAMETER_KEY_VALUE_SEPARATOR = '=';
     private static final String NOMINAL_ENTRIES_KEY = "nominalEntries";
 
-    private int _nominalEntries = Util.DEFAULT_NOMINAL_ENTRIES;
+    private int _nominalEntries = ThetaUtil.DEFAULT_NOMINAL_ENTRIES;
 
     Parameters(String parametersString) {
       StringUtils.deleteWhitespace(parametersString);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumValuesIntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumValuesIntegerTupleSketchAggregationFunction.java
@@ -20,7 +20,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
 import org.apache.datasketches.tuple.CompactSketch;
-import org.apache.datasketches.tuple.SketchIterator;
+import org.apache.datasketches.tuple.TupleSketchIterator;
 import org.apache.datasketches.tuple.Union;
 import org.apache.datasketches.tuple.aninteger.IntegerSummary;
 import org.apache.pinot.common.request.context.ExpressionContext;
@@ -54,7 +54,7 @@ public class SumValuesIntegerTupleSketchAggregationFunction extends IntegerTuple
     integerSummarySketches.forEach(union::union);
     double retainedTotal = 0L;
     CompactSketch<IntegerSummary> result = union.getResult();
-    SketchIterator<IntegerSummary> summaries = result.iterator();
+    TupleSketchIterator<IntegerSummary> summaries = result.iterator();
     while (summaries.next()) {
       retainedTotal += summaries.getSummary().getValue();
     }

--- a/pom.xml
+++ b/pom.xml
@@ -899,7 +899,7 @@
       <dependency>
         <groupId>org.apache.datasketches</groupId>
         <artifactId>datasketches-java</artifactId>
-        <version>3.3.0</version>
+        <version>4.0.0</version>
       </dependency>
       <dependency>
         <groupId>com.tdunning</groupId>


### PR DESCRIPTION
Upgrade to Apache Datasketches 4.0.0

The 4.0.0 release incorporates some of the following changes that are relevant to implementations within Pinot:

- API changes within Quantile Sketches, including the "SortedView" which is iterable and makes analysis of the quantile distribution even easier.
- Theta Sketches have been enhanced with an optional compress operation that makes the serialized theta sketch smaller.

Note that Theta compression is not yet enabled as this would require all clients using raw sketches to be upgraded.  Although the Pinot codebase uses the ClearSpring HLL sketch, the Datasketches 4.0.0 release includes major speed improvements to the Apache Datasketches HLL implementation.