### PR TITLE
quick fix to change uri of delete segments with timewindow

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -868,7 +868,7 @@ public class PinotSegmentRestletResource {
   @DELETE
   @Consumes(MediaType.APPLICATION_JSON)
   @Produces(MediaType.APPLICATION_JSON)
-  @Path("/segments/{tableName}/select")
+  @Path("/segments/{tableName}/choose")
   @Authenticate(AccessType.DELETE)
   @ApiOperation(value = "Delete selected segments. An optional 'excludeReplacedSegments' parameter is used to get the"
       + " list of segments which has not yet been replaced (determined by segment lineage entries) and can be queried"

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -423,7 +423,7 @@ public class ControllerRequestURLBuilder {
       long endTimeInMilliSeconds) {
     StringBuilder url = new StringBuilder();
     url.append(StringUtil.join("/", _baseUrl, "segments", tableName,
-        String.format("select?startTimestamp=%d&endTimestamp=%d", startTimeInMilliSeconds, endTimeInMilliSeconds)));
+        String.format("choose?startTimestamp=%d&endTimestamp=%d", startTimeInMilliSeconds, endTimeInMilliSeconds)));
     return url.toString();
   }
 


### PR DESCRIPTION
https://github.com/apache/pinot/issues/10740

Follow up of https://github.com/apache/pinot/pull/10758

avoid the confusion that `GET /segments/{table}/select` is deprecated. This API parameter is identical to `GET /segments/{table}`.
