### PR TITLE
Return true when _resultSet is not null

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
@@ -211,12 +211,7 @@ public class PinotPreparedStatement extends AbstractBasePreparedStatement {
   public boolean execute(String sql)
       throws SQLException {
     _resultSet = executeQuery(sql);
-    if (_resultSet.next()) {
-      _resultSet.beforeFirst();
-      return true;
-    } else {
-      return false;
-    }
+    return _resultSet != null;
   }
 
   @Override

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotStatement.java
@@ -80,13 +80,7 @@ public class PinotStatement extends AbstractBaseStatement {
   public boolean execute(String sql)
       throws SQLException {
     _resultSet = executeQuery(sql);
-    if (_resultSet.next()) {
-      _resultSet.beforeFirst();
-      return true;
-    } else {
-      _resultSet = null;
-      return false;
-    }
+    return _resultSet != null;
   }
 
   @Override


### PR DESCRIPTION
`bugfix`

https://github.com/apache/pinot/issues/10879

Return true when _resultSet is not null especially when there is no match

