### PR TITLE
V2 allocation optimizations

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOnlyOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOnlyOperator.java
@@ -75,8 +75,6 @@ public class SelectionOnlyOperator extends BaseOperator<SelectionResultsBlock> {
     _dataSchema = new DataSchema(columnNames, columnDataTypes);
 
     _numRowsToKeep = queryContext.getLimit();
-    // TODO(gortiz): I think this is incorrect. The SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY limit
-    //  is not enforced later in getNextBlock
     _rows = new ArrayList<>(Math.min(_numRowsToKeep, SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY));
     _nullBitmaps = _nullHandlingEnabled ? new RoaringBitmap[numExpressions] : null;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -64,7 +64,7 @@ public class HashJoinOperator extends MultiStageOperator {
   private static final Set<JoinRelType> SUPPORTED_JOIN_TYPES = ImmutableSet.of(
       JoinRelType.INNER, JoinRelType.LEFT, JoinRelType.RIGHT, JoinRelType.FULL, JoinRelType.SEMI, JoinRelType.ANTI);
 
-  private final HashMap<Key, List<Object[]>> _broadcastRightTable;
+  private final HashMap<Key, ArrayList<Object[]>> _broadcastRightTable;
 
   // Used to track matched right rows.
   // Only used for right join and full join to output non-matched right rows.
@@ -169,9 +169,14 @@ public class HashJoinOperator extends MultiStageOperator {
       }
       List<Object[]> container = rightBlock.getContainer();
       // put all the rows into corresponding hash collections keyed by the key selector function.
+      int initialHeuristicSize = 16;
       for (Object[] row : container) {
-        List<Object[]> hashCollection =
-            _broadcastRightTable.computeIfAbsent(new Key(_rightKeySelector.getKey(row)), k -> new ArrayList<>());
+        ArrayList<Object[]> hashCollection =
+            _broadcastRightTable.computeIfAbsent(new Key(_rightKeySelector.getKey(row)), k -> new ArrayList<>(16));
+        int size = hashCollection.size();
+        if ((size & size - 1) == 0 && size < Integer.MAX_VALUE / 2) { // is power of 2
+          hashCollection.ensureCapacity(size << 1);
+        }
         hashCollection.add(row);
       }
       rightBlock = _rightTableOperator.nextBlock();
@@ -198,7 +203,7 @@ public class HashJoinOperator extends MultiStageOperator {
     if (leftBlock.isSuccessfulEndOfStreamBlock() && needUnmatchedRightRows()) {
       // Return remaining non-matched rows for non-inner join.
       List<Object[]> returnRows = new ArrayList<>();
-      for (Map.Entry<Key, List<Object[]>> entry : _broadcastRightTable.entrySet()) {
+      for (Map.Entry<Key, ArrayList<Object[]>> entry : _broadcastRightTable.entrySet()) {
         Set<Integer> matchedIdx = _matchedRightRows.getOrDefault(entry.getKey(), new HashSet<>());
         List<Object[]> rightRows = entry.getValue();
         if (rightRows.size() == matchedIdx.size()) {
@@ -213,55 +218,95 @@ public class HashJoinOperator extends MultiStageOperator {
       _isTerminated = true;
       return new TransferableBlock(returnRows, _resultSchema, DataBlock.Type.ROW);
     }
-    List<Object[]> rows = new ArrayList<>();
-    List<Object[]> container = leftBlock.isEndOfStreamBlock() ? new ArrayList<>() : leftBlock.getContainer();
-    for (Object[] leftRow : container) {
-      Key key = new Key(_leftKeySelector.getKey(leftRow));
+    List<Object[]> rows;
+    if (leftBlock.isEndOfStreamBlock()) {
+      rows = new ArrayList<>();
+    } else {
       switch (_joinType) {
-        case SEMI:
-          // SEMI-JOIN only checks existence of the key
-          if (_broadcastRightTable.containsKey(key)) {
-            rows.add(joinRow(leftRow, null));
-          }
+        case SEMI: {
+          rows = buildJoinedDataBlockSemi(leftBlock);
           break;
-        case ANTI:
-          // ANTI-JOIN only checks non-existence of the key
-          if (!_broadcastRightTable.containsKey(key)) {
-            rows.add(joinRow(leftRow, null));
-          }
+        }
+        case ANTI: {
+          rows = buildJoinedDataBlockAnti(leftBlock);
           break;
-        default: // INNER, LEFT, RIGHT, FULL
-          // NOTE: Empty key selector will always give same hash code.
-          List<Object[]> matchedRightRows = _broadcastRightTable.getOrDefault(key, null);
-          if (matchedRightRows == null) {
-            if (needUnmatchedLeftRows()) {
-              rows.add(joinRow(leftRow, null));
-            }
-            continue;
-          }
-          boolean hasMatchForLeftRow = false;
-          for (int i = 0; i < matchedRightRows.size(); i++) {
-            Object[] rightRow = matchedRightRows.get(i);
-            // TODO: Optimize this to avoid unnecessary object copy.
-            Object[] resultRow = joinRow(leftRow, rightRow);
-            if (_joinClauseEvaluators.isEmpty() || _joinClauseEvaluators.stream().allMatch(
-                evaluator -> (Boolean) TypeUtils.convert(evaluator.apply(resultRow),
-                    DataSchema.ColumnDataType.BOOLEAN))) {
-              rows.add(resultRow);
-              hasMatchForLeftRow = true;
-              if (_matchedRightRows != null) {
-                HashSet<Integer> matchedRows = _matchedRightRows.computeIfAbsent(key, k -> new HashSet<>());
-                matchedRows.add(i);
-              }
-            }
-          }
-          if (!hasMatchForLeftRow && needUnmatchedLeftRows()) {
-            rows.add(joinRow(leftRow, null));
-          }
+        }
+        default: {
+          rows = buildJoinedDataBlockDefault(leftBlock);
           break;
+        }
       }
     }
     return new TransferableBlock(rows, _resultSchema, DataBlock.Type.ROW);
+  }
+
+  // INNER, LEFT, RIGHT, FULL
+  private List<Object[]> buildJoinedDataBlockSemi(TransferableBlock leftBlock) {
+    List<Object[]> container = leftBlock.getContainer();
+    List<Object[]> rows = new ArrayList<>(container.size());
+
+    for (Object[] leftRow : container) {
+      Key key = new Key(_leftKeySelector.getKey(leftRow));
+      // SEMI-JOIN only checks existence of the key
+      if (_broadcastRightTable.containsKey(key)) {
+        rows.add(joinRow(leftRow, null));
+      }
+    }
+
+    return rows;
+  }
+
+  private List<Object[]> buildJoinedDataBlockDefault(TransferableBlock leftBlock) {
+    List<Object[]> container = leftBlock.getContainer();
+    ArrayList<Object[]> rows = new ArrayList<>(container.size());
+
+    for (Object[] leftRow : container) {
+      Key key = new Key(_leftKeySelector.getKey(leftRow));
+      // NOTE: Empty key selector will always give same hash code.
+      List<Object[]> matchedRightRows = _broadcastRightTable.getOrDefault(key, null);
+      if (matchedRightRows == null) {
+        if (needUnmatchedLeftRows()) {
+          rows.add(joinRow(leftRow, null));
+        }
+        continue;
+      }
+      boolean hasMatchForLeftRow = false;
+      rows.ensureCapacity(rows.size() + matchedRightRows.size());
+      for (int i = 0; i < matchedRightRows.size(); i++) {
+        Object[] rightRow = matchedRightRows.get(i);
+        // TODO: Optimize this to avoid unnecessary object copy.
+        Object[] resultRow = joinRow(leftRow, rightRow);
+        if (_joinClauseEvaluators.isEmpty() || _joinClauseEvaluators.stream().allMatch(
+            evaluator -> (Boolean) TypeUtils.convert(evaluator.apply(resultRow),
+                DataSchema.ColumnDataType.BOOLEAN))) {
+          rows.add(resultRow);
+          hasMatchForLeftRow = true;
+          if (_matchedRightRows != null) {
+            HashSet<Integer> matchedRows = _matchedRightRows.computeIfAbsent(key, k -> new HashSet<>());
+            matchedRows.add(i);
+          }
+        }
+      }
+      if (!hasMatchForLeftRow && needUnmatchedLeftRows()) {
+        rows.add(joinRow(leftRow, null));
+      }
+    }
+
+    return rows;
+  }
+
+  private List<Object[]> buildJoinedDataBlockAnti(TransferableBlock leftBlock) {
+    List<Object[]> container = leftBlock.getContainer();
+    List<Object[]> rows = new ArrayList<>(container.size());
+
+    for (Object[] leftRow : container) {
+      Key key = new Key(_leftKeySelector.getKey(leftRow));
+      // ANTI-JOIN only checks non-existence of the key
+      if (!_broadcastRightTable.containsKey(key)) {
+        rows.add(joinRow(leftRow, null));
+      }
+    }
+    return rows;
   }
 
   private Object[] joinRow(@Nullable Object[] leftRow, @Nullable Object[] rightRow) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -231,7 +231,7 @@ public class HashJoinOperator extends MultiStageOperator {
           rows = buildJoinedDataBlockAnti(leftBlock);
           break;
         }
-        default: {
+        default: { // INNER, LEFT, RIGHT, FULL
           rows = buildJoinedDataBlockDefault(leftBlock);
           break;
         }
@@ -240,7 +240,6 @@ public class HashJoinOperator extends MultiStageOperator {
     return new TransferableBlock(rows, _resultSchema, DataBlock.Type.ROW);
   }
 
-  // INNER, LEFT, RIGHT, FULL
   private List<Object[]> buildJoinedDataBlockSemi(TransferableBlock leftBlock) {
     List<Object[]> container = leftBlock.getContainer();
     List<Object[]> rows = new ArrayList<>(container.size());

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -108,8 +108,8 @@ public class TransformOperator extends MultiStageOperator {
       return block;
     }
 
-    List<Object[]> resultRows = new ArrayList<>();
     List<Object[]> container = block.getContainer();
+    List<Object[]> resultRows = new ArrayList<>(container.size());
     for (Object[] row : container) {
       Object[] resultRow = new Object[_resultColumnSize];
       for (int i = 0; i < _resultColumnSize; i++) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/HashExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/HashExchange.java
@@ -48,10 +48,11 @@ class HashExchange extends BlockExchange {
   protected void route(List<SendingMailbox> destinations, TransferableBlock block)
       throws Exception {
     List<Object[]>[] destIdxToRows = new List[destinations.size()];
-    for (Object[] row : block.getContainer()) {
+    List<Object[]> container = block.getContainer();
+    for (Object[] row : container) {
       int partition = _keySelector.computeHash(row) % destinations.size();
       if (destIdxToRows[partition] == null) {
-        destIdxToRows[partition] = new ArrayList<>();
+        destIdxToRows[partition] = new ArrayList<>(container.size());
       }
       destIdxToRows[partition].add(row);
     }


### PR DESCRIPTION
This PR applies some easy win optimizations trying to reduce the Object[] allocation in V2. Results are not as good as expected, given that they mostly attack incorrect ArrayList initializations while the actual improvement will be trying to reduce how many ArrayList are created. The latter is something I would like to achieve, but the changes required are not as simple as the ones included here.

Allocations pre change:
![image](https://github.com/apache/pinot/assets/1913993/22e34578-5ebc-4966-a3e5-55cfca06fc65)

Allocations post change:
![image](https://github.com/apache/pinot/assets/1913993/d2b61c4e-ff19-45aa-8dcd-a3eb6f2e94ea)

Notice that:
* The improvement is mainly in the gray areas
* Flamegraphs show a relative performance
* The difference in outside TLAB allocation
* Charts were generated after running queries for 5 mins, but I've only made one execution per case, so I'm not sure about repeatability 