### PR TITLE
Fix BOOL_AND and BOOL_OR result type

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
@@ -140,6 +140,9 @@ public class AggregationResultsBlock extends BaseResultsBlock {
       throws IOException {
     ColumnDataType columnDataType = columnDataTypes[index];
     switch (columnDataType) {
+      case INT:
+        dataTableBuilder.setColumn(index, (int) result);
+        break;
       case LONG:
         dataTableBuilder.setColumn(index, (long) result);
         break;
@@ -158,7 +161,7 @@ public class AggregationResultsBlock extends BaseResultsBlock {
       Object result)
       throws IOException {
     ColumnDataType columnDataType = columnDataTypes[index];
-    switch (columnDataType) {
+    switch (columnDataType.getStoredType()) {
       case INT:
         dataTableBuilder.setColumn(index, (int) result);
         break;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.query.aggregation.function;
 
+import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -137,6 +138,8 @@ public class AggregationFunctionUtils {
    */
   public static Object getIntermediateResult(DataTable dataTable, ColumnDataType columnDataType, int rowId, int colId) {
     switch (columnDataType) {
+      case INT:
+        return dataTable.getInt(rowId, colId);
       case LONG:
         return dataTable.getLong(rowId, colId);
       case DOUBLE:
@@ -166,7 +169,12 @@ public class AggregationFunctionUtils {
         return dataTable.getDouble(rowId, colId);
       case BIG_DECIMAL:
         return dataTable.getBigDecimal(rowId, colId);
+      case BOOLEAN:
+        return dataTable.getInt(rowId, colId) == 1;
+      case TIMESTAMP:
+        return new Timestamp(dataTable.getLong(rowId, colId));
       case STRING:
+      case JSON:
         return dataTable.getString(rowId, colId);
       case BYTES:
         return dataTable.getBytes(rowId, colId).getBytes();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseBooleanAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseBooleanAggregationFunction.java
@@ -21,7 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
-import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.IntAggregateResultHolder;
@@ -232,13 +232,13 @@ public abstract class BaseBooleanAggregationFunction extends BaseSingleInputAggr
   }
 
   @Override
-  public DataSchema.ColumnDataType getIntermediateResultColumnType() {
-    return DataSchema.ColumnDataType.BOOLEAN;
+  public ColumnDataType getIntermediateResultColumnType() {
+    return ColumnDataType.INT;
   }
 
   @Override
-  public DataSchema.ColumnDataType getFinalResultColumnType() {
-    return DataSchema.ColumnDataType.BOOLEAN;
+  public ColumnDataType getFinalResultColumnType() {
+    return ColumnDataType.BOOLEAN;
   }
 
   @Override

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -770,6 +770,7 @@ public class ClusterIntegrationTestUtils {
             return;
           }
 
+          h2Value = convertBooleanToLowerCase(h2Value);
           String brokerValue = brokerResponseRows.get(0).get(c).asText();
           String connectionValue = resultTableResultSet.getString(0, c);
 
@@ -795,7 +796,7 @@ public class ClusterIntegrationTestUtils {
           if (h2ResultSet.first()) {
             for (int i = 0; i < numRows; i++) {
               for (int c = 0; c < numColumns; c++) {
-                String h2Value = h2ResultSet.getString(c + 1);
+                String h2Value = convertBooleanToLowerCase(h2ResultSet.getString(c + 1));
                 String brokerValue = brokerResponseRows.get(i).get(c).asText();
                 String connectionValue = resultTableResultSet.getString(i, c);
                 boolean error = fuzzyCompare(h2Value, brokerValue, connectionValue);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -2750,4 +2750,11 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(rows.size(), 1);
     assertFalse(rows.get(0).get(0).asBoolean());
   }
+
+  @Test
+  public void testBooleanAggregation()
+      throws Exception {
+    testQuery("SELECT BOOL_AND(CAST(Cancelled AS BOOLEAN)) FROM mytable");
+    testQuery("SELECT BOOL_OR(CAST(Diverted AS BOOLEAN)) FROM mytable");
+  }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.collect.ImmutableList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.calcite.sql.SqlKind;
@@ -206,10 +205,14 @@ public class AggregateOperatorTest {
       result = sum0GroupBy1.getNextBlock();
     }
     List<Object[]> resultRows = result.getContainer();
-    List<Object[]> expectedRows = Arrays.asList(new Object[]{"Aa", 1.0}, new Object[]{"BB", 5.0});
-    Assert.assertEquals(resultRows.size(), expectedRows.size());
-    Assert.assertEquals(resultRows.get(0), expectedRows.get(0));
-    Assert.assertEquals(resultRows.get(1), expectedRows.get(1));
+    Assert.assertEquals(resultRows.size(), 2);
+    if (resultRows.get(0).equals("Aa")) {
+      Assert.assertEquals(resultRows.get(0), new Object[]{"Aa", 1.0});
+      Assert.assertEquals(resultRows.get(1), new Object[]{"BB", 5.0});
+    } else {
+      Assert.assertEquals(resultRows.get(0), new Object[]{"BB", 5.0});
+      Assert.assertEquals(resultRows.get(1), new Object[]{"Aa", 1.0});
+    }
   }
 
   @Test(expectedExceptions = BadQueryRequestException.class, expectedExceptionsMessageRegExp = ".*average.*")

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -142,9 +142,9 @@ public enum AggregationFunctionType {
 
   // boolean aggregate functions
   BOOLAND("boolAnd", Collections.emptyList(), false, null, SqlKind.OTHER_FUNCTION, ReturnTypes.BOOLEAN, null,
-      OperandTypes.BOOLEAN, SqlFunctionCategory.USER_DEFINED_FUNCTION, null, ReturnTypes.BOOLEAN, null, null, null),
+      OperandTypes.BOOLEAN, SqlFunctionCategory.USER_DEFINED_FUNCTION, null, ReturnTypes.INTEGER, null, null, null),
   BOOLOR("boolOr", Collections.emptyList(), false, null, SqlKind.OTHER_FUNCTION, ReturnTypes.BOOLEAN, null,
-      OperandTypes.BOOLEAN, SqlFunctionCategory.USER_DEFINED_FUNCTION, null, ReturnTypes.BOOLEAN, null, null, null),
+      OperandTypes.BOOLEAN, SqlFunctionCategory.USER_DEFINED_FUNCTION, null, ReturnTypes.INTEGER, null, null, null),
 
   // argMin and argMax
   ARGMIN("argMin"),


### PR DESCRIPTION
- Fix the unsupported intermediate and final result type BOOLEAN
- Change intermediate result type to INT to match the actual intermediate result value
- Simplify the V2 aggregation handling and remove the special case for BOOL_AND and BOOL_OR
- Properly support DIRECT type in aggregation and group-by executor