### PR TITLE
Add serviceAccount to minion-stateless

### DIFF
--- a/kubernetes/helm/pinot/templates/minion-stateless/deployment.yaml
+++ b/kubernetes/helm/pinot/templates/minion-stateless/deployment.yaml
@@ -37,6 +37,7 @@ spec:
 {{ toYaml .Values.minionStateless.podAnnotations | indent 8 }}
     spec:
       terminationGracePeriodSeconds: {{ .Values.terminationGracePeriodSeconds }}
+      serviceAccountName: {{ include "pinot.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.minionStateless.podSecurityContext | nindent 8 }}
       {{- with .Values.imagePullSecrets }}


### PR DESCRIPTION
When submitting job for read data from some FS like S3, the minion need to have permission to read data.