### PR TITLE
[multistage] Register Pinot Transform Functions into Calcite

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -187,7 +187,7 @@ public class FunctionRegistry {
     }
 
     @ScalarFunction(names = {"jsonExtractKey", "json_extract_key"}, isPlaceholder = true)
-    public static String jsonExtractKey(String jsonFieldName, String jsonPath) {
+    public static Object jsonExtractKey(String jsonFieldName, String jsonPath) {
       throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
     }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -31,12 +31,10 @@ import org.apache.calcite.sql.SqlOperatorBinding;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.sql.type.SqlOperandTypeChecker;
-import org.apache.calcite.sql.type.SqlOperandTypeInference;
 import org.apache.calcite.sql.type.SqlReturnTypeInference;
 import org.apache.calcite.sql.type.SqlTypeFamily;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.calcite.sql.type.SqlTypeTransforms;
-import org.apache.commons.lang.StringUtils;
 
 
 public enum TransformFunctionType {
@@ -182,39 +180,36 @@ public enum TransformFunctionType {
   RADIANS("radians");
 
   private final String _name;
-  private final List<String> _aliases;
+  private final List<String> _alternativeNames;
   private final SqlKind _sqlKind;
-  private final SqlReturnTypeInference _sqlReturnTypeInference;
-  private final SqlOperandTypeInference _sqlOperandTypeInference;
-  private final SqlOperandTypeChecker _sqlOperandTypeChecker;
+  private final SqlReturnTypeInference _returnTypeInference;
+  private final SqlOperandTypeChecker _operandTypeChecker;
   private final SqlFunctionCategory _sqlFunctionCategory;
 
-  TransformFunctionType(String name, String... aliases) {
-    this(name, null, null, null, null, null, aliases);
+  TransformFunctionType(String name, String... alternativeNames) {
+    this(name, null, null, null, null, alternativeNames);
   }
 
-  TransformFunctionType(String name, SqlReturnTypeInference sqlReturnTypeInference,
-      SqlOperandTypeChecker sqlOperandTypeChecker, String... aliases) {
-    this(name, SqlKind.OTHER_FUNCTION, sqlReturnTypeInference, null, sqlOperandTypeChecker,
-        SqlFunctionCategory.USER_DEFINED_FUNCTION, aliases);
+  TransformFunctionType(String name, SqlReturnTypeInference returnTypeInference,
+      SqlOperandTypeChecker operandTypeChecker, String... alternativeNames) {
+    this(name, SqlKind.OTHER_FUNCTION, returnTypeInference, operandTypeChecker,
+        SqlFunctionCategory.USER_DEFINED_FUNCTION, alternativeNames);
   }
 
   /**
    * Constructor to use for transform functions which are supported in both v1 and multistage engines
    */
-  TransformFunctionType(String name, SqlKind sqlKind, SqlReturnTypeInference sqlReturnTypeInference,
-      SqlOperandTypeInference sqlOperandTypeInference, SqlOperandTypeChecker sqlOperandTypeChecker,
-      SqlFunctionCategory sqlFunctionCategory, String... aliases) {
+  TransformFunctionType(String name, SqlKind sqlKind, SqlReturnTypeInference returnTypeInference,
+      SqlOperandTypeChecker operandTypeChecker, SqlFunctionCategory sqlFunctionCategory, String... alternativeNames) {
     _name = name;
-    List<String> all = new ArrayList<>(aliases.length + 2);
+    List<String> all = new ArrayList<>(alternativeNames.length + 2);
     all.add(name);
     all.add(name());
-    all.addAll(Arrays.asList(aliases));
-    _aliases = Collections.unmodifiableList(all);
+    all.addAll(Arrays.asList(alternativeNames));
+    _alternativeNames = Collections.unmodifiableList(all);
     _sqlKind = sqlKind;
-    _sqlReturnTypeInference = sqlReturnTypeInference;
-    _sqlOperandTypeInference = sqlOperandTypeInference;
-    _sqlOperandTypeChecker = sqlOperandTypeChecker;
+    _returnTypeInference = returnTypeInference;
+    _operandTypeChecker = operandTypeChecker;
     _sqlFunctionCategory = sqlFunctionCategory;
   }
 
@@ -222,24 +217,20 @@ public enum TransformFunctionType {
     return _name;
   }
 
-  public List<String> getAliases() {
-    return _aliases;
+  public List<String> getAlternativeNames() {
+    return _alternativeNames;
   }
 
   public SqlKind getSqlKind() {
     return _sqlKind;
   }
 
-  public SqlReturnTypeInference getSqlReturnTypeInference() {
-    return _sqlReturnTypeInference;
+  public SqlReturnTypeInference getReturnTypeInference() {
+    return _returnTypeInference;
   }
 
-  public SqlOperandTypeInference getSqlOperandTypeInference() {
-    return _sqlOperandTypeInference;
-  }
-
-  public SqlOperandTypeChecker getSqlOperandTypeChecker() {
-    return _sqlOperandTypeChecker;
+  public SqlOperandTypeChecker getOperandTypeChecker() {
+    return _operandTypeChecker;
   }
 
   public SqlFunctionCategory getSqlFunctionCategory() {
@@ -272,18 +263,6 @@ public enum TransformFunctionType {
           throw new IllegalArgumentException("Invalid type: " + operandType);
         }
         return typeFactory.createSqlType(sqlTypeName);
-    }
-  }
-
-  public static String getNormalizedTransformFunctionName(String functionName) {
-    return StringUtils.remove(functionName, '_').toUpperCase();
-  }
-
-  public static boolean isTransformFunctionType(String functionName) {
-    try {
-      return valueOf(functionName.toUpperCase()) != null;
-    } catch (IllegalArgumentException e) {
-      return false;
     }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -298,24 +298,32 @@ public class DataSchema {
     public DataType toDataType() {
       switch (this) {
         case INT:
+        case INT_ARRAY:
           return DataType.INT;
         case LONG:
+        case LONG_ARRAY:
           return DataType.LONG;
         case FLOAT:
+        case FLOAT_ARRAY:
           return DataType.FLOAT;
         case DOUBLE:
+        case DOUBLE_ARRAY:
           return DataType.DOUBLE;
         case BIG_DECIMAL:
           return DataType.BIG_DECIMAL;
         case BOOLEAN:
+        case BOOLEAN_ARRAY:
           return DataType.BOOLEAN;
         case TIMESTAMP:
+        case TIMESTAMP_ARRAY:
           return DataType.TIMESTAMP;
         case STRING:
+        case STRING_ARRAY:
           return DataType.STRING;
         case JSON:
           return DataType.JSON;
         case BYTES:
+        case BYTES_ARRAY:
           return DataType.BYTES;
         case UNKNOWN:
           return DataType.UNKNOWN;

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
@@ -68,7 +68,7 @@ public class FunctionDefinitionRegistryTest {
     }
     for (TransformFunctionType enumType : TransformFunctionType.values()) {
       if (!isIgnored(enumType.getName().toLowerCase())) {
-        for (String funcName : enumType.getAliases()) {
+        for (String funcName : enumType.getAlternativeNames()) {
           assertTrue(registeredCalciteFunctionNameIgnoreCase.contains(funcName.toLowerCase()),
               "Unable to find transform function signature for: " + funcName);
         }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -218,7 +218,7 @@ public class TransformFunctionFactory {
 
     Map<String, Class<? extends TransformFunction>> registry = new HashMap<>(typeToImplementation.size());
     for (Map.Entry<TransformFunctionType, Class<? extends TransformFunction>> entry : typeToImplementation.entrySet()) {
-      for (String alias : entry.getKey().getAliases()) {
+      for (String alias : entry.getKey().getAlternativeNames()) {
         registry.put(canonicalize(alias), entry.getValue());
       }
     }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JsonPathClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JsonPathClusterIntegrationTest.java
@@ -263,7 +263,7 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
   }
 
   @Test
-  public void testComplexQueries2()
+  public void testComplexGroupByQuery()
       throws Exception {
     //Group By Query
     String query = "Select" + " jsonExtractScalar(complexMapStr,'$.k1','STRING'),"
@@ -279,6 +279,40 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
       Assert.assertEquals(row.get(0).asText(), "value-k1-" + seqId);
       Assert.assertEquals(row.get(1).asDouble(), Double.parseDouble(seqId));
     }
+  }
+
+  @Test
+  public void testQueryWithIntegerDefault()
+      throws Exception {
+    //Group By Query
+    String query = "Select" + " jsonExtractScalar(complexMapStr,'$.inExistKey','STRING','defaultKey'),"
+        + " sum(jsonExtractScalar(complexMapStr,'$.inExistMet','INT','1'))" + " from " + DEFAULT_TABLE_NAME
+        + " group by jsonExtractScalar(complexMapStr,'$.inExistKey','STRING','defaultKey')"
+        + " order by sum(jsonExtractScalar(complexMapStr,'$.inExistMet','INT','1')) DESC";
+    JsonNode pinotResponse = postQuery(query);
+    Assert.assertNotNull(pinotResponse.get("resultTable").get("rows"));
+    ArrayNode rows = (ArrayNode) pinotResponse.get("resultTable").get("rows");
+    Assert.assertEquals(rows.size(), 1);
+    final JsonNode row = rows.get(0);
+    Assert.assertEquals(row.get(0).asText(), "defaultKey");
+    Assert.assertEquals(row.get(1).asDouble(), 1000.0);
+  }
+
+  @Test
+  public void testQueryWithDoubleDefault()
+      throws Exception {
+    //Group By Query
+    String query = "Select" + " jsonExtractScalar(complexMapStr,'$.inExistKey','STRING', 'defaultKey'),"
+        + " sum(jsonExtractScalar(complexMapStr,'$.inExistMet','DOUBLE','0.1'))" + " from " + DEFAULT_TABLE_NAME
+        + " group by jsonExtractScalar(complexMapStr,'$.inExistKey','STRING','defaultKey')"
+        + " order by sum(jsonExtractScalar(complexMapStr,'$.inExistMet','DOUBLE','0.1')) DESC";
+    JsonNode pinotResponse = postQuery(query);
+    Assert.assertNotNull(pinotResponse.get("resultTable").get("rows"));
+    ArrayNode rows = (ArrayNode) pinotResponse.get("resultTable").get("rows");
+    Assert.assertEquals(rows.size(), 1);
+    final JsonNode row = rows.get(0);
+    Assert.assertEquals(row.get(0).asText(), "defaultKey");
+    Assert.assertTrue(Math.abs(row.get(1).asDouble() - 100.0) < 1e-10);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JsonPathClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/JsonPathClusterIntegrationTest.java
@@ -53,14 +53,14 @@ import org.testng.annotations.Test;
 
 
 public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
-  private static final int NUM_TOTAL_DOCS = 1000;
+  protected static final int NUM_TOTAL_DOCS = 1000;
   private static final String MY_MAP_STR_FIELD_NAME = "myMapStr";
   private static final String MY_MAP_STR_K1_FIELD_NAME = "myMapStr_k1";
   private static final String MY_MAP_STR_K2_FIELD_NAME = "myMapStr_k2";
   private static final String COMPLEX_MAP_STR_FIELD_NAME = "complexMapStr";
   private static final String COMPLEX_MAP_STR_K3_FIELD_NAME = "complexMapStr_k3";
 
-  private final List<String> _sortedSequenceIds = new ArrayList<>(NUM_TOTAL_DOCS);
+  protected final List<String> _sortedSequenceIds = new ArrayList<>(NUM_TOTAL_DOCS);
 
   @Override
   protected long getCountStarResult() {
@@ -260,15 +260,19 @@ public class JsonPathClusterIntegrationTest extends BaseClusterIntegrationTest {
       Assert.assertEquals(k4.get("k4-k3"), "value-k4-k3-" + seqId);
       Assert.assertEquals(Double.parseDouble(k4.get("met").toString()), Double.parseDouble(seqId));
     }
+  }
 
+  @Test
+  public void testComplexQueries2()
+      throws Exception {
     //Group By Query
-    query = "Select" + " jsonExtractScalar(complexMapStr,'$.k1','STRING'),"
+    String query = "Select" + " jsonExtractScalar(complexMapStr,'$.k1','STRING'),"
         + " sum(jsonExtractScalar(complexMapStr,'$.k4.met','INT'))" + " from " + DEFAULT_TABLE_NAME
         + " group by jsonExtractScalar(complexMapStr,'$.k1','STRING')"
         + " order by sum(jsonExtractScalar(complexMapStr,'$.k4.met','INT')) DESC";
-    pinotResponse = postQuery(query);
+    JsonNode pinotResponse = postQuery(query);
     Assert.assertNotNull(pinotResponse.get("resultTable").get("rows"));
-    rows = (ArrayNode) pinotResponse.get("resultTable").get("rows");
+    ArrayNode rows = (ArrayNode) pinotResponse.get("resultTable").get("rows");
     for (int i = 0; i < rows.size(); i++) {
       String seqId = _sortedSequenceIds.get(NUM_TOTAL_DOCS - 1 - i);
       final JsonNode row = rows.get(i);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineJsonPathClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineJsonPathClusterIntegrationTest.java
@@ -20,10 +20,6 @@ package org.apache.pinot.integration.tests;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ArrayNode;
-import com.google.common.collect.ImmutableMap;
-import java.util.Properties;
-import org.apache.pinot.client.Connection;
-import org.apache.pinot.client.ConnectionFactory;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -31,33 +27,12 @@ import org.testng.annotations.Test;
 public class MultiStageEngineJsonPathClusterIntegrationTest extends JsonPathClusterIntegrationTest {
 
   @Override
-  protected Connection getPinotConnection() {
-    Properties properties = new Properties();
-    properties.put("queryOptions", "useMultistageEngine=true");
-    if (_pinotConnection == null) {
-      _pinotConnection = ConnectionFactory.fromZookeeper(properties, getZkUrl() + "/" + getHelixClusterName());
-    }
-    return _pinotConnection;
-  }
-
-  @Override
-  protected void testQuery(String pinotQuery, String h2Query)
-      throws Exception {
-    ClusterIntegrationTestUtils.testQuery(pinotQuery, _brokerBaseApiUrl, getPinotConnection(), h2Query,
-        getH2Connection(), null, ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
-  }
-
-  /**
-   * Queries the broker's sql query endpoint (/query/sql)
-   */
-  @Override
-  protected JsonNode postQuery(String query)
-      throws Exception {
-    return postQuery(query, _brokerBaseApiUrl, null, ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
+  protected boolean useMultiStageQueryEngine() {
+    return true;
   }
 
   @Test
-  public void testComplexQueries2()
+  public void testComplexGroupByQuery()
       throws Exception {
     //Group By Query
     String query = "Select" + " jsonExtractScalar(complexMapStr,'$.k1','STRING'),"

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineJsonPathClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineJsonPathClusterIntegrationTest.java
@@ -1,0 +1,77 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.google.common.collect.ImmutableMap;
+import java.util.Properties;
+import org.apache.pinot.client.Connection;
+import org.apache.pinot.client.ConnectionFactory;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class MultiStageEngineJsonPathClusterIntegrationTest extends JsonPathClusterIntegrationTest {
+
+  @Override
+  protected Connection getPinotConnection() {
+    Properties properties = new Properties();
+    properties.put("queryOptions", "useMultistageEngine=true");
+    if (_pinotConnection == null) {
+      _pinotConnection = ConnectionFactory.fromZookeeper(properties, getZkUrl() + "/" + getHelixClusterName());
+    }
+    return _pinotConnection;
+  }
+
+  @Override
+  protected void testQuery(String pinotQuery, String h2Query)
+      throws Exception {
+    ClusterIntegrationTestUtils.testQuery(pinotQuery, _brokerBaseApiUrl, getPinotConnection(), h2Query,
+        getH2Connection(), null, ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
+  }
+
+  /**
+   * Queries the broker's sql query endpoint (/query/sql)
+   */
+  @Override
+  protected JsonNode postQuery(String query)
+      throws Exception {
+    return postQuery(query, _brokerBaseApiUrl, null, ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
+  }
+
+  @Test
+  public void testComplexQueries2()
+      throws Exception {
+    //Group By Query
+    String query = "Select" + " jsonExtractScalar(complexMapStr,'$.k1','STRING'),"
+        + " sum(jsonExtractScalar(complexMapStr,'$.k4.met','INT'))" + " from " + DEFAULT_TABLE_NAME
+        + " group by jsonExtractScalar(complexMapStr,'$.k1','STRING')"
+        + " order by sum(jsonExtractScalar(complexMapStr,'$.k4.met','INT')) DESC";
+    JsonNode pinotResponse = postQuery(query);
+    Assert.assertNotNull(pinotResponse.get("resultTable").get("rows"));
+    ArrayNode rows = (ArrayNode) pinotResponse.get("resultTable").get("rows");
+    for (int i = 0; i < rows.size(); i++) {
+      String seqId = String.valueOf(NUM_TOTAL_DOCS - 1 - i);
+      final JsonNode row = rows.get(i);
+      Assert.assertEquals(row.get(0).asText(), "value-k1-" + seqId);
+      Assert.assertEquals(row.get(1).asDouble(), Double.parseDouble(seqId));
+    }
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotAggregateExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotAggregateExchangeNodeInsertRule.java
@@ -18,7 +18,6 @@
  */
 package org.apache.calcite.rel.rules;
 
-import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -44,7 +43,6 @@ import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.PinotSqlAggFunction;
 import org.apache.calcite.sql.SqlAggFunction;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.calcite.sql.fun.PinotOperatorTable;
 import org.apache.calcite.sql.type.OperandTypes;
 import org.apache.calcite.sql.type.ReturnTypes;
 import org.apache.calcite.tools.RelBuilder;
@@ -294,8 +292,6 @@ public class PinotAggregateExchangeNodeInsertRule extends RelOptRule {
     final SqlKind aggKind = oldAggFunction.getKind();
     String functionName = getFunctionNameFromAggregateCall(orgAggCall);
     AggregationFunctionType functionType = AggregationFunctionType.getAggregationFunctionType(functionName);
-    // Check only the supported AGG functions are provided.
-    validateAggregationFunctionIsSupported(functionType.getName(), aggKind);
     // create the aggFunction
     SqlAggFunction sqlAggFunction;
     if (functionType.getIntermediateReturnTypeInference() != null) {
@@ -339,12 +335,6 @@ public class PinotAggregateExchangeNodeInsertRule extends RelOptRule {
   private static String getFunctionNameFromAggregateCall(AggregateCall aggregateCall) {
     return aggregateCall.getAggregation().getName().equalsIgnoreCase("COUNT") && aggregateCall.isDistinct()
         ? "distinctCount" : aggregateCall.getAggregation().getName();
-  }
-
-  private static void validateAggregationFunctionIsSupported(String functionName, SqlKind aggKind) {
-    Preconditions.checkState(PinotOperatorTable.isAggregationFunctionRegisteredWithOperatorTable(functionName),
-        String.format("Failed to create aggregation. Unsupported SQL aggregation kind: %s or function name: %s. "
-                + "Only splittable aggregation functions are supported!", aggKind, functionName));
   }
 
   private static RelHint createAggHint(AggType aggType) {

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/PinotSqlTransformFunction.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/PinotSqlTransformFunction.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.calcite.sql;
+
+import org.apache.calcite.sql.type.SqlOperandTypeChecker;
+import org.apache.calcite.sql.type.SqlOperandTypeInference;
+import org.apache.calcite.sql.type.SqlReturnTypeInference;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+
+/**
+ * Pinot SqlAggFunction class to register the Pinot aggregation functions with the Calcite operator table.
+ */
+public class PinotSqlTransformFunction extends SqlFunction {
+
+  public PinotSqlTransformFunction(String name, SqlKind kind, @Nullable SqlReturnTypeInference returnTypeInference,
+      @Nullable SqlOperandTypeInference operandTypeInference, @Nullable SqlOperandTypeChecker operandTypeChecker,
+      SqlFunctionCategory category) {
+    super(name, kind, returnTypeInference, operandTypeInference, operandTypeChecker, category);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
@@ -27,11 +27,13 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.calcite.sql.PinotSqlAggFunction;
+import org.apache.calcite.sql.PinotSqlTransformFunction;
 import org.apache.calcite.sql.SqlFunction;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.validate.SqlNameMatchers;
 import org.apache.calcite.util.Util;
+import org.apache.pinot.common.function.TransformFunctionType;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
@@ -73,9 +75,31 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
       // Uses two-phase construction, because we can't initialize the
       // table until the constructor of the sub-class has completed.
       _instance = new PinotOperatorTable();
-      _instance.initNoDuplicate();
+      _instance.initNoDuplicateFunctions();
+      _instance.initAggregationFunctions();
+      _instance.initTransformFunctions();
     }
     return _instance;
+  }
+
+  public static boolean isAggregationKindSupported(SqlKind sqlKind) {
+    return KINDS.contains(sqlKind);
+  }
+
+  public static boolean isAggregationReduceSupported(String functionName) {
+    if (AGGREGATION_REDUCE_SUPPORTED_FUNCTIONS.contains(functionName)) {
+      return true;
+    }
+    String upperCaseFunctionName = AggregationFunctionType.getNormalizedAggregationFunctionName(functionName);
+    return AGGREGATION_REDUCE_SUPPORTED_FUNCTIONS.contains(upperCaseFunctionName);
+  }
+
+  public static boolean isTransformFunctionRegisteredWithOperatorTable(String functionName) {
+    if (CALCITE_OPERATOR_TABLE_REGISTERED_FUNCTIONS.contains(functionName)) {
+      return true;
+    }
+    String upperCaseFunctionName = TransformFunctionType.getNormalizedTransformFunctionName(functionName);
+    return CALCITE_OPERATOR_TABLE_REGISTERED_FUNCTIONS.contains(upperCaseFunctionName);
   }
 
   public static boolean isAggregationFunctionRegisteredWithOperatorTable(String functionName) {
@@ -88,18 +112,18 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
    *
    * <p>This is a direct copy of the {@link org.apache.calcite.sql.util.ReflectiveSqlOperatorTable} and can be hard to
    * debug, suggest changing to a non-dynamic registration. Dynamic function support should happen via catalog.
-   *
-   * This also registers aggregation functions defined in {@link org.apache.pinot.segment.spi.AggregationFunctionType}
-   * which are multistage enabled.
    */
-  public final void initNoDuplicate() {
+  public final void initNoDuplicateFunctions() {
     // Use reflection to register the expressions stored in public fields.
     for (Field field : getClass().getFields()) {
       try {
         if (SqlFunction.class.isAssignableFrom(field.getType())) {
           SqlFunction op = (SqlFunction) field.get(this);
           if (op != null && notRegistered(op)) {
-            register(op);
+            if (!isPinotAggregationFunction(op.getName()) && !isPinotTransformFunction(op.getName())) {
+              // Register the standard Calcite functions and those defined in this class only
+              register(op);
+            }
           }
         } else if (
             SqlOperator.class.isAssignableFrom(field.getType())) {
@@ -112,10 +136,14 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
         throw Util.throwAsRuntime(Util.causeOrSelf(e));
       }
     }
+  }
 
-    // Walk through all the Pinot aggregation types and
-    //   1. register those that are supported in multistage in addition to calcite standard opt table.
-    //   2. register special handling that differs from calcite standard.
+  // Walk through all the Pinot aggregation types and
+  //   1. register those that are supported in multistage in addition to calcite standard opt table.
+  //   2. register special handling that differs from calcite standard.
+  public final void initAggregationFunctions() {
+    // Walk through all the Pinot aggregation types and register those that are supported in multistage and which
+    // aren't standard Calcite functions such as SUM / MIN / MAX / COUNT etc.
     for (AggregationFunctionType aggregationFunctionType : AggregationFunctionType.values()) {
       if (aggregationFunctionType.getSqlKind() != null) {
         // 1. Register the aggregation function with Calcite
@@ -129,16 +157,77 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
     }
   }
 
-  private void registerAggregateFunction(String functionName, AggregationFunctionType functionType) {
-    // register function behavior that's different from Calcite
-    if (functionType.getOperandTypeChecker() != null && functionType.getReturnTypeInference() != null) {
-      PinotSqlAggFunction sqlAggFunction = new PinotSqlAggFunction(functionName.toUpperCase(Locale.ROOT), null,
-          functionType.getSqlKind(), functionType.getReturnTypeInference(), null,
-          functionType.getOperandTypeChecker(), functionType.getSqlFunctionCategory());
-      if (notRegistered(sqlAggFunction)) {
-        register(sqlAggFunction);
+  /**
+   * This registers transform functions defined in {@link org.apache.pinot.common.function.TransformFunctionType}
+   * which are multistage enabled.
+   */
+  private void initTransformFunctions() {
+    // Walk through all the Pinot transform types and register those that are supported in multistage.
+    for (TransformFunctionType transformFunctionType : TransformFunctionType.values()) {
+      if (transformFunctionType.getSqlKind() == null) {
+        // Skip registering functions which are standard Calcite functions and functions which are not yet supported.
+        continue;
+      }
+
+      // Register the aggregation function with Calcite along with all alternative names
+      List<PinotSqlTransformFunction> sqlTransformFunctions = new ArrayList<>();
+      PinotSqlTransformFunction aggFunction = generatePinotSqlTransformFunction(transformFunctionType.getName(),
+          transformFunctionType, false);
+      sqlTransformFunctions.add(aggFunction);
+      List<String> alternativeFunctionNames = transformFunctionType.getAliases();
+      if (alternativeFunctionNames == null || alternativeFunctionNames.size() == 0) {
+        // If no alternative function names are specified, generate one which converts camel case to have underscores
+        // as delimiters instead. E.g. boolAnd -> BOOL_AND
+        String alternativeFunctionName =
+            convertCamelCaseToUseUnderscores(transformFunctionType.getName());
+        PinotSqlTransformFunction function =
+            generatePinotSqlTransformFunction(alternativeFunctionName, transformFunctionType,
+                false);
+        sqlTransformFunctions.add(function);
+      } else {
+        for (String alternativeFunctionName : alternativeFunctionNames) {
+          PinotSqlTransformFunction function =
+              generatePinotSqlTransformFunction(alternativeFunctionName, transformFunctionType,
+                  false);
+          sqlTransformFunctions.add(function);
+        }
+      }
+      for (PinotSqlTransformFunction sqlAggFunction : sqlTransformFunctions) {
+        if (notRegistered(sqlAggFunction)) {
+          register(sqlAggFunction);
+        }
       }
     }
+  }
+
+  private static String convertCamelCaseToUseUnderscores(String functionName) {
+    // Skip functions that have numbers for now and return their name as is
+    return functionName.matches(".*\\d.*")
+        ? functionName
+        : functionName.replaceAll("(.)(\\p{Upper}+|\\d+)", "$1_$2");
+  }
+
+  private static PinotSqlAggFunction generatePinotSqlAggFunction(String functionName,
+      AggregationFunctionType aggregationFunctionType, boolean isIntermediateStageFunction) {
+    return new PinotSqlAggFunction(functionName.toUpperCase(Locale.ROOT),
+        aggregationFunctionType.getSqlIdentifier(),
+        aggregationFunctionType.getSqlKind(),
+        isIntermediateStageFunction
+            ? aggregationFunctionType.getSqlIntermediateReturnTypeInference()
+            : aggregationFunctionType.getSqlReturnTypeInference(),
+        aggregationFunctionType.getSqlOperandTypeInference(),
+        aggregationFunctionType.getSqlOperandTypeChecker(),
+        aggregationFunctionType.getSqlFunctionCategory());
+  }
+
+  private static PinotSqlTransformFunction generatePinotSqlTransformFunction(String functionName,
+      TransformFunctionType transformFunctionType, boolean isIntermediateStageFunction) {
+    return new PinotSqlTransformFunction(functionName.toUpperCase(Locale.ROOT),
+        transformFunctionType.getSqlKind(),
+        transformFunctionType.getSqlReturnTypeInference(),
+        transformFunctionType.getSqlOperandTypeInference(),
+        transformFunctionType.getSqlOperandTypeChecker(),
+        transformFunctionType.getSqlFunctionCategory());
   }
 
   private boolean notRegistered(SqlFunction op) {
@@ -153,5 +242,25 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
     lookupOperatorOverloads(op.getNameAsId(), null, op.getSyntax(), operatorList,
         SqlNameMatchers.withCaseSensitive(false));
     return operatorList.size() == 0;
+  }
+
+  private boolean isPinotAggregationFunction(String name) {
+    AggregationFunctionType aggFunctionType = null;
+    if (isAggregationFunctionRegisteredWithOperatorTable(name)) {
+      aggFunctionType = AggregationFunctionType.getAggregationFunctionType(name);
+    }
+    return aggFunctionType != null && !aggFunctionType.isNativeCalciteAggregationFunctionType();
+  }
+
+  private boolean isPinotTransformFunction(String name) {
+    TransformFunctionType transformFunctionType = null;
+    if (isTransformFunctionRegisteredWithOperatorTable(name)) {
+      try {
+        transformFunctionType = TransformFunctionType.valueOf(name);
+      } catch (IllegalArgumentException e) {
+        // Ignore
+      }
+    }
+    return transformFunctionType != null;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
@@ -253,14 +253,9 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
   }
 
   private boolean isPinotTransformFunction(String name) {
-    TransformFunctionType transformFunctionType = null;
     if (isTransformFunctionRegisteredWithOperatorTable(name)) {
-      try {
-        transformFunctionType = TransformFunctionType.valueOf(name);
-      } catch (IllegalArgumentException e) {
-        // Ignore
-      }
+      return TransformFunctionType.isTransformFunctionType(name);
     }
-    return transformFunctionType != null;
+    return false;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
@@ -20,16 +20,11 @@ package org.apache.calcite.sql.fun;
 
 import java.lang.reflect.Field;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
 import java.util.Locale;
-import java.util.Set;
-import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.calcite.sql.PinotSqlAggFunction;
 import org.apache.calcite.sql.PinotSqlTransformFunction;
 import org.apache.calcite.sql.SqlFunction;
-import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlOperator;
 import org.apache.calcite.sql.validate.SqlNameMatchers;
 import org.apache.calcite.util.Util;
@@ -56,30 +51,6 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
 
   public static final SqlFunction COALESCE = new PinotSqlCoalesceFunction();
 
-  private static final Set<SqlKind> KINDS =
-      Stream.concat(
-              Arrays.stream(AggregationFunctionType.values())
-                  .filter(func -> func.getSqlKind() != null)
-                  .flatMap(func -> Stream.of(func.getSqlKind())),
-              Arrays.stream(TransformFunctionType.values())
-                  .filter(func -> func.getSqlKind() != null)
-                  .flatMap(func -> Stream.of(func.getSqlKind())))
-          .collect(Collectors.toSet());
-
-  private static final Set<String> CALCITE_OPERATOR_TABLE_REGISTERED_FUNCTIONS =
-      Stream.concat(
-              Arrays.stream(AggregationFunctionType.values())
-                  // TODO: remove below once all V1 AGG functions are registered
-                  .filter(func -> func.getSqlKind() != null)
-                  .flatMap(func -> Stream.of(func.name(), func.getName(), func.getName().toUpperCase(),
-                      func.getName().toLowerCase())),
-              Arrays.stream(TransformFunctionType.values())
-                  // TODO: remove below once all V1 Transform functions are registered
-                  .filter(func -> func.getSqlKind() != null)
-                  .flatMap(func -> Stream.of(func.name(), func.getName(), func.getName().toUpperCase(),
-                      func.getName().toLowerCase())))
-          .collect(Collectors.toSet());
-
   // TODO: clean up lazy init by using Suppliers.memorized(this::computeInstance) and make getter wrapped around
   // supplier instance. this should replace all lazy init static objects in the codebase
   public static synchronized PinotOperatorTable instance() {
@@ -91,10 +62,6 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
       _instance.initNoDuplicate();
     }
     return _instance;
-  }
-
-  public static boolean isAggregationFunctionRegisteredWithOperatorTable(String functionName) {
-    return CALCITE_OPERATOR_TABLE_REGISTERED_FUNCTIONS.contains(functionName);
   }
 
   /**

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
@@ -286,7 +286,7 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
               }
             }
           } else {
-            String[] rarray = (String[]) r;
+            String[] rarray = (r instanceof List) ? ((List<String>) r).toArray(new String[0]) : (String[]) r;
             for (int idx = 0; idx < larray.length; idx++) {
               if (!larray[idx].equals(rarray[idx])) {
                 return -1;

--- a/pinot-query-runtime/src/test/resources/queries/JsonType.json
+++ b/pinot-query-runtime/src/test/resources/queries/JsonType.json
@@ -9,7 +9,8 @@
         "inputs": [
           ["{\"key1\":\"val1\",\"key2\":\"val2\"}", "str1"],
           ["{\"key11\":\"val11\",\"key22\":\"val22\"}", "str22"],
-          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"]
+          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"],
+          ["{\"key1111\":22.23,\"key2222\":\"val2222\"}", "str44"]
         ]
       }
     },
@@ -19,7 +20,8 @@
         "outputs": [
           ["{\"key1\":\"val1\",\"key2\":\"val2\"}"],
           ["{\"key11\":\"val11\",\"key22\":\"val22\"}"],
-          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}"]
+          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}"],
+          ["{\"key1111\":22.23,\"key2222\":\"val2222\"}"]
         ]
       },
       {
@@ -27,7 +29,8 @@
         "outputs": [
           ["{\"key1\":\"val1\",\"key2\":\"val2\"}", "str1"],
           ["{\"key11\":\"val11\",\"key22\":\"val22\"}", "str22"],
-          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"]
+          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"],
+          ["{\"key1111\":22.23,\"key2222\":\"val2222\"}", "str44"]
         ]
       },
       {
@@ -47,7 +50,8 @@
         "sql": "SELECT jsonCol, stringCol FROM {jsonTbl} where jsonCol like '%key111%' OR jsonCol like '%val22%'",
         "outputs": [
           ["{\"key11\":\"val11\",\"key22\":\"val22\"}", "str22"],
-          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"]
+          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"],
+          ["{\"key1111\":22.23,\"key2222\":\"val2222\"}", "str44"]
         ]
       },
       {
@@ -56,7 +60,50 @@
         "outputs": [
           ["{\"key1\":\"val1\",\"key2\":\"val2\"}", "str1"],
           ["{\"key11\":\"val11\",\"key22\":\"val22\"}", "str22"],
-          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"]
+          ["{\"key111\":\"val111\",\"key222\":{\"key222_a\":\"val222_a\"}}", "str33"],
+          ["{\"key1111\":22.23,\"key2222\":\"val2222\"}", "str44"]
+        ]
+      },
+      {
+        "sql": "SELECT JSONEXTRACTKEY(jsonCol,'$.*') AS keys FROM {jsonTbl} where stringCol='str33'",
+        "outputs": [
+          [["$['key111']","$['key222']"]]
+        ]
+      },
+      {
+        "sql": "SELECT JSONEXTRACTKEY(jsonCol,'$.*') AS keys FROM {jsonTbl} where stringCol='str1'",
+        "outputs": [
+          [["$['key1']","$['key2']"]]
+        ]
+      },
+      {
+        "sql": "SELECT cardinality(JSONEXTRACTKEY(jsonCol,'$.*')) AS key_card FROM {jsonTbl} where stringCol='str1'",
+        "outputs": [
+          [2]
+        ]
+      },
+      {
+        "sql": "SELECT jsonextractscalar(jsonCol,'$.key222.key222_a', 'STRING') AS keys FROM {jsonTbl} where stringCol='str33'",
+        "outputs": [
+          ["val222_a"]
+        ]
+      },
+      {
+        "sql": "SELECT jsonextractscalar(jsonCol,'$.key1', 'STRING') AS keys FROM {jsonTbl} where stringCol='str1'",
+        "outputs": [
+          ["val1"]
+        ]
+      },
+      {
+        "sql": "SELECT jsonextractscalar(jsonCol,'$.key22', 'STRING', 'dummy') AS keys FROM {jsonTbl} where stringCol='str1'",
+        "outputs": [
+          ["dummy"]
+        ]
+      },
+      {
+        "sql": "SELECT jsonextractscalar(jsonCol,'$.key1111', 'FLOAT') AS keys FROM {jsonTbl} where stringCol='str44'",
+        "outputs": [
+          [22.23]
         ]
       }
     ]


### PR DESCRIPTION
- Introduce PinotSqlTransformFunction
- Use jsonExtractScalar as first example, which supports multiple(3 or 4) optional arguments.
