### PR TITLE
Update the version of jcabi log

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -993,7 +993,7 @@
       <dependency>
         <groupId>com.jcabi</groupId>
         <artifactId>jcabi-log</artifactId>
-        <version>0.17.1</version>
+        <version>0.18.1</version>
       </dependency>
       <dependency>
         <groupId>com.google.code.findbugs</groupId>


### PR DESCRIPTION
Upgrading jcabi log from 0.17.1 to 0.18.1 in order to stay up to date and leverage the most recent improvements"