### PR TITLE
Make RequestUtils always return a string array when getTableNames

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
@@ -191,9 +191,8 @@ public class Connection {
   private static String[] resolveTableName(String query) {
     try {
       SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
-      String tableName =
-          RequestUtils.getTableName(CalciteSqlParser.compileSqlNodeToPinotQuery(sqlNodeAndOptions.getSqlNode()));
-      return new String[]{tableName};
+      return RequestUtils.getTableNames(CalciteSqlParser.compileSqlNodeToPinotQuery(sqlNodeAndOptions.getSqlNode()))
+          .toArray(new String[0]);
     } catch (Exception e) {
       LOGGER.error("Cannot parse table name from query: {}. Fallback to broker selector default.", query, e);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -239,8 +239,8 @@ public class PinotQueryResource {
     String tableName;
     try {
       String inputTableName =
-          sqlNode != null ? RequestUtils.getTableName(CalciteSqlParser.compileSqlNodeToPinotQuery(sqlNode))
-              : CalciteSqlCompiler.compileToBrokerRequest(query).getQuerySource().getTableName();
+          sqlNode != null ? RequestUtils.getTableNames(CalciteSqlParser.compileSqlNodeToPinotQuery(sqlNode)).iterator()
+              .next() : CalciteSqlCompiler.compileToBrokerRequest(query).getQuerySource().getTableName();
       tableName = _pinotHelixResourceManager.getActualTableName(inputTableName);
     } catch (Exception e) {
       LOGGER.error("Caught exception while compiling query: {}", query, e);
@@ -274,7 +274,7 @@ public class PinotQueryResource {
   // given a list of tables, returns the list of tableConfigs
   private List<TableConfig> getListTableConfigs(List<String> tableNames) {
     List<TableConfig> allTableConfigList = new ArrayList<>();
-    for (String tableName: tableNames) {
+    for (String tableName : tableNames) {
       List<TableConfig> tableConfigList = new ArrayList<>();
       if (_pinotHelixResourceManager.hasRealtimeTable(tableName)) {
         tableConfigList.add(Objects.requireNonNull(_pinotHelixResourceManager.getRealtimeTableConfig(tableName)));

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TPCHQueryIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TPCHQueryIntegrationTest.java
@@ -64,12 +64,8 @@ public class TPCHQueryIntegrationTest extends BaseClusterIntegrationTest {
     TPCH_QUICKSTART_TABLE_RESOURCES.put("part", "examples/batch/tpch/part");
     TPCH_QUICKSTART_TABLE_RESOURCES.put("supplier", "examples/batch/tpch/supplier");
     EXEMPT_QUERIES = new HashSet<>();
-    // The following query fails due to a bug in resolving table names from query
-    EXEMPT_QUERIES.add(13);
     // The following queries fail due to lack of support for views.
     EXEMPT_QUERIES.addAll(ImmutableList.of(15, 16, 17));
-    // The following query fails due to inability of Aggregation operator to handle conversion from Boolean to Number.
-    EXEMPT_QUERIES.add(23);
   }
 
   @BeforeClass


### PR DESCRIPTION
Make RequestUtils always return a string array when getTableNames