### PR TITLE
Fixing table name extraction for lateral join queries

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -180,6 +180,8 @@ public class CalciteSqlParser {
         SqlNode firstOperand = ((SqlBasicCall) sqlNode).getOperandList().get(0);
         if (firstOperand instanceof SqlSelect) {
           tableNames.addAll(extractTableNamesFromNode(firstOperand));
+        } else if (firstOperand instanceof SqlBasicCall) {
+          tableNames.addAll(extractTableNamesFromNode(((SqlBasicCall) firstOperand).getOperandList().get(0)));
         } else {
           tableNames.addAll(((SqlIdentifier) firstOperand).names);
         }

--- a/pinot-query-planner/src/test/resources/queries/JoinPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/JoinPlans.json
@@ -328,6 +328,24 @@
           "\n              LogicalTableScan(table=[[b]])",
           "\n"
         ]
+      },
+      {
+        "description": "Lateral join",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1, newb.sum_col3 FROM a JOIN LATERAL (SELECT SUM(col3) as sum_col3 FROM b WHERE col2 = a.col2) AS newb ON TRUE;\n",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0], sum_col3=[$3])",
+          "\n  LogicalJoin(condition=[=($1, $2)], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[hash[1]])",
+          "\n      LogicalProject(col1=[$0], col2=[$1])",
+          "\n        LogicalTableScan(table=[[a]])",
+          "\n    PinotLogicalExchange(distribution=[hash[0]])",
+          "\n      LogicalAggregate(group=[{0}], sum_col3=[$SUM0($1)])",
+          "\n        PinotLogicalExchange(distribution=[hash[0]])",
+          "\n          LogicalAggregate(group=[{1}], sum_col3=[$SUM0($2)])",
+          "\n            LogicalTableScan(table=[[b]])",
+          "\n"
+        ]
       }
     ]
   },

--- a/pinot-query-runtime/src/test/resources/queries/BasicQuery.json
+++ b/pinot-query-runtime/src/test/resources/queries/BasicQuery.json
@@ -61,6 +61,11 @@
       {
         "description": "Correlated subquery test",
         "sql": "SELECT {tbl1}.col1 FROM {tbl1} WHERE {tbl1}.col2 > (SELECT 0.5 * SUM({tbl2}.col3) FROM {tbl2} WHERE {tbl1}.col2 = {tbl1}.col2 AND {tbl1}.col1 = {tbl2}.col1)"
+      },
+      {
+        "description": "Lateral join query test",
+        "sql": "SELECT {tbl1}.col1, newb.sum_col3 FROM {tbl1} JOIN LATERAL (SELECT SUM(col3) as sum_col3 FROM {tbl2} WHERE col2 = {tbl1}.col2) AS newb ON TRUE",
+        "h2Sql": "SELECT {tbl1}.col1, newb.sum_col3 FROM {tbl1} JOIN (SELECT {tbl2}.col2, SUM({tbl2}.col3) AS sum_col3 FROM {tbl2} GROUP BY {tbl2}.col2) AS newb ON newb.col2 = {tbl1}.col2"
       }
     ],
     "extraProps": {


### PR DESCRIPTION
- Fixing table name extraction for lateral join queries
- Adding test examples for lateral join
![image](https://github.com/apache/pinot/assets/1202120/e0052c94-3dcc-428d-a488-495a27cc1cb7)
