### PR TITLE
Bump up the netty and swagger library

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -131,7 +131,7 @@
     <jersey.version>2.39</jersey.version>
     <grizzly.version>2.4.4</grizzly.version>
     <hk2.version>2.6.1</hk2.version>
-    <swagger.version>1.6.6</swagger.version>
+    <swagger.version>1.6.9</swagger.version>
     <hadoop.version>2.10.1</hadoop.version>
     <antlr.version>4.6</antlr.version>
     <jsonpath.version>2.7.0</jsonpath.version>
@@ -152,7 +152,7 @@
     <zstd-jni.version>1.5.2-3</zstd-jni.version>
     <lz4-java.version>1.8.0</lz4-java.version>
     <log4j.version>2.17.1</log4j.version>
-    <netty.version>4.1.79.Final</netty.version>
+    <netty.version>4.1.94.Final</netty.version>
     <reactivestreams.version>1.0.3</reactivestreams.version>
     <jts.version>1.16.1</jts.version>
     <h3.version>4.1.1</h3.version>


### PR DESCRIPTION
- Bump up netty from 4.1.79.Final to 4.1.94.Final
- Bump up swagger from 1.6.6. to 1.6.9