### PR TITLE
Sanitise API inputs used as file path variables 

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUtils.java
@@ -114,4 +114,14 @@ public class FileUtils {
       throws IOException {
     close(Arrays.asList(closeables));
   }
+
+  public static File concatAndValidateFile(File folderDir, String filename, String msg, Object... args)
+      throws IllegalArgumentException, IOException {
+    File filePath = new File(folderDir, filename);
+    if (!filePath.getCanonicalPath().startsWith(folderDir.getCanonicalPath() + File.separator)) {
+      throw new IllegalArgumentException(String.format(msg, args));
+    }
+
+    return filePath;
+  }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUtils.java
@@ -115,6 +115,16 @@ public class FileUtils {
     close(Arrays.asList(closeables));
   }
 
+  /**
+   * Concatenates the folderDir and filename and validates that the resulting file path is still within the folderDir.
+   * @param folderDir the parent directory
+   * @param filename the filename to concatenate to the parent directory
+   * @param msg the error message if the resulting file path is not within the parent directory
+   * @param args the error message arguments
+   * @return File object representing the concatenated file path
+   * @throws IllegalArgumentException if the resulting file path is not within the parent directory
+   * @throws IOException if the resulting file path is invalid
+   */
   public static File concatAndValidateFile(File folderDir, String filename, String msg, Object... args)
       throws IllegalArgumentException, IOException {
     File filePath = new File(folderDir, filename);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -449,8 +449,8 @@ public class LLCSegmentCompletionHandlers {
       FormDataBodyPart bodyPart = map.values().iterator().next().get(0);
 
       File localTempFile = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(
-          ControllerFilePathProvider.getInstance().getFileUploadTempDir(), segmentName, "Invalid segment name: %s",
-          segmentName);
+          ControllerFilePathProvider.getInstance().getFileUploadTempDir(), getTempSegmentFileName(segmentName),
+          "Invalid segment name: %s", segmentName);
 
       try (InputStream inputStream = bodyPart.getValueAs(InputStream.class)) {
         Files.copy(inputStream, localTempFile.toPath());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -449,11 +449,8 @@ public class LLCSegmentCompletionHandlers {
       FormDataBodyPart bodyPart = map.values().iterator().next().get(0);
 
       File fileUploadTempDir = ControllerFilePathProvider.getInstance().getFileUploadTempDir();
-      File localTempFile = new File(fileUploadTempDir, getTempSegmentFileName(segmentName));
-
-      if (!localTempFile.getCanonicalPath().startsWith(fileUploadTempDir.getPath())) {
-        throw new IllegalArgumentException("Invalid segment name: " + segmentName);
-      }
+      File localTempFile = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(fileUploadTempDir, segmentName,
+          "Invalid segment name: %s", segmentName);
 
       try (InputStream inputStream = bodyPart.getValueAs(InputStream.class)) {
         Files.copy(inputStream, localTempFile.toPath());
@@ -474,10 +471,10 @@ public class LLCSegmentCompletionHandlers {
   private static SegmentMetadataImpl extractMetadataFromLocalSegmentFile(File segmentFile)
       throws Exception {
     File untarredFileTempDir = ControllerFilePathProvider.getInstance().getUntarredFileTempDir();
-    File tempIndexDir = new File(untarredFileTempDir, segmentFile.getName());
-    if (tempIndexDir.getCanonicalPath().startsWith(untarredFileTempDir.getPath())) {
-      throw new IllegalArgumentException("Invalid segment file: " + segmentFile);
-    }
+
+    File tempIndexDir =
+        org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(untarredFileTempDir, segmentFile.getName(),
+            "Invalid segment file: %s", segmentFile);
 
     try {
       FileUtils.forceMkdir(tempIndexDir);
@@ -503,13 +500,10 @@ public class LLCSegmentCompletionHandlers {
    */
   private static SegmentMetadataImpl extractSegmentMetadataFromForm(FormDataMultiPart form, String segmentName)
       throws IOException {
-    File tempIndexDir = new File(ControllerFilePathProvider.getInstance().getUntarredFileTempDir(),
-        getTempSegmentFileName(segmentName));
 
-    if (!tempIndexDir.getCanonicalPath()
-        .startsWith(ControllerFilePathProvider.getInstance().getUntarredFileTempDir().getPath())) {
-      throw new IllegalArgumentException("Invalid segment name: " + segmentName);
-    }
+    File tempIndexDir = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(
+        ControllerFilePathProvider.getInstance().getUntarredFileTempDir(), getTempSegmentFileName(segmentName),
+        "Invalid segment name: %s", segmentName);
 
     try {
       FileUtils.forceMkdir(tempIndexDir);
@@ -547,11 +541,9 @@ public class LLCSegmentCompletionHandlers {
    */
   private static SegmentMetadataImpl extractMetadataFromSegmentFileURI(URI segmentFileURI, String segmentName)
       throws Exception {
-    File fileUploadTempDir = ControllerFilePathProvider.getInstance().getFileUploadTempDir();
-    File localTempFile = new File(fileUploadTempDir, getTempSegmentFileName(segmentName));
-    if (!localTempFile.getCanonicalPath().startsWith(fileUploadTempDir.getPath())) {
-      throw new IllegalArgumentException("Invalid segment name: " + segmentName);
-    }
+    File localTempFile = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(
+        ControllerFilePathProvider.getInstance().getFileUploadTempDir(), getTempSegmentFileName(segmentName),
+        "Invalid segment name: %s", segmentName);
 
     try {
       SegmentFetcherFactory.fetchSegmentToLocal(segmentFileURI, localTempFile);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -448,9 +448,9 @@ public class LLCSegmentCompletionHandlers {
           "Invalid multi-part for segment: %s", segmentName);
       FormDataBodyPart bodyPart = map.values().iterator().next().get(0);
 
-      File fileUploadTempDir = ControllerFilePathProvider.getInstance().getFileUploadTempDir();
-      File localTempFile = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(fileUploadTempDir, segmentName,
-          "Invalid segment name: %s", segmentName);
+      File localTempFile = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(
+          ControllerFilePathProvider.getInstance().getFileUploadTempDir(), segmentName, "Invalid segment name: %s",
+          segmentName);
 
       try (InputStream inputStream = bodyPart.getValueAs(InputStream.class)) {
         Files.copy(inputStream, localTempFile.toPath());
@@ -470,11 +470,9 @@ public class LLCSegmentCompletionHandlers {
    */
   private static SegmentMetadataImpl extractMetadataFromLocalSegmentFile(File segmentFile)
       throws Exception {
-    File untarredFileTempDir = ControllerFilePathProvider.getInstance().getUntarredFileTempDir();
-
-    File tempIndexDir =
-        org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(untarredFileTempDir, segmentFile.getName(),
-            "Invalid segment file: %s", segmentFile);
+    File tempIndexDir = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(
+        ControllerFilePathProvider.getInstance().getUntarredFileTempDir(), segmentFile.getName(),
+        "Invalid segment file: %s", segmentFile);
 
     try {
       FileUtils.forceMkdir(tempIndexDir);
@@ -500,7 +498,6 @@ public class LLCSegmentCompletionHandlers {
    */
   private static SegmentMetadataImpl extractSegmentMetadataFromForm(FormDataMultiPart form, String segmentName)
       throws IOException {
-
     File tempIndexDir = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(
         ControllerFilePathProvider.getInstance().getUntarredFileTempDir(), getTempSegmentFileName(segmentName),
         "Invalid segment name: %s", segmentName);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -448,8 +448,13 @@ public class LLCSegmentCompletionHandlers {
           "Invalid multi-part for segment: %s", segmentName);
       FormDataBodyPart bodyPart = map.values().iterator().next().get(0);
 
-      File localTempFile = new File(ControllerFilePathProvider.getInstance().getFileUploadTempDir(),
-          getTempSegmentFileName(segmentName));
+      File fileUploadTempDir = ControllerFilePathProvider.getInstance().getFileUploadTempDir();
+      File localTempFile = new File(fileUploadTempDir, getTempSegmentFileName(segmentName));
+
+      if (!localTempFile.getCanonicalPath().startsWith(fileUploadTempDir.getPath())) {
+        throw new IllegalArgumentException("Invalid segment name: " + segmentName);
+      }
+
       try (InputStream inputStream = bodyPart.getValueAs(InputStream.class)) {
         Files.copy(inputStream, localTempFile.toPath());
       } catch (Exception e) {
@@ -468,8 +473,12 @@ public class LLCSegmentCompletionHandlers {
    */
   private static SegmentMetadataImpl extractMetadataFromLocalSegmentFile(File segmentFile)
       throws Exception {
-    File tempIndexDir =
-        new File(ControllerFilePathProvider.getInstance().getUntarredFileTempDir(), segmentFile.getName());
+    File untarredFileTempDir = ControllerFilePathProvider.getInstance().getUntarredFileTempDir();
+    File tempIndexDir = new File(untarredFileTempDir, segmentFile.getName());
+    if (tempIndexDir.getCanonicalPath().startsWith(untarredFileTempDir.getPath())) {
+      throw new IllegalArgumentException("Invalid segment file: " + segmentFile);
+    }
+
     try {
       FileUtils.forceMkdir(tempIndexDir);
 
@@ -496,6 +505,12 @@ public class LLCSegmentCompletionHandlers {
       throws IOException {
     File tempIndexDir = new File(ControllerFilePathProvider.getInstance().getUntarredFileTempDir(),
         getTempSegmentFileName(segmentName));
+
+    if (!tempIndexDir.getCanonicalPath()
+        .startsWith(ControllerFilePathProvider.getInstance().getUntarredFileTempDir().getPath())) {
+      throw new IllegalArgumentException("Invalid segment name: " + segmentName);
+    }
+
     try {
       FileUtils.forceMkdir(tempIndexDir);
 
@@ -532,8 +547,12 @@ public class LLCSegmentCompletionHandlers {
    */
   private static SegmentMetadataImpl extractMetadataFromSegmentFileURI(URI segmentFileURI, String segmentName)
       throws Exception {
-    File localTempFile =
-        new File(ControllerFilePathProvider.getInstance().getFileUploadTempDir(), getTempSegmentFileName(segmentName));
+    File fileUploadTempDir = ControllerFilePathProvider.getInstance().getFileUploadTempDir();
+    File localTempFile = new File(fileUploadTempDir, getTempSegmentFileName(segmentName));
+    if (!localTempFile.getCanonicalPath().startsWith(fileUploadTempDir.getPath())) {
+      throw new IllegalArgumentException("Invalid segment name: " + segmentName);
+    }
+
     try {
       SegmentFetcherFactory.fetchSegmentToLocal(segmentFileURI, localTempFile);
       return extractMetadataFromLocalSegmentFile(localTempFile);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -191,8 +191,9 @@ public class PinotSegmentUploadDownloadRestletResource {
       File downloadTempDir = ControllerFilePathProvider.getInstance().getFileDownloadTempDir();
       File tableDir = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(downloadTempDir, tableName,
           "Invalid table name: %s", tableName);
-      segmentFile = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(tableDir, segmentName + "-" + UUID.randomUUID(),
-          "Invalid segment name: %s", segmentName);
+      segmentFile =
+          org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(tableDir, segmentName + "-" + UUID.randomUUID(),
+              "Invalid segment name: %s", segmentName);
 
       pinotFS.copyToLocalFile(remoteSegmentFileURI, segmentFile);
       // Streaming in the tmp file and delete it afterward.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentUploadDownloadRestletResource.java
@@ -169,17 +169,10 @@ public class PinotSegmentUploadDownloadRestletResource {
     // If the segment file is local, just use it as the return entity; otherwise copy it from remote to local first.
     if (CommonConstants.Segment.LOCAL_SEGMENT_SCHEME.equals(dataDirURI.getScheme())) {
       File dataDir = new File(dataDirURI);
-      File tableDir = new File(dataDir, tableName);
-      if (!tableDir.getCanonicalPath().startsWith(dataDir.getCanonicalPath())) {
-        throw new ControllerApplicationException(LOGGER, "Invalid table name: " + tableName,
-            Response.Status.BAD_REQUEST);
-      }
-
-      segmentFile = new File(tableDir, segmentName);
-      if (!segmentFile.getCanonicalPath().startsWith(new File(dataDirURI).getPath())) {
-        throw new ControllerApplicationException(LOGGER, "Invalid segment name: " + segmentName,
-            Response.Status.BAD_REQUEST);
-      }
+      File tableDir = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(dataDir, tableName,
+          "Invalid table name: %s", tableName);
+      segmentFile = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(tableDir, segmentName,
+          "Invalid segment name: %s", segmentName);
 
       if (!segmentFile.exists()) {
         throw new ControllerApplicationException(LOGGER,
@@ -196,16 +189,10 @@ public class PinotSegmentUploadDownloadRestletResource {
             Response.Status.NOT_FOUND);
       }
       File downloadTempDir = ControllerFilePathProvider.getInstance().getFileDownloadTempDir();
-      File tableDir = new File(downloadTempDir, tableName);
-      if (!tableDir.getCanonicalPath().startsWith(downloadTempDir.getCanonicalPath())) {
-        throw new ControllerApplicationException(LOGGER, "Invalid table name: " + tableName,
-            Response.Status.BAD_REQUEST);
-      }
-      segmentFile = new File(tableDir, segmentName + "-" + UUID.randomUUID());
-      if (!segmentFile.getCanonicalPath().startsWith(tableDir.getCanonicalPath())) {
-        throw new ControllerApplicationException(LOGGER, "Invalid segment name: " + segmentName,
-            Response.Status.BAD_REQUEST);
-      }
+      File tableDir = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(downloadTempDir, tableName,
+          "Invalid table name: %s", tableName);
+      segmentFile = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(tableDir, segmentName + "-" + UUID.randomUUID(),
+          "Invalid segment name: %s", segmentName);
 
       pinotFS.copyToLocalFile(remoteSegmentFileURI, segmentFile);
       // Streaming in the tmp file and delete it afterward.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -98,6 +98,10 @@ public class FileIngestionHelper {
     LOGGER.info("Starting ingestion of {} payload to table: {} using working dir: {}", payload._payloadType,
         tableNameWithType, workingDir.getAbsolutePath());
 
+    if (!workingDir.getCanonicalPath().startsWith(_ingestionDir.getPath())) {
+      throw new IllegalArgumentException("Invalid working dir path %s" + workingDir.getAbsolutePath());
+    }
+
     // Setup working dir
     File inputDir = new File(workingDir, INPUT_DATA_DIR);
     File outputDir = new File(workingDir, OUTPUT_SEGMENT_DIR);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -92,20 +92,11 @@ public class FileIngestionHelper {
     String tableNameWithType = _tableConfig.getTableName();
     // 1. append a timestamp for easy debugging
     // 2. append a random string to avoid using the same working directory when multiple tasks are running in parallel
-    File workingDir = new File(_ingestionDir,
+    File workingDir = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(_ingestionDir,
         String.format("%s_%s_%d_%s", WORKING_DIR_PREFIX, tableNameWithType, System.currentTimeMillis(),
-            RandomStringUtils.random(10, true, false)));
-
-    if (!workingDir.getCanonicalPath().startsWith(_ingestionDir.getPath())) {
-      throw new IllegalArgumentException("Invalid working dir path %s" + workingDir.getAbsolutePath());
-    }
-
+            RandomStringUtils.random(10, true, false)), "Invalid table name: %S", tableNameWithType);
     LOGGER.info("Starting ingestion of {} payload to table: {} using working dir: {}", payload._payloadType,
         tableNameWithType, workingDir.getAbsolutePath());
-
-    if (!workingDir.getCanonicalPath().startsWith(_ingestionDir.getPath())) {
-      throw new IllegalArgumentException("Invalid working dir path %s" + workingDir.getAbsolutePath());
-    }
 
     // Setup working dir
     File inputDir = new File(workingDir, INPUT_DATA_DIR);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/FileIngestionHelper.java
@@ -95,6 +95,11 @@ public class FileIngestionHelper {
     File workingDir = new File(_ingestionDir,
         String.format("%s_%s_%d_%s", WORKING_DIR_PREFIX, tableNameWithType, System.currentTimeMillis(),
             RandomStringUtils.random(10, true, false)));
+
+    if (!workingDir.getCanonicalPath().startsWith(_ingestionDir.getPath())) {
+      throw new IllegalArgumentException("Invalid working dir path %s" + workingDir.getAbsolutePath());
+    }
+
     LOGGER.info("Starting ingestion of {} payload to table: {} using working dir: {}", payload._payloadType,
         tableNameWithType, workingDir.getAbsolutePath());
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -396,12 +396,9 @@ public class TablesResource {
 
       File segmentTarFile = new File(tmpSegmentTarDir, tableNameWithType + "_" + segmentName + "_" + UUID.randomUUID()
           + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
-
-      if (!segmentTarFile.getCanonicalPath().startsWith(tmpSegmentTarDir.getCanonicalPath())) {
-        throw new WebApplicationException(
-            String.format("Invalid table / segment name: %s , %s", tableNameWithType, segmentName),
-            Response.Status.BAD_REQUEST);
-      }
+      org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(tmpSegmentTarDir,
+          tableNameWithType + "_" + segmentName + "_" + UUID.randomUUID() + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION,
+          "Invalid table / segment name: %s , %s", tableNameWithType, segmentName);
 
       TarGzCompressionUtils.createTarGzFile(new File(tableDataManager.getTableDataDir(), segmentName), segmentTarFile);
       Response.ResponseBuilder builder = Response.ok();
@@ -538,12 +535,9 @@ public class TablesResource {
 
       segmentTarFile = new File(segmentTarUploadDir, tableNameWithType + "_" + segmentName + "_" + UUID.randomUUID()
           + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
-
-      if (!segmentTarFile.getCanonicalPath().startsWith(segmentTarUploadDir.getPath())) {
-        throw new WebApplicationException(
-            String.format("Invalid table / segment name: %s, %s", tableNameWithType, segmentName),
-            Response.Status.BAD_REQUEST);
-      }
+      segmentTarFile = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(segmentTarUploadDir,
+          tableNameWithType + "_" + segmentName + "_" + UUID.randomUUID() + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION,
+          "Invalid table / segment name: %s, %s", tableNameWithType, segmentName);
 
       TarGzCompressionUtils.createTarGzFile(new File(tableDataManager.getTableDataDir(), segmentName), segmentTarFile);
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -394,9 +394,7 @@ public class TablesResource {
           new File(_serverInstance.getInstanceDataManager().getSegmentFileDirectory(), PEER_SEGMENT_DOWNLOAD_DIR);
       tmpSegmentTarDir.mkdir();
 
-      File segmentTarFile = new File(tmpSegmentTarDir, tableNameWithType + "_" + segmentName + "_" + UUID.randomUUID()
-          + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
-      org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(tmpSegmentTarDir,
+      File segmentTarFile = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(tmpSegmentTarDir,
           tableNameWithType + "_" + segmentName + "_" + UUID.randomUUID() + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION,
           "Invalid table / segment name: %s , %s", tableNameWithType, segmentName);
 
@@ -533,8 +531,6 @@ public class TablesResource {
           new File(_serverInstance.getInstanceDataManager().getSegmentFileDirectory(), SEGMENT_UPLOAD_DIR);
       segmentTarUploadDir.mkdir();
 
-      segmentTarFile = new File(segmentTarUploadDir, tableNameWithType + "_" + segmentName + "_" + UUID.randomUUID()
-          + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
       segmentTarFile = org.apache.pinot.common.utils.FileUtils.concatAndValidateFile(segmentTarUploadDir,
           tableNameWithType + "_" + segmentName + "_" + UUID.randomUUID() + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION,
           "Invalid table / segment name: %s, %s", tableNameWithType, segmentName);

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -396,6 +396,13 @@ public class TablesResource {
 
       File segmentTarFile = new File(tmpSegmentTarDir, tableNameWithType + "_" + segmentName + "_" + UUID.randomUUID()
           + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+
+      if (!segmentTarFile.getCanonicalPath().startsWith(tmpSegmentTarDir.getCanonicalPath())) {
+        throw new WebApplicationException(
+            String.format("Invalid table / segment name: %s , %s", tableNameWithType, segmentName),
+            Response.Status.BAD_REQUEST);
+      }
+
       TarGzCompressionUtils.createTarGzFile(new File(tableDataManager.getTableDataDir(), segmentName), segmentTarFile);
       Response.ResponseBuilder builder = Response.ok();
       builder.entity((StreamingOutput) output -> {
@@ -531,6 +538,13 @@ public class TablesResource {
 
       segmentTarFile = new File(segmentTarUploadDir, tableNameWithType + "_" + segmentName + "_" + UUID.randomUUID()
           + TarGzCompressionUtils.TAR_GZ_FILE_EXTENSION);
+
+      if (!segmentTarFile.getCanonicalPath().startsWith(segmentTarUploadDir.getPath())) {
+        throw new WebApplicationException(
+            String.format("Invalid table / segment name: %s, %s", tableNameWithType, segmentName),
+            Response.Status.BAD_REQUEST);
+      }
+
       TarGzCompressionUtils.createTarGzFile(new File(tableDataManager.getTableDataDir(), segmentName), segmentTarFile);
 
       // Use segment uploader to upload the segment tar file to segment store and return the segment download url.


### PR DESCRIPTION
Adds sanity checks whenever API params are directly used to construct file paths