### PR TITLE
Backfill segments into real-time table

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *
+ *n
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,
@@ -33,6 +33,7 @@ import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.Nullable;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -138,6 +139,11 @@ public class SegmentGenerationUtils {
     } catch (IOException e) {
       throw new RuntimeException("Failed to decode table config into JSON from String - '" + tableConfigJson + "'", e);
     }
+
+    if(tableJsonNode.has(OFFLINE) && tableJsonNode.has(REALTIME)) {
+      throw new RuntimeException("You must specify 'REALTIME' or 'OFFLINE' when providing the tableConfigURI for a hybrid table");
+    }
+
     if (tableJsonNode.has(OFFLINE)) {
       tableJsonNode = tableJsonNode.get(OFFLINE);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
@@ -33,7 +33,6 @@ import java.nio.file.PathMatcher;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.Nullable;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.StringUtils;

--- a/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
@@ -6,7 +6,7 @@
  * to you under the Apache License, Version 2.0 (the
  * "License"); you may not use this file except in compliance
  * with the License.  You may obtain a copy of the License at
- *n
+ *
  *   http://www.apache.org/licenses/LICENSE-2.0
  *
  * Unless required by applicable law or agreed to in writing,

--- a/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
@@ -139,8 +139,9 @@ public class SegmentGenerationUtils {
       throw new RuntimeException("Failed to decode table config into JSON from String - '" + tableConfigJson + "'", e);
     }
 
-    if(tableJsonNode.has(OFFLINE) && tableJsonNode.has(REALTIME)) {
-      throw new RuntimeException("You must specify 'REALTIME' or 'OFFLINE' when providing the tableConfigURI for a hybrid table");
+    if (tableJsonNode.has(OFFLINE) && tableJsonNode.has(REALTIME)) {
+      throw new RuntimeException(
+              "You must specify 'REALTIME' or 'OFFLINE' when providing the tableConfigURI for a hybrid table");
     }
 
     if (tableJsonNode.has(OFFLINE)) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/segment/generation/SegmentGenerationUtils.java
@@ -48,6 +48,7 @@ public class SegmentGenerationUtils {
   }
 
   private static final String OFFLINE = "OFFLINE";
+  private static final String REALTIME = "REALTIME";
   public static final String PINOT_PLUGINS_TAR_GZ = "pinot-plugins.tar.gz";
   public static final String PINOT_PLUGINS_DIR = "pinot-plugins-dir";
 
@@ -139,6 +140,9 @@ public class SegmentGenerationUtils {
     }
     if (tableJsonNode.has(OFFLINE)) {
       tableJsonNode = tableJsonNode.get(OFFLINE);
+    }
+    if (tableJsonNode.has(REALTIME)) {
+      tableJsonNode = tableJsonNode.get(REALTIME);
     }
     try {
       return JsonUtils.jsonNodeToObject(tableJsonNode, TableConfig.class);

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunnerTest.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunnerTest.java
@@ -82,7 +82,9 @@ public class SegmentGenerationJobRunnerTest {
     try {
       new SegmentGenerationJobRunner(jobSpec);
     } catch (Exception e) {
-      Assert.assertEquals("You must specify 'REALTIME' or 'OFFLINE' when providing the tableConfigURI for a hybrid table", e.getMessage());
+      Assert.assertEquals(
+              "You must specify 'REALTIME' or 'OFFLINE' when providing the tableConfigURI for a hybrid table",
+              e.getMessage());
     }
   }
 


### PR DESCRIPTION
I want to backfill segments into a real-time table, but the code in `SegmentGenerationUtils#getTableConfig` seems to be designed to only allow that for offline tables.

The stub code in SegmentGenerationJobRunnerTest.java. doesn't properly reflect the actual values returned by the API. The stub returns:

```
{
"tableName": "events_rc_OFFLINE",
"tableType": "OFFLINE",
...
```

which misses the nesting that the API actually returns:

```
{
"OFFLINE": {
  "tableName": "events_rc_OFFLINE",
  "tableType": "OFFLINE",
```

This PR updates those tests as well.

I wasn't completely sure what to do if the user tries to upload a segment to a hybrid table without indicating if it should for the real-time or offline table, so we throw an exception in that case.