### PR TITLE
Add a new SegmentPurger interface method to get record purger based on table configs and schema

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
@@ -232,6 +232,9 @@ public class SegmentPurger {
      */
     RecordPurger getRecordPurger(String rawTableName);
 
+    /**
+     * Get the {@link RecordPurger} associated with the given taskConfig, tableConfig and tableSchema
+     */
     default RecordPurger getRecordPurger(PinotTaskConfig taskConfig, TableConfig tableConfig, Schema tableSchema) {
       return getRecordPurger(TableNameBuilder.extractRawTableName(tableConfig.getTableName()));
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
@@ -230,6 +230,11 @@ public class SegmentPurger {
      * Get the {@link RecordPurger} for the given table.
      */
     RecordPurger getRecordPurger(String rawTableName);
+
+    default RecordPurger getRecordPurger(String rawTableName, PinotTaskConfig taskConfig, TableConfig tableConfig,
+        Schema tableSchema) {
+      return null;
+    }
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/minion/SegmentPurger.java
@@ -32,6 +32,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -231,9 +232,8 @@ public class SegmentPurger {
      */
     RecordPurger getRecordPurger(String rawTableName);
 
-    default RecordPurger getRecordPurger(String rawTableName, PinotTaskConfig taskConfig, TableConfig tableConfig,
-        Schema tableSchema) {
-      return null;
+    default RecordPurger getRecordPurger(PinotTaskConfig taskConfig, TableConfig tableConfig, Schema tableSchema) {
+      return getRecordPurger(TableNameBuilder.extractRawTableName(tableConfig.getTableName()));
     }
   }
 

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutor.java
@@ -49,7 +49,7 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
     TableConfig tableConfig = getTableConfig(tableNameWithType);
     Schema schema = getSchema(tableNameWithType);
     SegmentPurger.RecordPurger recordPurger =
-        getRecordPurger(pinotTaskConfig, recordPurgerFactory, tableConfig, schema);
+        recordPurgerFactory != null ? recordPurgerFactory.getRecordPurger(pinotTaskConfig, tableConfig, schema) : null;
     SegmentPurger.RecordModifierFactory recordModifierFactory = MINION_CONTEXT.getRecordModifierFactory();
     SegmentPurger.RecordModifier recordModifier =
         recordModifierFactory != null ? recordModifierFactory.getRecordModifier(rawTableName) : null;
@@ -76,13 +76,5 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
     return new SegmentZKMetadataCustomMapModifier(SegmentZKMetadataCustomMapModifier.ModifyMode.UPDATE, Collections
         .singletonMap(MinionConstants.PurgeTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX,
             String.valueOf(System.currentTimeMillis())));
-  }
-
-  private static SegmentPurger.RecordPurger getRecordPurger(PinotTaskConfig pinotTaskConfig,
-      SegmentPurger.RecordPurgerFactory recordPurgerFactory, TableConfig tableConfig, Schema schema) {
-    if (recordPurgerFactory == null) {
-      return null;
-    }
-    return recordPurgerFactory.getRecordPurger(pinotTaskConfig, tableConfig, schema);
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutor.java
@@ -46,14 +46,14 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
     String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
 
     SegmentPurger.RecordPurgerFactory recordPurgerFactory = MINION_CONTEXT.getRecordPurgerFactory();
+    TableConfig tableConfig = getTableConfig(tableNameWithType);
+    Schema schema = getSchema(tableNameWithType);
     SegmentPurger.RecordPurger recordPurger =
-        recordPurgerFactory != null ? recordPurgerFactory.getRecordPurger(rawTableName) : null;
+        getRecordPurger(pinotTaskConfig, rawTableName, recordPurgerFactory, tableConfig, schema);
     SegmentPurger.RecordModifierFactory recordModifierFactory = MINION_CONTEXT.getRecordModifierFactory();
     SegmentPurger.RecordModifier recordModifier =
         recordModifierFactory != null ? recordModifierFactory.getRecordModifier(rawTableName) : null;
 
-    TableConfig tableConfig = getTableConfig(tableNameWithType);
-    Schema schema = getSchema(tableNameWithType);
     _eventObserver.notifyProgress(pinotTaskConfig, "Purging segment: " + indexDir);
     SegmentPurger segmentPurger =
         new SegmentPurger(indexDir, workingDir, tableConfig, schema, recordPurger, recordModifier);
@@ -76,5 +76,15 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
     return new SegmentZKMetadataCustomMapModifier(SegmentZKMetadataCustomMapModifier.ModifyMode.UPDATE, Collections
         .singletonMap(MinionConstants.PurgeTask.TASK_TYPE + MinionConstants.TASK_TIME_SUFFIX,
             String.valueOf(System.currentTimeMillis())));
+  }
+
+  private static SegmentPurger.RecordPurger getRecordPurger(PinotTaskConfig pinotTaskConfig, String rawTableName,
+      SegmentPurger.RecordPurgerFactory recordPurgerFactory, TableConfig tableConfig, Schema schema) {
+    if (recordPurgerFactory == null) {
+      return null;
+    }
+    SegmentPurger.RecordPurger recordPurger =
+        recordPurgerFactory.getRecordPurger(rawTableName, pinotTaskConfig, tableConfig, schema);
+    return recordPurger != null ? recordPurger : recordPurgerFactory.getRecordPurger(rawTableName);
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskExecutor.java
@@ -49,7 +49,7 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
     TableConfig tableConfig = getTableConfig(tableNameWithType);
     Schema schema = getSchema(tableNameWithType);
     SegmentPurger.RecordPurger recordPurger =
-        getRecordPurger(pinotTaskConfig, rawTableName, recordPurgerFactory, tableConfig, schema);
+        getRecordPurger(pinotTaskConfig, recordPurgerFactory, tableConfig, schema);
     SegmentPurger.RecordModifierFactory recordModifierFactory = MINION_CONTEXT.getRecordModifierFactory();
     SegmentPurger.RecordModifier recordModifier =
         recordModifierFactory != null ? recordModifierFactory.getRecordModifier(rawTableName) : null;
@@ -78,13 +78,11 @@ public class PurgeTaskExecutor extends BaseSingleSegmentConversionExecutor {
             String.valueOf(System.currentTimeMillis())));
   }
 
-  private static SegmentPurger.RecordPurger getRecordPurger(PinotTaskConfig pinotTaskConfig, String rawTableName,
+  private static SegmentPurger.RecordPurger getRecordPurger(PinotTaskConfig pinotTaskConfig,
       SegmentPurger.RecordPurgerFactory recordPurgerFactory, TableConfig tableConfig, Schema schema) {
     if (recordPurgerFactory == null) {
       return null;
     }
-    SegmentPurger.RecordPurger recordPurger =
-        recordPurgerFactory.getRecordPurger(rawTableName, pinotTaskConfig, tableConfig, schema);
-    return recordPurger != null ? recordPurger : recordPurgerFactory.getRecordPurger(rawTableName);
+    return recordPurgerFactory.getRecordPurger(pinotTaskConfig, tableConfig, schema);
   }
 }


### PR DESCRIPTION
This change adds a new default method to get the RecordPurger which also takes table and task configs and table schema


Context:
Because of our new requirements for record purger, we need a more comprehensive API in RecordPurgerFactory where taskConfig, tableConfig, and schema can be provided to the factory. I added a new default method to the interface which falls back to the existing one.

