### PR TITLE
[multistage] add option for table hints

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintOptions.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintOptions.java
@@ -28,6 +28,7 @@ package org.apache.calcite.rel.hint;
 public class PinotHintOptions {
   public static final String AGGREGATE_HINT_OPTIONS = "aggOptions";
   public static final String JOIN_HINT_OPTIONS = "joinOptions";
+  public static final String TABLE_HINT_OPTIONS = "tableOptions";
 
   /**
    * Hint to denote that the aggregation node is the final aggregation stage which extracts the final result.
@@ -50,5 +51,10 @@ public class PinotHintOptions {
   public static class JoinHintOptions {
     public static final String JOIN_STRATEGY = "join_strategy";
     public static final String IS_COLOCATED_BY_JOIN_KEYS = "is_colocated_by_join_keys";
+  }
+
+  public static class TableHintOptions {
+    public static final String PARTITION_KEY = "partition_key";
+    public static final String PARTITION_SIZE = "partition_size";
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintStrategyTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintStrategyTable.java
@@ -36,6 +36,7 @@ public class PinotHintStrategyTable {
       .hintStrategy(PinotHintOptions.INTERNAL_AGG_OPTIONS, HintPredicates.AGGREGATE)
       .hintStrategy(PinotHintOptions.AGGREGATE_HINT_OPTIONS, HintPredicates.AGGREGATE)
       .hintStrategy(PinotHintOptions.JOIN_HINT_OPTIONS, HintPredicates.JOIN)
+      .hintStrategy(PinotHintOptions.TABLE_HINT_OPTIONS, HintPredicates.TABLE_SCAN)
       .build();
 
   /**

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -172,7 +172,7 @@ public final class RelToPlanNodeConverter {
     String tableName = node.getTable().getQualifiedName().get(0);
     List<String> columnNames =
         node.getRowType().getFieldList().stream().map(RelDataTypeField::getName).collect(Collectors.toList());
-    return new TableScanNode(currentStageId, toDataSchema(node.getRowType()), tableName, columnNames);
+    return new TableScanNode(currentStageId, toDataSchema(node.getRowType()), node.getHints(), tableName, columnNames);
   }
 
   private static PlanNode convertLogicalJoin(LogicalJoin node, int currentStageId) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/AbstractPlanNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/AbstractPlanNode.java
@@ -19,9 +19,13 @@
 package org.apache.pinot.query.planner.plannode;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
+import org.apache.calcite.rel.hint.RelHint;
 import org.apache.pinot.common.proto.Plan;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.planner.serde.ProtoProperties;
 import org.apache.pinot.query.planner.serde.ProtoSerializable;
 import org.apache.pinot.query.planner.serde.ProtoSerializationUtils;
 
@@ -80,5 +84,20 @@ public abstract class AbstractPlanNode implements PlanNode, ProtoSerializable {
   @Override
   public Plan.ObjectField toObjectField() {
     return ProtoSerializationUtils.convertObjectToObjectField(this);
+  }
+
+  public static class NodeHint {
+    @ProtoProperties
+    public Map<String, Map<String, String>> _hintOptions;
+    public NodeHint() {
+    }
+
+    public NodeHint(List<RelHint> relHints) {
+      _hintOptions = new HashMap<>();
+      for (RelHint relHint : relHints) {
+        Map<String, String> kvOptions = new HashMap<>(relHint.kvOptions);
+        _hintOptions.put(relHint.hintName, kvOptions);
+      }
+    }
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/TableScanNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/TableScanNode.java
@@ -19,11 +19,14 @@
 package org.apache.pinot.query.planner.plannode;
 
 import java.util.List;
+import org.apache.calcite.rel.hint.RelHint;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
 
 
 public class TableScanNode extends AbstractPlanNode {
+  @ProtoProperties
+  private NodeHint _nodeHint;
   @ProtoProperties
   private String _tableName;
   @ProtoProperties
@@ -33,9 +36,11 @@ public class TableScanNode extends AbstractPlanNode {
     super(planFragmentId);
   }
 
-  public TableScanNode(int planFragmentId, DataSchema dataSchema, String tableName, List<String> tableScanColumns) {
+  public TableScanNode(int planFragmentId, DataSchema dataSchema, List<RelHint> relHints, String tableName,
+      List<String> tableScanColumns) {
     super(planFragmentId, dataSchema);
     _tableName = tableName;
+    _nodeHint = new NodeHint(relHints);
     _tableScanColumns = tableScanColumns;
   }
 
@@ -45,6 +50,10 @@ public class TableScanNode extends AbstractPlanNode {
 
   public List<String> getTableScanColumns() {
     return _tableScanColumns;
+  }
+
+  public NodeHint getNodeHint() {
+    return _nodeHint;
   }
 
   @Override


### PR DESCRIPTION
Hints for indicating whether a table is partitioned. 

Summary
===
This is necessary b/c even if tableConfig indicates a table is partitioned. it doesn't necessarily mean the underlying data is partitioned and properly co-located on the set of servers. thus we create this hint as an optimization control for users. 

Usage
===
```
select 
  a.dim1, b.dim2, COUNT(*) 
from tblA /*+ tableOptions(partition_key='key',partition_size='4') */
  JOIN tblB /*+ tableOptions(partition_key='key',partition_size='8') */
  ON tblA.key = tblB.key
group by 1, 2
limit 10
```

noted that `tableOptions` are attached next to the table name not to the select clause 