### PR TITLE
Fix TransformBlockValSet::getNullBitmap.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/TransformBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/TransformBlock.java
@@ -54,7 +54,7 @@ public class TransformBlock implements ValueBlock {
     if (expression.getType() == ExpressionContext.Type.IDENTIFIER) {
       return _sourceBlock.getBlockValueSet(expression);
     } else {
-      return new TransformBlockValSet(_sourceBlock, _transformFunctionMap.get(expression), expression);
+      return new TransformBlockValSet(_sourceBlock, _transformFunctionMap.get(expression));
     }
   }
 


### PR DESCRIPTION
Currently the `TransformBlockValSet::getNullBitmap` has incorrect result if the underlying transform function's `getNullBitmap` is not using the default implementation in `BaseTransformFunction`.

Tested in unit tests.