### PR TITLE
Fix colocated join quickstart script

### DIFF
--- a/pinot-tools/src/main/resources/examples/batch/colocated/userAttributes/userAttributes_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/colocated/userAttributes/userAttributes_offline_table_config.json
@@ -5,11 +5,7 @@
     "segmentPushType": "APPEND",
     "segmentAssignmentStrategy": "BalanceNumSegmentAssignmentStrategy",
     "schemaName": "userAttributes",
-    "replication": 2,
-    "replicaGroupStrategyConfig": {
-      "partitionColumn": "userUUID",
-      "numInstancesPerPartition": 2
-    }
+    "replication": 2
   },
   "instanceAssignmentConfigMap": {
     "OFFLINE": {
@@ -25,7 +21,8 @@
         "numInstancesPerReplicaGroup": 2,
         "numPartitions": 2,
         "numInstancesPerPartition": 1,
-        "minimizeDataMovement": false
+        "minimizeDataMovement": false,
+        "partitionColumn": "userUUID"
       },
       "partitionSelector": "INSTANCE_REPLICA_GROUP_PARTITION_SELECTOR"
     }


### PR DESCRIPTION
`labels`:
- bugfix

The colocated quickstart script seems broken and throws this error
```
INFO [AddTableCommand] [main] {"code":400,"error":"Invalid TableConfigs. 
Invalid TableConfigs: userAttributes. Both replicaGroupStrategyConfig and replicaGroupPartitionConfig is provided"}
java.lang.RuntimeException: Unable to create offline table - userAttributes from schema file 
[/var/folders/tq/2sn6f31541b4mxq_wzfhrz4h0000gn/T/1686425986892/userAttributes/userAttributes_schema.json]
and table conf file 
[/var/folders/tq/2sn6f31541b4mxq_wzfhrz4h0000gn/T/1686425986892/userAttributes/userAttributes_offline_table_config.json]
```
Most probably it was introduced in #10656. 

This is a quick-fix to make it working.

cc @abhioncbr @Jackie-Jiang 