### PR TITLE
Fix bug in reload segment when one or more indexes are removed.

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
@@ -157,9 +157,12 @@ public abstract class BaseH3IndexCreator implements GeoSpatialIndexCreator {
         FileChannel bitmapOffsetFileChannel = new RandomAccessFile(_bitmapOffsetFile, "r").getChannel();
         FileChannel bitmapValueFileChannel = new RandomAccessFile(_bitmapValueFile, "r").getChannel()) {
       indexFileChannel.write(headerBuffer);
-      dictionaryFileChannel.transferTo(0, _dictionaryFile.length(), indexFileChannel);
-      bitmapOffsetFileChannel.transferTo(0, _bitmapOffsetFile.length(), indexFileChannel);
-      bitmapValueFileChannel.transferTo(0, _bitmapValueFile.length(), indexFileChannel);
+      org.apache.pinot.common.utils.FileUtils.transferBytes(dictionaryFileChannel, 0, _dictionaryFile.length(),
+          indexFileChannel);
+      org.apache.pinot.common.utils.FileUtils.transferBytes(bitmapOffsetFileChannel, 0, _bitmapOffsetFile.length(),
+          indexFileChannel);
+      org.apache.pinot.common.utils.FileUtils.transferBytes(bitmapValueFileChannel, 0, _bitmapValueFile.length(),
+          indexFileChannel);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/BaseJsonIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/BaseJsonIndexCreator.java
@@ -148,8 +148,10 @@ public abstract class BaseJsonIndexCreator implements JsonIndexCreator {
         FileChannel dictionaryFileChannel = new RandomAccessFile(_dictionaryFile, "r").getChannel();
         FileChannel invertedIndexFileChannel = new RandomAccessFile(_invertedIndexFile, "r").getChannel()) {
       indexFileChannel.write(headerBuffer);
-      dictionaryFileChannel.transferTo(0, dictionaryFileLength, indexFileChannel);
-      invertedIndexFileChannel.transferTo(0, invertedIndexFileLength, indexFileChannel);
+      org.apache.pinot.common.utils.FileUtils.transferBytes(dictionaryFileChannel, 0, dictionaryFileLength,
+          indexFileChannel);
+      org.apache.pinot.common.utils.FileUtils.transferBytes(invertedIndexFileChannel, 0, invertedIndexFileLength,
+          indexFileChannel);
 
       // Write the doc id mapping to the index file
       ByteBuffer docIdMappingBuffer =

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/NativeTextIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/NativeTextIndexCreator.java
@@ -175,8 +175,9 @@ public class NativeTextIndexCreator extends AbstractTextIndexCreator {
         FileChannel invertedIndexFileChannel = new RandomAccessFile(_invertedIndexFile, "r").getChannel();
         FileChannel fstFileChannel = new RandomAccessFile(_fstIndexFile, "rw").getChannel()) {
       indexFileChannel.write(headerBuffer);
-      fstFileChannel.transferTo(0, _fstDataSize, indexFileChannel);
-      invertedIndexFileChannel.transferTo(0, invertedIndexFileLength, indexFileChannel);
+      org.apache.pinot.common.utils.FileUtils.transferBytes(fstFileChannel, 0, _fstDataSize, indexFileChannel);
+      org.apache.pinot.common.utils.FileUtils.transferBytes(invertedIndexFileChannel, 0, invertedIndexFileLength,
+          indexFileChannel);
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
@@ -417,7 +417,7 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
     try (FileChannel srcCh = new RandomAccessFile(srcFile, "r").getChannel();
         FileChannel dstCh = new RandomAccessFile(destFile, "rw").getChannel()) {
       for (IndexEntry index : indicesToCopy.values()) {
-        srcCh.transferTo(index._startOffset, index._size, dstCh);
+        org.apache.pinot.common.utils.FileUtils.transferBytes(srcCh, index._startOffset, index._size, dstCh);
         retained.add(new IndexEntry(index._key, nextOffset, index._size));
         nextOffset += index._size;
       }


### PR DESCRIPTION
- This PR fixes the bug reported in https://github.com/apache/pinot/issues/11130
- The PR also fixes other existing calls to `FileChannel.transferTo`