### PR TITLE
Make org.apache.pinot.client.BrokerResponse public

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerResponse.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerResponse.java
@@ -24,7 +24,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 /**
  * Reimplementation of BrokerResponse from pinot-common, so that pinot-api does not depend on pinot-common.
  */
-class BrokerResponse {
+public class BrokerResponse {
   private JsonNode _aggregationResults;
   private JsonNode _selectionResults;
   private JsonNode _resultTable;


### PR DESCRIPTION
bugfix #10924 

The org.apache.pinot.client.PinotClientTransport class is an interface to implement the client transport for Pinot Java Client connections. Currently, there is a default implementation provided by Pinot Java client which uses AsyncHttpClient.

We want to implement the PinotClientTransport interface to provide a Vert.x adapter for the Pinot Java Client but currently it is not possible because the interface methods return BrokerResponse class which is package-private. Hence, making BrokerResponse public so that the interface can be implemented externally.

cc @tsegismont