### PR TITLE
Use _hasNull in the object single column distinct executors.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBigDecimalSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBigDecimalSingleColumnDistinctExecutor.java
@@ -45,7 +45,7 @@ public abstract class BaseRawBigDecimalSingleColumnDistinctExecutor implements D
   final boolean _nullHandlingEnabled;
 
   final ObjectSet<BigDecimal> _valueSet;
-  protected boolean _hasNull;
+  private boolean _hasNull;
 
   BaseRawBigDecimalSingleColumnDistinctExecutor(ExpressionContext expression, DataType dataType, int limit,
       boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBigDecimalSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBigDecimalSingleColumnDistinctExecutor.java
@@ -45,6 +45,7 @@ public abstract class BaseRawBigDecimalSingleColumnDistinctExecutor implements D
   final boolean _nullHandlingEnabled;
 
   final ObjectSet<BigDecimal> _valueSet;
+  protected boolean _hasNull;
 
   BaseRawBigDecimalSingleColumnDistinctExecutor(ExpressionContext expression, DataType dataType, int limit,
       boolean nullHandlingEnabled) {
@@ -64,6 +65,10 @@ public abstract class BaseRawBigDecimalSingleColumnDistinctExecutor implements D
     for (BigDecimal value : _valueSet) {
       records.add(new Record(new Object[]{value}));
     }
+    if (_hasNull) {
+      records.add(new Record(new Object[]{null}));
+    }
+    assert records.size() <= _limit + 1;
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 
@@ -76,9 +81,8 @@ public abstract class BaseRawBigDecimalSingleColumnDistinctExecutor implements D
       RoaringBitmap nullBitmap = blockValueSet.getNullBitmap();
       for (int i = 0; i < numDocs; i++) {
         if (nullBitmap != null && nullBitmap.contains(i)) {
-          values[i] = null;
-        }
-        if (add(values[i])) {
+          _hasNull = true;
+        } else if (add(values[i])) {
           return true;
         }
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBytesSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBytesSingleColumnDistinctExecutor.java
@@ -45,6 +45,7 @@ abstract class BaseRawBytesSingleColumnDistinctExecutor implements DistinctExecu
   final boolean _nullHandlingEnabled;
 
   final ObjectSet<ByteArray> _valueSet;
+  protected boolean _hasNull;
 
   BaseRawBytesSingleColumnDistinctExecutor(ExpressionContext expression, DataType dataType, int limit,
       boolean nullHandlingEnabled) {
@@ -64,6 +65,10 @@ abstract class BaseRawBytesSingleColumnDistinctExecutor implements DistinctExecu
     for (ByteArray value : _valueSet) {
       records.add(new Record(new Object[]{value}));
     }
+    if (_hasNull) {
+      records.add(new Record(new Object[]{null}));
+    }
+    assert records.size() <= _limit + 1;
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 
@@ -76,9 +81,8 @@ abstract class BaseRawBytesSingleColumnDistinctExecutor implements DistinctExecu
       RoaringBitmap nullBitmap = blockValueSet.getNullBitmap();
       for (int i = 0; i < numDocs; i++) {
         if (nullBitmap != null && nullBitmap.contains(i)) {
-          values[i] = null;
-        }
-        if (add(values[i] == null ? null : new ByteArray(values[i]))) {
+          _hasNull = true;
+        } else if (add(new ByteArray(values[i]))) {
           return true;
         }
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBytesSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBytesSingleColumnDistinctExecutor.java
@@ -78,13 +78,13 @@ abstract class BaseRawBytesSingleColumnDistinctExecutor implements DistinctExecu
         if (nullBitmap != null && nullBitmap.contains(i)) {
           values[i] = null;
         }
-        if (add(values[i])) {
+        if (add(values[i] == null ? null : new ByteArray(values[i]))) {
           return true;
         }
       }
     } else {
       for (int i = 0; i < numDocs; i++) {
-        if (add(values[i])) {
+        if (add(new ByteArray(values[i]))) {
           return true;
         }
       }
@@ -92,5 +92,5 @@ abstract class BaseRawBytesSingleColumnDistinctExecutor implements DistinctExecu
     return false;
   }
 
-  protected abstract boolean add(byte[] value);
+  protected abstract boolean add(ByteArray byteArray);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBytesSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBytesSingleColumnDistinctExecutor.java
@@ -45,7 +45,7 @@ abstract class BaseRawBytesSingleColumnDistinctExecutor implements DistinctExecu
   final boolean _nullHandlingEnabled;
 
   final ObjectSet<ByteArray> _valueSet;
-  protected boolean _hasNull;
+  private boolean _hasNull;
 
   BaseRawBytesSingleColumnDistinctExecutor(ExpressionContext expression, DataType dataType, int limit,
       boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawStringSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawStringSingleColumnDistinctExecutor.java
@@ -44,7 +44,7 @@ abstract class BaseRawStringSingleColumnDistinctExecutor implements DistinctExec
   final boolean _nullHandlingEnabled;
 
   final ObjectSet<String> _valueSet;
-  protected boolean _hasNull;
+  private boolean _hasNull;
 
   BaseRawStringSingleColumnDistinctExecutor(ExpressionContext expression, DataType dataType, int limit,
       boolean nullHandlingEnabled) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawStringSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawStringSingleColumnDistinctExecutor.java
@@ -44,6 +44,7 @@ abstract class BaseRawStringSingleColumnDistinctExecutor implements DistinctExec
   final boolean _nullHandlingEnabled;
 
   final ObjectSet<String> _valueSet;
+  protected boolean _hasNull;
 
   BaseRawStringSingleColumnDistinctExecutor(ExpressionContext expression, DataType dataType, int limit,
       boolean nullHandlingEnabled) {
@@ -63,6 +64,10 @@ abstract class BaseRawStringSingleColumnDistinctExecutor implements DistinctExec
     for (String value : _valueSet) {
       records.add(new Record(new Object[]{value}));
     }
+    if (_hasNull) {
+      records.add(new Record(new Object[]{null}));
+    }
+    assert records.size() <= _limit + 1;
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 
@@ -76,9 +81,8 @@ abstract class BaseRawStringSingleColumnDistinctExecutor implements DistinctExec
         RoaringBitmap nullBitmap = blockValueSet.getNullBitmap();
         for (int i = 0; i < numDocs; i++) {
           if (nullBitmap != null && nullBitmap.contains(i)) {
-            values[i] = null;
-          }
-          if (add(values[i])) {
+            _hasNull = true;
+          } else if (add(values[i])) {
             return true;
           }
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBigDecimalSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBigDecimalSingleColumnDistinctOrderByExecutor.java
@@ -39,9 +39,19 @@ public class RawBigDecimalSingleColumnDistinctOrderByExecutor extends BaseRawBig
 
     assert orderByExpression.getExpression().equals(expression);
     int comparisonFactor = orderByExpression.isAsc() ? -1 : 1;
+    int nullComparisonFactor = orderByExpression.isNullsLast() ? -1 : 1;
     if (nullHandlingEnabled) {
-      _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY),
-          (b1, b2) -> b1 == null ? (b2 == null ? 0 : 1) : (b2 == null ? -1 : b1.compareTo(b2)) * comparisonFactor);
+      _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY), (b1, b2) -> {
+        if (b1 == null && b2 == null) {
+          return 0;
+        } else if (b1 == null) {
+          return nullComparisonFactor;
+        } else if (b2 == null) {
+          return -nullComparisonFactor;
+        } else {
+          return b1.compareTo(b2) * comparisonFactor;
+        }
+      });
     } else {
       _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY),
           (b1, b2) -> b1.compareTo(b2) * comparisonFactor);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBigDecimalSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBigDecimalSingleColumnDistinctOrderByExecutor.java
@@ -39,23 +39,8 @@ public class RawBigDecimalSingleColumnDistinctOrderByExecutor extends BaseRawBig
 
     assert orderByExpression.getExpression().equals(expression);
     int comparisonFactor = orderByExpression.isAsc() ? -1 : 1;
-    int nullComparisonFactor = orderByExpression.isNullsLast() ? -1 : 1;
-    if (nullHandlingEnabled) {
-      _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY), (b1, b2) -> {
-        if (b1 == null && b2 == null) {
-          return 0;
-        } else if (b1 == null) {
-          return nullComparisonFactor;
-        } else if (b2 == null) {
-          return -nullComparisonFactor;
-        } else {
-          return b1.compareTo(b2) * comparisonFactor;
-        }
-      });
-    } else {
-      _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY),
-          (b1, b2) -> b1.compareTo(b2) * comparisonFactor);
-    }
+    _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY),
+            (b1, b2) -> b1.compareTo(b2) * comparisonFactor);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBytesSingleColumnDistinctOnlyExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBytesSingleColumnDistinctOnlyExecutor.java
@@ -35,8 +35,8 @@ public class RawBytesSingleColumnDistinctOnlyExecutor extends BaseRawBytesSingle
   }
 
   @Override
-  protected boolean add(byte[] value) {
-    _valueSet.add(new ByteArray(value));
+  protected boolean add(ByteArray byteArray) {
+    _valueSet.add(byteArray);
     return _valueSet.size() >= _limit;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBytesSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBytesSingleColumnDistinctOrderByExecutor.java
@@ -39,9 +39,19 @@ public class RawBytesSingleColumnDistinctOrderByExecutor extends BaseRawBytesSin
 
     assert orderByExpression.getExpression().equals(expression);
     int comparisonFactor = orderByExpression.isAsc() ? -1 : 1;
+    int nullComparisonFactor = orderByExpression.isNullsLast() ? -1 : 1;
     if (nullHandlingEnabled) {
-      _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY),
-          (b1, b2) -> b1 == null ? (b2 == null ? 0 : 1) : (b2 == null ? -1 : b1.compareTo(b2)) * comparisonFactor);
+      _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY), (b1, b2) -> {
+        if (b1 == null && b2 == null) {
+          return 0;
+        } else if (b1 == null) {
+          return nullComparisonFactor;
+        } else if (b2 == null) {
+          return -nullComparisonFactor;
+        } else {
+          return b1.compareTo(b2) * comparisonFactor;
+        }
+      });
     } else {
       _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY),
           (b1, b2) -> b1.compareTo(b2) * comparisonFactor);
@@ -49,8 +59,7 @@ public class RawBytesSingleColumnDistinctOrderByExecutor extends BaseRawBytesSin
   }
 
   @Override
-  protected boolean add(byte[] value) {
-    ByteArray byteArray = new ByteArray(value);
+  protected boolean add(ByteArray byteArray) {
     if (!_valueSet.contains(byteArray)) {
       if (_valueSet.size() < _limit) {
         _valueSet.add(byteArray);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBytesSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBytesSingleColumnDistinctOrderByExecutor.java
@@ -39,23 +39,8 @@ public class RawBytesSingleColumnDistinctOrderByExecutor extends BaseRawBytesSin
 
     assert orderByExpression.getExpression().equals(expression);
     int comparisonFactor = orderByExpression.isAsc() ? -1 : 1;
-    int nullComparisonFactor = orderByExpression.isNullsLast() ? -1 : 1;
-    if (nullHandlingEnabled) {
-      _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY), (b1, b2) -> {
-        if (b1 == null && b2 == null) {
-          return 0;
-        } else if (b1 == null) {
-          return nullComparisonFactor;
-        } else if (b2 == null) {
-          return -nullComparisonFactor;
-        } else {
-          return b1.compareTo(b2) * comparisonFactor;
-        }
-      });
-    } else {
-      _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY),
-          (b1, b2) -> b1.compareTo(b2) * comparisonFactor);
-    }
+    _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY),
+            (b1, b2) -> b1.compareTo(b2) * comparisonFactor);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawStringSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawStringSingleColumnDistinctOrderByExecutor.java
@@ -38,9 +38,19 @@ public class RawStringSingleColumnDistinctOrderByExecutor extends BaseRawStringS
 
     assert orderByExpression.getExpression().equals(expression);
     int comparisonFactor = orderByExpression.isAsc() ? -1 : 1;
+    int nullComparisonFactor = orderByExpression.isNullsLast() ? -1 : 1;
     if (nullHandlingEnabled) {
-      _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY),
-          (s1, s2) -> s1 == null ? (s2 == null ? 0 : 1) : (s2 == null ? -1 : s1.compareTo(s2)) * comparisonFactor);
+      _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY), (s1, s2) -> {
+        if (s1 == null && s2 == null) {
+          return 0;
+        } else if (s1 == null) {
+          return nullComparisonFactor;
+        } else if (s2 == null) {
+          return -nullComparisonFactor;
+        } else {
+          return s1.compareTo(s2) * comparisonFactor;
+        }
+      });
     } else {
       _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY),
           (s1, s2) -> s1.compareTo(s2) * comparisonFactor);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawStringSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawStringSingleColumnDistinctOrderByExecutor.java
@@ -38,23 +38,8 @@ public class RawStringSingleColumnDistinctOrderByExecutor extends BaseRawStringS
 
     assert orderByExpression.getExpression().equals(expression);
     int comparisonFactor = orderByExpression.isAsc() ? -1 : 1;
-    int nullComparisonFactor = orderByExpression.isNullsLast() ? -1 : 1;
-    if (nullHandlingEnabled) {
-      _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY), (s1, s2) -> {
-        if (s1 == null && s2 == null) {
-          return 0;
-        } else if (s1 == null) {
-          return nullComparisonFactor;
-        } else if (s2 == null) {
-          return -nullComparisonFactor;
-        } else {
-          return s1.compareTo(s2) * comparisonFactor;
-        }
-      });
-    } else {
-      _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY),
-          (s1, s2) -> s1.compareTo(s2) * comparisonFactor);
-    }
+    _priorityQueue = new ObjectHeapPriorityQueue<>(Math.min(limit, MAX_INITIAL_CAPACITY),
+        (s1, s2) -> s1.compareTo(s2) * comparisonFactor);
   }
 
   @Override

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BigDecimalQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BigDecimalQueriesTest.java
@@ -211,7 +211,7 @@ public class BigDecimalQueriesTest extends BaseQueriesTest {
       }
     }
     {
-      String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s", BIG_DECIMAL_COLUMN,
+      String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s LIMIT 4000", BIG_DECIMAL_COLUMN,
           BIG_DECIMAL_COLUMN);
       BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
       ResultTable resultTable = brokerResponse.getResultTable();
@@ -219,7 +219,6 @@ public class BigDecimalQueriesTest extends BaseQueriesTest {
       assertEquals(dataSchema,
           new DataSchema(new String[]{BIG_DECIMAL_COLUMN}, new ColumnDataType[]{ColumnDataType.BIG_DECIMAL}));
       List<Object[]> rows = resultTable.getRows();
-      assertEquals(rows.size(), 10);
       int i = 0;
       for (int index = 0; index < rows.size() - 1; index++) {
         Object[] row = rows.get(index);
@@ -260,8 +259,6 @@ public class BigDecimalQueriesTest extends BaseQueriesTest {
         i++;
         index++;
       }
-      // The default null ordering is 'NULLS LAST'. Therefore, null will appear as the last record.
-      assertNull(rows.get(rows.size() - 1)[0]);
     }
     {
       // This test case was added to validate path-code for distinct w/o order by. See:

--- a/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
@@ -329,4 +329,23 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     assertEquals(resultTable.getRows().size(), 1);
     assertNotNull(resultTable.getRows().get(0)[0]);
   }
+
+  @Test
+  public void testTransformBlockValSetGetNullBitmap()
+      throws Exception {
+    _rows = new ArrayList<>();
+    insertRow(null);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT).build();
+    setUpSegments(tableConfig, schema, _rows);
+    Map<String, String> queryOptions = new HashMap<>();
+    queryOptions.put("enableNullHandling", "true");
+    String query = String.format("SELECT (CASE WHEN %s IS NULL THEN 1 END) FROM testTable", COLUMN1);
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+
+    ResultTable resultTable = brokerResponse.getResultTable();
+    assertEquals(resultTable.getRows().size(), NUM_OF_SEGMENT_COPIES);
+    assertEquals(resultTable.getRows().get(0)[0], 1);
+  }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
@@ -225,14 +225,14 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     assertEquals(resultTable.getRows().get(3), new Object[]{null, null});
   }
 
-  @DataProvider(name = "DataTypes")
-  public static Object[][] getDataTypes() {
+  @DataProvider(name = "NumberTypes")
+  public static Object[][] getPrimitiveDataTypes() {
     return new Object[][]{
         {FieldSpec.DataType.INT}, {FieldSpec.DataType.LONG}, {FieldSpec.DataType.DOUBLE}, {FieldSpec.DataType.FLOAT}
     };
   }
 
-  @Test(dataProvider = "DataTypes")
+  @Test(dataProvider = "NumberTypes")
   public void testSelectDistinctWithLimit(FieldSpec.DataType dataType)
       throws Exception {
     _rows = new ArrayList<>();
@@ -253,7 +253,7 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     assertEquals(resultTable.getRows().size(), 3);
   }
 
-  @Test(dataProvider = "DataTypes")
+  @Test(dataProvider = "NumberTypes")
   public void testSelectDistinctOrderByWithLimit(FieldSpec.DataType dataType)
       throws Exception {
     double delta = 0.01;
@@ -278,22 +278,55 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     assertTrue(Math.abs(((Number) resultTable.getRows().get(2)[0]).doubleValue() - 3.0) < delta);
   }
 
-  @Test
-  public void testTransformBlockValSetGetNullBitmap()
+
+  @DataProvider(name = "ObjectTypes")
+  public static Object[][] getObjectDataTypes() {
+    return new Object[][]{
+        {FieldSpec.DataType.STRING, "a"}, {
+        FieldSpec.DataType.BIG_DECIMAL, 1
+    }, {
+        FieldSpec.DataType.BYTES, "a string".getBytes()
+    }
+    };
+  }
+
+  @Test(dataProvider = "ObjectTypes")
+  public void testObjectSingleColumnDistinctOrderByNullsFirst(FieldSpec.DataType dataType, Object value)
       throws Exception {
     _rows = new ArrayList<>();
     insertRow(null);
+    insertRow(value);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
-    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT).build();
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, dataType).build();
     setUpSegments(tableConfig, schema, _rows);
     Map<String, String> queryOptions = new HashMap<>();
     queryOptions.put("enableNullHandling", "true");
-    String query = String.format("SELECT (CASE WHEN %s IS NULL THEN 1 END) FROM testTable", COLUMN1);
+    String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s NULLS FIRST LIMIT 1", COLUMN1, COLUMN1);
 
     BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
 
     ResultTable resultTable = brokerResponse.getResultTable();
-    assertEquals(resultTable.getRows().size(), NUM_OF_SEGMENT_COPIES);
-    assertEquals(resultTable.getRows().get(0)[0], 1);
+    assertEquals(resultTable.getRows().size(), 1);
+    assertNull(resultTable.getRows().get(0)[0]);
+  }
+
+  @Test(dataProvider = "ObjectTypes")
+  public void testObjectSingleColumnDistinctOrderByNullsLast(FieldSpec.DataType dataType, Object value)
+      throws Exception {
+    _rows = new ArrayList<>();
+    insertRow(null);
+    insertRow(value);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, dataType).build();
+    setUpSegments(tableConfig, schema, _rows);
+    Map<String, String> queryOptions = new HashMap<>();
+    queryOptions.put("enableNullHandling", "true");
+    String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s NULLS LAST LIMIT 1", COLUMN1, COLUMN1);
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+
+    ResultTable resultTable = brokerResponse.getResultTable();
+    assertEquals(resultTable.getRows().size(), 1);
+    assertNotNull(resultTable.getRows().get(0)[0]);
   }
 }


### PR DESCRIPTION
- Fix a bug in NULL ordering.
- Fix a bug in byte type NULL handling (currently `new ByteArray(value)` would throw an exception if `value` is NULL).

Tested in unit tests.