### PR TITLE
allow to add custom context into query trace

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/util/trace/BuiltInTracer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/trace/BuiltInTracer.java
@@ -50,6 +50,15 @@ public class BuiltInTracer implements Tracer {
       }
       TraceContext.logTime(operatorName, duration);
     }
+
+    @Override
+    public void close(Object context) {
+      String operatorName = _operator.getSimpleName();
+      if (LOGGER.isTraceEnabled()) {
+        LOGGER.trace("Context collected for {}: {}", operatorName, context);
+      }
+      TraceContext.logInfo(operatorName, context);
+    }
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Scope.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/Scope.java
@@ -26,4 +26,7 @@ public interface Scope extends AutoCloseable {
 
   @Override
   void close();
+
+  default void close(Object context) {
+  }
 }


### PR DESCRIPTION
Allow custom context to be added into query trace and returned as part of the TraceInfo field in query response.