### PR TITLE
`bugfix` Fix issue with extracting root-level field names for complex handling

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -328,7 +328,7 @@ public final class IngestionUtils {
     String delimiter = complexTypeConfig.getDelimiter() == null ? ComplexTypeTransformer.DEFAULT_DELIMITER
         : complexTypeConfig.getDelimiter();
     for (String field : fieldsToRead) {
-      result.add(StringUtils.split(field, delimiter)[0]);
+      result.add(StringUtils.splitByWholeSeparator(field, delimiter)[0]);
     }
     return result;
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IngestionUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/IngestionUtilsTest.java
@@ -233,4 +233,20 @@ public class IngestionUtilsTest {
     Assert.assertEquals(fields.size(), 1);
     Assert.assertTrue(fields.containsAll(Sets.newHashSet("s1")));
   }
+
+  @Test
+  public void testComplexTypeConfig() {
+    IngestionConfig ingestionConfig = new IngestionConfig();
+    ComplexTypeConfig complexTypeConfig = new ComplexTypeConfig(null, "__",
+        ComplexTypeConfig.CollectionNotUnnestedToJson.NON_PRIMITIVE, null);
+    Schema schema = new Schema();
+
+    ingestionConfig.setComplexTypeConfig(complexTypeConfig);
+    schema.addField(new DimensionFieldSpec("a_b__c_d", FieldSpec.DataType.STRING, true));
+    schema.addField(new DimensionFieldSpec("f_d", FieldSpec.DataType.STRING, false));
+    schema.addField(new DimensionFieldSpec("ab__cd", FieldSpec.DataType.STRING, true));
+    Set<String> fields = IngestionUtils.getFieldsForRecordExtractor(ingestionConfig, schema);
+    Assert.assertEquals(fields.size(), 3);
+    Assert.assertTrue(fields.containsAll(Sets.newHashSet("a_b", "f_d", "ab")));
+  }
 }


### PR DESCRIPTION
`org.apache.pinot.plugin.inputformat.avro.AvroUtils.getPinotSchemaFromAvroSchemaWithComplexTypeHandling` generates a flattened schema from a complex schema. 
Given a record field 
```
"a_b" : {
            "c_d"
}
```
the flattened generated schema with a delimiter `__` is a flattened column with name `a_b__c_d`. IngestionUtils.getFieldsToReadWithComplexType() is expected to return the original root-level field but returns `a`

If column names contain the same characters as a repeating delimiter, the root level field name is only extracted wrong.
For example if a column name is `a_b` and the delimiter is `__`, the extracted root level field name is `a`. We want `a_b`.
Similarly for `a_b__e_d`, the extracted root level field name is `a` and for `a_b_D_c_d` and a delimiter `_D_` will extract `a`.


This fix extracts the correct root level column name.