### PR TITLE
[multistage] Do Not Log Entire Plan in QueryServer

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryServer.java
@@ -100,7 +100,7 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
     try {
       distributedStagePlans = QueryPlanSerDeUtils.deserializeStagePlan(request);
     } catch (Exception e) {
-      LOGGER.error("Caught exception while deserializing the request: {}, payload: {}", requestId, request, e);
+      LOGGER.error("Caught exception while deserializing the request: {}", requestId, e);
       responseObserver.onError(Status.INVALID_ARGUMENT.withDescription("Bad request").withCause(e).asException());
       return;
     }


### PR DESCRIPTION
Saw this when fixing tpch tests. Logging entire plan can be dangerous in production scenarios (plans are usually large)

cc: @walterddr 