### PR TITLE
Add Support for Disabling Default User Agent for Http Client

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClientConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClientConfig.java
@@ -28,13 +28,16 @@ public class HttpClientConfig {
 
   protected static final String MAX_CONNS_CONFIG_NAME = "http.client.maxConnTotal";
   protected static final String MAX_CONNS_PER_ROUTE_CONFIG_NAME = "http.client.maxConnPerRoute";
+  protected static final String DISABLE_DEFAULT_USER_AGENT_CONFIG_NAME = "http.client.disableDefaultUserAgent";
 
   private final int _maxConnTotal;
   private final int _maxConnPerRoute;
+  private final boolean _disableDefaultUserAgent;
 
-  private HttpClientConfig(int maxConnTotal, int maxConnPerRoute) {
+  private HttpClientConfig(int maxConnTotal, int maxConnPerRoute, boolean disableDefaultUserAgent) {
     _maxConnTotal = maxConnTotal;
     _maxConnPerRoute = maxConnPerRoute;
+    _disableDefaultUserAgent = disableDefaultUserAgent;
   }
 
   public int getMaxConnTotal() {
@@ -43,6 +46,10 @@ public class HttpClientConfig {
 
   public int getMaxConnPerRoute() {
     return _maxConnPerRoute;
+  }
+
+  public boolean isDisableDefaultUserAgent() {
+    return _disableDefaultUserAgent;
   }
 
   /**
@@ -61,6 +68,10 @@ public class HttpClientConfig {
     if (StringUtils.isNotEmpty(maxConnsPerRoute)) {
       builder.withMaxConnsPerRoute(Integer.parseInt(maxConnsPerRoute));
     }
+    boolean disableDefaultUserAgent = pinotConfiguration.getProperty(DISABLE_DEFAULT_USER_AGENT_CONFIG_NAME, false);
+    if (disableDefaultUserAgent) {
+      builder.withDisableDefaultUserAgent(true);
+    }
     return builder;
   }
 
@@ -71,6 +82,7 @@ public class HttpClientConfig {
   public static class Builder {
     private int _maxConns = -1;
     private int _maxConnsPerRoute = -1;
+    private boolean _disableDefaultUserAgent = false;
 
     private Builder() {
     }
@@ -85,8 +97,13 @@ public class HttpClientConfig {
       return this;
     }
 
+    public Builder withDisableDefaultUserAgent(boolean disableDefaultUserAgent) {
+      _disableDefaultUserAgent = disableDefaultUserAgent;
+      return this;
+    }
+
     public HttpClientConfig build() {
-      return new HttpClientConfig(_maxConns, _maxConnsPerRoute);
+      return new HttpClientConfig(_maxConns, _maxConnsPerRoute, _disableDefaultUserAgent);
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClientConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClientConfig.java
@@ -69,9 +69,7 @@ public class HttpClientConfig {
       builder.withMaxConnsPerRoute(Integer.parseInt(maxConnsPerRoute));
     }
     boolean disableDefaultUserAgent = pinotConfiguration.getProperty(DISABLE_DEFAULT_USER_AGENT_CONFIG_NAME, false);
-    if (disableDefaultUserAgent) {
-      builder.withDisableDefaultUserAgent(true);
-    }
+    builder.withDisableDefaultUserAgent(disableDefaultUserAgent);
     return builder;
   }
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/http/HttpClientConfigTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/http/HttpClientConfigTest.java
@@ -39,5 +39,6 @@ public class HttpClientConfigTest {
     HttpClientConfig defaultConfig = HttpClientConfig.newBuilder(new PinotConfiguration()).build();
     Assert.assertTrue(defaultConfig.getMaxConnTotal() < 0, "default value should be < 0");
     Assert.assertTrue(defaultConfig.getMaxConnPerRoute() < 0, "default value should be < 0");
+    Assert.assertFalse(defaultConfig.isDisableDefaultUserAgent(), "Default user agent should be enabled by default");
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/http/HttpClientConfigTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/http/HttpClientConfigTest.java
@@ -31,9 +31,11 @@ public class HttpClientConfigTest {
     PinotConfiguration pinotConfiguration = new PinotConfiguration();
     pinotConfiguration.setProperty(HttpClientConfig.MAX_CONNS_CONFIG_NAME, "123");
     pinotConfiguration.setProperty(HttpClientConfig.MAX_CONNS_PER_ROUTE_CONFIG_NAME, "11");
+    pinotConfiguration.setProperty(HttpClientConfig.DISABLE_DEFAULT_USER_AGENT_CONFIG_NAME, "true");
     HttpClientConfig httpClientConfig = HttpClientConfig.newBuilder(pinotConfiguration).build();
     Assert.assertEquals(123, httpClientConfig.getMaxConnTotal());
     Assert.assertEquals(11, httpClientConfig.getMaxConnPerRoute());
+    Assert.assertTrue(httpClientConfig.isDisableDefaultUserAgent());
 
     // Ensure default builder uses negative values
     HttpClientConfig defaultConfig = HttpClientConfig.newBuilder(new PinotConfiguration()).build();

--- a/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.common.utils.ClientSSLContextGenerator;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
+import org.apache.pinot.common.utils.http.HttpClientConfig;
 import org.apache.pinot.core.data.manager.realtime.Server2ControllerSegmentUploader;
 import org.apache.pinot.core.util.SegmentCompletionProtocolUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
@@ -52,6 +53,7 @@ public class ServerSegmentCompletionProtocolHandler {
   private static final String HTTP_PROTOCOL = CommonConstants.HTTP_PROTOCOL;
 
   private static SSLContext _sslContext;
+  private static HttpClientConfig _httpClientConfig;
   private static Integer _controllerHttpsPort;
   private static int _segmentUploadRequestTimeoutMs;
   private static AuthProvider _authProvider;
@@ -76,10 +78,12 @@ public class ServerSegmentCompletionProtocolHandler {
         .getProperty(CONFIG_OF_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS, DEFAULT_SEGMENT_UPLOAD_REQUEST_TIMEOUT_MS);
 
     _authProvider = AuthProviderUtils.extractAuthProvider(uploaderConfig, CONFIG_OF_SEGMENT_UPLOADER_AUTH);
+
+    _httpClientConfig = HttpClientConfig.newBuilder(uploaderConfig).build();
   }
 
   public ServerSegmentCompletionProtocolHandler(ServerMetrics serverMetrics, String tableNameWithType) {
-    _fileUploadDownloadClient = new FileUploadDownloadClient(_sslContext);
+    _fileUploadDownloadClient = new FileUploadDownloadClient(_httpClientConfig, _sslContext);
     _serverMetrics = serverMetrics;
     _rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/server/realtime/ServerSegmentCompletionProtocolHandler.java
@@ -53,7 +53,7 @@ public class ServerSegmentCompletionProtocolHandler {
   private static final String HTTP_PROTOCOL = CommonConstants.HTTP_PROTOCOL;
 
   private static SSLContext _sslContext;
-  private static HttpClientConfig _httpClientConfig;
+  private static HttpClientConfig _httpClientConfig = HttpClientConfig.DEFAULT_HTTP_CLIENT_CONFIG;
   private static Integer _controllerHttpsPort;
   private static int _segmentUploadRequestTimeoutMs;
   private static AuthProvider _authProvider;


### PR DESCRIPTION
Potential fix for #10894.

The default value for this is `false` and we don't change the default behavior.

**Test Plan**: Tested on local and the config gets picked up as expected.

<img width="1183" alt="Screenshot 2023-06-13 at 4 47 32 PM" src="https://github.com/apache/pinot/assets/8644710/0a08569f-97ed-41cb-b4af-d8e5af76483b">

And this is where we see the exception and this config is used in HttpClientBuilder in Apache commons

<img width="675" alt="image" src="https://github.com/apache/pinot/assets/8644710/d1e4c1f7-c692-4857-b463-fc443bcc6f13">
