### PR TITLE
[refactor] improve disk read for partial upsert handler

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
-import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.common.metrics.ServerGauge;
@@ -53,9 +52,6 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
 
   @VisibleForTesting
   final ConcurrentHashMap<Object, RecordLocation> _primaryKeyToRecordLocationMap = new ConcurrentHashMap<>();
-
-  // Reused for reading previous record during partial upsert
-  private final GenericRow _reuse = new GenericRow();
 
   public ConcurrentMapPartitionUpsertMetadataManager(String tableNameWithType, int partitionId,
       List<String> primaryKeyColumns, List<String> comparisonColumns, @Nullable String deleteRecordColumn,
@@ -288,7 +284,6 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
   @Override
   protected GenericRow doUpdateRecord(GenericRow record, RecordInfo recordInfo) {
     assert _partialUpsertHandler != null;
-    AtomicReference<GenericRow> previousRecordReference = new AtomicReference<>();
     _primaryKeyToRecordLocationMap.computeIfPresent(HashUtils.hashPrimaryKey(recordInfo.getPrimaryKey(), _hashFunction),
         (pk, recordLocation) -> {
           // Read the previous record if the following conditions are met:
@@ -301,14 +296,12 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
             ThreadSafeMutableRoaringBitmap currentQueryableDocIds = currentSegment.getQueryableDocIds();
             int currentDocId = recordLocation.getDocId();
             if (currentQueryableDocIds == null || currentQueryableDocIds.contains(currentDocId)) {
-              _reuse.clear();
-              previousRecordReference.set(currentSegment.getRecord(currentDocId, _reuse));
+              _partialUpsertHandler.merge(currentSegment, currentDocId, record);
             }
           }
           return recordLocation;
         });
-    GenericRow previousRecord = previousRecordReference.get();
-    return previousRecord != null ? _partialUpsertHandler.merge(previousRecord, record) : record;
+    return record;
   }
 
   @VisibleForTesting

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
@@ -87,6 +87,7 @@ public class PartialUpsertHandler {
                 // non-null comparison column values from the previous record, and the sole non-null comparison column
                 // value from the new record.
                 newRecord.putValue(column, previousValue);
+                newRecord.removeNullValueField(column);
               } else if (!_comparisonColumns.contains(column)) {
                 newRecord.putValue(column, merger.merge(previousValue, newRecord.getValue(column)));
               }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandlerTest.java
@@ -59,7 +59,7 @@ public class PartialUpsertHandlerTest {
   @Test
   public void testComparisonColumn() {
     // Even though the default strategy is IGNORE, we do not apply the mergers to comparison columns
-    testMerge(true, 0, true, 0, "hoursSinceEpoch", 2);
+    testMerge(true, 0, true, 0, "hoursSinceEpoch", 0);
     testMerge(true, 0, false, 8, "hoursSinceEpoch", 8);
     testMerge(false, 8, true, 0, "hoursSinceEpoch", 8);
     testMerge(false, 2, false, 8, "hoursSinceEpoch", 8);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandlerTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.mockito.MockedConstruction;
+import org.mockito.internal.util.collections.Sets;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
@@ -84,6 +85,7 @@ public class PartialUpsertHandlerTest {
               Collections.singletonList("hoursSinceEpoch")));
 
       ImmutableSegmentImpl segment = mock(ImmutableSegmentImpl.class);
+      when(segment.getColumnNames()).thenReturn(Sets.newSet("field1", "field2", "hoursSinceEpoch"));
 
       GenericRow row = new GenericRow();
       if (isNewNull) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandlerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandlerTest.java
@@ -43,31 +43,31 @@ public class PartialUpsertHandlerTest {
 
   @Test
   public void testOverwrite() {
-    testMerge(true, 2, true, 2, "field1", 2);
-    testMerge(true, 2, false, 8, "field1", 8);
-    testMerge(false, 8, true, 2, "field1", 8);
-    testMerge(false, 3, false, 5, "field1", 5);
+    testMerge(true, 2, true, 2, "field1", 2, true);
+    testMerge(true, 2, false, 8, "field1", 8, false);
+    testMerge(false, 8, true, 2, "field1", 8, false);
+    testMerge(false, 3, false, 5, "field1", 5, false);
   }
 
   @Test
   public void testNonOverwrite() {
-    testMerge(true, 2, true, 2, "field2", 2);
-    testMerge(true, 2, false, 8, "field2", 8);
-    testMerge(false, 8, true, 2, "field2", 8);
-    testMerge(false, 3, false, 5, "field2", 3);
+    testMerge(true, 2, true, 2, "field2", 2, true);
+    testMerge(true, 2, false, 8, "field2", 8, false);
+    testMerge(false, 8, true, 2, "field2", 8, false);
+    testMerge(false, 3, false, 5, "field2", 3, false);
   }
 
   @Test
   public void testComparisonColumn() {
     // Even though the default strategy is IGNORE, we do not apply the mergers to comparison columns
-    testMerge(true, 0, true, 0, "hoursSinceEpoch", 0);
-    testMerge(true, 0, false, 8, "hoursSinceEpoch", 8);
-    testMerge(false, 8, true, 0, "hoursSinceEpoch", 8);
-    testMerge(false, 2, false, 8, "hoursSinceEpoch", 8);
+    testMerge(true, 0, true, 0, "hoursSinceEpoch", 0, true);
+    testMerge(true, 0, false, 8, "hoursSinceEpoch", 8, false);
+    testMerge(false, 8, true, 0, "hoursSinceEpoch", 8, false);
+    testMerge(false, 2, false, 8, "hoursSinceEpoch", 8, false);
   }
 
   public void testMerge(boolean isPreviousNull, Object previousValue, boolean isNewNull, Object newValue,
-      String columnName, Object expected) {
+      String columnName, Object expectedValue, boolean isExpectedNull) {
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension("pk", FieldSpec.DataType.STRING)
         .addSingleValueDimension("field1", FieldSpec.DataType.LONG).addMetric("field2", FieldSpec.DataType.LONG)
         .addDateTime("hoursSinceEpoch", FieldSpec.DataType.LONG, "1:HOURS:EPOCH", "1:HOURS")
@@ -94,7 +94,8 @@ public class PartialUpsertHandlerTest {
         row.putValue(columnName, newValue);
       }
       handler.merge(segment, 1, row);
-      assertEquals(row.getValue(columnName), expected);
+      assertEquals(row.getValue(columnName), expectedValue);
+      assertEquals(row.isNullValue(columnName), isExpectedNull);
     }
   }
 }


### PR DESCRIPTION
`refactor`: POC for improving disk read for partial upsert handler

- The current Partial upsert handler read all columns of prev and new value.
- To reduce num of column read, refactored the interface for overwrite merger as default merger. It will only access the previous value in the following two types
1. previous value is not null, new value is null, we will replace the new value with the previous value 
2. previous value is not null, mergers is not overwrite, we will merger the previous value and the new value.
3. For all the other cases, we will not read the previous value.
- Created this PR to learn and gather feedback. If it can work, will make it more generic
