### PR TITLE
do not readd lucene readers to queue if segment is destroyed

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneIndexReaderRefreshThread.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneIndexReaderRefreshThread.java
@@ -135,7 +135,9 @@ public class RealtimeLuceneIndexReaderRefreshThread implements Runnable {
             }
           }
         } finally {
-          _luceneRealtimeReaders.offer(realtimeReadersForSegment);
+          if (!realtimeReadersForSegment.isSegmentDestroyed()) {
+            _luceneRealtimeReaders.offer(realtimeReadersForSegment);
+          }
           realtimeReadersForSegment.getLock().unlock();
         }
       }


### PR DESCRIPTION
Issue described in: https://github.com/apache/pinot/issues/10976

Tested the cherry-picked commit on an internal cluster, verified via logs that `_luceneRealtimeReaders` no longer constantly increases as segments are created/committed (and should no longer incur an index creation lag). Spot checked that text_match on realtime SV columns continues to work as expected.

I didn't find an easy way to test this via unit tests, would appreciate some input if that is suggested. 

Tag: `performance`