### PR TITLE
Returning 403 status code in case of authorization failures

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -121,6 +121,8 @@ public class PinotClientRequest {
       }
       BrokerResponse brokerResponse = executeSqlQuery(requestJson, makeHttpIdentity(requestContext), true);
       asyncResponse.resume(brokerResponse.toJsonString());
+    } catch (WebApplicationException wae) {
+      asyncResponse.resume(wae);
     } catch (Exception e) {
       LOGGER.error("Caught exception while processing GET request", e);
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.UNCAUGHT_GET_EXCEPTIONS, 1L);
@@ -148,6 +150,8 @@ public class PinotClientRequest {
       BrokerResponse brokerResponse =
           executeSqlQuery((ObjectNode) requestJson, makeHttpIdentity(requestContext), false);
       asyncResponse.resume(brokerResponse.toJsonString());
+    } catch (WebApplicationException wae) {
+      asyncResponse.resume(wae);
     } catch (Exception e) {
       LOGGER.error("Caught exception while processing POST request", e);
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.UNCAUGHT_POST_EXCEPTIONS, 1L);

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -244,7 +244,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.REQUEST_DROPPED_DUE_TO_ACCESS_ERROR, 1);
       LOGGER.info("Access denied for requestId {}", requestId);
       requestContext.setErrorCode(QueryException.ACCESS_DENIED_ERROR_CODE);
-      return new BrokerResponseNative(QueryException.ACCESS_DENIED_ERROR);
+      throw new WebApplicationException("Permission denied", Response.Status.FORBIDDEN);
     }
 
     JsonNode sql = request.get(Broker.Request.SQL);
@@ -387,6 +387,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       if (!hasTableAccess) {
         _brokerMetrics.addMeteredTableValue(tableName, BrokerMeter.REQUEST_DROPPED_DUE_TO_ACCESS_ERROR, 1);
         LOGGER.info("Access denied for request {}: {}, table: {}", requestId, query, tableName);
+        requestContext.setErrorCode(QueryException.ACCESS_DENIED_ERROR_CODE);
         throw new WebApplicationException("Permission denied", Response.Status.FORBIDDEN);
       }
       _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.AUTHORIZATION,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -37,6 +37,8 @@ import java.util.concurrent.TimeoutException;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
+import javax.ws.rs.WebApplicationException;
+import javax.ws.rs.core.Response;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.httpclient.HttpConnectionManager;
 import org.apache.commons.httpclient.URI;
@@ -385,8 +387,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       if (!hasTableAccess) {
         _brokerMetrics.addMeteredTableValue(tableName, BrokerMeter.REQUEST_DROPPED_DUE_TO_ACCESS_ERROR, 1);
         LOGGER.info("Access denied for request {}: {}, table: {}", requestId, query, tableName);
-        requestContext.setErrorCode(QueryException.ACCESS_DENIED_ERROR_CODE);
-        return new BrokerResponseNative(QueryException.ACCESS_DENIED_ERROR);
+        throw new WebApplicationException("Permission denied", Response.Status.FORBIDDEN);
       }
       _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.AUTHORIZATION,
           System.nanoTime() - compilationEndTimeNs);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -44,8 +44,10 @@ import javax.ws.rs.GET;
 import javax.ws.rs.POST;
 import javax.ws.rs.Path;
 import javax.ws.rs.QueryParam;
+import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
+import javax.ws.rs.core.Response;
 import org.apache.calcite.jdbc.CalciteSchemaBuilder;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.commons.io.IOUtils;
@@ -117,6 +119,8 @@ public class PinotQueryResource {
     } catch (ProcessingException pe) {
       LOGGER.error("Caught exception while processing post request {}", pe.getMessage());
       return pe.getMessage();
+    } catch (WebApplicationException wae) {
+      throw wae;
     } catch (Exception e) {
       LOGGER.error("Caught exception while processing post request", e);
       return QueryException.getException(QueryException.INTERNAL_ERROR, e).toString();
@@ -133,6 +137,8 @@ public class PinotQueryResource {
     } catch (ProcessingException pe) {
       LOGGER.error("Caught exception while processing get request {}", pe.getMessage());
       return pe.getMessage();
+    } catch (WebApplicationException wae) {
+      throw wae;
     } catch (Exception e) {
       LOGGER.error("Caught exception while processing get request", e);
       return QueryException.getException(QueryException.INTERNAL_ERROR, e).toString();
@@ -390,7 +396,9 @@ public class PinotQueryResource {
       /*if (LOG.isInfoEnabled()){
         LOGGER.info("The http response code is " + responseCode);
       }*/
-      if (responseCode != HttpURLConnection.HTTP_OK) {
+      if (responseCode == HttpURLConnection.HTTP_FORBIDDEN) {
+        throw new WebApplicationException("Permission denied", Response.Status.FORBIDDEN);
+      } else if (responseCode != HttpURLConnection.HTTP_OK) {
         throw new IOException("Failed : HTTP error code : " + responseCode + ". Root Cause: "
             + IOUtils.toString(conn.getErrorStream(), StandardCharsets.UTF_8));
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -120,6 +120,7 @@ public class PinotQueryResource {
       LOGGER.error("Caught exception while processing post request {}", pe.getMessage());
       return pe.getMessage();
     } catch (WebApplicationException wae) {
+      LOGGER.error("Caught exception while processing post request", wae);
       throw wae;
     } catch (Exception e) {
       LOGGER.error("Caught exception while processing post request", e);
@@ -138,6 +139,7 @@ public class PinotQueryResource {
       LOGGER.error("Caught exception while processing get request {}", pe.getMessage());
       return pe.getMessage();
     } catch (WebApplicationException wae) {
+      LOGGER.error("Caught exception while processing get request", wae);
       throw wae;
     } catch (Exception e) {
       LOGGER.error("Caught exception while processing get request", e);
@@ -193,7 +195,7 @@ public class PinotQueryResource {
     // we don't have a cross table access control rule so only ADMIN can make request to multi-stage engine.
     AccessControl accessControl = _accessControlFactory.create();
     if (!accessControl.hasAccess(null, AccessType.READ, httpHeaders, endpointUrl)) {
-      return QueryException.ACCESS_DENIED_ERROR.toString();
+      throw new WebApplicationException("Permission denied", Response.Status.FORBIDDEN);
     }
 
     QueryEnvironment queryEnvironment = new QueryEnvironment(new TypeFactory(new TypeSystem()),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BasicAuthBatchIntegrationTest.java
@@ -100,10 +100,12 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
   @Test
   public void testBrokerNoAuth()
       throws Exception {
-    JsonNode response = JsonUtils.stringToJsonNode(
-        sendPostRequest("http://localhost:" + getRandomBrokerPort() + "/query/sql", "{\"sql\":\"SELECT now()\"}"));
-    Assert.assertFalse(response.has("resultTable"), "must not return result table");
-    Assert.assertTrue(response.get("exceptions").get(0).get("errorCode").asInt() != 0, "must return error code");
+    try {
+        sendPostRequest("http://localhost:" + getRandomBrokerPort() + "/query/sql", "{\"sql\":\"SELECT now()\"}");
+    } catch (IOException e) {
+      HttpErrorStatusException httpErrorStatusException = (HttpErrorStatusException) e.getCause();
+      Assert.assertEquals(httpErrorStatusException.getStatusCode(), 403, "must return 403");
+    }
   }
 
   @Test
@@ -183,7 +185,7 @@ public class BasicAuthBatchIntegrationTest extends ClusterTest {
           "{\"sql\":\"SELECT count(*) FROM baseballStats\"}", AUTH_HEADER_USER);
     } catch (IOException e) {
       HttpErrorStatusException httpErrorStatusException = (HttpErrorStatusException) e.getCause();
-      Assert.assertTrue(httpErrorStatusException.getStatusCode() == 403, "must return 403");
+      Assert.assertEquals(httpErrorStatusException.getStatusCode(), 403, "must return 403");
     }
   }
 }


### PR DESCRIPTION
Currently, if SQL query execution has authorization issues, the return code is 200 and the errorCode 180 is set in the response JSON. This happens for both controller and broker endpoints.

SQL execution using Controller:
% curl -v -X POST -H "accept: application/json" -H "Content-Type: application/json" -d '{"sql":"select * from transcript limit 10","trace":false,"queryOptions":""}' http://localhost:9000/sql ; echo
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:9000...
* Connected to localhost (127.0.0.1) port 9000 (#0)
> POST /sql HTTP/1.1
> Host: localhost:9000
> User-Agent: curl/7.88.1
> accept: application/json
> Content-Type: application/json
> Content-Length: 75
>
< HTTP/1.1 200 OK
< Pinot-Controller-Host: soumitras-mbp.attlocal.net
< Pinot-Controller-Version: 1.0.0-sk-bf66c10b03399e8682ed69cf7c087127ca986c36
< Access-Control-Allow-Origin: *
< Access-Control-Allow-Methods: GET, POST, PUT, OPTIONS, DELETE
< Access-Control-Allow-Headers: *
< Content-Type: application/json
< Content-Length: 1023
<
* Connection #0 to host localhost left intact
{"requestId":"1262666501000000001","exceptions":[{"message":null,"errorCode":180}],"numServersQueried":0,"numServersResponded":0,"numSegmentsQueried":0,"numSegmentsProcessed":0,"numSegmentsMatched":0,"numConsumingSegmentsQueried":0,"numConsumingSegmentsProcessed":0,"numConsumingSegmentsMatched":0,"numDocsScanned":0,"numEntriesScannedInFilter":0,"numEntriesScannedPostFilter":0,"numGroupsLimitReached":false,"totalDocs":0,"timeUsedMs":0,"offlineThreadCpuTimeNs":0,"realtimeThreadCpuTimeNs":0,"offlineSystemActivitiesCpuTimeNs":0,"realtimeSystemActivitiesCpuTimeNs":0,"offlineResponseSerializationCpuTimeNs":0,"realtimeResponseSerializationCpuTimeNs":0,"offlineTotalCpuTimeNs":0,"realtimeTotalCpuTimeNs":0,"segmentStatistics":[],"traceInfo":{},"numRowsResultSet":0,"minConsumingFreshnessTimeMs":0,"numSegmentsPrunedByBroker":0,"numSegmentsPrunedByServer":0,"numSegmentsPrunedInvalid":0,"numSegmentsPrunedByLimit":0,"numSegmentsPrunedByValue":0,"explainPlanNumEmptyFilterSegments":0,"explainPlanNumMatchAllFilterSegments":0}

SQL execution using Broker:
% curl -v -X POST -H "accept: application/json" -H "Content-Type: application/json" -d '{"sql":"select * from transcript limit 10","trace":false,"queryOptions":""}' http://localhost:8000/query/sql ; echo
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> POST /query/sql HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.88.1
> accept: application/json
> Content-Type: application/json
> Content-Length: 75
>
< HTTP/1.1 200 OK
< Content-Type: application/json
< Content-Length: 1023
<
* Connection #0 to host localhost left intact
{"requestId":"1262666501000000000","exceptions":[{"message":null,"errorCode":180}],"numServersQueried":0,"numServersResponded":0,"numSegmentsQueried":0,"numSegmentsProcessed":0,"numSegmentsMatched":0,"numConsumingSegmentsQueried":0,"numConsumingSegmentsProcessed":0,"numConsumingSegmentsMatched":0,"numDocsScanned":0,"numEntriesScannedInFilter":0,"numEntriesScannedPostFilter":0,"numGroupsLimitReached":false,"totalDocs":0,"timeUsedMs":0,"offlineThreadCpuTimeNs":0,"realtimeThreadCpuTimeNs":0,"offlineSystemActivitiesCpuTimeNs":0,"realtimeSystemActivitiesCpuTimeNs":0,"offlineResponseSerializationCpuTimeNs":0,"realtimeResponseSerializationCpuTimeNs":0,"offlineTotalCpuTimeNs":0,"realtimeTotalCpuTimeNs":0,"segmentStatistics":[],"traceInfo":{},"numRowsResultSet":0,"minConsumingFreshnessTimeMs":0,"numSegmentsPrunedByBroker":0,"numSegmentsPrunedByServer":0,"numSegmentsPrunedInvalid":0,"numSegmentsPrunedByLimit":0,"numSegmentsPrunedByValue":0,"explainPlanNumEmptyFilterSegments":0,"explainPlanNumMatchAllFilterSegments":0}

This PR changes the return code to 403, sample runs below:
% curl -v -X POST -H "accept: application/json" -H "Content-Type: application/json" -d '{"sql":"select * from transcript limit 10","trace":false,"queryOptions":""}' http://localhost:9000/sql ; echo
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:9000...
* Connected to localhost (127.0.0.1) port 9000 (#0)
> POST /sql HTTP/1.1
> Host: localhost:9000
> User-Agent: curl/7.88.1
> accept: application/json
> Content-Type: application/json
> Content-Length: 75
>
< HTTP/1.1 403 Forbidden

% curl -v -X POST -H "accept: application/json" -H "Content-Type: application/json" -d '{"sql":"select * from transcript limit 10","trace":false,"queryOptions":""}' http://localhost:8000/query/sql ; echo
Note: Unnecessary use of -X or --request, POST is already inferred.
*   Trying 127.0.0.1:8000...
* Connected to localhost (127.0.0.1) port 8000 (#0)
> POST /query/sql HTTP/1.1
> Host: localhost:8000
> User-Agent: curl/7.88.1
> accept: application/json
> Content-Type: application/json
> Content-Length: 75
>
< HTTP/1.1 403 Forbidden

label is 'bugfix'.