### PR TITLE
Fix double-checked locking in ConnectionFactory

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java
@@ -28,7 +28,7 @@ import java.util.Properties;
  * Creates connections to Pinot, given various initialization methods.
  */
 public class ConnectionFactory {
-  private static PinotClientTransport _defaultTransport;
+  private static volatile PinotClientTransport _defaultTransport;
 
   private ConnectionFactory() {
   }


### PR DESCRIPTION
`bugfix` `pinot-client`

The `_defaultTransport` in `ConnectionFactory` is created using double-checked locking.

https://github.com/apache/pinot/blob/03b9d4a708e6d09838e902857ebe1f255ced4ba1/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ConnectionFactory.java#L211-L222

However, the current implementation is buggy as described in https://rules.sonarsource.com/java/RSPEC-2168/. To fix it, make the field `volatile`.
