### PR TITLE
Avoid string splitting when fetching props

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -124,6 +124,7 @@ public class StreamConfigProperties {
   }
 
   public static String getPropertySuffix(String incoming, String propertyPrefix) {
-    return incoming.split(propertyPrefix + ".")[1];
+    String prefix = propertyPrefix + DOT_SEPARATOR;
+    return incoming.substring(prefix.length());
   }
 }


### PR DESCRIPTION
Avoids String.split() while fetching prop suffix