### PR TITLE
Fix a flaky test ADLSGen2PinotFSTest.testLastModified.

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSTest.java
+++ b/pinot-plugins/pinot-file-system/pinot-adls/src/test/java/org/apache/pinot/plugin/filesystem/test/ADLSGen2PinotFSTest.java
@@ -232,7 +232,7 @@ public class ADLSGen2PinotFSTest {
     when(_mockFileSystemClient.getDirectoryClient(any())).thenReturn(_mockDirectoryClient);
     when(_mockDirectoryClient.getProperties()).thenReturn(_mockPathProperties);
     Instant now = Instant.now();
-    OffsetDateTime mtime = Instant.now().atOffset(ZoneOffset.UTC);
+    OffsetDateTime mtime = now.atOffset(ZoneOffset.UTC);
     when(_mockPathProperties.getLastModified()).thenReturn(mtime);
 
     long actual = _adlsGen2PinotFsUnderTest.lastModified(_mockURI);


### PR DESCRIPTION
The two adjacent `Instant.now()` calls might differ, resulting in an assert failure:
```
java.lang.AssertionError: expected [1688094601164] but found [1688094601165]
	at org.testng.Assert.fail(Assert.java:93)
	at org.testng.Assert.failNotEquals(Assert.java:512)
	at org.testng.Assert.assertEqualsImpl(Assert.java:134)
	at org.testng.Assert.assertEquals(Assert.java:115)
	at org.testng.Assert.assertEquals(Assert.java:283)
	at org.testng.Assert.assertEquals(Assert.java:293)
	at org.apache.pinot.plugin.filesystem.test.ADLSGen2PinotFSTest.testLastModified(ADLSGen2PinotFSTest.java:239)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:578)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:108)
...
```