### PR TITLE
Preserve non-null comparison column values during segment commit

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -1232,6 +1232,11 @@ public class MutableSegmentImpl implements MutableSegment {
     return columnNameToAggregator;
   }
 
+  @Override
+  public List<String> getComparisonColumnNames() {
+    return _upsertComparisonColumns;
+  }
+
   private class IndexContainer implements Closeable {
     final FieldSpec _fieldSpec;
     final PartitionFunction _partitionFunction;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment.java
@@ -134,4 +134,13 @@ public interface IndexSegment {
    * Destroys segment in memory and closes file handlers if in MMAP mode.
    */
   void destroy();
+
+  /**
+   * Returns the number of rows already indexed into the segment.
+   *
+   * @return The number of rows indexed
+   */
+  default List<String> getComparisonColumnNames() {
+    return null;
+  }
 }


### PR DESCRIPTION
This PR completes the bug fix introduced with https://github.com/apache/pinot/pull/10704

With the fix introduced previously, although we merge the comparison column values, we still mark the original columns as null in the bitmap so that it can help during restart.

However, during the segment build, we simply filter out all the columns which have null set in the bitmap and thus we lose all these values.

## Reproducing the bug

* create a partital upsert table with two comparison columns `mtime` and `mtime_2`

* publish the following two records to the table

```jsonl
{ "rsvp_count": 23, "venue_name": "Venue A", "event_id": "E12345", "event_time": 1688372645422, "group_city": "San Francisco", "group_country": "USA", "group_id": 1234567890, "group_name": "OpenAI enthusiasts", "group_lat": 37.7749, "group_lon": -122.4194, "mtime_2": 1687341314322 }


{ "rsvp_count": 23, "venue_name": "Venue A", "event_id": "E12345", "event_time": 1688372645422, "group_city": "San Francisco", "group_country": "USA", "group_id": 1234567890, "group_name": "OpenAI enthusiasts", "group_lat": 37.7749, "group_lon": -122.4194, "mtime": 1687341314100 }
```

* verify the records are showing up correctly in the table. Then do either reload or force commit.

* You will see that no records show up in the table now. If you use `skipUpsert(true)` though, you will be able to see everything