### PR TITLE
[cleanup] Consolidate some query and controller/broker methods in integration tests

### DIFF
--- a/pinot-connectors/pinot-flink-connector/src/test/java/org/apache/pinot/connector/flink/sink/PinotSinkIntegrationTest.java
+++ b/pinot-connectors/pinot-flink-connector/src/test/java/org/apache/pinot/connector/flink/sink/PinotSinkIntegrationTest.java
@@ -79,7 +79,7 @@ public class PinotSinkIntegrationTest extends BaseClusterIntegrationTest {
     Map<String, String> batchConfigs = new HashMap<>();
     batchConfigs.put(BatchConfigProperties.OUTPUT_DIR_URI, _tarDir.getAbsolutePath());
     batchConfigs.put(BatchConfigProperties.OVERWRITE_OUTPUT, "false");
-    batchConfigs.put(BatchConfigProperties.PUSH_CONTROLLER_URI, _controllerBaseApiUrl);
+    batchConfigs.put(BatchConfigProperties.PUSH_CONTROLLER_URI, getControllerBaseApiUrl());
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setBatchIngestionConfig(
         new BatchIngestionConfig(Collections.singletonList(batchConfigs), "APPEND", "HOURLY"));

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerTest.java
@@ -119,8 +119,8 @@ public class ControllerTest {
 
   protected static HttpClient _httpClient = null;
 
-  protected int _controllerPort;
-  protected String _controllerBaseApiUrl;
+  private int _controllerPort;
+  private String _controllerBaseApiUrl;
   protected ControllerConf _controllerConfig;
   protected ControllerRequestURLBuilder _controllerRequestURLBuilder;
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -679,7 +679,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
         if (stateMap.size() != 1) {
           return false;
         }
-        String instanceId = LeadControllerUtils.generateParticipantInstanceId(LOCAL_HOST, _controllerPort);
+        String instanceId = LeadControllerUtils.generateParticipantInstanceId(LOCAL_HOST, getControllerPort());
         return MasterSlaveSMD.States.MASTER.name().equals(stateMap.get(instanceId));
       }
       return true;

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -743,7 +743,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
    */
   protected void testQuery(String pinotQuery, String h2Query)
       throws Exception {
-    ClusterIntegrationTestUtils.testQuery(pinotQuery, _brokerBaseApiUrl, getPinotConnection(), h2Query,
+    ClusterIntegrationTestUtils.testQuery(pinotQuery, getBrokerBaseApiUrl(), getPinotConnection(), h2Query,
         getH2Connection());
   }
 }

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -95,10 +95,13 @@ public abstract class ClusterTest extends ControllerTest {
   protected BaseMinionStarter _minionStarter;
 
   private String _brokerBaseApiUrl;
-  private boolean _useMultiStageQueryEngine;
 
   protected String getBrokerBaseApiUrl() {
     return _brokerBaseApiUrl;
+  }
+
+  protected boolean useMultiStageQueryEngine() {
+    return false;
   }
 
   protected PinotConfiguration getDefaultBrokerConfiguration() {
@@ -429,11 +432,14 @@ public abstract class ClusterTest extends ControllerTest {
    */
   protected JsonNode postQuery(String query)
       throws Exception {
-    return postQuery(query, getBrokerBaseApiUrl(), null, getMultiStageQueryProperties(_useMultiStageQueryEngine));
+    return postQuery(query, getBrokerBaseApiUrl(), null, getExtraQueryProperties());
   }
 
-  private static Map<String, String> getMultiStageQueryProperties(boolean useMultiStageQueryEngine) {
-    return ImmutableMap.of("queryOptions", "useMultistageEngine=" + useMultiStageQueryEngine);
+  protected Map<String, String> getExtraQueryProperties() {
+    if (!useMultiStageQueryEngine()) {
+      return Collections.emptyMap();
+    }
+    return ImmutableMap.of("queryOptions", "useMultistageEngine=true");
   }
 
   /**
@@ -465,8 +471,7 @@ public abstract class ClusterTest extends ControllerTest {
    */
   public JsonNode postQueryToController(String query)
       throws Exception {
-    return postQueryToController(query, getInstance().getControllerBaseApiUrl(), null,
-        getMultiStageQueryProperties(_useMultiStageQueryEngine));
+    return postQueryToController(query, getControllerBaseApiUrl(), null, getExtraQueryProperties());
   }
 
   /**

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.integration.tests;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
@@ -95,6 +96,8 @@ public abstract class ClusterTest extends ControllerTest {
   protected List<BaseServerStarter> _serverStarters;
   protected List<Integer> _brokerPorts;
   protected BaseMinionStarter _minionStarter;
+
+  protected boolean _useMultiStageQueryEngine = true;
 
   protected PinotConfiguration getDefaultBrokerConfiguration() {
     return new PinotConfiguration();
@@ -425,23 +428,8 @@ public abstract class ClusterTest extends ControllerTest {
    */
   protected JsonNode postQuery(String query)
       throws Exception {
-    return postQuery(query, _brokerBaseApiUrl);
-  }
-
-  /**
-   * Queries the broker's sql query endpoint (/sql)
-   */
-  public static JsonNode postQuery(String query, String brokerBaseApiUrl)
-      throws Exception {
-    return postQuery(query, brokerBaseApiUrl, null);
-  }
-
-  /**
-   * Queries the broker's sql query endpoint (/sql)
-   */
-  public static JsonNode postQuery(String query, String brokerBaseApiUrl, Map<String, String> headers)
-      throws Exception {
-    return postQuery(query, brokerBaseApiUrl, headers, null);
+    return postQuery(query, _brokerBaseApiUrl, null,
+        ImmutableMap.of("queryOptions", "useMultistageEngine=" + _useMultiStageQueryEngine));
   }
 
   /**
@@ -453,7 +441,7 @@ public abstract class ClusterTest extends ControllerTest {
     ObjectNode payload = JsonUtils.newObjectNode();
     payload.put("sql", query);
     if (MapUtils.isNotEmpty(extraJsonProperties)) {
-      for (Map.Entry<String, String> extraProperty :extraJsonProperties.entrySet()) {
+      for (Map.Entry<String, String> extraProperty : extraJsonProperties.entrySet()) {
         payload.put(extraProperty.getKey(), extraProperty.getValue());
       }
     }
@@ -463,7 +451,8 @@ public abstract class ClusterTest extends ControllerTest {
   /**
    * Queries the broker's sql query endpoint (/query/sql) using query and queryOptions strings
    */
-  protected JsonNode postQueryWithOptions(String query, String queryOptions) throws Exception {
+  protected JsonNode postQueryWithOptions(String query, String queryOptions)
+      throws Exception {
     ObjectNode payload = JsonUtils.newObjectNode();
     payload.put("sql", query);
     payload.put("queryOptions", queryOptions);
@@ -495,7 +484,7 @@ public abstract class ClusterTest extends ControllerTest {
     ObjectNode payload = JsonUtils.newObjectNode();
     payload.put("sql", query);
     if (MapUtils.isNotEmpty(extraJsonProperties)) {
-      for (Map.Entry<String, String> extraProperty :extraJsonProperties.entrySet()) {
+      for (Map.Entry<String, String> extraProperty : extraJsonProperties.entrySet()) {
         payload.put(extraProperty.getKey(), extraProperty.getValue());
       }
     }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/AdminConsoleIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/AdminConsoleIntegrationTest.java
@@ -63,21 +63,21 @@ public class AdminConsoleIntegrationTest extends BaseClusterIntegrationTest {
   public void testApiHelp()
       throws Exception {
     // test controller
-    String response = sendGetRequest(_controllerBaseApiUrl + "/help");
+    String response = sendGetRequest(getControllerBaseApiUrl() + "/help");
     String expected = IOUtils
         .toString(ControllerAdminApiApplication.class.getClassLoader().getResourceAsStream("api/index.html"), "UTF-8");
     Assert.assertEquals(response, expected);
     // help and api map to the same content
-    response = sendGetRequest(_controllerBaseApiUrl + "/api");
+    response = sendGetRequest(getControllerBaseApiUrl() + "/api");
     Assert.assertEquals(response, expected);
 
     // test broker
-    response = sendGetRequest(_brokerBaseApiUrl + "/help");
+    response = sendGetRequest(getBrokerBaseApiUrl() + "/help");
     expected = IOUtils
         .toString(BrokerAdminApiApplication.class.getClassLoader().getResourceAsStream("api/index.html"), "UTF-8");
     Assert.assertEquals(response, expected);
     // help and api map to the same content
-    response = sendGetRequest(_brokerBaseApiUrl + "/api");
+    response = sendGetRequest(getBrokerBaseApiUrl() + "/api");
     Assert.assertEquals(response, expected);
 
     String serverBaseApiUrl = "http://localhost:" + CommonConstants.Server.DEFAULT_ADMIN_API_PORT;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/AggregateMetricsClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/AggregateMetricsClusterIntegrationTest.java
@@ -90,7 +90,7 @@ public class AggregateMetricsClusterIntegrationTest extends BaseClusterIntegrati
     String sql = "SELECT SUM(AirTime), SUM(ArrDelay) FROM mytable";
     TestUtils.waitForCondition(aVoid -> {
       try {
-        JsonNode queryResult = postQuery(sql, _brokerBaseApiUrl);
+        JsonNode queryResult = postQuery(sql);
         JsonNode aggregationResults = queryResult.get("resultTable").get("rows").get(0);
         return aggregationResults.get(0).asInt() == -165429728 && aggregationResults.get(1).asInt() == -175625957;
       } catch (Exception e) {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BrokerServiceDiscoveryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BrokerServiceDiscoveryIntegrationTest.java
@@ -75,7 +75,7 @@ public class BrokerServiceDiscoveryIntegrationTest extends BaseClusterIntegratio
   @Test
   public void testBrokerExtraEndpointsAutoLoaded()
       throws Exception {
-    String response = sendGetRequest(_brokerBaseApiUrl + "/test/echo/doge");
+    String response = sendGetRequest(getBrokerBaseApiUrl() + "/test/echo/doge");
     Assert.assertEquals(response, "doge");
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerServiceDiscoveryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerServiceDiscoveryIntegrationTest.java
@@ -84,9 +84,9 @@ public class ControllerServiceDiscoveryIntegrationTest extends BaseClusterIntegr
   @Test
   public void testControllerExtraEndpointsAutoLoaded()
       throws Exception {
-    String response = sendGetRequest(_controllerBaseApiUrl + "/test/echo/doge");
+    String response = sendGetRequest(getControllerBaseApiUrl() + "/test/echo/doge");
     Assert.assertEquals(response, "doge");
-    response = sendGetRequest(_brokerBaseApiUrl + "/test/echo/doge");
+    response = sendGetRequest(getBrokerBaseApiUrl() + "/test/echo/doge");
     Assert.assertEquals(response, "doge");
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/KafkaConfluentSchemaRegistryAvroMessageDecoderRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/KafkaConfluentSchemaRegistryAvroMessageDecoderRealtimeClusterIntegrationTest.java
@@ -251,7 +251,7 @@ public class KafkaConfluentSchemaRegistryAvroMessageDecoderRealtimeClusterIntegr
     if (onlyFirstSegment) {
       numSegments = 1;
     }
-    URI uploadSegmentHttpURI = FileUploadDownloadClient.getUploadSegmentHttpURI(LOCAL_HOST, _controllerPort);
+    URI uploadSegmentHttpURI = URI.create(getControllerRequestURLBuilder().forSegmentUpload());
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
       if (numSegments == 1) {
         File segmentTarFile = segmentTarFiles[0];

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -162,7 +162,7 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
     if (onlyFirstSegment) {
       numSegments = 1;
     }
-    URI uploadSegmentHttpURI = FileUploadDownloadClient.getUploadSegmentHttpURI(LOCAL_HOST, _controllerPort);
+    URI uploadSegmentHttpURI = URI.create(getControllerRequestURLBuilder().forSegmentUpload());
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
       if (numSegments == 1) {
         File segmentTarFile = segmentTarFiles[0];

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MergeRollupMinionClusterIntegrationTest.java
@@ -393,7 +393,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     //      -> {merged_100days_T5_0_myTable1_16400_16435_0}
 
     String sqlQuery = "SELECT count(*) FROM myTable1"; // 115545 rows for the test table
-    JsonNode expectedJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode expectedJson = postQuery(sqlQuery);
     int[] expectedNumSubTasks = {1, 2, 2, 2, 1};
     int[] expectedNumSegmentsQueried = {13, 12, 13, 13, 12};
     long expectedWatermark = 16000 * 86_400_000L;
@@ -434,7 +434,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
       TestUtils.waitForCondition(aVoid -> {
         try {
           // Check num total doc of merged segments are the same as the original segments
-          JsonNode actualJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+          JsonNode actualJson = postQuery(sqlQuery);
           if (!SqlResultComparator.areEqual(actualJson, expectedJson, sqlQuery)) {
             return false;
           }
@@ -505,7 +505,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     //      -> {merged_100days_T5_0_myTable1_16400_16435_0}
 
     String sqlQuery = "SELECT count(*) FROM myTable4"; // 115545 rows for the test table
-    JsonNode expectedJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode expectedJson = postQuery(sqlQuery);
     int[] expectedNumSubTasks = {1, 2, 2, 2, 1};
     int[] expectedNumSegmentsQueried = {13, 12, 13, 13, 12};
     long expectedWatermark = 16000 * 86_400_000L;
@@ -546,7 +546,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
       TestUtils.waitForCondition(aVoid -> {
         try {
           // Check num total doc of merged segments are the same as the original segments
-          JsonNode actualJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+          JsonNode actualJson = postQuery(sqlQuery);
           if (!SqlResultComparator.areEqual(actualJson, expectedJson, sqlQuery)) {
             return false;
           }
@@ -611,7 +611,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     //      -> {merged_150days_1628644105127_0_myTable2_16352_16429_0}
 
     String sqlQuery = "SELECT count(*) FROM myTable2"; // 115545 rows for the test table
-    JsonNode expectedJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode expectedJson = postQuery(sqlQuery);
     int[] expectedNumSegmentsQueried = {16, 7, 3};
     long expectedWatermark = 16050 * 86_400_000L;
     String offlineTableName = TableNameBuilder.OFFLINE.tableNameWithType(SINGLE_LEVEL_ROLLUP_TEST_TABLE);
@@ -651,7 +651,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
       TestUtils.waitForCondition(aVoid -> {
         try {
           // Check total doc of merged segments are less than the original segments
-          JsonNode actualJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+          JsonNode actualJson = postQuery(sqlQuery);
           if (actualJson.get("resultTable").get("rows").get(0).get(0).asInt() >= expectedJson.get("resultTable")
               .get("rows").get(0).get(0).asInt()) {
             return false;
@@ -666,7 +666,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     }
 
     // Check total doc is half of the original after all merge tasks are finished
-    JsonNode actualJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode actualJson = postQuery(sqlQuery);
     assertEquals(actualJson.get("resultTable").get("rows").get(0).get(0).asInt(),
         expectedJson.get("resultTable").get("rows").get(0).get(0).asInt() / 2);
     // Check time column is rounded
@@ -750,7 +750,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     //    90days: [16380, 16470) is not a valid merge window because windowEndTime > 45days watermark, not scheduling
 
     String sqlQuery = "SELECT count(*) FROM myTable3"; // 115545 rows for the test table
-    JsonNode expectedJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode expectedJson = postQuery(sqlQuery);
     int[] expectedNumSubTasks = {1, 2, 1, 2, 1, 2, 1, 2, 1};
     int[] expectedNumSegmentsQueried = {12, 12, 11, 10, 9, 8, 7, 6, 5};
     Long[] expectedWatermarks45Days = {16065L, 16110L, 16155L, 16200L, 16245L, 16290L, 16335L, 16380L};
@@ -805,7 +805,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
       TestUtils.waitForCondition(aVoid -> {
         try {
           // Check total doc of merged segments are the same as the original segments
-          JsonNode actualJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+          JsonNode actualJson = postQuery(sqlQuery);
           if (!SqlResultComparator.areEqual(actualJson, expectedJson, sqlQuery)) {
             return false;
           }
@@ -884,7 +884,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     String tableName = getTableName();
 
     String sqlQuery = "SELECT count(*) FROM " + tableName; // 115545 rows for the test table
-    JsonNode expectedJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode expectedJson = postQuery(sqlQuery);
     // disable some checks for now because github does not generate the same number of tasks sometimes
     // need to figure out why they work locally all the time but not on github
     // I feel it maybe related to resources or timestamps
@@ -929,7 +929,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
       TestUtils.waitForCondition(aVoid -> {
         try {
           // Check num total doc of merged segments are the same as the original segments
-          JsonNode actualJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+          JsonNode actualJson = postQuery(sqlQuery);
           if (!SqlResultComparator.areEqual(actualJson, expectedJson, sqlQuery)) {
             return false;
           }
@@ -990,7 +990,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     String tableName = MULTI_LEVEL_CONCAT_PROCESS_ALL_REALTIME_TABLE;
 
     String sqlQuery = "SELECT count(*) FROM " + tableName;
-    JsonNode expectedJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode expectedJson = postQuery(sqlQuery);
     long[] expectedNumBucketsToProcess100Days = {3, 2, 1, 0, 3, 2, 1, 0};
     long[] expectedNumBucketsToProcess200Days = {0, 0, 1, 1, 0, 0, 1, 1};
     String realtimeTableName = TableNameBuilder.REALTIME.tableNameWithType(tableName);
@@ -1027,7 +1027,7 @@ public class MergeRollupMinionClusterIntegrationTest extends BaseClusterIntegrat
     assertEquals(numTasks, 4);
 
     // Check query results
-    JsonNode actualJson = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode actualJson = postQuery(sqlQuery);
     assertTrue(SqlResultComparator.areEqual(actualJson, expectedJson, sqlQuery));
 
     // Upload historical data and schedule

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineCustomTenantIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineCustomTenantIntegrationTest.java
@@ -114,9 +114,8 @@ public class MultiStageEngineCustomTenantIntegrationTest extends MultiStageEngin
       throws Exception {
     String pinotQuery = "SET multistageLeafLimit = 1; SELECT * FROM mytable;";
     String h2Query = "SELECT * FROM mytable limit 1";
-    ClusterIntegrationTestUtils
-        .testQueryWithMatchingRowCount(pinotQuery, _brokerBaseApiUrl, getPinotConnection(), h2Query, getH2Connection(),
-            null, ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
+    ClusterIntegrationTestUtils.testQueryWithMatchingRowCount(pinotQuery, getBrokerBaseApiUrl(), getPinotConnection(),
+        h2Query, getH2Connection(), null, ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
   }
 
   @Override
@@ -130,11 +129,9 @@ public class MultiStageEngineCustomTenantIntegrationTest extends MultiStageEngin
   }
 
   @Override
-  protected void testQuery(String pinotQuery, String h2Query)
-      throws Exception {
-    ClusterIntegrationTestUtils
-        .testQueryViaController(pinotQuery, _controllerBaseApiUrl, getPinotConnection(), h2Query, getH2Connection(),
-            null, ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
+  protected void testQuery(String pinotQuery, String h2Query) {
+    ClusterIntegrationTestUtils.testQueryViaController(pinotQuery, getControllerBaseApiUrl(), getPinotConnection(),
+        h2Query, getH2Connection(), null, ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
   }
 
   @AfterClass

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineCustomTenantIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineCustomTenantIntegrationTest.java
@@ -18,32 +18,13 @@
  */
 package org.apache.pinot.integration.tests;
 
-import com.google.common.collect.ImmutableMap;
-import java.io.File;
-import java.util.List;
+import java.io.IOException;
 import java.util.Map;
-import java.util.Properties;
-import org.apache.commons.io.FileUtils;
-import org.apache.pinot.client.Connection;
-import org.apache.pinot.client.ConnectionFactory;
 import org.apache.pinot.controller.ControllerConf;
-import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.data.Schema;
-import org.apache.pinot.util.TestUtils;
-import org.testng.annotations.AfterClass;
-import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 
 public class MultiStageEngineCustomTenantIntegrationTest extends MultiStageEngineIntegrationTest {
-  private static final String SCHEMA_FILE_NAME =
-      "On_Time_On_Time_Performance_2014_100k_subset_nonulls.schema";
   private static final String TEST_TENANT = "TestTenant";
-
-  @Override
-  protected String getSchemaFileName() {
-    return SCHEMA_FILE_NAME;
-  }
 
   @Override
   protected String getBrokerTenant() {
@@ -55,95 +36,16 @@ public class MultiStageEngineCustomTenantIntegrationTest extends MultiStageEngin
     return TEST_TENANT;
   }
 
-  @BeforeClass
-  public void setUp()
-      throws Exception {
-    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+  protected void setupTenants()
+      throws IOException {
+    createBrokerTenant(getBrokerTenant(), 1);
+    createServerTenant(getServerTenant(), 1, 0);
+  }
 
-    // Start the Pinot cluster
-    startZk();
-    Map<String, Object> properties = getDefaultControllerConfiguration();
+  @Override
+  public Map<String, Object> getDefaultControllerConfiguration() {
+    Map<String, Object> properties = super.getDefaultControllerConfiguration();
     properties.put(ControllerConf.CLUSTER_TENANT_ISOLATION_ENABLE, false);
-    startController(properties);
-
-    startBroker();
-    startServer();
-    createBrokerTenant(TEST_TENANT, 1);
-    createServerTenant(TEST_TENANT, 1, 0);
-
-    // Create and upload the schema and table config
-    Schema schema = createSchema();
-    addSchema(schema);
-    TableConfig tableConfig = createOfflineTableConfig();
-    addTableConfig(tableConfig);
-
-    // Unpack the Avro files
-    List<File> avroFiles = unpackAvroData(_tempDir);
-
-    // Create and upload segments
-    ClusterIntegrationTestUtils.buildSegmentsFromAvro(avroFiles, tableConfig, schema, 0, _segmentDir, _tarDir);
-    uploadSegments(getTableName(), _tarDir);
-
-    // Set up the H2 connection
-    setUpH2Connection(avroFiles);
-
-    // Initialize the query generator
-    setUpQueryGenerator(avroFiles);
-
-    // Wait for all documents loaded
-    waitForAllDocsLoaded(600_000L);
-  }
-
-  @Test
-  @Override
-  public void testHardcodedQueriesMultiStage()
-      throws Exception {
-    super.testHardcodedQueriesMultiStage();
-  }
-
-  @Test
-  @Override
-  public void testGeneratedQueries()
-      throws Exception {
-    // test multistage engine, currently we don't support MV columns.
-    super.testGeneratedQueries(false, true);
-  }
-
-  @Test
-  public void testQueryOptions()
-      throws Exception {
-    String pinotQuery = "SET multistageLeafLimit = 1; SELECT * FROM mytable;";
-    String h2Query = "SELECT * FROM mytable limit 1";
-    ClusterIntegrationTestUtils.testQueryWithMatchingRowCount(pinotQuery, getBrokerBaseApiUrl(), getPinotConnection(),
-        h2Query, getH2Connection(), null, ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
-  }
-
-  @Override
-  protected Connection getPinotConnection() {
-    Properties properties = new Properties();
-    properties.put("queryOptions", "useMultistageEngine=true");
-    if (_pinotConnection == null) {
-      _pinotConnection = ConnectionFactory.fromZookeeper(properties, getZkUrl() + "/" + getHelixClusterName());
-    }
-    return _pinotConnection;
-  }
-
-  @Override
-  protected void testQuery(String pinotQuery, String h2Query) {
-    ClusterIntegrationTestUtils.testQueryViaController(pinotQuery, getControllerBaseApiUrl(), getPinotConnection(),
-        h2Query, getH2Connection(), null, ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
-  }
-
-  @AfterClass
-  public void tearDown()
-      throws Exception {
-    dropOfflineTable(DEFAULT_TABLE_NAME);
-
-    stopServer();
-    stopBroker();
-    stopController();
-    stopZk();
-
-    FileUtils.deleteDirectory(_tempDir);
+    return properties;
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -95,7 +95,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
       throws Exception {
     String pinotQuery = "SET multistageLeafLimit = 1; SELECT * FROM mytable;";
     String h2Query = "SELECT * FROM mytable limit 1";
-    ClusterIntegrationTestUtils.testQueryWithMatchingRowCount(pinotQuery, _brokerBaseApiUrl, getPinotConnection(),
+    ClusterIntegrationTestUtils.testQueryWithMatchingRowCount(pinotQuery, getBrokerBaseApiUrl(), getPinotConnection(),
         h2Query, getH2Connection(), null, ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
   }
 
@@ -107,7 +107,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
             + "'1:DAYS:SIMPLE_DATE_FORMAT:yyyy-MM-dd''T''HH:mm:ss.SSS''Z''', '1:DAYS') = '2014-09-05T00:00:00.000Z'";
     String h2Query =
         "SELECT DivAirportIDs[1], DivAirports[1] FROM mytable WHERE DaysSinceEpoch = 16318 LIMIT 10000";
-    ClusterIntegrationTestUtils.testQueryWithMatchingRowCount(pinotQuery, _brokerBaseApiUrl, getPinotConnection(),
+    ClusterIntegrationTestUtils.testQueryWithMatchingRowCount(pinotQuery, getBrokerBaseApiUrl(), getPinotConnection(),
         h2Query, getH2Connection(), null, ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
   }
 
@@ -124,7 +124,7 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
   @Override
   protected void testQuery(String pinotQuery, String h2Query)
       throws Exception {
-    ClusterIntegrationTestUtils.testQuery(pinotQuery, _brokerBaseApiUrl, getPinotConnection(), h2Query,
+    ClusterIntegrationTestUtils.testQuery(pinotQuery, getBrokerBaseApiUrl(), getPinotConnection(), h2Query,
         getH2Connection(), null, ImmutableMap.of("queryOptions", "useMultistageEngine=true"));
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/NullHandlingIntegrationTest.java
@@ -210,7 +210,7 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
       throws Exception {
     // Null literal only
     String sqlQuery = "SELECT null FROM mytable OPTION(enableNullHandling=true)";
-    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode response = postQuery(sqlQuery);
     JsonNode rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
@@ -218,14 +218,14 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
 
     // Null related functions
     sqlQuery = "SELECT isNull(null) FROM " + getTableName() + "  OPTION (enableNullHandling=true);";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
     assertEquals(rows.get(0).get(0).asBoolean(), true);
 
     sqlQuery = "SELECT isNotNull(null) FROM " + getTableName() + "  OPTION (enableNullHandling=true);";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
@@ -233,28 +233,28 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
 
 
     sqlQuery = "SELECT coalesce(null, 1) FROM " + getTableName() + "  OPTION (enableNullHandling=true);";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
     assertEquals(rows.get(0).get(0).asInt(), 1);
 
     sqlQuery = "SELECT coalesce(null, null) FROM " + getTableName() + "  OPTION (enableNullHandling=true);";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
     assertEquals(rows.get(0).get(0).asText(), "null");
 
     sqlQuery = "SELECT isDistinctFrom(null, null) FROM " + getTableName() + "  OPTION (enableNullHandling=true);";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
     assertEquals(rows.get(0).get(0).asBoolean(), false);
 
     sqlQuery = "SELECT isNotDistinctFrom(null, null) FROM " + getTableName() + "  OPTION (enableNullHandling=true);";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
@@ -262,21 +262,21 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
 
 
     sqlQuery = "SELECT isDistinctFrom(null, 1) FROM " + getTableName() + "  OPTION (enableNullHandling=true);";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
     assertEquals(rows.get(0).get(0).asBoolean(), true);
 
     sqlQuery = "SELECT isNotDistinctFrom(null, 1) FROM " + getTableName() + "  OPTION (enableNullHandling=true);";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
     assertEquals(rows.get(0).get(0).asBoolean(), false);
 
     sqlQuery = "SELECT case when true then null end FROM " + getTableName() + "  OPTION (enableNullHandling=true);";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
@@ -284,7 +284,7 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
 
 
     sqlQuery = "SELECT case when false then 1 end FROM " + getTableName() + "  OPTION (enableNullHandling=true);";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
@@ -293,7 +293,7 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
 
     // Null intolerant functions
     sqlQuery = "SELECT add(null, 1) FROM " + getTableName() + "  OPTION (enableNullHandling=true);";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
@@ -333,7 +333,7 @@ public class NullHandlingIntegrationTest extends BaseClusterIntegrationTestSet {
     // querying the segment.
     String sqlQuery = "SELECT NULL, salary FROM mytable OPTION(enableNullHandling=true)";
 
-    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode response = postQuery(sqlQuery);
 
     JsonNode rows = response.get("resultTable").get("rows");
     assertEquals(rows.get(0).get(0).asText(), "null");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -401,7 +401,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         TableNameBuilder.extractRawTableName(offlineTableName));
     parameters.add(tableNameParameter);
 
-    URI uploadSegmentHttpURI = FileUploadDownloadClient.getUploadSegmentHttpURI(LOCAL_HOST, _controllerPort);
+    URI uploadSegmentHttpURI = URI.create(getControllerRequestURLBuilder().forSegmentUpload());
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
       // Refresh non-existing segment
       File segmentTarFile = segmentTarFiles[0];
@@ -2616,57 +2616,57 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   public void testAggregateMetadataAPI()
       throws IOException {
     JsonNode oneSVColumnResponse = JsonUtils.stringToJsonNode(
-        sendGetRequest(_controllerBaseApiUrl + "/tables/mytable/metadata?columns=DestCityMarketID"));
+        sendGetRequest(getControllerBaseApiUrl() + "/tables/mytable/metadata?columns=DestCityMarketID"));
     // DestCityMarketID is a SV column
     validateMetadataResponse(oneSVColumnResponse, 1, 0);
 
     JsonNode oneMVColumnResponse = JsonUtils.stringToJsonNode(
-        sendGetRequest(_controllerBaseApiUrl + "/tables/mytable/metadata?columns=DivLongestGTimes"));
+        sendGetRequest(getControllerBaseApiUrl() + "/tables/mytable/metadata?columns=DivLongestGTimes"));
     // DivLongestGTimes is a MV column
     validateMetadataResponse(oneMVColumnResponse, 1, 1);
 
-    JsonNode threeSVColumnsResponse = JsonUtils.stringToJsonNode(sendGetRequest(_controllerBaseApiUrl
+    JsonNode threeSVColumnsResponse = JsonUtils.stringToJsonNode(sendGetRequest(getControllerBaseApiUrl()
         + "/tables/mytable/metadata?columns=DivActualElapsedTime&columns=CRSElapsedTime&columns=OriginStateName"));
     validateMetadataResponse(threeSVColumnsResponse, 3, 0);
 
     JsonNode threeSVColumnsWholeEncodedResponse = JsonUtils.stringToJsonNode(sendGetRequest(
-        _controllerBaseApiUrl + "/tables/mytable/metadata?columns="
+        getControllerBaseApiUrl() + "/tables/mytable/metadata?columns="
             + "DivActualElapsedTime%26columns%3DCRSElapsedTime%26columns%3DOriginStateName"));
     validateMetadataResponse(threeSVColumnsWholeEncodedResponse, 3, 0);
 
-    JsonNode threeMVColumnsResponse = JsonUtils.stringToJsonNode(sendGetRequest(_controllerBaseApiUrl
+    JsonNode threeMVColumnsResponse = JsonUtils.stringToJsonNode(sendGetRequest(getControllerBaseApiUrl()
         + "/tables/mytable/metadata?columns=DivLongestGTimes&columns=DivWheelsOns&columns=DivAirports"));
     validateMetadataResponse(threeMVColumnsResponse, 3, 3);
 
     JsonNode threeMVColumnsWholeEncodedResponse = JsonUtils.stringToJsonNode(sendGetRequest(
-        _controllerBaseApiUrl + "/tables/mytable/metadata?columns="
+        getControllerBaseApiUrl() + "/tables/mytable/metadata?columns="
             + "DivLongestGTimes%26columns%3DDivWheelsOns%26columns%3DDivAirports"));
     validateMetadataResponse(threeMVColumnsWholeEncodedResponse, 3, 3);
 
     JsonNode zeroColumnResponse =
-        JsonUtils.stringToJsonNode(sendGetRequest(_controllerBaseApiUrl + "/tables/mytable/metadata"));
+        JsonUtils.stringToJsonNode(sendGetRequest(getControllerBaseApiUrl() + "/tables/mytable/metadata"));
     validateMetadataResponse(zeroColumnResponse, 0, 0);
 
     JsonNode starColumnResponse =
-        JsonUtils.stringToJsonNode(sendGetRequest(_controllerBaseApiUrl + "/tables/mytable/metadata?columns=*"));
+        JsonUtils.stringToJsonNode(sendGetRequest(getControllerBaseApiUrl() + "/tables/mytable/metadata?columns=*"));
     validateMetadataResponse(starColumnResponse, 82, 9);
 
     JsonNode starEncodedColumnResponse =
-        JsonUtils.stringToJsonNode(sendGetRequest(_controllerBaseApiUrl + "/tables/mytable/metadata?columns=%2A"));
+        JsonUtils.stringToJsonNode(sendGetRequest(getControllerBaseApiUrl() + "/tables/mytable/metadata?columns=%2A"));
     validateMetadataResponse(starEncodedColumnResponse, 82, 9);
 
     JsonNode starWithExtraColumnResponse = JsonUtils.stringToJsonNode(sendGetRequest(
-        _controllerBaseApiUrl + "/tables/mytable/metadata?columns="
+        getControllerBaseApiUrl() + "/tables/mytable/metadata?columns="
             + "CRSElapsedTime&columns=*&columns=OriginStateName"));
     validateMetadataResponse(starWithExtraColumnResponse, 82, 9);
 
     JsonNode starWithExtraEncodedColumnResponse = JsonUtils.stringToJsonNode(sendGetRequest(
-        _controllerBaseApiUrl + "/tables/mytable/metadata?columns="
+        getControllerBaseApiUrl() + "/tables/mytable/metadata?columns="
             + "CRSElapsedTime&columns=%2A&columns=OriginStateName"));
     validateMetadataResponse(starWithExtraEncodedColumnResponse, 82, 9);
 
     JsonNode starWithExtraColumnWholeEncodedResponse = JsonUtils.stringToJsonNode(sendGetRequest(
-        _controllerBaseApiUrl + "/tables/mytable/metadata?columns="
+        getControllerBaseApiUrl() + "/tables/mytable/metadata?columns="
             + "CRSElapsedTime%26columns%3D%2A%26columns%3DOriginStateName"));
     validateMetadataResponse(starWithExtraColumnWholeEncodedResponse, 82, 9);
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -571,7 +571,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   public void testTimeFunc()
       throws Exception {
     String sqlQuery = "SELECT toDateTime(now(), 'yyyy-MM-dd z'), toDateTime(ago('PT1H'), 'yyyy-MM-dd z') FROM mytable";
-    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode response = postQuery(sqlQuery);
     String todayStr = response.get("resultTable").get("rows").get(0).get(0).asText();
     String expectedTodayStr =
         Instant.now().atZone(ZoneId.of("UTC")).format(DateTimeFormatter.ofPattern("yyyy-MM-dd z"));
@@ -590,90 +590,90 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     // Test replace all.
     String sqlQuery = "SELECT regexpReplace('CA', 'C', 'TEST')";
-    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode response = postQuery(sqlQuery);
     String result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "TESTA");
 
     sqlQuery = "SELECT regexpReplace('foobarbaz', 'b', 'X')";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "fooXarXaz");
 
     sqlQuery = "SELECT regexpReplace('foobarbaz', 'b', 'XY')";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "fooXYarXYaz");
 
     sqlQuery = "SELECT regexpReplace('Argentina', '(.)', '$1 ')";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "A r g e n t i n a ");
 
     sqlQuery = "SELECT regexpReplace('Pinot is  blazing  fast', '( ){2,}', ' ')";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "Pinot is blazing fast");
 
     sqlQuery = "SELECT regexpReplace('healthy, wealthy, and wise','\\w+thy', 'something')";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "something, something, and wise");
 
     sqlQuery = "SELECT regexpReplace('11234567898','(\\d)(\\d{3})(\\d{3})(\\d{4})', '$1-($2) $3-$4')";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "1-(123) 456-7898");
 
     // Test replace starting at index.
 
     sqlQuery = "SELECT regexpReplace('healthy, wealthy, stealthy and wise','\\w+thy', 'something', 4)";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "healthy, something, something and wise");
 
     sqlQuery = "SELECT regexpReplace('healthy, wealthy, stealthy and wise','\\w+thy', 'something', 1)";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "hsomething, something, something and wise");
 
     // Test occurence
     sqlQuery = "SELECT regexpReplace('healthy, wealthy, stealthy and wise','\\w+thy', 'something', 0, 2)";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "healthy, wealthy, something and wise");
 
     sqlQuery = "SELECT regexpReplace('healthy, wealthy, stealthy and wise','\\w+thy', 'something', 0, 0)";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "something, wealthy, stealthy and wise");
 
     // Test flags
     sqlQuery = "SELECT regexpReplace('healthy, wealthy, stealthy and wise','\\w+tHy', 'something', 0, 0, 'i')";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "something, wealthy, stealthy and wise");
 
     // Negative test. Pattern match not found.
     sqlQuery = "SELECT regexpReplace('healthy, wealthy, stealthy and wise','\\w+tHy', 'something')";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "healthy, wealthy, stealthy and wise");
 
     // Negative test. Pattern match not found.
     sqlQuery = "SELECT regexpReplace('healthy, wealthy, stealthy and wise','\\w+tHy', 'something', 3, 21, 'i')";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "healthy, wealthy, stealthy and wise");
 
     // Negative test - incorrect flag
     sqlQuery = "SELECT regexpReplace('healthy, wealthy, stealthy and wise','\\w+tHy', 'something', 3, 12, 'xyz')";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     result = response.get("resultTable").get("rows").get(0).get(0).asText();
     assertEquals(result, "healthy, wealthy, stealthy and wise");
 
     // Test in select clause with column values
     sqlQuery = "SELECT regexpReplace(DestCityName, ' ', '', 0, -1, 'i') from myTable where OriginState = 'CA'";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     JsonNode rows = response.get("resultTable").get("rows");
     for (int i = 0; i < rows.size(); i++) {
       JsonNode row = rows.get(i);
@@ -682,20 +682,20 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     // Test in where clause
     sqlQuery = "SELECT count(*) from myTable where regexpReplace(originState, '[VC]A', 'TEST') = 'TEST'";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     int count1 = response.get("resultTable").get("rows").get(0).get(0).asInt();
     sqlQuery = "SELECT count(*) from myTable where originState='CA' or originState='VA'";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     int count2 = response.get("resultTable").get("rows").get(0).get(0).asInt();
     assertEquals(count1, count2);
 
     // Test nested transform
     sqlQuery =
         "SELECT count(*) from myTable where contains(regexpReplace(originState, '(C)(A)', '$1TEST$2'), 'CTESTA')";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     count1 = response.get("resultTable").get("rows").get(0).get(0).asInt();
     sqlQuery = "SELECT count(*) from myTable where originState='CA'";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     count2 = response.get("resultTable").get("rows").get(0).get(0).asInt();
     assertEquals(count1, count2);
   }
@@ -706,7 +706,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     // simple cast
     String sqlQuery = "SELECT DivLongestGTimes, CAST(DivLongestGTimes as DOUBLE) from myTable LIMIT 100";
-    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode response = postQuery(sqlQuery);
     JsonNode resultTable = response.get("resultTable");
     JsonNode dataSchema = resultTable.get("dataSchema");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"FLOAT_ARRAY\",\"DOUBLE_ARRAY\"]");
@@ -730,7 +730,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // nested cast
     sqlQuery = "SELECT DivAirportIDs, CAST(CAST(CAST(DivAirportIDs AS FLOAT) as INT) as STRING),"
         + " DivTotalGTimes, CAST(CAST(DivTotalGTimes AS STRING) AS LONG) from myTable ORDER BY CARRIER LIMIT 100";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
     assertEquals(dataSchema.get("columnDataTypes").toString(),
@@ -769,7 +769,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       throws Exception {
     String sqlQuery = "SELECT encodeUrl('key1=value 1&key2=value@!$2&key3=value%3'), "
         + "decodeUrl('key1%3Dvalue+1%26key2%3Dvalue%40%21%242%26key3%3Dvalue%253') FROM myTable";
-    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode response = postQuery(sqlQuery);
     String encodedString = response.get("resultTable").get("rows").get(0).get(0).asText();
     String expectedUrlStr = encodeUrl("key1=value 1&key2=value@!$2&key3=value%3");
     assertEquals(encodedString, expectedUrlStr);
@@ -785,7 +785,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     // string literal
     String sqlQuery = "SELECT toBase64(toUtf8('hello!')), " + "fromUtf8(fromBase64('aGVsbG8h')) FROM myTable";
-    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode response = postQuery(sqlQuery);
     JsonNode resultTable = response.get("resultTable");
     JsonNode dataSchema = resultTable.get("dataSchema");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"STRING\",\"STRING\"]");
@@ -802,7 +802,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     sqlQuery =
         "SELECT toBase64(toUtf8('this is a long string that will encode to more than 76 characters using base64')) "
             + "FROM myTable";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     resultTable = response.get("resultTable");
     rows = resultTable.get("rows");
     encodedString = rows.get(0).get(0).asText();
@@ -813,7 +813,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     sqlQuery = "SELECT fromUtf8(fromBase64"
         + "('dGhpcyBpcyBhIGxvbmcgc3RyaW5nIHRoYXQgd2lsbCBlbmNvZGUgdG8gbW9yZSB0aGFuIDc2IGNoYXJhY3RlcnMgdXNpbmcgYmFzZTY0"
         + "')) FROM myTable";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     resultTable = response.get("resultTable");
     rows = resultTable.get("rows");
     decodedString = rows.get(0).get(0).asText();
@@ -822,7 +822,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     // non-string literal
     sqlQuery = "SELECT toBase64(toUtf8(123)), fromUtf8(fromBase64(toBase64(toUtf8(123)))), 123 FROM myTable";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     resultTable = response.get("resultTable");
     rows = resultTable.get("rows");
     encodedString = rows.get(0).get(0).asText();
@@ -834,7 +834,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // identifier
     sqlQuery = "SELECT Carrier, toBase64(toUtf8(Carrier)), fromUtf8(fromBase64(toBase64(toUtf8(Carrier)))), "
         + "fromBase64(toBase64(toUtf8(Carrier))) FROM myTable LIMIT 100";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"STRING\",\"STRING\",\"STRING\",\"BYTES\"]");
@@ -851,42 +851,42 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
     // invalid argument
     sqlQuery = "SELECT toBase64() FROM myTable";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     assertTrue(response.get("exceptions").get(0).get("message").toString().startsWith("\"QueryExecutionError"));
 
     // invalid argument
     sqlQuery = "SELECT fromBase64() FROM myTable";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     assertTrue(response.get("exceptions").get(0).get("message").toString().startsWith("\"QueryExecutionError"));
 
     // invalid argument
     sqlQuery = "SELECT toBase64('hello!') FROM myTable";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     assertTrue(response.get("exceptions").get(0).get("message").toString().contains("SqlCompilationException"));
 
     // invalid argument
     sqlQuery = "SELECT fromBase64('hello!') FROM myTable";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     assertTrue(response.get("exceptions").get(0).get("message").toString().contains("IllegalArgumentException"));
 
     // string literal used in a filter
     sqlQuery = "SELECT * FROM myTable WHERE fromUtf8(fromBase64('aGVsbG8h')) != Carrier AND "
         + "toBase64(toUtf8('hello!')) != Carrier LIMIT 10";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     resultTable = response.get("resultTable");
     rows = resultTable.get("rows");
     assertEquals(rows.size(), 10);
 
     // non-string literal used in a filter
     sqlQuery = "SELECT * FROM myTable WHERE fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))) != Carrier LIMIT 10";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     resultTable = response.get("resultTable");
     rows = resultTable.get("rows");
     assertEquals(rows.size(), 10);
 
     // string identifier used in a filter
     sqlQuery = "SELECT * FROM myTable WHERE fromUtf8(fromBase64(toBase64(toUtf8(Carrier)))) = Carrier LIMIT 10";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     resultTable = response.get("resultTable");
     rows = resultTable.get("rows");
     assertEquals(rows.size(), 10);
@@ -894,7 +894,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // non-string identifier used in a filter
     sqlQuery = "SELECT fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))), AirlineID FROM myTable WHERE "
         + "fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))) = AirlineID LIMIT 10";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"STRING\",\"LONG\"]");
@@ -906,7 +906,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         + "fromUtf8(fromBase64(toBase64(toUtf8(Carrier)))) as decoded FROM myTable "
         + "GROUP BY Carrier, toBase64(toUtf8(Carrier)), fromUtf8(fromBase64(toBase64(toUtf8(Carrier)))) "
         + "ORDER BY toBase64(toUtf8(Carrier)) LIMIT 10";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"STRING\",\"STRING\",\"STRING\"]");
@@ -926,7 +926,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         + "fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))) as decoded FROM myTable "
         + "GROUP BY AirlineID, toBase64(toUtf8(AirlineID)), fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))) "
         + "ORDER BY fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))) LIMIT 10";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     resultTable = response.get("resultTable");
     dataSchema = resultTable.get("dataSchema");
     assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"LONG\",\"STRING\",\"STRING\"]");
@@ -1922,7 +1922,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     }
     caseStatementBuilder.append("ELSE 0 END");
     String sqlQuery = "SELECT origin, " + caseStatementBuilder + " AS origin_code FROM mytable LIMIT 1000";
-    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode response = postQuery(sqlQuery);
     JsonNode rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     for (int i = 0; i < rows.size(); i++) {
@@ -1942,7 +1942,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     String sqlQuery =
         "SELECT ArrDelay, CASE WHEN ArrDelay > 0 THEN ArrDelay WHEN ArrDelay < 0 THEN ArrDelay * -1 ELSE 0 END AS "
             + "ArrTimeDiff FROM mytable LIMIT 1000";
-    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode response = postQuery(sqlQuery);
     JsonNode rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     for (int i = 0; i < rows.size(); i++) {
@@ -1961,7 +1961,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       throws Exception {
     String sqlQuery = "SELECT ArrDelay" + ", CASE WHEN ArrDelay > 50 OR ArrDelay < 10 THEN 10 ELSE 0 END"
         + ", CASE WHEN ArrDelay < 50 AND ArrDelay >= 10 THEN 10 ELSE 0 END" + " FROM mytable LIMIT 1000";
-    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode response = postQuery(sqlQuery);
     JsonNode rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     for (int i = 0; i < rows.size(); i++) {
@@ -1998,10 +1998,10 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   private void testCountVsCaseQuery(String predicate)
       throws Exception {
     String sqlQuery = String.format("SELECT COUNT(*) FROM mytable WHERE %s", predicate);
-    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode response = postQuery(sqlQuery);
     long countValue = response.get("resultTable").get("rows").get(0).get(0).asLong();
     sqlQuery = String.format("SELECT SUM(CASE WHEN %s THEN 1 ELSE 0 END) as sum1 FROM mytable", predicate);
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     long caseSum = response.get("resultTable").get("rows").get(0).get(0).asLong();
     assertEquals(caseSum, countValue);
   }
@@ -2376,7 +2376,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // The Accurate value is 6538.
     query = "SELECT distinctCount(FlightNum) FROM mytable ";
     assertEquals(postQuery(query).get("resultTable").get("rows").get(0).get(0).asLong(), 6538);
-    assertEquals(postQuery(query, _brokerBaseApiUrl).get("resultTable").get("rows").get(0).get(0).asLong(), 6538);
+    assertEquals(postQuery(query).get("resultTable").get("rows").get(0).get(0).asLong(), 6538);
 
     // Expected distinctCountHll with different log2m value from 2 to 19. The Accurate value is 6538.
     long[] expectedResults = new long[]{
@@ -2386,14 +2386,14 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     for (int i = 2; i < 20; i++) {
       query = String.format("SELECT distinctCountHLL(FlightNum, %d) FROM mytable ", i);
       assertEquals(postQuery(query).get("resultTable").get("rows").get(0).get(0).asLong(), expectedResults[i - 2]);
-      assertEquals(postQuery(query, _brokerBaseApiUrl).get("resultTable").get("rows").get(0).get(0).asLong(),
+      assertEquals(postQuery(query).get("resultTable").get("rows").get(0).get(0).asLong(),
           expectedResults[i - 2]);
     }
 
     // Default HLL is set as log2m=12
     query = "SELECT distinctCountHLL(FlightNum) FROM mytable ";
     assertEquals(postQuery(query).get("resultTable").get("rows").get(0).get(0).asLong(), expectedResults[10]);
-    assertEquals(postQuery(query, _brokerBaseApiUrl).get("resultTable").get("rows").get(0).get(0).asLong(),
+    assertEquals(postQuery(query).get("resultTable").get("rows").get(0).get(0).asLong(),
         expectedResults[10]);
   }
 
@@ -2415,7 +2415,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   public void testExplainPlanQuery()
       throws Exception {
     String query1 = "EXPLAIN PLAN FOR SELECT count(*) AS count, Carrier AS name FROM mytable GROUP BY name ORDER BY 1";
-    String response1 = postQuery(query1, _brokerBaseApiUrl).get("resultTable").toString();
+    String response1 = postQuery(query1).get("resultTable").toString();
 
     // Replace string "docs:[0-9]+" with "docs:*" so that test doesn't fail when number of documents change. This is
     // needed because both OfflineClusterIntegrationTest and MultiNodesOfflineClusterIntegrationTest run this test
@@ -2432,7 +2432,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // In the query below, FlightNum column has an inverted index and there is no data satisfying the predicate
     // "FlightNum < 0". Hence, all segments are pruned out before query execution on the server side.
     String query2 = "EXPLAIN PLAN FOR SELECT * FROM mytable WHERE FlightNum < 0";
-    String response2 = postQuery(query2, _brokerBaseApiUrl).get("resultTable").toString();
+    String response2 = postQuery(query2).get("resultTable").toString();
 
     assertEquals(response2, "{\"dataSchema\":{\"columnNames\":[\"Operator\",\"Operator_Id\",\"Parent_Id\"],"
         + "\"columnDataTypes\":[\"STRING\",\"INT\",\"INT\"]},\"rows\":[[\"BROKER_REDUCE(limit:10)\",1,0],"
@@ -2445,19 +2445,19 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       throws Exception {
     // compare two string columns.
     String query1 = "SELECT count(*) FROM mytable WHERE OriginState = DestState";
-    String response1 = postQuery(query1, _brokerBaseApiUrl).get("resultTable").toString();
+    String response1 = postQuery(query1).get("resultTable").toString();
     assertEquals(response1,
         "{\"dataSchema\":{\"columnNames\":[\"count(*)\"],\"columnDataTypes\":[\"LONG\"]}," + "\"rows\":[[14011]]}");
 
     // compare string function with string column.
     String query2 = "SELECT count(*) FROM mytable WHERE trim(OriginState) = DestState";
-    String response2 = postQuery(query2, _brokerBaseApiUrl).get("resultTable").toString();
+    String response2 = postQuery(query2).get("resultTable").toString();
     assertEquals(response2,
         "{\"dataSchema\":{\"columnNames\":[\"count(*)\"],\"columnDataTypes\":[\"LONG\"]}," + "\"rows\":[[14011]]}");
 
     // compare string function with string function.
     String query3 = "SELECT count(*) FROM mytable WHERE substr(OriginState, 0, 1) = substr(DestState, 0, 1)";
-    String response3 = postQuery(query3, _brokerBaseApiUrl).get("resultTable").toString();
+    String response3 = postQuery(query3).get("resultTable").toString();
     assertEquals(response3,
         "{\"dataSchema\":{\"columnNames\":[\"count(*)\"],\"columnDataTypes\":[\"LONG\"]}," + "\"rows\":[[19755]]}");
   }
@@ -2723,28 +2723,28 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       throws Exception {
     // Test boolean equal true case.
     String sqlQuery = "SELECT (true = true) = true FROM mytable where true = true";
-    JsonNode response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    JsonNode response = postQuery(sqlQuery);
     JsonNode rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
     assertTrue(rows.get(0).get(0).asBoolean());
     // Test boolean equal false case.
     sqlQuery = "SELECT (true = true) = false FROM mytable";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
     assertFalse(rows.get(0).get(0).asBoolean());
     // Test boolean not equal true case.
     sqlQuery = "SELECT true != false FROM mytable";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);
     assertTrue(rows.get(0).get(0).asBoolean());
     // Test boolean not equal false case.
     sqlQuery = "SELECT true != true FROM mytable";
-    response = postQuery(sqlQuery, _brokerBaseApiUrl);
+    response = postQuery(sqlQuery);
     rows = response.get("resultTable").get("rows");
     assertTrue(response.get("exceptions").isEmpty());
     assertEquals(rows.size(), 1);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SSBQueryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SSBQueryIntegrationTest.java
@@ -27,10 +27,7 @@ import java.sql.Statement;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import java.util.Properties;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.client.Connection;
-import org.apache.pinot.client.ConnectionFactory;
 import org.apache.pinot.client.ResultSetGroup;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
@@ -153,13 +150,8 @@ public class SSBQueryIntegrationTest extends BaseClusterIntegrationTest {
   }
 
   @Override
-  protected Connection getPinotConnection() {
-    Properties properties = new Properties();
-    properties.put("queryOptions", "useMultistageEngine=true");
-    if (_pinotConnection == null) {
-      _pinotConnection = ConnectionFactory.fromZookeeper(properties, getZkUrl() + "/" + getHelixClusterName());
-    }
-    return _pinotConnection;
+  protected boolean useMultiStageQueryEngine() {
+    return true;
   }
 
   @AfterClass

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentGenerationMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentGenerationMinionClusterIntegrationTest.java
@@ -102,7 +102,7 @@ public class SegmentGenerationMinionClusterIntegrationTest extends BaseClusterIn
         return false;
       }
     }, 5000L, 600_000L, "Failed to load " + rowCnt + " documents", true);
-    JsonNode result = postQuery("SELECT COUNT(*) FROM " + tableName, _brokerBaseApiUrl);
+    JsonNode result = postQuery("SELECT COUNT(*) FROM " + tableName);
     // One segment per file.
     assertEquals(result.get("numSegmentsQueried").asInt(), 7);
   }
@@ -135,7 +135,7 @@ public class SegmentGenerationMinionClusterIntegrationTest extends BaseClusterIn
       try {
         if (getTotalDocs(tableName) < rowCnt) {
           JsonNode response = queryController ? postQueryToController(insertFileStatement, _controllerBaseApiUrl)
-              : postQuery(insertFileStatement, _brokerBaseApiUrl);
+              : postQuery(insertFileStatement);
           Assert.assertEquals(response.get("resultTable").get("rows").get(0).get(0).asText(),
               tableName + "_OFFLINE");
           Assert.assertEquals(response.get("resultTable").get("rows").get(0).get(1).asText(),
@@ -147,7 +147,7 @@ public class SegmentGenerationMinionClusterIntegrationTest extends BaseClusterIn
         return false;
       }
     }, 5000L, 600_000L, "Failed to load " + rowCnt + " documents", true);
-    JsonNode result = postQuery("SELECT COUNT(*) FROM " + tableName, _brokerBaseApiUrl);
+    JsonNode result = postQuery("SELECT COUNT(*) FROM " + tableName);
     // One segment per file.
     assertEquals(result.get("numSegmentsQueried").asInt(), 7);
   }
@@ -178,7 +178,7 @@ public class SegmentGenerationMinionClusterIntegrationTest extends BaseClusterIn
   private int getTotalDocs(String tableName)
       throws Exception {
     String query = "SELECT COUNT(*) FROM " + tableName;
-    JsonNode response = postQuery(query, _brokerBaseApiUrl);
+    JsonNode response = postQuery(query);
     JsonNode resTbl = response.get("resultTable");
     return (resTbl == null) ? 0 : resTbl.get("rows").get(0).get(0).asInt();
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentGenerationMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentGenerationMinionClusterIntegrationTest.java
@@ -88,7 +88,7 @@ public class SegmentGenerationMinionClusterIntegrationTest extends BaseClusterIn
     AdhocTaskConfig adhocTaskConfig =
         new AdhocTaskConfig("SegmentGenerationAndPushTask", tableNameWithType, null, taskConfigs);
 
-    String url = _controllerBaseApiUrl + "/tasks/execute";
+    String url = getControllerBaseApiUrl() + "/tasks/execute";
     TestUtils.waitForCondition(aVoid -> {
       try {
         if (getTotalDocs(tableName) < rowCnt) {
@@ -134,7 +134,7 @@ public class SegmentGenerationMinionClusterIntegrationTest extends BaseClusterIn
     TestUtils.waitForCondition(aVoid -> {
       try {
         if (getTotalDocs(tableName) < rowCnt) {
-          JsonNode response = queryController ? postQueryToController(insertFileStatement, _controllerBaseApiUrl)
+          JsonNode response = queryController ? postQueryToController(insertFileStatement)
               : postQuery(insertFileStatement);
           Assert.assertEquals(response.get("resultTable").get("rows").get(0).get(0).asText(),
               tableName + "_OFFLINE");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
@@ -140,7 +140,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(DEFAULT_TABLE_NAME));
     jobSpec.setTableSpec(tableSpec);
     PinotClusterSpec clusterSpec = new PinotClusterSpec();
-    clusterSpec.setControllerURI(_controllerBaseApiUrl);
+    clusterSpec.setControllerURI(getControllerBaseApiUrl());
     jobSpec.setPinotClusterSpecs(new PinotClusterSpec[]{clusterSpec});
 
     File dataDir = new File(_controllerConfig.getDataDir());
@@ -241,7 +241,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(DEFAULT_TABLE_NAME));
     jobSpec.setTableSpec(tableSpec);
     PinotClusterSpec clusterSpec = new PinotClusterSpec();
-    clusterSpec.setControllerURI(_controllerBaseApiUrl);
+    clusterSpec.setControllerURI(getControllerBaseApiUrl());
     jobSpec.setPinotClusterSpecs(new PinotClusterSpec[]{clusterSpec});
 
     File dataDir = new File(_controllerConfig.getDataDir());
@@ -267,7 +267,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
 
     // Fetch segment lineage entry after running segment metadata push with consistent push enabled.
     String segmentLineageResponse = ControllerTest.sendGetRequest(
-        ControllerRequestURLBuilder.baseUrl(_controllerBaseApiUrl)
+        ControllerRequestURLBuilder.baseUrl(getControllerBaseApiUrl())
             .forListAllSegmentLineages(DEFAULT_TABLE_NAME, TableType.OFFLINE.toString()));
     // Segment lineage should be in completed state.
     Assert.assertTrue(segmentLineageResponse.contains("\"state\":\"COMPLETED\""));
@@ -316,7 +316,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
 
     // Fetch segment lineage entry after running segment tar push with consistent push enabled.
     segmentLineageResponse = ControllerTest.sendGetRequest(
-        ControllerRequestURLBuilder.baseUrl(_controllerBaseApiUrl)
+        ControllerRequestURLBuilder.baseUrl(getControllerBaseApiUrl())
             .forListAllSegmentLineages(DEFAULT_TABLE_NAME, TableType.OFFLINE.toString()));
     // Segment lineage should be in completed state.
     Assert.assertTrue(segmentLineageResponse.contains("\"state\":\"COMPLETED\""));

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentWriterUploaderIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentWriterUploaderIntegrationTest.java
@@ -88,7 +88,7 @@ public class SegmentWriterUploaderIntegrationTest extends BaseClusterIntegration
     Map<String, String> batchConfigMap = new HashMap<>();
     batchConfigMap.put(BatchConfigProperties.OUTPUT_DIR_URI, _tarDir.getAbsolutePath());
     batchConfigMap.put(BatchConfigProperties.OVERWRITE_OUTPUT, "false");
-    batchConfigMap.put(BatchConfigProperties.PUSH_CONTROLLER_URI, _controllerBaseApiUrl);
+    batchConfigMap.put(BatchConfigProperties.PUSH_CONTROLLER_URI, getControllerBaseApiUrl());
     IngestionConfig ingestionConfig = new IngestionConfig();
     ingestionConfig.setBatchIngestionConfig(
         new BatchIngestionConfig(Collections.singletonList(batchConfigMap), "APPEND", "HOURLY"));

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentWriterUploaderIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentWriterUploaderIntegrationTest.java
@@ -162,7 +162,7 @@ public class SegmentWriterUploaderIntegrationTest extends BaseClusterIntegration
 
   private int getTotalDocsFromQuery()
       throws Exception {
-    JsonNode response = postQuery(String.format("select count(*) from %s", _tableNameWithType), _brokerBaseApiUrl);
+    JsonNode response = postQuery(String.format("select count(*) from %s", _tableNameWithType));
     return response.get("resultTable").get("rows").get(0).get(0).asInt();
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TPCHQueryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TPCHQueryIntegrationTest.java
@@ -29,13 +29,10 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Properties;
 import java.util.Set;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.IOUtils;
-import org.apache.pinot.client.Connection;
-import org.apache.pinot.client.ConnectionFactory;
 import org.apache.pinot.client.ResultSetGroup;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
@@ -147,13 +144,8 @@ public class TPCHQueryIntegrationTest extends BaseClusterIntegrationTest {
   }
 
   @Override
-  protected Connection getPinotConnection() {
-    Properties properties = new Properties();
-    properties.put("queryOptions", "useMultistageEngine=true");
-    if (_pinotConnection == null) {
-      _pinotConnection = ConnectionFactory.fromZookeeper(properties, getZkUrl() + "/" + getHelixClusterName());
-    }
-    return _pinotConnection;
+  protected boolean useMultiStageQueryEngine() {
+    return true;
   }
 
   @AfterClass

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ThetaSketchIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ThetaSketchIntegrationTest.java
@@ -232,7 +232,7 @@ public class ThetaSketchIntegrationTest extends BaseClusterIntegrationTest {
 
   private void runAndAssert(String query, int expected)
       throws Exception {
-    JsonNode jsonNode = postQuery(query, _brokerBaseApiUrl);
+    JsonNode jsonNode = postQuery(query);
     int actual = Integer.parseInt(jsonNode.get("resultTable").get("rows").get(0).get(0).asText());
     assertEquals(actual, expected);
   }
@@ -240,7 +240,7 @@ public class ThetaSketchIntegrationTest extends BaseClusterIntegrationTest {
   private void runAndAssert(String query, Map<String, Integer> expectedGroupToValueMap)
       throws Exception {
     Map<String, Integer> actualGroupToValueMap = new HashMap<>();
-    JsonNode jsonNode = postQuery(query, _brokerBaseApiUrl);
+    JsonNode jsonNode = postQuery(query);
     jsonNode.get("resultTable").get("rows").forEach(node -> {
       String group = node.get(0).textValue();
       int value = node.get(1).intValue();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -542,4 +542,8 @@ public class ControllerRequestURLBuilder {
       throw new RuntimeException(e);
     }
   }
+
+  public String forSegmentUpload() {
+    return StringUtil.join("/", _baseUrl, "v2/segments");
+  }
 }


### PR DESCRIPTION
- Remove unnecessary usage of static `PostQuery` calls.
- Remove direct reference to `_controllerBaseApiUrl`, `_controllerPort` and `_brokerBaseApiUrl` in extended test classes.
- Always add `useMultistageEngine` query option if possible.
- Simplify MultiStageEngineCustomTenantIntegrationTest