### PR TITLE
[Multi-stage] Support partition based colocated join

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
@@ -46,7 +46,6 @@ import org.apache.pinot.broker.routing.instanceselector.InstanceSelectorFactory;
 import org.apache.pinot.broker.routing.segmentmetadata.SegmentZkMetadataFetchListener;
 import org.apache.pinot.broker.routing.segmentmetadata.SegmentZkMetadataFetcher;
 import org.apache.pinot.broker.routing.segmentpartition.SegmentPartitionMetadataManager;
-import org.apache.pinot.broker.routing.segmentpartition.TablePartitionInfo;
 import org.apache.pinot.broker.routing.segmentpreselector.SegmentPreSelector;
 import org.apache.pinot.broker.routing.segmentpreselector.SegmentPreSelectorFactory;
 import org.apache.pinot.broker.routing.segmentpruner.SegmentPruner;
@@ -63,6 +62,7 @@ import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.RoutingTable;
+import org.apache.pinot.core.routing.TablePartitionInfo;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.core.transport.server.routing.stats.ServerRoutingStatsManager;
@@ -651,8 +651,7 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
 
   @Override
   public Map<String, ServerInstance> getEnabledServersForTableTenant(String tableNameWithType) {
-    return _tableTenantServersMap.containsKey(tableNameWithType) ? _tableTenantServersMap.get(tableNameWithType)
-        : new HashMap<String, ServerInstance>();
+    return _tableTenantServersMap.getOrDefault(tableNameWithType, Collections.emptyMap());
   }
 
   private String getIdealStatePath(String tableNameWithType) {
@@ -680,6 +679,7 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
   }
 
   @Nullable
+  @Override
   public TablePartitionInfo getTablePartitionInfo(String tableNameWithType) {
     RoutingEntry routingEntry = _routingEntryMap.get(tableNameWithType);
     if (routingEntry == null) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManagerTest.java
@@ -37,6 +37,7 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentPartitionMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.core.routing.TablePartitionInfo;
 import org.apache.pinot.segment.spi.partition.metadata.ColumnPartitionMetadata;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.SegmentPartitionConfig;

--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/RoutingManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/RoutingManager.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.routing;
 
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
@@ -50,6 +51,7 @@ public interface RoutingManager {
    * @param brokerRequest the broker request constructed from a query.
    * @return the route table.
    */
+  @Nullable
   RoutingTable getRoutingTable(BrokerRequest brokerRequest, long requestId);
 
   /**
@@ -66,7 +68,14 @@ public interface RoutingManager {
    * @param offlineTableName offline table name
    * @return time boundary info.
    */
+  @Nullable
   TimeBoundaryInfo getTimeBoundaryInfo(String offlineTableName);
+
+  /**
+   * Returns the {@link TablePartitionInfo} for a given table.
+   */
+  @Nullable
+  TablePartitionInfo getTablePartitionInfo(String tableNameWithType);
 
   /**
    * Returns all enabled server instances for a given table's server tenant.

--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/TablePartitionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/TablePartitionInfo.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.broker.routing.segmentpartition;
+package org.apache.pinot.core.routing;
 
 import java.util.List;
 import java.util.Set;
@@ -65,7 +65,12 @@ public class TablePartitionInfo {
   }
 
   public static class PartitionInfo {
-    List<String> _segments;
-    Set<String> _fullyReplicatedServers;
+    public final Set<String> _fullyReplicatedServers;
+    public final List<String> _segments;
+
+    public PartitionInfo(Set<String> fullyReplicatedServers, List<String> segments) {
+      _fullyReplicatedServers = fullyReplicatedServers;
+      _segments = segments;
+    }
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotJoinExchangeNodeInsertRule.java
@@ -65,8 +65,9 @@ public class PinotJoinExchangeNodeInsertRule extends RelOptRule {
     RelNode rightExchange;
     JoinInfo joinInfo = join.analyzeCondition();
 
-    boolean isColocatedJoin = PinotHintStrategyTable.containsHintOption(join.getHints(),
-        PinotHintOptions.JOIN_HINT_OPTIONS, PinotHintOptions.JoinHintOptions.IS_COLOCATED_BY_JOIN_KEYS);
+    boolean isColocatedJoin =
+        PinotHintStrategyTable.containsHintOption(join.getHints(), PinotHintOptions.JOIN_HINT_OPTIONS,
+            PinotHintOptions.JoinHintOptions.IS_COLOCATED_BY_JOIN_KEYS);
     if (isColocatedJoin) {
       // join exchange are colocated, we should directly pass through via join key
       leftExchange = PinotLogicalExchange.create(leftInput, RelDistributions.SINGLETON);
@@ -82,10 +83,9 @@ public class PinotJoinExchangeNodeInsertRule extends RelOptRule {
     }
 
     RelNode newJoinNode =
-        new LogicalJoin(join.getCluster(), join.getTraitSet(), leftExchange, rightExchange, join.getCondition(),
-            join.getVariablesSet(), join.getJoinType(), join.isSemiJoinDone(),
+        new LogicalJoin(join.getCluster(), join.getTraitSet(), join.getHints(), leftExchange, rightExchange,
+            join.getCondition(), join.getVariablesSet(), join.getJoinType(), join.isSemiJoinDone(),
             ImmutableList.copyOf(join.getSystemFieldList()));
-
     call.transformTo(newJoinNode);
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/PinotDispatchPlanner.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/PinotDispatchPlanner.java
@@ -50,28 +50,24 @@ public class PinotDispatchPlanner {
    */
   public DispatchableSubPlan createDispatchableSubPlan(SubPlan subPlan) {
     // perform physical plan conversion and assign workers to each stage.
-    DispatchablePlanContext dispatchablePlanContext = new DispatchablePlanContext(_workerManager, _requestId,
-        _plannerContext, subPlan.getSubPlanMetadata().getFields(), subPlan.getSubPlanMetadata().getTableNames());
-    PlanNode subPlanRoot = subPlan.getSubPlanRoot().getFragmentRoot();
+    DispatchablePlanContext context = new DispatchablePlanContext(_workerManager, _requestId, _plannerContext,
+        subPlan.getSubPlanMetadata().getFields(), subPlan.getSubPlanMetadata().getTableNames());
+    PlanFragment rootFragment = subPlan.getSubPlanRoot();
+    PlanNode rootNode = rootFragment.getFragmentRoot();
     // 1. start by visiting the sub plan fragment root.
-    subPlanRoot.visit(DispatchablePlanVisitor.INSTANCE, dispatchablePlanContext);
+    rootNode.visit(DispatchablePlanVisitor.INSTANCE, context);
     // 2. add a special stage for the global mailbox receive, this runs on the dispatcher.
-    dispatchablePlanContext.getDispatchablePlanStageRootMap().put(0, subPlanRoot);
+    context.getDispatchablePlanStageRootMap().put(0, rootNode);
     // 3. add worker assignment after the dispatchable plan context is fulfilled after the visit.
-    computeWorkerAssignment(subPlan.getSubPlanRoot(), dispatchablePlanContext);
+    context.getWorkerManager().assignWorkers(rootFragment, context);
     // 4. compute the mailbox assignment for each stage.
     // TODO: refactor this to be a pluggable interface.
-    computeMailboxAssignment(dispatchablePlanContext);
+    rootNode.visit(MailboxAssignmentVisitor.INSTANCE, context);
     // 5. Run physical optimizations
-    runPhysicalOptimizers(subPlanRoot, dispatchablePlanContext, _tableCache);
+    runPhysicalOptimizers(rootNode, context, _tableCache);
     // 6. convert it into query plan.
     // TODO: refactor this to be a pluggable interface.
-    return finalizeDispatchableSubPlan(subPlan.getSubPlanRoot(), dispatchablePlanContext);
-  }
-
-  private void computeMailboxAssignment(DispatchablePlanContext dispatchablePlanContext) {
-    dispatchablePlanContext.getDispatchablePlanStageRootMap().get(0).visit(MailboxAssignmentVisitor.INSTANCE,
-        dispatchablePlanContext);
+    return finalizeDispatchableSubPlan(rootFragment, context);
   }
 
   // TODO: Switch to Worker SPI to avoid multiple-places where workers are assigned.
@@ -89,17 +85,5 @@ public class PinotDispatchPlanner {
     return new DispatchableSubPlan(dispatchablePlanContext.getResultFields(),
         dispatchablePlanContext.constructDispatchablePlanFragmentList(subPlanRoot),
         dispatchablePlanContext.getTableNames());
-  }
-
-  private static void computeWorkerAssignment(PlanFragment planFragment, DispatchablePlanContext context) {
-    computeWorkerAssignment(planFragment.getFragmentRoot(), context);
-    planFragment.getChildren().forEach(child -> computeWorkerAssignment(child, context));
-  }
-
-  private static void computeWorkerAssignment(PlanNode node, DispatchablePlanContext context) {
-    int planFragmentId = node.getPlanFragmentId();
-    context.getWorkerManager()
-        .assignWorkerToStage(planFragmentId, context.getDispatchablePlanMetadataMap().get(planFragmentId),
-            context.getRequestId(), context.getPlannerContext().getOptions(), context.getTableNames());
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/JoinNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/JoinNode.java
@@ -36,6 +36,8 @@ public class JoinNode extends AbstractPlanNode {
   @ProtoProperties
   private List<RexExpression> _joinClause;
   @ProtoProperties
+  private boolean _isColocatedJoin;
+  @ProtoProperties
   private List<String> _leftColumnNames;
   @ProtoProperties
   private List<String> _rightColumnNames;
@@ -45,13 +47,14 @@ public class JoinNode extends AbstractPlanNode {
   }
 
   public JoinNode(int planFragmentId, DataSchema dataSchema, DataSchema leftSchema, DataSchema rightSchema,
-      JoinRelType joinRelType, JoinKeys joinKeys, List<RexExpression> joinClause) {
+      JoinRelType joinRelType, JoinKeys joinKeys, List<RexExpression> joinClause, boolean isColocatedJoin) {
     super(planFragmentId, dataSchema);
     _leftColumnNames = Arrays.asList(leftSchema.getColumnNames());
     _rightColumnNames = Arrays.asList(rightSchema.getColumnNames());
     _joinRelType = joinRelType;
     _joinKeys = joinKeys;
     _joinClause = joinClause;
+    _isColocatedJoin = isColocatedJoin;
   }
 
   public JoinRelType getJoinRelType() {
@@ -64,6 +67,10 @@ public class JoinNode extends AbstractPlanNode {
 
   public List<RexExpression> getJoinClauses() {
     return _joinClause;
+  }
+
+  public boolean isColocatedJoin() {
+    return _isColocatedJoin;
   }
 
   public List<String> getLeftColumnNames() {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -27,17 +27,25 @@ import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import java.util.Set;
-import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.RoutingTable;
+import org.apache.pinot.core.routing.TablePartitionInfo;
+import org.apache.pinot.core.routing.TablePartitionInfo.PartitionInfo;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
-import org.apache.pinot.query.planner.PlannerUtils;
+import org.apache.pinot.query.planner.PlanFragment;
+import org.apache.pinot.query.planner.physical.DispatchablePlanContext;
 import org.apache.pinot.query.planner.physical.DispatchablePlanMetadata;
+import org.apache.pinot.query.planner.plannode.JoinNode;
+import org.apache.pinot.query.planner.plannode.PlanNode;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -45,11 +53,9 @@ import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
  *
  * <p>It contains the logic to assign worker to a particular stages. If it is a leaf stage the logic fallback to
  * how Pinot server assigned server and server-segment mapping.
- *
- * TODO: Currently it is implemented by wrapping routing manager from Pinot Broker. however we can abstract out
- * the worker manager later when we split out the query-spi layer.
  */
 public class WorkerManager {
+  private static final Logger LOGGER = LoggerFactory.getLogger(WorkerManager.class);
   private static final Random RANDOM = new Random();
 
   private final String _hostName;
@@ -62,42 +68,48 @@ public class WorkerManager {
     _routingManager = routingManager;
   }
 
-  public void assignWorkerToStage(int planFragmentId, DispatchablePlanMetadata dispatchablePlanMetadata, long requestId,
-      Map<String, String> options, Set<String> tableNames) {
-    if (PlannerUtils.isRootPlanFragment(planFragmentId)) {
-      // --- ROOT STAGE / BROKER REDUCE STAGE ---
-      // ROOT stage doesn't have a QueryServer as it is strictly only reducing results.
-      // here we simply assign the worker instance with identical server/mailbox port number.
-      dispatchablePlanMetadata.setServerInstanceToWorkerIdMap(Collections.singletonMap(
-          new QueryServerInstance(_hostName, _port, _port), Collections.singletonList(0)));
-      dispatchablePlanMetadata.setTotalWorkerCount(1);
-    } else if (isLeafStage(dispatchablePlanMetadata)) {
-      // --- LEAF STAGE ---
-      assignWorkerToLeafStage(requestId, dispatchablePlanMetadata);
-    } else {
-      // --- INTERMEDIATE STAGES ---
-      // If the query has more than one table, it is possible that the tables could be hosted on different tenants.
-      // The intermediate stage will be processed on servers randomly picked from the tenants belonging to either or
-      // all of the tables in the query.
-      // TODO: actually make assignment strategy decisions for intermediate stages
-      assignWorkerToIntermediateStage(dispatchablePlanMetadata, tableNames, options);
+  public void assignWorkers(PlanFragment rootFragment, DispatchablePlanContext context) {
+    // ROOT stage doesn't have a QueryServer as it is strictly only reducing results, so here we simply assign the
+    // worker instance with identical server/mailbox port number.
+    DispatchablePlanMetadata metadata = context.getDispatchablePlanMetadataMap().get(0);
+    metadata.setServerInstanceToWorkerIdMap(
+        Collections.singletonMap(new QueryServerInstance(_hostName, _port, _port), Collections.singletonList(0)));
+    metadata.setTotalWorkerCount(1);
+    for (PlanFragment child : rootFragment.getChildren()) {
+      assignWorkersToNonRootFragment(child, context);
     }
   }
 
-  private void assignWorkerToLeafStage(long requestId, DispatchablePlanMetadata dispatchablePlanMetadata) {
+  private void assignWorkersToNonRootFragment(PlanFragment fragment, DispatchablePlanContext context) {
+    if (isLeafPlan(context.getDispatchablePlanMetadataMap().get(fragment.getFragmentId()))) {
+      assignWorkersToLeafFragment(fragment, context);
+    } else {
+      assignWorkersToIntermediateFragment(fragment, context);
+    }
+  }
+
+  // TODO: Find a better way to determine whether a stage is leaf stage or intermediary. We could have query plans that
+  //       process table data even in intermediary stages.
+  private static boolean isLeafPlan(DispatchablePlanMetadata metadata) {
+    return metadata.getScannedTables().size() == 1;
+  }
+
+  private void assignWorkersToLeafFragment(PlanFragment fragment, DispatchablePlanContext context) {
+    DispatchablePlanMetadata metadata = context.getDispatchablePlanMetadataMap().get(fragment.getFragmentId());
     // table scan stage, need to attach server as well as segment info for each physical table type.
-    List<String> scannedTables = dispatchablePlanMetadata.getScannedTables();
+    List<String> scannedTables = metadata.getScannedTables();
     String logicalTableName = scannedTables.get(0);
-    Map<String, RoutingTable> routingTableMap = getRoutingTable(logicalTableName, requestId);
+    Map<String, RoutingTable> routingTableMap = getRoutingTable(logicalTableName, context.getRequestId());
     if (routingTableMap.size() == 0) {
       throw new IllegalArgumentException("Unable to find routing entries for table: " + logicalTableName);
     }
     // acquire time boundary info if it is a hybrid table.
     if (routingTableMap.size() > 1) {
-      TimeBoundaryInfo timeBoundaryInfo = _routingManager.getTimeBoundaryInfo(TableNameBuilder
-          .forType(TableType.OFFLINE).tableNameWithType(TableNameBuilder.extractRawTableName(logicalTableName)));
+      TimeBoundaryInfo timeBoundaryInfo = _routingManager.getTimeBoundaryInfo(
+          TableNameBuilder.forType(TableType.OFFLINE)
+              .tableNameWithType(TableNameBuilder.extractRawTableName(logicalTableName)));
       if (timeBoundaryInfo != null) {
-        dispatchablePlanMetadata.setTimeBoundaryInfo(timeBoundaryInfo);
+        metadata.setTimeBoundaryInfo(timeBoundaryInfo);
       } else {
         // remove offline table routing if no time boundary info is acquired.
         routingTableMap.remove(TableType.OFFLINE.name());
@@ -110,8 +122,8 @@ public class WorkerManager {
       String tableType = routingEntry.getKey();
       RoutingTable routingTable = routingEntry.getValue();
       // for each server instance, attach all table types and their associated segment list.
-      for (Map.Entry<ServerInstance, List<String>> serverEntry
-          : routingTable.getServerInstanceToSegmentsMap().entrySet()) {
+      for (Map.Entry<ServerInstance, List<String>> serverEntry : routingTable.getServerInstanceToSegmentsMap()
+          .entrySet()) {
         serverInstanceToSegmentsMap.putIfAbsent(serverEntry.getKey(), new HashMap<>());
         Map<String, List<String>> tableTypeToSegmentListMap = serverInstanceToSegmentsMap.get(serverEntry.getKey());
         Preconditions.checkState(tableTypeToSegmentListMap.put(tableType, serverEntry.getValue()) == null,
@@ -127,53 +139,14 @@ public class WorkerManager {
       workerIdToSegmentsMap.put(globalIdx, entry.getValue());
       globalIdx++;
     }
-    dispatchablePlanMetadata.setServerInstanceToWorkerIdMap(serverInstanceToWorkerIdMap);
-    dispatchablePlanMetadata.setWorkerIdToSegmentsMap(workerIdToSegmentsMap);
-    dispatchablePlanMetadata.setTotalWorkerCount(globalIdx);
-  }
+    metadata.setServerInstanceToWorkerIdMap(serverInstanceToWorkerIdMap);
+    metadata.setWorkerIdToSegmentsMap(workerIdToSegmentsMap);
+    metadata.setTotalWorkerCount(globalIdx);
 
-  private void assignWorkerToIntermediateStage(DispatchablePlanMetadata dispatchablePlanMetadata,
-      Set<String> tableNames, Map<String, String> options) {
-    // If the query has more than one table, it is possible that the tables could be hosted on different tenants.
-    // The intermediate stage will be processed on servers randomly picked from the tenants belonging to either or
-    // all of the tables in the query.
-    // TODO: actually make assignment strategy decisions for intermediate stages
-    Set<ServerInstance> serverInstances = new HashSet<>();
-    if (tableNames.size() == 0) {
-      // This could be the case from queries that don't actually fetch values from the tables. In such cases the
-      // routing need not be tenant aware.
-      // Eg: SELECT 1 AS one FROM select_having_expression_test_test_having HAVING 1 > 2;
-      serverInstances = _routingManager.getEnabledServerInstanceMap().values().stream().collect(Collectors.toSet());
-    } else {
-      serverInstances = fetchServersForIntermediateStage(tableNames);
+    // NOTE: For pipeline breaker, leaf fragment can also have children
+    for (PlanFragment child : fragment.getChildren()) {
+      assignWorkersToNonRootFragment(child, context);
     }
-    assignServers(dispatchablePlanMetadata, serverInstances, dispatchablePlanMetadata.isRequiresSingletonInstance(),
-        options);
-  }
-
-  private static void assignServers(DispatchablePlanMetadata dispatchablePlanMetadata, Set<ServerInstance> servers,
-      boolean requiresSingletonInstance, Map<String, String> options) {
-    int stageParallelism = Integer.parseInt(
-        options.getOrDefault(CommonConstants.Broker.Request.QueryOptionKey.STAGE_PARALLELISM, "1"));
-    List<ServerInstance> serverInstances = new ArrayList<>(servers);
-    Map<QueryServerInstance, List<Integer>> serverInstanceToWorkerIdMap = new HashMap<>();
-    if (requiresSingletonInstance) {
-      // require singleton should return a single global worker ID with 0;
-      ServerInstance serverInstance = serverInstances.get(RANDOM.nextInt(serverInstances.size()));
-      serverInstanceToWorkerIdMap.put(new QueryServerInstance(serverInstance), Collections.singletonList(0));
-      dispatchablePlanMetadata.setTotalWorkerCount(1);
-    } else {
-      int globalIdx = 0;
-      for (ServerInstance server : servers) {
-        List<Integer> workerIdList = new ArrayList<>();
-        for (int virtualId = 0; virtualId < stageParallelism; virtualId++) {
-          workerIdList.add(globalIdx++);
-        }
-        serverInstanceToWorkerIdMap.put(new QueryServerInstance(server), workerIdList);
-      }
-      dispatchablePlanMetadata.setTotalWorkerCount(globalIdx);
-    }
-    dispatchablePlanMetadata.setServerInstanceToWorkerIdMap(serverInstanceToWorkerIdMap);
   }
 
   /**
@@ -206,41 +179,321 @@ public class WorkerManager {
   }
 
   private RoutingTable getRoutingTable(String tableName, TableType tableType, long requestId) {
-    String tableNameWithType = TableNameBuilder.forType(tableType).tableNameWithType(
-        TableNameBuilder.extractRawTableName(tableName));
+    String tableNameWithType =
+        TableNameBuilder.forType(tableType).tableNameWithType(TableNameBuilder.extractRawTableName(tableName));
     return _routingManager.getRoutingTable(
         CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM " + tableNameWithType), requestId);
   }
 
-  // TODO: Find a better way to determine whether a stage is leaf stage or intermediary. We could have query plans that
-  //       process table data even in intermediary stages.
-  private boolean isLeafStage(DispatchablePlanMetadata dispatchablePlanMetadata) {
-    return dispatchablePlanMetadata.getScannedTables().size() == 1;
-  }
-
-  private Set<ServerInstance> fetchServersForIntermediateStage(Set<String> tableNames) {
-    Set<ServerInstance> serverInstances = new HashSet<>();
-
-    for (String table : tableNames) {
-      String rawTableName = TableNameBuilder.extractRawTableName(table);
-      TableType tableType = TableNameBuilder.getTableTypeFromTableName(table);
-      if (tableType == null) {
-        String offlineTable = TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(rawTableName);
-        String realtimeTable = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(rawTableName);
-
-        // Servers in the offline table's tenant.
-        Map<String, ServerInstance> servers = _routingManager.getEnabledServersForTableTenant(offlineTable);
-        serverInstances.addAll(servers.values());
-
-        // Servers in the online table's tenant.
-        servers = _routingManager.getEnabledServersForTableTenant(realtimeTable);
-        serverInstances.addAll(servers.values());
-      } else {
-        Map<String, ServerInstance> servers = _routingManager.getEnabledServersForTableTenant(table);
-        serverInstances.addAll(servers.values());
+  private void assignWorkersToIntermediateFragment(PlanFragment fragment, DispatchablePlanContext context) {
+    if (isColocatedJoin(fragment.getFragmentRoot())) {
+      // TODO: Make it more general so that it can be used for other partitioned cases (e.g. group-by, window function)
+      try {
+        assignWorkersForColocatedJoin(fragment, context);
+        return;
+      } catch (Exception e) {
+        LOGGER.warn("[RequestId: {}] Caught exception while assigning workers for colocated join, "
+            + "falling back to regular worker assignment", context.getRequestId(), e);
       }
     }
 
-    return serverInstances;
+    // If the query has more than one table, it is possible that the tables could be hosted on different tenants.
+    // The intermediate stage will be processed on servers randomly picked from the tenants belonging to either or
+    // all of the tables in the query.
+    // TODO: actually make assignment strategy decisions for intermediate stages
+    List<ServerInstance> serverInstances;
+    Set<String> tableNames = context.getTableNames();
+    if (tableNames.size() == 0) {
+      // TODO: Short circuit it when no table needs to be scanned
+      // This could be the case from queries that don't actually fetch values from the tables. In such cases the
+      // routing need not be tenant aware.
+      // Eg: SELECT 1 AS one FROM select_having_expression_test_test_having HAVING 1 > 2;
+      serverInstances = new ArrayList<>(_routingManager.getEnabledServerInstanceMap().values());
+    } else {
+      serverInstances = fetchServersForIntermediateStage(tableNames);
+    }
+    DispatchablePlanMetadata metadata = context.getDispatchablePlanMetadataMap().get(fragment.getFragmentId());
+    Map<String, String> options = context.getPlannerContext().getOptions();
+    int stageParallelism = Integer.parseInt(options.getOrDefault(QueryOptionKey.STAGE_PARALLELISM, "1"));
+    if (metadata.isRequiresSingletonInstance()) {
+      // require singleton should return a single global worker ID with 0;
+      ServerInstance serverInstance = serverInstances.get(RANDOM.nextInt(serverInstances.size()));
+      metadata.setServerInstanceToWorkerIdMap(
+          Collections.singletonMap(new QueryServerInstance(serverInstance), Collections.singletonList(0)));
+      metadata.setTotalWorkerCount(1);
+    } else {
+      Map<QueryServerInstance, List<Integer>> serverInstanceToWorkerIdMap = new HashMap<>();
+      int nextWorkerId = 0;
+      for (ServerInstance serverInstance : serverInstances) {
+        List<Integer> workerIds = new ArrayList<>();
+        for (int i = 0; i < stageParallelism; i++) {
+          workerIds.add(nextWorkerId++);
+        }
+        serverInstanceToWorkerIdMap.put(new QueryServerInstance(serverInstance), workerIds);
+      }
+      metadata.setServerInstanceToWorkerIdMap(serverInstanceToWorkerIdMap);
+      metadata.setTotalWorkerCount(nextWorkerId);
+    }
+
+    for (PlanFragment child : fragment.getChildren()) {
+      assignWorkersToNonRootFragment(child, context);
+    }
+  }
+
+  private boolean isColocatedJoin(PlanNode planNode) {
+    if (planNode instanceof JoinNode) {
+      return ((JoinNode) planNode).isColocatedJoin();
+    }
+    for (PlanNode child : planNode.getInputs()) {
+      if (isColocatedJoin(child)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private void assignWorkersForColocatedJoin(PlanFragment fragment, DispatchablePlanContext context) {
+    List<PlanFragment> children = fragment.getChildren();
+    Preconditions.checkArgument(children.size() == 2, "Expecting 2 children, find: %s", children.size());
+    PlanFragment leftFragment = children.get(0);
+    PlanFragment rightFragment = children.get(1);
+    Map<Integer, DispatchablePlanMetadata> metadataMap = context.getDispatchablePlanMetadataMap();
+    // TODO: Support multi-level colocated join (more than 2 tables colocated)
+    DispatchablePlanMetadata leftMetadata = metadataMap.get(leftFragment.getFragmentId());
+    Preconditions.checkArgument(isLeafPlan(leftMetadata), "Left side is not leaf");
+    DispatchablePlanMetadata rightMetadata = metadataMap.get(rightFragment.getFragmentId());
+    Preconditions.checkArgument(isLeafPlan(rightMetadata), "Right side is not leaf");
+
+    String leftTable = leftMetadata.getScannedTables().get(0);
+    String rightTable = rightMetadata.getScannedTables().get(0);
+    ColocatedTableInfo leftColocatedTableInfo = getColocatedTableInfo(leftTable);
+    ColocatedTableInfo rightColocatedTableInfo = getColocatedTableInfo(rightTable);
+    ColocatedPartitionInfo[] leftPartitionInfoMap = leftColocatedTableInfo._partitionInfoMap;
+    ColocatedPartitionInfo[] rightPartitionInfoMap = rightColocatedTableInfo._partitionInfoMap;
+    // TODO: Support colocated join when both side have different number of partitions (e.g. left: 8, right: 16)
+    int numPartitions = leftPartitionInfoMap.length;
+    Preconditions.checkState(numPartitions == rightPartitionInfoMap.length,
+        "Got different number of partitions in left table: %s (%s) and right table: %s (%s)", leftTable, numPartitions,
+        rightTable, rightPartitionInfoMap.length);
+
+    // Pick one server per partition
+    int nextWorkerId = 0;
+    Map<QueryServerInstance, List<Integer>> serverInstanceToWorkerIdMap = new HashMap<>();
+    Map<Integer, Map<String, List<String>>> leftWorkerIdToSegmentsMap = new HashMap<>();
+    Map<Integer, Map<String, List<String>>> rightWorkerIdToSegmentsMap = new HashMap<>();
+    Map<String, ServerInstance> enabledServerInstanceMap = _routingManager.getEnabledServerInstanceMap();
+    for (int i = 0; i < numPartitions; i++) {
+      ColocatedPartitionInfo leftPartitionInfo = leftPartitionInfoMap[i];
+      ColocatedPartitionInfo rightPartitionInfo = rightPartitionInfoMap[i];
+      if (leftPartitionInfo == null && rightPartitionInfo == null) {
+        continue;
+      }
+      // TODO: Currently we don't support the case when for a partition only one side has segments. The reason is that
+      //       the leaf stage won't be able to directly return empty response.
+      Preconditions.checkState(leftPartitionInfo != null && rightPartitionInfo != null,
+          "One side doesn't have any segment for partition: %s", i);
+      Set<String> candidates = new HashSet<>(leftPartitionInfo._fullyReplicatedServers);
+      candidates.retainAll(rightPartitionInfo._fullyReplicatedServers);
+      ServerInstance serverInstance = pickRandomEnabledServer(candidates, enabledServerInstanceMap);
+      Preconditions.checkState(serverInstance != null,
+          "Failed to find enabled fully replicated server for partition: %s in table: %s and %s", i, leftTable,
+          rightTable);
+      QueryServerInstance queryServerInstance = new QueryServerInstance(serverInstance);
+      int workerId = nextWorkerId++;
+      serverInstanceToWorkerIdMap.computeIfAbsent(queryServerInstance, k -> new ArrayList<>()).add(workerId);
+      leftWorkerIdToSegmentsMap.put(workerId, getSegmentsMap(leftPartitionInfo));
+      rightWorkerIdToSegmentsMap.put(workerId, getSegmentsMap(rightPartitionInfo));
+    }
+
+    DispatchablePlanMetadata joinMetadata = metadataMap.get(fragment.getFragmentId());
+    joinMetadata.setServerInstanceToWorkerIdMap(serverInstanceToWorkerIdMap);
+    joinMetadata.setTotalWorkerCount(nextWorkerId);
+
+    leftMetadata.setServerInstanceToWorkerIdMap(serverInstanceToWorkerIdMap);
+    leftMetadata.setWorkerIdToSegmentsMap(leftWorkerIdToSegmentsMap);
+    leftMetadata.setTotalWorkerCount(nextWorkerId);
+    leftMetadata.setTimeBoundaryInfo(leftColocatedTableInfo._timeBoundaryInfo);
+
+    rightMetadata.setServerInstanceToWorkerIdMap(serverInstanceToWorkerIdMap);
+    rightMetadata.setWorkerIdToSegmentsMap(rightWorkerIdToSegmentsMap);
+    rightMetadata.setTotalWorkerCount(nextWorkerId);
+    rightMetadata.setTimeBoundaryInfo(rightColocatedTableInfo._timeBoundaryInfo);
+
+    // NOTE: For pipeline breaker, leaf fragment can also have children
+    for (PlanFragment child : leftFragment.getChildren()) {
+      assignWorkersToNonRootFragment(child, context);
+    }
+    for (PlanFragment child : rightFragment.getChildren()) {
+      assignWorkersToNonRootFragment(child, context);
+    }
+  }
+
+  private ColocatedTableInfo getColocatedTableInfo(String tableName) {
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+    if (tableType == null) {
+      String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(tableName);
+      String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
+      boolean offlineRoutingExists = _routingManager.routingExists(offlineTableName);
+      boolean realtimeRoutingExists = _routingManager.routingExists(realtimeTableName);
+      Preconditions.checkState(offlineRoutingExists || realtimeRoutingExists, "Routing doesn't exist for table: %s",
+          tableName);
+      if (offlineRoutingExists && realtimeRoutingExists) {
+        // For hybrid table, find the common servers for each partition
+        TimeBoundaryInfo timeBoundaryInfo = _routingManager.getTimeBoundaryInfo(offlineTableName);
+        // Ignore OFFLINE side when time boundary info is unavailable
+        if (timeBoundaryInfo == null) {
+          return getRealtimeColocatedTableInfo(realtimeTableName);
+        }
+        PartitionInfo[] offlinePartitionInfoMap = getTablePartitionInfo(offlineTableName).getPartitionInfoMap();
+        PartitionInfo[] realtimePartitionInfoMap = getTablePartitionInfo(realtimeTableName).getPartitionInfoMap();
+        int numPartitions = offlinePartitionInfoMap.length;
+        Preconditions.checkState(numPartitions == realtimePartitionInfoMap.length,
+            "Got different number of partitions in OFFLINE side: %s and REALTIME side: %s of table: %s", numPartitions,
+            realtimePartitionInfoMap.length, tableName);
+        ColocatedPartitionInfo[] colocatedPartitionInfoMap = new ColocatedPartitionInfo[numPartitions];
+        for (int i = 0; i < numPartitions; i++) {
+          PartitionInfo offlinePartitionInfo = offlinePartitionInfoMap[i];
+          PartitionInfo realtimePartitionInfo = realtimePartitionInfoMap[i];
+          if (offlinePartitionInfo == null && realtimePartitionInfo == null) {
+            continue;
+          }
+          if (offlinePartitionInfo == null) {
+            colocatedPartitionInfoMap[i] =
+                new ColocatedPartitionInfo(realtimePartitionInfo._fullyReplicatedServers, null,
+                    realtimePartitionInfo._segments);
+            continue;
+          }
+          if (realtimePartitionInfo == null) {
+            colocatedPartitionInfoMap[i] =
+                new ColocatedPartitionInfo(offlinePartitionInfo._fullyReplicatedServers, offlinePartitionInfo._segments,
+                    null);
+            continue;
+          }
+          Set<String> fullyReplicatedServers = new HashSet<>(offlinePartitionInfo._fullyReplicatedServers);
+          fullyReplicatedServers.retainAll(realtimePartitionInfo._fullyReplicatedServers);
+          Preconditions.checkState(!fullyReplicatedServers.isEmpty(),
+              "Failed to find fully replicated server for partition: %s in hybrid table: %s", i, tableName);
+          colocatedPartitionInfoMap[i] =
+              new ColocatedPartitionInfo(fullyReplicatedServers, offlinePartitionInfo._segments,
+                  realtimePartitionInfo._segments);
+        }
+        return new ColocatedTableInfo(colocatedPartitionInfoMap, timeBoundaryInfo);
+      } else if (offlineRoutingExists) {
+        return getOfflineColocatedTableInfo(offlineTableName);
+      } else {
+        return getRealtimeColocatedTableInfo(realtimeTableName);
+      }
+    } else {
+      if (tableType == TableType.OFFLINE) {
+        return getOfflineColocatedTableInfo(tableName);
+      } else {
+        return getRealtimeColocatedTableInfo(tableName);
+      }
+    }
+  }
+
+  private TablePartitionInfo getTablePartitionInfo(String tableNameWithType) {
+    TablePartitionInfo tablePartitionInfo = _routingManager.getTablePartitionInfo(tableNameWithType);
+    Preconditions.checkState(tablePartitionInfo != null, "Failed to find table partition info for table: %s",
+        tableNameWithType);
+    Preconditions.checkState(tablePartitionInfo.getSegmentsWithInvalidPartition().isEmpty(),
+        "Find %s segments with invalid partition for table: %s",
+        tablePartitionInfo.getSegmentsWithInvalidPartition().size(), tableNameWithType);
+    return tablePartitionInfo;
+  }
+
+  private ColocatedTableInfo getOfflineColocatedTableInfo(String offlineTableName) {
+    PartitionInfo[] partitionInfoMap = getTablePartitionInfo(offlineTableName).getPartitionInfoMap();
+    int numPartitions = partitionInfoMap.length;
+    ColocatedPartitionInfo[] colocatedPartitionInfoMap = new ColocatedPartitionInfo[numPartitions];
+    for (int i = 0; i < numPartitions; i++) {
+      PartitionInfo partitionInfo = partitionInfoMap[i];
+      if (partitionInfo != null) {
+        colocatedPartitionInfoMap[i] =
+            new ColocatedPartitionInfo(partitionInfo._fullyReplicatedServers, partitionInfo._segments, null);
+      }
+    }
+    return new ColocatedTableInfo(colocatedPartitionInfoMap, null);
+  }
+
+  private ColocatedTableInfo getRealtimeColocatedTableInfo(String realtimeTableName) {
+    PartitionInfo[] partitionInfoMap = getTablePartitionInfo(realtimeTableName).getPartitionInfoMap();
+    int numPartitions = partitionInfoMap.length;
+    ColocatedPartitionInfo[] colocatedPartitionInfoMap = new ColocatedPartitionInfo[numPartitions];
+    for (int i = 0; i < numPartitions; i++) {
+      PartitionInfo partitionInfo = partitionInfoMap[i];
+      if (partitionInfo != null) {
+        colocatedPartitionInfoMap[i] =
+            new ColocatedPartitionInfo(partitionInfo._fullyReplicatedServers, null, partitionInfo._segments);
+      }
+    }
+    return new ColocatedTableInfo(colocatedPartitionInfoMap, null);
+  }
+
+  private static class ColocatedTableInfo {
+    final ColocatedPartitionInfo[] _partitionInfoMap;
+    final TimeBoundaryInfo _timeBoundaryInfo;
+
+    ColocatedTableInfo(ColocatedPartitionInfo[] partitionInfoMap, @Nullable TimeBoundaryInfo timeBoundaryInfo) {
+      _partitionInfoMap = partitionInfoMap;
+      _timeBoundaryInfo = timeBoundaryInfo;
+    }
+  }
+
+  private static class ColocatedPartitionInfo {
+    final Set<String> _fullyReplicatedServers;
+    final List<String> _offlineSegments;
+    final List<String> _realtimeSegments;
+
+    public ColocatedPartitionInfo(Set<String> fullyReplicatedServers, @Nullable List<String> offlineSegments,
+        @Nullable List<String> realtimeSegments) {
+      _fullyReplicatedServers = fullyReplicatedServers;
+      _offlineSegments = offlineSegments;
+      _realtimeSegments = realtimeSegments;
+    }
+  }
+
+  @Nullable
+  private static ServerInstance pickRandomEnabledServer(Set<String> candidates,
+      Map<String, ServerInstance> enabledServerInstanceMap) {
+    if (candidates.isEmpty()) {
+      return null;
+    }
+    String[] servers = candidates.toArray(new String[0]);
+    ArrayUtils.shuffle(servers, RANDOM);
+    for (String server : servers) {
+      ServerInstance serverInstance = enabledServerInstanceMap.get(server);
+      if (serverInstance != null) {
+        return serverInstance;
+      }
+    }
+    return null;
+  }
+
+  private static Map<String, List<String>> getSegmentsMap(ColocatedPartitionInfo partitionInfo) {
+    Map<String, List<String>> segmentsMap = new HashMap<>();
+    if (partitionInfo._offlineSegments != null) {
+      segmentsMap.put(TableType.OFFLINE.name(), partitionInfo._offlineSegments);
+    }
+    if (partitionInfo._realtimeSegments != null) {
+      segmentsMap.put(TableType.REALTIME.name(), partitionInfo._realtimeSegments);
+    }
+    return segmentsMap;
+  }
+
+  private List<ServerInstance> fetchServersForIntermediateStage(Set<String> tableNames) {
+    Set<ServerInstance> serverInstances = new HashSet<>();
+    for (String tableName : tableNames) {
+      TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+      if (tableType == null) {
+        String offlineTableName = TableNameBuilder.forType(TableType.OFFLINE).tableNameWithType(tableName);
+        serverInstances.addAll(_routingManager.getEnabledServersForTableTenant(offlineTableName).values());
+        String realtimeTableName = TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(tableName);
+        serverInstances.addAll(_routingManager.getEnabledServersForTableTenant(realtimeTableName).values());
+      } else {
+        serverInstances.addAll(_routingManager.getEnabledServersForTableTenant(tableName).values());
+      }
+    }
+    return new ArrayList<>(serverInstances);
   }
 }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/testutils/MockRoutingManagerFactory.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/testutils/MockRoutingManagerFactory.java
@@ -24,12 +24,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.RoutingTable;
+import org.apache.pinot.core.routing.TablePartitionInfo;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
 import org.apache.pinot.spi.config.table.TableType;
@@ -176,6 +178,12 @@ public class MockRoutingManagerFactory {
       String rawTableName = TableNameBuilder.extractRawTableName(tableName);
       return _hybridTables.contains(rawTableName) ? new TimeBoundaryInfo(TIME_BOUNDARY_COLUMN,
           String.valueOf(System.currentTimeMillis() - TimeUnit.DAYS.toMillis(1))) : null;
+    }
+
+    @Nullable
+    @Override
+    public TablePartitionInfo getTablePartitionInfo(String tableNameWithType) {
+      return null;
     }
 
     @Override

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -94,7 +94,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
+        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, false);
     HashJoinOperator joinOnString =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
@@ -132,7 +132,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, false);
     HashJoinOperator joinOnInt =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = joinOnInt.nextBlock();
@@ -167,7 +167,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses);
+        getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses, false);
     HashJoinOperator joinOnInt =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = joinOnInt.nextBlock();
@@ -209,7 +209,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.LEFT,
-        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
+        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, false);
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
@@ -244,7 +244,7 @@ public class HashJoinOperatorTest {
         });
     List<RexExpression> joinClauses = new ArrayList<>();
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, false);
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
@@ -276,7 +276,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.LEFT,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, false);
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
@@ -312,7 +312,7 @@ public class HashJoinOperatorTest {
         });
 
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, false);
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
@@ -351,7 +351,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses);
+        getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses, false);
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
@@ -390,7 +390,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses);
+        getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses, false);
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
@@ -425,7 +425,7 @@ public class HashJoinOperatorTest {
         DataSchema.ColumnDataType.STRING
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.RIGHT,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, false);
     HashJoinOperator joinOnNum =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = joinOnNum.nextBlock();
@@ -475,7 +475,7 @@ public class HashJoinOperatorTest {
         DataSchema.ColumnDataType.STRING
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.SEMI,
-        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
+        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, false);
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
@@ -515,7 +515,7 @@ public class HashJoinOperatorTest {
         DataSchema.ColumnDataType.STRING
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.FULL,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, false);
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
@@ -568,7 +568,7 @@ public class HashJoinOperatorTest {
         DataSchema.ColumnDataType.STRING
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.ANTI,
-        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
+        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, false);
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
@@ -607,7 +607,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, false);
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
@@ -641,7 +641,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, false);
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
@@ -678,7 +678,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, false);
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/ColocatedJoinEngineQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/ColocatedJoinEngineQuickStart.java
@@ -38,10 +38,7 @@ public class ColocatedJoinEngineQuickStart extends MultistageEngineQuickStart {
 
   @Override
   public String[] getDefaultBatchTableDirectories() {
-    List<String> colocatedTableDirs = new ArrayList<>(Arrays.asList(COLOCATED_JOIN_DIRECTORIES));
-    String[] multiStageTableDirs = super.getDefaultBatchTableDirectories();
-    colocatedTableDirs.addAll(Arrays.asList(multiStageTableDirs));
-    return colocatedTableDirs.toArray(new String[0]);
+    return COLOCATED_JOIN_DIRECTORIES;
   }
 
   @Override

--- a/pinot-tools/src/main/resources/examples/batch/colocated/userAttributes/userAttributes_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/colocated/userAttributes/userAttributes_offline_table_config.json
@@ -3,37 +3,13 @@
   "tableType": "OFFLINE",
   "segmentsConfig": {
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-    "schemaName": "userAttributes",
     "replication": 2
   },
-  "instanceAssignmentConfigMap": {
-    "OFFLINE": {
-      "tagPoolConfig": {
-        "tag": "DefaultTenant_OFFLINE",
-        "poolBased": false,
-        "numPools": 0
-      },
-      "replicaGroupPartitionConfig": {
-        "replicaGroupBased": true,
-        "numInstances": 0,
-        "numReplicaGroups": 2,
-        "numInstancesPerReplicaGroup": 2,
-        "numPartitions": 2,
-        "numInstancesPerPartition": 1,
-        "minimizeDataMovement": false,
-        "partitionColumn": "userUUID"
-      },
-      "partitionSelector": "INSTANCE_REPLICA_GROUP_PARTITION_SELECTOR"
-    }
-  },
-  "routing": {
-    "instanceSelectorType": "multiStageReplicaGroup"
-  },
   "tenants": {
+    "broker": "DefaultTenant",
+    "server": "DefaultTenant"
   },
   "tableIndexConfig": {
-    "loadMode": "HEAP",
     "invertedIndexColumns": [
       "userUUID"
     ],
@@ -45,6 +21,24 @@
         }
       }
     }
+  },
+  "instanceAssignmentConfigMap": {
+    "OFFLINE": {
+      "tagPoolConfig": {
+        "tag": "DefaultTenant_OFFLINE"
+      },
+      "replicaGroupPartitionConfig": {
+        "replicaGroupBased": true,
+        "numReplicaGroups": 2,
+        "numInstancesPerReplicaGroup": 2,
+        "numPartitions": 2,
+        "numInstancesPerPartition": 1,
+        "partitionColumn": "userUUID"
+      }
+    }
+  },
+  "routing": {
+    "instanceSelectorType": "multiStageReplicaGroup"
   },
   "metadata": {
     "customConfigs": {

--- a/pinot-tools/src/main/resources/examples/batch/colocated/userGroups/userGroups_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/colocated/userGroups/userGroups_offline_table_config.json
@@ -3,21 +3,17 @@
   "tableType": "OFFLINE",
   "segmentsConfig": {
     "segmentPushType": "APPEND",
-    "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
-    "schemaName": "userGroups",
     "replication": "2",
     "replicaGroupStrategyConfig": {
       "partitionColumn": "userUUID",
       "numInstancesPerPartition": 2
     }
   },
-  "instancePartitionsMap": {
-    "OFFLINE": "userAttributes_OFFLINE"
-  },
   "tenants": {
+    "broker": "DefaultTenant",
+    "server": "DefaultTenant"
   },
   "tableIndexConfig": {
-    "loadMode": "HEAP",
     "invertedIndexColumns": [
       "userUUID",
       "groupUUID"
@@ -30,6 +26,9 @@
         }
       }
     }
+  },
+  "instancePartitionsMap": {
+    "OFFLINE": "userAttributes_OFFLINE"
   },
   "routing": {
     "instanceSelectorType": "multiStageReplicaGroup"


### PR DESCRIPTION
When partitioning is enabled, and 2 tables have segments colocated for each partition, we may process each partition in parallel.
This PR leverages the partition information gathered in `SegmentPartitionMetadataManager`, and when `is_colocated_by_join_keys` is provided in the query hint, query planner will pick a server for each partition that serves all the segments for the partition. Then it will distribute the work for each partition into multiple workers to achieve the parallelism.
To enable `SegmentPartitionMetadataManager`, the following config needs to be set in the pinot broker: `pinot.broker.enable.partition.metadata.manager = true`.

Tested in `ColocatedJoinEngineQuickStart`. Will add more tests