### PR TITLE
Updated code for setting value of segment min/max property.

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -140,7 +140,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   private static final String COLUMN_LENGTH_MAP_KEY = "columnLengthMap";
   private static final String COLUMN_CARDINALITY_MAP_KEY = "columnCardinalityMap";
   private static final String MAX_NUM_MULTI_VALUES_MAP_KEY = "maxNumMultiValuesMap";
-  private static final int DISK_SIZE_IN_BYTES = 20797324;
+  private static final int DISK_SIZE_IN_BYTES = 20798304;
   private static final int NUM_ROWS = 115545;
 
   private final List<ServiceStatus.ServiceStatusCallback> _serviceStatusCallbacks =

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -667,8 +667,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       case STRING:
       case JSON:
         if (isMax) {
-          alteredValue = value.substring(0, METADATA_PROPERTY_LENGTH_LIMIT - 1)
-              + (char) (value.charAt(METADATA_PROPERTY_LENGTH_LIMIT - 1) + 1);
+          alteredValue = value.substring(0, METADATA_PROPERTY_LENGTH_LIMIT - 1) + Character.toString(126);
         } else {
           alteredValue = value.substring(0, METADATA_PROPERTY_LENGTH_LIMIT);
         }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -669,10 +669,15 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         if (isMax) {
           int trimIndexValue = METADATA_PROPERTY_LENGTH_LIMIT - 1;
           // determining the index for the character having value less than '\uFFFF'
-          while (trimIndexValue < value.length() && value.charAt(trimIndexValue) == '\uFFFF') {
+          while (trimIndexValue < length && value.charAt(trimIndexValue) == '\uFFFF') {
             trimIndexValue++;
           }
-          alteredValue = value.substring(0, trimIndexValue) + '\uFFFF'; // assigning the '\uFFFF' to make the value max.
+          if (trimIndexValue == length) {
+            alteredValue = value;
+          } else {
+            // assigning the '\uFFFF' to make the value max.
+            alteredValue = value.substring(0, trimIndexValue) + '\uFFFF';
+          }
         } else {
           alteredValue = value.substring(0, METADATA_PROPERTY_LENGTH_LIMIT);
         }
@@ -682,12 +687,16 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
           byte[] valueInByteArray = BytesUtils.toBytes(value);
           int trimIndexValue = METADATA_PROPERTY_LENGTH_LIMIT / 2 - 1;
           // determining the index for the byte having value less than 0xFF
-          while (trimIndexValue < value.length() && (valueInByteArray[trimIndexValue] & 0xff) == 0xFF) {
+          while (trimIndexValue < valueInByteArray.length && valueInByteArray[trimIndexValue] == (byte) 0xFF) {
             trimIndexValue++;
           }
-          byte[] shortByteValue = Arrays.copyOf(valueInByteArray, trimIndexValue + 1);
-          shortByteValue[trimIndexValue] = (byte) 0xFF; // assigning the 0xFF to make the value max.
-          alteredValue = BytesUtils.toHexString(shortByteValue);
+          if (trimIndexValue == valueInByteArray.length) {
+            alteredValue = value;
+          } else {
+            byte[] shortByteValue = Arrays.copyOf(valueInByteArray, trimIndexValue + 1);
+            shortByteValue[trimIndexValue] = (byte) 0xFF; // assigning the 0xFF to make the value max.
+            alteredValue = BytesUtils.toHexString(shortByteValue);
+          }
         } else {
           alteredValue = BytesUtils.toHexString(
               Arrays.copyOf(BytesUtils.toBytes(value), (METADATA_PROPERTY_LENGTH_LIMIT / 2)));

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -603,16 +603,24 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
   @VisibleForTesting
   static String getValidPropertyValue(String value) {
     int length = value.length();
-    // strip the value if first or last character of the value is whitespace.
-    if (length > 0 && (Character.isWhitespace(value.charAt(0)) || Character.isWhitespace(value.charAt(length - 1)))) {
-      value = value.strip();
-      length = value.length(); // updating the length value after striping
+    if (length > 0) {
+      // check and replace first character if it's a white space
+      if (Character.isWhitespace(value.charAt(0))) {
+        String unicodeValue = "\\u" + String.format("%04x", (int) value.charAt(0));
+        value = unicodeValue + value.substring(1);
+      }
+
+      // check and replace last character if it's a white space
+      if (Character.isWhitespace(value.charAt(value.length() - 1))) {
+        String unicodeValue = "\\u" + String.format("%04x", (int) value.charAt(value.length() - 1));
+        value = value.substring(0, value.length() - 1) + unicodeValue;
+      }
     }
 
     // removing the ',' from the value if it's present.
     if (length > 0 && value.contains(",")) {
-      value = value.replace(",", "");
-      length = value.length(); // updating the length value after removing ','
+      value = value.replace(",", "\\,");
+      length = value.length(); // updating the length value after escaping ','
     }
 
     // taking first m characters of the value if length is greater than METADATA_PROPERTY_LENGTH_LIMIT

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -621,11 +621,11 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
         valueWithinLengthLimit =
             valueWithinLengthLimit.substring(0, valueWithinLengthLimit.length() - 1) + unicodeValue;
       }
-    }
 
-    // removing the ',' from the value if it's present.
-    if (length > 0 && valueWithinLengthLimit.contains(",")) {
-      valueWithinLengthLimit = valueWithinLengthLimit.replace(",", "\\,");
+      // removing the ',' from the value if it's present.
+      if (valueWithinLengthLimit.contains(",")) {
+        valueWithinLengthLimit = valueWithinLengthLimit.replace(",", "\\,");
+      }
     }
 
     return valueWithinLengthLimit;
@@ -657,7 +657,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
     int length = value.length();
 
     // if length is less, no need of trimming the value.
-    if (length < METADATA_PROPERTY_LENGTH_LIMIT) {
+    if (length <= METADATA_PROPERTY_LENGTH_LIMIT) {
       return value;
     }
 
@@ -670,22 +670,14 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
           alteredValue = value.substring(0, METADATA_PROPERTY_LENGTH_LIMIT - 1)
               + (char) (value.charAt(METADATA_PROPERTY_LENGTH_LIMIT - 1) + 1);
         } else {
-          // property type is min value take first METADATA_PROPERTY_LENGTH_LIMIT - 1 characters
-          // and decrement the last character value by 1.
-          alteredValue = value.substring(0, METADATA_PROPERTY_LENGTH_LIMIT - 1)
-              + (char) (value.charAt(METADATA_PROPERTY_LENGTH_LIMIT - 1) - 1);
+          alteredValue = value.substring(0, METADATA_PROPERTY_LENGTH_LIMIT);
         }
         break;
       case BYTES:
-        byte[] shortByteValue = Arrays.copyOf(BytesUtils.toBytes(value),
-            (METADATA_PROPERTY_LENGTH_LIMIT / 2) + 1);
-        char ch;
+        byte[] shortByteValue = Arrays.copyOf(BytesUtils.toBytes(value), (METADATA_PROPERTY_LENGTH_LIMIT / 2));
         if (isMax) {
-          ch = (char) ((char) shortByteValue[METADATA_PROPERTY_LENGTH_LIMIT / 2] + 1);
-        } else {
-          ch = (char) ((char) shortByteValue[METADATA_PROPERTY_LENGTH_LIMIT / 2] - 1);
+          shortByteValue[METADATA_PROPERTY_LENGTH_LIMIT / 2 - 1] += 1;
         }
-        shortByteValue[METADATA_PROPERTY_LENGTH_LIMIT / 2] = (byte) ch;
         alteredValue = BytesUtils.toHexString(shortByteValue);
         break;
       default:

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -665,6 +665,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
     // For Numeric Data Type(INT, LONG, DOUBLE, FLOAT) value longer than METADATA_PROPERTY_LENGTH_LIMIT is not possible.
     switch (dataType) {
       case STRING:
+      case JSON:
         if (isMax) {
           alteredValue = value.substring(0, METADATA_PROPERTY_LENGTH_LIMIT - 1)
               + (char) (value.charAt(METADATA_PROPERTY_LENGTH_LIMIT - 1) + 1);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -667,7 +667,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       case STRING:
       case JSON:
         if (isMax) {
-          alteredValue = value.substring(0, METADATA_PROPERTY_LENGTH_LIMIT - 1) + Character.toString(126);
+          alteredValue = value.substring(0, METADATA_PROPERTY_LENGTH_LIMIT - 1) + 'z';
         } else {
           alteredValue = value.substring(0, METADATA_PROPERTY_LENGTH_LIMIT);
         }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
@@ -44,6 +44,7 @@ import org.apache.pinot.segment.spi.utils.SegmentMetadataUtils;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.BytesUtils;
 
 import static org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -370,7 +371,7 @@ public class ColumnMinMaxValueGenerator {
             }
           }
           SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(_segmentProperties, columnName,
-              String.valueOf(new ByteArray(min)), String.valueOf(new ByteArray(max)), dataType);
+              BytesUtils.toHexString(min), BytesUtils.toHexString(max), dataType);
           }
           break;
         default:

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
@@ -146,39 +146,39 @@ public class ColumnMinMaxValueGenerator {
         case INT:
           try (IntDictionary intDictionary = new IntDictionary(dictionaryBuffer, length)) {
             SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(_segmentProperties, columnName,
-                intDictionary.getStringValue(0), intDictionary.getStringValue(length - 1));
+                intDictionary.getStringValue(0), intDictionary.getStringValue(length - 1), dataType);
           }
           break;
         case LONG:
           try (LongDictionary longDictionary = new LongDictionary(dictionaryBuffer, length)) {
             SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(_segmentProperties, columnName,
-                longDictionary.getStringValue(0), longDictionary.getStringValue(length - 1));
+                longDictionary.getStringValue(0), longDictionary.getStringValue(length - 1), dataType);
           }
           break;
         case FLOAT:
           try (FloatDictionary floatDictionary = new FloatDictionary(dictionaryBuffer, length)) {
             SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(_segmentProperties, columnName,
-                floatDictionary.getStringValue(0), floatDictionary.getStringValue(length - 1));
+                floatDictionary.getStringValue(0), floatDictionary.getStringValue(length - 1), dataType);
           }
           break;
         case DOUBLE:
           try (DoubleDictionary doubleDictionary = new DoubleDictionary(dictionaryBuffer, length)) {
             SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(_segmentProperties, columnName,
-                doubleDictionary.getStringValue(0), doubleDictionary.getStringValue(length - 1));
+                doubleDictionary.getStringValue(0), doubleDictionary.getStringValue(length - 1), dataType);
           }
           break;
         case STRING:
           try (StringDictionary stringDictionary = new StringDictionary(dictionaryBuffer, length,
               columnMetadata.getColumnMaxLength())) {
             SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(_segmentProperties, columnName,
-                stringDictionary.getStringValue(0), stringDictionary.getStringValue(length - 1));
+                stringDictionary.getStringValue(0), stringDictionary.getStringValue(length - 1), dataType);
           }
           break;
         case BYTES:
           try (BytesDictionary bytesDictionary = new BytesDictionary(dictionaryBuffer, length,
               columnMetadata.getColumnMaxLength())) {
             SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(_segmentProperties, columnName,
-                bytesDictionary.getStringValue(0), bytesDictionary.getStringValue(length - 1));
+                bytesDictionary.getStringValue(0), bytesDictionary.getStringValue(length - 1), dataType);
           }
           break;
         default:
@@ -215,7 +215,7 @@ public class ColumnMinMaxValueGenerator {
             }
           }
           SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(_segmentProperties, columnName,
-              String.valueOf(min), String.valueOf(max));
+              String.valueOf(min), String.valueOf(max), dataType);
          }
          break;
         case LONG: {
@@ -243,7 +243,7 @@ public class ColumnMinMaxValueGenerator {
             }
           }
           SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(_segmentProperties, columnName,
-                String.valueOf(min), String.valueOf(max));
+                String.valueOf(min), String.valueOf(max), dataType);
          }
          break;
         case FLOAT: {
@@ -271,7 +271,7 @@ public class ColumnMinMaxValueGenerator {
             }
           }
           SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(_segmentProperties, columnName,
-                String.valueOf(min), String.valueOf(max));
+                String.valueOf(min), String.valueOf(max), dataType);
          }
          break;
         case DOUBLE: {
@@ -299,7 +299,7 @@ public class ColumnMinMaxValueGenerator {
             }
           }
           SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(_segmentProperties, columnName,
-                String.valueOf(min), String.valueOf(max));
+                String.valueOf(min), String.valueOf(max), dataType);
           }
           break;
         case STRING: {
@@ -334,7 +334,7 @@ public class ColumnMinMaxValueGenerator {
                 }
             }
           }
-          SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(_segmentProperties, columnName, min, max);
+          SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(_segmentProperties, columnName, min, max, dataType);
           }
           break;
         case BYTES: {
@@ -370,7 +370,7 @@ public class ColumnMinMaxValueGenerator {
             }
           }
           SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(_segmentProperties, columnName,
-              String.valueOf(new ByteArray(min)), String.valueOf(new ByteArray(max)));
+              String.valueOf(new ByteArray(min)), String.valueOf(new ByteArray(max)), dataType);
           }
           break;
         default:

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreatorTest.java
@@ -243,9 +243,9 @@ public class SegmentColumnarIndexCreatorTest {
     // test for value length grater than METADATA_PROPERTY_LENGTH_LIMIT
     props = new PropertiesConfiguration();
     String stringMinValue = RandomStringUtils.
-        randomAlphabetic(SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT + 3);
+        randomAlphanumeric(SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT + 3);
     String stringMaxValue = RandomStringUtils.
-        randomAlphabetic(SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT + 3);
+        randomAlphanumeric(SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT + 3);
     SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", stringMinValue,
         stringMaxValue, FieldSpec.DataType.STRING);
     compareLongValuesWithColumnMinMax(stringMinValue, stringMaxValue, props, FieldSpec.DataType.STRING);
@@ -294,6 +294,18 @@ public class SegmentColumnarIndexCreatorTest {
     SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", byteMinValueString,
         byteMaxValueString, FieldSpec.DataType.BYTES);
     compareLongValuesWithColumnMinMax(byteMinValueString, byteMaxValueString, props, FieldSpec.DataType.BYTES);
+
+    // Byte value test with overflow condition at index 255
+    props = new PropertiesConfiguration();
+    byte[] byteMaxValueWithOverflowCondition = new byte[SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT + 3];
+    random.nextBytes(byteMinValue);
+    random.nextBytes(byteMaxValue);
+    byteMaxValueWithOverflowCondition[SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT / 2 - 1] = (byte) 127;
+    String byteMaxValueWithOverflowConditionString = BytesUtils.toHexString(byteMaxValueWithOverflowCondition);
+    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", byteMinValueString,
+        byteMaxValueWithOverflowConditionString, FieldSpec.DataType.BYTES);
+    compareLongValuesWithColumnMinMax(byteMinValueString, byteMaxValueWithOverflowConditionString,
+        props, FieldSpec.DataType.BYTES);
   }
 
   private void compareLongValuesWithColumnMinMax(String longMinValue, String longMaxValue,

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/SegmentGenerationWithMinMaxTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/SegmentGenerationWithMinMaxTest.java
@@ -40,17 +40,17 @@ import org.testng.annotations.Test;
 /**
  * Tests filtering of records during segment generation
  */
-public class SegmentGenerationWithMinMaxInvalidTest {
+public class SegmentGenerationWithMinMaxTest {
   private static final String STRING_COLUMN = "col1";
-  private static final String[] STRING_VALUES_INVALID = {"A,", "B,", "C,", "D,", "E"};
+  private static final String[] STRING_VALUES_WITH_UNALLOWED_CHARACTER = {"A,", "B,", "C,", "D,", "E "};
   private static final String[] STRING_VALUES_VALID = {"A", "B", "C", "D", "E"};
   private static final String LONG_COLUMN = "col2";
   private static final long[] LONG_VALUES =
       {1588316400000L, 1588489200000L, 1588662000000L, 1588834800000L, 1589007600000L};
 
   private static final String SEGMENT_DIR_NAME =
-      FileUtils.getTempDirectoryPath() + File.separator + "segmentMinMaxInvalidTest";
-  private static final String SEGMENT_NAME = "testSegmentMinMaxInvalid";
+      FileUtils.getTempDirectoryPath() + File.separator + "segmentMinMaxTest";
+  private static final String SEGMENT_NAME = "testSegmentMinMax";
 
   private Schema _schema;
   private TableConfig _tableConfig;
@@ -63,7 +63,7 @@ public class SegmentGenerationWithMinMaxInvalidTest {
   }
 
   @Test
-  public void testMinMaxInvalidFlagInMetadata()
+  public void testMinMaxInMetadata()
       throws Exception {
     FileUtils.deleteQuietly(new File(SEGMENT_DIR_NAME));
     File segmentDir = buildSegment(_tableConfig, _schema, STRING_VALUES_VALID);
@@ -74,12 +74,12 @@ public class SegmentGenerationWithMinMaxInvalidTest {
     Assert.assertEquals(metadata.getColumnMetadataFor("col1").getMaxValue(), "E");
 
     FileUtils.deleteQuietly(new File(SEGMENT_DIR_NAME));
-    segmentDir = buildSegment(_tableConfig, _schema, STRING_VALUES_INVALID);
+    segmentDir = buildSegment(_tableConfig, _schema, STRING_VALUES_WITH_UNALLOWED_CHARACTER);
     metadata = new SegmentMetadataImpl(segmentDir);
     Assert.assertEquals(metadata.getTotalDocs(), 5);
-    Assert.assertTrue(metadata.getColumnMetadataFor("col1").isMinMaxValueInvalid());
-    Assert.assertNull(metadata.getColumnMetadataFor("col1").getMinValue());
-    Assert.assertNull(metadata.getColumnMetadataFor("col1").getMaxValue());
+    Assert.assertFalse(metadata.getColumnMetadataFor("col1").isMinMaxValueInvalid());
+    Assert.assertEquals(metadata.getColumnMetadataFor("col1").getMinValue(), "A");
+    Assert.assertEquals(metadata.getColumnMetadataFor("col1").getMaxValue(), "E");
   }
 
   private File buildSegment(final TableConfig tableConfig, final Schema schema, String[] stringValues)

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/SegmentGenerationWithMinMaxTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/creator/SegmentGenerationWithMinMaxTest.java
@@ -42,7 +42,8 @@ import org.testng.annotations.Test;
  */
 public class SegmentGenerationWithMinMaxTest {
   private static final String STRING_COLUMN = "col1";
-  private static final String[] STRING_VALUES_WITH_UNALLOWED_CHARACTER = {"A,", "B,", "C,", "D,", "E "};
+  private static final String[] STRING_VALUES_WITH_COMMA_CHARACTER = {"A,,", ",B,", "C,Z,", "D,", "E,"};
+  private static final String[] STRING_VALUES_WITH_WHITESPACE_CHARACTERS = {"A ", " B ", "  Z ", "  \r D", "E"};
   private static final String[] STRING_VALUES_VALID = {"A", "B", "C", "D", "E"};
   private static final String LONG_COLUMN = "col2";
   private static final long[] LONG_VALUES =
@@ -74,11 +75,19 @@ public class SegmentGenerationWithMinMaxTest {
     Assert.assertEquals(metadata.getColumnMetadataFor("col1").getMaxValue(), "E");
 
     FileUtils.deleteQuietly(new File(SEGMENT_DIR_NAME));
-    segmentDir = buildSegment(_tableConfig, _schema, STRING_VALUES_WITH_UNALLOWED_CHARACTER);
+    segmentDir = buildSegment(_tableConfig, _schema, STRING_VALUES_WITH_COMMA_CHARACTER);
     metadata = new SegmentMetadataImpl(segmentDir);
     Assert.assertEquals(metadata.getTotalDocs(), 5);
     Assert.assertFalse(metadata.getColumnMetadataFor("col1").isMinMaxValueInvalid());
-    Assert.assertEquals(metadata.getColumnMetadataFor("col1").getMinValue(), "A");
+    Assert.assertEquals(metadata.getColumnMetadataFor("col1").getMinValue(), ",B,");
+    Assert.assertEquals(metadata.getColumnMetadataFor("col1").getMaxValue(), "E,");
+
+    FileUtils.deleteQuietly(new File(SEGMENT_DIR_NAME));
+    segmentDir = buildSegment(_tableConfig, _schema, STRING_VALUES_WITH_WHITESPACE_CHARACTERS);
+    metadata = new SegmentMetadataImpl(segmentDir);
+    Assert.assertEquals(metadata.getTotalDocs(), 5);
+    Assert.assertFalse(metadata.getColumnMetadataFor("col1").isMinMaxValueInvalid());
+    Assert.assertEquals(metadata.getColumnMetadataFor("col1").getMinValue(), "  \r D");
     Assert.assertEquals(metadata.getColumnMetadataFor("col1").getMaxValue(), "E");
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
@@ -251,8 +251,10 @@ public class ColumnMetadataImpl implements ColumnMetadata {
     // NOTE: Use getProperty() instead of getString() to avoid variable substitution ('${anotherKey}'), which can cause
     //       problem for special values such as '$${' where the first '$' is identified as escape character.
     // TODO: Use getProperty() for other properties as well to avoid the overhead of variable substitution
-    String minString = (String) config.getProperty(Column.getKeyFor(column, Column.MIN_VALUE));
-    String maxString = (String) config.getProperty(Column.getKeyFor(column, Column.MAX_VALUE));
+    String minString = StringEscapeUtils.unescapeJava((String)
+        config.getProperty(Column.getKeyFor(column, Column.MIN_VALUE)));
+    String maxString = StringEscapeUtils.unescapeJava((String)
+        config.getProperty(Column.getKeyFor(column, Column.MAX_VALUE)));
     if (minString != null && maxString != null) {
       switch (dataType.getStoredType()) {
         case INT:


### PR DESCRIPTION
Previously, we skipped to set the value for min/max if the value was invalid. We were determining invalid values based on the following checks 
- If value contains leading or trailing whitespace character.
- if the value contains `,`
- if the value length is greater than 512.


Changes in this PR are intended to ensure we will set the value of the segment's min/max property. It's part of the fix for the [issue](10793) and as per the discussion in the other [PR](https://github.com/apache/pinot/pull/10891)

cc: @Jackie-Jiang 
