### PR TITLE
Fix a bug in SELECT DISTINCT ORDER BY LIMIT.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawDoubleSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawDoubleSingleColumnDistinctExecutor.java
@@ -69,6 +69,7 @@ abstract class BaseRawDoubleSingleColumnDistinctExecutor implements DistinctExec
     if (_hasNull) {
       records.add(new Record(new Object[]{null}));
     }
+    assert records.size() <= _limit + 1;
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawFloatSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawFloatSingleColumnDistinctExecutor.java
@@ -69,7 +69,7 @@ abstract class BaseRawFloatSingleColumnDistinctExecutor implements DistinctExecu
     if (_hasNull) {
       records.add(new Record(new Object[]{null}));
     }
-    assert records.size() <= _limit;
+    assert records.size() <= _limit + 1;
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawIntSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawIntSingleColumnDistinctExecutor.java
@@ -70,7 +70,7 @@ abstract class BaseRawIntSingleColumnDistinctExecutor implements DistinctExecuto
     if (_hasNull) {
       records.add(new Record(new Object[]{null}));
     }
-    assert records.size() <= _limit;
+    assert records.size() <= _limit + 1;
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawLongSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawLongSingleColumnDistinctExecutor.java
@@ -69,7 +69,7 @@ abstract class BaseRawLongSingleColumnDistinctExecutor implements DistinctExecut
     if (_hasNull) {
       records.add(new Record(new Object[]{null}));
     }
-    assert records.size() <= _limit;
+    assert records.size() <= _limit + 1;
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawDoubleSingleColumnDistinctOnlyExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawDoubleSingleColumnDistinctOnlyExecutor.java
@@ -36,6 +36,6 @@ public class RawDoubleSingleColumnDistinctOnlyExecutor extends BaseRawDoubleSing
   @Override
   protected boolean add(double value) {
     _valueSet.add(value);
-    return _valueSet.size() >= _limit - (_hasNull ? 1 : 0);
+    return _valueSet.size() >= _limit;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawDoubleSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawDoubleSingleColumnDistinctOrderByExecutor.java
@@ -45,7 +45,7 @@ public class RawDoubleSingleColumnDistinctOrderByExecutor extends BaseRawDoubleS
   @Override
   protected boolean add(double value) {
     if (!_valueSet.contains(value)) {
-      if (_valueSet.size() < _limit - (_hasNull ? 1 : 0)) {
+      if (_valueSet.size() < _limit) {
         _valueSet.add(value);
         _priorityQueue.enqueue(value);
       } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawFloatSingleColumnDistinctOnlyExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawFloatSingleColumnDistinctOnlyExecutor.java
@@ -36,6 +36,6 @@ public class RawFloatSingleColumnDistinctOnlyExecutor extends BaseRawFloatSingle
   @Override
   protected boolean add(float value) {
     _valueSet.add(value);
-    return _valueSet.size() >= _limit - (_hasNull ? 1 : 0);
+    return _valueSet.size() >= _limit;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawFloatSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawFloatSingleColumnDistinctOrderByExecutor.java
@@ -45,7 +45,7 @@ public class RawFloatSingleColumnDistinctOrderByExecutor extends BaseRawFloatSin
   @Override
   protected boolean add(float value) {
     if (!_valueSet.contains(value)) {
-      if (_valueSet.size() < _limit - (_hasNull ? 1 : 0)) {
+      if (_valueSet.size() < _limit) {
         _valueSet.add(value);
         _priorityQueue.enqueue(value);
       } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawIntSingleColumnDistinctOnlyExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawIntSingleColumnDistinctOnlyExecutor.java
@@ -36,6 +36,6 @@ public class RawIntSingleColumnDistinctOnlyExecutor extends BaseRawIntSingleColu
   @Override
   protected boolean add(int val) {
     _valueSet.add(val);
-    return (_valueSet.size() >= _limit - (_hasNull ? 1 : 0));
+    return (_valueSet.size() >= _limit);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawIntSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawIntSingleColumnDistinctOrderByExecutor.java
@@ -45,7 +45,7 @@ public class RawIntSingleColumnDistinctOrderByExecutor extends BaseRawIntSingleC
   @Override
   protected boolean add(int value) {
     if (!_valueSet.contains(value)) {
-      if (_valueSet.size() < _limit - (_hasNull ? 1 : 0)) {
+      if (_valueSet.size() < _limit) {
         _valueSet.add(value);
         _priorityQueue.enqueue(value);
       } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawLongSingleColumnDistinctOnlyExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawLongSingleColumnDistinctOnlyExecutor.java
@@ -36,6 +36,6 @@ public class RawLongSingleColumnDistinctOnlyExecutor extends BaseRawLongSingleCo
   @Override
   protected boolean add(long val) {
     _valueSet.add(val);
-    return _valueSet.size() >= _limit - (_hasNull ? 1 : 0);
+    return _valueSet.size() >= _limit;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawLongSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawLongSingleColumnDistinctOrderByExecutor.java
@@ -45,7 +45,7 @@ public class RawLongSingleColumnDistinctOrderByExecutor extends BaseRawLongSingl
   @Override
   protected boolean add(long value) {
     if (!_valueSet.contains(value)) {
-      if (_valueSet.size() < _limit - (_hasNull ? 1 : 0)) {
+      if (_valueSet.size() < _limit) {
         _valueSet.add(value);
         _priorityQueue.enqueue(value);
       } else {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/NullEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NullEnabledQueriesTest.java
@@ -428,13 +428,9 @@ public class NullEnabledQueriesTest extends BaseQueriesTest {
         i++;
         index++;
       }
-      // The default null ordering is 'NULLS LAST'. Therefore, null will appear as the last record.
-      if (nullValuesExist) {
-        assertNull(rows.get(rows.size() - 1)[0]);
-      }
     }
     {
-      int limit = 40;
+      int limit = NUM_RECORDS / 2 + 1;
       String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s LIMIT %d", COLUMN_NAME, COLUMN_NAME,
           limit);
       BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);


### PR DESCRIPTION
Currently we might incorrectly include NULL in the `SELECT DISTINCT ORDRE BY LIMIT` query result.

Tested in unit tests.