### PR TITLE
Improve error message in case of throwables in multistage

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -218,9 +218,9 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       queryResults = _queryDispatcher.submitAndReduce(requestId, dispatchableSubPlan, _mailboxService,
           _reducerScheduler,
           queryTimeoutMs, sqlNodeAndOptions.getOptions(), stageIdStatsMap, traceEnabled);
-    } catch (Exception e) {
-      LOGGER.info("query execution failed", e);
-      return new BrokerResponseNative(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, e));
+    } catch (Throwable t) {
+      LOGGER.error("query execution failed: " + t);
+      return new BrokerResponseNative(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, t));
     }
 
     BrokerResponseNativeV2 brokerResponse = new BrokerResponseNativeV2();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -219,7 +219,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
           _reducerScheduler,
           queryTimeoutMs, sqlNodeAndOptions.getOptions(), stageIdStatsMap, traceEnabled);
     } catch (Throwable t) {
-      LOGGER.error("query execution failed: " + t);
+      LOGGER.error("query execution failed", t);
       return new BrokerResponseNative(QueryException.getException(QueryException.QUERY_EXECUTION_ERROR, t));
     }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -101,6 +101,8 @@ public class QueryDispatcher {
     } catch (Exception e) {
       cancel(requestId, dispatchableSubPlan);
       throw new RuntimeException("Error executing query: " + ExplainPlanPlanVisitor.explain(dispatchableSubPlan), e);
+    } catch (Throwable t) {
+      throw new RuntimeException("Error executing query: " + t.getMessage());
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -101,8 +101,6 @@ public class QueryDispatcher {
     } catch (Exception e) {
       cancel(requestId, dispatchableSubPlan);
       throw new RuntimeException("Error executing query: " + ExplainPlanPlanVisitor.explain(dispatchableSubPlan), e);
-    } catch (Throwable t) {
-      throw new RuntimeException(ExplainPlanPlanVisitor.explain(dispatchableSubPlan), t);
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/QueryDispatcher.java
@@ -102,7 +102,7 @@ public class QueryDispatcher {
       cancel(requestId, dispatchableSubPlan);
       throw new RuntimeException("Error executing query: " + ExplainPlanPlanVisitor.explain(dispatchableSubPlan), e);
     } catch (Throwable t) {
-      throw new RuntimeException("Error executing query: " + t.getMessage());
+      throw new RuntimeException(ExplainPlanPlanVisitor.explain(dispatchableSubPlan), t);
     }
   }
 


### PR DESCRIPTION
In #11076 we were getting a very vague message in case of version conflicts. 

`
java.io.IOException: Failed : HTTP error code : 500. Root Cause: <html><head><title>Grizzly 2.4.4</title><style><!--div.header {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#003300;font-size:22px;-moz-border-radius-topleft: 10px;border-top-left-radius: 10px;-moz-border-radius-topright: 10px;border-top-right-radius: 10px;padding-left: 5px}div.body {font-family:Tahoma,Arial,sans-serif;color:black;background-color:#FFFFCC;font-size:16px;padding-top:10px;padding-bottom:10px;padding-left:10px}div.footer {font-family:Tahoma,Arial,sans-serif;color:white;background-color:#666633;font-size:14px;-moz-border-radius-bottomleft: 10px;border-bottom-left-radius: 10px;-moz-border-radius-bottomright: 10px;border-bottom-right-radius: 10px;padding-left: 5px}BODY {font-family:Tahoma,Arial,sans-serif;color:black;background-color:white;}B {font-family:Tahoma,Arial,sans-serif;color:black;}A {color : black;}HR {color : #999966;}--></style> </head><body><div class="header">Request failed.</div><div class="body">Request failed.</div><div class="footer">Grizzly 2.4.4</div></body></html>
`

This patch gets the throwable message and propagates to the user. Sample error message:
`
[
  {
    "message": "QueryExecutionError:\njava.lang.RuntimeException: Error executing query: 'io.grpc.NameResolver$Args$Builder io.grpc.NameResolver$Args$Builder.setOverrideAuthority(java.lang.String)'\n\tat org.apache.pinot.query.service.dispatch.QueryDispatcher.submitAndReduce(QueryDispatcher.java:105)\n\tat org.apache.pinot.broker.requesthandler.MultiStageBrokerRequestHandler.handleRequest(MultiStageBrokerRequestHandler.java:218)\n\tat org.apache.pinot.broker.requesthandler.MultiStageBrokerRequestHandler.handleRequest(MultiStageBrokerRequestHandler.java:146)\n\tat org.apache.pinot.broker.requesthandler.BrokerRequestHandler.handleRequest(BrokerRequestHandler.java:47)",
    "errorCode": 200
  }
]
`
