### PR TITLE
Removes special null-but-not-null case in multiple comparison columns

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -550,12 +550,12 @@ public class MutableSegmentImpl implements MutableSegment {
             "Documents must have exactly 1 non-null comparison column value");
 
         comparableIndex = i;
-
-        Object comparisonValue = row.getValue(columnName);
-        Preconditions.checkState(comparisonValue instanceof Comparable,
-            "Upsert comparison column: %s must be comparable", columnName);
-        comparisonValues[i] = (Comparable) comparisonValue;
       }
+
+      Object comparisonValue = row.getValue(columnName);
+      Preconditions.checkState(comparisonValue instanceof Comparable,
+          "Upsert comparison column: %s must be comparable", columnName);
+      comparisonValues[i] = (Comparable) comparisonValue;
     }
     Preconditions.checkState(comparableIndex != -1, "Documents must have exactly 1 non-null comparison column value");
     return new ComparisonColumns(comparisonValues, comparableIndex);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ComparisonColumns.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ComparisonColumns.java
@@ -52,18 +52,9 @@ public class ComparisonColumns implements Comparable<ComparisonColumns> {
         continue;
       }
 
-      // Always keep the record with non-null value, or that with the greater comparisonResult
-      if (comparisonValue == null) {
-        // implies comparisonValue == null && otherComparisonValue != null
-        return -1;
-      } else if (otherComparisonValue == null) {
-        // implies comparisonValue != null && otherComparisonValue == null
-        return 1;
-      } else {
-        int comparisonResult = comparisonValue.compareTo(otherComparisonValue);
-        if (comparisonResult != 0) {
-          return comparisonResult;
-        }
+      int comparisonResult = comparisonValue.compareTo(otherComparisonValue);
+      if (comparisonResult != 0) {
+        return comparisonResult;
       }
     }
     return 0;
@@ -78,18 +69,10 @@ public class ComparisonColumns implements Comparable<ComparisonColumns> {
     // _comparisonColumns should only at most one non-null comparison value for newly ingested data. If not, it is
     // the user's responsibility. There is no attempt to guarantee behavior in the case where there are multiple
     // non-null values
-    int comparisonResult;
-
     Comparable comparisonValue = _values[_comparableIndex];
     Comparable otherComparisonValue = other.getValues()[_comparableIndex];
 
-    if (otherComparisonValue == null) {
-      // Keep this record because the existing record has no value for the same comparison column, therefore the
-      // (lack of) existing value could not possibly cause the new value to be rejected.
-      comparisonResult = 1;
-    } else {
-      comparisonResult = comparisonValue.compareTo(otherComparisonValue);
-    }
+    int comparisonResult = comparisonValue.compareTo(otherComparisonValue);
 
     if (comparisonResult >= 0) {
       // TODO(egalpin):  This method currently may have side-effects on _values. Depending on the comparison result,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
@@ -69,17 +69,8 @@ public class PartialUpsertHandler {
       if (!_primaryKeyColumns.contains(column)) {
         if (!previousRecord.isNullValue(column)) {
           if (newRecord.isNullValue(column)) {
-            // Note that we intentionally want to overwrite any previous _comparisonColumn value in the case of using
-            // multiple comparison columns. We never apply a merge function to it, rather we just take any/all non-null
-            // comparison column values from the previous record, and the sole non-null comparison column value from
-            // the new record.
             newRecord.putValue(column, previousRecord.getValue(column));
-            if (!_comparisonColumns.contains(column)) {
-              // Despite wanting to overwrite the values to comparison columns from prior records, we want to
-              // preserve for _this_ record which comparison column was non-null. Doing so will allow us to
-              // re-evaluate the same comparisons when reading a segment and during steady-state stream ingestion
-              newRecord.removeNullValueField(column);
-            }
+            newRecord.removeNullValueField(column);
           } else if (!_comparisonColumns.contains(column)) {
             PartialUpsertMerger merger = _column2Mergers.getOrDefault(column, _defaultPartialUpsertMerger);
             newRecord.putValue(column,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertUtils.java
@@ -193,10 +193,7 @@ public class UpsertUtils {
 
       for (int i = 0; i < _comparisonColumnReaders.length; i++) {
         PinotSegmentColumnReader columnReader = _comparisonColumnReaders[i];
-        Comparable comparisonValue = null;
-        if (!columnReader.isNull(docId)) {
-          comparisonValue = (Comparable) UpsertUtils.getValue(columnReader, docId);
-        }
+        Comparable comparisonValue = (Comparable) UpsertUtils.getValue(columnReader, docId);
         comparisonColumns[i] = comparisonValue;
       }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -139,7 +139,9 @@ public class MutableSegmentImplUpsertTest {
       // Confirm that both comparison column values have made it into the persisted upserted doc
       Assert.assertEquals(1567205397L, _mutableSegmentImpl.getValue(2, "secondsSinceEpoch"));
       Assert.assertEquals(1567205395L, _mutableSegmentImpl.getValue(2, "otherComparisonColumn"));
-      Assert.assertTrue(_mutableSegmentImpl.getDataSource("secondsSinceEpoch").getNullValueVector().isNull(2));
+      // Confirm that both comparison columns are marked as not null
+      Assert.assertFalse(_mutableSegmentImpl.getDataSource("otherComparisonColumn").getNullValueVector().isNull(2));
+      Assert.assertFalse(_mutableSegmentImpl.getDataSource("secondsSinceEpoch").getNullValueVector().isNull(2));
 
       // bb
       Assert.assertFalse(bitmap.contains(4));
@@ -148,6 +150,8 @@ public class MutableSegmentImplUpsertTest {
       // Confirm that comparison column values have made it into the persisted upserted doc
       Assert.assertEquals(1567205396L, _mutableSegmentImpl.getValue(5, "secondsSinceEpoch"));
       Assert.assertEquals(Long.MIN_VALUE, _mutableSegmentImpl.getValue(5, "otherComparisonColumn"));
+      // Confirm that only "secondsSinceEpoch" comparison columns is not marked as null
+      Assert.assertFalse(_mutableSegmentImpl.getDataSource("secondsSinceEpoch").getNullValueVector().isNull(5));
       Assert.assertTrue(_mutableSegmentImpl.getDataSource("otherComparisonColumn").getNullValueVector().isNull(5));
     }
   }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ComparisonColumnsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ComparisonColumnsTest.java
@@ -24,9 +24,9 @@ import org.testng.annotations.Test;
 
 
 public class ComparisonColumnsTest {
-  private void nullFill(Comparable[]... comparables) {
+  private void minIntFill(Comparable[]... comparables) {
     for (Comparable[] comps : comparables) {
-      Arrays.fill(comps, null);
+      Arrays.fill(comps, Integer.MIN_VALUE);
     }
   }
 
@@ -44,31 +44,31 @@ public class ComparisonColumnsTest {
     Assert.assertEquals(comparisonResult, -1);
 
     // persist same col with equal value
-    nullFill(newComparables, persistedComparables);
+    minIntFill(newComparables, persistedComparables);
     newComparables[0] = 2;
     persistedComparables[0] = 2;
     comparisonResult = toBeIngested.compareTo(alreadyPersisted);
     Assert.assertEquals(comparisonResult, 0);
 
     // persist same col with larger value
-    nullFill(newComparables, persistedComparables);
+    minIntFill(newComparables, persistedComparables);
     newComparables[0] = 2;
     persistedComparables[0] = 1;
     comparisonResult = toBeIngested.compareTo(alreadyPersisted);
     Assert.assertEquals(comparisonResult, 1);
-    Assert.assertEquals(toBeIngested.getValues(), new Comparable[]{2, null, null});
+    Assert.assertEquals(toBeIngested.getValues(), new Comparable[]{2, Integer.MIN_VALUE, Integer.MIN_VALUE});
 
     // persist doc with col which was previously null, even though its value is smaller than the previous non-null col
-    nullFill(newComparables, persistedComparables);
+    minIntFill(newComparables, persistedComparables);
     toBeIngested = new ComparisonColumns(newComparables, newComparables.length - 1);
     newComparables[newComparables.length - 1] = 1;
     persistedComparables[0] = 2;
     comparisonResult = toBeIngested.compareTo(alreadyPersisted);
     Assert.assertEquals(comparisonResult, 1);
-    Assert.assertEquals(toBeIngested.getValues(), new Comparable[]{2, null, 1});
+    Assert.assertEquals(toBeIngested.getValues(), new Comparable[]{2, Integer.MIN_VALUE, 1});
 
     // persist new doc where existing doc has multiple non-null comparison values
-    nullFill(newComparables, persistedComparables);
+    minIntFill(newComparables, persistedComparables);
     toBeIngested = new ComparisonColumns(newComparables, 1);
     newComparables[1] = 2;
     Arrays.fill(persistedComparables, 1);
@@ -77,7 +77,7 @@ public class ComparisonColumnsTest {
     Assert.assertEquals(toBeIngested.getValues(), new Comparable[]{1, 2, 1});
 
     // reject new doc where existing doc has multiple non-null comparison values
-    nullFill(newComparables, persistedComparables);
+    minIntFill(newComparables, persistedComparables);
     newComparables[1] = 0;
     Arrays.fill(persistedComparables, 1);
     comparisonResult = toBeIngested.compareTo(alreadyPersisted);
@@ -106,7 +106,7 @@ public class ComparisonColumnsTest {
     Assert.assertEquals(comparisonResult, -1);
 
     // persist same col with equal value
-    nullFill(newComparables, persistedComparables);
+    minIntFill(newComparables, persistedComparables);
     newComparables[0] = 2;
     persistedComparables[0] = 2;
     comparisonResult = toBeIngested.compareTo(alreadyPersisted);
@@ -115,7 +115,7 @@ public class ComparisonColumnsTest {
     Assert.assertEquals(toBeIngested.getValues(), newComparables);
 
     // persist same col with larger value
-    nullFill(newComparables, persistedComparables);
+    minIntFill(newComparables, persistedComparables);
     newComparables[0] = 2;
     persistedComparables[0] = 1;
     comparisonResult = toBeIngested.compareTo(alreadyPersisted);
@@ -124,7 +124,7 @@ public class ComparisonColumnsTest {
     // reject doc where existing doc has more than one, but not all, non-null comparison values, but _this_ doc has 2
     // null columns. The presence of null columns in one of the docs implies that it must have come before the doc
     // with non-null columns.
-    nullFill(newComparables, persistedComparables);
+    minIntFill(newComparables, persistedComparables);
     newComparables[1] = 1;
     persistedComparables[0] = 1;
     persistedComparables[2] = 1;
@@ -132,7 +132,7 @@ public class ComparisonColumnsTest {
     Assert.assertEquals(comparisonResult, -1);
 
     // persist doc where existing doc has more than one, but not all, non-null comparison values, but _this_ doc has
-    nullFill(newComparables, persistedComparables);
+    minIntFill(newComparables, persistedComparables);
     newComparables[0] = 1;
     newComparables[2] = 2;
     persistedComparables[0] = 1;
@@ -142,7 +142,7 @@ public class ComparisonColumnsTest {
 
     // persist doc with non-null value where existing doc had null value in same column previously (but multiple
     // non-null in other columns)
-    nullFill(newComparables, persistedComparables);
+    minIntFill(newComparables, persistedComparables);
     newComparables[0] = 1;
     newComparables[1] = 1;
     newComparables[2] = 1;
@@ -154,14 +154,14 @@ public class ComparisonColumnsTest {
     // reject doc where existing doc has all non-null comparison values, but _this_ doc has 2 null values.
     // The presence of null columns in one of the docs implies that it must have come before the doc with non-null
     // columns.
-    nullFill(newComparables, persistedComparables);
+    minIntFill(newComparables, persistedComparables);
     newComparables[1] = 1;
     Arrays.fill(persistedComparables, 1);
     comparisonResult = toBeIngested.compareTo(alreadyPersisted);
     Assert.assertEquals(comparisonResult, -1);
 
     // Persist doc where existing doc has all non-null comparison values, but _this_ doc has a larger value.
-    nullFill(newComparables, persistedComparables);
+    minIntFill(newComparables, persistedComparables);
     Arrays.fill(newComparables, 1);
     Arrays.fill(persistedComparables, 1);
     newComparables[1] = 2;


### PR DESCRIPTION
Relates to #11027 (and https://github.com/apache/pinot/pull/10704). 

**The summary of changes in this PR is:  don't have `null` in `ComparisonColumns` list of `Comparables`, ever.**

I believe this PR represents a way to _avoid_ getting into a situation where #11027 would be needed to recover.

Given a column for which `isNull(<docId>)` returns true, previously an explicit `null` would be stored in the list of Comparables.  After this PR, the `defaultValue` for that column would be stored in the list of Comparables instead of `null`.  This allows for "regular" use of `removeNullValueField` for all (post-combined) non-null comparison columns.

cc @KKcorps @Jackie-Jiang thoughts?