### PR TITLE
[Upsert TTL] Add Watermark for each partitions for Primary key cleanup

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -675,6 +675,10 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         // Take upsert snapshot before starting consuming events
         if (_partitionUpsertMetadataManager != null) {
           _partitionUpsertMetadataManager.takeSnapshot();
+          // If upsertTTL is enabled, we will remove expired primary keys from upsertMetadata after taking snapshot.
+          if (_tableConfig.getUpsertConfig().getMetadataTTL() > 0) {
+            _partitionUpsertMetadataManager.removeExpiredPrimaryKeys();
+          }
         }
 
         while (!_state.isFinal()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -676,9 +676,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         if (_partitionUpsertMetadataManager != null) {
           _partitionUpsertMetadataManager.takeSnapshot();
           // If upsertTTL is enabled, we will remove expired primary keys from upsertMetadata after taking snapshot.
-          if (_tableConfig.getUpsertConfig().getMetadataTTL() > 0) {
-            _partitionUpsertMetadataManager.removeExpiredPrimaryKeys();
-          }
+          _partitionUpsertMetadataManager.removeExpiredPrimaryKeys();
         }
 
         while (!_state.isFinal()) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -131,8 +131,8 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     _upsertIndexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     ((ImmutableSegmentImpl) _upsertIndexSegment).enableUpsert(
         new ConcurrentMapPartitionUpsertMetadataManager("testTable_REALTIME", 0, Collections.singletonList("column6"),
-            Collections.singletonList("daysSinceEpoch"), null, HashFunction.NONE, null, false, serverMetrics),
-        new ThreadSafeMutableRoaringBitmap(), null);
+            Collections.singletonList("daysSinceEpoch"), null, HashFunction.NONE, null, false, 0, INDEX_DIR,
+            serverMetrics), new ThreadSafeMutableRoaringBitmap(), null);
   }
 
   @AfterClass

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -284,7 +284,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
           assert _deleteRecordColumn == null;
           _logger.info("Skip adding segment: {} because it's out of TTL", segment.getSegmentName());
           // If delete is not enabled, set valid doc ids snapshot into the segment.
-          segment.enableUpsert(this, validDocIds, queryableDocIds);
+          enableSegmentWithSnapshot(segment, validDocIds, queryableDocIds);
           return;
         }
       }
@@ -307,6 +307,13 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   protected void addSegmentWithoutUpsert(ImmutableSegmentImpl segment, ThreadSafeMutableRoaringBitmap validDocIds,
       @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, Iterator<RecordInfo> recordInfoIterator) {
     addOrReplaceSegment(segment, validDocIds, queryableDocIds, recordInfoIterator, null, null);
+  }
+
+  protected void enableSegmentWithSnapshot(ImmutableSegmentImpl segment, ThreadSafeMutableRoaringBitmap validDocIds,
+      @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds) {
+    MutableRoaringBitmap validDocIdsSnapshot = segment.loadValidDocIdsFromSnapshot();
+    validDocIdsSnapshot.forEach((int docId) -> validDocIds.add(docId));
+    segment.enableUpsert(this, validDocIds, queryableDocIds);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -234,9 +234,4 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
   public UpsertConfig.Mode getUpsertMode() {
     return _partialUpsertHandler == null ? UpsertConfig.Mode.FULL : UpsertConfig.Mode.PARTIAL;
   }
-
-  @Override
-  public double getMetadataTTL() {
-    return _metadataTTL;
-  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -67,6 +67,8 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
   protected HashFunction _hashFunction;
   protected PartialUpsertHandler _partialUpsertHandler;
   protected boolean _enableSnapshot;
+  protected double _metadataTTL;
+  protected File _tableIndexDir;
   protected ServerMetrics _serverMetrics;
   private volatile boolean _isPreloading = false;
 
@@ -104,6 +106,8 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
     }
 
     _enableSnapshot = upsertConfig.isEnableSnapshot();
+    _metadataTTL = upsertConfig.getMetadataTTL();
+    _tableIndexDir = tableDataManager.getTableDataDir();
     _serverMetrics = serverMetrics;
     if (_enableSnapshot && segmentPreloadExecutor != null && upsertConfig.isEnablePreload()) {
       // Preloading the segments with snapshots for fast upsert metadata recovery.
@@ -229,5 +233,10 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
   @Override
   public UpsertConfig.Mode getUpsertMode() {
     return _partialUpsertHandler == null ? UpsertConfig.Mode.FULL : UpsertConfig.Mode.PARTIAL;
+  }
+
+  @Override
+  public double getMetadataTTL() {
+    return _metadataTTL;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -207,17 +207,6 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
   protected void removeSegment(IndexSegment segment, MutableRoaringBitmap validDocIds) {
     assert !validDocIds.isEmpty();
 
-    // Skip removing segments that has segment EndTime in the comparison cols earlier than (largestSeenTimestamp - TTL).
-    // Note: We only support single comparison column for TTL-enabled upsert tables.
-    if (_largestSeenComparisonValue > 0) {
-      Number endTime =
-          (Number) segment.getSegmentMetadata().getColumnMetadataMap().get(_comparisonColumns.get(0)).getMaxValue();
-      if (endTime.doubleValue() < _largestSeenComparisonValue - _metadataTTL) {
-        _logger.info("Skip removing segment: {} because it's out of TTL", segment.getSegmentName());
-        return;
-      }
-    }
-
     PrimaryKey primaryKey = new PrimaryKey(new Object[_primaryKeyColumns.size()]);
     PeekableIntIterator iterator = validDocIds.getIntIterator();
     try (

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -36,8 +36,8 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   public ConcurrentMapPartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
     return _partitionMetadataManagerMap.computeIfAbsent(partitionId,
         k -> new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _primaryKeyColumns,
-            _comparisonColumns, _deleteRecordColumn, _hashFunction, _partialUpsertHandler, _enableSnapshot,
-            _serverMetrics));
+            _comparisonColumns, _deleteRecordColumn, _hashFunction, _partialUpsertHandler,
+            _enableSnapshot, _metadataTTL, _tableIndexDir, _serverMetrics));
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -98,6 +98,11 @@ public interface PartitionUpsertMetadataManager extends Closeable {
   void takeSnapshot();
 
   /**
+   * Remove from the primary key index when the PK are expired if TTL is enabled.
+   */
+  void removeExpiredPrimaryKeys();
+
+  /**
    * Stops the metadata manager. After invoking this method, no access to the metadata will be accepted.
    */
   void stop();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -98,7 +98,7 @@ public interface PartitionUpsertMetadataManager extends Closeable {
   void takeSnapshot();
 
   /**
-   * Remove from the primary key index when the PK are expired if TTL is enabled.
+   * Remove the expired primary keys from the metadata when TTL is enabled.
    */
   void removeExpiredPrimaryKeys();
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -42,6 +42,8 @@ public interface TableUpsertMetadataManager extends Closeable {
 
   UpsertConfig.Mode getUpsertMode();
 
+  double getMetadataTTL();
+
   /**
    * Stops the metadata manager. After invoking this method, no access to the metadata will be accepted.
    */

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -42,8 +42,6 @@ public interface TableUpsertMetadataManager extends Closeable {
 
   UpsertConfig.Mode getUpsertMode();
 
-  double getMetadataTTL();
-
   /**
    * Stops the metadata manager. After invoking this method, no access to the metadata will be accepted.
    */

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -615,7 +615,7 @@ public final class TableConfigUtils {
 
       // currently we only support 1 comparison column since we need to fetch endTime in comparisonValue time unit from
       // columnMetadata. If we have multiple comparison columns, we can only use the first comparison column as filter.
-      Preconditions.checkState(comparisonColumns.size() <= 1,
+      Preconditions.checkState(comparisonColumns.size() == 1,
           String.format("Currently upsert TTL only support 1 comparison columns."));
 
       String column = comparisonColumns.size() == 1 ? comparisonColumns.get(0)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -628,6 +628,11 @@ public final class TableConfigUtils {
     // snapshotEnabled has to be enabled for TTL feature
     Preconditions.checkState(tableConfig.getUpsertConfig().isEnableSnapshot(),
         String.format("Snapshot has to be enabled for TTL feature."));
+
+    // delete feature cannot co-exist with upsert TTL feature.
+    // TODO: Fix the deletion handling for TTL. Currently TTL cannot co-exist with delete.
+    Preconditions.checkState(tableConfig.getUpsertConfig().getDeleteRecordColumn() == null,
+        String.format("TTL feature cannot co-exist with delete in upsert."));
   }
 
   /**

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -862,7 +862,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList("timeCol"), null, HashFunction.NONE, null, false, 30, tableDir,
+            Collections.singletonList("timeCol"), null, HashFunction.NONE, null, true, 30, tableDir,
             mock(ServerMetrics.class));
     Map<Object, ConcurrentMapPartitionUpsertMetadataManager.RecordLocation> recordLocationMap =
         upsertMetadataManager._primaryKeyToRecordLocationMap;
@@ -928,7 +928,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList("timeCol"), null, HashFunction.NONE, null, false, 30, tableDir,
+            Collections.singletonList("timeCol"), null, HashFunction.NONE, null, true, 30, tableDir,
             mock(ServerMetrics.class));
     Map<Object, ConcurrentMapPartitionUpsertMetadataManager.RecordLocation> recordLocationMap =
         upsertMetadataManager._primaryKeyToRecordLocationMap;
@@ -962,8 +962,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   private List<RecordInfo> getRecordInfoListForTTL(int numRecords, int[] primaryKeys, Number[] timestamps) {
     List<RecordInfo> recordInfoList = new ArrayList<>();
     for (int i = 0; i < numRecords; i++) {
-      recordInfoList.add(new RecordInfo(makePrimaryKey(primaryKeys[i]), i, new Double(timestamps[i].doubleValue()),
-          false));
+      recordInfoList.add(
+          new RecordInfo(makePrimaryKey(primaryKeys[i]), i, new Double(timestamps[i].doubleValue()), false));
     }
     return recordInfoList;
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -910,7 +910,6 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
     // Add an out-of-ttl segment, verify all the invalid docs should not show up again.
     // Add a segment with segmentEndTime: 80, largest seen timestamp: 120. the segment will be skipped.
-    Number[] timestamps2 = new Number[]{80, 80, 80, 80};
     List<PrimaryKey> primaryKeys2 = getPrimaryKeyList(numRecords, new int[]{100, 101, 102, 103});
     int[] docIds2 = new int[]{0, 1};
     MutableRoaringBitmap validDocIdsSnapshot2 = new MutableRoaringBitmap();
@@ -919,12 +918,9 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     ImmutableSegmentImpl segment2 =
         mockImmutableSegmentWithEndTime(1, validDocIds2, null, primaryKeys2, Collections.singletonList("timeCol"),
             new Double(80), validDocIdsSnapshot2);
-    upsertMetadataManager.addSegment(segment2, validDocIds2, null,
-        getRecordInfoListForTTL(numRecords, primaryKeys, timestamps2).iterator());
+    upsertMetadataManager.addSegment(segment2);
     // out of ttl segment should not be added to recordLocationMap
     assertEquals(recordLocationMap.size(), 5);
-    // out of ttl segment should still maintain validDocIds.
-    assertEquals(validDocIds2.getMutableRoaringBitmap().toArray(), new int[]{0, 1});
   }
 
   private void verifyAddSegmentForTTL(Comparable comparisonValue) {
@@ -946,7 +942,6 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     // add a segment with segmentEndTime = -1 so it will be skipped since it out-of-TTL
     int numRecords = 4;
     int[] primaryKeys = new int[]{0, 1, 2, 3};
-    Number[] timestamps = new Number[]{100, 100, 120, 80};
     ThreadSafeMutableRoaringBitmap validDocIds1 = new ThreadSafeMutableRoaringBitmap();
     List<PrimaryKey> primaryKeys1 = getPrimaryKeyList(numRecords, primaryKeys);
     ImmutableSegmentImpl segment1 =
@@ -958,8 +953,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     validDocIdsSnapshot1.add(docIds1);
 
     // load segment1.
-    upsertMetadataManager.addSegment(segment1, validDocIds1, null,
-        getRecordInfoListForTTL(numRecords, primaryKeys, timestamps).iterator());
+    upsertMetadataManager.addSegment(segment1);
     assertEquals(recordLocationMap.size(), 1);
     checkRecordLocationForTTL(recordLocationMap, 10, segment0, 1, 80, HashFunction.NONE);
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1799,9 +1799,9 @@ public class TableConfigUtilsTest {
     UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
     upsertConfig.setMetadataTTL(3600);
     upsertConfig.setEnableSnapshot(true);
-
-    TableConfig tableConfigWithoutComparisonColumn = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setTimeColumnName(TIME_COLUMN).setUpsertConfig(upsertConfig).build();
+    TableConfig tableConfigWithoutComparisonColumn =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
+            .setUpsertConfig(upsertConfig).build();
     TableConfigUtils.validateTTLForUpsertConfig(tableConfigWithoutComparisonColumn, schema);
 
     // Invalid comparison columns: "myCol"
@@ -1809,31 +1809,29 @@ public class TableConfigUtilsTest {
     upsertConfig.setComparisonColumns(Collections.singletonList("myCol"));
     upsertConfig.setEnableSnapshot(true);
     upsertConfig.setMetadataTTL(3600);
-    TableConfig tableConfigWithInvalidComparisonColumn = new TableConfigBuilder(TableType.REALTIME)
-        .setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
-        .setUpsertConfig(upsertConfig).build();
-
+    TableConfig tableConfigWithInvalidComparisonColumn =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
+            .setUpsertConfig(upsertConfig).build();
     try {
       TableConfigUtils.validateTTLForUpsertConfig(tableConfigWithInvalidComparisonColumn, schema);
       Assert.fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("The column myCol: STRING is not a numeric values"));
+      // Expected
     }
 
-    // Invalid comparison columns: multiple comparison columns are not supported for TTL-enabled uspert table.
+    // Invalid comparison columns: multiple comparison columns are not supported for TTL-enabled upsert table.
     upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
     upsertConfig.setComparisonColumns(Lists.newArrayList(TIME_COLUMN, "myCol"));
     upsertConfig.setEnableSnapshot(true);
     upsertConfig.setMetadataTTL(3600);
-    TableConfig tableConfigWithInvalidComparisonColumn2 = new TableConfigBuilder(TableType.REALTIME)
-        .setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
-        .setUpsertConfig(upsertConfig).build();
-
+    TableConfig tableConfigWithInvalidComparisonColumn2 =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
+            .setUpsertConfig(upsertConfig).build();
     try {
       TableConfigUtils.validateTTLForUpsertConfig(tableConfigWithInvalidComparisonColumn2, schema);
       Assert.fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("Currently upsert TTL only support 1 comparison columns"));
+      // Expected
     }
 
     // Invalid config with TTLConfig but Snapshot is not enabled
@@ -1844,15 +1842,14 @@ public class TableConfigUtilsTest {
     upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
     upsertConfig.setMetadataTTL(3600);
     upsertConfig.setEnableSnapshot(false);
-
-    TableConfig tableConfigWithInvalidTTLConfig = new TableConfigBuilder(TableType.REALTIME)
-        .setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).setUpsertConfig(upsertConfig).build();
-
+    TableConfig tableConfigWithInvalidTTLConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
+            .setUpsertConfig(upsertConfig).build();
     try {
       TableConfigUtils.validateTTLForUpsertConfig(tableConfigWithInvalidTTLConfig, schema);
       Assert.fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("Snapshot has to be enabled for TTL feature."));
+      // Expected
     }
 
     // Invalid config with both delete and TTL enabled
@@ -1866,15 +1863,14 @@ public class TableConfigUtilsTest {
     upsertConfig.setMetadataTTL(3600);
     upsertConfig.setEnableSnapshot(true);
     upsertConfig.setDeleteRecordColumn(delCol);
-
-    TableConfig tableConfigWithBothDeleteAndTTL = new TableConfigBuilder(TableType.REALTIME)
-        .setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN).setUpsertConfig(upsertConfig).build();
-
+    TableConfig tableConfigWithBothDeleteAndTTL =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
+            .setUpsertConfig(upsertConfig).build();
     try {
       TableConfigUtils.validateTTLForUpsertConfig(tableConfigWithBothDeleteAndTTL, schema);
       Assert.fail();
     } catch (IllegalStateException e) {
-      Assert.assertTrue(e.getMessage().contains("TTL feature cannot co-exist with delete in upsert."));
+      // Expected
     }
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -26,6 +26,7 @@ public class V1Constants {
   public static final String INDEX_MAP_FILE_NAME = "index_map";
   public static final String INDEX_FILE_NAME = "columns.psf";
   public static final String VALID_DOC_IDS_SNAPSHOT_FILE_NAME = "validdocids.bitmap.snapshot";
+  public static final String TTL_WATERMARK_TABLE_PARTITION = ".ttl.watermark.partition.";
 
   public static class Str {
     public static final char DEFAULT_STRING_PAD_CHAR = '\0';

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -26,7 +26,7 @@ public class V1Constants {
   public static final String INDEX_MAP_FILE_NAME = "index_map";
   public static final String INDEX_FILE_NAME = "columns.psf";
   public static final String VALID_DOC_IDS_SNAPSHOT_FILE_NAME = "validdocids.bitmap.snapshot";
-  public static final String TTL_WATERMARK_TABLE_PARTITION = ".ttl.watermark.partition.";
+  public static final String TTL_WATERMARK_TABLE_PARTITION = "ttl.watermark.partition.";
 
   public static class Str {
     public static final char DEFAULT_STRING_PAD_CHAR = '\0';

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/ThreadSafeMutableRoaringBitmap.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/ThreadSafeMutableRoaringBitmap.java
@@ -36,6 +36,10 @@ public class ThreadSafeMutableRoaringBitmap {
     _mutableRoaringBitmap.add(firstDocId);
   }
 
+  public ThreadSafeMutableRoaringBitmap(MutableRoaringBitmap mutableRoaringBitmap) {
+    _mutableRoaringBitmap = mutableRoaringBitmap;
+  }
+
   public synchronized void add(int docId) {
     _mutableRoaringBitmap.add(docId);
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -60,6 +60,9 @@ public class UpsertConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Whether to use snapshot for fast upsert metadata recovery")
   private boolean _enableSnapshot;
 
+  @JsonPropertyDescription("Whether to use TTL for upsert metadata cleanup, it uses the same unit as comparison col")
+  private double _metadataTTL;
+
   @JsonPropertyDescription("Whether to preload segments for fast upsert metadata recovery")
   private boolean _enablePreload;
 
@@ -109,6 +112,10 @@ public class UpsertConfig extends BaseJsonConfig {
 
   public boolean isEnableSnapshot() {
     return _enableSnapshot;
+  }
+
+  public double getMetadataTTL() {
+    return _metadataTTL;
   }
 
   public boolean isEnablePreload() {
@@ -177,6 +184,10 @@ public class UpsertConfig extends BaseJsonConfig {
 
   public void setEnableSnapshot(boolean enableSnapshot) {
     _enableSnapshot = enableSnapshot;
+  }
+
+  public void setMetadataTTL(double metadataTTL) {
+    _metadataTTL = metadataTTL;
   }
 
   public void setEnablePreload(boolean enablePreload) {


### PR DESCRIPTION
`feature`: The watermark is the time used to clean up the metadata in the previous round

Added TTLConfig in upsertConfig
Added API in partitionManager for PrimaryKey cleanup when TTL enabled
Added Functions to Persist/load Watermark
Persist/Load Watermark for when cleanup primary keys.
When restart servers and load Segments, only addRecords that are after watermark.


