### PR TITLE
add support for mv cols with realtime lucene index

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableTextIndex.java
@@ -83,6 +83,11 @@ public class NativeMutableTextIndex implements MutableTextIndex {
   }
 
   @Override
+  public void add(String[] document) {
+    throw new UnsupportedOperationException("Mutable native text indexes are not supported for multi-valued columns");
+  }
+
+  @Override
   public ImmutableRoaringBitmap getDictIds(String searchQuery) {
     throw new UnsupportedOperationException();
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableTextIndex.java
@@ -83,7 +83,7 @@ public class NativeMutableTextIndex implements MutableTextIndex {
   }
 
   @Override
-  public void add(String[] document) {
+  public void add(String[] documents) {
     throw new UnsupportedOperationException("Mutable native text indexes are not supported for multi-valued columns");
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
@@ -93,6 +93,14 @@ public class RealtimeLuceneTextIndex implements MutableTextIndex {
     _indexCreator.add(document);
   }
 
+  /**
+   * Adds a new document, made up of multiple values.
+   */
+  @Override
+  public void add(String[] document) {
+    _indexCreator.add(document, document.length);
+  }
+
   @Override
   public ImmutableRoaringBitmap getDictIds(String searchQuery) {
     throw new UnsupportedOperationException();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
@@ -97,8 +97,8 @@ public class RealtimeLuceneTextIndex implements MutableTextIndex {
    * Adds a new document, made up of multiple values.
    */
   @Override
-  public void add(String[] document) {
-    _indexCreator.add(document, document.length);
+  public void add(String[] documents) {
+    _indexCreator.add(documents, documents.length);
   }
 
   @Override

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -28,47 +28,45 @@ import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
 
+
 public class LuceneMutableTextIndexTest {
-    private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "LuceneMutableIndexTest");
-    private static final String TEXT_COLUMN_NAME = "testColumnName";
+  private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "LuceneMutableIndexTest");
+  private static final String TEXT_COLUMN_NAME = "testColumnName";
 
-    private RealtimeLuceneTextIndex _realtimeLuceneTextIndex;
+  private RealtimeLuceneTextIndex _realtimeLuceneTextIndex;
 
-    private String[][] getTextData() {
-        return new String[][]{{"realtime stream processing"}, {"publish subscribe",
-                "columnar processing for data warehouses", "concurrency"}};
+  private String[][] getTextData() {
+    return new String[][]{
+        {"realtime stream processing"}, {"publish subscribe", "columnar processing for data warehouses", "concurrency"}
+    };
+  }
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    _realtimeLuceneTextIndex = new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null);
+    String[][] documents = getTextData();
+    for (String[] row : documents) {
+      _realtimeLuceneTextIndex.add(row);
     }
 
-    @BeforeClass
-    public void setUp()
-            throws Exception {
-        _realtimeLuceneTextIndex = new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null,
-                null);
-        String[][] documents = getTextData();
-        for (String[] row : documents) {
-            _realtimeLuceneTextIndex.add(row);
-        }
-
-        SearcherManager searcherManager = _realtimeLuceneTextIndex.getSearcherManager();
-        try {
-            searcherManager.maybeRefresh();
-        } catch (Exception e) {
-            throw new RuntimeException(e);
-        }
+    SearcherManager searcherManager = _realtimeLuceneTextIndex.getSearcherManager();
+    try {
+      searcherManager.maybeRefresh();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
     }
+  }
 
-    @AfterClass
-    public void tearDown() {
-        _realtimeLuceneTextIndex.close();
-    }
+  @AfterClass
+  public void tearDown() {
+    _realtimeLuceneTextIndex.close();
+  }
 
-    @Test
-    public void testQueries() {
-        assertEquals(_realtimeLuceneTextIndex.getDocIds("stream"),
-                ImmutableRoaringBitmap.bitmapOf(0));
-        assertEquals(_realtimeLuceneTextIndex.getDocIds("/.*house.*/"),
-                ImmutableRoaringBitmap.bitmapOf(1));
-        assertEquals(_realtimeLuceneTextIndex.getDocIds("invalid"),
-                ImmutableRoaringBitmap.bitmapOf());
-    }
+  @Test
+  public void testQueries() {
+    assertEquals(_realtimeLuceneTextIndex.getDocIds("stream"), ImmutableRoaringBitmap.bitmapOf(0));
+    assertEquals(_realtimeLuceneTextIndex.getDocIds("/.*house.*/"), ImmutableRoaringBitmap.bitmapOf(1));
+    assertEquals(_realtimeLuceneTextIndex.getDocIds("invalid"), ImmutableRoaringBitmap.bitmapOf());
+  }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -1,0 +1,74 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.realtime.impl.invertedindex;
+
+import java.io.File;
+import org.apache.commons.io.FileUtils;
+import org.apache.lucene.search.SearcherManager;
+import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class LuceneMutableTextIndexTest {
+    private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "LuceneMutableIndexTest");
+    private static final String TEXT_COLUMN_NAME = "testColumnName";
+
+    private RealtimeLuceneTextIndex _realtimeLuceneTextIndex;
+
+    private String[][] getTextData() {
+        return new String[][]{{"realtime stream processing"}, {"publish subscribe",
+                "columnar processing for data warehouses", "concurrency"}};
+    }
+
+    @BeforeClass
+    public void setUp()
+            throws Exception {
+        _realtimeLuceneTextIndex = new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null,
+                null);
+        String[][] documents = getTextData();
+        for (String[] row : documents) {
+            _realtimeLuceneTextIndex.add(row);
+        }
+
+        SearcherManager searcherManager = _realtimeLuceneTextIndex.getSearcherManager();
+        try {
+            searcherManager.maybeRefresh();
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @AfterClass
+    public void tearDown() {
+        _realtimeLuceneTextIndex.close();
+    }
+
+    @Test
+    public void testQueries() {
+        assertEquals(_realtimeLuceneTextIndex.getDocIds("stream"),
+                ImmutableRoaringBitmap.bitmapOf(0));
+        assertEquals(_realtimeLuceneTextIndex.getDocIds("/.*house.*/"),
+                ImmutableRoaringBitmap.bitmapOf(1));
+        assertEquals(_realtimeLuceneTextIndex.getDocIds("invalid"),
+                ImmutableRoaringBitmap.bitmapOf());
+    }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/MutableTextIndex.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/MutableTextIndex.java
@@ -31,7 +31,17 @@ public interface MutableTextIndex extends TextIndexReader, MutableIndex {
 
   @Override
   default void add(@Nonnull Object[] values, @Nullable int[] dictIds, int docId) {
-    add((String[]) values);
+    if (values instanceof String[]) {
+      add((String[]) values);
+      return;
+    }
+
+    int length = values.length;
+    String[] strings = new String[length];
+    for (int i = 0; i < length; i++) {
+      strings[i] = (String) values[i];
+    }
+    add(strings);
   }
 
   /**
@@ -42,7 +52,7 @@ public interface MutableTextIndex extends TextIndexReader, MutableIndex {
 
   /**
    * Index the multi-value document
-   * @param document the document as an array of Strings
+   * @param documents the documents as an array of strings
    */
-  void add(String[] document);
+  void add(String[] documents);
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/MutableTextIndex.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/mutable/MutableTextIndex.java
@@ -31,7 +31,7 @@ public interface MutableTextIndex extends TextIndexReader, MutableIndex {
 
   @Override
   default void add(@Nonnull Object[] values, @Nullable int[] dictIds, int docId) {
-    throw new UnsupportedOperationException("Mutable text indexes are not supported for multi-valued columns");
+    add((String[]) values);
   }
 
   /**
@@ -39,4 +39,10 @@ public interface MutableTextIndex extends TextIndexReader, MutableIndex {
    * @param document the document as a string
    */
   void add(String document);
+
+  /**
+   * Index the multi-value document
+   * @param document the document as an array of Strings
+   */
+  void add(String[] document);
 }


### PR DESCRIPTION
Adds support to build lucene text index in the mutable segment for MV cols

addresses: https://github.com/apache/pinot/issues/10975
