### PR TITLE
Fix BOOL_AND and BOOL_OR result type

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
@@ -140,6 +140,9 @@ public class AggregationResultsBlock extends BaseResultsBlock {
       throws IOException {
     ColumnDataType columnDataType = columnDataTypes[index];
     switch (columnDataType) {
+      case INT:
+        dataTableBuilder.setColumn(index, (int) result);
+        break;
       case LONG:
         dataTableBuilder.setColumn(index, (long) result);
         break;
@@ -158,7 +161,7 @@ public class AggregationResultsBlock extends BaseResultsBlock {
       Object result)
       throws IOException {
     ColumnDataType columnDataType = columnDataTypes[index];
-    switch (columnDataType) {
+    switch (columnDataType.getStoredType()) {
       case INT:
         dataTableBuilder.setColumn(index, (int) result);
         break;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -137,6 +138,8 @@ public class AggregationFunctionUtils {
    */
   public static Object getIntermediateResult(DataTable dataTable, ColumnDataType columnDataType, int rowId, int colId) {
     switch (columnDataType) {
+      case INT:
+        return dataTable.getInt(rowId, colId);
       case LONG:
         return dataTable.getLong(rowId, colId);
       case DOUBLE:
@@ -166,7 +169,12 @@ public class AggregationFunctionUtils {
         return dataTable.getDouble(rowId, colId);
       case BIG_DECIMAL:
         return dataTable.getBigDecimal(rowId, colId);
+      case BOOLEAN:
+        return dataTable.getInt(rowId, colId) == 1;
+      case TIMESTAMP:
+        return new Timestamp(dataTable.getLong(rowId, colId));
       case STRING:
+      case JSON:
         return dataTable.getString(rowId, colId);
       case BYTES:
         return dataTable.getBytes(rowId, colId).getBytes();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseBooleanAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseBooleanAggregationFunction.java
@@ -21,7 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.IntAggregateResultHolder;
@@ -232,13 +232,13 @@ public abstract class BaseBooleanAggregationFunction extends BaseSingleInputAggr
   }
 
   @Override
-  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
-    return DataSchema.ColumnDataType.BOOLEAN;
+  public ColumnDataType getIntermediateResultColumnType() {
+    return ColumnDataType.INT;
   }
 
   @Override
-  public DataSchema.ColumnDataType getFinalResultColumnType() {
-    return DataSchema.ColumnDataType.BOOLEAN;
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.BOOLEAN;
   }
 
   @Override

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -770,6 +770,7 @@ public class ClusterIntegrationTestUtils {
             return;
           }
 
+          h2Value = convertBooleanToLowerCase(h2Value);
           String brokerValue = brokerResponseRows.get(0).get(c).asText();
           String connectionValue = resultTableResultSet.getString(0, c);
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -140,7 +140,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   private static final String COLUMN_LENGTH_MAP_KEY = "columnLengthMap";
   private static final String COLUMN_CARDINALITY_MAP_KEY = "columnCardinalityMap";
   private static final String MAX_NUM_MULTI_VALUES_MAP_KEY = "maxNumMultiValuesMap";
-  private static final int DISK_SIZE_IN_BYTES = 20797324;
+  private static final int DISK_SIZE_IN_BYTES = 20797336;
   private static final int NUM_ROWS = 115545;
 
   private final List<ServiceStatus.ServiceStatusCallback> _serviceStatusCallbacks =
@@ -2749,5 +2749,12 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
     assertFalse(rows.get(0).get(0).asBoolean());
+  }
+
+  @Test
+  public void testBooleanAggregation()
+      throws Exception {
+    testQuery("SELECT BOOL_AND(Cancelled) FROM mytable");
+    testQuery("SELECT BOOL_OR(Diverted) FROM mytable");
   }
 }

--- a/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls.schema
+++ b/pinot-integration-tests/src/test/resources/On_Time_On_Time_Performance_2014_100k_subset_nonulls.schema
@@ -30,6 +30,10 @@
       "dataType": "STRING"
     },
     {
+      "name": "Cancelled",
+      "dataType": "BOOLEAN"
+    },
+    {
       "name": "Carrier",
       "dataType": "STRING"
     },
@@ -155,7 +159,7 @@
     },
     {
       "name": "Diverted",
-      "dataType": "INT"
+      "dataType": "BOOLEAN"
     },
     {
       "name": "FirstDepTime",
@@ -283,10 +287,6 @@
     {
       "name": "ArrDelayMinutes",
       "dataType": "DOUBLE"
-    },
-    {
-      "name": "Cancelled",
-      "dataType": "INT"
     },
     {
       "name": "CarrierDelay",

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
@@ -56,12 +56,7 @@ public class MultistageGroupByExecutor {
 
   // Mapping from the row-key to a zero based integer index. This is used when we invoke the v1 aggregation functions
   // because they use the zero based integer indexes to store results.
-  private int _groupId = 0;
-  private Map<Key, Integer> _groupKeyToIdMap;
-
-  // Mapping from the group by row-key to the values in the row which form the key. Used to fetch the actual row
-  // values when populating the result.
-  private final Map<Key, Object[]> _groupByKeyHolder;
+  private final Map<Key, Integer> _groupKeyToIdMap;
 
   public MultistageGroupByExecutor(List<ExpressionContext> groupByExpr, AggregationFunction[] aggFunctions,
       NewAggregateOperator.Mode mode, Map<String, Integer> colNameToIndexMap) {
@@ -75,7 +70,6 @@ public class MultistageGroupByExecutor {
     _finalResultHolder = new ArrayList<>();
 
     _groupKeyToIdMap = new HashMap<>();
-    _groupByKeyHolder = new HashMap<>();
 
     for (int i = 0; i < _aggFunctions.length; i++) {
       _aggregateResultHolders[i] =
@@ -88,12 +82,18 @@ public class MultistageGroupByExecutor {
    * Performs group-by aggregation for the data in the block.
    */
   public void processBlock(TransferableBlock block, DataSchema inputDataSchema) {
-    if (_mode.equals(NewAggregateOperator.Mode.AGGREGATE)) {
-      processAggregate(block, inputDataSchema);
-    } else if (_mode.equals(NewAggregateOperator.Mode.MERGE)) {
-      processMerge(block);
-    } else if (_mode.equals(NewAggregateOperator.Mode.EXTRACT_RESULT)) {
-      collectResult(block);
+    switch (_mode) {
+      case AGGREGATE:
+        processAggregate(block, inputDataSchema);
+        break;
+      case MERGE:
+        processMerge(block);
+        break;
+      case EXTRACT_RESULT:
+        collectResult(block);
+        break;
+      default:
+        throw new IllegalStateException();
     }
   }
 
@@ -101,32 +101,28 @@ public class MultistageGroupByExecutor {
    * Fetches the result.
    */
   public List<Object[]> getResult() {
-    List<Object[]> rows = new ArrayList<>();
-
-    if (_mode.equals(NewAggregateOperator.Mode.EXTRACT_RESULT)) {
+    if (_mode == NewAggregateOperator.Mode.EXTRACT_RESULT) {
       return extractFinalGroupByResult();
     }
 
     // If the mode is MERGE or AGGREGATE, the groupby keys are already collected in _groupByKeyHolder by virtue of
     // generating the row keys.
-    for (Map.Entry<Key, Object[]> e : _groupByKeyHolder.entrySet()) {
-      int numCols = _groupSet.size() + _aggFunctions.length;
-      Object[] row = new Object[numCols];
-      Object[] keyElements = e.getValue();
-      System.arraycopy(keyElements, 0, row, 0, keyElements.length);
-
+    List<Object[]> rows = new ArrayList<>(_groupKeyToIdMap.size());
+    int numKeys = _groupSet.size();
+    int numColumns = numKeys + _aggFunctions.length;
+    for (Map.Entry<Key, Integer> entry : _groupKeyToIdMap.entrySet()) {
+      Object[] row = new Object[numColumns];
+      Object[] keyValues = entry.getKey().getValues();
+      System.arraycopy(keyValues, 0, row, 0, numKeys);
       for (int i = 0; i < _aggFunctions.length; i++) {
-        int index = i + _groupSet.size();
-        int groupId = _groupKeyToIdMap.get(e.getKey());
-        if (_mode.equals(NewAggregateOperator.Mode.MERGE)) {
-          Object value = _mergeResultHolder.get(groupId)[i];
-          row[index] = convertObjectToReturnType(_aggFunctions[i].getType(), value);
-        } else if (_mode.equals(NewAggregateOperator.Mode.AGGREGATE)) {
-          Object value = _aggFunctions[i].extractGroupByResult(_aggregateResultHolders[i], groupId);
-          row[index] = convertObjectToReturnType(_aggFunctions[i].getType(), value);
+        int groupId = entry.getValue();
+        if (_mode == NewAggregateOperator.Mode.AGGREGATE) {
+          row[numKeys + i] = _aggFunctions[i].extractGroupByResult(_aggregateResultHolders[i], groupId);
+        } else {
+          assert _mode == NewAggregateOperator.Mode.MERGE;
+          row[numKeys + i] = _mergeResultHolder.get(groupId)[i];
         }
       }
-
       rows.add(row);
     }
 
@@ -134,33 +130,20 @@ public class MultistageGroupByExecutor {
   }
 
   private List<Object[]> extractFinalGroupByResult() {
-    List<Object[]> rows = new ArrayList<>();
+    List<Object[]> rows = new ArrayList<>(_finalResultHolder.size());
+    int numKeys = _groupSet.size();
+    int numColumns = numKeys + _aggFunctions.length;
     for (Object[] resultRow : _finalResultHolder) {
-      int numCols = _groupSet.size() + _aggFunctions.length;
-      Object[] row = new Object[numCols];
-      System.arraycopy(resultRow, 0, row, 0, _groupSet.size());
-
+      Object[] row = new Object[numColumns];
+      System.arraycopy(resultRow, 0, row, 0, numKeys);
       for (int i = 0; i < _aggFunctions.length; i++) {
-        int aggIdx = i + _groupSet.size();
-        Comparable result = _aggFunctions[i].extractFinalResult(resultRow[aggIdx]);
-        row[aggIdx] = result == null ? null : _aggFunctions[i].getFinalResultColumnType().convert(result);
+        int index = numKeys + i;
+        Comparable result = _aggFunctions[i].extractFinalResult(resultRow[index]);
+        row[index] = result == null ? null : _aggFunctions[i].getFinalResultColumnType().convert(result);
       }
-
       rows.add(row);
     }
     return rows;
-  }
-
-  private Object convertObjectToReturnType(AggregationFunctionType aggType, Object value) {
-    // For bool_and and bool_or aggregation functions, the return type for aggregate and merge modes are set as
-    // boolean. However, the v1 bool_and and bool_or function uses Integer as the intermediate type.
-    boolean boolAndOrAgg =
-        aggType.equals(AggregationFunctionType.BOOLAND) || aggType.equals(AggregationFunctionType.BOOLOR);
-    if (boolAndOrAgg && value instanceof Integer) {
-      Boolean boolVal = ((Number) value).intValue() > 0 ? true : false;
-      return boolVal;
-    }
-    return value;
   }
 
   private void processAggregate(TransferableBlock block, DataSchema inputDataSchema) {
@@ -227,29 +210,19 @@ public class MultistageGroupByExecutor {
    * Returns the int key for each row.
    */
   private int[] generateGroupByKeys(List<Object[]> rows) {
-    int[] rowKeys = new int[rows.size()];
-    int numGroups = _groupSet.size();
-
-    for (int i = 0; i < rows.size(); i++) {
+    int numRows = rows.size();
+    int[] rowIntKeys = new int[numRows];
+    int numKeys = _groupSet.size();
+    for (int i = 0; i < numRows; i++) {
       Object[] row = rows.get(i);
-
-      Object[] keyElements = new Object[numGroups];
-      for (int j = 0; j < numGroups; j++) {
-        String colName = _groupSet.get(j).getIdentifier();
-        int colIndex = _colNameToIndexMap.get(colName);
-        keyElements[j] = row[colIndex];
+      Object[] keyValues = new Object[numKeys];
+      for (int j = 0; j < numKeys; j++) {
+        keyValues[j] = row[_colNameToIndexMap.get(_groupSet.get(j).getIdentifier())];
       }
-
-      Key rowKey = new Key(keyElements);
-      _groupByKeyHolder.put(rowKey, rowKey.getValues());
-      if (!_groupKeyToIdMap.containsKey(rowKey)) {
-        _groupKeyToIdMap.put(rowKey, _groupId);
-        ++_groupId;
-      }
-      rowKeys[i] = _groupKeyToIdMap.get(rowKey);
+      Key rowKey = new Key(keyValues);
+      rowIntKeys[i] = _groupKeyToIdMap.computeIfAbsent(rowKey, k -> _groupKeyToIdMap.size());
     }
-
-    return rowKeys;
+    return rowIntKeys;
   }
 
   private Map<ExpressionContext, BlockValSet> getBlockValSetMap(AggregationFunction aggFunction,
@@ -274,34 +247,18 @@ public class MultistageGroupByExecutor {
         new IntermediateStageBlockValSet(dataType, block.getDataBlock(), index));
   }
 
-  Object extractValueFromRow(AggregationFunction aggregationFunction, Object[] row) {
+  private Object extractValueFromRow(AggregationFunction aggregationFunction, Object[] row) {
     // TODO: Add support to handle aggregation functions where:
     //       1. The identifier need not be the first argument
     //       2. There are more than one identifiers.
     List<ExpressionContext> expressions = aggregationFunction.getInputExpressions();
-    Preconditions.checkState(expressions.size() == 1);
+    Preconditions.checkState(expressions.size() == 1, "Only support single expression, got: %s", expressions.size());
     ExpressionContext expr = expressions.get(0);
     ExpressionContext.Type exprType = expr.getType();
-
-    if (exprType.equals(ExpressionContext.Type.IDENTIFIER)) {
-      String colName = expr.getIdentifier();
-      int colIndex = _colNameToIndexMap.get(colName);
-      Object value = row[colIndex];
-
-      // Boolean aggregation functions like BOOL_AND and BOOL_OR have return types set to Boolean. However, their
-      // intermediateResultType is Integer. To handle this case convert Boolean objects to Integer objects.
-      boolean boolAndOrAgg =
-          aggregationFunction.getType().equals(AggregationFunctionType.BOOLAND) || aggregationFunction.getType()
-              .equals(AggregationFunctionType.BOOLOR);
-      if (boolAndOrAgg && value instanceof Boolean) {
-        Integer intVal = ((Boolean) value).booleanValue() ? 1 : 0;
-        return intVal;
-      }
-
-      return value;
+    if (exprType == ExpressionContext.Type.IDENTIFIER) {
+      return row[_colNameToIndexMap.get(expr.getIdentifier())];
     }
-
-    Preconditions.checkState(exprType.equals(ExpressionContext.Type.LITERAL), "Invalid expression type");
+    Preconditions.checkState(exprType == ExpressionContext.Type.LITERAL, "Unsupported expression type: %s", exprType);
     return expr.getLiteral().getValue();
   }
 }


### PR DESCRIPTION
- Fix the unsupported intermediate and final result type BOOLEAN
- Change intermediate result type to INT to match the actual intermediate result value
- Simplify the V2 aggregation handling and remove the special case for BOOL_AND and BOOL_OR