### PR TITLE
[multistage]: Better SQL Syntax Error Messages

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -69,6 +69,7 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.PinotSqlType;
+import org.apache.pinot.sql.parsers.SqlCompilationException;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -139,9 +140,8 @@ public class PinotQueryResource {
     SqlNodeAndOptions sqlNodeAndOptions;
     try {
       sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery);
-    } catch (Exception ex) {
-      String errorMessage = String.format("Unable to parse the SQL: '%s'", sqlQuery);
-      throw QueryException.getException(QueryException.SQL_PARSING_ERROR, new Exception(errorMessage));
+    } catch (SqlCompilationException ex) {
+      throw QueryException.getException(QueryException.SQL_PARSING_ERROR, ex);
     }
     Map<String, String> options = sqlNodeAndOptions.getOptions();
     if (queryOptions != null) {


### PR DESCRIPTION
As per the [issue discussion](https://github.com/apache/pinot/issues/10921), changing it to `SqlCompilationException` to get the error message indicating the problem. With the changes in this PR, the message on the UI for non-compilable SQL query looks like this
<img width="1122" alt="Screen Shot 2023-06-29 at 10 41 44 PM" src="https://github.com/apache/pinot/assets/1076944/af30467e-e8f0-4bff-8be4-0ee3bbe26aa7">

cc: @walterddr @Jackie-Jiang 