### PR TITLE
Remove handle out-of-order-events call from updateRecord method

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -413,7 +413,8 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     if (currentTimeNs - _lastOutOfOrderEventReportTimeNs > OUT_OF_ORDER_EVENT_MIN_REPORT_INTERVAL_NS) {
       _logger.warn("Skipped {} out-of-order events for {} upsert table {} (the last event has current comparison "
               + "value: {}, record comparison value: {})", _numOutOfOrderEvents,
-          (isPartialUpsertTable ? "partial" : ""), _tableNameWithType, currentComparisonValue, recordComparisonValue);
+          (isPartialUpsertTable ? "partial" : "full"), _tableNameWithType, currentComparisonValue,
+          recordComparisonValue);
       _lastOutOfOrderEventReportTimeNs = currentTimeNs;
       _numOutOfOrderEvents = 0;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -235,7 +235,6 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
       if (previousRecord != null) {
         return _partialUpsertHandler.merge(previousRecord, record);
       } else {
-        handleOutOfOrderEvent(currentRecordLocation.getComparisonValue(), recordInfo.getComparisonValue());
         return record;
       }
     } else {


### PR DESCRIPTION
Follow-up to a comment in #10944 to remove double accounting of out-of-order events for partial upsert table.