### PR TITLE
[Draft] Skip Zk Call in Segment Post Commit Phase

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1029,7 +1029,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       return false;
     }
 
-    _realtimeTableDataManager.replaceLLSegment(_segmentNameStr, _indexLoadingConfig);
+    _realtimeTableDataManager.replaceLLSegment(_segmentNameStr, _indexLoadingConfig, _tableConfig, _schema);
     removeSegmentFile();
     return true;
   }
@@ -1061,7 +1061,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     if (descriptor == null) {
       return false;
     }
-    _realtimeTableDataManager.replaceLLSegment(_segmentNameStr, _indexLoadingConfig);
+    _realtimeTableDataManager.replaceLLSegment(_segmentNameStr, _indexLoadingConfig, _tableConfig, _schema);
     return true;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -660,11 +660,21 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
    * Replaces a committed LLC REALTIME segment.
    */
   public void replaceLLSegment(String segmentName, IndexLoadingConfig indexLoadingConfig) {
-    File indexDir = new File(_indexDir, segmentName);
     // Use the latest table config and schema to load the segment
     TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, _tableNameWithType);
     Preconditions.checkState(tableConfig != null, "Failed to get table config for table: {}", _tableNameWithType);
     Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, tableConfig);
+
+    replaceLLSegment(segmentName, indexLoadingConfig, tableConfig, schema);
+  }
+
+  /**
+   * Same as {@link #replaceLLSegment(String, IndexLoadingConfig)} except this does not make any ZK calls for
+   * retrieving table config and schema. Instead the caller needs to pass it themselves.
+   */
+  public void replaceLLSegment(
+      String segmentName, IndexLoadingConfig indexLoadingConfig, TableConfig tableConfig, Schema schema) {
+    File indexDir = new File(_indexDir, segmentName);
 
     // Construct a new indexLoadingConfig with the updated tableConfig and schema.
     InstanceDataManagerConfig instanceDataManagerConfig = indexLoadingConfig.getInstanceDataManagerConfig();


### PR DESCRIPTION
As part of graceful shutdown, we wait for each consumer thread to stop.

If a segment is committing, we will wait for the commit to finish before continuing with the shutdown (assuming commit happens within the grace period).

At present after the `SegmentCommitter` returns success, we call `replaceLLSegment` which makes a ZK call. However, as part of graceful shutdown we stop the HelixManager before destroying the segment data managers so the ZK client is already closed.

We don't need to refetch the table-config and schema because they are already present in the segment data manager and this PR essentially makes that change.

The goal is to ensure the commit completes cleanly during server shutdown.

cc: @Jackie-Jiang