### PR TITLE
Add stat to track number of segments that have valid doc id snapshots

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -48,7 +48,9 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   JVM_HEAP_USED_BYTES("bytes", true),
   // Ingestion delay metrics
   REALTIME_INGESTION_DELAY_MS("milliseconds", false),
-  END_TO_END_REALTIME_INGESTION_DELAY_MS("milliseconds", false);
+  END_TO_END_REALTIME_INGESTION_DELAY_MS("milliseconds", false),
+  // Needed to track if valid doc id snapshots are present for faster restarts
+  UPSERT_VALID_DOC_ID_SNAPSHOT_COUNT("upsertValidDocIdSnapshotCount", false);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -540,6 +540,8 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       }
     }
 
+    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId,
+        ServerGauge.UPSERT_VALID_DOC_ID_SNAPSHOT_COUNT, numImmutableSegments);
     _logger.info("Finished taking snapshot for {} immutable segments (out of {} total segments) in {}ms",
         numImmutableSegments, numTrackedSegments, System.currentTimeMillis() - startTimeMs);
   }


### PR DESCRIPTION
* Need to track if valid doc id snapshot is working fine or not
* Can be tracked `upsertValidDocIdSnapshotCount` in your reporting tool.