### PR TITLE
Add CLPDecodeRewriter to make it easier to call clpDecode with a column-group name rather than the individual columns.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CLPDecodeRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CLPDecodeRewriter.java
@@ -1,0 +1,176 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.common.request.Expression;
+import org.apache.pinot.common.request.ExpressionType;
+import org.apache.pinot.common.request.Function;
+import org.apache.pinot.common.request.Identifier;
+import org.apache.pinot.common.request.Literal;
+import org.apache.pinot.common.request.PinotQuery;
+import org.apache.pinot.sql.parsers.SqlCompilationException;
+
+
+/**
+ * Query rewriter to rewrite clpDecode so that users can pass in the name of a CLP-encoded column group instead of the
+ * names of all the columns in the group.
+ * <p>
+ * Usage:
+ * <pre>
+ *   clpDecode("columnGroupName"[, defaultValue])
+ * </pre>
+ * which will be rewritten to:
+ * <pre>
+ *   clpDecode("columnGroupName_logtype", "columnGroupName_dictionaryVars", "columnGroupName_encodedVars"[,
+ *   defaultValue])
+ * </pre>
+ * The "defaultValue" is optional. See
+ * {@link org.apache.pinot.core.operator.transform.function.CLPDecodeTransformFunction} for its description.
+ * <p>
+ * Sample queries:
+ * <pre>
+ *   SELECT clpDecode("message") FROM table
+ *   SELECT clpDecode("message", 'null') FROM table
+ * </pre>
+ * See {@link org.apache.pinot.core.operator.transform.function.CLPDecodeTransformFunction} for details about the
+ * underlying clpDecode transformer.
+ */
+public class CLPDecodeRewriter implements QueryRewriter {
+  public static final String LOGTYPE_COLUMN_SUFFIX = "_logtype";
+  public static final String DICTIONARY_VARS_COLUMN_SUFFIX = "_dictionaryVars";
+  public static final String ENCODED_VARS_COLUMN_SUFFIX = "_encodedVars";
+
+  private static final String _CLPDECODE_LOWERCASE_TRANSFORM_NAME =
+      TransformFunctionType.CLPDECODE.getName().toLowerCase();
+
+  @Override
+  public PinotQuery rewrite(PinotQuery pinotQuery) {
+    List<Expression> selectExpressions = pinotQuery.getSelectList();
+    if (null != selectExpressions) {
+      for (Expression e : selectExpressions) {
+        tryRewritingExpression(e);
+      }
+    }
+    List<Expression> groupByExpressions = pinotQuery.getGroupByList();
+    if (null != groupByExpressions) {
+      for (Expression e : groupByExpressions) {
+        tryRewritingExpression(e);
+      }
+    }
+    List<Expression> orderByExpressions = pinotQuery.getOrderByList();
+    if (null != orderByExpressions) {
+      for (Expression e : orderByExpressions) {
+        tryRewritingExpression(e);
+      }
+    }
+    tryRewritingExpression(pinotQuery.getFilterExpression());
+    tryRewritingExpression(pinotQuery.getHavingExpression());
+    return pinotQuery;
+  }
+
+  /**
+   * Rewrites any instances of clpDecode in the given expression
+   * @param expression Expression which may contain instances of clpDecode
+   */
+  private void tryRewritingExpression(Expression expression) {
+    if (null == expression) {
+      return;
+    }
+    Function function = expression.getFunctionCall();
+    if (null == function) {
+      return;
+    }
+
+    String functionName = function.getOperator();
+    if (functionName.equals(_CLPDECODE_LOWERCASE_TRANSFORM_NAME)) {
+      rewriteCLPDecodeFunction(expression);
+    } else {
+      // Function isn't a CLP function that needs rewriting, but the arguments might be, so we recursively process them.
+      for (Expression op : function.getOperands()) {
+        tryRewritingExpression(op);
+      }
+    }
+  }
+
+  /**
+   * Rewrites the given instance of clpDecode as described in the class docstring
+   * @param expression clpDecode function expression
+   */
+  private void rewriteCLPDecodeFunction(Expression expression) {
+    Function function = expression.getFunctionCall();
+    List<Expression> arguments = function.getOperands();
+
+    // Validate clpDecode's arguments
+    int numArgs = arguments.size();
+    if (numArgs < 1 || numArgs > 2) {
+      // Too few/many args for this rewriter, so do nothing and let it pass through to the clpDecode transform function
+      return;
+    }
+
+    Expression arg0 = arguments.get(0);
+    if (ExpressionType.IDENTIFIER != arg0.getType()) {
+      throw new SqlCompilationException("clpDecode: 1st argument must be a column group name (identifier).");
+    }
+    String columnGroupName = arg0.getIdentifier().getName();
+
+    Literal defaultValueLiteral = null;
+    if (numArgs > 1) {
+      Expression arg1 = arguments.get(1);
+      if (ExpressionType.LITERAL != arg1.getType()) {
+        throw new SqlCompilationException("clpDecode: 2nd argument must be a default value (literal).");
+      }
+      defaultValueLiteral = arg1.getLiteral();
+    }
+
+    // Replace the columnGroup with the individual columns
+    arguments.clear();
+    addCLPDecodeOperands(columnGroupName, defaultValueLiteral, function);
+  }
+
+  /**
+   * Adds the CLPDecode transform function's operands to the given function
+   * @param columnGroupName Name of the CLP-encoded column group
+   * @param defaultValueLiteral Optional default value to pass through to the transform function
+   * @param clpDecode The function to add the operands to
+   */
+  private void addCLPDecodeOperands(String columnGroupName, @Nullable Literal defaultValueLiteral, Function clpDecode) {
+    Expression e;
+
+    e = new Expression(ExpressionType.IDENTIFIER);
+    e.setIdentifier(new Identifier(columnGroupName + LOGTYPE_COLUMN_SUFFIX));
+    clpDecode.addToOperands(e);
+
+    e = new Expression(ExpressionType.IDENTIFIER);
+    e.setIdentifier(new Identifier(columnGroupName + DICTIONARY_VARS_COLUMN_SUFFIX));
+    clpDecode.addToOperands(e);
+
+    e = new Expression(ExpressionType.IDENTIFIER);
+    e.setIdentifier(new Identifier(columnGroupName + ENCODED_VARS_COLUMN_SUFFIX));
+    clpDecode.addToOperands(e);
+
+    if (null != defaultValueLiteral) {
+      e = new Expression(ExpressionType.LITERAL);
+      e.setLiteral(defaultValueLiteral);
+      clpDecode.addToOperands(e);
+    }
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CLPDecodeRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CLPDecodeRewriter.java
@@ -103,16 +103,17 @@ public class CLPDecodeRewriter implements QueryRewriter {
     String functionName = function.getOperator();
     if (functionName.equals(_CLPDECODE_LOWERCASE_TRANSFORM_NAME)) {
       rewriteCLPDecodeFunction(expression);
-    } else {
-      // Function isn't a CLP function that needs rewriting, but the arguments might be, so we recursively process them.
-      for (Expression op : function.getOperands()) {
-        tryRewritingExpression(op);
-      }
+      return;
+    }
+
+    // Function isn't a CLP function that needs rewriting, but the arguments might be, so we recursively process them.
+    for (Expression op : function.getOperands()) {
+      tryRewritingExpression(op);
     }
   }
 
   /**
-   * Rewrites the given instance of clpDecode as described in the class docstring
+   * Rewrites the given instance of clpDecode as described in the class' Javadoc
    * @param expression clpDecode function expression
    */
   private void rewriteCLPDecodeFunction(Expression expression) {

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/CLPDecodeRewriterTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/CLPDecodeRewriterTest.java
@@ -1,0 +1,65 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.sql.parsers.rewriter;
+
+import org.apache.pinot.sql.parsers.CalciteSqlParser;
+import org.apache.pinot.sql.parsers.SqlCompilationException;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+
+public class CLPDecodeRewriterTest {
+  private static final QueryRewriter _QUERY_REWRITER = new CLPDecodeRewriter();
+
+  @Test
+  public void testCLPDecodeRewrite() {
+    // clpDecode rewrite from column group to individual columns
+    testQueryRewrite("SELECT clpDecode(message) FROM clpTable",
+        "SELECT clpDecode(message_logtype, message_dictionaryVars, message_encodedVars) FROM clpTable");
+    testQueryRewrite("SELECT clpDecode(message, 'null') FROM clpTable",
+        "SELECT clpDecode(message_logtype, message_dictionaryVars, message_encodedVars, 'null') FROM clpTable");
+
+    // clpDecode passthrough
+    testQueryRewrite("SELECT clpDecode(message_logtype, message_dictionaryVars, message_encodedVars) FROM clpTable",
+        "SELECT clpDecode(message_logtype, message_dictionaryVars, message_encodedVars) FROM clpTable");
+    testQueryRewrite(
+        "SELECT clpDecode(message_logtype, message_dictionaryVars, message_encodedVars, 'null') FROM clpTable",
+        "SELECT clpDecode(message_logtype, message_dictionaryVars, message_encodedVars, 'null') FROM clpTable");
+  }
+
+  @Test
+  public void testUnsupportedCLPDecodeQueries() {
+    testUnsupportedQuery("SELECT clpDecode('message') FROM clpTable");
+    testUnsupportedQuery("SELECT clpDecode('message', 'default') FROM clpTable");
+    testUnsupportedQuery("SELECT clpDecode('message', default) FROM clpTable");
+    testUnsupportedQuery("SELECT clpDecode(message, default) FROM clpTable");
+  }
+
+  private void testQueryRewrite(String original, String expected) {
+    assertEquals(_QUERY_REWRITER.rewrite(CalciteSqlParser.compileToPinotQuery(original)),
+        CalciteSqlParser.compileToPinotQuery(expected));
+  }
+
+  private void testUnsupportedQuery(String query) {
+     assertThrows(SqlCompilationException.class,
+        () -> _QUERY_REWRITER.rewrite(CalciteSqlParser.compileToPinotQuery(query)));
+  }
+}

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/pom.xml
@@ -42,5 +42,9 @@
       <groupId>com.yscope.clp</groupId>
       <artifactId>clp-ffi</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-common</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractor.java
@@ -30,12 +30,9 @@ import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.readers.BaseRecordExtractor;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordExtractorConfig;
+import org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import static org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter.DICTIONARY_VARS_COLUMN_SUFFIX;
-import static org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter.ENCODED_VARS_COLUMN_SUFFIX;
-import static org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter.LOGTYPE_COLUMN_SUFFIX;
 
 
 /**
@@ -162,8 +159,8 @@ public class CLPLogRecordExtractor extends BaseRecordExtractor<Map<String, Objec
       }
     }
 
-    to.putValue(key + LOGTYPE_COLUMN_SUFFIX, logtype);
-    to.putValue(key + DICTIONARY_VARS_COLUMN_SUFFIX, dictVars);
-    to.putValue(key + ENCODED_VARS_COLUMN_SUFFIX, encodedVars);
+    to.putValue(key + CLPDecodeRewriter.LOGTYPE_COLUMN_SUFFIX, logtype);
+    to.putValue(key + CLPDecodeRewriter.DICTIONARY_VARS_COLUMN_SUFFIX, dictVars);
+    to.putValue(key + CLPDecodeRewriter.ENCODED_VARS_COLUMN_SUFFIX, encodedVars);
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/main/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractor.java
@@ -33,6 +33,10 @@ import org.apache.pinot.spi.data.readers.RecordExtractorConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import static org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter.DICTIONARY_VARS_COLUMN_SUFFIX;
+import static org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter.ENCODED_VARS_COLUMN_SUFFIX;
+import static org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter.LOGTYPE_COLUMN_SUFFIX;
+
 
 /**
  * A record extractor for log events. For configuration options, see {@link CLPLogRecordExtractorConfig}. This is an
@@ -62,10 +66,6 @@ import org.slf4j.LoggerFactory;
  * This class' implementation is based on {@link org.apache.pinot.plugin.inputformat.json.JSONRecordExtractor}.
  */
 public class CLPLogRecordExtractor extends BaseRecordExtractor<Map<String, Object>> {
-  public static final String LOGTYPE_COLUMN_SUFFIX = "_logtype";
-  public static final String DICTIONARY_VARS_COLUMN_SUFFIX = "_dictionaryVars";
-  public static final String ENCODED_VARS_COLUMN_SUFFIX = "_encodedVars";
-
   private static final Logger LOGGER = LoggerFactory.getLogger(CLPLogRecordExtractor.class);
 
   private Set<String> _fields;

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/test/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/test/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorTest.java
@@ -27,13 +27,11 @@ import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter;
 import org.testng.annotations.Test;
 
 import static org.apache.pinot.plugin.inputformat.clplog.CLPLogRecordExtractorConfig.FIELDS_FOR_CLP_ENCODING_CONFIG_KEY;
 import static org.apache.pinot.plugin.inputformat.clplog.CLPLogRecordExtractorConfig.FIELDS_FOR_CLP_ENCODING_SEPARATOR;
-import static org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter.DICTIONARY_VARS_COLUMN_SUFFIX;
-import static org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter.ENCODED_VARS_COLUMN_SUFFIX;
-import static org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter.LOGTYPE_COLUMN_SUFFIX;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;
@@ -138,9 +136,9 @@ public class CLPLogRecordExtractorTest {
   }
 
   private void addCLPEncodedField(String fieldName, Set<String> fields) {
-    fields.add(fieldName + LOGTYPE_COLUMN_SUFFIX);
-    fields.add(fieldName + DICTIONARY_VARS_COLUMN_SUFFIX);
-    fields.add(fieldName + ENCODED_VARS_COLUMN_SUFFIX);
+    fields.add(fieldName + CLPDecodeRewriter.LOGTYPE_COLUMN_SUFFIX);
+    fields.add(fieldName + CLPDecodeRewriter.DICTIONARY_VARS_COLUMN_SUFFIX);
+    fields.add(fieldName + CLPDecodeRewriter.ENCODED_VARS_COLUMN_SUFFIX);
   }
 
   private GenericRow extract(Map<String, String> props, Set<String> fieldsToRead) {
@@ -165,12 +163,12 @@ public class CLPLogRecordExtractorTest {
     try {
       // Decode and validate field
       assertNull(row.getValue(fieldName));
-      String logtype = (String) row.getValue(fieldName + LOGTYPE_COLUMN_SUFFIX);
+      String logtype = (String) row.getValue(fieldName + CLPDecodeRewriter.LOGTYPE_COLUMN_SUFFIX);
       assertNotEquals(logtype, null);
       String[] dictionaryVars =
-          (String[]) row.getValue(fieldName + DICTIONARY_VARS_COLUMN_SUFFIX);
+          (String[]) row.getValue(fieldName + CLPDecodeRewriter.DICTIONARY_VARS_COLUMN_SUFFIX);
       assertNotEquals(dictionaryVars, null);
-      Long[] encodedVars = (Long[]) row.getValue(fieldName + ENCODED_VARS_COLUMN_SUFFIX);
+      Long[] encodedVars = (Long[]) row.getValue(fieldName + CLPDecodeRewriter.ENCODED_VARS_COLUMN_SUFFIX);
       assertNotEquals(encodedVars, null);
       long[] encodedVarsAsPrimitives = Arrays.stream(encodedVars).mapToLong(Long::longValue).toArray();
 

--- a/pinot-plugins/pinot-input-format/pinot-clp-log/src/test/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-clp-log/src/test/java/org/apache/pinot/plugin/inputformat/clplog/CLPLogRecordExtractorTest.java
@@ -29,11 +29,11 @@ import java.util.Set;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.plugin.inputformat.clplog.CLPLogRecordExtractor.DICTIONARY_VARS_COLUMN_SUFFIX;
-import static org.apache.pinot.plugin.inputformat.clplog.CLPLogRecordExtractor.ENCODED_VARS_COLUMN_SUFFIX;
-import static org.apache.pinot.plugin.inputformat.clplog.CLPLogRecordExtractor.LOGTYPE_COLUMN_SUFFIX;
 import static org.apache.pinot.plugin.inputformat.clplog.CLPLogRecordExtractorConfig.FIELDS_FOR_CLP_ENCODING_CONFIG_KEY;
 import static org.apache.pinot.plugin.inputformat.clplog.CLPLogRecordExtractorConfig.FIELDS_FOR_CLP_ENCODING_SEPARATOR;
+import static org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter.DICTIONARY_VARS_COLUMN_SUFFIX;
+import static org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter.ENCODED_VARS_COLUMN_SUFFIX;
+import static org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter.LOGTYPE_COLUMN_SUFFIX;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotEquals;
 import static org.testng.Assert.assertNull;


### PR DESCRIPTION
tags: feature

This adds a query rewriter to make it easier to call `clpDecode`. Recall that the [`CLPLogMessageDecoder`](https://github.com/apache/pinot/pull/9942) encodes unstructured log fields into three columns, each with a common prefix (and different suffixes). We refer to this common prefix as the column-group name. This PR adds support for calling `clpDecode` using the column-group name rather than specifying the three individual columns.

E.g., if the `message` field was encoded with CLP, users currently have to call `clpDecode` as follows to reconstruct the field's original value:

`clpDecode(message_logtype, message_dictionaryVars, message_encodedVars)`

After this PR, users can call `clpDecode` as follows:

`clpDecode(message)`

To use the rewriter, users need to change their broker config to add `org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter` to `pinot.broker.query.rewriter.class.names`. Assuming the default set of query rewriters, that would look like:

```
org.apache.pinot.sql.parsers.rewriter.CompileTimeFunctionsInvoker,org.apache.pinot.sql.parsers.rewriter.SelectionsRewriter,org.apache.pinot.sql.parsers.rewriter.PredicateComparisonRewriter,org.apache.pinot.sql.parsers.rewriter.OrdinalsUpdater,org.apache.pinot.sql.parsers.rewriter.CLPDecodeRewriter,org.apache.pinot.sql.parsers.rewriter.AliasApplier,org.apache.pinot.sql.parsers.rewriter.NonAggregationGroupByToDistinctQueryRewriter
```
Note that we added it before the `AliasApplier` so that any aliasing of `message` happens only after the `clpDecode` rewrite.

This is part of the change requested in #9819 and described in this [design doc](https://docs.google.com/document/d/1nHZb37re4mUwEA258x3a2pgX13EWLWMJ0uLEDk1dUyU/edit#heading=h.x12tsj9ok16d).

Note also that this is a precursor to `clpMatch` which will be a much more involved query rewriter.

# Testing performed
* Added new unit tests.
* Validated fields encoded with CLP could be decoded correctly, using the column-group name.
