### PR TITLE
Replace Long attributes with primitive values to reduce boxing

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/fst/PinotBufferIndexInput.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/fst/PinotBufferIndexInput.java
@@ -31,11 +31,11 @@ import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
  */
 public class PinotBufferIndexInput extends IndexInput {
   private final PinotDataBuffer _pinotDataBuffer;
-  private final Long _sliceOffset;
-  private final Long _length;
-  private Long _readPointerOffset;
+  private final long _sliceOffset;
+  private final long _length;
+  private long _readPointerOffset;
 
-  public PinotBufferIndexInput(PinotDataBuffer pinotDataBuffer, Long offset, Long length) {
+  public PinotBufferIndexInput(PinotDataBuffer pinotDataBuffer, long offset, long length) {
     super("");
     _pinotDataBuffer = pinotDataBuffer;
     _sliceOffset = offset;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/fst/PinotBufferIndexInput.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/fst/PinotBufferIndexInput.java
@@ -73,7 +73,7 @@ public class PinotBufferIndexInput extends IndexInput {
   @Override
   public byte readByte()
       throws IOException {
-    Byte b = _pinotDataBuffer.getByte(_readPointerOffset);
+    byte b = _pinotDataBuffer.getByte(_readPointerOffset);
     _readPointerOffset += 1;
     return b;
   }


### PR DESCRIPTION
tag: performance

Doing some benchmarking I've found a large number of Long allocations. It seems clear that the main reason is what it looks like an incorrect `Long` usage in `PinotBufferIndexInput._readPointerOffset`, although I also changed `PinotBufferIndexInput._length` and `PinotBufferIndexInput._sliceOffset`.

This is the flamegraph where I've found the issue:
![image](https://github.com/apache/pinot/assets/1913993/41631d95-08a8-4dd2-b9cd-72e920bea45d)


cc @Jackie-Jiang @xiangfu0 @pradeepgv42 which seem to be the people that actually wrote the class.