### PR TITLE
Push out-of-order events metrics for full upsert

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -46,6 +46,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   UPSERT_KEYS_IN_WRONG_SEGMENT("rows", false),
   PARTIAL_UPSERT_OUT_OF_ORDER("rows", false),
   PARTIAL_UPSERT_KEYS_NOT_REPLACED("rows", false),
+  UPSERT_OUT_OF_ORDER("rows", false),
   ROWS_WITH_ERRORS("rows", false),
   LLC_CONTROLLER_RESPONSE_NOT_SENT("messages", true),
   LLC_CONTROLLER_RESPONSE_COMMIT("messages", true),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -375,9 +375,9 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     _numOutOfOrderEvents++;
     long currentTimeNs = System.nanoTime();
     if (currentTimeNs - _lastOutOfOrderEventReportTimeNs > OUT_OF_ORDER_EVENT_MIN_REPORT_INTERVAL_NS) {
-      _logger.warn("Skipped {} out-of-order events for partial-upsert table (the last event has current comparison "
-              + "value: {}, record comparison value: {})", _numOutOfOrderEvents, currentComparisonValue,
-          recordComparisonValue);
+      _logger.warn("Skipped {} out-of-order events for upsert table {} (the last event has current comparison "
+              + "value: {}, record comparison value: {})", _numOutOfOrderEvents, _tableNameWithType,
+          currentComparisonValue, recordComparisonValue);
       _lastOutOfOrderEventReportTimeNs = currentTimeNs;
       _numOutOfOrderEvents = 0;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -371,13 +371,15 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   protected abstract GenericRow doUpdateRecord(GenericRow record, RecordInfo recordInfo);
 
   protected void handleOutOfOrderEvent(Object currentComparisonValue, Object recordComparisonValue) {
-    _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.PARTIAL_UPSERT_OUT_OF_ORDER, 1L);
+    boolean isPartialUpsertTable = (_partialUpsertHandler != null);
+    _serverMetrics.addMeteredTableValue(_tableNameWithType,
+        isPartialUpsertTable ? ServerMeter.PARTIAL_UPSERT_OUT_OF_ORDER : ServerMeter.UPSERT_OUT_OF_ORDER, 1L);
     _numOutOfOrderEvents++;
     long currentTimeNs = System.nanoTime();
     if (currentTimeNs - _lastOutOfOrderEventReportTimeNs > OUT_OF_ORDER_EVENT_MIN_REPORT_INTERVAL_NS) {
-      _logger.warn("Skipped {} out-of-order events for upsert table {} (the last event has current comparison "
-              + "value: {}, record comparison value: {})", _numOutOfOrderEvents, _tableNameWithType,
-          currentComparisonValue, recordComparisonValue);
+      _logger.warn("Skipped {} out-of-order events for {} upsert table {} (the last event has current comparison "
+              + "value: {}, record comparison value: {})", _numOutOfOrderEvents,
+          (isPartialUpsertTable ? "partial" : ""), _tableNameWithType, currentComparisonValue, recordComparisonValue);
       _lastOutOfOrderEventReportTimeNs = currentTimeNs;
       _numOutOfOrderEvents = 0;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -202,6 +202,7 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
               }
               return new RecordLocation(segment, recordInfo.getDocId(), recordInfo.getComparisonValue());
             } else {
+              handleOutOfOrderEvent(currentRecordLocation.getComparisonValue(), recordInfo.getComparisonValue());
               return currentRecordLocation;
             }
           } else {


### PR DESCRIPTION
In case of full-upsert, we don't log or push any metrics when events are out-of-order. Adding support for that.
cc @Jackie-Jiang 