### PR TITLE
allow to preload segments with upsert snapshots to speedup table loading

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -100,7 +100,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected File _resourceTmpDir;
   protected Logger _logger;
   protected HelixManager _helixManager;
-  protected ExecutorService _preloadExecutor;
+  protected ExecutorService _segmentPreloadExecutor;
   protected AuthProvider _authProvider;
   protected long _streamSegmentDownloadUntarRateLimitBytesPerSec;
   protected boolean _isStreamSegmentDownloadUntar;
@@ -116,7 +116,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   @Override
   public void init(TableDataManagerConfig tableDataManagerConfig, String instanceId,
       ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager,
-      @Nullable ExecutorService preloadExecutor,
+      @Nullable ExecutorService segmentPreloadExecutor,
       @Nullable LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache,
       TableDataManagerParams tableDataManagerParams) {
     LOGGER.info("Initializing table data manager for table: {}", tableDataManagerConfig.getTableName());
@@ -126,7 +126,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     _propertyStore = propertyStore;
     _serverMetrics = serverMetrics;
     _helixManager = helixManager;
-    _preloadExecutor = preloadExecutor;
+    _segmentPreloadExecutor = segmentPreloadExecutor;
 
     _authProvider =
         AuthProviderUtils.extractAuthProvider(toPinotConfiguration(_tableDataManagerConfig.getAuthConfig()), null);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -99,6 +100,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected File _resourceTmpDir;
   protected Logger _logger;
   protected HelixManager _helixManager;
+  protected ExecutorService _preloadExecutor;
   protected AuthProvider _authProvider;
   protected long _streamSegmentDownloadUntarRateLimitBytesPerSec;
   protected boolean _isStreamSegmentDownloadUntar;
@@ -114,6 +116,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   @Override
   public void init(TableDataManagerConfig tableDataManagerConfig, String instanceId,
       ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager,
+      @Nullable ExecutorService preloadExecutor,
       @Nullable LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache,
       TableDataManagerParams tableDataManagerParams) {
     LOGGER.info("Initializing table data manager for table: {}", tableDataManagerConfig.getTableName());
@@ -123,6 +126,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
     _propertyStore = propertyStore;
     _serverMetrics = serverMetrics;
     _helixManager = helixManager;
+    _preloadExecutor = preloadExecutor;
 
     _authProvider =
         AuthProviderUtils.extractAuthProvider(toPinotConfiguration(_tableDataManagerConfig.getAuthConfig()), null);
@@ -681,8 +685,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
     return new File(_indexDir, segmentName);
   }
 
-  @VisibleForTesting
-  File getSegmentDataDir(String segmentName, @Nullable String segmentTier, TableConfig tableConfig) {
+  @Override
+  public File getSegmentDataDir(String segmentName, @Nullable String segmentTier, TableConfig tableConfig) {
     if (segmentTier == null) {
       return getSegmentDataDir(segmentName);
     }
@@ -763,7 +767,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
    * object may be created when trying to load the segment, but it's closed if the method
    * returns false; otherwise it's opened and to be referred by ImmutableSegment object.
    */
-  protected boolean tryLoadExistingSegment(String segmentName, IndexLoadingConfig indexLoadingConfig,
+  @Override
+  public boolean tryLoadExistingSegment(String segmentName, IndexLoadingConfig indexLoadingConfig,
       SegmentZKMetadata zkMetadata) {
     // Try to recover the segment from potential segment reloading failure.
     String segmentTier = zkMetadata.getTier();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/TableDataManagerProvider.java
@@ -20,8 +20,10 @@ package org.apache.pinot.core.data.manager.offline;
 
 import com.google.common.cache.LoadingCache;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.function.Supplier;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.HelixManager;
@@ -60,13 +62,14 @@ public class TableDataManagerProvider {
   public static TableDataManager getTableDataManager(TableDataManagerConfig tableDataManagerConfig, String instanceId,
       ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager,
       LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache) {
-    return getTableDataManager(tableDataManagerConfig, instanceId, propertyStore, serverMetrics, helixManager,
+    return getTableDataManager(tableDataManagerConfig, instanceId, propertyStore, serverMetrics, helixManager, null,
         errorCache, () -> true);
   }
 
   public static TableDataManager getTableDataManager(TableDataManagerConfig tableDataManagerConfig, String instanceId,
       ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager,
-      LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache, Supplier<Boolean> isServerReadyToServeQueries) {
+      @Nullable ExecutorService segmentPreloadExecutor, LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache,
+      Supplier<Boolean> isServerReadyToServeQueries) {
     TableDataManager tableDataManager;
     switch (tableDataManagerConfig.getTableType()) {
       case OFFLINE:
@@ -90,8 +93,8 @@ public class TableDataManagerProvider {
       default:
         throw new IllegalStateException();
     }
-    tableDataManager.init(tableDataManagerConfig, instanceId, propertyStore, serverMetrics, helixManager, errorCache,
-        _tableDataManagerParams);
+    tableDataManager.init(tableDataManagerConfig, instanceId, propertyStore, serverMetrics, helixManager,
+        segmentPreloadExecutor, errorCache, _tableDataManagerParams);
     return tableDataManager;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -535,7 +535,11 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     ImmutableSegmentDataManager newSegmentManager = new ImmutableSegmentDataManager(immutableSegment);
     SegmentDataManager oldSegmentManager = registerSegment(segmentName, newSegmentManager);
     if (oldSegmentManager == null) {
-      partitionUpsertMetadataManager.addSegment(immutableSegment);
+      if (_tableUpsertMetadataManager.isPreloading()) {
+        partitionUpsertMetadataManager.preloadSegment(immutableSegment);
+      } else {
+        partitionUpsertMetadataManager.addSegment(immutableSegment);
+      }
       _logger.info("Added new immutable segment: {} to upsert-enabled table: {}", segmentName, _tableNameWithType);
     } else {
       IndexSegment oldSegment = oldSegmentManager.getSegment();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -205,9 +205,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
           _tableUpsertMetadataManager);
       Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
       Preconditions.checkState(schema != null, "Failed to find schema for table: %s", _tableNameWithType);
-      _tableUpsertMetadataManager =
-          TableUpsertMetadataManagerFactory.create(tableConfig, schema, this, _serverMetrics, _helixManager,
-              _segmentPreloadExecutor);
+      _tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(tableConfig);
+      _tableUpsertMetadataManager.init(tableConfig, schema, this, _serverMetrics, _helixManager,
+          _segmentPreloadExecutor);
     }
 
     // For dedup and partial-upsert, need to wait for all segments loaded before starting consuming data

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -207,7 +207,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       Preconditions.checkState(schema != null, "Failed to find schema for table: %s", _tableNameWithType);
       _tableUpsertMetadataManager =
           TableUpsertMetadataManagerFactory.create(tableConfig, schema, this, _serverMetrics, _helixManager,
-              _preloadExecutor);
+              _segmentPreloadExecutor);
     }
 
     // For dedup and partial-upsert, need to wait for all segments loaded before starting consuming data
@@ -381,11 +381,6 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   @Override
   public void addSegment(String segmentName, IndexLoadingConfig indexLoadingConfig, SegmentZKMetadata segmentZKMetadata)
       throws Exception {
-    if (isUpsertEnabled()) {
-      _logger.debug("Wait for tableUpsertMetadataManager to be ready to add segment: {}", segmentName);
-      _tableUpsertMetadataManager.waitTillReady();
-      _logger.debug("The tableUpsertMetadataManager is ready to add segment: {}", segmentName);
-    }
     SegmentDataManager segmentDataManager = _segmentDataManagerMap.get(segmentName);
     if (segmentDataManager != null) {
       _logger.warn("Skipping adding existing segment: {} for table: {} with data manager class: {}", segmentName,

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerAcquireSegmentTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerAcquireSegmentTest.java
@@ -130,7 +130,7 @@ public class BaseTableDataManagerAcquireSegmentTest {
       when(config.getTableDeletedSegmentsCacheTtlMinutes()).thenReturn(DELETED_SEGMENTS_TTL_MINUTES);
     }
     tableDataManager.init(config, "dummyInstance", mock(ZkHelixPropertyStore.class),
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null,
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null, null,
         new TableDataManagerParams(0, false, -1));
     tableDataManager.start();
     Field segsMapField = BaseTableDataManager.class.getDeclaredField("_segmentDataManagerMap");

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/BaseTableDataManagerTest.java
@@ -719,7 +719,7 @@ public class BaseTableDataManagerTest {
 
     OfflineTableDataManager tableDataManager = new OfflineTableDataManager();
     tableDataManager.init(config, "dummyInstance", mock(ZkHelixPropertyStore.class),
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null,
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null, null,
         new TableDataManagerParams(0, false, -1));
     tableDataManager.start();
     return tableDataManager;
@@ -728,7 +728,7 @@ public class BaseTableDataManagerTest {
   private static BaseTableDataManager createTableManager(TableDataManagerConfig config, HelixManager helixManager) {
     OfflineTableDataManager tableDataManager = new OfflineTableDataManager();
     tableDataManager.init(config, "dummyInstance", mock(ZkHelixPropertyStore.class),
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), helixManager, null,
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), helixManager, null, null,
         new TableDataManagerParams(0, false, -1));
     tableDataManager.start();
     return tableDataManager;
@@ -737,7 +737,7 @@ public class BaseTableDataManagerTest {
   private static OfflineTableDataManager createSpyOfflineTableManager(TableDataManagerConfig tableDataManagerConfig) {
     OfflineTableDataManager tableDataManager = new OfflineTableDataManager();
     tableDataManager.init(tableDataManagerConfig, "dummyInstance", mock(ZkHelixPropertyStore.class),
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null,
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null, null,
         new TableDataManagerParams(0, false, -1));
     tableDataManager.start();
     return Mockito.spy(tableDataManager);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/offline/DimensionTableDataManagerTest.java
@@ -133,7 +133,7 @@ public class DimensionTableDataManagerTest {
       when(config.getDataDir()).thenReturn(TEMP_DIR.getAbsolutePath());
     }
     tableDataManager.init(config, "dummyInstance", helixManager.getHelixPropertyStore(),
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), helixManager, null,
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), helixManager, null, null,
         new TableDataManagerParams(0, false, -1));
     tableDataManager.start();
     return tableDataManager;

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManagerTest.java
@@ -100,7 +100,7 @@ public class RealtimeTableDataManagerTest {
     TableConfig tableConfig = setupTableConfig(propertyStore);
     Schema schema = setupSchema(propertyStore);
     tmgr.init(tableDataManagerConfig, "server01", propertyStore,
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null,
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null, null,
         new TableDataManagerParams(0, false, -1));
 
     // Create a dummy local segment.
@@ -135,7 +135,7 @@ public class RealtimeTableDataManagerTest {
     TableConfig tableConfig = setupTableConfig(propertyStore);
     Schema schema = setupSchema(propertyStore);
     tmgr.init(tableDataManagerConfig, "server01", propertyStore,
-        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null,
+        new ServerMetrics(PinotMetricUtils.getPinotMetricsRegistry()), mock(HelixManager.class), null, null,
         new TableDataManagerParams(0, false, -1));
 
     // Create a raw segment and put it in deep store backed by local fs.

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -37,7 +37,6 @@ import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUt
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
-import org.apache.pinot.segment.local.upsert.BaseTableUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.ConcurrentMapPartitionUpsertMetadataManager;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
@@ -55,6 +54,7 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
@@ -62,7 +62,6 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
-import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -128,12 +127,12 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
   public void loadSegment()
       throws Exception {
     _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
-    ServerMetrics serverMetrics = mock(ServerMetrics.class);
+    ServerMetrics serverMetrics = Mockito.mock(ServerMetrics.class);
     _upsertIndexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     ((ImmutableSegmentImpl) _upsertIndexSegment).enableUpsert(
         new ConcurrentMapPartitionUpsertMetadataManager("testTable_REALTIME", 0, Collections.singletonList("column6"),
-            Collections.singletonList("daysSinceEpoch"), null, HashFunction.NONE, null, false, serverMetrics,
-            mock(BaseTableUpsertMetadataManager.class)), new ThreadSafeMutableRoaringBitmap(), null);
+            Collections.singletonList("daysSinceEpoch"), null, HashFunction.NONE, null, false, serverMetrics),
+        new ThreadSafeMutableRoaringBitmap(), null);
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -37,6 +37,7 @@ import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUt
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.upsert.BaseTableUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.ConcurrentMapPartitionUpsertMetadataManager;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
@@ -54,7 +55,6 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
@@ -62,6 +62,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -127,12 +128,12 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
   public void loadSegment()
       throws Exception {
     _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
-    ServerMetrics serverMetrics = Mockito.mock(ServerMetrics.class);
+    ServerMetrics serverMetrics = mock(ServerMetrics.class);
     _upsertIndexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     ((ImmutableSegmentImpl) _upsertIndexSegment).enableUpsert(
         new ConcurrentMapPartitionUpsertMetadataManager("testTable_REALTIME", 0, Collections.singletonList("column6"),
-            Collections.singletonList("daysSinceEpoch"), null, HashFunction.NONE, null, false, serverMetrics),
-        new ThreadSafeMutableRoaringBitmap(), null);
+            Collections.singletonList("daysSinceEpoch"), null, HashFunction.NONE, null, false, serverMetrics,
+            mock(BaseTableUpsertMetadataManager.class)), new ThreadSafeMutableRoaringBitmap(), null);
   }
 
   @AfterClass

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -50,7 +50,7 @@ public interface TableDataManager {
    */
   void init(TableDataManagerConfig tableDataManagerConfig, String instanceId,
       ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager,
-      @Nullable ExecutorService preloadExecutor,
+      @Nullable ExecutorService segmentPreloadExecutor,
       @Nullable LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache,
       TableDataManagerParams tableDataManagerParams);
 
@@ -130,14 +130,20 @@ public interface TableDataManager {
    */
   void removeSegment(String segmentName);
 
-  default boolean tryLoadExistingSegment(String segmentName, IndexLoadingConfig indexLoadingConfig,
-      SegmentZKMetadata zkMetadata) {
-    return false;
-  }
+  /**
+   * Try to load a segment from an existing segment directory managed by the server. The segment loading may fail
+   * because the directory may not exist any more, or the segment data has a different crc now, or the existing segment
+   * data got corrupted etc.
+   *
+   * @return true if the segment is loaded successfully from the existing segment directory; false otherwise.
+   */
+  boolean tryLoadExistingSegment(String segmentName, IndexLoadingConfig indexLoadingConfig,
+      SegmentZKMetadata zkMetadata);
 
-  default File getSegmentDataDir(String segmentName, @Nullable String segmentTier, TableConfig tableConfig) {
-    return null;
-  }
+  /**
+   * Get the segment data directory, considering the segment tier if provided.
+   */
+  File getSegmentDataDir(String segmentName, @Nullable String segmentTier, TableConfig tableConfig);
 
   /**
    * Returns true if the segment was deleted in the last few minutes.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -22,6 +22,7 @@ import com.google.common.cache.LoadingCache;
 import java.io.File;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.lang3.tuple.Pair;
@@ -34,6 +35,7 @@ import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 
 
@@ -48,7 +50,9 @@ public interface TableDataManager {
    */
   void init(TableDataManagerConfig tableDataManagerConfig, String instanceId,
       ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager,
-      LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache, TableDataManagerParams tableDataManagerParams);
+      @Nullable ExecutorService preloadExecutor,
+      @Nullable LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache,
+      TableDataManagerParams tableDataManagerParams);
 
   /**
    * Starts the table data manager. Should be called only once after table data manager gets initialized but before
@@ -125,6 +129,15 @@ public interface TableDataManager {
    * Removes a segment from the table.
    */
   void removeSegment(String segmentName);
+
+  default boolean tryLoadExistingSegment(String segmentName, IndexLoadingConfig indexLoadingConfig,
+      SegmentZKMetadata zkMetadata) {
+    return false;
+  }
+
+  default File getSegmentDataDir(String segmentName, @Nullable String segmentTier, TableConfig tableConfig) {
+    return null;
+  }
 
   /**
    * Returns true if the segment was deleted in the last few minutes.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -192,7 +192,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       if (queryableDocIds == null && _deleteRecordColumn != null) {
         queryableDocIds = new ThreadSafeMutableRoaringBitmap();
       }
-      if (_tableUpsertMetadataManager.isPreloadingSegment(segmentName)) {
+      if (_tableUpsertMetadataManager.isPreloading()) {
         addSegmentWithoutUpsert(segment, validDocIds, queryableDocIds, recordInfoIterator);
       } else {
         addOrReplaceSegment(segment, validDocIds, queryableDocIds, recordInfoIterator, null, null);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -180,18 +180,12 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       _logger.info("Skip preloading segment: {} because metadata manager is already stopped", segmentName);
       return;
     }
-    if (!_enableSnapshot) {
-      _logger.info("Skip preloading segment: {} because snapshot is not enabled", segmentName);
-      return;
-    }
-    if (segment instanceof EmptyIndexSegment) {
-      _logger.info("Skip preloading empty segment: {}", segmentName);
-      return;
-    }
+    Preconditions.checkArgument(_enableSnapshot, "Snapshot must be enabled to preload segment: {}, table: {}",
+        segmentName, _tableNameWithType);
+    // Note that EmptyIndexSegment should not reach here either, as it doesn't have validDocIds snapshot.
     Preconditions.checkArgument(segment instanceof ImmutableSegmentImpl,
         "Got unsupported segment implementation: {} for segment: {}, table: {}", segment.getClass(), segmentName,
         _tableNameWithType);
-
     _snapshotLock.readLock().lock();
     startOperation();
     try {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -245,7 +245,8 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     addSegment(segment, validDocIds, queryableDocIds, recordInfoIterator, false);
   }
 
-  private void addSegment(ImmutableSegmentImpl segment, @Nullable ThreadSafeMutableRoaringBitmap validDocIds,
+  @VisibleForTesting
+  public void addSegment(ImmutableSegmentImpl segment, @Nullable ThreadSafeMutableRoaringBitmap validDocIds,
       @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, Iterator<RecordInfo> recordInfoIterator,
       boolean isPreloading) {
     String segmentName = segment.getSegmentName();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -115,9 +115,9 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
         // Note that there is an implicit waiting logic between the thread doing the segment preloading here and the
         // other helix threads about to process segment state transitions (e.g. taking segments from OFFLINE to ONLINE).
         // The thread doing the segment preloading here must complete before the other helix threads start to handle
-        // segment state transitions. This is ensured implicitly because segment preloading happens here when creating
-        // this TableUpsertMetadataManager, which happens when creating the TableDataManager, which happens as the
-        // lambda of ConcurrentHashMap.computeIfAbsent() method, which ensures the waiting logic to happen.
+        // segment state transitions. This is ensured implicitly because segment preloading happens here when
+        // initializing this TableUpsertMetadataManager, which happens when initializing the TableDataManager, which
+        // happens as the lambda of ConcurrentHashMap.computeIfAbsent() method, which ensures the waiting logic.
         _isPreloading = true;
         preloadSegments();
       }
@@ -133,7 +133,7 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
 
   /**
    * Get the ideal state and find segments assigned to current instance, then preload those with validDocIds snapshot.
-   * Skip those without the snapshots and those whose crc has changed. Those will be handled by the normal Helix state
+   * Skip those without the snapshots and those whose crc has changed, as they will be handled by normal Helix state
    * transitions, which will proceed after the preloading phase fully completes.
    */
   private void preloadSegments()

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -59,9 +59,9 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
   public ConcurrentMapPartitionUpsertMetadataManager(String tableNameWithType, int partitionId,
       List<String> primaryKeyColumns, List<String> comparisonColumns, @Nullable String deleteRecordColumn,
       HashFunction hashFunction, @Nullable PartialUpsertHandler partialUpsertHandler, boolean enableSnapshot,
-      ServerMetrics serverMetrics, BaseTableUpsertMetadataManager tableUpsertMetadataManager) {
+      ServerMetrics serverMetrics) {
     super(tableNameWithType, partitionId, primaryKeyColumns, comparisonColumns, deleteRecordColumn, hashFunction,
-        partialUpsertHandler, enableSnapshot, serverMetrics, tableUpsertMetadataManager);
+        partialUpsertHandler, enableSnapshot, serverMetrics);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -37,7 +37,7 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
     return _partitionMetadataManagerMap.computeIfAbsent(partitionId,
         k -> new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _primaryKeyColumns,
             _comparisonColumns, _deleteRecordColumn, _hashFunction, _partialUpsertHandler, _enableSnapshot,
-            _serverMetrics));
+            _serverMetrics, this));
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -37,7 +37,7 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
     return _partitionMetadataManagerMap.computeIfAbsent(partitionId,
         k -> new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _primaryKeyColumns,
             _comparisonColumns, _deleteRecordColumn, _hashFunction, _partialUpsertHandler, _enableSnapshot,
-            _serverMetrics, this));
+            _serverMetrics));
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -66,6 +66,8 @@ public interface PartitionUpsertMetadataManager extends Closeable {
 
   /**
    * Different from adding a segment, when preloading a segment, the upsert metadata may be updated more efficiently.
+   * Basically the upsert metadata can be directly updated for each primary key, without doing the more costly
+   * read-compare-update.
    */
   void preloadSegment(ImmutableSegment segment);
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -65,6 +65,11 @@ public interface PartitionUpsertMetadataManager extends Closeable {
   void addSegment(ImmutableSegment segment);
 
   /**
+   * Different from adding a segment, when preloading a segment, the upsert metadata may be updated more efficiently.
+   */
+  void preloadSegment(ImmutableSegment segment);
+
+  /**
    * Updates the upsert metadata for a new consumed record in the given consuming segment.
    */
   void addRecord(MutableSegment segment, RecordInfo recordInfo);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -19,7 +19,10 @@
 package org.apache.pinot.segment.local.upsert;
 
 import java.io.Closeable;
+import java.util.concurrent.ExecutorService;
+import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import org.apache.helix.HelixManager;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -32,8 +35,8 @@ import org.apache.pinot.spi.data.Schema;
  */
 @ThreadSafe
 public interface TableUpsertMetadataManager extends Closeable {
-
-  void init(TableConfig tableConfig, Schema schema, TableDataManager tableDataManager, ServerMetrics serverMetrics);
+  void init(TableConfig tableConfig, Schema schema, TableDataManager tableDataManager, ServerMetrics serverMetrics,
+      HelixManager helixManager, @Nullable ExecutorService executorService);
 
   PartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId);
 
@@ -43,4 +46,9 @@ public interface TableUpsertMetadataManager extends Closeable {
    * Stops the metadata manager. After invoking this method, no access to the metadata will be accepted.
    */
   void stop();
+
+  void waitTillReady()
+      throws InterruptedException;
+
+  boolean isReady();
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -36,7 +36,7 @@ import org.apache.pinot.spi.data.Schema;
 @ThreadSafe
 public interface TableUpsertMetadataManager extends Closeable {
   void init(TableConfig tableConfig, Schema schema, TableDataManager tableDataManager, ServerMetrics serverMetrics,
-      HelixManager helixManager, @Nullable ExecutorService executorService);
+      HelixManager helixManager, @Nullable ExecutorService segmentPreloadExecutor);
 
   PartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId);
 
@@ -47,8 +47,5 @@ public interface TableUpsertMetadataManager extends Closeable {
    */
   void stop();
 
-  void waitTillReady()
-      throws InterruptedException;
-
-  boolean isReady();
+  boolean isPreloading();
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
@@ -19,9 +19,15 @@
 package org.apache.pinot.segment.local.upsert;
 
 import com.google.common.base.Preconditions;
+import java.util.concurrent.ExecutorService;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.helix.HelixManager;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.apache.pinot.spi.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -32,7 +38,9 @@ public class TableUpsertMetadataManagerFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TableUpsertMetadataManagerFactory.class);
 
-  public static TableUpsertMetadataManager create(TableConfig tableConfig) {
+  public static TableUpsertMetadataManager create(TableConfig tableConfig, Schema schema,
+      TableDataManager tableDataManager, ServerMetrics serverMetrics, HelixManager helixManager,
+      @Nullable ExecutorService segmentPreloadExecutor) {
     String tableNameWithType = tableConfig.getTableName();
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
     Preconditions.checkArgument(upsertConfig != null, "Must provide upsert config for table: %s", tableNameWithType);
@@ -55,6 +63,7 @@ public class TableUpsertMetadataManagerFactory {
       metadataManager = new ConcurrentMapTableUpsertMetadataManager();
     }
 
+    metadataManager.init(tableConfig, schema, tableDataManager, serverMetrics, helixManager, segmentPreloadExecutor);
     return metadataManager;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
@@ -19,15 +19,9 @@
 package org.apache.pinot.segment.local.upsert;
 
 import com.google.common.base.Preconditions;
-import java.util.concurrent.ExecutorService;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.helix.HelixManager;
-import org.apache.pinot.common.metrics.ServerMetrics;
-import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
-import org.apache.pinot.spi.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -38,9 +32,7 @@ public class TableUpsertMetadataManagerFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TableUpsertMetadataManagerFactory.class);
 
-  public static TableUpsertMetadataManager create(TableConfig tableConfig, Schema schema,
-      TableDataManager tableDataManager, ServerMetrics serverMetrics, HelixManager helixManager,
-      @Nullable ExecutorService segmentPreloadExecutor) {
+  public static TableUpsertMetadataManager create(TableConfig tableConfig) {
     String tableNameWithType = tableConfig.getTableName();
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
     Preconditions.checkArgument(upsertConfig != null, "Must provide upsert config for table: %s", tableNameWithType);
@@ -63,7 +55,6 @@ public class TableUpsertMetadataManagerFactory {
       metadataManager = new ConcurrentMapTableUpsertMetadataManager();
     }
 
-    metadataManager.init(tableConfig, schema, tableDataManager, serverMetrics, helixManager, segmentPreloadExecutor);
     return metadataManager;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
@@ -19,7 +19,10 @@
 package org.apache.pinot.segment.local.upsert;
 
 import com.google.common.base.Preconditions;
+import java.util.concurrent.ExecutorService;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.helix.HelixManager;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -36,7 +39,8 @@ public class TableUpsertMetadataManagerFactory {
   private static final Logger LOGGER = LoggerFactory.getLogger(TableUpsertMetadataManagerFactory.class);
 
   public static TableUpsertMetadataManager create(TableConfig tableConfig, Schema schema,
-      TableDataManager tableDataManager, ServerMetrics serverMetrics) {
+      TableDataManager tableDataManager, ServerMetrics serverMetrics, HelixManager helixManager,
+      @Nullable ExecutorService preloadExecutor) {
     String tableNameWithType = tableConfig.getTableName();
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
     Preconditions.checkArgument(upsertConfig != null, "Must provide upsert config for table: %s", tableNameWithType);
@@ -59,7 +63,7 @@ public class TableUpsertMetadataManagerFactory {
       metadataManager = new ConcurrentMapTableUpsertMetadataManager();
     }
 
-    metadataManager.init(tableConfig, schema, tableDataManager, serverMetrics);
+    metadataManager.init(tableConfig, schema, tableDataManager, serverMetrics, helixManager, preloadExecutor);
     return metadataManager;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
@@ -40,7 +40,7 @@ public class TableUpsertMetadataManagerFactory {
 
   public static TableUpsertMetadataManager create(TableConfig tableConfig, Schema schema,
       TableDataManager tableDataManager, ServerMetrics serverMetrics, HelixManager helixManager,
-      @Nullable ExecutorService preloadExecutor) {
+      @Nullable ExecutorService segmentPreloadExecutor) {
     String tableNameWithType = tableConfig.getTableName();
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
     Preconditions.checkArgument(upsertConfig != null, "Must provide upsert config for table: %s", tableNameWithType);
@@ -63,7 +63,7 @@ public class TableUpsertMetadataManagerFactory {
       metadataManager = new ConcurrentMapTableUpsertMetadataManager();
     }
 
-    metadataManager.init(tableConfig, schema, tableDataManager, serverMetrics, helixManager, preloadExecutor);
+    metadataManager.init(tableConfig, schema, tableDataManager, serverMetrics, helixManager, segmentPreloadExecutor);
     return metadataManager;
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
@@ -27,7 +27,6 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.recordtransformer.CompositeTransformer;
 import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
-import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManagerFactory;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -68,10 +67,10 @@ public class MutableSegmentImplUpsertComparisonColTest {
             .build();
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
-    TableUpsertMetadataManager tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(_tableConfig);
-    tableUpsertMetadataManager.init(_tableConfig, _schema, mock(TableDataManager.class), mock(ServerMetrics.class),
-        mock(HelixManager.class), mock(ExecutorService.class));
-    _partitionUpsertMetadataManager = tableUpsertMetadataManager.getOrCreatePartitionManager(0);
+    _partitionUpsertMetadataManager =
+        TableUpsertMetadataManagerFactory.create(_tableConfig, _schema, mock(TableDataManager.class),
+                mock(ServerMetrics.class), mock(HelixManager.class), mock(ExecutorService.class))
+            .getOrCreatePartitionManager(0);
     _mutableSegmentImpl =
         MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(),
             Collections.emptySet(), false, true, offsetUpsertConfig, "secondsSinceEpoch",

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
@@ -21,6 +21,8 @@ package org.apache.pinot.segment.local.indexsegment.mutable;
 import java.io.File;
 import java.net.URL;
 import java.util.Collections;
+import java.util.concurrent.ExecutorService;
+import org.apache.helix.HelixManager;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.recordtransformer.CompositeTransformer;
@@ -67,7 +69,8 @@ public class MutableSegmentImplUpsertComparisonColTest {
     File jsonFile = new File(dataResourceUrl.getFile());
     _partitionUpsertMetadataManager =
         TableUpsertMetadataManagerFactory.create(_tableConfig, _schema, mock(TableDataManager.class),
-            mock(ServerMetrics.class)).getOrCreatePartitionManager(0);
+                mock(ServerMetrics.class), mock(HelixManager.class), mock(ExecutorService.class))
+            .getOrCreatePartitionManager(0);
     _mutableSegmentImpl =
         MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(),
             Collections.emptySet(), false, true, offsetUpsertConfig, "secondsSinceEpoch",

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
@@ -27,6 +27,7 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.recordtransformer.CompositeTransformer;
 import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
+import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManagerFactory;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -67,10 +68,10 @@ public class MutableSegmentImplUpsertComparisonColTest {
             .build();
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
-    _partitionUpsertMetadataManager =
-        TableUpsertMetadataManagerFactory.create(_tableConfig, _schema, mock(TableDataManager.class),
-                mock(ServerMetrics.class), mock(HelixManager.class), mock(ExecutorService.class))
-            .getOrCreatePartitionManager(0);
+    TableUpsertMetadataManager tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(_tableConfig);
+    tableUpsertMetadataManager.init(_tableConfig, _schema, mock(TableDataManager.class), mock(ServerMetrics.class),
+        mock(HelixManager.class), mock(ExecutorService.class));
+    _partitionUpsertMetadataManager = tableUpsertMetadataManager.getOrCreatePartitionManager(0);
     _mutableSegmentImpl =
         MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(),
             Collections.emptySet(), false, true, offsetUpsertConfig, "secondsSinceEpoch",

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -29,7 +29,6 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.recordtransformer.CompositeTransformer;
 import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
-import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManagerFactory;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -83,10 +82,10 @@ public class MutableSegmentImplUpsertTest {
             .build();
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
-    TableUpsertMetadataManager tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(_tableConfig);
-    tableUpsertMetadataManager.init(_tableConfig, _schema, mock(TableDataManager.class), mock(ServerMetrics.class),
-        mock(HelixManager.class), mock(ExecutorService.class));
-    _partitionUpsertMetadataManager = tableUpsertMetadataManager.getOrCreatePartitionManager(0);
+    _partitionUpsertMetadataManager =
+        TableUpsertMetadataManagerFactory.create(_tableConfig, _schema, mock(TableDataManager.class),
+                mock(ServerMetrics.class), mock(HelixManager.class), mock(ExecutorService.class))
+            .getOrCreatePartitionManager(0);
     _mutableSegmentImpl =
         MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(),
             Collections.emptySet(), false, true, upsertConfigWithHash, "secondsSinceEpoch",

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.recordtransformer.CompositeTransformer;
 import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
+import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManagerFactory;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -82,10 +83,10 @@ public class MutableSegmentImplUpsertTest {
             .build();
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
-    _partitionUpsertMetadataManager =
-        TableUpsertMetadataManagerFactory.create(_tableConfig, _schema, mock(TableDataManager.class),
-                mock(ServerMetrics.class), mock(HelixManager.class), mock(ExecutorService.class))
-            .getOrCreatePartitionManager(0);
+    TableUpsertMetadataManager tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(_tableConfig);
+    tableUpsertMetadataManager.init(_tableConfig, _schema, mock(TableDataManager.class), mock(ServerMetrics.class),
+        mock(HelixManager.class), mock(ExecutorService.class));
+    _partitionUpsertMetadataManager = tableUpsertMetadataManager.getOrCreatePartitionManager(0);
     _mutableSegmentImpl =
         MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(),
             Collections.emptySet(), false, true, upsertConfigWithHash, "secondsSinceEpoch",

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -23,6 +23,8 @@ import java.net.URL;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.concurrent.ExecutorService;
+import org.apache.helix.HelixManager;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.recordtransformer.CompositeTransformer;
@@ -82,7 +84,8 @@ public class MutableSegmentImplUpsertTest {
     File jsonFile = new File(dataResourceUrl.getFile());
     _partitionUpsertMetadataManager =
         TableUpsertMetadataManagerFactory.create(_tableConfig, _schema, mock(TableDataManager.class),
-            mock(ServerMetrics.class)).getOrCreatePartitionManager(0);
+                mock(ServerMetrics.class), mock(HelixManager.class), mock(ExecutorService.class))
+            .getOrCreatePartitionManager(0);
     _mutableSegmentImpl =
         MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(),
             Collections.emptySet(), false, true, upsertConfigWithHash, "secondsSinceEpoch",

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -78,8 +78,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     String comparisonColumn = "timeCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, mock(ServerMetrics.class),
-            mock(BaseTableUpsertMetadataManager.class));
+            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, mock(ServerMetrics.class));
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
     Set<IndexSegment> trackedSegments = upsertMetadataManager._trackedSegments;
 
@@ -242,7 +241,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
             Collections.singletonList(comparisonColumn), deleteRecordColumn, hashFunction, null, false,
-            mock(ServerMetrics.class), mock(BaseTableUpsertMetadataManager.class));
+            mock(ServerMetrics.class));
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
     Set<IndexSegment> trackedSegments = upsertMetadataManager._trackedSegments;
 
@@ -505,8 +504,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     String comparisonColumn = "timeCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, mock(ServerMetrics.class),
-            mock(BaseTableUpsertMetadataManager.class));
+            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, mock(ServerMetrics.class));
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add the first segment
@@ -599,7 +597,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
             Collections.singletonList(comparisonColumn), deleteColumn, hashFunction, null, false,
-            mock(ServerMetrics.class), mock(BaseTableUpsertMetadataManager.class));
+            mock(ServerMetrics.class));
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // queryableDocIds is same as validDocIds in the absence of delete markers

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -78,7 +78,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     String comparisonColumn = "timeCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, mock(ServerMetrics.class));
+            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, mock(ServerMetrics.class),
+            mock(BaseTableUpsertMetadataManager.class));
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
     Set<IndexSegment> trackedSegments = upsertMetadataManager._trackedSegments;
 
@@ -241,7 +242,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
             Collections.singletonList(comparisonColumn), deleteRecordColumn, hashFunction, null, false,
-            mock(ServerMetrics.class));
+            mock(ServerMetrics.class), mock(BaseTableUpsertMetadataManager.class));
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
     Set<IndexSegment> trackedSegments = upsertMetadataManager._trackedSegments;
 
@@ -504,7 +505,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     String comparisonColumn = "timeCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, mock(ServerMetrics.class));
+            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, mock(ServerMetrics.class),
+            mock(BaseTableUpsertMetadataManager.class));
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add the first segment
@@ -596,8 +598,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     String deleteColumn = "deleteCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), deleteColumn, hashFunction, null,
-            false, mock(ServerMetrics.class));
+            Collections.singletonList(comparisonColumn), deleteColumn, hashFunction, null, false,
+            mock(ServerMetrics.class), mock(BaseTableUpsertMetadataManager.class));
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // queryableDocIds is same as validDocIds in the absence of delete markers

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManagerTest.java
@@ -60,7 +60,6 @@ import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 
 public class ConcurrentMapTableUpsertMetadataManagerTest {
@@ -107,14 +106,11 @@ public class ConcurrentMapTableUpsertMetadataManagerTest {
     upsertConfig.setEnablePreload(true);
     mgr = new ConcurrentMapTableUpsertMetadataManager();
     assertFalse(mgr.isPreloading());
-    try {
-      // The preloading logic will hit on error as the HelixManager mock is not fully setup.
-      mgr.init(tableConfig, schema, mock(TableDataManager.class), mock(ServerMetrics.class), mock(HelixManager.class),
-          null);
-      fail();
-    } catch (Exception ignore) {
-      assertFalse(mgr.isPreloading());
-    }
+    // The preloading logic will hit on error as the HelixManager mock is not fully setup. But failure of preloading
+    // should not fail the init() method.
+    mgr.init(tableConfig, schema, mock(TableDataManager.class), mock(ServerMetrics.class), mock(HelixManager.class),
+        null);
+    assertFalse(mgr.isPreloading());
   }
 
   @Test
@@ -194,6 +190,7 @@ public class ConcurrentMapTableUpsertMetadataManagerTest {
         eq(ZKMetadataProvider.constructPropertyStorePathForSegment(tableNameWithType, "online_seg02")), any(),
         anyInt())).thenReturn(realtimeSegmentZKMetadata.toZNRecord());
 
+    // No snapshot file for online_seg01, so it's skipped.
     File seg01IdxDir = new File(TEMP_DIR, "online_seg01");
     FileUtils.forceMkdir(seg01IdxDir);
     when(tableDataManager.getSegmentDataDir("online_seg01", null, tableConfig)).thenReturn(seg01IdxDir);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManagerTest.java
@@ -25,11 +25,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
@@ -95,30 +91,29 @@ public class ConcurrentMapTableUpsertMetadataManagerTest {
 
     // Preloading is skipped as snapshot is not enabled.
     ConcurrentMapTableUpsertMetadataManager mgr = new ConcurrentMapTableUpsertMetadataManager();
-    assertFalse(mgr.isReady());
+    assertFalse(mgr.isPreloading());
     mgr.init(tableConfig, schema, mock(TableDataManager.class), mock(ServerMetrics.class), mock(HelixManager.class),
         null);
-    assertTrue(mgr.isReady());
+    assertFalse(mgr.isPreloading());
 
     // Preloading is skipped as preloading is not turned on.
     upsertConfig.setEnableSnapshot(true);
     mgr = new ConcurrentMapTableUpsertMetadataManager();
-    assertFalse(mgr.isReady());
+    assertFalse(mgr.isPreloading());
     mgr.init(tableConfig, schema, mock(TableDataManager.class), mock(ServerMetrics.class), mock(HelixManager.class),
         null);
-    assertTrue(mgr.isReady());
+    assertFalse(mgr.isPreloading());
 
     upsertConfig.setEnablePreload(true);
     mgr = new ConcurrentMapTableUpsertMetadataManager();
-    assertFalse(mgr.isReady());
+    assertFalse(mgr.isPreloading());
     try {
       // The preloading logic will hit on error as the HelixManager mock is not fully setup.
       mgr.init(tableConfig, schema, mock(TableDataManager.class), mock(ServerMetrics.class), mock(HelixManager.class),
           null);
       fail();
     } catch (Exception ignore) {
-      // Even if
-      assertTrue(mgr.isReady());
+      assertFalse(mgr.isPreloading());
     }
   }
 
@@ -126,6 +121,7 @@ public class ConcurrentMapTableUpsertMetadataManagerTest {
   public void testPreloadOnlineSegments()
       throws Exception {
     Set<String> preloadedSegments = new HashSet<>();
+    AtomicBoolean wasPreloading = new AtomicBoolean(false);
     ConcurrentMapTableUpsertMetadataManager mgr = new ConcurrentMapTableUpsertMetadataManager() {
       @Override
       protected IndexLoadingConfig createIndexLoadingConfig() {
@@ -135,6 +131,7 @@ public class ConcurrentMapTableUpsertMetadataManagerTest {
       @Override
       protected void preloadSegmentWithSnapshot(String segmentName, IndexLoadingConfig indexLoadingConfig,
           SegmentZKMetadata zkMetadata) {
+        wasPreloading.set(isPreloading());
         preloadedSegments.add(segmentName);
       }
     };
@@ -206,127 +203,11 @@ public class ConcurrentMapTableUpsertMetadataManagerTest {
     FileUtils.touch(new File(new File(seg02IdxDir, "v3"), V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME));
     when(tableDataManager.getSegmentDataDir("online_seg02", null, tableConfig)).thenReturn(seg02IdxDir);
 
-    assertFalse(mgr.isReady());
+    assertFalse(mgr.isPreloading());
     mgr.init(tableConfig, schema, tableDataManager, mock(ServerMetrics.class), helixManager, null);
     assertEquals(preloadedSegments.size(), 1);
     assertTrue(preloadedSegments.contains("online_seg02"));
-    assertTrue(mgr.isReady());
-  }
-
-  @Test
-  public void testWaitTillReady()
-      throws Exception {
-    CountDownLatch latch = new CountDownLatch(1);
-    Set<String> preloadedSegments = new HashSet<>();
-    ConcurrentMapTableUpsertMetadataManager mgr = new ConcurrentMapTableUpsertMetadataManager() {
-      @Override
-      protected IndexLoadingConfig createIndexLoadingConfig() {
-        return mock(IndexLoadingConfig.class);
-      }
-
-      @Override
-      protected void preloadSegmentWithSnapshot(String segmentName, IndexLoadingConfig indexLoadingConfig,
-          SegmentZKMetadata zkMetadata) {
-        try {
-          latch.await();
-          preloadedSegments.add(segmentName);
-        } catch (InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-      }
-    };
-    // Setup mocks for TableConfig and Schema.
-    String tableNameWithType = "myTable_REALTIME";
-    TableConfig tableConfig = mock(TableConfig.class);
-    UpsertConfig upsertConfig = new UpsertConfig();
-    upsertConfig.setComparisonColumn("ts");
-    upsertConfig.setEnablePreload(true);
-    upsertConfig.setEnableSnapshot(true);
-    when(tableConfig.getUpsertConfig()).thenReturn(upsertConfig);
-    when(tableConfig.getTableName()).thenReturn(tableNameWithType);
-    Schema schema = mock(Schema.class);
-    when(schema.getPrimaryKeyColumns()).thenReturn(Collections.singletonList("pk"));
-
-    // Setup mocks for HelixManager.
-    HelixManager helixManager = mock(HelixManager.class);
-    IdealState idealState = mock(IdealState.class);
-    HelixDataAccessor dataAccessor = mock(HelixDataAccessor.class);
-    PropertyKey.Builder keyBuilder = mock(PropertyKey.Builder.class);
-    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
-    PropertyKey propKey = mock(PropertyKey.class);
-    when(helixManager.getHelixDataAccessor()).thenReturn(dataAccessor);
-    when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
-    when(dataAccessor.keyBuilder()).thenReturn(keyBuilder);
-    when(keyBuilder.idealStates(anyString())).thenReturn(propKey);
-    when(dataAccessor.getProperty(propKey)).thenReturn(idealState);
-
-    // Setup mocks to return the instanceId.
-    String instanceId = "server01";
-    TableDataManager tableDataManager = mock(TableDataManager.class);
-    TableDataManagerConfig tdmc = mock(TableDataManagerConfig.class);
-    InstanceDataManagerConfig idmc = mock(InstanceDataManagerConfig.class);
-    when(tableDataManager.getTableDataManagerConfig()).thenReturn(tdmc);
-    when(tdmc.getInstanceDataManagerConfig()).thenReturn(idmc);
-    when(idmc.getInstanceId()).thenReturn(instanceId);
-
-    // Only ONLINE segments are preloaded.
-    Map<String, Map<String, String>> segStates = new HashMap<>();
-    segStates.put("online_seg01", ImmutableMap.of(instanceId, "ONLINE"));
-    when(idealState.getPartitionSet()).thenReturn(segStates.keySet());
-    for (String segName : segStates.keySet()) {
-      when(idealState.getInstanceStateMap(segName)).thenReturn(segStates.get(segName));
-    }
-
-    // Setup mocks to get file path to validDocIds snapshot.
-    SegmentZKMetadata realtimeSegmentZKMetadata = new SegmentZKMetadata("online_seg01");
-    realtimeSegmentZKMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
-    when(propertyStore.get(
-        eq(ZKMetadataProvider.constructPropertyStorePathForSegment(tableNameWithType, "online_seg01")), any(),
-        anyInt())).thenReturn(realtimeSegmentZKMetadata.toZNRecord());
-    File seg01IdxDir = new File(TEMP_DIR, "online_seg01");
-    FileUtils.forceMkdir(seg01IdxDir);
-    FileUtils.touch(new File(new File(seg01IdxDir, "v3"), V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME));
-    when(tableDataManager.getSegmentDataDir("online_seg01", null, tableConfig)).thenReturn(seg01IdxDir);
-
-    ExecutorService bgThreads = Executors.newFixedThreadPool(2);
-    try {
-      long sleepMs = 2000;
-      AtomicLong waitMs = new AtomicLong(0);
-      long start = System.currentTimeMillis();
-      CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
-        try {
-          LOGGER.info("Waiting for mgr to be ready");
-          mgr.waitTillReady();
-          LOGGER.info("The mgr is ready now");
-          waitMs.set(System.currentTimeMillis() - start);
-        } catch (InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-      }, bgThreads);
-      CompletableFuture.runAsync(() -> {
-        try {
-          LOGGER.info("Sleeping for: " + sleepMs);
-          Thread.sleep(sleepMs);
-          latch.countDown();
-          LOGGER.info("Waked up and opened latch");
-        } catch (InterruptedException e) {
-          throw new RuntimeException(e);
-        }
-      }, bgThreads);
-      // init() will be blocked on CountDown latch for at least `sleepMs` long, then it'll finish
-      // and then the thread waiting on waitTillReady() is unblocked, after at least `sleepMs` long.
-      LOGGER.info("Initializing the mgr");
-      assertFalse(mgr.isReady());
-      mgr.init(tableConfig, schema, tableDataManager, mock(ServerMetrics.class), helixManager, null);
-      LOGGER.info("The mgr is initialized");
-      assertTrue(mgr.isReady());
-      assertTrue(preloadedSegments.contains("online_seg01"));
-
-      // Wait for the waiting thread to finish, so that the waitMs is updated.
-      future.get();
-      assertTrue(waitMs.get() >= sleepMs, "wait duration: " + waitMs.get());
-    } finally {
-      bgThreads.shutdownNow();
-    }
+    assertTrue(wasPreloading.get());
+    assertFalse(mgr.isPreloading());
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManagerTest.java
@@ -1,0 +1,332 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.upsert;
+
+import com.google.common.collect.ImmutableMap;
+import java.io.File;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.commons.io.FileUtils;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.local.data.manager.TableDataManagerConfig;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.fail;
+
+
+public class ConcurrentMapTableUpsertMetadataManagerTest {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConcurrentMapTableUpsertMetadataManagerTest.class);
+
+  private static final File TEMP_DIR =
+      new File(FileUtils.getTempDirectory(), "ConcurrentMapTableUpsertMetadataManagerTest");
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    FileUtils.deleteQuietly(TEMP_DIR);
+  }
+
+  @AfterClass
+  public void tearDown() {
+    FileUtils.deleteQuietly(TEMP_DIR);
+  }
+
+  @Test
+  public void testSkipPreloadSegments() {
+    TableConfig tableConfig = mock(TableConfig.class);
+    UpsertConfig upsertConfig = new UpsertConfig();
+    upsertConfig.setComparisonColumn("ts");
+    when(tableConfig.getUpsertConfig()).thenReturn(upsertConfig);
+    Schema schema = mock(Schema.class);
+    when(schema.getPrimaryKeyColumns()).thenReturn(Collections.singletonList("pk"));
+
+    // Preloading is skipped as snapshot is not enabled.
+    ConcurrentMapTableUpsertMetadataManager mgr = new ConcurrentMapTableUpsertMetadataManager();
+    assertFalse(mgr.isReady());
+    mgr.init(tableConfig, schema, mock(TableDataManager.class), mock(ServerMetrics.class), mock(HelixManager.class),
+        null);
+    assertTrue(mgr.isReady());
+
+    // Preloading is skipped as preloading is not turned on.
+    upsertConfig.setEnableSnapshot(true);
+    mgr = new ConcurrentMapTableUpsertMetadataManager();
+    assertFalse(mgr.isReady());
+    mgr.init(tableConfig, schema, mock(TableDataManager.class), mock(ServerMetrics.class), mock(HelixManager.class),
+        null);
+    assertTrue(mgr.isReady());
+
+    upsertConfig.setEnablePreload(true);
+    mgr = new ConcurrentMapTableUpsertMetadataManager();
+    assertFalse(mgr.isReady());
+    try {
+      // The preloading logic will hit on error as the HelixManager mock is not fully setup.
+      mgr.init(tableConfig, schema, mock(TableDataManager.class), mock(ServerMetrics.class), mock(HelixManager.class),
+          null);
+      fail();
+    } catch (Exception ignore) {
+      // Even if
+      assertTrue(mgr.isReady());
+    }
+  }
+
+  @Test
+  public void testPreloadOnlineSegments()
+      throws Exception {
+    Set<String> preloadedSegments = new HashSet<>();
+    ConcurrentMapTableUpsertMetadataManager mgr = new ConcurrentMapTableUpsertMetadataManager() {
+      @Override
+      protected IndexLoadingConfig createIndexLoadingConfig() {
+        return mock(IndexLoadingConfig.class);
+      }
+
+      @Override
+      protected void preloadSegmentWithSnapshot(String segmentName, IndexLoadingConfig indexLoadingConfig,
+          SegmentZKMetadata zkMetadata) {
+        preloadedSegments.add(segmentName);
+      }
+    };
+    // Setup mocks for TableConfig and Schema.
+    String tableNameWithType = "myTable_REALTIME";
+    TableConfig tableConfig = mock(TableConfig.class);
+    UpsertConfig upsertConfig = new UpsertConfig();
+    upsertConfig.setComparisonColumn("ts");
+    upsertConfig.setEnablePreload(true);
+    upsertConfig.setEnableSnapshot(true);
+    when(tableConfig.getUpsertConfig()).thenReturn(upsertConfig);
+    when(tableConfig.getTableName()).thenReturn(tableNameWithType);
+    Schema schema = mock(Schema.class);
+    when(schema.getPrimaryKeyColumns()).thenReturn(Collections.singletonList("pk"));
+
+    // Setup mocks for HelixManager.
+    HelixManager helixManager = mock(HelixManager.class);
+    IdealState idealState = mock(IdealState.class);
+    HelixDataAccessor dataAccessor = mock(HelixDataAccessor.class);
+    PropertyKey.Builder keyBuilder = mock(PropertyKey.Builder.class);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    PropertyKey propKey = mock(PropertyKey.class);
+    when(helixManager.getHelixDataAccessor()).thenReturn(dataAccessor);
+    when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
+    when(dataAccessor.keyBuilder()).thenReturn(keyBuilder);
+    when(keyBuilder.idealStates(anyString())).thenReturn(propKey);
+    when(dataAccessor.getProperty(propKey)).thenReturn(idealState);
+
+    // Setup mocks to return the instanceId.
+    String instanceId = "server01";
+    TableDataManager tableDataManager = mock(TableDataManager.class);
+    TableDataManagerConfig tdmc = mock(TableDataManagerConfig.class);
+    InstanceDataManagerConfig idmc = mock(InstanceDataManagerConfig.class);
+    when(tableDataManager.getTableDataManagerConfig()).thenReturn(tdmc);
+    when(tdmc.getInstanceDataManagerConfig()).thenReturn(idmc);
+    when(idmc.getInstanceId()).thenReturn(instanceId);
+
+    // Only ONLINE segments are preloaded.
+    Map<String, Map<String, String>> segStates = new HashMap<>();
+    segStates.put("consuming_seg01", ImmutableMap.of(instanceId, "CONSUMING"));
+    segStates.put("consuming_seg02", ImmutableMap.of(instanceId, "CONSUMING"));
+    segStates.put("online_seg01", ImmutableMap.of(instanceId, "ONLINE"));
+    segStates.put("online_seg02", ImmutableMap.of(instanceId, "ONLINE"));
+    segStates.put("offline_seg01", ImmutableMap.of(instanceId, "OFFLINE"));
+    segStates.put("offline_seg02", ImmutableMap.of(instanceId, "OFFLINE"));
+    when(idealState.getPartitionSet()).thenReturn(segStates.keySet());
+    for (String segName : segStates.keySet()) {
+      when(idealState.getInstanceStateMap(segName)).thenReturn(segStates.get(segName));
+    }
+
+    // Setup mocks to get file path to validDocIds snapshot.
+    SegmentZKMetadata realtimeSegmentZKMetadata = new SegmentZKMetadata("online_seg01");
+    realtimeSegmentZKMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
+    when(propertyStore.get(
+        eq(ZKMetadataProvider.constructPropertyStorePathForSegment(tableNameWithType, "online_seg01")), any(),
+        anyInt())).thenReturn(realtimeSegmentZKMetadata.toZNRecord());
+    realtimeSegmentZKMetadata = new SegmentZKMetadata("online_seg02");
+    realtimeSegmentZKMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
+    when(propertyStore.get(
+        eq(ZKMetadataProvider.constructPropertyStorePathForSegment(tableNameWithType, "online_seg02")), any(),
+        anyInt())).thenReturn(realtimeSegmentZKMetadata.toZNRecord());
+
+    File seg01IdxDir = new File(TEMP_DIR, "online_seg01");
+    FileUtils.forceMkdir(seg01IdxDir);
+    when(tableDataManager.getSegmentDataDir("online_seg01", null, tableConfig)).thenReturn(seg01IdxDir);
+
+    File seg02IdxDir = new File(TEMP_DIR, "online_seg02");
+    FileUtils.forceMkdir(seg02IdxDir);
+    FileUtils.touch(new File(new File(seg02IdxDir, "v3"), V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME));
+    when(tableDataManager.getSegmentDataDir("online_seg02", null, tableConfig)).thenReturn(seg02IdxDir);
+
+    assertFalse(mgr.isReady());
+    mgr.init(tableConfig, schema, tableDataManager, mock(ServerMetrics.class), helixManager, null);
+    assertEquals(preloadedSegments.size(), 1);
+    assertTrue(preloadedSegments.contains("online_seg02"));
+    assertTrue(mgr.isReady());
+  }
+
+  @Test
+  public void testWaitTillReady()
+      throws Exception {
+    CountDownLatch latch = new CountDownLatch(1);
+    Set<String> preloadedSegments = new HashSet<>();
+    ConcurrentMapTableUpsertMetadataManager mgr = new ConcurrentMapTableUpsertMetadataManager() {
+      @Override
+      protected IndexLoadingConfig createIndexLoadingConfig() {
+        return mock(IndexLoadingConfig.class);
+      }
+
+      @Override
+      protected void preloadSegmentWithSnapshot(String segmentName, IndexLoadingConfig indexLoadingConfig,
+          SegmentZKMetadata zkMetadata) {
+        try {
+          latch.await();
+          preloadedSegments.add(segmentName);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }
+    };
+    // Setup mocks for TableConfig and Schema.
+    String tableNameWithType = "myTable_REALTIME";
+    TableConfig tableConfig = mock(TableConfig.class);
+    UpsertConfig upsertConfig = new UpsertConfig();
+    upsertConfig.setComparisonColumn("ts");
+    upsertConfig.setEnablePreload(true);
+    upsertConfig.setEnableSnapshot(true);
+    when(tableConfig.getUpsertConfig()).thenReturn(upsertConfig);
+    when(tableConfig.getTableName()).thenReturn(tableNameWithType);
+    Schema schema = mock(Schema.class);
+    when(schema.getPrimaryKeyColumns()).thenReturn(Collections.singletonList("pk"));
+
+    // Setup mocks for HelixManager.
+    HelixManager helixManager = mock(HelixManager.class);
+    IdealState idealState = mock(IdealState.class);
+    HelixDataAccessor dataAccessor = mock(HelixDataAccessor.class);
+    PropertyKey.Builder keyBuilder = mock(PropertyKey.Builder.class);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    PropertyKey propKey = mock(PropertyKey.class);
+    when(helixManager.getHelixDataAccessor()).thenReturn(dataAccessor);
+    when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
+    when(dataAccessor.keyBuilder()).thenReturn(keyBuilder);
+    when(keyBuilder.idealStates(anyString())).thenReturn(propKey);
+    when(dataAccessor.getProperty(propKey)).thenReturn(idealState);
+
+    // Setup mocks to return the instanceId.
+    String instanceId = "server01";
+    TableDataManager tableDataManager = mock(TableDataManager.class);
+    TableDataManagerConfig tdmc = mock(TableDataManagerConfig.class);
+    InstanceDataManagerConfig idmc = mock(InstanceDataManagerConfig.class);
+    when(tableDataManager.getTableDataManagerConfig()).thenReturn(tdmc);
+    when(tdmc.getInstanceDataManagerConfig()).thenReturn(idmc);
+    when(idmc.getInstanceId()).thenReturn(instanceId);
+
+    // Only ONLINE segments are preloaded.
+    Map<String, Map<String, String>> segStates = new HashMap<>();
+    segStates.put("online_seg01", ImmutableMap.of(instanceId, "ONLINE"));
+    when(idealState.getPartitionSet()).thenReturn(segStates.keySet());
+    for (String segName : segStates.keySet()) {
+      when(idealState.getInstanceStateMap(segName)).thenReturn(segStates.get(segName));
+    }
+
+    // Setup mocks to get file path to validDocIds snapshot.
+    SegmentZKMetadata realtimeSegmentZKMetadata = new SegmentZKMetadata("online_seg01");
+    realtimeSegmentZKMetadata.setStatus(CommonConstants.Segment.Realtime.Status.DONE);
+    when(propertyStore.get(
+        eq(ZKMetadataProvider.constructPropertyStorePathForSegment(tableNameWithType, "online_seg01")), any(),
+        anyInt())).thenReturn(realtimeSegmentZKMetadata.toZNRecord());
+    File seg01IdxDir = new File(TEMP_DIR, "online_seg01");
+    FileUtils.forceMkdir(seg01IdxDir);
+    FileUtils.touch(new File(new File(seg01IdxDir, "v3"), V1Constants.VALID_DOC_IDS_SNAPSHOT_FILE_NAME));
+    when(tableDataManager.getSegmentDataDir("online_seg01", null, tableConfig)).thenReturn(seg01IdxDir);
+
+    ExecutorService bgThreads = Executors.newFixedThreadPool(2);
+    try {
+      long sleepMs = 2000;
+      AtomicLong waitMs = new AtomicLong(0);
+      long start = System.currentTimeMillis();
+      CompletableFuture<Void> future = CompletableFuture.runAsync(() -> {
+        try {
+          LOGGER.info("Waiting for mgr to be ready");
+          mgr.waitTillReady();
+          LOGGER.info("The mgr is ready now");
+          waitMs.set(System.currentTimeMillis() - start);
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }, bgThreads);
+      CompletableFuture.runAsync(() -> {
+        try {
+          LOGGER.info("Sleeping for: " + sleepMs);
+          Thread.sleep(sleepMs);
+          latch.countDown();
+          LOGGER.info("Waked up and opened latch");
+        } catch (InterruptedException e) {
+          throw new RuntimeException(e);
+        }
+      }, bgThreads);
+      // init() will be blocked on CountDown latch for at least `sleepMs` long, then it'll finish
+      // and then the thread waiting on waitTillReady() is unblocked, after at least `sleepMs` long.
+      LOGGER.info("Initializing the mgr");
+      assertFalse(mgr.isReady());
+      mgr.init(tableConfig, schema, tableDataManager, mock(ServerMetrics.class), helixManager, null);
+      LOGGER.info("The mgr is initialized");
+      assertTrue(mgr.isReady());
+      assertTrue(preloadedSegments.contains("online_seg01"));
+
+      // Wait for the waiting thread to finish, so that the waitMs is updated.
+      future.get();
+      assertTrue(waitMs.get() >= sleepMs, "wait duration: " + waitMs.get());
+    } finally {
+      bgThreads.shutdownNow();
+    }
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -244,7 +244,7 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   }
 
   public int getMaxSegmentPreloadThreads() {
-    return _instanceDataManagerConfiguration.getProperty(MAX_SEGMENT_PRELOAD_THREADS, 1);
+    return _instanceDataManagerConfiguration.getProperty(MAX_SEGMENT_PRELOAD_THREADS, 0);
   }
 
   public int getMaxParallelSegmentBuilds() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -121,6 +121,9 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   //
   private static final String MAX_PARALLEL_REFRESH_THREADS = "max.parallel.refresh.threads";
 
+  // To preload segments of table using upsert in parallel for fast upsert metadata recovery.
+  private static final String MAX_SEGMENT_PRELOAD_THREADS = "max.segment.preload.threads";
+
   // Size of cache that holds errors.
   private static final String ERROR_CACHE_SIZE = "error.cache.size";
 
@@ -238,6 +241,10 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
 
   public int getMaxParallelRefreshThreads() {
     return _instanceDataManagerConfiguration.getProperty(MAX_PARALLEL_REFRESH_THREADS, 1);
+  }
+
+  public int getMaxSegmentPreloadThreads() {
+    return _instanceDataManagerConfiguration.getProperty(MAX_SEGMENT_PRELOAD_THREADS, 1);
   }
 
   public int getMaxParallelSegmentBuilds() {

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/BaseResourceTest.java
@@ -193,9 +193,8 @@ public abstract class BaseResourceTest {
     // NOTE: Use OfflineTableDataManager for both OFFLINE and REALTIME table because RealtimeTableDataManager requires
     //       table config.
     TableDataManager tableDataManager = new OfflineTableDataManager();
-    tableDataManager
-        .init(tableDataManagerConfig, "testInstance", mock(ZkHelixPropertyStore.class), mock(ServerMetrics.class),
-            mock(HelixManager.class), null, new TableDataManagerParams(0, false, -1));
+    tableDataManager.init(tableDataManagerConfig, "testInstance", mock(ZkHelixPropertyStore.class),
+        mock(ServerMetrics.class), mock(HelixManager.class), null, null, new TableDataManagerParams(0, false, -1));
     tableDataManager.start();
     _tableDataManagerMap.put(tableNameWithType, tableDataManager);
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -60,6 +60,9 @@ public class UpsertConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Whether to use snapshot for fast upsert metadata recovery")
   private boolean _enableSnapshot;
 
+  @JsonPropertyDescription("Whether to preload segments for fast upsert metadata recovery")
+  private boolean _enablePreload;
+
   @JsonPropertyDescription("Custom class for upsert metadata manager")
   private String _metadataManagerClass;
 
@@ -106,6 +109,10 @@ public class UpsertConfig extends BaseJsonConfig {
 
   public boolean isEnableSnapshot() {
     return _enableSnapshot;
+  }
+
+  public boolean isEnablePreload() {
+    return _enablePreload;
   }
 
   @Nullable
@@ -170,6 +177,10 @@ public class UpsertConfig extends BaseJsonConfig {
 
   public void setEnableSnapshot(boolean enableSnapshot) {
     _enableSnapshot = enableSnapshot;
+  }
+
+  public void setEnablePreload(boolean enablePreload) {
+    _enablePreload = enablePreload;
   }
 
   public void setMetadataManagerClass(String metadataManagerClass) {

--- a/pinot-tools/src/main/resources/examples/stream/upsertMeetupRsvp/upsertMeetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/upsertMeetupRsvp/upsertMeetupRsvp_realtime_table_config.json
@@ -57,6 +57,8 @@
     "instanceSelectorType": "strictReplicaGroup"
   },
   "upsertConfig": {
-    "mode": "FULL"
+    "mode": "FULL",
+    "enableSnapshot": "true",
+    "enablePreload": "true"
   }
 }


### PR DESCRIPTION
`feature`

This PR adds a feature to preload segments from table that uses the upsert snapshot feature. The segments with validDocIds snapshots can be preloaded in a more efficient manner to speed up the table loading (thus server restarts). 

Basically, the primary keys from all valid docs from all segments with validDocIds snapshots are unique, so we can simply put their primary keys into the upsert metadata map, w/o doing the costly checks for duplicate primary keys. Once preloading is done, the remaining segments can be loaded as usual, i.e. check for duplicates and update validDocIds in the existing segments.

## Release Note ##
1. added a new instance config: `max.segment.preload.threads` to configure how many bg threads to preload segments. The thread pool is shared across tables.
2. added a table config (upsert config): `enablePreload`, whether to enable preloading.