### PR TITLE
Add clpDecode transform function for decoding CLP-encoded fields.

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -270,7 +270,7 @@ com.uber:h3:4.0.0
 com.yahoo.datasketches:memory:0.8.3
 com.yahoo.datasketches:sketches-core:0.8.3
 com.yammer.metrics:metrics-core:2.2.0
-com.yscope.clp:clp-ffi:0.2.1
+com.yscope.clp:clp-ffi:0.4.3
 com.zaxxer:HikariCP-java7:2.4.13
 commons-cli:commons-cli:1.2
 commons-codec:commons-codec:1.15

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -205,5 +205,16 @@ public class FunctionRegistry {
     public static boolean jsonMatch(String text, String pattern) {
       throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
     }
+
+    @ScalarFunction(names = {"clpDecode", "clp_decode"}, isPlaceholder = true)
+    public static Object clpDecode(String logtypeFieldName, String dictVarsFieldName, String encodedVarsFieldName) {
+      throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
+    }
+
+    @ScalarFunction(names = {"clpDecode", "clp_decode"}, isPlaceholder = true)
+    public static Object clpDecode(String logtypeFieldName, String dictVarsFieldName, String encodedVarsFieldName,
+        String defaultValue) {
+      throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
+    }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -113,6 +113,7 @@ public enum TransformFunctionType {
   INIDSET("inIdSet"),
   LOOKUP("lookUp"),
   GROOVY("groovy"),
+  CLPDECODE("clpDecode"),
 
   // Regexp functions
   REGEXP_EXTRACT("regexpExtract"),

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -56,6 +56,10 @@
 
   <dependencies>
     <dependency>
+      <groupId>com.yscope.clp</groupId>
+      <artifactId>clp-ffi</artifactId>
+    </dependency>
+    <dependency>
       <groupId>com.uber</groupId>
       <artifactId>h3</artifactId>
     </dependency>

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CLPDecodeTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CLPDecodeTransformFunction.java
@@ -47,11 +47,22 @@ import static org.apache.pinot.spi.data.FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_O
  * </pre>
  * The "defaultValue" is optional and is used when a column group can't be decoded for some reason.
  * <p>
- * Sample queries
+ * Sample queries:
  * <pre>
  *   SELECT clpDecode("message_logtype", "message_dictionaryVars", "message_encodedVars") FROM table
  *   SELECT clpDecode("message_logtype", "message_dictionaryVars", "message_encodedVars", 'null') FROM table
  * </pre>
+ * For instance, consider a record that contains a "message" field with this value:
+ * <pre>INFO Task task_12 assigned to container: [ContainerID:container_15], operation took 0.335 seconds. 8 tasks
+ * remaining.</pre>
+ * {@link org.apache.pinot.plugin.inputformat.clplog.CLPLogMessageDecoder} will encode it into 3 columns:
+ * <ul>
+ *   <li>message_logtype: "INFO Task \x12 assigned to container: [ContainerID:\x12], operation took \x13 seconds.
+ *   \x11 tasks remaining."</li>
+ *   <li>message_dictionaryVars: [“task_12”, “container_15”]</li>
+ *   <li>message_encodedVars: [[0x190000000000014f, 8]]</li>
+ * </ul>
+ * Then we can use the sample queries above to decode the columns back into the original value of the "message" field.
  */
 public class CLPDecodeTransformFunction extends BaseTransformFunction {
   private static final Logger _logger = LoggerFactory.getLogger(CLPDecodeTransformFunction.class);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CLPDecodeTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CLPDecodeTransformFunction.java
@@ -1,0 +1,120 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import com.google.common.base.Preconditions;
+import com.yscope.clp.compressorfrontend.BuiltInVariableHandlingRuleVersions;
+import com.yscope.clp.compressorfrontend.MessageDecoder;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.core.operator.ColumnContext;
+import org.apache.pinot.core.operator.blocks.ValueBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import static org.apache.pinot.spi.data.FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_STRING;
+
+
+/**
+ * Decodes a CLP-encoded column group into the original value. In Pinot, a CLP-encoded field is encoded into three
+ * Pinot columns, what we collectively refer to as a column group. E.g., A CLP-encoded "message" field would be
+ * stored in three columns: "message_logtype", "message_dictionaryVars", and "message_encodedVars".
+ * <p>
+ * Usage:
+ * <pre>
+ *   clpDecode("columnGroupName_logtype", "columnGroupName_dictionaryVars",
+ *             "columnGroupName_encodedVars"[, defaultValue])
+ * </pre>
+ * The "defaultValue" is optional and is used when a column group can't be decoded for some reason.
+ * <p>
+ * Sample queries
+ * <pre>
+ *   SELECT clpDecode("message_logtype", "message_dictionaryVars", "message_encodedVars") FROM table
+ *   SELECT clpDecode("message_logtype", "message_dictionaryVars", "message_encodedVars", 'null') FROM table
+ * </pre>
+ */
+public class CLPDecodeTransformFunction extends BaseTransformFunction {
+  private static final Logger _logger = LoggerFactory.getLogger(CLPDecodeTransformFunction.class);
+  private final List<TransformFunction> _transformFunctions = new ArrayList<>();
+  private String _defaultValue = DEFAULT_DIMENSION_NULL_VALUE_OF_STRING;
+
+  @Override
+  public String getName() {
+    return TransformFunctionType.CLPDECODE.getName();
+  }
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, ColumnContext> columnContextMap) {
+    int numArgs = arguments.size();
+    Preconditions.checkArgument(3 == numArgs || 4 == numArgs,
+        "Syntax error: clpDecode takes 3 or 4 arguments - "
+            + "clpDecode(ColumnGroupName_logtype, ColumnGroupName_dictionaryVars, ColumnGroupName_encodedVars, "
+            + "defaultValue)");
+
+    int i;
+    for (i = 0; i < 3; i++) {
+      TransformFunction f = arguments.get(i);
+      Preconditions.checkArgument(f instanceof IdentifierTransformFunction,
+          "Argument " + i + " must be a column name (identifier)");
+      _transformFunctions.add(f);
+    }
+    if (i < numArgs) {
+      TransformFunction f = arguments.get(i++);
+      Preconditions.checkArgument(f instanceof LiteralTransformFunction,
+          "Argument " + i + " must be a default value (literal)");
+      _defaultValue = ((LiteralTransformFunction) f).getStringLiteral();
+    }
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return new TransformResultMetadata(FieldSpec.DataType.STRING, true, false);
+  }
+
+  @Override
+  public String[] transformToStringValuesSV(ValueBlock valueBlock) {
+    int length = valueBlock.getNumDocs();
+    initStringValuesSV(length);
+
+    int functionIdx = 0;
+    TransformFunction logtypeTransformFunction = _transformFunctions.get(functionIdx++);
+    TransformFunction dictionaryVarsTransformFunction = _transformFunctions.get(functionIdx++);
+    TransformFunction encodedVarsTransformFunction = _transformFunctions.get(functionIdx);
+    String[] logtypes = logtypeTransformFunction.transformToStringValuesSV(valueBlock);
+    String[][] dictionaryVars = dictionaryVarsTransformFunction.transformToStringValuesMV(valueBlock);
+    long[][] encodedVars = encodedVarsTransformFunction.transformToLongValuesMV(valueBlock);
+
+    MessageDecoder clpMessageDecoder = new MessageDecoder(BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
+        BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
+    for (int i = 0; i < length; i++) {
+      try {
+        _stringValuesSV[i] = clpMessageDecoder.decodeMessage(logtypes[i], dictionaryVars[i], encodedVars[i]);
+      } catch (Exception ex) {
+        _logger.error("Failed to decode CLP-encoded field.", ex);
+        _stringValuesSV[i] = _defaultValue;
+      }
+    }
+
+    return _stringValuesSV;
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -134,6 +134,7 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.MAPVALUE, MapValueTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.INIDSET, InIdSetTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.LOOKUP, LookupTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.CLPDECODE, CLPDecodeTransformFunction.class);
 
     typeToImplementation.put(TransformFunctionType.EXTRACT, ExtractTransformFunction.class);
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CLPDecodeTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CLPDecodeTransformFunctionTest.java
@@ -1,0 +1,244 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import com.yscope.clp.compressorfrontend.BuiltInVariableHandlingRuleVersions;
+import com.yscope.clp.compressorfrontend.EncodedMessage;
+import com.yscope.clp.compressorfrontend.MessageEncoder;
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.Set;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.core.operator.DocIdSetOperator;
+import org.apache.pinot.core.operator.ProjectionOperator;
+import org.apache.pinot.core.operator.blocks.ProjectionBlock;
+import org.apache.pinot.core.operator.filter.MatchAllFilterOperator;
+import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.exception.BadQueryRequestException;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.apache.pinot.spi.data.FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_STRING;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+import static org.testng.Assert.fail;
+
+
+public class CLPDecodeTransformFunctionTest {
+  private static final String SEGMENT_NAME = "testSegmentForClpDecode";
+  private static final String INDEX_DIR_PATH = FileUtils.getTempDirectoryPath() + File.separator + SEGMENT_NAME;
+  private static final String TIMESTAMP_COLUMN = "timestampColumn";
+  private static final String LOGTYPE_COLUMN = "field_logtype";
+  private static final String DICT_VARS_COLUMN = "field_dictionaryVars";
+  private static final String ENCODED_VARS_COLUMN = "field_encodedVars";
+  private static final String TEST_MESSAGE = "Started job_123 on node-987: 4 cores, 8 threads and 51.4% memory used.";
+  private static final int NUM_ROWS = 1000;
+
+  private final long[] _timestampValues = new long[NUM_ROWS];
+
+  private final String[] _logtypeValues = new String[NUM_ROWS];
+  private final String[][] _dictVarValues = new String[NUM_ROWS][];
+
+  private final Long[][] _encodedVarValues = new Long[NUM_ROWS][];
+
+  SegmentGeneratorConfig _segmentGenConfig;
+  protected Map<String, DataSource> _dataSourceMap;
+  protected ProjectionBlock _projectionBlock;
+
+  @BeforeClass
+  public void setup()
+      throws Exception {
+    // Setup the schema and table config
+    Schema schema = new Schema.SchemaBuilder()
+        .addSingleValueDimension(LOGTYPE_COLUMN, FieldSpec.DataType.STRING)
+        .addMultiValueDimension(DICT_VARS_COLUMN, FieldSpec.DataType.STRING)
+        .addMultiValueDimension(ENCODED_VARS_COLUMN, FieldSpec.DataType.LONG)
+        .addDateTime(TIMESTAMP_COLUMN, FieldSpec.DataType.TIMESTAMP, "1:MILLISECONDS:EPOCH", "1:MILLISECONDS")
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName("testTableForClpDecode")
+        .setTimeColumnName(TIMESTAMP_COLUMN)
+        .build();
+    _segmentGenConfig = new SegmentGeneratorConfig(tableConfig, schema);
+    _segmentGenConfig.setOutDir(INDEX_DIR_PATH);
+    _segmentGenConfig.setSegmentName(SEGMENT_NAME);
+
+    // Create the rows
+    long currentTimeMs = System.currentTimeMillis();
+    Random randomNumGen = new Random();
+    MessageEncoder clpMessageEncoder = new MessageEncoder(BuiltInVariableHandlingRuleVersions.VariablesSchemaV2,
+        BuiltInVariableHandlingRuleVersions.VariableEncodingMethodsV1);
+    EncodedMessage clpEncodedMessage = new EncodedMessage();
+    clpMessageEncoder.encodeMessage(TEST_MESSAGE, clpEncodedMessage);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      _timestampValues[i] = currentTimeMs + randomNumGen.nextInt(365 * 24 * 3600) * 1000L;
+      _logtypeValues[i] = clpEncodedMessage.getLogTypeAsString();
+      _dictVarValues[i] = clpEncodedMessage.getDictionaryVarsAsStrings();
+      _encodedVarValues[i] = clpEncodedMessage.getEncodedVarsAsBoxedLongs();
+    }
+    // Replace the last row with a null row
+    clpMessageEncoder.encodeMessage(DEFAULT_DIMENSION_NULL_VALUE_OF_STRING, clpEncodedMessage);
+    _logtypeValues[NUM_ROWS - 1] = clpEncodedMessage.getLogTypeAsString();
+    _dictVarValues[NUM_ROWS - 1] = clpEncodedMessage.getDictionaryVarsAsStrings();
+    _encodedVarValues[NUM_ROWS - 1] = clpEncodedMessage.getEncodedVarsAsBoxedLongs();
+    // Corrupt the previous two rows, so we can test the default value
+    _dictVarValues[NUM_ROWS - 2] = null;
+    _encodedVarValues[NUM_ROWS - 3] = null;
+
+    List<GenericRow> rows = new ArrayList<>(NUM_ROWS);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      GenericRow row = new GenericRow();
+      row.putValue(TIMESTAMP_COLUMN, _timestampValues[i]);
+      row.putValue(LOGTYPE_COLUMN, _logtypeValues[i]);
+      row.putValue(DICT_VARS_COLUMN, _dictVarValues[i]);
+      row.putValue(ENCODED_VARS_COLUMN, _encodedVarValues[i]);
+      rows.add(row);
+    }
+
+    // Build a segment
+    SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+    try {
+      driver.init(_segmentGenConfig, new GenericRowRecordReader(rows));
+      driver.build();
+
+      IndexSegment indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR_PATH, SEGMENT_NAME), ReadMode.heap);
+      Set<String> columnNames = indexSegment.getPhysicalColumnNames();
+      _dataSourceMap = new HashMap<>(columnNames.size());
+      for (String columnName : columnNames) {
+        _dataSourceMap.put(columnName, indexSegment.getDataSource(columnName));
+      }
+    } catch (Exception ex) {
+      fail("Failed to build and load segment", ex);
+    }
+
+    _projectionBlock = new ProjectionOperator(_dataSourceMap,
+        new DocIdSetOperator(new MatchAllFilterOperator(NUM_ROWS), DocIdSetPlanNode.MAX_DOC_PER_CALL)).nextBlock();
+  }
+
+  @BeforeTest
+  public void deleteOldIndex() {
+    FileUtils.deleteQuietly(new File(INDEX_DIR_PATH));
+  }
+
+  @Test
+  public void testTransform() {
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("%s(%s,%s,%s)", TransformFunctionType.CLPDECODE.getName(), LOGTYPE_COLUMN, DICT_VARS_COLUMN,
+            ENCODED_VARS_COLUMN));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CLPDecodeTransformFunction);
+
+    String[] expectedValues = new String[NUM_ROWS];
+    Arrays.fill(expectedValues, TEST_MESSAGE);
+    expectedValues[NUM_ROWS - 3] = DEFAULT_DIMENSION_NULL_VALUE_OF_STRING;
+    expectedValues[NUM_ROWS - 2] = DEFAULT_DIMENSION_NULL_VALUE_OF_STRING;
+    expectedValues[NUM_ROWS - 1] = DEFAULT_DIMENSION_NULL_VALUE_OF_STRING;
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testTransformWithDefaultValue() {
+    String defaultValue = "default";
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("%s(%s,%s,%s,'%s')", TransformFunctionType.CLPDECODE.getName(), LOGTYPE_COLUMN, DICT_VARS_COLUMN,
+            ENCODED_VARS_COLUMN, defaultValue));
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof CLPDecodeTransformFunction);
+
+    String[] expectedValues = new String[NUM_ROWS];
+    Arrays.fill(expectedValues, TEST_MESSAGE);
+    expectedValues[NUM_ROWS - 3] = defaultValue;
+    expectedValues[NUM_ROWS - 2] = defaultValue;
+    expectedValues[NUM_ROWS - 1] = DEFAULT_DIMENSION_NULL_VALUE_OF_STRING;
+    testTransformFunction(transformFunction, expectedValues);
+  }
+
+  @Test
+  public void testInvalidArgs() {
+    String defaultValue = "default";
+
+    // 1st parameter literal
+    assertThrows(BadQueryRequestException.class, () -> {
+      ExpressionContext expression = RequestContextUtils.getExpression(
+          String.format("%s('%s',%s,%s,'%s')", TransformFunctionType.CLPDECODE.getName(), LOGTYPE_COLUMN,
+              DICT_VARS_COLUMN, ENCODED_VARS_COLUMN, defaultValue));
+      TransformFunctionFactory.get(expression, _dataSourceMap);
+    });
+
+    // 2nd parameter literal
+    assertThrows(BadQueryRequestException.class, () -> {
+      ExpressionContext expression = RequestContextUtils.getExpression(
+          String.format("%s(%s,'%s',%s,'%s')", TransformFunctionType.CLPDECODE.getName(), LOGTYPE_COLUMN,
+              DICT_VARS_COLUMN, ENCODED_VARS_COLUMN, defaultValue));
+      TransformFunctionFactory.get(expression, _dataSourceMap);
+    });
+
+    // 3rd parameter literal
+    assertThrows(BadQueryRequestException.class, () -> {
+      ExpressionContext expression = RequestContextUtils.getExpression(
+          String.format("%s(%s,%s,'%s','%s')", TransformFunctionType.CLPDECODE.getName(), LOGTYPE_COLUMN,
+              DICT_VARS_COLUMN, ENCODED_VARS_COLUMN, defaultValue));
+      TransformFunctionFactory.get(expression, _dataSourceMap);
+    });
+
+    // 4th parameter identifier
+    assertThrows(BadQueryRequestException.class, () -> {
+      ExpressionContext expression = RequestContextUtils.getExpression(
+          String.format("%s(%s,%s,%s,%s)", TransformFunctionType.CLPDECODE.getName(), LOGTYPE_COLUMN,
+              DICT_VARS_COLUMN, ENCODED_VARS_COLUMN, defaultValue));
+      TransformFunctionFactory.get(expression, _dataSourceMap);
+    });
+
+    // Missing arg
+    assertThrows(BadQueryRequestException.class, () -> {
+      ExpressionContext expression = RequestContextUtils.getExpression(
+          String.format("%s(%s,%s)", TransformFunctionType.CLPDECODE.getName(), LOGTYPE_COLUMN, DICT_VARS_COLUMN));
+      TransformFunctionFactory.get(expression, _dataSourceMap);
+    });
+  }
+
+  private void testTransformFunction(TransformFunction transformFunction, String[] expectedValues) {
+    String[] values = transformFunction.transformToStringValuesSV(_projectionBlock);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      assertEquals(values[i], expectedValues[i]);
+    }
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
@@ -41,7 +41,6 @@
     <dependency>
       <groupId>com.yscope.clp</groupId>
       <artifactId>clp-ffi</artifactId>
-      <version>0.2.1</version>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -158,6 +158,7 @@
     <h3.version>4.1.1</h3.version>
     <jmh.version>1.26</jmh.version>
     <audienceannotations.version>0.13.0</audienceannotations.version>
+    <clp-ffi.version>0.4.3</clp-ffi.version>
 
     <!-- Sets the VM argument line used when unit tests are run. -->
     <argLine>-Xms4g -Xmx4g</argLine>
@@ -1265,6 +1266,12 @@
         <groupId>net.java.dev.jna</groupId>
         <artifactId>jna</artifactId>
         <version>5.5.0</version>
+      </dependency>
+
+      <dependency>
+        <groupId>com.yscope.clp</groupId>
+        <artifactId>clp-ffi</artifactId>
+        <version>${clp-ffi.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
tags: feature

This adds the `clpDecode` transform function for decoding a field that was encoded with CLP using the `CLPLogMessageDecoder`. 

E.g., if the `message` field was encoded with CLP, this transform function could be used as follows to reconstruct the field's original value:

`clpDecode(message_logtype, message_dictionaryVars, message_encodedVars)`


This is part of the change requested in #9819 and described in this [design doc](https://docs.google.com/document/d/1nHZb37re4mUwEA258x3a2pgX13EWLWMJ0uLEDk1dUyU/edit#heading=h.x12tsj9ok16d).

The query rewriter mentioned in the design doc for supporting the `clpDecode(field)` syntax will be added in another PR.

# Testing performed
* Added new unit tests.
* Validated fields encoded with CLP could be decoded correctly.
