### PR TITLE
Avoid parsing commit response's offset field unnecessarily

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -687,7 +687,6 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           _state = State.HOLDING;
           SegmentCompletionProtocol.Response response = postSegmentConsumedMsg();
           SegmentCompletionProtocol.ControllerResponseStatus status = response.getStatus();
-          StreamPartitionMsgOffset rspOffset = extractOffset(response);
           boolean success;
           switch (status) {
             case NOT_LEADER:
@@ -696,6 +695,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
               hold();
               break;
             case CATCH_UP:
+              StreamPartitionMsgOffset rspOffset = extractOffset(response);
               if (rspOffset.compareTo(_currentOffset) <= 0) {
                 // Something wrong with the controller. Back off and try again.
                 _segmentLogger.error("Invalid catchup offset {} in controller response, current offset {}", rspOffset,


### PR DESCRIPTION
When controller asks an instance to discard the segment during `/segmentConsumed` call, the offset returned is default (-1)
(https://github.com/apache/pinot/blob/master/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/SegmentCompletionManager.java#L692)

But, this offset is parsed regardless of the status in the LLRealtimeSegmentDataManager
[https://github.com/apache/pinot/blob/master/pinot-core/src/main/java/org/apache/pi[…]ot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java](https://github.com/apache/pinot/blob/master/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java#L690)
which in case of DISCARD always fails with for kinesis based tables.

```
2023/06/09 11:53:54.895 ERROR [LLRealtimeSegmentDataManager_TABLE_NAME__70__1684__20230609T0553Z] [TABLE_NAME__70__1684__20230609T0553Z] Exception while in work
java.lang.IllegalStateException: Caught exception when creating KinesisPartitionGroupOffset from offsetStr: -1
        at org.apache.pinot.plugin.stream.kinesis.KinesisMsgOffsetFactory.create(KinesisMsgOffsetFactory.java:41)
        at org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager.extractOffset(LLRealtimeSegmentDataManager.java:783)
        at org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager$PartitionConsumer.run(LLRealtimeSegmentDataManager.java:670)
        at java.lang.Thread.run(Thread.java:829) [?:?]
 ```
 
This leads to the consuming segment going in an error state and getting committed prematurely with reason = Exception. This PR fixes this