### PR TITLE
Fixes SQL wildcard escaping in LIKE queries

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/RegexpPatternConverterUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/RegexpPatternConverterUtils.java
@@ -110,7 +110,7 @@ public class RegexpPatternConverterUtils {
   }
 
   private static int indexOf(char[] arr, char c) {
-    for (int i = 0; i < arr.length; ++i) {
+    for (int i = 0; i < arr.length; i++) {
       if (arr[i] == c) {
         return i;
       }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/RegexpPatternConverterUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/RegexpPatternConverterUtils.java
@@ -93,8 +93,9 @@ public class RegexpPatternConverterUtils {
     // handling SQL wildcards (_, %) by replacing them with corresponding regex equivalents
     // we ignore them if the SQL wildcards are escaped
     int i = 0;
+    int len = input.length();
     boolean isPrevCharBackSlash = false;
-    while (i < input.length()) {
+    while (i < len) {
       char c = input.charAt(i);
       if (c == '_') {
         sb.append(isPrevCharBackSlash ? c : ".");
@@ -113,7 +114,7 @@ public class RegexpPatternConverterUtils {
         sb.append(c);
       }
       isPrevCharBackSlash = (c == BACK_SLASH);
-      ++i;
+      i++;
     }
 
     // handle trailing \

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/RegexpPatternConverterUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/RegexpPatternConverterUtils.java
@@ -82,17 +82,9 @@ public class RegexpPatternConverterUtils {
     while (i < likePattern.length()) {
       char c = likePattern.charAt(i);
       if (c == '_') {
-        if (isPrevCharBackSlash) {
-          sb.append(c);
-        } else {
-          sb.append(".");
-        }
+        sb.append(isPrevCharBackSlash ? c : ".");
       } else if (c == '%') {
-        if (isPrevCharBackSlash) {
-          sb.append(c);
-        } else {
-          sb.append(".*");
-        }
+        sb.append(isPrevCharBackSlash ? c : ".*");
       } else if (REGEXP_METACHARACTERS.contains(String.valueOf(c))) {
         sb.append('\\').append(c);
       } else {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/RegexpPatternConverterUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/RegexpPatternConverterUtils.java
@@ -19,6 +19,8 @@
 package org.apache.pinot.common.utils;
 
 
+import com.google.common.primitives.Chars;
+
 /**
  * Utility for converting regex patterns.
  */
@@ -71,20 +73,34 @@ public class RegexpPatternConverterUtils {
     }
 
     likePattern = likePattern.substring(start, end);
+    return escapeMetaCharsAndWildcards(likePattern, prefix, suffix);
+  }
+
+  /**
+   * Escapes the provided pattern by considering the following constraints:
+   * <ul>
+   *     <li> SQL wildcards escaping is handled (_, %) </li>
+   *     <li> Regex meta characters escaping is handled </li>
+   * </ul>
+   * @param input the provided input string
+   * @param prefix the prefix to be added to the output string
+   * @param suffix the suffix to be added to the output string
+   * @return the final output string
+   */
+  private static String escapeMetaCharsAndWildcards(String input, String prefix, String suffix) {
     StringBuilder sb = new StringBuilder();
     sb.append(prefix);
-
-    // handling SQL wildcards by replacing them with corresponding regex equivalents
+    // handling SQL wildcards (_, %) by replacing them with corresponding regex equivalents
     // we ignore them if the SQL wildcards are escaped
     int i = 0;
     boolean isPrevCharBackSlash = false;
-    while (i < likePattern.length()) {
-      char c = likePattern.charAt(i);
+    while (i < input.length()) {
+      char c = input.charAt(i);
       if (c == '_') {
         sb.append(isPrevCharBackSlash ? c : ".");
       } else if (c == '%') {
         sb.append(isPrevCharBackSlash ? c : ".*");
-      } else if (indexOf(REGEXP_METACHARACTERS, c) >= 0) {
+      } else if (Chars.indexOf(REGEXP_METACHARACTERS, c) >= 0) {
         sb.append(BACK_SLASH).append(c);
       } else {
         if (isPrevCharBackSlash) {
@@ -107,15 +123,6 @@ public class RegexpPatternConverterUtils {
 
     sb.append(suffix);
     return sb.toString();
-  }
-
-  private static int indexOf(char[] arr, char c) {
-    for (int i = 0; i < arr.length; i++) {
-      if (arr[i] == c) {
-        return i;
-      }
-    }
-    return -1;
   }
 
   private static int indexOfFirstDifferent(String str, char character) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/RegexpPatternConverterUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/RegexpPatternConverterUtils.java
@@ -97,21 +97,25 @@ public class RegexpPatternConverterUtils {
     boolean isPrevCharBackSlash = false;
     while (i < len) {
       char c = input.charAt(i);
-      if (c == '_') {
-        sb.append(isPrevCharBackSlash ? c : ".");
-      } else if (c == '%') {
-        sb.append(isPrevCharBackSlash ? c : ".*");
-      } else if (Chars.indexOf(REGEXP_METACHARACTERS, c) >= 0) {
-        sb.append(BACK_SLASH).append(c);
-      } else {
-        if (isPrevCharBackSlash) {
+      switch (c) {
+        case '_':
+          sb.append(isPrevCharBackSlash ? c : ".");
+          break;
+        case '%':
+          sb.append(isPrevCharBackSlash ? c : ".*");
+          break;
+        default:
+          // either the current character is a meta-character
+          // OR
           // this means the previous character is a \
           // but it was not used for escaping SQL wildcards
           // so let's escape this \ in the output
-          // this case is separately handled outside of the meta characters list
-          sb.append(BACK_SLASH);
-        }
-        sb.append(c);
+          // this case is separately handled outside the meta characters list
+          if (Chars.indexOf(REGEXP_METACHARACTERS, c) >= 0 || isPrevCharBackSlash) {
+            sb.append(BACK_SLASH);
+          }
+          sb.append(c);
+          break;
       }
       isPrevCharBackSlash = (c == BACK_SLASH);
       i++;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/RegexpPatternConverterUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/RegexpPatternConverterUtils.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.common.utils;
 
 import com.google.common.collect.ImmutableSet;
-
 import java.util.Set;
 
 /**

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/RegexpPatternConverterUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/RegexpPatternConverterUtilsTest.java
@@ -141,4 +141,11 @@ public class RegexpPatternConverterUtilsTest {
     String luceneRegExpPattern = RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(regexpLikePattern);
     assertEquals(luceneRegExpPattern, "a\\%b\\\\cde");
   }
+  @Test
+  public void testEscapedWildcard3() {
+    String regexpLikePattern = RegexpPatternConverterUtils.likeToRegexpLike("%2\\_2%");
+    assertEquals(regexpLikePattern, "2\\_2");
+    String luceneRegExpPattern = RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(regexpLikePattern);
+    assertEquals(luceneRegExpPattern, ".*2\\_2.*");
+  }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/RegexpPatternConverterUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/RegexpPatternConverterUtilsTest.java
@@ -128,6 +128,10 @@ public class RegexpPatternConverterUtilsTest {
 
   @Test
   public void testEscapedWildcard1() {
+    // the first underscore (_ in _b) is escaped, so it is meant to match an actual "_b" string in the provided
+    // string
+    // the second underscore (_ in b_) is not escaped, so it is a SQL wildcard that is used to match a single
+    // character, which in the regex space is "."
     String regexpLikePattern = RegexpPatternConverterUtils.likeToRegexpLike("a\\_b_\\");
     assertEquals(regexpLikePattern, "^a\\_b.\\\\$");
     String luceneRegExpPattern = RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(regexpLikePattern);
@@ -136,6 +140,13 @@ public class RegexpPatternConverterUtilsTest {
 
   @Test
   public void testEscapedWildcard2() {
+    // the % (% in %b) is escaped, so it is meant to match an actual "%b" string in the provided
+    // string
+    // the "\" before c is a normal "\", so it is meant to match an actual "\" string in the provided
+    // string, this is done because "c" is not a SQL wildcard - hence the "\" before that is used as-is
+    // and is not used for escaping "c"
+    // so, this "\" is escaped in the output as it is a regex metacharacter and the converted regex
+    // will match "a%b\cde" in the provided string
     String regexpLikePattern = RegexpPatternConverterUtils.likeToRegexpLike("a\\%b\\cde");
     assertEquals(regexpLikePattern, "^a\\%b\\\\cde$");
     String luceneRegExpPattern = RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(regexpLikePattern);
@@ -143,6 +154,9 @@ public class RegexpPatternConverterUtilsTest {
   }
   @Test
   public void testEscapedWildcard3() {
+    // here the "\" character is used to escape _, so _ here is not treated as a SQL wildcard
+    // but it is meant to actually match "_" in the provided string
+    // so the corresponding regex doesn't convert the "_" to "."
     String regexpLikePattern = RegexpPatternConverterUtils.likeToRegexpLike("%2\\_2%");
     assertEquals(regexpLikePattern, "2\\_2");
     String luceneRegExpPattern = RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(regexpLikePattern);

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/RegexpPatternConverterUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/RegexpPatternConverterUtilsTest.java
@@ -125,4 +125,20 @@ public class RegexpPatternConverterUtilsTest {
     String regexpLikePattern = RegexpPatternConverterUtils.likeToRegexpLike("z%");
     assertEquals(regexpLikePattern, "^z");
   }
+
+  @Test
+  public void testEscapedWildcard1() {
+    String regexpLikePattern = RegexpPatternConverterUtils.likeToRegexpLike("a\\_b_\\");
+    assertEquals(regexpLikePattern, "^a\\_b.\\\\$");
+    String luceneRegExpPattern = RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(regexpLikePattern);
+    assertEquals(luceneRegExpPattern, "a\\_b.\\\\");
+  }
+
+  @Test
+  public void testEscapedWildcard2() {
+    String regexpLikePattern = RegexpPatternConverterUtils.likeToRegexpLike("a\\%b\\cde");
+    assertEquals(regexpLikePattern, "^a\\%b\\\\cde$");
+    String luceneRegExpPattern = RegexpPatternConverterUtils.regexpLikeToLuceneRegExp(regexpLikePattern);
+    assertEquals(luceneRegExpPattern, "a\\%b\\\\cde");
+  }
 }


### PR DESCRIPTION
Fixes #10849.

**Approach**: The escaping of SQL wildcards (`\_`, `\%`) is handled as a special case. The escaping of `\` is handled separately from the escaping of other meta characters.

**Test plan**: 
- Existing unit tests pass.
- Added unit tests to validate the specific case that this fix solves.
- Verified the behaviour by running an e2e query locally (```select * from starbucksStores where address like '%3\_9%' limit 10```): before the patch it returned zero records, but after the patch it matched the valid records only.