### PR TITLE
Fix a flaky test OfflineGRPCServerIntegrationTest.testQueryingGrpcServer.

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineGRPCServerIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineGRPCServerIntegrationTest.java
@@ -202,10 +202,16 @@ public class OfflineGRPCServerIntegrationTest extends BaseClusterIntegrationTest
         // Process server response.
         QueryContext queryContext = QueryContextConverterUtils.getQueryContext(sql);
         DataTableReducer reducer = ResultReducerFactory.getResultReducer(queryContext);
-        BrokerResponseNative brokerResponse = new BrokerResponseNative();
-        reducer.reduceAndSetResults("mytable_OFFLINE", cachedDataSchema, dataTableMap, brokerResponse,
+        BrokerResponseNative streamingBrokerResponse = new BrokerResponseNative();
+        reducer.reduceAndSetResults("mytable_OFFLINE", cachedDataSchema, dataTableMap, streamingBrokerResponse,
             DATATABLE_REDUCER_CONTEXT, mock(BrokerMetrics.class));
-        assertEquals(brokerResponse.getResultTable().getRows().size(), nonStreamResultDataTable.getNumberOfRows());
+        dataTableMap.clear();
+        dataTableMap.put(mock(ServerRoutingInstance.class), nonStreamResultDataTable);
+        BrokerResponseNative nonStreamBrokerResponse = new BrokerResponseNative();
+        reducer.reduceAndSetResults("mytable_OFFLINE", cachedDataSchema, dataTableMap, nonStreamBrokerResponse,
+            DATATABLE_REDUCER_CONTEXT, mock(BrokerMetrics.class));
+        assertEquals(streamingBrokerResponse.getResultTable().getRows().size(),
+            nonStreamBrokerResponse.getResultTable().getRows().size());
 
         // validate final metadata return
         assertEquals(responseType, CommonConstants.Query.Response.ResponseType.METADATA);


### PR DESCRIPTION
The test is flaky because the query uses the default `LIMIT` of 10 and there is a race condition in [`ConcurrentIndexedTable::upsertWithoutOrderBy`](https://github.com/apache/pinot/blob/f3068bc93165e359cc3d846c40f62312ecc98af3/pinot-core/src/main/java/org/apache/pinot/core/data/table/ConcurrentIndexedTable.java#L73) which might return more than `LIMIT` number of rows from the server.

The race condition will not produce wrong query results because the broker reducer trims additional rows.

The test is inconsistent: it gets the number of streaming table rows from the broker and the number of offline table rows from the server. The fix is to get both numbers from the broker.

Tested using `invocationCount = 200`.