### PR TITLE
Properly set the records list initial size to avoid unnecessary resizing.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawDoubleSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawDoubleSingleColumnDistinctExecutor.java
@@ -61,7 +61,7 @@ abstract class BaseRawDoubleSingleColumnDistinctExecutor implements DistinctExec
   public DistinctTable getResult() {
     DataSchema dataSchema = new DataSchema(new String[]{_expression.toString()},
         new ColumnDataType[]{ColumnDataType.fromDataTypeSV(_dataType)});
-    List<Record> records = new ArrayList<>(_valueSet.size());
+    List<Record> records = new ArrayList<>(_valueSet.size() + (_hasNull ? 1 : 0));
     DoubleIterator valueIterator = _valueSet.iterator();
     while (valueIterator.hasNext()) {
       records.add(new Record(new Object[]{valueIterator.nextDouble()}));

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawFloatSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawFloatSingleColumnDistinctExecutor.java
@@ -61,7 +61,7 @@ abstract class BaseRawFloatSingleColumnDistinctExecutor implements DistinctExecu
   public DistinctTable getResult() {
     DataSchema dataSchema = new DataSchema(new String[]{_expression.toString()},
         new ColumnDataType[]{ColumnDataType.fromDataTypeSV(_dataType)});
-    List<Record> records = new ArrayList<>(_valueSet.size());
+    List<Record> records = new ArrayList<>(_valueSet.size() + (_hasNull ? 1 : 0));
     FloatIterator valueIterator = _valueSet.iterator();
     while (valueIterator.hasNext()) {
       records.add(new Record(new Object[]{valueIterator.nextFloat()}));

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawIntSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawIntSingleColumnDistinctExecutor.java
@@ -62,7 +62,7 @@ abstract class BaseRawIntSingleColumnDistinctExecutor implements DistinctExecuto
   public DistinctTable getResult() {
     DataSchema dataSchema = new DataSchema(new String[]{_expression.toString()},
         new ColumnDataType[]{ColumnDataType.fromDataTypeSV(_dataType)});
-    List<Record> records = new ArrayList<>(_valueSet.size());
+    List<Record> records = new ArrayList<>(_valueSet.size() + (_hasNull ? 1 : 0));
     IntIterator valueIterator = _valueSet.iterator();
     while (valueIterator.hasNext()) {
       records.add(new Record(new Object[]{valueIterator.nextInt()}));

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawLongSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawLongSingleColumnDistinctExecutor.java
@@ -61,7 +61,7 @@ abstract class BaseRawLongSingleColumnDistinctExecutor implements DistinctExecut
   public DistinctTable getResult() {
     DataSchema dataSchema = new DataSchema(new String[]{_expression.toString()},
         new ColumnDataType[]{ColumnDataType.fromDataTypeSV(_dataType)});
-    List<Record> records = new ArrayList<>(_valueSet.size());
+    List<Record> records = new ArrayList<>(_valueSet.size() + (_hasNull ? 1 : 0));
     LongIterator valueIterator = _valueSet.iterator();
     while (valueIterator.hasNext()) {
       records.add(new Record(new Object[]{valueIterator.nextLong()}));


### PR DESCRIPTION
Tested in unit tests.

@Jackie-Jiang identified this unnecessary resizing issue.