### PR TITLE
[enhance]: When enable case-insensitive, don't allow to add newly col…

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSchemaRestletResource.java
@@ -359,7 +359,8 @@ public class PinotSchemaRestletResource {
     validateSchemaName(schema.getSchemaName());
     try {
       List<TableConfig> tableConfigs = _pinotHelixResourceManager.getTableConfigsForSchema(schema.getSchemaName());
-      SchemaUtils.validate(schema, tableConfigs);
+      boolean isIgnoreCase = _pinotHelixResourceManager.getTableCache().isIgnoreCase();
+      SchemaUtils.validate(schema, tableConfigs, isIgnoreCase);
     } catch (Exception e) {
       throw new ControllerApplicationException(LOGGER,
           "Invalid schema: " + schema.getSchemaName() + ". Reason: " + e.getMessage(), Response.Status.BAD_REQUEST, e);

--- a/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/util/SchemaUtilsTest.java
@@ -249,6 +249,19 @@ public class SchemaUtilsTest {
   }
 
   @Test
+  public void testValidateCaseInsensitive() {
+    Schema pinotSchema;
+    pinotSchema =
+      new Schema.SchemaBuilder().addTime(new TimeGranularitySpec(DataType.LONG, TimeUnit.MILLISECONDS, "incoming"),
+          new TimeGranularitySpec(DataType.INT, TimeUnit.DAYS, "outgoing"))
+        .addSingleValueDimension("dim1", DataType.INT)
+        .addSingleValueDimension("Dim1", DataType.INT)
+        .build();
+
+    checkValidationFails(pinotSchema, true);
+  }
+
+  @Test
   public void testValidatePrimaryKeyColumns() {
     Schema pinotSchema;
     // non-existing column used as primary key
@@ -416,12 +429,16 @@ public class SchemaUtilsTest {
     checkValidationFails(pinotSchema);
   }
 
-  private void checkValidationFails(Schema pinotSchema) {
+  private void checkValidationFails(Schema pinotSchema, boolean isIgnoreCase) {
     try {
-      SchemaUtils.validate(pinotSchema);
+      SchemaUtils.validate(pinotSchema, isIgnoreCase);
       Assert.fail("Schema validation should have failed.");
     } catch (IllegalArgumentException | IllegalStateException e) {
       // expected
     }
+  }
+
+  private void checkValidationFails(Schema pinotSchema) {
+    checkValidationFails(pinotSchema, false);
   }
 }


### PR DESCRIPTION
Even though we enabled case-insensitive，we found a potential risk in some occasions. My two colleagues want to add one column to the same table in the same pinot environment. But theirs naming style is different. One person add name callType, another person add CallType, and they all succeed. Because we've already enabled case-insensitive option, so they us all could query from Controller UI and no one found potential risk. But one of clients report an incident, they can't query from Trino, it will report Multi Entries error.
![image](https://github.com/apache/pinot/assets/38196564/3be2d573-3790-4ab7-bbbb-3bfe35935e76)

In my opinion, after we enabled case insensitive, we should't allow user to add the same lowercase column with existed columns. because two column that have the same lowercase name is meaningless.
Waiting for someone to review!