### PR TITLE
Fix an integer overflow bug.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawDoubleSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawDoubleSingleColumnDistinctExecutor.java
@@ -69,7 +69,7 @@ abstract class BaseRawDoubleSingleColumnDistinctExecutor implements DistinctExec
     if (_hasNull) {
       records.add(new Record(new Object[]{null}));
     }
-    assert records.size() <= _limit + 1;
+    assert records.size() - (_hasNull ? 1 : 0) <= _limit;
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawFloatSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawFloatSingleColumnDistinctExecutor.java
@@ -69,7 +69,7 @@ abstract class BaseRawFloatSingleColumnDistinctExecutor implements DistinctExecu
     if (_hasNull) {
       records.add(new Record(new Object[]{null}));
     }
-    assert records.size() <= _limit + 1;
+    assert records.size() - (_hasNull ? 1 : 0) <= _limit;
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawIntSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawIntSingleColumnDistinctExecutor.java
@@ -70,7 +70,7 @@ abstract class BaseRawIntSingleColumnDistinctExecutor implements DistinctExecuto
     if (_hasNull) {
       records.add(new Record(new Object[]{null}));
     }
-    assert records.size() <= _limit + 1;
+    assert records.size() - (_hasNull ? 1 : 0) <= _limit;
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawLongSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawLongSingleColumnDistinctExecutor.java
@@ -69,7 +69,7 @@ abstract class BaseRawLongSingleColumnDistinctExecutor implements DistinctExecut
     if (_hasNull) {
       records.add(new Record(new Object[]{null}));
     }
-    assert records.size() <= _limit + 1;
+    assert records.size() - (_hasNull ? 1 : 0) <= _limit;
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 


### PR DESCRIPTION
Currently the when the `_limit` is `Integer.MAX_VALUE`, the assertion will fail because of the integer overflow. This bug makes the `MultiStageEngineCustomTenantIntegrationTest` flaky.

Tested by rerunning a generated test which previously failed:
```
Error:  org.apache.pinot.integration.tests.MultiStageEngineCustomTenantIntegrationTest.testGeneratedQueries  Time elapsed: 41.272 s  <<< FAILURE!
java.lang.AssertionError: 
Caught exception while testing query!
Pinot query: SELECT "CRSDepTime" FROM mytable WHERE "LateAircraftDelay" BETWEEN 291 AND 372 OR "DestState" >= 'ME' GROUP BY "CRSDepTime" LIMIT 10000
H2 query: SELECT `CRSDepTime` FROM mytable WHERE `LateAircraftDelay` BETWEEN 291 AND 372 OR `DestState` >= 'ME' GROUP BY `CRSDepTime` LIMIT 10000
```