### PR TITLE
Reverts strictly skipping removeNull from comparison column

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartialUpsertHandler.java
@@ -74,12 +74,7 @@ public class PartialUpsertHandler {
             // comparison column values from the previous record, and the sole non-null comparison column value from
             // the new record.
             newRecord.putValue(column, previousRecord.getValue(column));
-            if (!_comparisonColumns.contains(column)) {
-              // Despite wanting to overwrite the values to comparison columns from prior records, we want to
-              // preserve for _this_ record which comparison column was non-null. Doing so will allow us to
-              // re-evaluate the same comparisons when reading a segment and during steady-state stream ingestion
-              newRecord.removeNullValueField(column);
-            }
+            newRecord.removeNullValueField(column);
           } else if (!_comparisonColumns.contains(column)) {
             PartialUpsertMerger merger = _column2Mergers.getOrDefault(column, _defaultPartialUpsertMerger);
             newRecord.putValue(column,

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -139,7 +139,8 @@ public class MutableSegmentImplUpsertTest {
       // Confirm that both comparison column values have made it into the persisted upserted doc
       Assert.assertEquals(1567205397L, _mutableSegmentImpl.getValue(2, "secondsSinceEpoch"));
       Assert.assertEquals(1567205395L, _mutableSegmentImpl.getValue(2, "otherComparisonColumn"));
-      Assert.assertTrue(_mutableSegmentImpl.getDataSource("secondsSinceEpoch").getNullValueVector().isNull(2));
+      Assert.assertFalse(_mutableSegmentImpl.getDataSource("secondsSinceEpoch").getNullValueVector().isNull(2));
+      Assert.assertFalse(_mutableSegmentImpl.getDataSource("otherComparisonColumn").getNullValueVector().isNull(2));
 
       // bb
       Assert.assertFalse(bitmap.contains(4));
@@ -149,6 +150,7 @@ public class MutableSegmentImplUpsertTest {
       Assert.assertEquals(1567205396L, _mutableSegmentImpl.getValue(5, "secondsSinceEpoch"));
       Assert.assertEquals(Long.MIN_VALUE, _mutableSegmentImpl.getValue(5, "otherComparisonColumn"));
       Assert.assertTrue(_mutableSegmentImpl.getDataSource("otherComparisonColumn").getNullValueVector().isNull(5));
+      Assert.assertFalse(_mutableSegmentImpl.getDataSource("secondsSinceEpoch").getNullValueVector().isNull(5));
     }
   }
 }


### PR DESCRIPTION
Relates to #11035, https://github.com/apache/pinot/pull/11027, and https://github.com/apache/pinot/pull/10704.  The algorithm for processing multiple comparison columns at segment read time evolved such that the need to try to encode exactly which index was non-null for a record is no longer needed.  This PR allows for the proper indication of which values are actually null or non-null as compared to Schrödinger's null introduced by [this code](https://github.com/apache/pinot/pull/10704/files#diff-16ee7661b0b915ef4243d66e9915af0f9e3112a402b34853e357f50e75a05ff9R77-R82) trying to encode only one non-null value despite multiple values actually being non-null.

cc @KKcorps @Jackie-Jiang 