### PR TITLE
Support for new dataTime format in `DateTimeGranularitySpec` without explicitly setting size

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DateTimeConversionTransformFunctionTest.java
@@ -66,7 +66,7 @@ public class DateTimeConversionTransformFunctionTest extends BaseTransformFuncti
         }, new Object[]{"dateTimeConvert(5,'1:MILLISECONDS:EPOCH','1:MINUTES:EPOCH','1:MINUTES')"}, new Object[]{
         String.format("dateTimeConvert(%s,'1:MILLISECONDS:EPOCH','1:MINUTES:EPOCH','1:MINUTES')", INT_MV_COLUMN)
     }, new Object[]{
-        String.format("dateTimeConvert(%s,'1:MILLISECONDS:EPOCH','1:MINUTES:EPOCH','MINUTES')", TIME_COLUMN)
+        String.format("dateTimeConvert(%s,'1:MILLISECONDS:EPOCH','1:MINUTES:EPOCH','MINUTES:1')", TIME_COLUMN)
     }, new Object[]{
         String.format("dateTimeConvert(%s,%s,'1:MINUTES:EPOCH','1:MINUTES')", TIME_COLUMN, INT_SV_COLUMN)
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeGranularitySpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeGranularitySpec.java
@@ -33,6 +33,7 @@ public class DateTimeGranularitySpec {
   private static final char COLON_SEPARATOR = ':';
   private static final int COLON_FORMAT_SIZE_POSITION = 0;
   private static final int COLON_FORMAT_TIME_UNIT_POSITION = 1;
+  private static final int COLON_FORMAT_NUM_TOKENS = 2;
 
   // Pipe format: 'timeUnit|size'
   private static final char PIPE_SEPARATOR = '|';
@@ -40,8 +41,6 @@ public class DateTimeGranularitySpec {
   private static final int PIPE_FORMAT_SIZE_POSITION = 1;
   private static final int PIPE_FORMAT_MIN_TOKENS = 1;
   private static final int PIPE_FORMAT_MAX_TOKENS = 2;
-
-  private static final int NUM_TOKENS = 2;
 
   private final int _size;
   private final TimeUnit _timeUnit;
@@ -55,14 +54,17 @@ public class DateTimeGranularitySpec {
     char separator;
     int sizePosition;
     int timeUnitPosition;
-    int minTokens = NUM_TOKENS;
-    int maxTokens = NUM_TOKENS;
+    int minTokens;
+    int maxTokens;
 
     if (Character.isDigit(granularity.charAt(0))) {
       // Colon format: 'size:timeUnit'
       separator = COLON_SEPARATOR;
       sizePosition = COLON_FORMAT_SIZE_POSITION;
       timeUnitPosition = COLON_FORMAT_TIME_UNIT_POSITION;
+
+      minTokens = COLON_FORMAT_NUM_TOKENS;
+      maxTokens = COLON_FORMAT_NUM_TOKENS;
     } else {
       // Pipe format: 'timeUnit(|size)'
       separator = PIPE_SEPARATOR;
@@ -86,7 +88,7 @@ public class DateTimeGranularitySpec {
     }
 
     // New format without explicitly setting size - use default size = 1
-    if (granularityTokens.length == 1) {
+    if (granularityTokens.length == PIPE_FORMAT_MIN_TOKENS) {
       _size = 1;
       return;
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeGranularitySpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeGranularitySpec.java
@@ -38,6 +38,8 @@ public class DateTimeGranularitySpec {
   private static final char PIPE_SEPARATOR = '|';
   private static final int PIPE_FORMAT_TIME_UNIT_POSITION = 0;
   private static final int PIPE_FORMAT_SIZE_POSITION = 1;
+  private static final int PIPE_FORMAT_MIN_TOKENS = 1;
+  private static final int PIPE_FORMAT_MAX_TOKENS = 2;
 
   private static final int NUM_TOKENS = 2;
 
@@ -53,6 +55,8 @@ public class DateTimeGranularitySpec {
     char separator;
     int sizePosition;
     int timeUnitPosition;
+    int minTokens = NUM_TOKENS;
+    int maxTokens = NUM_TOKENS;
 
     if (Character.isDigit(granularity.charAt(0))) {
       // Colon format: 'size:timeUnit'
@@ -60,23 +64,18 @@ public class DateTimeGranularitySpec {
       sizePosition = COLON_FORMAT_SIZE_POSITION;
       timeUnitPosition = COLON_FORMAT_TIME_UNIT_POSITION;
     } else {
-      // Pipe format: 'timeUnit|size'
+      // Pipe format: 'timeUnit(|size)'
       separator = PIPE_SEPARATOR;
       sizePosition = PIPE_FORMAT_SIZE_POSITION;
       timeUnitPosition = PIPE_FORMAT_TIME_UNIT_POSITION;
+
+      minTokens = PIPE_FORMAT_MIN_TOKENS;
+      maxTokens = PIPE_FORMAT_MAX_TOKENS;
     }
 
     String[] granularityTokens = StringUtil.split(granularity, separator, 2);
-    Preconditions.checkArgument(granularityTokens.length >= NUM_TOKENS,
-            "Invalid granularity: %s, must be of format 'timeUnit|size' or 'size:timeUnit'", granularity);
-
-    try {
-      _size = Integer.parseInt(granularityTokens[sizePosition]);
-    } catch (Exception e) {
-      throw new IllegalArgumentException(
-          String.format("Invalid size: %s in granularity: %s", granularityTokens[sizePosition], granularity));
-    }
-    Preconditions.checkArgument(_size > 0, "Invalid size: %s in granularity: %s, must be positive", _size, granularity);
+    Preconditions.checkArgument(granularityTokens.length >= minTokens && granularityTokens.length <= maxTokens,
+            "Invalid granularity: %s, must be of format 'timeUnit(|size)' or 'size:timeUnit'", granularity);
 
     try {
       _timeUnit = TimeUnit.valueOf(granularityTokens[timeUnitPosition]);
@@ -85,6 +84,20 @@ public class DateTimeGranularitySpec {
           String.format("Invalid time unit: %s in granularity: %s", granularityTokens[timeUnitPosition],
               granularity));
     }
+
+    // New format without explicitly setting size - use default size = 1
+    if (granularityTokens.length == 1) {
+      _size = 1;
+      return;
+    }
+
+    try {
+      _size = Integer.parseInt(granularityTokens[sizePosition]);
+    } catch (Exception e) {
+      throw new IllegalArgumentException(
+          String.format("Invalid size: %s in granularity: %s", granularityTokens[sizePosition], granularity));
+    }
+    Preconditions.checkArgument(_size > 0, "Invalid size: %s in granularity: %s, must be positive", _size, granularity);
   }
 
   /**

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/data/DateTimeGranularitySpecTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/data/DateTimeGranularitySpecTest.java
@@ -62,10 +62,32 @@ public class DateTimeGranularitySpecTest {
     assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MILLISECONDS);
     assertEquals(dateTimeGranularitySpec.granularityToMillis(), 1);
 
+    // New format without explicitly setting size
+    dateTimeGranularitySpec = new DateTimeGranularitySpec("HOURS");
+    assertEquals(dateTimeGranularitySpec.getSize(), 1);
+    assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.HOURS);
+    assertEquals(dateTimeGranularitySpec.granularityToMillis(), 3600000);
+
+    dateTimeGranularitySpec = new DateTimeGranularitySpec("MINUTES");
+    assertEquals(dateTimeGranularitySpec.getSize(), 1);
+    assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MINUTES);
+    assertEquals(dateTimeGranularitySpec.granularityToMillis(), 60000);
+
+    dateTimeGranularitySpec = new DateTimeGranularitySpec("MILLISECONDS");
+    assertEquals(dateTimeGranularitySpec.getSize(), 1);
+    assertEquals(dateTimeGranularitySpec.getTimeUnit(), TimeUnit.MILLISECONDS);
+    assertEquals(dateTimeGranularitySpec.granularityToMillis(), 1);
+
+    // IllegalArguments
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec(""));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1"));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1:1"));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1|1"));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("DAY:DAY"));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("DAY|DAY"));
     assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("DAY:1"));
     assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1|DAY"));
-    assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("DAY:DAY"));
-    assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1:1"));
+    assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("EPOCH|DAY|1"));
     assertThrows(IllegalArgumentException.class, () -> new DateTimeGranularitySpec("1:DAY:EPOCH"));
   }
 }


### PR DESCRIPTION
This is a follow-up PR for issue [#11028](https://github.com/apache/pinot/issues/11028)

Adding support for new dataTime format in `DateTimeGranularitySpec` without explicitly setting the size 
( ref comment by @Jackie-Jiang : https://github.com/apache/pinot/pull/11030#pullrequestreview-1515740305) 

Test Plan:
- Current UT passed
- Added new UT's