### PR TITLE
Fix casting when prefetching mmap'd segment larger than 2GB

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SegmentLocalFSDirectory.java
@@ -332,11 +332,9 @@ public class SegmentLocalFSDirectory extends SegmentDirectory {
         PREFETCHED_PAGES.incrementAndGet();
       }
     } else {
-      // pos needs to be long because buffer.size() is 32 bit but
-      // adding 4k can make it go over int size
       for (long pos = 0; pos < buffer.size() && PREFETCHED_PAGES.get() < prefetchSlowdownPageLimit;
           pos += PAGE_SIZE_BYTES) {
-        buffer.getByte((int) pos);
+        buffer.getByte(pos);
         PREFETCHED_PAGES.incrementAndGet();
       }
     }


### PR DESCRIPTION
### What
This PR fixes a bug which may trigger when an mmap'd segment larger than 2GB (Integer.MAX_VALUE bytes) is prefetched by SegmentLocalFSDirectory.

There is an (outdated) comment above the prefetching code that specifies that `buffer.size()` is 32-bit and therefore `pos` cannot be greater than `Integer.MAX_VALUE`. That isn't true as LArray-backed buffers can exceed Integer.MAX_VALUE in size (and `PinotDataBuffer#size` returns a `long`). If a buffer with a size that exceeds `Integer.MAX_VALUE` is pre-fetched, `pos` will be casted to an `int` (`Integer.MIN_VALUE`) and passed to `PinotDataBuffer#getByte`. On some implementations, this will loudly throw. On others (like LArray), the behavior is undefined as that buffer implementation is backed by Unsafe and the memory address being accessed is out of the range of the buffer.

I've observed this cause a (hard) JVM crash when running batch ingestion jobs on Java 17 with a recent patch https://github.com/apache/pinot/pull/10528 that adds a substitute for LArray for buffers that map more than 2^31-1 bytes. The logs for that crash are captured in this gist: https://gist.github.com/jbewing/471fb86f419c9975e5f22994673b0c1b

I hypothesize that this bug is less noticeable on java versions less than 17 as it may not result in a hard crash of the JVM when using the LArray large buffer implementation.

### Testing
I've tested this patch by re-running the batch ingestion job that caused the crash and verifying that it didn't cause the crash. I welcome any advice on additional testing steps needed here.