### PR TITLE
Update pinot client to not use Calcite extractTableNames

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
@@ -26,7 +26,6 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.request.RequestUtils;
-import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.slf4j.Logger;
@@ -192,12 +191,11 @@ public class Connection {
   private static String[] resolveTableName(String query) {
     try {
       SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
-      String tableName = (sqlNodeAndOptions.getSqlNode() != null
-          ? RequestUtils.getTableName(CalciteSqlParser.compileSqlNodeToPinotQuery(sqlNodeAndOptions.getSqlNode()))
-          : CalciteSqlCompiler.compileToBrokerRequest(query).getQuerySource().getTableName());
+      String tableName =
+          RequestUtils.getTableName(CalciteSqlParser.compileSqlNodeToPinotQuery(sqlNodeAndOptions.getSqlNode()));
       return new String[]{tableName};
     } catch (Exception e) {
-      LOGGER.error("Cannot parse table name from query: {}", query, e);
+      LOGGER.error("Cannot parse table name from query: {}. Fallback to broker selector default.", query, e);
     }
     return null;
   }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
@@ -25,6 +25,8 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
+import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.slf4j.Logger;
@@ -190,8 +192,10 @@ public class Connection {
   private static String[] resolveTableName(String query) {
     try {
       SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
-      List<String> tableNames = CalciteSqlParser.extractTableNamesFromNode(sqlNodeAndOptions.getSqlNode());
-      return tableNames.toArray(new String[0]);
+      String tableName = (sqlNodeAndOptions.getSqlNode() != null
+          ? RequestUtils.getTableName(CalciteSqlParser.compileSqlNodeToPinotQuery(sqlNodeAndOptions.getSqlNode()))
+          : CalciteSqlCompiler.compileToBrokerRequest(query).getQuerySource().getTableName());
+      return new String[]{tableName};
     } catch (Exception e) {
       LOGGER.error("Cannot parse table name from query: {}", query, e);
     }


### PR DESCRIPTION
As discussed in #10873 , removing pinot-client using `extractTableNamesFromNode` which got introduced in #10692.
Now in case of multistage queries, it will randomly select a broker.

cc @walterddr @abhioncbr 