### PR TITLE
Bug fix: TableUpsertMetadataManager is null

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -210,8 +210,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       // this status with a boolean, instead of relying on if _tableUpsertMetadataManager is null or not.
       _isUpsertEnabled = true;
       _tableUpsertMetadataManager =
-          TableUpsertMetadataManagerFactory.create(tableConfig, schema, this, _serverMetrics, _helixManager,
-              _segmentPreloadExecutor);
+          TableUpsertMetadataManagerFactory.create(tableConfig);
+      _tableUpsertMetadataManager.init(tableConfig, schema, this, _serverMetrics, _helixManager,
+          _segmentPreloadExecutor);
     }
 
     // For dedup and partial-upsert, need to wait for all segments loaded before starting consuming data

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
@@ -19,15 +19,9 @@
 package org.apache.pinot.segment.local.upsert;
 
 import com.google.common.base.Preconditions;
-import java.util.concurrent.ExecutorService;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.helix.HelixManager;
-import org.apache.pinot.common.metrics.ServerMetrics;
-import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
-import org.apache.pinot.spi.data.Schema;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -37,14 +31,6 @@ public class TableUpsertMetadataManagerFactory {
   }
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TableUpsertMetadataManagerFactory.class);
-
-  public static TableUpsertMetadataManager create(TableConfig tableConfig, Schema schema,
-      TableDataManager tableDataManager, ServerMetrics serverMetrics, HelixManager helixManager,
-      @Nullable ExecutorService segmentPreloadExecutor) {
-    TableUpsertMetadataManager metadataManager = create(tableConfig);
-    metadataManager.init(tableConfig, schema, tableDataManager, serverMetrics, helixManager, segmentPreloadExecutor);
-    return metadataManager;
-  }
 
   public static TableUpsertMetadataManager create(TableConfig tableConfig) {
     String tableNameWithType = tableConfig.getTableName();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
@@ -41,6 +41,12 @@ public class TableUpsertMetadataManagerFactory {
   public static TableUpsertMetadataManager create(TableConfig tableConfig, Schema schema,
       TableDataManager tableDataManager, ServerMetrics serverMetrics, HelixManager helixManager,
       @Nullable ExecutorService segmentPreloadExecutor) {
+    TableUpsertMetadataManager metadataManager = create(tableConfig);
+    metadataManager.init(tableConfig, schema, tableDataManager, serverMetrics, helixManager, segmentPreloadExecutor);
+    return metadataManager;
+  }
+
+  public static TableUpsertMetadataManager create(TableConfig tableConfig) {
     String tableNameWithType = tableConfig.getTableName();
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
     Preconditions.checkArgument(upsertConfig != null, "Must provide upsert config for table: %s", tableNameWithType);
@@ -63,7 +69,6 @@ public class TableUpsertMetadataManagerFactory {
       metadataManager = new ConcurrentMapTableUpsertMetadataManager();
     }
 
-    metadataManager.init(tableConfig, schema, tableDataManager, serverMetrics, helixManager, segmentPreloadExecutor);
     return metadataManager;
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
@@ -27,6 +27,7 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.recordtransformer.CompositeTransformer;
 import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
+import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManagerFactory;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -67,10 +68,10 @@ public class MutableSegmentImplUpsertComparisonColTest {
             .build();
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
-    _partitionUpsertMetadataManager =
-        TableUpsertMetadataManagerFactory.create(_tableConfig, _schema, mock(TableDataManager.class),
-                mock(ServerMetrics.class), mock(HelixManager.class), mock(ExecutorService.class))
-            .getOrCreatePartitionManager(0);
+    TableUpsertMetadataManager tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(_tableConfig);
+    tableUpsertMetadataManager.init(_tableConfig, _schema, mock(TableDataManager.class), mock(ServerMetrics.class),
+        mock(HelixManager.class), mock(ExecutorService.class));
+    _partitionUpsertMetadataManager = tableUpsertMetadataManager.getOrCreatePartitionManager(0);
     _mutableSegmentImpl =
         MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(),
             Collections.emptySet(), false, true, offsetUpsertConfig, "secondsSinceEpoch",

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.segment.local.recordtransformer.CompositeTransformer;
 import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
+import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManagerFactory;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -78,14 +79,13 @@ public class MutableSegmentImplUpsertTest {
     _schema = Schema.fromFile(new File(schemaResourceUrl.getFile()));
     _tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName("testTable").setUpsertConfig(upsertConfigWithHash)
-            .setNullHandlingEnabled(true)
-            .build();
+            .setNullHandlingEnabled(true).build();
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
-    _partitionUpsertMetadataManager =
-        TableUpsertMetadataManagerFactory.create(_tableConfig, _schema, mock(TableDataManager.class),
-                mock(ServerMetrics.class), mock(HelixManager.class), mock(ExecutorService.class))
-            .getOrCreatePartitionManager(0);
+    TableUpsertMetadataManager tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(_tableConfig);
+    tableUpsertMetadataManager.init(_tableConfig, _schema, mock(TableDataManager.class), mock(ServerMetrics.class),
+        mock(HelixManager.class), mock(ExecutorService.class));
+    _partitionUpsertMetadataManager = tableUpsertMetadataManager.getOrCreatePartitionManager(0);
     _mutableSegmentImpl =
         MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(),
             Collections.emptySet(), false, true, upsertConfigWithHash, "secondsSinceEpoch",


### PR DESCRIPTION
* _tableUpsertMetadataManager variable is never initialised because we keep on waiting for `init`

* this leads to NullPointerException when trying to preload the segments

```
2023/07/18 10:20:13.526 INFO [ImmutableSegmentLoader] [segment-preload-thread-7] Successfully loaded segment: upsertMeetupRsvp_1678410006394_1678499996394_10 with SegmentDirectory
2023/07/18 10:20:13.526 INFO [upsertMeetupRsvpLarge_REALTIME-RealtimeTableDataManager] [segment-preload-thread-7] Adding immutable segment: upsertMeetupRsvp_1678410006394_1678499996394_10 to upsert-enabled table: upsertMeetupRsvpLarge_REALTIME
2023/07/18 10:20:13.526 ERROR [BaseTableDataManager] [segment-preload-thread-7] Failed to load existing segment: upsertMeetupRsvp_1678410006394_1678499996394_10 of table: upsertMeetupRsvpLarge_REALTIME with crc: 2719970321 on tier: default
java.lang.NullPointerException: null
        at org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager.handleUpsert(RealtimeTableDataManager.java:534) ~[pinot-all-0.13.0-SNAPSHOT-jar-with-dependencies.jar:0.13.0-SNAPSHOT-47ec950074e6f5e6ce06671e376d828880b587d2]
        at org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager.addSegment(RealtimeTableDataManager.java:499) ~[pinot-all-0.13.0-SNAPSHOT-jar-with-dependencies.jar:0.13.0-SNAPSHOT-47ec950074e6f5e6ce06671e376d828880b587d2]
        at org.apache.pinot.core.data.manager.BaseTableDataManager.tryLoadExistingSegment(BaseTableDataManager.java:816) ~[pinot-all-0.13.0-SNAPSHOT-jar-with-dependencies.jar:0.13.0-SNAPSHOT-47ec950074e6f5e6ce06671e376d828880b587d2]
        at org.apache.pinot.segment.local.upsert.BaseTableUpsertMetadataManager.preloadSegmentWithSnapshot(BaseTableUpsertMetadataManager.java:213) ~[pinot-all-0.13.0-SNAPSHOT-jar-with-dependencies.jar:0.13.0-SNAPSHOT-47ec950074e6f5e6ce06671e376d828880b587d2]
        at org.apache.pinot.segment.local.upsert.BaseTableUpsertMetadataManager.preloadSegment(BaseTableUpsertMetadataManager.java:201) ~[pinot-all-0.13.0-SNAPSHOT-jar-with-dependencies.jar:0.13.0-SNAPSHOT-47ec950074e6f5e6ce06671e376d828880b587d2]
        at org.apache.pinot.segment.local.upsert.BaseTableUpsertMetadataManager.lambda$preloadSegments$0(BaseTableUpsertMetadataManager.java:157) ~[pinot-all-0.13.0-SNAPSHOT-jar-with-dependencies.jar:0.13.0-SNAPSHOT-47ec950074e6f5e6ce06671e376d828880b587d2]
        at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515) [?:?]
        at java.util.concurrent.FutureTask.run(FutureTask.java:264) [?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128) [?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628) [?:?]
        at java.lang.Thread.run(Thread.java:829) [?:?]
2023/07/18 10:20:13.528 INFO [BaseTableUpsertMetadataManager] [segment-preload-thread-7] Preloaded segment: upsertMeetupRsvp_1678410006394_1678499996394_10 from table: upsertMeetupRsvpLarge_REALTIME
```

* solution is to seperate out the create and init steps.

