### PR TITLE
Null check before closing reader

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -138,7 +138,9 @@ public class SegmentMapper {
                   recordReaderFileConfig._fieldsToRead, recordReaderFileConfig._recordReaderConfig);
           mapAndTransformRow(recordReader, reuse, observer, count, totalCount);
         } finally {
-          recordReader.close();
+          if (recordReader != null) {
+            recordReader.close();
+          }
         }
       } else {
         mapAndTransformRow(recordReader, reuse, observer, count, totalCount);


### PR DESCRIPTION
Bubble up the exception, and not fail due to NPE, when reader does not get initialized for some reason (eg: out of memory..)