### PR TITLE
update jersey to fix Denial of Service (DoS)

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
@@ -41,7 +41,7 @@
     <jetty-server.version>9.4.51.v20230217</jetty-server.version>
     <javax.servlet-api.version>3.1.0</javax.servlet-api.version>
     <javax.ws.rs-api.version>2.1</javax.ws.rs-api.version>
-    <jersey-container-grizzly2-http.version>2.35</jersey-container-grizzly2-http.version>
+    <jersey-container-grizzly2-http.version>2.39</jersey-container-grizzly2-http.version>
     <simpleclient_common.version>0.8.1</simpleclient_common.version>
     <grpc-proto.version>1.12.0</grpc-proto.version>
     <grpc-context.version>1.14.0</grpc-context.version>

--- a/pom.xml
+++ b/pom.xml
@@ -128,7 +128,7 @@
     <jackson.version>2.12.7</jackson.version>
     <zookeeper.version>3.6.3</zookeeper.version>
     <async-http-client.version>2.12.3</async-http-client.version>
-    <jersey.version>2.35</jersey.version>
+    <jersey.version>2.39</jersey.version>
     <grizzly.version>2.4.4</grizzly.version>
     <hk2.version>2.6.1</hk2.version>
     <swagger.version>1.6.6</swagger.version>


### PR DESCRIPTION
the problem is in jersey's dependency: [com.fasterxml.jackson.core:jackson-databind](https://security.snyk.io/package/maven/com.fasterxml.jackson.core%3Ajackson-databind)

2.39 has fixed the problem