### PR TITLE
Updated calcite version to 1.30.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <jsonpath.version>2.7.0</jsonpath.version>
     <jsonsmart.version>2.4.10</jsonsmart.version>
     <quartz.version>2.3.2</quartz.version>
-    <calcite.version>1.29.0</calcite.version>
+    <calcite.version>1.30.0</calcite.version>
     <lucene.version>8.2.0</lucene.version>
     <reflections.version>0.9.11</reflections.version>
     <!-- commons-configuration, hadoop-common, hadoop-client use commons-lang -->


### PR DESCRIPTION
- updated calcite dependency version to `1.30.0`
- Calcite `1.30.0` has the [CVE-2021-27568 fixed](https://issues.apache.org/jira/browse/CALCITE-5030) fix. Release [docs](https://calcite.apache.org/news/2022/03/19/release-1.30.0/)

cc: @walterddr 