### PR TITLE
Allow using Lucene text indexes on mutable MV columns.

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
@@ -183,10 +183,10 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
     if (config.isDisabled()) {
       return null;
     }
-    if (!context.getFieldSpec().isSingleValueField()) {
-      return null;
-    }
     if (config.getFstType() == FSTType.NATIVE) {
+      if (!context.getFieldSpec().isSingleValueField()) {
+        return null;
+      }
       return new NativeMutableTextIndex(context.getFieldSpec().getName());
     }
     if (context.getConsumerDir() == null) {


### PR DESCRIPTION
tags: bugfix

#11000 added support for Lucene text indexes on mutable MV columns; this PR enables their use by updating `createMutableIndex` to reflect the change in #11000.

# Testing performed
* Created a table with a MV column with a Lucene text index applied
* Validated that `text_match` could be used on the column
