### PR TITLE
Support NULL for multi-column GROUP BY.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
@@ -99,7 +99,8 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
                   _nullHandlingEnabled);
         } else {
           _groupKeyGenerator =
-              new NoDictionaryMultiColumnGroupKeyGenerator(projectOperator, groupByExpressions, numGroupsLimit);
+              new NoDictionaryMultiColumnGroupKeyGenerator(projectOperator, groupByExpressions, numGroupsLimit,
+                  _nullHandlingEnabled);
         }
       } else {
         _groupKeyGenerator = new DictionaryBasedGroupKeyGenerator(projectOperator, groupByExpressions, numGroupsLimit,

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
@@ -35,6 +35,7 @@ import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.FixedIntArray;
+import org.roaringbitmap.RoaringBitmap;
 
 
 /**
@@ -47,6 +48,8 @@ import org.apache.pinot.spi.utils.FixedIntArray;
  * 2. Add support for trimming group-by results.
  */
 public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerator {
+  private static final int ID_FOR_NULL = INVALID_ID - 1;
+
   private final ExpressionContext[] _groupByExpressions;
   private final int _numGroupByExpressions;
   private final DataType[] _storedTypes;
@@ -55,23 +58,25 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
   private final Object2IntOpenHashMap<FixedIntArray> _groupKeyMap;
   private final boolean[] _isSingleValueExpressions;
   private final int _globalGroupIdUpperBound;
+  private final boolean _nullHandlingEnabled;
 
   private int _numGroups = 0;
 
   public NoDictionaryMultiColumnGroupKeyGenerator(BaseProjectOperator<?> projectOperator,
-      ExpressionContext[] groupByExpressions, int numGroupsLimit) {
+      ExpressionContext[] groupByExpressions, int numGroupsLimit, boolean nullHandlingEnabled) {
     _groupByExpressions = groupByExpressions;
     _numGroupByExpressions = groupByExpressions.length;
     _storedTypes = new DataType[_numGroupByExpressions];
     _dictionaries = new Dictionary[_numGroupByExpressions];
     _onTheFlyDictionaries = new ValueToIdMap[_numGroupByExpressions];
     _isSingleValueExpressions = new boolean[_numGroupByExpressions];
+    _nullHandlingEnabled = nullHandlingEnabled;
 
     for (int i = 0; i < _numGroupByExpressions; i++) {
       ExpressionContext groupByExpression = groupByExpressions[i];
       ColumnContext columnContext = projectOperator.getResultColumnContext(groupByExpression);
       _storedTypes[i] = columnContext.getDataType().getStoredType();
-      Dictionary dictionary = columnContext.getDictionary();
+      Dictionary dictionary = _nullHandlingEnabled ? null : columnContext.getDictionary();
       if (dictionary != null) {
         _dictionaries[i] = dictionary;
       } else {
@@ -126,29 +131,60 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
     int[] keyValues = new int[_numGroupByExpressions];
     // note that we are mutating its backing array for memory efficiency
     FixedIntArray flyweightKey = new FixedIntArray(keyValues);
-    for (int row = 0; row < numDocs; row++) {
-      for (int col = 0; col < _numGroupByExpressions; col++) {
-        Object columnValues = values[col];
-        ValueToIdMap onTheFlyDictionary = _onTheFlyDictionaries[col];
-        if (columnValues instanceof int[]) {
-          if (onTheFlyDictionary == null) {
-            keyValues[col] = ((int[]) columnValues)[row];
-          } else {
-            keyValues[col] = onTheFlyDictionary.put(((int[]) columnValues)[row]);
-          }
-        } else if (columnValues instanceof long[]) {
-          keyValues[col] = onTheFlyDictionary.put(((long[]) columnValues)[row]);
-        } else if (columnValues instanceof float[]) {
-          keyValues[col] = onTheFlyDictionary.put(((float[]) columnValues)[row]);
-        } else if (columnValues instanceof double[]) {
-          keyValues[col] = onTheFlyDictionary.put(((double[]) columnValues)[row]);
-        } else if (columnValues instanceof String[]) {
-          keyValues[col] = onTheFlyDictionary.put(((String[]) columnValues)[row]);
-        } else if (columnValues instanceof byte[][]) {
-          keyValues[col] = onTheFlyDictionary.put(new ByteArray(((byte[][]) columnValues)[row]));
-        }
+    if (_nullHandlingEnabled) {
+      RoaringBitmap[] nullBitmaps = new RoaringBitmap[_numGroupByExpressions];
+      for (int i = 0; i < _numGroupByExpressions; i++) {
+        nullBitmaps[i] = valueBlock.getBlockValueSet(_groupByExpressions[i]).getNullBitmap();
       }
-      groupKeys[row] = getGroupIdForFlyweightKey(flyweightKey);
+      for (int row = 0; row < numDocs; row++) {
+        for (int col = 0; col < _numGroupByExpressions; col++) {
+          if (nullBitmaps[col] != null && nullBitmaps[col].contains(row)) {
+            keyValues[col] = ID_FOR_NULL;
+          } else {
+            Object columnValues = values[col];
+            ValueToIdMap onTheFlyDictionary = _onTheFlyDictionaries[col];
+            if (columnValues instanceof int[]) {
+              keyValues[col] = onTheFlyDictionary.put(((int[]) columnValues)[row]);
+            } else if (columnValues instanceof long[]) {
+              keyValues[col] = onTheFlyDictionary.put(((long[]) columnValues)[row]);
+            } else if (columnValues instanceof float[]) {
+              keyValues[col] = onTheFlyDictionary.put(((float[]) columnValues)[row]);
+            } else if (columnValues instanceof double[]) {
+              keyValues[col] = onTheFlyDictionary.put(((double[]) columnValues)[row]);
+            } else if (columnValues instanceof String[]) {
+              keyValues[col] = onTheFlyDictionary.put(((String[]) columnValues)[row]);
+            } else if (columnValues instanceof byte[][]) {
+              keyValues[col] = onTheFlyDictionary.put(new ByteArray(((byte[][]) columnValues)[row]));
+            }
+          }
+        }
+        groupKeys[row] = getGroupIdForFlyweightKey(flyweightKey);
+      }
+    } else {
+      for (int row = 0; row < numDocs; row++) {
+        for (int col = 0; col < _numGroupByExpressions; col++) {
+          Object columnValues = values[col];
+          ValueToIdMap onTheFlyDictionary = _onTheFlyDictionaries[col];
+          if (columnValues instanceof int[]) {
+            if (onTheFlyDictionary == null) {
+              keyValues[col] = ((int[]) columnValues)[row];
+            } else {
+              keyValues[col] = onTheFlyDictionary.put(((int[]) columnValues)[row]);
+            }
+          } else if (columnValues instanceof long[]) {
+            keyValues[col] = onTheFlyDictionary.put(((long[]) columnValues)[row]);
+          } else if (columnValues instanceof float[]) {
+            keyValues[col] = onTheFlyDictionary.put(((float[]) columnValues)[row]);
+          } else if (columnValues instanceof double[]) {
+            keyValues[col] = onTheFlyDictionary.put(((double[]) columnValues)[row]);
+          } else if (columnValues instanceof String[]) {
+            keyValues[col] = onTheFlyDictionary.put(((String[]) columnValues)[row]);
+          } else if (columnValues instanceof byte[][]) {
+            keyValues[col] = onTheFlyDictionary.put(new ByteArray(((byte[][]) columnValues)[row]));
+          }
+        }
+        groupKeys[row] = getGroupIdForFlyweightKey(flyweightKey);
+      }
     }
   }
 
@@ -392,10 +428,14 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
     Object[] keys = new Object[_numGroupByExpressions];
     int[] dictIds = keyList.elements();
     for (int i = 0; i < _numGroupByExpressions; i++) {
-      if (_dictionaries[i] != null) {
-        keys[i] = _dictionaries[i].getInternal(dictIds[i]);
+      if (dictIds[i] == ID_FOR_NULL) {
+        keys[i] = null;
       } else {
-        keys[i] = _onTheFlyDictionaries[i].get(dictIds[i]);
+        if (_dictionaries[i] != null) {
+          keys[i] = _dictionaries[i].getInternal(dictIds[i]);
+        } else {
+          keys[i] = _onTheFlyDictionaries[i].get(dictIds[i]);
+        }
       }
     }
     return keys;

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
@@ -206,7 +206,7 @@ public class NoDictionaryGroupKeyGeneratorTest {
         groupByExpressions[i] = ExpressionContext.forIdentifier(COLUMNS.get(groupByColumnIndexes[i]));
       }
       groupKeyGenerator = new NoDictionaryMultiColumnGroupKeyGenerator(_projectOperator, groupByExpressions,
-          InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT);
+          InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, false);
     }
     groupKeyGenerator.generateKeysForBlock(_valueBlock, new int[NUM_RECORDS]);
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
@@ -18,16 +18,14 @@
  */
 package org.apache.pinot.queries;
 
+import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.common.response.broker.ResultTable;
-import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
@@ -56,10 +54,10 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   private static final String SEGMENT_NAME = "testSegment";
   private static final String COLUMN1 = "column1";
   private static final String COLUMN2 = "column2";
-  private static final int NULL_PLACEHOLDER = (int) DataSchema.ColumnDataType.INT.getNullPlaceholder();
   private static final int NUM_OF_SEGMENT_COPIES = 4;
+  private final List<GenericRow> _rows = new ArrayList<>();
+  private static final ImmutableMap<String, String> QUERY_OPTIONS = ImmutableMap.of("enableNullHandling", "true");
 
-  private List<GenericRow> _rows;
   private IndexSegment _indexSegment;
   private List<IndexSegment> _indexSegments;
 
@@ -78,7 +76,7 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     return _indexSegments;
   }
 
-  private void setUpSegments(TableConfig tableConfig, Schema schema, List<GenericRow> records)
+  private void setUpSegments(TableConfig tableConfig, Schema schema)
       throws Exception {
     FileUtils.deleteDirectory(INDEX_DIR);
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
@@ -88,12 +86,16 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     segmentGeneratorConfig.setOutDir(INDEX_DIR.getPath());
 
     SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+    driver.init(segmentGeneratorConfig, new GenericRowRecordReader(_rows));
     driver.build();
 
     ImmutableSegment immutableSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.mmap);
     _indexSegment = immutableSegment;
     _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+  }
+
+  private void initializeRows() {
+    _rows.clear();
   }
 
   private void insertRow(Object value) {
@@ -113,17 +115,15 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   public void testSelectDistinctOrderByNullsFirst()
       throws Exception {
     FileUtils.deleteDirectory(INDEX_DIR);
-    _rows = new ArrayList<>();
+    initializeRows();
     insertRow(1);
     insertRow(null);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT).build();
-    setUpSegments(tableConfig, schema, _rows);
-    Map<String, String> queryOptions = new HashMap<>();
-    queryOptions.put("enableNullHandling", "true");
+    setUpSegments(tableConfig, schema);
     String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s NULLS FIRST", COLUMN1, COLUMN1);
 
-    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
 
     ResultTable resultTable = brokerResponse.getResultTable();
     assertNull(resultTable.getRows().get(0)[0]);
@@ -134,17 +134,15 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   public void testSelectDistinctOrderByNullsLast()
       throws Exception {
     FileUtils.deleteDirectory(INDEX_DIR);
-    _rows = new ArrayList<>();
+    initializeRows();
     insertRow(1);
     insertRow(null);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT).build();
-    setUpSegments(tableConfig, schema, _rows);
-    Map<String, String> queryOptions = new HashMap<>();
-    queryOptions.put("enableNullHandling", "true");
+    setUpSegments(tableConfig, schema);
     String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s NULLS LAST", COLUMN1, COLUMN1);
 
-    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
 
     ResultTable resultTable = brokerResponse.getResultTable();
     assertNotNull(resultTable.getRows().get(0)[0]);
@@ -152,30 +150,27 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   }
 
   @Test
-  public void testSelectDistinctNullPlaceholderDiffersFromNull()
+  public void testSelectDistinctIntegerMinValueDiffersFromNull()
       throws Exception {
     FileUtils.deleteDirectory(INDEX_DIR);
-    _rows = new ArrayList<>();
-    insertRow(1);
-    insertRow(NULL_PLACEHOLDER);
+    initializeRows();
+    insertRow(Integer.MIN_VALUE);
     insertRow(null);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT).build();
-    setUpSegments(tableConfig, schema, _rows);
-    Map<String, String> queryOptions = new HashMap<>();
-    queryOptions.put("enableNullHandling", "true");
-    String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s NULLS LAST", COLUMN1, COLUMN1);
+    setUpSegments(tableConfig, schema);
+    String query = String.format("SELECT DISTINCT %s FROM testTable", COLUMN1);
 
-    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
 
     ResultTable resultTable = brokerResponse.getResultTable();
-    assertEquals(resultTable.getRows().size(), 3);
+    assertEquals(resultTable.getRows().size(), 2);
   }
 
   @Test
   public void testSelectDistinctMultiColumn()
       throws Exception {
-    _rows = new ArrayList<>();
+    initializeRows();
     insertRowWithTwoColumns(1, 1);
     insertRowWithTwoColumns(1, 1);
     insertRowWithTwoColumns(null, 1);
@@ -185,13 +180,11 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT)
         .addSingleValueDimension(COLUMN2, FieldSpec.DataType.INT).build();
-    setUpSegments(tableConfig, schema, _rows);
-    Map<String, String> queryOptions = new HashMap<>();
-    queryOptions.put("enableNullHandling", "true");
+    setUpSegments(tableConfig, schema);
     String query =
         String.format("SELECT DISTINCT %s,%s FROM testTable ORDER BY %s,%s", COLUMN1, COLUMN2, COLUMN1, COLUMN2);
 
-    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
 
     ResultTable resultTable = brokerResponse.getResultTable();
     assertEquals(resultTable.getRows().size(), 4);
@@ -200,7 +193,7 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   @Test
   public void testSelectDistinctOrderByMultiColumn()
       throws Exception {
-    _rows = new ArrayList<>();
+    initializeRows();
     insertRowWithTwoColumns(null, 1);
     insertRowWithTwoColumns(null, 2);
     insertRowWithTwoColumns(null, 2);
@@ -209,13 +202,11 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT)
         .addSingleValueDimension(COLUMN2, FieldSpec.DataType.INT).build();
-    setUpSegments(tableConfig, schema, _rows);
-    Map<String, String> queryOptions = new HashMap<>();
-    queryOptions.put("enableNullHandling", "true");
+    setUpSegments(tableConfig, schema);
     String query =
         String.format("SELECT DISTINCT %s,%s FROM testTable ORDER BY %s,%s", COLUMN1, COLUMN2, COLUMN1, COLUMN2);
 
-    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
 
     ResultTable resultTable = brokerResponse.getResultTable();
     assertEquals(resultTable.getRows().size(), 4);
@@ -235,19 +226,17 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   @Test(dataProvider = "NumberTypes")
   public void testSelectDistinctWithLimit(FieldSpec.DataType dataType)
       throws Exception {
-    _rows = new ArrayList<>();
+    initializeRows();
     insertRow(null);
     insertRow(1);
     insertRow(2);
     insertRow(3);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, dataType).build();
-    setUpSegments(tableConfig, schema, _rows);
-    Map<String, String> queryOptions = new HashMap<>();
-    queryOptions.put("enableNullHandling", "true");
+    setUpSegments(tableConfig, schema);
     String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s LIMIT 3", COLUMN1, COLUMN1);
 
-    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
 
     ResultTable resultTable = brokerResponse.getResultTable();
     assertEquals(resultTable.getRows().size(), 3);
@@ -257,19 +246,17 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   public void testSelectDistinctOrderByWithLimit(FieldSpec.DataType dataType)
       throws Exception {
     double delta = 0.01;
-    _rows = new ArrayList<>();
+    initializeRows();
     insertRow(null);
     insertRow(1);
     insertRow(2);
     insertRow(3);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, dataType).build();
-    setUpSegments(tableConfig, schema, _rows);
-    Map<String, String> queryOptions = new HashMap<>();
-    queryOptions.put("enableNullHandling", "true");
+    setUpSegments(tableConfig, schema);
     String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s LIMIT 3", COLUMN1, COLUMN1);
 
-    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
 
     ResultTable resultTable = brokerResponse.getResultTable();
     assertEquals(resultTable.getRows().size(), 3);
@@ -277,7 +264,6 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     assertTrue(Math.abs(((Number) resultTable.getRows().get(1)[0]).doubleValue() - 2.0) < delta);
     assertTrue(Math.abs(((Number) resultTable.getRows().get(2)[0]).doubleValue() - 3.0) < delta);
   }
-
 
   @DataProvider(name = "ObjectTypes")
   public static Object[][] getObjectDataTypes() {
@@ -293,17 +279,15 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   @Test(dataProvider = "ObjectTypes")
   public void testObjectSingleColumnDistinctOrderByNullsFirst(FieldSpec.DataType dataType, Object value)
       throws Exception {
-    _rows = new ArrayList<>();
+    initializeRows();
     insertRow(null);
     insertRow(value);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, dataType).build();
-    setUpSegments(tableConfig, schema, _rows);
-    Map<String, String> queryOptions = new HashMap<>();
-    queryOptions.put("enableNullHandling", "true");
+    setUpSegments(tableConfig, schema);
     String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s NULLS FIRST LIMIT 1", COLUMN1, COLUMN1);
 
-    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
 
     ResultTable resultTable = brokerResponse.getResultTable();
     assertEquals(resultTable.getRows().size(), 1);
@@ -313,17 +297,15 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   @Test(dataProvider = "ObjectTypes")
   public void testObjectSingleColumnDistinctOrderByNullsLast(FieldSpec.DataType dataType, Object value)
       throws Exception {
-    _rows = new ArrayList<>();
+    initializeRows();
     insertRow(null);
     insertRow(value);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, dataType).build();
-    setUpSegments(tableConfig, schema, _rows);
-    Map<String, String> queryOptions = new HashMap<>();
-    queryOptions.put("enableNullHandling", "true");
+    setUpSegments(tableConfig, schema);
     String query = String.format("SELECT DISTINCT %s FROM testTable ORDER BY %s NULLS LAST LIMIT 1", COLUMN1, COLUMN1);
 
-    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
 
     ResultTable resultTable = brokerResponse.getResultTable();
     assertEquals(resultTable.getRows().size(), 1);
@@ -333,19 +315,81 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   @Test
   public void testTransformBlockValSetGetNullBitmap()
       throws Exception {
-    _rows = new ArrayList<>();
+    initializeRows();
     insertRow(null);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT).build();
-    setUpSegments(tableConfig, schema, _rows);
-    Map<String, String> queryOptions = new HashMap<>();
-    queryOptions.put("enableNullHandling", "true");
+    setUpSegments(tableConfig, schema);
     String query = String.format("SELECT (CASE WHEN %s IS NULL THEN 1 END) FROM testTable", COLUMN1);
 
-    BrokerResponseNative brokerResponse = getBrokerResponse(query, queryOptions);
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
 
     ResultTable resultTable = brokerResponse.getResultTable();
     assertEquals(resultTable.getRows().size(), NUM_OF_SEGMENT_COPIES);
     assertEquals(resultTable.getRows().get(0)[0], 1);
+  }
+
+  private boolean contains(List<Object[]> rows, Object[] target) {
+    for (Object[] row : rows) {
+      if (Arrays.equals(row, target)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Test
+  public void testMultiColumnGroupBy()
+      throws Exception {
+    initializeRows();
+    insertRowWithTwoColumns(null, null);
+    insertRowWithTwoColumns(null, 1);
+    insertRowWithTwoColumns(null, 1);
+    insertRowWithTwoColumns(1, 1);
+    insertRowWithTwoColumns(1, null);
+    insertRowWithTwoColumns(1, Integer.MIN_VALUE);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT)
+        .addSingleValueDimension(COLUMN2, FieldSpec.DataType.INT).build();
+    setUpSegments(tableConfig, schema);
+    String query =
+        String.format("SELECT count(*), %s, %s FROM testTable GROUP BY %s, %s", COLUMN1, COLUMN2, COLUMN1,
+            COLUMN2);
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
+
+    ResultTable resultTable = brokerResponse.getResultTable();
+    List<Object[]> rows = resultTable.getRows();
+    assertEquals(rows.size(), 5);
+    assertTrue(contains(rows, new Object[]{(long) NUM_OF_SEGMENT_COPIES, null, null}));
+    assertTrue(contains(rows, new Object[]{(long) 2 * NUM_OF_SEGMENT_COPIES, null, 1}));
+    assertTrue(contains(rows, new Object[]{(long) NUM_OF_SEGMENT_COPIES, 1, 1}));
+    assertTrue(contains(rows, new Object[]{(long) NUM_OF_SEGMENT_COPIES, 1, null}));
+    assertTrue(contains(rows, new Object[]{(long) NUM_OF_SEGMENT_COPIES, 1, Integer.MIN_VALUE}));
+  }
+
+  @Test
+  public void testMultiColumnGroupByWithLimit()
+      throws Exception {
+    initializeRows();
+    insertRowWithTwoColumns(null, null);
+    insertRowWithTwoColumns(null, 1);
+    insertRowWithTwoColumns(null, 1);
+    insertRowWithTwoColumns(1, 1);
+    insertRowWithTwoColumns(1, null);
+    insertRowWithTwoColumns(1, Integer.MIN_VALUE);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT)
+        .addSingleValueDimension(COLUMN2, FieldSpec.DataType.INT).build();
+    setUpSegments(tableConfig, schema);
+    String query =
+        String.format("SELECT count(*), %s, %s FROM testTable GROUP BY %s, %s LIMIT 3", COLUMN1, COLUMN2, COLUMN1,
+            COLUMN2);
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
+
+    ResultTable resultTable = brokerResponse.getResultTable();
+    List<Object[]> rows = resultTable.getRows();
+    assertEquals(rows.size(), 3);
   }
 }


### PR DESCRIPTION
This PR enables queries like `SELECT aggregate_function, column1, column2 FROM table GROUP BY column1, column2` in which `column1` and `column2` can contain NULL.

Also cleaned up the unit tests.