### PR TITLE
Improve `DateTimeGranularitySpec` to follow the convention of new dateTimeField format

### DIFF
--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -55,14 +55,6 @@
           </execution>
         </executions>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>8</source>
-          <target>8</target>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -55,6 +55,14 @@
           </execution>
         </executions>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <dependencies>

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeGranularitySpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeGranularitySpec.java
@@ -29,10 +29,16 @@ import org.apache.pinot.spi.utils.StringUtil;
  * Class to represent granularity from {@link DateTimeFieldSpec}
  */
 public class DateTimeGranularitySpec {
-  // 'size:timeUnit'
-  private static final char SEPARATOR = '|';
-  private static final int TIME_UNIT_POSITION = 0;
-  private static final int SIZE_POSITION = 1;
+  // Colon format:
+  private static final char COLON_SEPARATOR = ':';
+  private static final int COLON_FORMAT_SIZE_POSITION = 0;
+  private static final int COLON_FORMAT_TIME_UNIT_POSITION = 1;
+
+  // Pipe format:
+  private static final char PIPE_SEPARATOR = '|';
+  private static final int PIPE_FORMAT_TIME_UNIT_POSITION = 0;
+  private static final int PIPE_FORMAT_SIZE_POSITION = 1;
+
   private static final int NUM_TOKENS = 2;
 
   private final int _size;
@@ -43,21 +49,41 @@ public class DateTimeGranularitySpec {
    */
   public DateTimeGranularitySpec(String granularity) {
     Preconditions.checkArgument(StringUtils.isNotEmpty(granularity), "Must provide granularity");
-    String[] granularityTokens = StringUtil.split(granularity, SEPARATOR, 2);
-    Preconditions.checkArgument(granularityTokens.length >= NUM_TOKENS,
-        "Invalid granularity: %s, must be of format 'timeUnit|size", granularity);
+
+    int sizePosition;
+    int timeUnitPosition;
+    String[] granularityTokens;
+
+    if (Character.isDigit(granularity.charAt(0))) {
+      // Colon format
+      granularityTokens = StringUtil.split(granularity, COLON_SEPARATOR, 2);
+      Preconditions.checkArgument(granularityTokens.length >= NUM_TOKENS,
+              "Invalid granularity: %s, must be of format 'size:timeUnit", granularity);
+
+      sizePosition = COLON_FORMAT_SIZE_POSITION;
+      timeUnitPosition = COLON_FORMAT_TIME_UNIT_POSITION;
+    } else {
+      // Pipe format
+      granularityTokens = StringUtil.split(granularity, PIPE_SEPARATOR, 2);
+      Preconditions.checkArgument(granularityTokens.length >= NUM_TOKENS,
+              "Invalid granularity: %s, must be of format 'timeUnit|size", granularity);
+
+      sizePosition = PIPE_FORMAT_SIZE_POSITION;
+      timeUnitPosition = PIPE_FORMAT_TIME_UNIT_POSITION;
+    }
+
     try {
-      _size = Integer.parseInt(granularityTokens[SIZE_POSITION]);
+      _size = Integer.parseInt(granularityTokens[sizePosition]);
     } catch (Exception e) {
       throw new IllegalArgumentException(
-          String.format("Invalid size: %s in granularity: %s", granularityTokens[SIZE_POSITION], granularity));
+          String.format("Invalid size: %s in granularity: %s", granularityTokens[sizePosition], granularity));
     }
     Preconditions.checkArgument(_size > 0, "Invalid size: %s in granularity: %s, must be positive", _size, granularity);
     try {
-      _timeUnit = TimeUnit.valueOf(granularityTokens[TIME_UNIT_POSITION]);
+      _timeUnit = TimeUnit.valueOf(granularityTokens[timeUnitPosition]);
     } catch (Exception e) {
       throw new IllegalArgumentException(
-          String.format("Invalid time unit: %s in granularity: %s", granularityTokens[TIME_UNIT_POSITION],
+          String.format("Invalid time unit: %s in granularity: %s", granularityTokens[timeUnitPosition],
               granularity));
     }
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeGranularitySpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeGranularitySpec.java
@@ -30,9 +30,9 @@ import org.apache.pinot.spi.utils.StringUtil;
  */
 public class DateTimeGranularitySpec {
   // 'size:timeUnit'
-  private static final char SEPARATOR = ':';
-  private static final int SIZE_POSITION = 0;
-  private static final int TIME_UNIT_POSITION = 1;
+  private static final char SEPARATOR = '|';
+  private static final int TIME_UNIT_POSITION = 0;
+  private static final int SIZE_POSITION = 1;
   private static final int NUM_TOKENS = 2;
 
   private final int _size;
@@ -45,7 +45,7 @@ public class DateTimeGranularitySpec {
     Preconditions.checkArgument(StringUtils.isNotEmpty(granularity), "Must provide granularity");
     String[] granularityTokens = StringUtil.split(granularity, SEPARATOR, 2);
     Preconditions.checkArgument(granularityTokens.length >= NUM_TOKENS,
-        "Invalid granularity: %s, must be of format 'size:timeUnit", granularity);
+        "Invalid granularity: %s, must be of format 'timeUnit|size", granularity);
     try {
       _size = Integer.parseInt(granularityTokens[SIZE_POSITION]);
     } catch (Exception e) {
@@ -83,9 +83,9 @@ public class DateTimeGranularitySpec {
   /**
    * Converts a granularity to millis.
    * <ul>
-   *   <li>1) granularityToMillis(1:HOURS) = 3600000 (60*60*1000)</li>
-   *   <li>2) granularityToMillis(1:MILLISECONDS) = 1</li>
-   *   <li>3) granularityToMillis(15:MINUTES) = 900000 (15*60*1000)</li>
+   *   <li>1) granularityToMillis(HOURS|1) = 3600000 (60*60*1000)</li>
+   *   <li>2) granularityToMillis(MILLISECONDS|1) = 1</li>
+   *   <li>3) granularityToMillis(MINUTES|15) = 900000 (15*60*1000)</li>
    * </ul>
    */
   public long granularityToMillis() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeGranularitySpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeGranularitySpec.java
@@ -29,12 +29,12 @@ import org.apache.pinot.spi.utils.StringUtil;
  * Class to represent granularity from {@link DateTimeFieldSpec}
  */
 public class DateTimeGranularitySpec {
-  // Colon format:
+  // Colon format: 'size:timeUnit'
   private static final char COLON_SEPARATOR = ':';
   private static final int COLON_FORMAT_SIZE_POSITION = 0;
   private static final int COLON_FORMAT_TIME_UNIT_POSITION = 1;
 
-  // Pipe format:
+  // Pipe format: 'timeUnit|size'
   private static final char PIPE_SEPARATOR = '|';
   private static final int PIPE_FORMAT_TIME_UNIT_POSITION = 0;
   private static final int PIPE_FORMAT_SIZE_POSITION = 1;

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/DateTimeGranularitySpecTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/DateTimeGranularitySpecTest.java
@@ -25,46 +25,47 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertThrows;
 
+
 public class DateTimeGranularitySpecTest {
 
-    @Test
-    public void testDateTimeGranularitySpec() {
-        // Old format
-        DateTimeGranularitySpec dateTimeGranularitySpec = new DateTimeGranularitySpec("1:HOURS");
-        assertEquals(dateTimeGranularitySpec.getSize(), 1);
-        assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.HOURS);
-        assertEquals(dateTimeGranularitySpec.granularityToMillis(), 3600000);
+  @Test
+  public void testDateTimeGranularitySpec() {
+    // Old format
+    DateTimeGranularitySpec dateTimeGranularitySpec = new DateTimeGranularitySpec("1:HOURS");
+    assertEquals(dateTimeGranularitySpec.getSize(), 1);
+    assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.HOURS);
+    assertEquals(dateTimeGranularitySpec.granularityToMillis(), 3600000);
 
-        dateTimeGranularitySpec = new DateTimeGranularitySpec("15:MINUTES");
-        assertEquals(dateTimeGranularitySpec.getSize(), 15);
-        assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MINUTES);
-        assertEquals(dateTimeGranularitySpec.granularityToMillis(), 900000);
+    dateTimeGranularitySpec = new DateTimeGranularitySpec("15:MINUTES");
+    assertEquals(dateTimeGranularitySpec.getSize(), 15);
+    assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MINUTES);
+    assertEquals(dateTimeGranularitySpec.granularityToMillis(), 900000);
 
-        dateTimeGranularitySpec = new DateTimeGranularitySpec("1:MILLISECONDS");
-        assertEquals(dateTimeGranularitySpec.getSize(), 1);
-        assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MILLISECONDS);
-        assertEquals(dateTimeGranularitySpec.granularityToMillis(), 1);
+    dateTimeGranularitySpec = new DateTimeGranularitySpec("1:MILLISECONDS");
+    assertEquals(dateTimeGranularitySpec.getSize(), 1);
+    assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MILLISECONDS);
+    assertEquals(dateTimeGranularitySpec.granularityToMillis(), 1);
 
-        // New format
-        dateTimeGranularitySpec = new DateTimeGranularitySpec("HOURS|1");
-        assertEquals(dateTimeGranularitySpec.getSize(), 1);
-        assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.HOURS);
-        assertEquals(dateTimeGranularitySpec.granularityToMillis(), 3600000);
+    // New format
+    dateTimeGranularitySpec = new DateTimeGranularitySpec("HOURS|1");
+    assertEquals(dateTimeGranularitySpec.getSize(), 1);
+    assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.HOURS);
+    assertEquals(dateTimeGranularitySpec.granularityToMillis(), 3600000);
 
-        dateTimeGranularitySpec = new DateTimeGranularitySpec("MINUTES|15");
-        assertEquals(dateTimeGranularitySpec.getSize(), 15);
-        assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MINUTES);
-        assertEquals(dateTimeGranularitySpec.granularityToMillis(), 900000);
+    dateTimeGranularitySpec = new DateTimeGranularitySpec("MINUTES|15");
+    assertEquals(dateTimeGranularitySpec.getSize(), 15);
+    assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MINUTES);
+    assertEquals(dateTimeGranularitySpec.granularityToMillis(), 900000);
 
-        dateTimeGranularitySpec = new DateTimeGranularitySpec("MILLISECONDS|1");
-        assertEquals(dateTimeGranularitySpec.getSize(), 1);
-        assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MILLISECONDS);
-        assertEquals(dateTimeGranularitySpec.granularityToMillis(), 1);
+    dateTimeGranularitySpec = new DateTimeGranularitySpec("MILLISECONDS|1");
+    assertEquals(dateTimeGranularitySpec.getSize(), 1);
+    assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MILLISECONDS);
+    assertEquals(dateTimeGranularitySpec.granularityToMillis(), 1);
 
-        assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("DAY:1"));
-        assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1|DAY"));
-        assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("DAY:DAY"));
-        assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1:1"));
-        assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1:DAY:EPOCH"));
-    }
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("DAY:1"));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1|DAY"));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("DAY:DAY"));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1:1"));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1:DAY:EPOCH"));
+  }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/DateTimeGranularitySpecTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/DateTimeGranularitySpecTest.java
@@ -1,0 +1,70 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.spi.data;
+
+import java.util.concurrent.TimeUnit;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
+
+public class DateTimeGranularitySpecTest {
+
+    @Test
+    public void testDateTimeGranularitySpec() {
+        // Old format
+        DateTimeGranularitySpec dateTimeGranularitySpec = new DateTimeGranularitySpec("1:HOURS");
+        assertEquals(dateTimeGranularitySpec.getSize(), 1);
+        assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.HOURS);
+        assertEquals(dateTimeGranularitySpec.granularityToMillis(), 3600000);
+
+        dateTimeGranularitySpec = new DateTimeGranularitySpec("15:MINUTES");
+        assertEquals(dateTimeGranularitySpec.getSize(), 15);
+        assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MINUTES);
+        assertEquals(dateTimeGranularitySpec.granularityToMillis(), 900000);
+
+        dateTimeGranularitySpec = new DateTimeGranularitySpec("1:MILLISECONDS");
+        assertEquals(dateTimeGranularitySpec.getSize(), 1);
+        assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MILLISECONDS);
+        assertEquals(dateTimeGranularitySpec.granularityToMillis(), 1);
+
+        // New format
+        dateTimeGranularitySpec = new DateTimeGranularitySpec("HOURS|1");
+        assertEquals(dateTimeGranularitySpec.getSize(), 1);
+        assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.HOURS);
+        assertEquals(dateTimeGranularitySpec.granularityToMillis(), 3600000);
+
+        dateTimeGranularitySpec = new DateTimeGranularitySpec("MINUTES|15");
+        assertEquals(dateTimeGranularitySpec.getSize(), 15);
+        assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MINUTES);
+        assertEquals(dateTimeGranularitySpec.granularityToMillis(), 900000);
+
+        dateTimeGranularitySpec = new DateTimeGranularitySpec("MILLISECONDS|1");
+        assertEquals(dateTimeGranularitySpec.getSize(), 1);
+        assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MILLISECONDS);
+        assertEquals(dateTimeGranularitySpec.granularityToMillis(), 1);
+
+        assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("DAY:1"));
+        assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1|DAY"));
+        assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("DAY:DAY"));
+        assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1:1"));
+        assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1:DAY:EPOCH"));
+    }
+}


### PR DESCRIPTION
Fixes [#11028](https://github.com/apache/pinot/issues/11028)

Adding support for new datetime format for DateTimeGranularitySpec as well.

Proposed change:

```
old format: 
size:timeUnit -> 1:MILLISECONDS

new format:
timeUnit|size -> MILLISECONDS|1
```
