### PR TITLE
[multistage][hotfix] remove singleton pass-through in dynamic broadcast rule when not colocated

### DIFF
--- a/pinot-query-planner/src/test/resources/queries/PinotHintablePlans.json
+++ b/pinot-query-planner/src/test/resources/queries/PinotHintablePlans.json
@@ -39,7 +39,7 @@
         "sql": "EXPLAIN PLAN FOR SELECT /*+ joinOptions(join_strategy='dynamic_broadcast',is_colocated_by_join_keys='false') */ a.col1, a.col2 FROM a WHERE a.col1 IN (SELECT col2 FROM b WHERE b.col3 > 0)",
         "output": [
           "Execution Plan",
-          "\nPinotLogicalExchange(distribution=[single])",
+          "\nPinotLogicalExchange(distribution=[hash[0]])",
           "\n  LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n    LogicalProject(col1=[$0], col2=[$1])",
           "\n      LogicalTableScan(table=[[a]])",
@@ -87,7 +87,7 @@
         "output": [
           "Execution Plan",
           "\nLogicalAggregate(group=[{0}], EXPR$1=[$SUM0($1)])",
-          "\n  PinotLogicalExchange(distribution=[single])",
+          "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalJoin(condition=[=($0, $2)], joinType=[semi])",
           "\n      LogicalProject(col1=[$0], col3=[$2])",
           "\n        LogicalTableScan(table=[[a]])",
@@ -106,7 +106,7 @@
           "\nLogicalAggregate(group=[{0}], EXPR$1=[$SUM0($1)])",
           "\n  PinotLogicalExchange(distribution=[hash[0]])",
           "\n    LogicalAggregate(group=[{1}], EXPR$1=[$SUM0($2)])",
-          "\n      PinotLogicalExchange(distribution=[single])",
+          "\n      PinotLogicalExchange(distribution=[hash[0]])",
           "\n        LogicalJoin(condition=[=($0, $3)], joinType=[semi])",
           "\n          LogicalProject(col1=[$0], col2=[$1], col3=[$2])",
           "\n            LogicalTableScan(table=[[a]])",


### PR DESCRIPTION
singleton exchange assignment rule changed in #10886. removing it from the pass-through until we have a partition & worker assignment working with all conditions