### PR TITLE
Set _disableAcl appropriately when initializing FS directly with S3 client

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -178,6 +178,7 @@ public class S3PinotFS extends BasePinotFS {
     S3Config s3Config = new S3Config(serverSideEncryptionConfig);
     setServerSideEncryption(serverSideEncryption, s3Config);
     setMultiPartUploadConfigs(s3Config);
+    setDisableAcl(s3Config);
   }
 
   private void setServerSideEncryption(@Nullable String serverSideEncryption, S3Config s3Config) {
@@ -631,6 +632,10 @@ public class S3PinotFS extends BasePinotFS {
 
   private void setMultiPartUploadConfigs(S3Config s3Config) {
     setMultiPartUploadConfigs(s3Config.getMinObjectSizeForMultiPartUpload(), s3Config.getMultiPartUploadPartSize());
+  }
+
+  private void setDisableAcl(S3Config s3Config) {
+    _disableAcl = s3Config.getDisableAcl();
   }
 
   @VisibleForTesting


### PR DESCRIPTION
Allows for setting _disableAcl when initializing FS instance directly with s3 client