### PR TITLE
Add fromController method that accepts a PinotClientTransport

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java
@@ -126,6 +126,23 @@ public class ConnectionFactory {
       throw new PinotClientException(e);
     }
   }
+
+  /**
+   * @param properties
+   * @param controllerUrl url host:port of the controller
+   * @param transport pinot transport
+   * @return A connection that connects to brokers as per the given controller
+   */
+  public static Connection fromController(Properties properties, String controllerUrl, PinotClientTransport transport) {
+    try {
+      return new Connection(properties,
+          new ControllerBasedBrokerSelector(properties, controllerUrl),
+          transport);
+    } catch (Exception e) {
+      throw new PinotClientException(e);
+    }
+  }
+
   /**
    * Creates a connection to a Pinot cluster, given its Zookeeper URL
    *


### PR DESCRIPTION
`feature` (partially fixes #10924).

`ConnectionFactory` class is used to create instances on pinot client's `Connection` class. There are different methods available depending upon the kind of broker that we want to use. All of these except `fromController` also provide a variant to accept a `PinotClientTransport` from the user.

We are wrapping around the `ConnectionFactory` class in the Vert.x wrapper for pinot client to provide our custom transport. Since the constructors of the `Connection` class are package-private, we cannot directly add this method to an external package. Further, this method seems to be absent from the class only as a mistake (there are methods to specify custom transports with all other brokers).

Hence, adding this method.
