### PR TITLE
Fix a flaky test LLCRealtimeClusterIntegrationTest.testAddRemoveDicionaryAndInvertedIndex.

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -386,7 +386,7 @@ public class ClusterIntegrationTestUtils {
   public static void pushCsvIntoKafka(List<String> csvRecords, String kafkaTopic,
       @Nullable Integer partitionColumnIndex, boolean injectTombstones, StreamDataProducer producer)
       throws Exception {
-    int counter = 0;
+    long counter = 0;
     if (injectTombstones) {
       // publish lots of tombstones to livelock the consumer if it can't handle this properly
       for (int i = 0; i < 1000; i++) {
@@ -435,7 +435,7 @@ public class ClusterIntegrationTestUtils {
     StreamDataProducer producer =
         StreamDataProvider.getStreamDataProducer(KafkaStarterUtils.KAFKA_PRODUCER_CLASS_NAME, properties);
 
-    int counter = 0;
+    long counter = 0;
     try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(65536)) {
       if (injectTombstones) {
         // publish lots of tombstones to livelock the consumer if it can't handle this properly
@@ -492,7 +492,7 @@ public class ClusterIntegrationTestUtils {
     // initiate transaction.
     producer.initTransactions();
     producer.beginTransaction();
-    int counter = 0;
+    long counter = 0;
     try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(65536)) {
       for (File avroFile : avroFiles) {
         try (DataFileStream<GenericRecord> reader = AvroUtils.getAvroReader(avroFile)) {
@@ -545,7 +545,7 @@ public class ClusterIntegrationTestUtils {
     properties.put("request.required.acks", "1");
     properties.put("partitioner.class", "kafka.producer.ByteArrayPartitioner");
 
-    int counter = 0;
+    long counter = 0;
     StreamDataProducer producer =
         StreamDataProvider.getStreamDataProducer(KafkaStarterUtils.KAFKA_PRODUCER_CLASS_NAME, properties);
     try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(65536)) {

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -352,18 +352,18 @@ public class ClusterIntegrationTestUtils {
   public static void pushCsvIntoKafka(File csvFile, String kafkaTopic,
       @Nullable Integer partitionColumnIndex, boolean injectTombstones, StreamDataProducer producer)
       throws Exception {
-
+    long counter = 0;
     if (injectTombstones) {
       // publish lots of tombstones to livelock the consumer if it can't handle this properly
       for (int i = 0; i < 1000; i++) {
         // publish a tombstone first
-        producer.produce(kafkaTopic, Longs.toByteArray(System.currentTimeMillis()), null);
+        producer.produce(kafkaTopic, Longs.toByteArray(counter++), null);
       }
     }
     CSVFormat csvFormat = CSVFormat.DEFAULT.withSkipHeaderRecord(true);
     try (CSVParser parser = CSVParser.parse(csvFile, StandardCharsets.UTF_8, csvFormat)) {
       for (CSVRecord csv : parser) {
-        byte[] keyBytes = (partitionColumnIndex == null) ? Longs.toByteArray(System.currentTimeMillis())
+        byte[] keyBytes = (partitionColumnIndex == null) ? Longs.toByteArray(counter++)
             : csv.get(partitionColumnIndex).getBytes(StandardCharsets.UTF_8);
         List<String> cols = new ArrayList<>();
         for (String col : csv) {
@@ -386,19 +386,19 @@ public class ClusterIntegrationTestUtils {
   public static void pushCsvIntoKafka(List<String> csvRecords, String kafkaTopic,
       @Nullable Integer partitionColumnIndex, boolean injectTombstones, StreamDataProducer producer)
       throws Exception {
-
+    int counter = 0;
     if (injectTombstones) {
       // publish lots of tombstones to livelock the consumer if it can't handle this properly
       for (int i = 0; i < 1000; i++) {
         // publish a tombstone first
-        producer.produce(kafkaTopic, Longs.toByteArray(System.currentTimeMillis()), null);
+        producer.produce(kafkaTopic, Longs.toByteArray(counter++), null);
       }
     }
     CSVFormat csvFormat = CSVFormat.DEFAULT.withSkipHeaderRecord(true);
     for (String recordCsv: csvRecords) {
       try (CSVParser parser = CSVParser.parse(recordCsv, csvFormat)) {
         for (CSVRecord csv : parser) {
-          byte[] keyBytes = (partitionColumnIndex == null) ? Longs.toByteArray(System.currentTimeMillis())
+          byte[] keyBytes = (partitionColumnIndex == null) ? Longs.toByteArray(counter++)
               : csv.get(partitionColumnIndex).getBytes(StandardCharsets.UTF_8);
           List<String> cols = new ArrayList<>();
           for (String col : csv) {
@@ -435,12 +435,13 @@ public class ClusterIntegrationTestUtils {
     StreamDataProducer producer =
         StreamDataProvider.getStreamDataProducer(KafkaStarterUtils.KAFKA_PRODUCER_CLASS_NAME, properties);
 
+    int counter = 0;
     try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(65536)) {
       if (injectTombstones) {
         // publish lots of tombstones to livelock the consumer if it can't handle this properly
         for (int i = 0; i < 1000; i++) {
           // publish a tombstone first
-          producer.produce(kafkaTopic, Longs.toByteArray(System.currentTimeMillis()), null);
+          producer.produce(kafkaTopic, Longs.toByteArray(counter++), null);
         }
       }
       for (File avroFile : avroFiles) {
@@ -455,7 +456,7 @@ public class ClusterIntegrationTestUtils {
             datumWriter.write(genericRecord, binaryEncoder);
             binaryEncoder.flush();
 
-            byte[] keyBytes = (partitionColumn == null) ? Longs.toByteArray(System.currentTimeMillis())
+            byte[] keyBytes = (partitionColumn == null) ? Longs.toByteArray(counter++)
                 : (genericRecord.get(partitionColumn)).toString().getBytes();
             byte[] bytes = outputStream.toByteArray();
             producer.produce(kafkaTopic, keyBytes, bytes);
@@ -491,6 +492,7 @@ public class ClusterIntegrationTestUtils {
     // initiate transaction.
     producer.initTransactions();
     producer.beginTransaction();
+    int counter = 0;
     try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(65536)) {
       for (File avroFile : avroFiles) {
         try (DataFileStream<GenericRecord> reader = AvroUtils.getAvroReader(avroFile)) {
@@ -504,7 +506,7 @@ public class ClusterIntegrationTestUtils {
             datumWriter.write(genericRecord, binaryEncoder);
             binaryEncoder.flush();
 
-            byte[] keyBytes = (partitionColumn == null) ? Longs.toByteArray(System.currentTimeMillis())
+            byte[] keyBytes = (partitionColumn == null) ? Longs.toByteArray(counter++)
                 : (genericRecord.get(partitionColumn)).toString().getBytes();
             byte[] bytes = outputStream.toByteArray();
             ProducerRecord<byte[], byte[]> record = new ProducerRecord(kafkaTopic, keyBytes, bytes);
@@ -543,6 +545,7 @@ public class ClusterIntegrationTestUtils {
     properties.put("request.required.acks", "1");
     properties.put("partitioner.class", "kafka.producer.ByteArrayPartitioner");
 
+    int counter = 0;
     StreamDataProducer producer =
         StreamDataProvider.getStreamDataProducer(KafkaStarterUtils.KAFKA_PRODUCER_CLASS_NAME, properties);
     try (ByteArrayOutputStream outputStream = new ByteArrayOutputStream(65536)) {
@@ -562,7 +565,7 @@ public class ClusterIntegrationTestUtils {
           datumWriter.write(genericRecord, binaryEncoder);
           binaryEncoder.flush();
 
-          byte[] keyBytes = (partitionColumn == null) ? Longs.toByteArray(System.currentTimeMillis())
+          byte[] keyBytes = (partitionColumn == null) ? Longs.toByteArray(counter++)
               : (genericRecord.get(partitionColumn)).toString().getBytes();
           byte[] bytes = outputStream.toByteArray();
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -273,8 +273,9 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
     // Full table scan without dictionary
     // The offline segments are created deterministically and all the offline segments contain "ActualElapsedTime =
     // -9999" records.
-    // The realtime segments are created non-deterministically and there is a small chance some segments may not
-    // contain any "ActualElapsedTime = -9999" records, so these segments are pruned and not scanned.
+    // The realtime segments are created non-deterministically (uses system time for Kafka partitioning) and there is
+    // a small chance some segments may not contain any "ActualElapsedTime = -9999" records, so these segments are
+    // pruned and not scanned.
     long numEntriesScannedInFilter = queryResponse.get("numEntriesScannedInFilter").asLong();
     if (queryResponse.get("numSegmentsQueried") == queryResponse.get("numSegmentsProcessed")) {
       assertEquals(numEntriesScannedInFilter, numTotalDocs);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -271,17 +271,7 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
     JsonNode queryResponse = postQuery(query);
     assertEquals(queryResponse.get("totalDocs").asLong(), numTotalDocs);
     // Full table scan without dictionary
-    // The offline segments are created deterministically and all the offline segments contain "ActualElapsedTime =
-    // -9999" records.
-    // The realtime segments are created non-deterministically (uses system time for Kafka partitioning) and there is
-    // a small chance some segments may not contain any "ActualElapsedTime = -9999" records, so these segments are
-    // pruned and not scanned.
-    long numEntriesScannedInFilter = queryResponse.get("numEntriesScannedInFilter").asLong();
-    if (queryResponse.get("numSegmentsQueried") == queryResponse.get("numSegmentsProcessed")) {
-      assertEquals(numEntriesScannedInFilter, numTotalDocs);
-    } else {
-      assertTrue(numEntriesScannedInFilter >= numTotalDocs / 2);
-    }
+    assertEquals(queryResponse.get("numEntriesScannedInFilter").asLong(), numTotalDocs);
     long queryResult = queryResponse.get("resultTable").get("rows").get(0).get(0).asLong();
 
     // Enable dictionary and inverted index.
@@ -330,7 +320,7 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
     }, 60_000L, "Failed to remove dictionary and inverted index");
     // Should get back to full table scan
     queryResponse = postQuery(query);
-    assertEquals(queryResponse.get("numEntriesScannedInFilter").asLong(), numEntriesScannedInFilter);
+    assertEquals(queryResponse.get("numEntriesScannedInFilter").asLong(), numTotalDocs);
   }
 
   @Test


### PR DESCRIPTION
For more explanations see https://github.com/apache/pinot/issues/11084.

Fixed the flakiness by generating the Kafka partition key deterministically.