### PR TITLE
Close PinotFS after Data Manager Shutdowns

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -643,8 +643,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
     _serverQueriesDisabledTracker.stop();
     _realtimeLuceneIndexRefreshState.stop();
     try {
-      // Close PinotFS after all data managers are shutdown. Otherwise, committing segments might not be able to
-      // upload segments to the deep-store.
+      // Close PinotFS after all data managers are shutdown. Otherwise, segments which are being committed will not
+      // be uploaded to the deep-store.
       LOGGER.info("Closing PinotFS classes");
       PinotFSFactory.shutdown();
     } catch (IOException e) {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -624,12 +624,6 @@ public abstract class BaseServerStarter implements ServiceStartable {
     LOGGER.info("Shutting down Pinot server");
     long startTimeMs = System.currentTimeMillis();
 
-    try {
-      LOGGER.info("Closing PinotFS classes");
-      PinotFSFactory.shutdown();
-    } catch (IOException e) {
-      LOGGER.warn("Caught exception closing PinotFS classes", e);
-    }
     _adminApiApplication.startShuttingDown();
     _helixAdmin.setConfig(_instanceConfigScope,
         Collections.singletonMap(Helix.IS_SHUTDOWN_IN_PROGRESS, Boolean.toString(true)));
@@ -648,6 +642,14 @@ public abstract class BaseServerStarter implements ServiceStartable {
     }
     _serverQueriesDisabledTracker.stop();
     _realtimeLuceneIndexRefreshState.stop();
+    try {
+      // Close PinotFS after all data managers are shutdown. Otherwise, committing segments might not be able to
+      // upload segments to the deep-store.
+      LOGGER.info("Closing PinotFS classes");
+      PinotFSFactory.shutdown();
+    } catch (IOException e) {
+      LOGGER.warn("Caught exception closing PinotFS classes", e);
+    }
     LOGGER.info("Deregistering service status handler");
     ServiceStatus.removeServiceStatusCallback(_instanceId);
     _adminApiApplication.stop();


### PR DESCRIPTION
When a pinot server is shutting down gracefully, at present it first closes the PinotFS instances and then it waits for all data managers to be destroyed. This could mean that the segments that are getting committed in parallel will not be uploaded to the deep-store.

In this PR I am simply changing the order of these events: making PinotFS close after all segment data managers are destroyed.

This and some other issues are also documented in #10876