### PR TITLE
Adding segmentRowComputer interface for SegmentProcessorFramework to use

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/DefaultSegmentNumRowProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/DefaultSegmentNumRowProvider.java
@@ -1,0 +1,39 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.processing.framework;
+
+/**
+ * Provides the configured maxRecordsPerSegment
+ */
+public class DefaultSegmentNumRowProvider implements SegmentNumRowProvider {
+  private int _maxRecordsPerSegment;
+
+  public DefaultSegmentNumRowProvider(int maxRecordsPerSegment) {
+    _maxRecordsPerSegment = maxRecordsPerSegment;
+  }
+
+  @Override
+  public int getNumRows() {
+    return _maxRecordsPerSegment;
+  }
+
+  @Override
+  public void updateSegmentInfo(int numRows, long segmentSize) {
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentNumRowProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentNumRowProvider.java
@@ -22,7 +22,7 @@ package org.apache.pinot.core.segment.processing.framework;
  * Interface to compute rows for a segment, using past segment size
  * and number of rows. This will be used by SegmentProcessorFramework.
  */
-public interface SegmentRowComputer {
+public interface SegmentNumRowProvider {
   int getNumRows();
   void updateSegmentInfo(int numRows, long segmentSize);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
@@ -65,6 +65,7 @@ public class SegmentProcessorFramework {
   private final File _reducerOutputDir;
   private final File _segmentsOutputDir;
   private Map<String, GenericRowFileManager> _partitionToFileManagerMap;
+  private final SegmentRowComputer _segmentRowComputer;
 
   /**
    * Initializes the SegmentProcessorFramework with record readers, config and working directory. We will now rely on
@@ -75,11 +76,11 @@ public class SegmentProcessorFramework {
   public SegmentProcessorFramework(List<RecordReader> recordReaders, SegmentProcessorConfig segmentProcessorConfig,
       File workingDir)
       throws IOException {
-    this(segmentProcessorConfig, workingDir, convertRecordReadersToRecordReaderFileConfig(recordReaders));
+    this(segmentProcessorConfig, workingDir, convertRecordReadersToRecordReaderFileConfig(recordReaders), null);
   }
 
   public SegmentProcessorFramework(SegmentProcessorConfig segmentProcessorConfig, File workingDir,
-      List<RecordReaderFileConfig> recordReaderFileConfigs)
+      List<RecordReaderFileConfig> recordReaderFileConfigs, SegmentRowComputer segmentRowComputer)
       throws IOException {
 
     Preconditions.checkState(!recordReaderFileConfigs.isEmpty(), "No recordReaderFileConfigs provided");
@@ -95,6 +96,8 @@ public class SegmentProcessorFramework {
     FileUtils.forceMkdir(_reducerOutputDir);
     _segmentsOutputDir = new File(workingDir, "segments_output");
     FileUtils.forceMkdir(_segmentsOutputDir);
+
+    _segmentRowComputer = segmentRowComputer;
   }
 
   private static List<RecordReaderFileConfig> convertRecordReadersToRecordReaderFileConfig(
@@ -180,7 +183,6 @@ public class SegmentProcessorFramework {
       generatorConfig.setSegmentNamePostfix(segmentNamePostfix);
     }
 
-    int maxNumRecordsPerSegment = _segmentProcessorConfig.getSegmentConfig().getMaxNumRecordsPerSegment();
     int sequenceId = 0;
     for (Map.Entry<String, GenericRowFileManager> entry : _partitionToFileManagerMap.entrySet()) {
       String partitionId = entry.getKey();
@@ -192,7 +194,10 @@ public class SegmentProcessorFramework {
         LOGGER.info("Start creating segments on partition: {}, numRows: {}, numSortFields: {}", partitionId, numRows,
             numSortFields);
         GenericRowFileRecordReader recordReader = fileReader.getRecordReader();
+        int maxNumRecordsPerSegment;
         for (int startRowId = 0; startRowId < numRows; startRowId += maxNumRecordsPerSegment, sequenceId++) {
+          maxNumRecordsPerSegment = (_segmentRowComputer != null) ? _segmentRowComputer.getNumRows()
+              : _segmentProcessorConfig.getSegmentConfig().getMaxNumRecordsPerSegment();
           int endRowId = Math.min(startRowId + maxNumRecordsPerSegment, numRows);
           LOGGER.info("Start creating segment of sequenceId: {} with row range: {} to {}", sequenceId, startRowId,
               endRowId);
@@ -206,6 +211,10 @@ public class SegmentProcessorFramework {
               TransformPipeline.getPassThroughPipeline());
           driver.build();
           outputSegmentDirs.add(driver.getOutputDirectory());
+          if (_segmentRowComputer != null) {
+            _segmentRowComputer.updateSegmentInfo(driver.getSegmentStats().getTotalDocCount(),
+                FileUtils.sizeOfDirectory(driver.getOutputDirectory()));
+          }
         }
       } finally {
         fileManager.cleanUp();

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentRowComputer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentRowComputer.java
@@ -1,0 +1,28 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.segment.processing.framework;
+
+/**
+ * Interface to compute rows for a segment, using past segment size
+ * and number of rows. This will be used by SegmentProcessorFramework.
+ */
+public interface SegmentRowComputer {
+  int getNumRows();
+  void updateSegmentInfo(int numRows, long segmentSize);
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFrameworkTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFrameworkTest.java
@@ -205,7 +205,8 @@ public class SegmentProcessorFrameworkTest {
 
     SegmentProcessorConfig config =
         new SegmentProcessorConfig.Builder().setTableConfig(tableConfig).setSchema(schema).build();
-    SegmentProcessorFramework framework = new SegmentProcessorFramework(config, workingDir, ImmutableList.of(reader));
+    SegmentProcessorFramework framework = new SegmentProcessorFramework(config, workingDir, ImmutableList.of(reader),
+        null);
     List<File> outputSegments = framework.process();
     assertEquals(outputSegments.size(), 1);
     ImmutableSegment segment = ImmutableSegmentLoader.load(outputSegments.get(0), ReadMode.mmap);


### PR DESCRIPTION
**Problem**:
Currently, we dont have size based segment creation for batch ingestion that uses SegmentProcessorFramework.  With maxNumRecordsPerSegment, we cannot create segment of desired size. Often times, this either results in small segments or large segments or even OOM during ingestion.
**Solution**
Inspired by the realtime [segment auto tuning](https://engineering.linkedin.com/blog/2019/auto-tuning-pinot) , we will introduce a similar capability for batch ingestion, to create segments of desired size. This change is just to introduce an interface to use in SegmentProcessorFramework. 

 