### PR TITLE
Use PUT request to enable/disable table/instance

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -216,6 +216,48 @@ public class PinotInstanceRestletResource {
     }
   }
 
+  @PUT
+  @Path("/instances/{instanceName}/state")
+  @Authenticate(AccessType.UPDATE)
+  @Produces(MediaType.APPLICATION_JSON)
+  @Consumes(MediaType.TEXT_PLAIN)
+  @ApiOperation(value = "Enable/disable an instance", notes = "Enable/disable an instance")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"),
+      @ApiResponse(code = 400, message = "Bad Request"),
+      @ApiResponse(code = 404, message = "Instance not found"),
+      @ApiResponse(code = 500, message = "Internal error")
+  })
+  public SuccessResponse toggleInstanceState(
+      @ApiParam(value = "Instance name", required = true, example = "Server_a.b.com_20000 | Broker_my.broker.com_30000")
+      @PathParam("instanceName") String instanceName,
+      @ApiParam(value = "enable|disable", required = true) @QueryParam("state") String state) {
+    if (!_pinotHelixResourceManager.instanceExists(instanceName)) {
+      throw new ControllerApplicationException(LOGGER, "Instance '" + instanceName + "' does not exist",
+          Response.Status.NOT_FOUND);
+    }
+
+    if (StateType.ENABLE.name().equalsIgnoreCase(state)) {
+      PinotResourceManagerResponse response = _pinotHelixResourceManager.enableInstance(instanceName);
+      if (!response.isSuccessful()) {
+        throw new ControllerApplicationException(LOGGER,
+            "Failed to enable instance '" + instanceName + "': " + response.getMessage(),
+            Response.Status.INTERNAL_SERVER_ERROR);
+      }
+    } else if (StateType.DISABLE.name().equalsIgnoreCase(state)) {
+      PinotResourceManagerResponse response = _pinotHelixResourceManager.disableInstance(instanceName);
+      if (!response.isSuccessful()) {
+        throw new ControllerApplicationException(LOGGER,
+            "Failed to disable instance '" + instanceName + "': " + response.getMessage(),
+            Response.Status.INTERNAL_SERVER_ERROR);
+      }
+    } else {
+      throw new ControllerApplicationException(LOGGER, "Unknown state '" + state + "'", Response.Status.BAD_REQUEST);
+    }
+    return new SuccessResponse("Request to " + state + " instance '" + instanceName + "' is successful");
+  }
+
+  @Deprecated
   @POST
   @Path("/instances/{instanceName}/state")
   @Authenticate(AccessType.UPDATE)
@@ -229,7 +271,7 @@ public class PinotInstanceRestletResource {
       @ApiResponse(code = 409, message = "Instance cannot be dropped"),
       @ApiResponse(code = 500, message = "Internal error")
   })
-  public SuccessResponse toggleInstanceState(
+  public SuccessResponse toggleInstanceStateDeprecated(
       @ApiParam(value = "Instance name", required = true, example = "Server_a.b.com_20000 | Broker_my.broker.com_30000")
       @PathParam("instanceName") String instanceName, String state) {
     if (!_pinotHelixResourceManager.instanceExists(instanceName)) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerInstanceToggleTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/ControllerInstanceToggleTest.java
@@ -116,7 +116,8 @@ public class ControllerInstanceToggleTest extends ControllerTest {
     // It may take time for an instance to toggle the state.
     TestUtils.waitForCondition(aVoid -> {
       try {
-        sendPostRequest(DEFAULT_INSTANCE.getControllerRequestURLBuilder().forInstanceState(instanceName), state);
+        sendPutRequest(
+            DEFAULT_INSTANCE.getControllerRequestURLBuilder().forInstanceState(instanceName) + "?state=" + state);
       } catch (IOException ioe) {
         // receive non-200 status code
         return false;


### PR DESCRIPTION
Currently we allow using GET request to enable/disable/drop a table; we allow using POST request to enable/disable/drop an instance.
Add PUT request to enable/disable table/instance. We will remove the current behavior after the next major release.