### PR TITLE
Instance retag validation check api

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TagNameUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/TagNameUtils.java
@@ -102,6 +102,13 @@ public class TagNameUtils {
     return getTagForTenant(tenantName, REALTIME_SERVER_TAG_SUFFIX);
   }
 
+  /**
+   * Returns the server tag name for the given tenant and the given table type.
+   */
+  public static String getServerTagForTenant(@Nullable String tenantName, TableType type) {
+    return getTagForTenant(tenantName, String.format("_%s", type));
+  }
+
   private static String getTagForTenant(@Nullable String tenantName, String tagSuffix) {
     if (tenantName == null) {
       return DEFAULT_TENANT_NAME + tagSuffix;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/InstanceTagUpdateRequest.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/InstanceTagUpdateRequest.java
@@ -30,7 +30,6 @@ public class InstanceTagUpdateRequest {
   @ApiModelProperty(example = "Server_a.b.com_20000")
   private String _instanceName;
   @JsonProperty("newTags")
-  @ApiModelProperty(example = "[Server_a.c.com_20000,Server_b.c.com_20000")
   private List<String> _newTags;
 
   public String getInstanceName() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/InstanceTagUpdateRequest.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/InstanceTagUpdateRequest.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.api.resources;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import io.swagger.annotations.ApiModel;
+import io.swagger.annotations.ApiModelProperty;
+import java.util.List;
+
+
+@ApiModel
+public class InstanceTagUpdateRequest {
+  @JsonProperty("instanceName")
+  @ApiModelProperty(example = "Server_a.b.com_20000")
+  private String _instanceName;
+  @JsonProperty("newTags")
+  @ApiModelProperty(example = "[Server_a.c.com_20000,Server_b.c.com_20000")
+  private List<String> _newTags;
+
+  public String getInstanceName() {
+    return _instanceName;
+  }
+
+  public void setInstanceName(String instanceName) {
+    _instanceName = instanceName;
+  }
+
+  public List<String> getNewTags() {
+    return _newTags;
+  }
+
+  public void setNewTags(List<String> newTags) {
+    _newTags = newTags;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/OperationValidationResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/OperationValidationResponse.java
@@ -90,7 +90,7 @@ public class OperationValidationResponse {
     CONTAINS_RESOURCE("Instance %s exists in ideal state for %s"),
     MINIMUM_INSTANCE_UNSATISFIED(
         "Tenant '%s' will not satisfy minimum '%s' requirement if tag '%s' is removed from %s instance '%s'."),
-    ALREADY_DEFICIENT_TENANT("Tenant '%s' is low on '%s' instances by %s even with given allocation"),
+    ALREADY_DEFICIENT_TENANT("Tenant '%s' is low on '%s' instances by %s even after allocating instance %s"),
     UNRECOGNISED_TAG_TYPE("The tag '%s' does not follow the suffix convention of either broker or server");
 
     public final String _description;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/OperationValidationResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/OperationValidationResponse.java
@@ -90,7 +90,7 @@ public class OperationValidationResponse {
     CONTAINS_RESOURCE("Instance %s exists in ideal state for %s"),
     MINIMUM_INSTANCE_UNSATISFIED(
         "Tenant '%s' will not satisfy minimum '%s' requirement if tag '%s' is removed from %s instance '%s'."),
-    ALREADY_DEFICIENT_TENANT("Tenant '%s' is low on '%s' instances by %d even with given allocation"),
+    ALREADY_DEFICIENT_TENANT("Tenant '%s' is low on '%s' instances by %s even with given allocation"),
     UNRECOGNISED_TAG_TYPE("The tag '%s' does not follow the suffix convention of either broker or server");
 
     public final String _description;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/OperationValidationResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/OperationValidationResponse.java
@@ -88,7 +88,10 @@ public class OperationValidationResponse {
   public enum ErrorCode {
     IS_ALIVE("Instance %s is still live"),
     CONTAINS_RESOURCE("Instance %s exists in ideal state for %s"),
-    MINIMUM_SERVERS_UNSATISFIED("Tenant %s will not satisfy minimum servers requirement if removed from server %s.");
+    MINIMUM_INSTANCE_UNSATISFIED(
+        "Tenant '%s' will not satisfy minimum '%s' requirement if tag '%s' is removed from %s instance '%s'."),
+    ALREADY_DEFICIENT_TENANT("Tenant '%s' is low on '%s' instances by %d even with given allocation"),
+    UNRECOGNISED_TAG_TYPE("The tag '%s' does not follow the suffix convention of either broker or server");
 
     public final String _description;
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/OperationValidationResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/OperationValidationResponse.java
@@ -68,8 +68,13 @@ public class OperationValidationResponse {
   }
 
   public static class ErrorWrapper {
+    @JsonProperty("code")
     ErrorCode _code;
+    @JsonProperty("message")
     String _message;
+
+    public ErrorWrapper() {
+    }
 
     public ErrorWrapper(ErrorCode code, String... args) {
       _code = code;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/OperationValidationResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/OperationValidationResponse.java
@@ -58,6 +58,11 @@ public class OperationValidationResponse {
     return this;
   }
 
+  public OperationValidationResponse putAllIssues(List<ErrorWrapper> issues) {
+    _issues.addAll(issues);
+    return this;
+  }
+
   public String getIssueMessage(int index) {
     return _issues.get(index).getMessage();
   }
@@ -82,7 +87,8 @@ public class OperationValidationResponse {
 
   public enum ErrorCode {
     IS_ALIVE("Instance %s is still live"),
-    CONTAINS_RESOURCE("Instance %s exists in ideal state for %s");
+    CONTAINS_RESOURCE("Instance %s exists in ideal state for %s"),
+    MINIMUM_SERVERS_UNSATISFIED("Tenant %s will not satisfy minimum servers requirement if removed from server %s.");
 
     public final String _description;
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -465,14 +465,15 @@ public class PinotInstanceRestletResource {
     removedInstances.forEach((tag, removed) -> instanceIssueHandling(tag, tenantMinServerMap,
         () -> Objects.requireNonNullElse(addedInstances.remove(tag), new ArrayList<>()).size() - removed.size(),
         // assumes existing tags are valid tenant tags
-        () -> {},
+        () -> { },
         (type, deficiency) -> {
       for (int i = 0; i < deficiency && i < removed.size(); i++) {
         String instance = removed.get(i);
         String tenant = TagNameUtils.getTenantFromTag(tag);
         responseMap.get(instance).add(new OperationValidationResponse.ErrorWrapper(
             OperationValidationResponse.ErrorCode.MINIMUM_INSTANCE_UNSATISFIED, tenant, type, tag, type, instance));
-      }}));
+      }
+    }));
     // record issue if even after adding new instance to a tenant, it still has instance deficiency
     addedInstances.forEach((tag, added) -> instanceIssueHandling(tag, tenantMinServerMap, added::size,
         () -> added.forEach(instance -> responseMap.get(instance).add(new OperationValidationResponse.ErrorWrapper(

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -1225,7 +1225,7 @@ public class PinotHelixResourceManager {
     return tenantSet;
   }
 
-  private List<String> getTagsForInstance(String instanceName) {
+  public List<String> getTagsForInstance(String instanceName) {
     InstanceConfig config = _helixDataAccessor.getProperty(_keyBuilder.instanceConfig(instanceName));
     return config.getTags();
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3025,6 +3025,15 @@ public class PinotHelixResourceManager {
   }
 
   /**
+   * Get all table configs.
+   *
+   * @return List of table configs. Empty list in case of tables configs does not exist.
+   */
+  public List<TableConfig> getAllTableConfigs() {
+    return ZKMetadataProvider.getAllTableConfigs(_propertyStore);
+  }
+
+  /**
    * Get the offline table config for the given table name.
    *
    * @param tableName Table name with or without type suffix
@@ -4138,12 +4147,7 @@ public class PinotHelixResourceManager {
   public Map<String, Integer> minimumServersRequiredForTenants() {
     Map<String, Integer> tenantMinServerMap = new HashMap<>();
     getAllServerTenantNames().forEach(tenant -> tenantMinServerMap.put(tenant, 0));
-    for (String table : getAllTables()) {
-      TableConfig tableConfig = getTableConfig(table);
-      if (tableConfig == null) {
-        LOGGER.error("Unable to retrieve table config for table: {}", table);
-        continue;
-      }
+    for (TableConfig tableConfig : getAllTableConfigs()) {
       String tenant = tableConfig.getTenantConfig().getServer();
       int maxReplication = Math.max(Objects.requireNonNullElse(tenantMinServerMap.get(tenant), 0),
           tableConfig.getReplication());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -4140,26 +4140,26 @@ public class PinotHelixResourceManager {
   /**
    * Construct a map of all the tags and their respective minimum instance requirements.
    * The minimum instance requirement is computed by
-   * - for BROKER tenant tag set it to 1.
+   * - for BROKER tenant tag set it to 1 if it hosts any table else set it to 0
    * - for SERVER tenant tag iterate over all the tables of that tenant and find the maximum table replication.
    * - for rest of the tags just set it to 0
    * @return map of tags and their minimum instance requirements
    */
   public Map<String, Integer> minimumInstancesRequiredForTags() {
-    Map<String, Integer> tagMinServerMap = new HashMap<>();
+    Map<String, Integer> tagMinInstanceMap = new HashMap<>();
     for (InstanceConfig instanceConfig : getAllHelixInstanceConfigs()) {
       for (String tag : instanceConfig.getTags()) {
-        tagMinServerMap.put(tag, TagNameUtils.isBrokerTag(tag) ? 1 : 0);
+        tagMinInstanceMap.put(tag, 0);
       }
     }
     for (TableConfig tableConfig : getAllTableConfigs()) {
       String tag = TagNameUtils.getServerTagForTenant(tableConfig.getTenantConfig().getServer(),
           tableConfig.getTableType());
-      tagMinServerMap.put(tag, Math.max(tagMinServerMap.getOrDefault(tag, 0), tableConfig.getReplication()));
+      tagMinInstanceMap.put(tag, Math.max(tagMinInstanceMap.getOrDefault(tag, 0), tableConfig.getReplication()));
       String brokerTag = TagNameUtils.getBrokerTagForTenant(tableConfig.getTenantConfig().getBroker());
-      tagMinServerMap.put(brokerTag, 1);
+      tagMinInstanceMap.put(brokerTag, 1);
     }
-    return tagMinServerMap;
+    return tagMinInstanceMap;
   }
 
   /*

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -42,7 +42,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.TreeMap;
@@ -4154,11 +4153,9 @@ public class PinotHelixResourceManager {
       }
     }
     for (TableConfig tableConfig : getAllTableConfigs()) {
-      String serverTag = TagNameUtils.getServerTagForTenant(tableConfig.getTenantConfig().getServer(),
+      String tag = TagNameUtils.getServerTagForTenant(tableConfig.getTenantConfig().getServer(),
           tableConfig.getTableType());
-      int maxReplication = Math.max(Objects.requireNonNullElse(tagMinServerMap.get(serverTag), 0),
-          tableConfig.getReplication());
-      tagMinServerMap.put(serverTag, maxReplication);
+      tagMinServerMap.put(tag, Math.max(tagMinServerMap.getOrDefault(tag, 0), tableConfig.getReplication()));
       String brokerTag = TagNameUtils.getBrokerTagForTenant(tableConfig.getTenantConfig().getBroker());
       tagMinServerMap.put(brokerTag, 1);
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
@@ -46,10 +46,10 @@ import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.assertNotNull;
 
 
 /**

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotInstanceRestletResourceTest.java
@@ -19,19 +19,28 @@
 package org.apache.pinot.controller.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.google.common.collect.Lists;
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import javax.annotation.Nullable;
+import org.apache.pinot.controller.api.resources.InstanceTagUpdateRequest;
+import org.apache.pinot.controller.api.resources.OperationValidationResponse;
 import org.apache.pinot.controller.helix.ControllerTest;
 import org.apache.pinot.spi.config.instance.Instance;
 import org.apache.pinot.spi.config.instance.InstanceType;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.CommonConstants.Helix;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.ControllerRequestURLBuilder;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -40,6 +49,7 @@ import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertThrows;
 import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.assertNotNull;
 
 
 /**
@@ -47,22 +57,24 @@ import static org.testng.Assert.assertTrue;
  */
 public class PinotInstanceRestletResourceTest extends ControllerTest {
 
+  private ControllerRequestURLBuilder _urlBuilder = null;
+
   @BeforeClass
   public void setUp()
       throws Exception {
     DEFAULT_INSTANCE.setupSharedStateAndValidate();
+    _urlBuilder = DEFAULT_INSTANCE.getControllerRequestURLBuilder();
   }
 
   @Test
   public void testInstanceListingAndCreation()
       throws Exception {
-    ControllerRequestURLBuilder requestURLBuilder = DEFAULT_INSTANCE.getControllerRequestURLBuilder();
-    String listInstancesUrl = requestURLBuilder.forInstanceList();
+    String listInstancesUrl = _urlBuilder.forInstanceList();
     int expectedNumInstances = 1 + DEFAULT_NUM_BROKER_INSTANCES + DEFAULT_NUM_SERVER_INSTANCES;
     checkNumInstances(listInstancesUrl, expectedNumInstances);
 
     // Create untagged broker and server instances
-    String createInstanceUrl = requestURLBuilder.forInstanceCreate();
+    String createInstanceUrl = _urlBuilder.forInstanceCreate();
     Instance brokerInstance1 = new Instance("1.2.3.4", 1234, InstanceType.BROKER, null, null, 0, 0, 0, 0, false);
     sendPostRequest(createInstanceUrl, brokerInstance1.toJsonString());
     Instance serverInstance1 =
@@ -110,14 +122,14 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
         new Instance("1.2.3.4", 1234, InstanceType.BROKER, Collections.singletonList(newBrokerTag), null, 0, 0, 0, 0,
             false);
     String brokerInstanceId = "Broker_1.2.3.4_1234";
-    String brokerInstanceUrl = requestURLBuilder.forInstance(brokerInstanceId);
+    String brokerInstanceUrl = _urlBuilder.forInstance(brokerInstanceId);
     sendPutRequest(brokerInstanceUrl, newBrokerInstance.toJsonString());
     String newServerTag = "new-server-tag";
     Instance newServerInstance =
         new Instance("1.2.3.4", 2345, InstanceType.SERVER, Collections.singletonList(newServerTag), null, 28090, 28091,
             28092, 28093, true);
     String serverInstanceId = "Server_1.2.3.4_2345";
-    String serverInstanceUrl = requestURLBuilder.forInstance(serverInstanceId);
+    String serverInstanceUrl = _urlBuilder.forInstance(serverInstanceId);
     sendPutRequest(serverInstanceUrl, newServerInstance.toJsonString());
 
     checkInstanceInfo(brokerInstanceId, "1.2.3.4", 1234, new String[]{newBrokerTag}, null, -1, -1, -1, -1, false);
@@ -126,9 +138,9 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
 
     // Test Instance updateTags API
     String brokerInstanceUpdateTagsUrl =
-        requestURLBuilder.forInstanceUpdateTags(brokerInstanceId, Lists.newArrayList("tag_BROKER", "newTag_BROKER"));
+        _urlBuilder.forInstanceUpdateTags(brokerInstanceId, Lists.newArrayList("tag_BROKER", "newTag_BROKER"));
     sendPutRequest(brokerInstanceUpdateTagsUrl);
-    String serverInstanceUpdateTagsUrl = requestURLBuilder.forInstanceUpdateTags(serverInstanceId,
+    String serverInstanceUpdateTagsUrl = _urlBuilder.forInstanceUpdateTags(serverInstanceId,
         Lists.newArrayList("tag_REALTIME", "newTag_OFFLINE", "newTag_REALTIME"));
     sendPutRequest(serverInstanceUpdateTagsUrl);
     checkInstanceInfo(brokerInstanceId, "1.2.3.4", 1234, new String[]{"tag_BROKER", "newTag_BROKER"}, null, -1, -1, -1,
@@ -137,10 +149,10 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
         new String[]{"tag_REALTIME", "newTag_OFFLINE", "newTag_REALTIME"}, null, 28090, 28091, 28092, 28093, true);
 
     // Test DELETE instance API
-    sendDeleteRequest(requestURLBuilder.forInstance("Broker_1.2.3.4_1234"));
-    sendDeleteRequest(requestURLBuilder.forInstance("Server_1.2.3.4_2345"));
-    sendDeleteRequest(requestURLBuilder.forInstance("Broker_2.3.4.5_1234"));
-    sendDeleteRequest(requestURLBuilder.forInstance("Server_2.3.4.5_2345"));
+    sendDeleteRequest(_urlBuilder.forInstance("Broker_1.2.3.4_1234"));
+    sendDeleteRequest(_urlBuilder.forInstance("Server_1.2.3.4_2345"));
+    sendDeleteRequest(_urlBuilder.forInstance("Broker_2.3.4.5_1234"));
+    sendDeleteRequest(_urlBuilder.forInstance("Server_2.3.4.5_2345"));
     checkNumInstances(listInstancesUrl, expectedNumInstances);
   }
 
@@ -163,7 +175,7 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
       boolean queriesDisabled)
       throws Exception {
     JsonNode response = JsonUtils.stringToJsonNode(
-        ControllerTest.sendGetRequest(DEFAULT_INSTANCE.getControllerRequestURLBuilder().forInstance(instanceName)));
+        ControllerTest.sendGetRequest(_urlBuilder.forInstance(instanceName)));
     assertEquals(response.get("instanceName").asText(), instanceName);
     assertEquals(response.get("hostName").asText(), hostName);
     assertTrue(response.get("enabled").asBoolean());
@@ -191,6 +203,95 @@ public class PinotInstanceRestletResourceTest extends ControllerTest {
     } else {
       assertNull(response.get("queriesDisabled"));
     }
+  }
+
+  @Test
+  public void instanceRetagHappyPathTest()
+      throws IOException {
+    Map<String, List<String>> currentInstanceTagsMap = getCurrentInstanceTagsMap();
+    List<InstanceTagUpdateRequest> request = new ArrayList<>();
+    currentInstanceTagsMap.forEach((instance, tags) -> {
+      if (instance.startsWith(Helix.PREFIX_OF_SERVER_INSTANCE)
+          || instance.startsWith(Helix.PREFIX_OF_BROKER_INSTANCE)) {
+        InstanceTagUpdateRequest payload = new InstanceTagUpdateRequest();
+        payload.setInstanceName(instance);
+        payload.setNewTags(tags);
+        request.add(payload);
+      }
+    });
+    List<OperationValidationResponse> response = Arrays.asList(new ObjectMapper().readValue(
+        sendPostRequest(_urlBuilder.forUpdateTagsValidation(), JsonUtils.objectToString(request)),
+        OperationValidationResponse[].class));
+    assertNotNull(response);
+    response.forEach(item -> assertTrue(item.isSafe()));
+  }
+
+  @Test
+  public void instanceRetagServerDeficiencyTest()
+      throws Exception {
+    String tableName = "testTable";
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(tableName)
+        .setNumReplicas(2).build();
+    // create table with replication as 2 so that DefaultTenant has a minimum server requirement as 2.
+    DEFAULT_INSTANCE.addTableConfig(tableConfig);
+    Map<String, List<String>> currentInstanceTagsMap = getCurrentInstanceTagsMap();
+    List<InstanceTagUpdateRequest> request = new ArrayList<>();
+    currentInstanceTagsMap.forEach((instance, tags) -> {
+      if (instance.startsWith(Helix.PREFIX_OF_SERVER_INSTANCE)
+          || instance.startsWith(Helix.PREFIX_OF_BROKER_INSTANCE)) {
+        InstanceTagUpdateRequest payload = new InstanceTagUpdateRequest();
+        payload.setInstanceName(instance);
+        payload.setNewTags(Lists.newArrayList());
+        request.add(payload);
+      }
+    });
+    List<OperationValidationResponse> response = Arrays.asList(new ObjectMapper().readValue(
+        sendPostRequest(_urlBuilder.forUpdateTagsValidation(), JsonUtils.objectToString(request)),
+        OperationValidationResponse[].class));
+    assertNotNull(response);
+
+    int deficientServers = 2;
+    int deficientBrokers = 1;
+    for (OperationValidationResponse item : response) {
+      String instanceName = item.getInstanceName();
+      boolean validity = item.isSafe();
+      if (!validity) {
+        List<OperationValidationResponse.ErrorWrapper> issues = item.getIssues();
+        assertEquals(issues.size(), 1);
+        assertEquals(issues.get(0).getCode(), OperationValidationResponse.ErrorCode.MINIMUM_INSTANCE_UNSATISFIED);
+        if (instanceName.startsWith(Helix.PREFIX_OF_SERVER_INSTANCE)) {
+          deficientServers--;
+        } else if (instanceName.startsWith(Helix.PREFIX_OF_BROKER_INSTANCE)) {
+          deficientBrokers--;
+        }
+      }
+    }
+    assertEquals(deficientServers, 0);
+    assertEquals(deficientBrokers, 0);
+    DEFAULT_INSTANCE.dropOfflineTable(tableName);
+  }
+
+  private Map<String, List<String>> getCurrentInstanceTagsMap()
+      throws IOException {
+    String listInstancesUrl = _urlBuilder.forInstanceList();
+    JsonNode response = JsonUtils.stringToJsonNode(sendGetRequest(listInstancesUrl));
+    JsonNode instances = response.get("instances");
+    Map<String, List<String>> map = new HashMap<>(instances.size());
+    for (int i = 0; i < instances.size(); i++) {
+      String instance = instances.get(i).asText();
+      map.put(instance, getInstanceTags(instance));
+    }
+    return map;
+  }
+
+  private List<String> getInstanceTags(String instance)
+      throws IOException {
+    String getInstancesUrl = _urlBuilder.forInstance(instance);
+    List<String> tags = new ArrayList<>();
+    for (JsonNode tag : JsonUtils.stringToJsonNode(sendGetRequest(getInstancesUrl)).get("tags")) {
+      tags.add(tag.asText());
+    }
+    return tags;
   }
 
   @AfterClass

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -534,6 +534,10 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "tables", tableName, "pauseStatus");
   }
 
+  public String forUpdateTagsValidation() {
+    return String.format("%s/instances/updateTags/validate", _baseUrl);
+  }
+
   private static String encode(String s) {
     try {
       return URLEncoder.encode(s, "UTF-8");


### PR DESCRIPTION
Expose an endpoint to perform safety check validation of the instance retag/ tag update operation. 
Right now in order to update the tags on an instance we use

- `/instances/{instanceName}/updateTags` 

**Problem**
This operation blindly updates the instance tags without taking into consideration the possible consequences such as table replication not being satsfied. 

**Proposal**
Provide a validation API that takes the desired user state as input and provides the user with the information if the retag is safe else give all the possible reasons for it being unsafe.

Endpoint : `/instances/updateTags/validate`
Method type : `POST`
Request body : 
```
[
  {
    "instanceName": "Server_a.c.com_20000",
    "newTags": [
      "tenantA_OFFLINE",
      "tenantA_REALTIME"
    ]
  },
  {
    "instanceName": "Server_b.c.com_20000",
    "newTags": [
      "tenantB_OFFLINE",
      "tenantB_REALTIME"
    ]
  }
]
```
Sample Response : 

```
[
  {
    "instanceName": "Broker_127.0.0.1_8000",
    "issues": [
      {
        "code": "MINIMUM_INSTANCE_UNSATISFIED",
        "message": "Tenant 'DefaultTenant' will not satisfy minimum 'broker' requirement if tag 'DefaultTenant_BROKER' is removed from broker instance 'Broker_127.0.0.1_8000'."
      },
      {
        "code": "UNRECOGNISED_TAG_TYPE",
        "message": "The tag 'tenantA' does not follow the suffix convention of either broker or server"
      }
    ],
    "isSafe": false
  },
  {
    "instanceName": "Server_127.0.0.1_7050",
    "issues": [
      {
        "code": "MINIMUM_INSTANCE_UNSATISFIED",
        "message": "Tenant 'DefaultTenant' will not satisfy minimum 'server' requirement if tag 'DefaultTenant_REALTIME' is removed from server instance 'Server_127.0.0.1_7050'."
      }
    ],
    "isSafe": false
  },
  {
    "instanceName": null,
    "issues": [
      {
        "code": "ALREADY_DEFICIENT_TENANT",
        "message": "Tenant 'DefaultTenant_OFFLINE' is low on 'server' instances by 1 even with given allocation"
      }
    ],
    "isSafe": false
  }
]
```