### PR TITLE
[multistage][agg] support agg with filter

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
@@ -279,6 +279,297 @@ public final class DataBlockUtils {
    * TODO: Add support for COLUMNAR format.
    * @return int array of values in the column
    */
+  public static int[] extractIntValuesForColumn(DataBlock dataBlock, int columnIndex) {
+    DataSchema dataSchema = dataBlock.getDataSchema();
+    DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
+
+    // Get null bitmap for the column.
+    RoaringBitmap nullBitmap = extractNullBitmaps(dataBlock)[columnIndex];
+    int numRows = dataBlock.getNumberOfRows();
+
+    int[] rows = new int[numRows];
+    for (int rowId = 0; rowId < numRows; rowId++) {
+      if (nullBitmap != null && nullBitmap.contains(rowId)) {
+        continue;
+      }
+
+      switch (columnDataTypes[columnIndex]) {
+        case INT:
+        case BOOLEAN:
+          rows[rowId] = dataBlock.getInt(rowId, columnIndex);
+          break;
+        case LONG:
+          rows[rowId] = (int) dataBlock.getLong(rowId, columnIndex);
+          break;
+        case FLOAT:
+          rows[rowId] = (int) dataBlock.getFloat(rowId, columnIndex);
+          break;
+        case DOUBLE:
+          rows[rowId] = (int) dataBlock.getDouble(rowId, columnIndex);
+          break;
+        case BIG_DECIMAL:
+          rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).intValue();
+          break;
+        default:
+          throw new IllegalStateException(
+              String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+      }
+    }
+    return rows;
+  }
+
+  /**
+   * Given a datablock and the column index, extracts the long values for the column. Prefer using this function over
+   * extractRowFromDatablock if the desired datatype is known to prevent autoboxing to Object and later unboxing to the
+   * desired type.
+   * This only works on ROW format.
+   * TODO: Add support for COLUMNAR format.
+   * @return long array of values in the column
+   */
+  public static long[] extractLongValuesForColumn(DataBlock dataBlock, int columnIndex) {
+    DataSchema dataSchema = dataBlock.getDataSchema();
+    DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
+
+    // Get null bitmap for the column.
+    RoaringBitmap nullBitmap = extractNullBitmaps(dataBlock)[columnIndex];
+    int numRows = dataBlock.getNumberOfRows();
+
+    long[] rows = new long[numRows];
+    for (int rowId = 0; rowId < numRows; rowId++) {
+      if (nullBitmap != null && nullBitmap.contains(rowId)) {
+        continue;
+      }
+
+      switch (columnDataTypes[columnIndex]) {
+        case INT:
+        case BOOLEAN:
+          rows[rowId] = dataBlock.getInt(rowId, columnIndex);
+          break;
+        case LONG:
+          rows[rowId] = dataBlock.getLong(rowId, columnIndex);
+          break;
+        case FLOAT:
+          rows[rowId] = (long) dataBlock.getFloat(rowId, columnIndex);
+          break;
+        case DOUBLE:
+          rows[rowId] = (long) dataBlock.getDouble(rowId, columnIndex);
+          break;
+        case BIG_DECIMAL:
+          rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).longValue();
+          break;
+        default:
+          throw new IllegalStateException(
+              String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+      }
+    }
+    return rows;
+  }
+
+  /**
+   * Given a datablock and the column index, extracts the float values for the column. Prefer using this function over
+   * extractRowFromDatablock if the desired datatype is known to prevent autoboxing to Object and later unboxing to the
+   * desired type.
+   * This only works on ROW format.
+   * TODO: Add support for COLUMNAR format.
+   * @return float array of values in the column
+   */
+  public static float[] extractFloatValuesForColumn(DataBlock dataBlock, int columnIndex) {
+    DataSchema dataSchema = dataBlock.getDataSchema();
+    DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
+
+    // Get null bitmap for the column.
+    RoaringBitmap nullBitmap = extractNullBitmaps(dataBlock)[columnIndex];
+    int numRows = dataBlock.getNumberOfRows();
+
+    float[] rows = new float[numRows];
+    for (int rowId = 0; rowId < numRows; rowId++) {
+      if (nullBitmap != null && nullBitmap.contains(rowId)) {
+        continue;
+      }
+
+      switch (columnDataTypes[columnIndex]) {
+        case INT:
+        case BOOLEAN:
+          rows[rowId] = dataBlock.getInt(rowId, columnIndex);
+          break;
+        case LONG:
+          rows[rowId] = dataBlock.getLong(rowId, columnIndex);
+          break;
+        case FLOAT:
+          rows[rowId] = dataBlock.getFloat(rowId, columnIndex);
+          break;
+        case DOUBLE:
+          rows[rowId] = (float) dataBlock.getDouble(rowId, columnIndex);
+          break;
+        case BIG_DECIMAL:
+          rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).floatValue();
+          break;
+        default:
+          throw new IllegalStateException(
+              String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+      }
+    }
+
+    return rows;
+  }
+
+  /**
+   * Given a datablock and the column index, extracts the double values for the column. Prefer using this function over
+   * extractRowFromDatablock if the desired datatype is known to prevent autoboxing to Object and later unboxing to the
+   * desired type.
+   * This only works on ROW format.
+   * TODO: Add support for COLUMNAR format.
+   * @return double array of values in the column
+   */
+  public static double[] extractDoubleValuesForColumn(DataBlock dataBlock, int columnIndex) {
+    DataSchema dataSchema = dataBlock.getDataSchema();
+    DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
+
+    // Get null bitmap for the column.
+    RoaringBitmap nullBitmap = extractNullBitmaps(dataBlock)[columnIndex];
+    int numRows = dataBlock.getNumberOfRows();
+
+    double[] rows = new double[numRows];
+    for (int rowId = 0; rowId < numRows; rowId++) {
+      if (nullBitmap != null && nullBitmap.contains(rowId)) {
+        continue;
+      }
+      switch (columnDataTypes[columnIndex]) {
+        case INT:
+        case BOOLEAN:
+          rows[rowId] = dataBlock.getInt(rowId, columnIndex);
+          break;
+        case LONG:
+          rows[rowId] = dataBlock.getLong(rowId, columnIndex);
+          break;
+        case FLOAT:
+          rows[rowId] = dataBlock.getFloat(rowId, columnIndex);
+          break;
+        case DOUBLE:
+          rows[rowId] = dataBlock.getDouble(rowId, columnIndex);
+          break;
+        case BIG_DECIMAL:
+          rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).doubleValue();
+          break;
+        default:
+          throw new IllegalStateException(
+              String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+      }
+    }
+
+    return rows;
+  }
+
+  /**
+   * Given a datablock and the column index, extracts the BigDecimal values for the column. Prefer using this function
+   * over extractRowFromDatablock if the desired datatype is known to prevent autoboxing to Object and later unboxing to
+   * the desired type.
+   * This only works on ROW format.
+   * TODO: Add support for COLUMNAR format.
+   * @return BigDecimal array of values in the column
+   */
+  public static BigDecimal[] extractBigDecimalValuesForColumn(DataBlock dataBlock, int columnIndex) {
+    DataSchema dataSchema = dataBlock.getDataSchema();
+    DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
+
+    // Get null bitmap for the column.
+    RoaringBitmap nullBitmap = extractNullBitmaps(dataBlock)[columnIndex];
+    int numRows = dataBlock.getNumberOfRows();
+
+    BigDecimal[] rows = new BigDecimal[numRows];
+    for (int rowId = 0; rowId < numRows; rowId++) {
+      if (nullBitmap != null && nullBitmap.contains(rowId)) {
+        continue;
+      }
+
+      switch (columnDataTypes[columnIndex]) {
+        case INT:
+        case BOOLEAN:
+          rows[rowId] = BigDecimal.valueOf(dataBlock.getInt(rowId, columnIndex));
+          break;
+        case LONG:
+          rows[rowId] = BigDecimal.valueOf(dataBlock.getLong(rowId, columnIndex));
+          break;
+        case FLOAT:
+          rows[rowId] = BigDecimal.valueOf(dataBlock.getFloat(rowId, columnIndex));
+          break;
+        case DOUBLE:
+          rows[rowId] = BigDecimal.valueOf(dataBlock.getDouble(rowId, columnIndex));
+          break;
+        case BIG_DECIMAL:
+          rows[rowId] = BigDecimal.valueOf(dataBlock.getBigDecimal(rowId, columnIndex).doubleValue());
+          break;
+        default:
+          throw new IllegalStateException(
+              String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+      }
+    }
+
+    return rows;
+  }
+
+  /**
+   * Given a datablock and the column index, extracts the String values for the column. Prefer using this function over
+   * extractRowFromDatablock if the desired datatype is known to prevent autoboxing to Object and later unboxing to the
+   * desired type.
+   * This only works on ROW format.
+   * TODO: Add support for COLUMNAR format.
+   * @return String array of values in the column
+   */
+  public static String[] extractStringValuesForColumn(DataBlock dataBlock, int columnIndex) {
+    DataSchema dataSchema = dataBlock.getDataSchema();
+    DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
+
+    // Get null bitmap for the column.
+    RoaringBitmap nullBitmap = extractNullBitmaps(dataBlock)[columnIndex];
+    int numRows = dataBlock.getNumberOfRows();
+
+    String[] rows = new String[numRows];
+    for (int rowId = 0; rowId < numRows; rowId++) {
+      if (nullBitmap != null && nullBitmap.contains(rowId)) {
+        continue;
+      }
+      rows[rowId] = dataBlock.getString(rowId, columnIndex);
+    }
+
+    return rows;
+  }
+
+  /**
+   * Given a datablock and the column index, extracts the byte values for the column. Prefer using this function over
+   * extractRowFromDatablock if the desired datatype is known to prevent autoboxing to Object and later unboxing to the
+   * desired type.
+   * This only works on ROW format.
+   * TODO: Add support for COLUMNAR format.
+   * @return byte array of values in the column
+   */
+  public static byte[][] extractBytesValuesForColumn(DataBlock dataBlock, int columnIndex) {
+    DataSchema dataSchema = dataBlock.getDataSchema();
+    DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
+
+    // Get null bitmap for the column.
+    RoaringBitmap nullBitmap = extractNullBitmaps(dataBlock)[columnIndex];
+    int numRows = dataBlock.getNumberOfRows();
+
+    byte[][] rows = new byte[numRows][];
+    for (int rowId = 0; rowId < numRows; rowId++) {
+      if (nullBitmap != null && nullBitmap.contains(rowId)) {
+        continue;
+      }
+      rows[rowId] = dataBlock.getBytes(rowId, columnIndex).getBytes();
+    }
+
+    return rows;
+  }
+
+  /**
+   * Given a datablock and the column index, extracts the integer values for the column. Prefer using this function over
+   * extractRowFromDatablock if the desired datatype is known to prevent autoboxing to Object and later unboxing to the
+   * desired type.
+   * This only works on ROW format.
+   * TODO: Add support for COLUMNAR format.
+   * @return int array of values in the column
+   */
   public static int[] extractIntValuesForColumn(DataBlock dataBlock, int columnIndex, int filterArgIdx) {
     DataSchema dataSchema = dataBlock.getDataSchema();
     DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
@@ -288,67 +579,37 @@ public final class DataBlockUtils {
     int numRows = dataBlock.getNumberOfRows();
 
     int[] rows = new int[numRows];
-    if (filterArgIdx == -1) {
-      for (int rowId = 0; rowId < numRows; rowId++) {
-        if (nullBitmap != null && nullBitmap.contains(rowId)) {
+    int outRowId = 0;
+    for (int inRowId = 0; inRowId < numRows; inRowId++) {
+      if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
+        if (nullBitmap != null && nullBitmap.contains(inRowId)) {
+          outRowId++;
           continue;
         }
         switch (columnDataTypes[columnIndex]) {
           case INT:
           case BOOLEAN:
-            rows[rowId] = dataBlock.getInt(rowId, columnIndex);
+            rows[outRowId++] = dataBlock.getInt(inRowId, columnIndex);
             break;
           case LONG:
-            rows[rowId] = (int) dataBlock.getLong(rowId, columnIndex);
+            rows[outRowId++] = (int) dataBlock.getLong(inRowId, columnIndex);
             break;
           case FLOAT:
-            rows[rowId] = (int) dataBlock.getFloat(rowId, columnIndex);
+            rows[outRowId++] = (int) dataBlock.getFloat(inRowId, columnIndex);
             break;
           case DOUBLE:
-            rows[rowId] = (int) dataBlock.getDouble(rowId, columnIndex);
+            rows[outRowId++] = (int) dataBlock.getDouble(inRowId, columnIndex);
             break;
           case BIG_DECIMAL:
-            rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).intValue();
+            rows[outRowId++] = dataBlock.getBigDecimal(inRowId, columnIndex).intValue();
             break;
           default:
             throw new IllegalStateException(
                 String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
         }
       }
-      return rows;
-    } else {
-      int outRowId = 0;
-      for (int inRowId = 0; inRowId < numRows; inRowId++) {
-        if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
-          if (nullBitmap != null && nullBitmap.contains(inRowId)) {
-            outRowId++;
-            continue;
-          }
-          switch (columnDataTypes[columnIndex]) {
-            case INT:
-            case BOOLEAN:
-              rows[outRowId++] = dataBlock.getInt(inRowId, columnIndex);
-              break;
-            case LONG:
-              rows[outRowId++] = (int) dataBlock.getLong(inRowId, columnIndex);
-              break;
-            case FLOAT:
-              rows[outRowId++] = (int) dataBlock.getFloat(inRowId, columnIndex);
-              break;
-            case DOUBLE:
-              rows[outRowId++] = (int) dataBlock.getDouble(inRowId, columnIndex);
-              break;
-            case BIG_DECIMAL:
-              rows[outRowId++] = dataBlock.getBigDecimal(inRowId, columnIndex).intValue();
-              break;
-            default:
-              throw new IllegalStateException(
-                  String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
-          }
-        }
-      }
-      return Arrays.copyOfRange(rows, 0, outRowId);
     }
+    return Arrays.copyOfRange(rows, 0, outRowId);
   }
 
   /**
@@ -368,67 +629,37 @@ public final class DataBlockUtils {
     int numRows = dataBlock.getNumberOfRows();
 
     long[] rows = new long[numRows];
-    if (filterArgIdx == -1) {
-      for (int rowId = 0; rowId < numRows; rowId++) {
-        if (nullBitmap != null && nullBitmap.contains(rowId)) {
+    int outRowId = 0;
+    for (int inRowId = 0; inRowId < numRows; inRowId++) {
+      if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
+        if (nullBitmap != null && nullBitmap.contains(inRowId)) {
+          outRowId++;
           continue;
         }
         switch (columnDataTypes[columnIndex]) {
           case INT:
           case BOOLEAN:
-            rows[rowId] = dataBlock.getInt(rowId, columnIndex);
+            rows[outRowId++] = dataBlock.getInt(inRowId, columnIndex);
             break;
           case LONG:
-            rows[rowId] = dataBlock.getLong(rowId, columnIndex);
+            rows[outRowId++] = dataBlock.getLong(inRowId, columnIndex);
             break;
           case FLOAT:
-            rows[rowId] = (long) dataBlock.getFloat(rowId, columnIndex);
+            rows[outRowId++] = (long) dataBlock.getFloat(inRowId, columnIndex);
             break;
           case DOUBLE:
-            rows[rowId] = (long) dataBlock.getDouble(rowId, columnIndex);
+            rows[outRowId++] = (long) dataBlock.getDouble(inRowId, columnIndex);
             break;
           case BIG_DECIMAL:
-            rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).longValue();
+            rows[outRowId++] = dataBlock.getBigDecimal(inRowId, columnIndex).longValue();
             break;
           default:
             throw new IllegalStateException(
                 String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
         }
       }
-      return rows;
-    } else {
-      int outRowId = 0;
-      for (int inRowId = 0; inRowId < numRows; inRowId++) {
-        if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
-          if (nullBitmap != null && nullBitmap.contains(inRowId)) {
-            outRowId++;
-            continue;
-          }
-          switch (columnDataTypes[columnIndex]) {
-            case INT:
-            case BOOLEAN:
-              rows[outRowId++] = dataBlock.getInt(inRowId, columnIndex);
-              break;
-            case LONG:
-              rows[outRowId++] = dataBlock.getLong(inRowId, columnIndex);
-              break;
-            case FLOAT:
-              rows[outRowId++] = (long) dataBlock.getFloat(inRowId, columnIndex);
-              break;
-            case DOUBLE:
-              rows[outRowId++] = (long) dataBlock.getDouble(inRowId, columnIndex);
-              break;
-            case BIG_DECIMAL:
-              rows[outRowId++] = dataBlock.getBigDecimal(inRowId, columnIndex).longValue();
-              break;
-            default:
-              throw new IllegalStateException(
-                  String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
-          }
-        }
-      }
-      return Arrays.copyOfRange(rows, 0, outRowId);
     }
+    return Arrays.copyOfRange(rows, 0, outRowId);
   }
 
   /**
@@ -448,67 +679,37 @@ public final class DataBlockUtils {
     int numRows = dataBlock.getNumberOfRows();
 
     float[] rows = new float[numRows];
-    if (filterArgIdx == -1) {
-      for (int rowId = 0; rowId < numRows; rowId++) {
-        if (nullBitmap != null && nullBitmap.contains(rowId)) {
+    int outRowId = 0;
+    for (int inRowId = 0; inRowId < numRows; inRowId++) {
+      if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
+        if (nullBitmap != null && nullBitmap.contains(inRowId)) {
+          outRowId++;
           continue;
         }
         switch (columnDataTypes[columnIndex]) {
           case INT:
           case BOOLEAN:
-            rows[rowId] = dataBlock.getInt(rowId, columnIndex);
+            rows[outRowId++] = dataBlock.getInt(inRowId, columnIndex);
             break;
           case LONG:
-            rows[rowId] = dataBlock.getLong(rowId, columnIndex);
+            rows[outRowId++] = dataBlock.getLong(inRowId, columnIndex);
             break;
           case FLOAT:
-            rows[rowId] = dataBlock.getFloat(rowId, columnIndex);
+            rows[outRowId++] = dataBlock.getFloat(inRowId, columnIndex);
             break;
           case DOUBLE:
-            rows[rowId] = (float) dataBlock.getDouble(rowId, columnIndex);
+            rows[outRowId++] = (float) dataBlock.getDouble(inRowId, columnIndex);
             break;
           case BIG_DECIMAL:
-            rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).floatValue();
+            rows[outRowId++] = dataBlock.getBigDecimal(inRowId, columnIndex).floatValue();
             break;
           default:
             throw new IllegalStateException(
                 String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
         }
       }
-      return rows;
-    } else {
-      int outRowId = 0;
-      for (int inRowId = 0; inRowId < numRows; inRowId++) {
-        if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
-          if (nullBitmap != null && nullBitmap.contains(inRowId)) {
-            outRowId++;
-            continue;
-          }
-          switch (columnDataTypes[columnIndex]) {
-            case INT:
-            case BOOLEAN:
-              rows[outRowId++] = dataBlock.getInt(inRowId, columnIndex);
-              break;
-            case LONG:
-              rows[outRowId++] = dataBlock.getLong(inRowId, columnIndex);
-              break;
-            case FLOAT:
-              rows[outRowId++] = dataBlock.getFloat(inRowId, columnIndex);
-              break;
-            case DOUBLE:
-              rows[outRowId++] = (float) dataBlock.getDouble(inRowId, columnIndex);
-              break;
-            case BIG_DECIMAL:
-              rows[outRowId++] = dataBlock.getBigDecimal(inRowId, columnIndex).floatValue();
-              break;
-            default:
-              throw new IllegalStateException(
-                  String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
-          }
-        }
-      }
-      return Arrays.copyOfRange(rows, 0, outRowId);
     }
+    return Arrays.copyOfRange(rows, 0, outRowId);
   }
 
   /**
@@ -528,67 +729,37 @@ public final class DataBlockUtils {
     int numRows = dataBlock.getNumberOfRows();
 
     double[] rows = new double[numRows];
-    if (filterArgIdx == -1) {
-      for (int rowId = 0; rowId < numRows; rowId++) {
-        if (nullBitmap != null && nullBitmap.contains(rowId)) {
+    int outRowId = 0;
+    for (int inRowId = 0; inRowId < numRows; inRowId++) {
+      if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
+        if (nullBitmap != null && nullBitmap.contains(inRowId)) {
+          outRowId++;
           continue;
         }
         switch (columnDataTypes[columnIndex]) {
           case INT:
           case BOOLEAN:
-            rows[rowId] = dataBlock.getInt(rowId, columnIndex);
+            rows[outRowId++] = dataBlock.getInt(inRowId, columnIndex);
             break;
           case LONG:
-            rows[rowId] = dataBlock.getLong(rowId, columnIndex);
+            rows[outRowId++] = dataBlock.getLong(inRowId, columnIndex);
             break;
           case FLOAT:
-            rows[rowId] = dataBlock.getFloat(rowId, columnIndex);
+            rows[outRowId++] = dataBlock.getFloat(inRowId, columnIndex);
             break;
           case DOUBLE:
-            rows[rowId] = dataBlock.getDouble(rowId, columnIndex);
+            rows[outRowId++] = dataBlock.getDouble(inRowId, columnIndex);
             break;
           case BIG_DECIMAL:
-            rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).doubleValue();
+            rows[outRowId++] = dataBlock.getBigDecimal(inRowId, columnIndex).doubleValue();
             break;
           default:
             throw new IllegalStateException(
                 String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
         }
       }
-      return rows;
-    } else {
-      int outRowId = 0;
-      for (int inRowId = 0; inRowId < numRows; inRowId++) {
-        if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
-          if (nullBitmap != null && nullBitmap.contains(inRowId)) {
-            outRowId++;
-            continue;
-          }
-          switch (columnDataTypes[columnIndex]) {
-            case INT:
-            case BOOLEAN:
-              rows[outRowId++] = dataBlock.getInt(inRowId, columnIndex);
-              break;
-            case LONG:
-              rows[outRowId++] = dataBlock.getLong(inRowId, columnIndex);
-              break;
-            case FLOAT:
-              rows[outRowId++] = dataBlock.getFloat(inRowId, columnIndex);
-              break;
-            case DOUBLE:
-              rows[outRowId++] = dataBlock.getDouble(inRowId, columnIndex);
-              break;
-            case BIG_DECIMAL:
-              rows[outRowId++] = dataBlock.getBigDecimal(inRowId, columnIndex).doubleValue();
-              break;
-            default:
-              throw new IllegalStateException(
-                  String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
-          }
-        }
-      }
-      return Arrays.copyOfRange(rows, 0, outRowId);
     }
+    return Arrays.copyOfRange(rows, 0, outRowId);
   }
 
   /**
@@ -608,67 +779,37 @@ public final class DataBlockUtils {
     int numRows = dataBlock.getNumberOfRows();
 
     BigDecimal[] rows = new BigDecimal[numRows];
-    if (filterArgIdx == -1) {
-      for (int rowId = 0; rowId < numRows; rowId++) {
-        if (nullBitmap != null && nullBitmap.contains(rowId)) {
+    int outRowId = 0;
+    for (int inRowId = 0; inRowId < numRows; inRowId++) {
+      if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
+        if (nullBitmap != null && nullBitmap.contains(inRowId)) {
+          outRowId++;
           continue;
         }
         switch (columnDataTypes[columnIndex]) {
           case INT:
           case BOOLEAN:
-            rows[rowId] = BigDecimal.valueOf(dataBlock.getInt(rowId, columnIndex));
+            rows[outRowId++] = BigDecimal.valueOf(dataBlock.getInt(inRowId, columnIndex));
             break;
           case LONG:
-            rows[rowId] = BigDecimal.valueOf(dataBlock.getLong(rowId, columnIndex));
+            rows[outRowId++] = BigDecimal.valueOf(dataBlock.getLong(inRowId, columnIndex));
             break;
           case FLOAT:
-            rows[rowId] = BigDecimal.valueOf(dataBlock.getFloat(rowId, columnIndex));
+            rows[outRowId++] = BigDecimal.valueOf(dataBlock.getFloat(inRowId, columnIndex));
             break;
           case DOUBLE:
-            rows[rowId] = BigDecimal.valueOf(dataBlock.getDouble(rowId, columnIndex));
+            rows[outRowId++] = BigDecimal.valueOf(dataBlock.getDouble(inRowId, columnIndex));
             break;
           case BIG_DECIMAL:
-            rows[rowId] = BigDecimal.valueOf(dataBlock.getBigDecimal(rowId, columnIndex).doubleValue());
+            rows[outRowId++] = BigDecimal.valueOf(dataBlock.getBigDecimal(inRowId, columnIndex).doubleValue());
             break;
           default:
             throw new IllegalStateException(
                 String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
         }
       }
-      return rows;
-    } else {
-      int outRowId = 0;
-      for (int inRowId = 0; inRowId < numRows; inRowId++) {
-        if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
-          if (nullBitmap != null && nullBitmap.contains(inRowId)) {
-            outRowId++;
-            continue;
-          }
-          switch (columnDataTypes[columnIndex]) {
-            case INT:
-            case BOOLEAN:
-              rows[outRowId++] = BigDecimal.valueOf(dataBlock.getInt(inRowId, columnIndex));
-              break;
-            case LONG:
-              rows[outRowId++] = BigDecimal.valueOf(dataBlock.getLong(inRowId, columnIndex));
-              break;
-            case FLOAT:
-              rows[outRowId++] = BigDecimal.valueOf(dataBlock.getFloat(inRowId, columnIndex));
-              break;
-            case DOUBLE:
-              rows[outRowId++] = BigDecimal.valueOf(dataBlock.getDouble(inRowId, columnIndex));
-              break;
-            case BIG_DECIMAL:
-              rows[outRowId++] = BigDecimal.valueOf(dataBlock.getBigDecimal(inRowId, columnIndex).doubleValue());
-              break;
-            default:
-              throw new IllegalStateException(
-                  String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
-          }
-        }
-      }
-      return Arrays.copyOfRange(rows, 0, outRowId);
     }
+    return Arrays.copyOfRange(rows, 0, outRowId);
   }
 
   /**
@@ -688,27 +829,17 @@ public final class DataBlockUtils {
     int numRows = dataBlock.getNumberOfRows();
 
     String[] rows = new String[numRows];
-    if (filterArgIdx == -1) {
-      for (int rowId = 0; rowId < numRows; rowId++) {
-        if (nullBitmap != null && nullBitmap.contains(rowId)) {
+    int outRowId = 0;
+    for (int inRowId = 0; inRowId < numRows; inRowId++) {
+      if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
+        if (nullBitmap != null && nullBitmap.contains(inRowId)) {
+          outRowId++;
           continue;
         }
-        rows[rowId] = dataBlock.getString(rowId, columnIndex);
+        rows[outRowId++] = dataBlock.getString(inRowId, columnIndex);
       }
-      return rows;
-    } else {
-      int outRowId = 0;
-      for (int inRowId = 0; inRowId < numRows; inRowId++) {
-        if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
-          if (nullBitmap != null && nullBitmap.contains(inRowId)) {
-            outRowId++;
-            continue;
-          }
-          rows[outRowId++] = dataBlock.getString(inRowId, columnIndex);
-        }
-      }
-      return Arrays.copyOfRange(rows, 0, outRowId);
     }
+    return Arrays.copyOfRange(rows, 0, outRowId);
   }
 
   /**
@@ -728,26 +859,16 @@ public final class DataBlockUtils {
     int numRows = dataBlock.getNumberOfRows();
 
     byte[][] rows = new byte[numRows][];
-    if (filterArgIdx == -1) {
-      for (int rowId = 0; rowId < numRows; rowId++) {
-        if (nullBitmap != null && nullBitmap.contains(rowId)) {
+    int outRowId = 0;
+    for (int inRowId = 0; inRowId < numRows; inRowId++) {
+      if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
+        if (nullBitmap != null && nullBitmap.contains(inRowId)) {
+          outRowId++;
           continue;
         }
-        rows[rowId] = dataBlock.getBytes(rowId, columnIndex).getBytes();
+        rows[outRowId++] = dataBlock.getBytes(inRowId, columnIndex).getBytes();
       }
-      return rows;
-    } else {
-      int outRowId = 0;
-      for (int inRowId = 0; inRowId < numRows; inRowId++) {
-        if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
-          if (nullBitmap != null && nullBitmap.contains(inRowId)) {
-            outRowId++;
-            continue;
-          }
-          rows[outRowId++] = dataBlock.getBytes(inRowId, columnIndex).getBytes();
-        }
-      }
-      return Arrays.copyOfRange(rows, 0, outRowId);
     }
+    return Arrays.copyOfRange(rows, 0, outRowId);
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datablock/DataBlockUtils.java
@@ -23,6 +23,7 @@ import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.sql.Timestamp;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -278,7 +279,7 @@ public final class DataBlockUtils {
    * TODO: Add support for COLUMNAR format.
    * @return int array of values in the column
    */
-  public static int[] extractIntValuesForColumn(DataBlock dataBlock, int columnIndex) {
+  public static int[] extractIntValuesForColumn(DataBlock dataBlock, int columnIndex, int filterArgIdx) {
     DataSchema dataSchema = dataBlock.getDataSchema();
     DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
 
@@ -287,34 +288,67 @@ public final class DataBlockUtils {
     int numRows = dataBlock.getNumberOfRows();
 
     int[] rows = new int[numRows];
-    for (int rowId = 0; rowId < numRows; rowId++) {
-      if (nullBitmap != null && nullBitmap.contains(rowId)) {
-        continue;
+    if (filterArgIdx == -1) {
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        if (nullBitmap != null && nullBitmap.contains(rowId)) {
+          continue;
+        }
+        switch (columnDataTypes[columnIndex]) {
+          case INT:
+          case BOOLEAN:
+            rows[rowId] = dataBlock.getInt(rowId, columnIndex);
+            break;
+          case LONG:
+            rows[rowId] = (int) dataBlock.getLong(rowId, columnIndex);
+            break;
+          case FLOAT:
+            rows[rowId] = (int) dataBlock.getFloat(rowId, columnIndex);
+            break;
+          case DOUBLE:
+            rows[rowId] = (int) dataBlock.getDouble(rowId, columnIndex);
+            break;
+          case BIG_DECIMAL:
+            rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).intValue();
+            break;
+          default:
+            throw new IllegalStateException(
+                String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+        }
       }
-
-      switch (columnDataTypes[columnIndex]) {
-        case INT:
-        case BOOLEAN:
-          rows[rowId] = dataBlock.getInt(rowId, columnIndex);
-          break;
-        case LONG:
-          rows[rowId] = (int) dataBlock.getLong(rowId, columnIndex);
-          break;
-        case FLOAT:
-          rows[rowId] = (int) dataBlock.getFloat(rowId, columnIndex);
-          break;
-        case DOUBLE:
-          rows[rowId] = (int) dataBlock.getDouble(rowId, columnIndex);
-          break;
-        case BIG_DECIMAL:
-          rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).intValue();
-          break;
-        default:
-          throw new IllegalStateException(
-              String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+      return rows;
+    } else {
+      int outRowId = 0;
+      for (int inRowId = 0; inRowId < numRows; inRowId++) {
+        if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
+          if (nullBitmap != null && nullBitmap.contains(inRowId)) {
+            outRowId++;
+            continue;
+          }
+          switch (columnDataTypes[columnIndex]) {
+            case INT:
+            case BOOLEAN:
+              rows[outRowId++] = dataBlock.getInt(inRowId, columnIndex);
+              break;
+            case LONG:
+              rows[outRowId++] = (int) dataBlock.getLong(inRowId, columnIndex);
+              break;
+            case FLOAT:
+              rows[outRowId++] = (int) dataBlock.getFloat(inRowId, columnIndex);
+              break;
+            case DOUBLE:
+              rows[outRowId++] = (int) dataBlock.getDouble(inRowId, columnIndex);
+              break;
+            case BIG_DECIMAL:
+              rows[outRowId++] = dataBlock.getBigDecimal(inRowId, columnIndex).intValue();
+              break;
+            default:
+              throw new IllegalStateException(
+                  String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+          }
+        }
       }
+      return Arrays.copyOfRange(rows, 0, outRowId);
     }
-    return rows;
   }
 
   /**
@@ -325,7 +359,7 @@ public final class DataBlockUtils {
    * TODO: Add support for COLUMNAR format.
    * @return long array of values in the column
    */
-  public static long[] extractLongValuesForColumn(DataBlock dataBlock, int columnIndex) {
+  public static long[] extractLongValuesForColumn(DataBlock dataBlock, int columnIndex, int filterArgIdx) {
     DataSchema dataSchema = dataBlock.getDataSchema();
     DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
 
@@ -334,34 +368,67 @@ public final class DataBlockUtils {
     int numRows = dataBlock.getNumberOfRows();
 
     long[] rows = new long[numRows];
-    for (int rowId = 0; rowId < numRows; rowId++) {
-      if (nullBitmap != null && nullBitmap.contains(rowId)) {
-        continue;
+    if (filterArgIdx == -1) {
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        if (nullBitmap != null && nullBitmap.contains(rowId)) {
+          continue;
+        }
+        switch (columnDataTypes[columnIndex]) {
+          case INT:
+          case BOOLEAN:
+            rows[rowId] = dataBlock.getInt(rowId, columnIndex);
+            break;
+          case LONG:
+            rows[rowId] = dataBlock.getLong(rowId, columnIndex);
+            break;
+          case FLOAT:
+            rows[rowId] = (long) dataBlock.getFloat(rowId, columnIndex);
+            break;
+          case DOUBLE:
+            rows[rowId] = (long) dataBlock.getDouble(rowId, columnIndex);
+            break;
+          case BIG_DECIMAL:
+            rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).longValue();
+            break;
+          default:
+            throw new IllegalStateException(
+                String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+        }
       }
-
-      switch (columnDataTypes[columnIndex]) {
-        case INT:
-        case BOOLEAN:
-          rows[rowId] = dataBlock.getInt(rowId, columnIndex);
-          break;
-        case LONG:
-          rows[rowId] = dataBlock.getLong(rowId, columnIndex);
-          break;
-        case FLOAT:
-          rows[rowId] = (long) dataBlock.getFloat(rowId, columnIndex);
-          break;
-        case DOUBLE:
-          rows[rowId] = (long) dataBlock.getDouble(rowId, columnIndex);
-          break;
-        case BIG_DECIMAL:
-          rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).longValue();
-          break;
-        default:
-          throw new IllegalStateException(
-              String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+      return rows;
+    } else {
+      int outRowId = 0;
+      for (int inRowId = 0; inRowId < numRows; inRowId++) {
+        if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
+          if (nullBitmap != null && nullBitmap.contains(inRowId)) {
+            outRowId++;
+            continue;
+          }
+          switch (columnDataTypes[columnIndex]) {
+            case INT:
+            case BOOLEAN:
+              rows[outRowId++] = dataBlock.getInt(inRowId, columnIndex);
+              break;
+            case LONG:
+              rows[outRowId++] = dataBlock.getLong(inRowId, columnIndex);
+              break;
+            case FLOAT:
+              rows[outRowId++] = (long) dataBlock.getFloat(inRowId, columnIndex);
+              break;
+            case DOUBLE:
+              rows[outRowId++] = (long) dataBlock.getDouble(inRowId, columnIndex);
+              break;
+            case BIG_DECIMAL:
+              rows[outRowId++] = dataBlock.getBigDecimal(inRowId, columnIndex).longValue();
+              break;
+            default:
+              throw new IllegalStateException(
+                  String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+          }
+        }
       }
+      return Arrays.copyOfRange(rows, 0, outRowId);
     }
-    return rows;
   }
 
   /**
@@ -372,7 +439,7 @@ public final class DataBlockUtils {
    * TODO: Add support for COLUMNAR format.
    * @return float array of values in the column
    */
-  public static float[] extractFloatValuesForColumn(DataBlock dataBlock, int columnIndex) {
+  public static float[] extractFloatValuesForColumn(DataBlock dataBlock, int columnIndex, int filterArgIdx) {
     DataSchema dataSchema = dataBlock.getDataSchema();
     DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
 
@@ -381,35 +448,67 @@ public final class DataBlockUtils {
     int numRows = dataBlock.getNumberOfRows();
 
     float[] rows = new float[numRows];
-    for (int rowId = 0; rowId < numRows; rowId++) {
-      if (nullBitmap != null && nullBitmap.contains(rowId)) {
-        continue;
+    if (filterArgIdx == -1) {
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        if (nullBitmap != null && nullBitmap.contains(rowId)) {
+          continue;
+        }
+        switch (columnDataTypes[columnIndex]) {
+          case INT:
+          case BOOLEAN:
+            rows[rowId] = dataBlock.getInt(rowId, columnIndex);
+            break;
+          case LONG:
+            rows[rowId] = dataBlock.getLong(rowId, columnIndex);
+            break;
+          case FLOAT:
+            rows[rowId] = dataBlock.getFloat(rowId, columnIndex);
+            break;
+          case DOUBLE:
+            rows[rowId] = (float) dataBlock.getDouble(rowId, columnIndex);
+            break;
+          case BIG_DECIMAL:
+            rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).floatValue();
+            break;
+          default:
+            throw new IllegalStateException(
+                String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+        }
       }
-
-      switch (columnDataTypes[columnIndex]) {
-        case INT:
-        case BOOLEAN:
-          rows[rowId] = dataBlock.getInt(rowId, columnIndex);
-          break;
-        case LONG:
-          rows[rowId] = dataBlock.getLong(rowId, columnIndex);
-          break;
-        case FLOAT:
-          rows[rowId] = dataBlock.getFloat(rowId, columnIndex);
-          break;
-        case DOUBLE:
-          rows[rowId] = (float) dataBlock.getDouble(rowId, columnIndex);
-          break;
-        case BIG_DECIMAL:
-          rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).floatValue();
-          break;
-        default:
-          throw new IllegalStateException(
-              String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+      return rows;
+    } else {
+      int outRowId = 0;
+      for (int inRowId = 0; inRowId < numRows; inRowId++) {
+        if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
+          if (nullBitmap != null && nullBitmap.contains(inRowId)) {
+            outRowId++;
+            continue;
+          }
+          switch (columnDataTypes[columnIndex]) {
+            case INT:
+            case BOOLEAN:
+              rows[outRowId++] = dataBlock.getInt(inRowId, columnIndex);
+              break;
+            case LONG:
+              rows[outRowId++] = dataBlock.getLong(inRowId, columnIndex);
+              break;
+            case FLOAT:
+              rows[outRowId++] = dataBlock.getFloat(inRowId, columnIndex);
+              break;
+            case DOUBLE:
+              rows[outRowId++] = (float) dataBlock.getDouble(inRowId, columnIndex);
+              break;
+            case BIG_DECIMAL:
+              rows[outRowId++] = dataBlock.getBigDecimal(inRowId, columnIndex).floatValue();
+              break;
+            default:
+              throw new IllegalStateException(
+                  String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+          }
+        }
       }
+      return Arrays.copyOfRange(rows, 0, outRowId);
     }
-
-    return rows;
   }
 
   /**
@@ -420,7 +519,7 @@ public final class DataBlockUtils {
    * TODO: Add support for COLUMNAR format.
    * @return double array of values in the column
    */
-  public static double[] extractDoubleValuesForColumn(DataBlock dataBlock, int columnIndex) {
+  public static double[] extractDoubleValuesForColumn(DataBlock dataBlock, int columnIndex, int filterArgIdx) {
     DataSchema dataSchema = dataBlock.getDataSchema();
     DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
 
@@ -429,34 +528,67 @@ public final class DataBlockUtils {
     int numRows = dataBlock.getNumberOfRows();
 
     double[] rows = new double[numRows];
-    for (int rowId = 0; rowId < numRows; rowId++) {
-      if (nullBitmap != null && nullBitmap.contains(rowId)) {
-        continue;
+    if (filterArgIdx == -1) {
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        if (nullBitmap != null && nullBitmap.contains(rowId)) {
+          continue;
+        }
+        switch (columnDataTypes[columnIndex]) {
+          case INT:
+          case BOOLEAN:
+            rows[rowId] = dataBlock.getInt(rowId, columnIndex);
+            break;
+          case LONG:
+            rows[rowId] = dataBlock.getLong(rowId, columnIndex);
+            break;
+          case FLOAT:
+            rows[rowId] = dataBlock.getFloat(rowId, columnIndex);
+            break;
+          case DOUBLE:
+            rows[rowId] = dataBlock.getDouble(rowId, columnIndex);
+            break;
+          case BIG_DECIMAL:
+            rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).doubleValue();
+            break;
+          default:
+            throw new IllegalStateException(
+                String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+        }
       }
-      switch (columnDataTypes[columnIndex]) {
-        case INT:
-        case BOOLEAN:
-          rows[rowId] = dataBlock.getInt(rowId, columnIndex);
-          break;
-        case LONG:
-          rows[rowId] = dataBlock.getLong(rowId, columnIndex);
-          break;
-        case FLOAT:
-          rows[rowId] = dataBlock.getFloat(rowId, columnIndex);
-          break;
-        case DOUBLE:
-          rows[rowId] = dataBlock.getDouble(rowId, columnIndex);
-          break;
-        case BIG_DECIMAL:
-          rows[rowId] = dataBlock.getBigDecimal(rowId, columnIndex).doubleValue();
-          break;
-        default:
-          throw new IllegalStateException(
-              String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+      return rows;
+    } else {
+      int outRowId = 0;
+      for (int inRowId = 0; inRowId < numRows; inRowId++) {
+        if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
+          if (nullBitmap != null && nullBitmap.contains(inRowId)) {
+            outRowId++;
+            continue;
+          }
+          switch (columnDataTypes[columnIndex]) {
+            case INT:
+            case BOOLEAN:
+              rows[outRowId++] = dataBlock.getInt(inRowId, columnIndex);
+              break;
+            case LONG:
+              rows[outRowId++] = dataBlock.getLong(inRowId, columnIndex);
+              break;
+            case FLOAT:
+              rows[outRowId++] = dataBlock.getFloat(inRowId, columnIndex);
+              break;
+            case DOUBLE:
+              rows[outRowId++] = dataBlock.getDouble(inRowId, columnIndex);
+              break;
+            case BIG_DECIMAL:
+              rows[outRowId++] = dataBlock.getBigDecimal(inRowId, columnIndex).doubleValue();
+              break;
+            default:
+              throw new IllegalStateException(
+                  String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+          }
+        }
       }
+      return Arrays.copyOfRange(rows, 0, outRowId);
     }
-
-    return rows;
   }
 
   /**
@@ -467,7 +599,7 @@ public final class DataBlockUtils {
    * TODO: Add support for COLUMNAR format.
    * @return BigDecimal array of values in the column
    */
-  public static BigDecimal[] extractBigDecimalValuesForColumn(DataBlock dataBlock, int columnIndex) {
+  public static BigDecimal[] extractBigDecimalValuesForColumn(DataBlock dataBlock, int columnIndex, int filterArgIdx) {
     DataSchema dataSchema = dataBlock.getDataSchema();
     DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
 
@@ -476,35 +608,67 @@ public final class DataBlockUtils {
     int numRows = dataBlock.getNumberOfRows();
 
     BigDecimal[] rows = new BigDecimal[numRows];
-    for (int rowId = 0; rowId < numRows; rowId++) {
-      if (nullBitmap != null && nullBitmap.contains(rowId)) {
-        continue;
+    if (filterArgIdx == -1) {
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        if (nullBitmap != null && nullBitmap.contains(rowId)) {
+          continue;
+        }
+        switch (columnDataTypes[columnIndex]) {
+          case INT:
+          case BOOLEAN:
+            rows[rowId] = BigDecimal.valueOf(dataBlock.getInt(rowId, columnIndex));
+            break;
+          case LONG:
+            rows[rowId] = BigDecimal.valueOf(dataBlock.getLong(rowId, columnIndex));
+            break;
+          case FLOAT:
+            rows[rowId] = BigDecimal.valueOf(dataBlock.getFloat(rowId, columnIndex));
+            break;
+          case DOUBLE:
+            rows[rowId] = BigDecimal.valueOf(dataBlock.getDouble(rowId, columnIndex));
+            break;
+          case BIG_DECIMAL:
+            rows[rowId] = BigDecimal.valueOf(dataBlock.getBigDecimal(rowId, columnIndex).doubleValue());
+            break;
+          default:
+            throw new IllegalStateException(
+                String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+        }
       }
-
-      switch (columnDataTypes[columnIndex]) {
-        case INT:
-        case BOOLEAN:
-          rows[rowId] = BigDecimal.valueOf(dataBlock.getInt(rowId, columnIndex));
-          break;
-        case LONG:
-          rows[rowId] = BigDecimal.valueOf(dataBlock.getLong(rowId, columnIndex));
-          break;
-        case FLOAT:
-          rows[rowId] = BigDecimal.valueOf(dataBlock.getFloat(rowId, columnIndex));
-          break;
-        case DOUBLE:
-          rows[rowId] = BigDecimal.valueOf(dataBlock.getDouble(rowId, columnIndex));
-          break;
-        case BIG_DECIMAL:
-          rows[rowId] = BigDecimal.valueOf(dataBlock.getBigDecimal(rowId, columnIndex).doubleValue());
-          break;
-        default:
-          throw new IllegalStateException(
-              String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+      return rows;
+    } else {
+      int outRowId = 0;
+      for (int inRowId = 0; inRowId < numRows; inRowId++) {
+        if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
+          if (nullBitmap != null && nullBitmap.contains(inRowId)) {
+            outRowId++;
+            continue;
+          }
+          switch (columnDataTypes[columnIndex]) {
+            case INT:
+            case BOOLEAN:
+              rows[outRowId++] = BigDecimal.valueOf(dataBlock.getInt(inRowId, columnIndex));
+              break;
+            case LONG:
+              rows[outRowId++] = BigDecimal.valueOf(dataBlock.getLong(inRowId, columnIndex));
+              break;
+            case FLOAT:
+              rows[outRowId++] = BigDecimal.valueOf(dataBlock.getFloat(inRowId, columnIndex));
+              break;
+            case DOUBLE:
+              rows[outRowId++] = BigDecimal.valueOf(dataBlock.getDouble(inRowId, columnIndex));
+              break;
+            case BIG_DECIMAL:
+              rows[outRowId++] = BigDecimal.valueOf(dataBlock.getBigDecimal(inRowId, columnIndex).doubleValue());
+              break;
+            default:
+              throw new IllegalStateException(
+                  String.format("Unsupported data type: %s for column: %s", columnDataTypes[columnIndex], columnIndex));
+          }
+        }
       }
+      return Arrays.copyOfRange(rows, 0, outRowId);
     }
-
-    return rows;
   }
 
   /**
@@ -515,7 +679,7 @@ public final class DataBlockUtils {
    * TODO: Add support for COLUMNAR format.
    * @return String array of values in the column
    */
-  public static String[] extractStringValuesForColumn(DataBlock dataBlock, int columnIndex) {
+  public static String[] extractStringValuesForColumn(DataBlock dataBlock, int columnIndex, int filterArgIdx) {
     DataSchema dataSchema = dataBlock.getDataSchema();
     DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
 
@@ -524,14 +688,27 @@ public final class DataBlockUtils {
     int numRows = dataBlock.getNumberOfRows();
 
     String[] rows = new String[numRows];
-    for (int rowId = 0; rowId < numRows; rowId++) {
-      if (nullBitmap != null && nullBitmap.contains(rowId)) {
-        continue;
+    if (filterArgIdx == -1) {
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        if (nullBitmap != null && nullBitmap.contains(rowId)) {
+          continue;
+        }
+        rows[rowId] = dataBlock.getString(rowId, columnIndex);
       }
-      rows[rowId] = dataBlock.getString(rowId, columnIndex);
+      return rows;
+    } else {
+      int outRowId = 0;
+      for (int inRowId = 0; inRowId < numRows; inRowId++) {
+        if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
+          if (nullBitmap != null && nullBitmap.contains(inRowId)) {
+            outRowId++;
+            continue;
+          }
+          rows[outRowId++] = dataBlock.getString(inRowId, columnIndex);
+        }
+      }
+      return Arrays.copyOfRange(rows, 0, outRowId);
     }
-
-    return rows;
   }
 
   /**
@@ -542,7 +719,7 @@ public final class DataBlockUtils {
    * TODO: Add support for COLUMNAR format.
    * @return byte array of values in the column
    */
-  public static byte[][] extractBytesValuesForColumn(DataBlock dataBlock, int columnIndex) {
+  public static byte[][] extractBytesValuesForColumn(DataBlock dataBlock, int columnIndex, int filterArgIdx) {
     DataSchema dataSchema = dataBlock.getDataSchema();
     DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
 
@@ -551,13 +728,26 @@ public final class DataBlockUtils {
     int numRows = dataBlock.getNumberOfRows();
 
     byte[][] rows = new byte[numRows][];
-    for (int rowId = 0; rowId < numRows; rowId++) {
-      if (nullBitmap != null && nullBitmap.contains(rowId)) {
-        continue;
+    if (filterArgIdx == -1) {
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        if (nullBitmap != null && nullBitmap.contains(rowId)) {
+          continue;
+        }
+        rows[rowId] = dataBlock.getBytes(rowId, columnIndex).getBytes();
       }
-      rows[rowId] = dataBlock.getBytes(rowId, columnIndex).getBytes();
+      return rows;
+    } else {
+      int outRowId = 0;
+      for (int inRowId = 0; inRowId < numRows; inRowId++) {
+        if (dataBlock.getInt(inRowId, filterArgIdx) == 1) {
+          if (nullBitmap != null && nullBitmap.contains(inRowId)) {
+            outRowId++;
+            continue;
+          }
+          rows[outRowId++] = dataBlock.getBytes(inRowId, columnIndex).getBytes();
+        }
+      }
+      return Arrays.copyOfRange(rows, 0, outRowId);
     }
-
-    return rows;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/IntermediateStageBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/IntermediateStageBlockValSet.java
@@ -37,13 +37,16 @@ import org.roaringbitmap.RoaringBitmap;
 public class IntermediateStageBlockValSet implements BlockValSet {
   private final FieldSpec.DataType _dataType;
   private final DataBlock _dataBlock;
-  private final int _index;
+  private final int _colIndex;
+  private final int _filterArgIdx;
   private final RoaringBitmap _nullBitMap;
 
-  public IntermediateStageBlockValSet(DataSchema.ColumnDataType columnDataType, DataBlock dataBlock, int colIndex) {
+  public IntermediateStageBlockValSet(DataSchema.ColumnDataType columnDataType, DataBlock dataBlock, int colIndex,
+      int filterArgIdx) {
     _dataType = columnDataType.toDataType();
     _dataBlock = dataBlock;
-    _index = colIndex;
+    _colIndex = colIndex;
+    _filterArgIdx = filterArgIdx;
     _nullBitMap = dataBlock.getNullRowIds(colIndex);
   }
 
@@ -80,37 +83,37 @@ public class IntermediateStageBlockValSet implements BlockValSet {
 
   @Override
   public int[] getIntValuesSV() {
-    return DataBlockUtils.extractIntValuesForColumn(_dataBlock, _index);
+    return DataBlockUtils.extractIntValuesForColumn(_dataBlock, _colIndex, _filterArgIdx);
   }
 
   @Override
   public long[] getLongValuesSV() {
-    return DataBlockUtils.extractLongValuesForColumn(_dataBlock, _index);
+    return DataBlockUtils.extractLongValuesForColumn(_dataBlock, _colIndex, _filterArgIdx);
   }
 
   @Override
   public float[] getFloatValuesSV() {
-    return DataBlockUtils.extractFloatValuesForColumn(_dataBlock, _index);
+    return DataBlockUtils.extractFloatValuesForColumn(_dataBlock, _colIndex, _filterArgIdx);
   }
 
   @Override
   public double[] getDoubleValuesSV() {
-    return DataBlockUtils.extractDoubleValuesForColumn(_dataBlock, _index);
+    return DataBlockUtils.extractDoubleValuesForColumn(_dataBlock, _colIndex, _filterArgIdx);
   }
 
   @Override
   public BigDecimal[] getBigDecimalValuesSV() {
-    return DataBlockUtils.extractBigDecimalValuesForColumn(_dataBlock, _index);
+    return DataBlockUtils.extractBigDecimalValuesForColumn(_dataBlock, _colIndex, _filterArgIdx);
   }
 
   @Override
   public String[] getStringValuesSV() {
-    return DataBlockUtils.extractStringValuesForColumn(_dataBlock, _index);
+    return DataBlockUtils.extractStringValuesForColumn(_dataBlock, _colIndex, _filterArgIdx);
   }
 
   @Override
   public byte[][] getBytesValuesSV() {
-    return DataBlockUtils.extractBytesValuesForColumn(_dataBlock, _index);
+    return DataBlockUtils.extractBytesValuesForColumn(_dataBlock, _colIndex, _filterArgIdx);
   }
 
   @Override

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotAggregateExchangeNodeInsertRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotAggregateExchangeNodeInsertRule.java
@@ -324,7 +324,7 @@ public class PinotAggregateExchangeNodeInsertRule extends RelOptRule {
         orgAggCall.isApproximate(),
         orgAggCall.ignoreNulls(),
         argList,
-        orgAggCall.filterArg,
+        aggType.isInputIntermediateFormat() ? -1 : orgAggCall.filterArg,
         orgAggCall.distinctKeys,
         orgAggCall.collation,
         numberGroups,

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/CalciteRexExpressionParser.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/CalciteRexExpressionParser.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.parser;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -67,18 +68,29 @@ public class CalciteRexExpressionParser {
   // Relational conversion Utils
   // --------------------------------------------------------------------------
 
-  public static List<Expression> overwriteSelectList(List<RexExpression> rexNodeList, PinotQuery pinotQuery) {
-    return addSelectList(new ArrayList<>(), rexNodeList, pinotQuery);
-  }
-
-  public static List<Expression> addSelectList(List<Expression> existingList, List<RexExpression> rexNodeList,
-      PinotQuery pinotQuery) {
-    List<Expression> selectExpr = new ArrayList<>(existingList);
-
-    final Iterator<RexExpression> iterator = rexNodeList.iterator();
+  public static List<Expression> convertProjectList(List<RexExpression> projectList, PinotQuery pinotQuery) {
+    List<Expression> selectExpr = new ArrayList<>();
+    final Iterator<RexExpression> iterator = projectList.iterator();
     while (iterator.hasNext()) {
       final RexExpression next = iterator.next();
       selectExpr.add(toExpression(next, pinotQuery));
+    }
+    return selectExpr;
+  }
+
+  public static List<Expression> convertAggregateList(List<Expression> groupSetList, List<RexExpression> aggCallList,
+      List<Integer> filterArgIndices, PinotQuery pinotQuery) {
+    List<Expression> selectExpr = new ArrayList<>(groupSetList);
+
+    for (int idx = 0; idx < aggCallList.size(); idx++) {
+      final RexExpression aggCall = aggCallList.get(idx);
+      int filterArgIdx = filterArgIndices.get(idx);
+      if (filterArgIdx == -1) {
+        selectExpr.add(toExpression(aggCall, pinotQuery));
+      } else {
+        selectExpr.add(toExpression(new RexExpression.FunctionCall(SqlKind.FILTER, aggCall.getDataType(), "FILTER",
+            Arrays.asList(aggCall, new RexExpression.InputRef(filterArgIdx))), pinotQuery));
+      }
     }
 
     return selectExpr;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/AggregateNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/AggregateNode.java
@@ -36,6 +36,8 @@ public class AggregateNode extends AbstractPlanNode {
   @ProtoProperties
   private List<RexExpression> _aggCalls;
   @ProtoProperties
+  private List<Integer> _filterArgIndices;
+  @ProtoProperties
   private List<RexExpression> _groupSet;
   @ProtoProperties
   private AggType _aggType;
@@ -49,6 +51,7 @@ public class AggregateNode extends AbstractPlanNode {
     super(planFragmentId, dataSchema);
     Preconditions.checkState(areHintsValid(relHints), "invalid sql hint for agg node: {}", relHints);
     _aggCalls = aggCalls.stream().map(RexExpression::toRexExpression).collect(Collectors.toList());
+    _filterArgIndices = aggCalls.stream().map(c -> c.filterArg).collect(Collectors.toList());
     _groupSet = groupSet;
     _nodeHint = new NodeHint(relHints);
     _aggType = AggType.valueOf(PinotHintStrategyTable.getHintOption(relHints, PinotHintOptions.INTERNAL_AGG_OPTIONS,
@@ -61,6 +64,10 @@ public class AggregateNode extends AbstractPlanNode {
 
   public List<RexExpression> getAggCalls() {
     return _aggCalls;
+  }
+
+  public List<Integer> getFilterArgIndices() {
+    return _filterArgIndices;
   }
 
   public List<RexExpression> getGroupSet() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -22,7 +22,6 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -103,9 +102,8 @@ public class AggregateOperator extends MultiStageOperator {
     _aggType = aggType;
     // filter arg index array
     int[] filterArgIndexArray;
-    if (filterArgIndices == null) {
-      filterArgIndexArray = new int[aggCalls.size()];
-      Arrays.fill(filterArgIndexArray, -1);
+    if (filterArgIndices == null || filterArgIndices.size() == 0) {
+      filterArgIndexArray = null;
     } else {
       filterArgIndexArray = filterArgIndices.stream().mapToInt(Integer::intValue).toArray();
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -22,6 +22,7 @@ import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
@@ -45,6 +46,7 @@ import org.apache.pinot.query.planner.plannode.AggregateNode.AggType;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 /**
@@ -90,26 +92,24 @@ public class AggregateOperator extends MultiStageOperator {
   private MultistageAggregationExecutor _aggregationExecutor;
   private MultistageGroupByExecutor _groupByExecutor;
 
-  // TODO: refactor Pinot Reducer code to support the intermediate stage agg operator.
-  // aggCalls has to be a list of FunctionCall and cannot be null
-  // groupSet has to be a list of InputRef and cannot be null
-  // TODO: Add these two checks when we confirm we can handle error in upstream ctor call.
-  public AggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator,
-      DataSchema resultSchema, DataSchema inputSchema, List<RexExpression> aggCalls, List<RexExpression> groupSet,
-      AggType aggType) {
-    this(context, inputOperator, resultSchema, inputSchema, aggCalls, groupSet, aggType,
-        new AbstractPlanNode.NodeHint());
-  }
-
   @VisibleForTesting
-  public AggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator,
-      DataSchema resultSchema, DataSchema inputSchema, List<RexExpression> aggCalls, List<RexExpression> groupSet,
-      AggType aggType, AbstractPlanNode.NodeHint nodeHint) {
+  public AggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator, DataSchema resultSchema,
+      DataSchema inputSchema, List<RexExpression> aggCalls, List<RexExpression> groupSet, AggType aggType,
+      @Nullable List<Integer> filterArgIndices, @Nullable AbstractPlanNode.NodeHint nodeHint) {
     super(context);
     _inputOperator = inputOperator;
     _resultSchema = resultSchema;
     _inputSchema = inputSchema;
     _aggType = aggType;
+    // filter arg index array
+    int[] filterArgIndexArray;
+    if (filterArgIndices == null) {
+      filterArgIndexArray = new int[aggCalls.size()];
+      Arrays.fill(filterArgIndexArray, -1);
+    } else {
+      filterArgIndexArray = filterArgIndices.stream().mapToInt(Integer::intValue).toArray();
+    }
+    // filter operand and literal hints
     if (nodeHint != null && nodeHint._hintOptions != null
         && nodeHint._hintOptions.get(PinotHintOptions.INTERNAL_AGG_OPTIONS) != null) {
       _aggCallSignatureMap = LiteralHintUtils.hintStringToLiteralMap(nodeHint._hintOptions
@@ -126,6 +126,7 @@ public class AggregateOperator extends MultiStageOperator {
 
     // Convert groupSet to ExpressionContext that our aggregation functions understand.
     List<ExpressionContext> groupByExpr = getGroupSet(groupSet);
+
     List<FunctionContext> functionContexts = getFunctionContexts(aggCalls);
     AggregationFunction[] aggFunctions = new AggregationFunction[functionContexts.size()];
 
@@ -136,12 +137,12 @@ public class AggregateOperator extends MultiStageOperator {
     // Initialize the appropriate executor.
     if (!groupSet.isEmpty()) {
       _isGroupByAggregation = true;
-      _groupByExecutor = new MultistageGroupByExecutor(groupByExpr, aggFunctions, aggType, _colNameToIndexMap,
-          _resultSchema);
+      _groupByExecutor = new MultistageGroupByExecutor(groupByExpr, aggFunctions, filterArgIndexArray, aggType,
+          _colNameToIndexMap, _resultSchema);
     } else {
       _isGroupByAggregation = false;
-      _aggregationExecutor = new MultistageAggregationExecutor(aggFunctions, aggType, _colNameToIndexMap,
-          _resultSchema);
+      _aggregationExecutor = new MultistageAggregationExecutor(aggFunctions, filterArgIndexArray, aggType,
+          _colNameToIndexMap, _resultSchema);
     }
   }
 
@@ -253,7 +254,7 @@ public class AggregateOperator extends MultiStageOperator {
     // The literal value here does not matter. We create a dummy literal here just so that the count aggregation
     // has some column to process.
     if (aggArguments.isEmpty()) {
-      aggArguments.add(ExpressionContext.forIdentifier("__PLACEHOLDER__"));
+      aggArguments.add(ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "__PLACEHOLDER__"));
     }
 
     return new FunctionContext(FunctionContext.Type.AGGREGATION, functionName, aggArguments);
@@ -321,7 +322,7 @@ public class AggregateOperator extends MultiStageOperator {
   //  convert the unserialized format to serialized format of BaseDataBlock. Then it will convert it back to column
   //  value primitive type.
   static Map<ExpressionContext, BlockValSet> getBlockValSetMap(AggregationFunction aggFunction,
-      TransferableBlock block, DataSchema inputDataSchema, Map<String, Integer> colNameToIndexMap) {
+      TransferableBlock block, DataSchema inputDataSchema, Map<String, Integer> colNameToIndexMap, int filterArgIdx) {
     List<ExpressionContext> expressions = aggFunction.getInputExpressions();
     int numExpressions = expressions.size();
     if (numExpressions == 0) {
@@ -335,10 +336,23 @@ public class AggregateOperator extends MultiStageOperator {
         int index = colNameToIndexMap.get(expression.getIdentifier());
         DataSchema.ColumnDataType dataType = inputDataSchema.getColumnDataType(index);
         Preconditions.checkState(block.getType().equals(DataBlock.Type.ROW), "Datablock type is not ROW");
-        blockValSetMap.put(expression, new IntermediateStageBlockValSet(dataType, block.getDataBlock(), index));
+        blockValSetMap.put(expression, new IntermediateStageBlockValSet(dataType, block.getDataBlock(), index,
+            filterArgIdx));
       }
     }
     return blockValSetMap;
+  }
+
+  static int computeBlockNumRows(TransferableBlock block, int filterArgIdx) {
+    if (filterArgIdx == -1) {
+      return block.getNumRows();
+    } else {
+      int rowCount = 0;
+      for (int rowId = 0; rowId < block.getNumRows(); rowId++) {
+        rowCount += block.getDataBlock().getInt(rowId, filterArgIdx) == 1 ? 1 : 0;
+      }
+      return rowCount;
+    }
   }
 
   static Object extractValueFromRow(AggregationFunction aggregationFunction, Object[] row,

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageAggregationExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageAggregationExecutor.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.runtime.operator;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
@@ -48,7 +49,7 @@ public class MultistageAggregationExecutor {
   private final AggregationResultHolder[] _aggregateResultHolder;
   private final Object[] _mergeResultHolder;
 
-  public MultistageAggregationExecutor(AggregationFunction[] aggFunctions, int[] filterArgIndices,
+  public MultistageAggregationExecutor(AggregationFunction[] aggFunctions, @Nullable int[] filterArgIndices,
       AggType aggType, Map<String, Integer> colNameToIndexMap, DataSchema resultSchema) {
     _filterArgIndices = filterArgIndices;
     _aggFunctions = aggFunctions;
@@ -118,13 +119,23 @@ public class MultistageAggregationExecutor {
   }
 
   private void processAggregate(TransferableBlock block, DataSchema inputDataSchema) {
-    for (int i = 0; i < _aggFunctions.length; i++) {
-      AggregationFunction aggregationFunction = _aggFunctions[i];
-      int filterArgIdx = _filterArgIndices[i];
-      Map<ExpressionContext, BlockValSet> blockValSetMap = AggregateOperator.getBlockValSetMap(
-          aggregationFunction, block, inputDataSchema, _colNameToIndexMap, filterArgIdx);
-      int numRows = AggregateOperator.computeBlockNumRows(block, filterArgIdx);
-      aggregationFunction.aggregate(numRows, _aggregateResultHolder[i], blockValSetMap);
+    if (_filterArgIndices == null) {
+      for (int i = 0; i < _aggFunctions.length; i++) {
+        AggregationFunction aggregationFunction = _aggFunctions[i];
+        Map<ExpressionContext, BlockValSet> blockValSetMap =
+            AggregateOperator.getBlockValSetMap(aggregationFunction, block, inputDataSchema, _colNameToIndexMap, -1);
+        aggregationFunction.aggregate(block.getNumRows(), _aggregateResultHolder[i], blockValSetMap);
+      }
+    } else {
+      for (int i = 0; i < _aggFunctions.length; i++) {
+        AggregationFunction aggregationFunction = _aggFunctions[i];
+        int filterArgIdx = _filterArgIndices[i];
+        Map<ExpressionContext, BlockValSet> blockValSetMap =
+            AggregateOperator.getBlockValSetMap(aggregationFunction, block, inputDataSchema, _colNameToIndexMap,
+                filterArgIdx);
+        int numRows = AggregateOperator.computeBlockNumRows(block, filterArgIdx);
+        aggregationFunction.aggregate(numRows, _aggregateResultHolder[i], blockValSetMap);
+      }
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.runtime.operator;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,7 @@ public class MultistageGroupByExecutor {
 
   private final List<ExpressionContext> _groupSet;
   private final AggregationFunction[] _aggFunctions;
+  private final int[] _filterArgIndices;
 
   // Group By Result holders for each mode
   private final GroupByResultHolder[] _aggregateResultHolders;
@@ -57,11 +59,12 @@ public class MultistageGroupByExecutor {
   private final Map<Key, Integer> _groupKeyToIdMap;
 
   public MultistageGroupByExecutor(List<ExpressionContext> groupByExpr, AggregationFunction[] aggFunctions,
-      AggType aggType, Map<String, Integer> colNameToIndexMap, DataSchema resultSchema) {
+      int[] filterArgIndices, AggType aggType, Map<String, Integer> colNameToIndexMap, DataSchema resultSchema) {
     _aggType = aggType;
     _colNameToIndexMap = colNameToIndexMap;
     _groupSet = groupByExpr;
     _aggFunctions = aggFunctions;
+    _filterArgIndices = filterArgIndices;
     _resultSchema = resultSchema;
 
     _aggregateResultHolders = new GroupByResultHolder[_aggFunctions.length];
@@ -129,15 +132,16 @@ public class MultistageGroupByExecutor {
   }
 
   private void processAggregate(TransferableBlock block, DataSchema inputDataSchema) {
-    int[] intKeys = generateGroupByKeys(block.getContainer());
-
     for (int i = 0; i < _aggFunctions.length; i++) {
       AggregationFunction aggregationFunction = _aggFunctions[i];
-      Map<ExpressionContext, BlockValSet> blockValSetMap =
-          AggregateOperator.getBlockValSetMap(aggregationFunction, block, inputDataSchema, _colNameToIndexMap);
+      int filterArgIdx = _filterArgIndices[i];
+      Map<ExpressionContext, BlockValSet> blockValSetMap = AggregateOperator.getBlockValSetMap(
+          aggregationFunction, block, inputDataSchema, _colNameToIndexMap, filterArgIdx);
+      int numRows = AggregateOperator.computeBlockNumRows(block, filterArgIdx);
+      int[] intKeys = generateGroupByKeys(block.getContainer(), filterArgIdx);
       GroupByResultHolder groupByResultHolder = _aggregateResultHolders[i];
       groupByResultHolder.ensureCapacity(_groupKeyToIdMap.size());
-      aggregationFunction.aggregateGroupBySV(block.getNumRows(), intKeys, groupByResultHolder, blockValSetMap);
+      aggregationFunction.aggregateGroupBySV(numRows, intKeys, groupByResultHolder, blockValSetMap);
     }
   }
 
@@ -190,5 +194,43 @@ public class MultistageGroupByExecutor {
       rowIntKeys[i] = _groupKeyToIdMap.computeIfAbsent(rowKey, k -> _groupKeyToIdMap.size());
     }
     return rowIntKeys;
+  }
+
+  /**
+   * Creates the group by key for each row. Converts the key into a 0-index based int value that can be used by
+   * GroupByAggregationResultHolders used in v1 aggregations.
+   * <p>
+   * Returns the int key for each row.
+   */
+  private int[] generateGroupByKeys(List<Object[]> rows, int filterArgIndex) {
+    int numRows = rows.size();
+    int[] rowIntKeys = new int[numRows];
+    int numKeys = _groupSet.size();
+    if (filterArgIndex == -1) {
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        Object[] row = rows.get(rowId);
+        Object[] keyValues = new Object[numKeys];
+        for (int j = 0; j < numKeys; j++) {
+          keyValues[j] = row[_colNameToIndexMap.get(_groupSet.get(j).getIdentifier())];
+        }
+        Key rowKey = new Key(keyValues);
+        rowIntKeys[rowId] = _groupKeyToIdMap.computeIfAbsent(rowKey, k -> _groupKeyToIdMap.size());
+      }
+      return rowIntKeys;
+    } else {
+      int outRowId = 0;
+      for (int inRowId = 0; inRowId < numRows; inRowId++) {
+        Object[] row = rows.get(inRowId);
+        if ((Boolean) row[filterArgIndex]) {
+          Object[] keyValues = new Object[numKeys];
+          for (int j = 0; j < numKeys; j++) {
+            keyValues[j] = row[_colNameToIndexMap.get(_groupSet.get(j).getIdentifier())];
+          }
+          Key rowKey = new Key(keyValues);
+          rowIntKeys[outRowId++] = _groupKeyToIdMap.computeIfAbsent(rowKey, k -> _groupKeyToIdMap.size());
+        }
+      }
+      return Arrays.copyOfRange(rowIntKeys, 0, outRowId);
+    }
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/block/DataBlockValSet.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/block/DataBlockValSet.java
@@ -16,13 +16,14 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.core.common;
+package org.apache.pinot.query.runtime.operator.block;
 
 import java.math.BigDecimal;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.RoaringBitmap;
@@ -34,19 +35,16 @@ import org.roaringbitmap.RoaringBitmap;
  * aggregations using v1 aggregation functions.
  * TODO: Support MV
  */
-public class IntermediateStageBlockValSet implements BlockValSet {
-  private final FieldSpec.DataType _dataType;
-  private final DataBlock _dataBlock;
-  private final int _colIndex;
-  private final int _filterArgIdx;
-  private final RoaringBitmap _nullBitMap;
+public class DataBlockValSet implements BlockValSet {
+  protected final FieldSpec.DataType _dataType;
+  protected final DataBlock _dataBlock;
+  protected final int _index;
+  protected final RoaringBitmap _nullBitMap;
 
-  public IntermediateStageBlockValSet(DataSchema.ColumnDataType columnDataType, DataBlock dataBlock, int colIndex,
-      int filterArgIdx) {
+  public DataBlockValSet(DataSchema.ColumnDataType columnDataType, DataBlock dataBlock, int colIndex) {
     _dataType = columnDataType.toDataType();
     _dataBlock = dataBlock;
-    _colIndex = colIndex;
-    _filterArgIdx = filterArgIdx;
+    _index = colIndex;
     _nullBitMap = dataBlock.getNullRowIds(colIndex);
   }
 
@@ -83,37 +81,37 @@ public class IntermediateStageBlockValSet implements BlockValSet {
 
   @Override
   public int[] getIntValuesSV() {
-    return DataBlockUtils.extractIntValuesForColumn(_dataBlock, _colIndex, _filterArgIdx);
+    return DataBlockUtils.extractIntValuesForColumn(_dataBlock, _index);
   }
 
   @Override
   public long[] getLongValuesSV() {
-    return DataBlockUtils.extractLongValuesForColumn(_dataBlock, _colIndex, _filterArgIdx);
+    return DataBlockUtils.extractLongValuesForColumn(_dataBlock, _index);
   }
 
   @Override
   public float[] getFloatValuesSV() {
-    return DataBlockUtils.extractFloatValuesForColumn(_dataBlock, _colIndex, _filterArgIdx);
+    return DataBlockUtils.extractFloatValuesForColumn(_dataBlock, _index);
   }
 
   @Override
   public double[] getDoubleValuesSV() {
-    return DataBlockUtils.extractDoubleValuesForColumn(_dataBlock, _colIndex, _filterArgIdx);
+    return DataBlockUtils.extractDoubleValuesForColumn(_dataBlock, _index);
   }
 
   @Override
   public BigDecimal[] getBigDecimalValuesSV() {
-    return DataBlockUtils.extractBigDecimalValuesForColumn(_dataBlock, _colIndex, _filterArgIdx);
+    return DataBlockUtils.extractBigDecimalValuesForColumn(_dataBlock, _index);
   }
 
   @Override
   public String[] getStringValuesSV() {
-    return DataBlockUtils.extractStringValuesForColumn(_dataBlock, _colIndex, _filterArgIdx);
+    return DataBlockUtils.extractStringValuesForColumn(_dataBlock, _index);
   }
 
   @Override
   public byte[][] getBytesValuesSV() {
-    return DataBlockUtils.extractBytesValuesForColumn(_dataBlock, _colIndex, _filterArgIdx);
+    return DataBlockUtils.extractBytesValuesForColumn(_dataBlock, _index);
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/block/FilteredDataBlockValSet.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/block/FilteredDataBlockValSet.java
@@ -1,0 +1,152 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.block;
+
+import java.math.BigDecimal;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.datablock.DataBlock;
+import org.apache.pinot.common.datablock.DataBlockUtils;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.segment.spi.index.reader.Dictionary;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.roaringbitmap.RoaringBitmap;
+
+
+/**
+ * In the multistage engine, the leaf stage servers process the data in columnar fashion. By the time the
+ * intermediate stage receives the projected column, they are converted to a row based format. This class provides
+ * the capability to convert the row based representation into columnar blocks so that they can be used to process
+ * aggregations using v1 aggregation functions.
+ * TODO: Support MV
+ */
+public class FilteredDataBlockValSet extends DataBlockValSet {
+  private final int _filterIdx;
+
+  public FilteredDataBlockValSet(DataSchema.ColumnDataType columnDataType, DataBlock dataBlock, int colIndex,
+      int filterIdx) {
+    super(columnDataType, dataBlock, colIndex);
+    _filterIdx = filterIdx;
+  }
+
+  /**
+   * Returns a bitmap of indices where null values are found.
+   */
+  @Nullable
+  @Override
+  public RoaringBitmap getNullBitmap() {
+    return _nullBitMap;
+  }
+
+  @Override
+  public FieldSpec.DataType getValueType() {
+    return _dataType;
+  }
+
+  @Override
+  public boolean isSingleValue() {
+    // TODO: Needs to be changed when we start supporting MV in multistage
+    return true;
+  }
+
+  @Nullable
+  @Override
+  public Dictionary getDictionary() {
+    return null;
+  }
+
+  @Override
+  public int[] getDictionaryIdsSV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int[] getIntValuesSV() {
+    return DataBlockUtils.extractIntValuesForColumn(_dataBlock, _index, _filterIdx);
+  }
+
+  @Override
+  public long[] getLongValuesSV() {
+    return DataBlockUtils.extractLongValuesForColumn(_dataBlock, _index, _filterIdx);
+  }
+
+  @Override
+  public float[] getFloatValuesSV() {
+    return DataBlockUtils.extractFloatValuesForColumn(_dataBlock, _index, _filterIdx);
+  }
+
+  @Override
+  public double[] getDoubleValuesSV() {
+    return DataBlockUtils.extractDoubleValuesForColumn(_dataBlock, _index, _filterIdx);
+  }
+
+  @Override
+  public BigDecimal[] getBigDecimalValuesSV() {
+    return DataBlockUtils.extractBigDecimalValuesForColumn(_dataBlock, _index, _filterIdx);
+  }
+
+  @Override
+  public String[] getStringValuesSV() {
+    return DataBlockUtils.extractStringValuesForColumn(_dataBlock, _index, _filterIdx);
+  }
+
+  @Override
+  public byte[][] getBytesValuesSV() {
+    return DataBlockUtils.extractBytesValuesForColumn(_dataBlock, _index, _filterIdx);
+  }
+
+  @Override
+  public int[][] getDictionaryIdsMV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int[][] getIntValuesMV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public long[][] getLongValuesMV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public float[][] getFloatValuesMV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public double[][] getDoubleValuesMV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public String[][] getStringValuesMV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public byte[][][] getBytesValuesMV() {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  public int[] getNumMVEntries() {
+    throw new UnsupportedOperationException();
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -101,7 +101,7 @@ public class PhysicalPlanVisitor implements PlanNodeVisitor<MultiStageOperator, 
     DataSchema resultSchema = node.getDataSchema();
 
     return new AggregateOperator(context.getOpChainExecutionContext(), nextOperator, resultSchema, inputSchema,
-        node.getAggCalls(), node.getGroupSet(), node.getAggType(), node.getNodeHint());
+        node.getAggCalls(), node.getGroupSet(), node.getAggType(), node.getFilterArgIndices(), node.getNodeHint());
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestVisitor.java
@@ -71,8 +71,8 @@ public class ServerPlanRequestVisitor implements PlanNodeVisitor<Void, ServerPla
         .setGroupByList(CalciteRexExpressionParser.convertGroupByList(node.getGroupSet(), context.getPinotQuery()));
     // set agg list
     context.getPinotQuery().setSelectList(
-        CalciteRexExpressionParser.addSelectList(context.getPinotQuery().getGroupByList(), node.getAggCalls(),
-            context.getPinotQuery()));
+        CalciteRexExpressionParser.convertAggregateList(context.getPinotQuery().getGroupByList(), node.getAggCalls(),
+            node.getFilterArgIndices(), context.getPinotQuery()));
     return null;
   }
 
@@ -149,7 +149,7 @@ public class ServerPlanRequestVisitor implements PlanNodeVisitor<Void, ServerPla
   public Void visitProject(ProjectNode node, ServerPlanRequestContext context) {
     visitChildren(node, context);
     context.getPinotQuery()
-        .setSelectList(CalciteRexExpressionParser.overwriteSelectList(node.getProjects(), context.getPinotQuery()));
+        .setSelectList(CalciteRexExpressionParser.convertProjectList(node.getProjects(), context.getPinotQuery()));
     return null;
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
@@ -79,7 +79,7 @@ public class AggregateOperatorTest {
     DataSchema outSchema = new DataSchema(new String[]{"group", "sum"}, new ColumnDataType[]{INT, DOUBLE});
     AggregateOperator operator =
         new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, inSchema, calls, group,
-            AggType.INTERMEDIATE);
+            AggType.INTERMEDIATE, null, null);
 
     // When:
     TransferableBlock block1 = operator.nextBlock(); // build
@@ -101,7 +101,7 @@ public class AggregateOperatorTest {
     DataSchema outSchema = new DataSchema(new String[]{"group", "sum"}, new ColumnDataType[]{INT, DOUBLE});
     AggregateOperator operator =
         new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, inSchema, calls, group,
-            AggType.LEAF);
+            AggType.LEAF, null, null);
 
     // When:
     TransferableBlock block = operator.nextBlock();
@@ -125,7 +125,7 @@ public class AggregateOperatorTest {
     DataSchema outSchema = new DataSchema(new String[]{"group", "sum"}, new ColumnDataType[]{INT, DOUBLE});
     AggregateOperator operator =
         new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, inSchema, calls, group,
-            AggType.LEAF);
+            AggType.LEAF, null, null);
 
     // When:
     TransferableBlock block1 = operator.nextBlock(); // build when reading NoOp block
@@ -150,7 +150,7 @@ public class AggregateOperatorTest {
     DataSchema outSchema = new DataSchema(new String[]{"group", "sum"}, new ColumnDataType[]{INT, DOUBLE});
     AggregateOperator operator =
         new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, inSchema, calls, group,
-            AggType.INTERMEDIATE);
+            AggType.INTERMEDIATE, null, null);
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -177,7 +177,7 @@ public class AggregateOperatorTest {
     DataSchema outSchema = new DataSchema(new String[]{"group", "sum"}, new ColumnDataType[]{INT, LONG});
     AggregateOperator operator =
         new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, inSchema, calls, group,
-            AggType.FINAL);
+            AggType.FINAL, null, null);
 
     // When:
     TransferableBlock block1 = operator.nextBlock();
@@ -201,7 +201,7 @@ public class AggregateOperatorTest {
     DataSchema outSchema = new DataSchema(new String[]{"group", "sum"}, new ColumnDataType[]{STRING, DOUBLE});
     AggregateOperator sum0GroupBy1 = new AggregateOperator(OperatorTestUtil.getDefaultContext(), upstreamOperator,
         outSchema, inSchema, Collections.singletonList(agg),
-        Collections.singletonList(new RexExpression.InputRef(1)), AggType.LEAF);
+        Collections.singletonList(new RexExpression.InputRef(1)), AggType.LEAF, null, null);
     TransferableBlock result = sum0GroupBy1.getNextBlock();
     while (result.isNoOpBlock()) {
       result = sum0GroupBy1.getNextBlock();
@@ -229,7 +229,7 @@ public class AggregateOperatorTest {
     // When:
     AggregateOperator operator =
         new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, inSchema, calls, group,
-            AggType.INTERMEDIATE);
+            AggType.INTERMEDIATE, null, null);
   }
 
   @Test
@@ -248,7 +248,7 @@ public class AggregateOperatorTest {
     DataSchema outSchema = new DataSchema(new String[]{"sum"}, new ColumnDataType[]{DOUBLE});
     AggregateOperator operator =
         new AggregateOperator(OperatorTestUtil.getDefaultContext(), _input, outSchema, inSchema, calls, group,
-            AggType.INTERMEDIATE);
+            AggType.INTERMEDIATE, null, null);
 
     // When:
     TransferableBlock block = operator.nextBlock();

--- a/pinot-query-runtime/src/test/resources/queries/FilterAggregates.json
+++ b/pinot-query-runtime/src/test/resources/queries/FilterAggregates.json
@@ -1,0 +1,166 @@
+{
+  "general_aggregate_with_filter_where": {
+    "tables": {
+      "tbl": {
+        "schema": [
+          {"name": "int_col", "type": "INT"},
+          {"name": "double_col", "type": "DOUBLE"},
+          {"name": "string_col", "type": "STRING"},
+          {"name": "bool_col", "type": "BOOLEAN"}
+        ],
+        "inputs": [
+          [2, 300, "a", true],
+          [2, 400, "a", true],
+          [3, 100, "b", false],
+          [100, 1, "b", false],
+          [101, 1.01, "c", false],
+          [150, 1.5, "c", false],
+          [175, 1.75, "c", true]
+        ]
+      }
+    },
+    "queries": [
+      { 
+        "ignored": true,
+        "comments": "FILTER WHERE clause with IN hard-wired to translate into subquery, which in this case should not happen.",
+        "sql": "SELECT min(double_col) FILTER (WHERE string_col IN ('a', 'b')), count(*) FROM {tbl}"
+      },
+      {
+        "ignored": true,
+        "comments": "IS NULL and IS NOT NULL is not yet supported in filter conversion.",
+        "sql": "SELECT min(double_col) FILTER (WHERE string_col IS NOT NULL), count(*) FROM {tbl}"
+      },
+      {
+        "ignored": true,
+        "comments": "agg with filter and group-by causes conversion issue on v1 if the group-by field is not in the select list",
+        "sql": "SELECT count(*) FILTER (WHERE string_col = 'a' OR int_col > 10) FROM {tbl} GROUP BY int_col"
+      },
+      {
+        "ignored": true,
+        "comments": "agg with group by and filter will create NULL-able columns that are unsupported with current AGG FILTER WHERE semantics.",
+        "sql": "SELECT min(double_col) FILTER (WHERE string_col = 'a' OR string_col = 'b'), max(double_col) FILTER (WHERE string_col = 'a' OR int_col > 10), avg(double_col), sum(double_col), count(double_col), count(distinct(double_col)) FILTER (WHERE string_col = 'b' OR int_col > 10), count(*) FROM {tbl} GROUP BY int_col, string_col"
+      },
+      {
+        "ignored": true,
+        "comments": "mixed/conflict filter that requires merging in v1 is not supported",
+        "sql": "SELECT double_col, bool_col, count(int_col) FILTER (WHERE string_col = 'a' OR int_col > 10) FROM {tbl} WHERE string_col = 'b' GROUP BY double_col, bool_col"
+      },
+      {
+        "ignored": true,
+        "comments": "FILTER WHERE clause might omit group key entirely if nothing is being selected out, this is non-standard SQL behavior but it is v1 behavior",
+        "sql": "SELECT int_col, count(double_col) FILTER (WHERE string_col = 'a' OR int_col > 10) FROM {tbl} GROUP BY int_col"
+      },
+      { "sql": "SELECT count(*) FILTER (WHERE string_col = 'a' OR int_col > 10) FROM {tbl}" },
+      { "sql": "SELECT min(double_col) FILTER (WHERE string_col = 'a' OR string_col = 'b'), max(double_col) FILTER (WHERE string_col = 'a' OR int_col > 10), avg(double_col), sum(double_col), count(double_col), count(distinct(double_col)) FILTER (WHERE string_col = 'b' OR int_col > 10), count(*) FROM {tbl}" },
+      { "sql": "SELECT min(int_col) FILTER (WHERE bool_col IS TRUE), max(int_col) FILTER (WHERE bool_col AND int_col < 10), avg(int_col) FILTER (WHERE MOD(int_col, 3) = 0), sum(int_col), count(int_col), count(distinct(int_col)), count(*) FILTER (WHERE MOD(int_col, 3) = 0) FROM {tbl}" },
+      { "sql": "SELECT count(*) FILTER (WHERE string_col = 'a' OR int_col > 10) FROM {tbl} WHERE string_col='b'" },
+      { "sql": "SELECT min(double_col) FILTER (WHERE string_col = 'a' OR string_col = 'b'), max(double_col) FILTER (WHERE string_col = 'a' OR int_col > 10), avg(double_col), sum(double_col), count(double_col), count(distinct(double_col)) FILTER (WHERE string_col = 'b' OR int_col > 10), count(*) FROM {tbl} WHERE string_col='b'" },
+      { "sql": "SELECT int_col, COALESCE(count(double_col) FILTER (WHERE string_col = 'a' OR int_col > 0), 0), count(*) FROM {tbl} GROUP BY int_col" },
+      {
+        "ignored": true,
+        "comments": "Calcite limitation on SQL type inference and Relational type inference has mismatched info (regarding filterArg existent, thus nullability mismatched",
+        "sql": "SELECT int_col, string_col, COALESCE(min(double_col) FILTER (WHERE string_col = 'a' OR string_col = 'b'), 0), COALESCE(max(double_col) FILTER (WHERE string_col = 'a' OR int_col > 10), 0), avg(double_col), sum(double_col), count(double_col), COALESCE(count(distinct(double_col)) FILTER (WHERE string_col = 'b' OR int_col > 10), 0) FROM {tbl} GROUP BY int_col, string_col"
+      },
+      {
+        "ignored": true,
+        "comments": "Calcite limitation on SQL type inference and Relational type inference has mismatched info (regarding filterArg existent, thus nullability mismatched",
+        "sql": "SELECT double_col, COALESCE(min(int_col) FILTER (WHERE bool_col IS TRUE), 0), COALESCE(max(int_col) FILTER (WHERE bool_col AND int_col < 10), 0), COALESCE(avg(int_col) FILTER (WHERE MOD(int_col, 3) = 0), 0), sum(int_col), count(int_col), count(distinct(int_col)), count(string_col) FILTER (WHERE MOD(int_col, 3) = 0) FROM {tbl} GROUP BY double_col"
+      },
+      { "sql": "SELECT double_col, bool_col, count(int_col) FILTER (WHERE string_col = 'a' OR int_col > 10), count(int_col) FROM {tbl} WHERE string_col IN ('a', 'b') GROUP BY double_col, bool_col" },
+      {
+        "ignored": true,
+        "comments": "Calcite limitation on SQL type inference and Relational type inference has mismatched info (regarding filterArg existent, thus nullability mismatched",
+        "sql": "SELECT bool_col, COALESCE(min(double_col) FILTER (WHERE string_col = 'a' OR string_col = 'b'), 0), COALESCE(max(double_col) FILTER (WHERE string_col = 'a' OR int_col > 10), 0), avg(double_col), sum(double_col), count(double_col), count(distinct(double_col)) FILTER (WHERE string_col = 'b' OR int_col > 10), count(string_col) FROM {tbl} WHERE string_col='b' GROUP BY bool_col"
+      }
+    ]
+  },
+  "general_aggregate_with_filter_where_after_join": {
+    "tables": {
+      "tbl1": {
+        "schema": [
+          {"name": "int_col", "type": "INT"},
+          {"name": "double_col", "type": "DOUBLE"},
+          {"name": "string_col", "type": "STRING"},
+          {"name": "bool_col", "type": "BOOLEAN"}
+        ],
+        "inputs": [
+          [2, 300, "a", true],
+          [2, 400, "a", true],
+          [3, 100, "b", false],
+          [100, 1, "b", false],
+          [101, 1.01, "c", false],
+          [150, 1.5, "c", false],
+          [175, 1.75, "c", true]
+        ]
+      },
+      "tbl2": {
+        "schema":[
+          {"name": "int_col2", "type": "INT"},
+          {"name": "string_col2", "type": "STRING"},
+          {"name":  "double_col2", "type":  "DOUBLE"}
+        ],
+        "inputs": [
+          [1, "apple", 1000.0],
+          [2, "a", 1.323],
+          [3, "b", 1212.12],
+          [3, "c", 341],
+          [4, "orange", 1212.121]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "ignored": true,
+        "comments": "FILTER WHERE clause with IN hard-wired to translate into subquery, which in this case should not happen.",
+        "sql": "SELECT min(double_col) FILTER (WHERE string_col IN ('a', 'b')), count(*) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2"
+      },
+      {
+        "ignored": true,
+        "comments": "IS NULL and IS NOT NULL is not yet supported in filter conversion.",
+        "sql": "SELECT min(double_col) FILTER (WHERE string_col IS NOT NULL), count(*) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2"
+      },
+      {
+        "ignored": true,
+        "comments": "agg with filter and group-by causes conversion issue on v1 if the group-by field is not in the select list",
+        "sql": "SELECT count(*) FILTER (WHERE string_col = 'a' OR int_col2 > 10) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2 GROUP BY int_col2"
+      },
+      {
+        "ignored": true,
+        "comments": "agg with group by and filter will create NULL-able columns that are unsupported with current AGG FILTER WHERE semantics.",
+        "sql": "SELECT min(double_col) FILTER (WHERE string_col = 'a' OR string_col = 'b'), max(double_col) FILTER (WHERE string_col = 'a' OR int_col2 > 10), avg(double_col), sum(double_col), count(double_col), count(distinct(double_col)) FILTER (WHERE string_col = 'b' OR int_col2 > 10), count(*) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2 GROUP BY int_col2, string_col"
+      },
+      {
+        "ignored": true,
+        "comments": "mixed/conflict filter that requires merging in v1 is not supported",
+        "sql": "SELECT double_col, bool_col, count(int_col2) FILTER (WHERE string_col = 'a' OR int_col2 > 10) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2 WHERE string_col = 'b' GROUP BY double_col, bool_col"
+      },
+      {
+        "ignored": true,
+        "comments": "FILTER WHERE clause might omit group key entirely if nothing is being selected out, this is non-standard SQL behavior but it is v1 behavior",
+        "sql": "SELECT int_col2, count(double_col) FILTER (WHERE string_col = 'a' OR int_col2 > 10) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2 GROUP BY int_col2"
+      },
+      { "sql": "SELECT count(*) FILTER (WHERE string_col = 'a' OR int_col2 > 10) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2" },
+      { "sql": "SELECT min(double_col) FILTER (WHERE string_col = 'a' OR string_col = 'b'), max(double_col) FILTER (WHERE string_col = 'a' OR int_col2 > 10), avg(double_col), sum(double_col), count(double_col), count(distinct(double_col)) FILTER (WHERE string_col = 'b' OR int_col2 > 10), count(*) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2" },
+      { "sql": "SELECT min(int_col2) FILTER (WHERE bool_col IS TRUE), max(int_col2) FILTER (WHERE bool_col AND int_col2 < 10), avg(int_col2) FILTER (WHERE MOD(int_col2, 3) = 0), sum(int_col2), count(int_col2), count(distinct(int_col2)), count(*) FILTER (WHERE MOD(int_col2, 3) = 0) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2" },
+      { "sql": "SELECT count(*) FILTER (WHERE string_col = 'a' OR int_col2 > 10) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2 WHERE string_col='b'" },
+      { "sql": "SELECT min(double_col) FILTER (WHERE string_col = 'a' OR string_col = 'b'), max(double_col) FILTER (WHERE string_col = 'a' OR int_col2 > 10), avg(double_col), sum(double_col), count(double_col), count(distinct(double_col)) FILTER (WHERE string_col = 'b' OR int_col2 > 10), count(*) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2 WHERE string_col='b'" },
+      { "sql": "SELECT int_col2, COALESCE(count(double_col) FILTER (WHERE string_col = 'a' OR int_col2 > 0), 0), count(*) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2 GROUP BY int_col2" },
+      {
+        "ignored": true,
+        "comments": "Calcite limitation on SQL type inference and Relational type inference has mismatched info (regarding filterArg existent, thus nullability mismatched",
+        "sql": "SELECT int_col2, string_col, COALESCE(min(double_col) FILTER (WHERE string_col = 'a' OR string_col = 'b'), 0), COALESCE(max(double_col) FILTER (WHERE string_col = 'a' OR int_col2 > 10), 0), avg(double_col), sum(double_col), count(double_col), COALESCE(count(distinct(double_col)) FILTER (WHERE string_col = 'b' OR int_col2 > 10), 0) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2 GROUP BY int_col2, string_col"
+      },
+      {
+        "ignored": true,
+        "comments": "Calcite limitation on SQL type inference and Relational type inference has mismatched info (regarding filterArg existent, thus nullability mismatched",
+        "sql": "SELECT double_col, COALESCE(min(int_col2) FILTER (WHERE bool_col IS TRUE), 0), COALESCE(max(int_col2) FILTER (WHERE bool_col AND int_col2 < 10), 0), COALESCE(avg(int_col2) FILTER (WHERE MOD(int_col2, 3) = 0), 0), sum(int_col2), count(int_col2), count(distinct(int_col2)), count(string_col) FILTER (WHERE MOD(int_col2, 3) = 0) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2 GROUP BY double_col"
+      },
+      { "sql": "SELECT double_col, bool_col, count(int_col2) FILTER (WHERE string_col = 'a' OR int_col2 > 10), count(int_col2) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2 WHERE string_col IN ('a', 'b') GROUP BY double_col, bool_col" },
+      {
+        "ignored": true,
+        "comments": "Calcite limitation on SQL type inference and Relational type inference has mismatched info (regarding filterArg existent, thus nullability mismatched",
+        "sql": "SELECT bool_col, COALESCE(min(double_col) FILTER (WHERE string_col = 'a' OR string_col = 'b'), 0), COALESCE(max(double_col) FILTER (WHERE string_col = 'a' OR int_col2 > 10), 0), avg(double_col), sum(double_col), count(double_col), count(distinct(double_col)) FILTER (WHERE string_col = 'b' OR int_col2 > 10), count(string_col) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2 WHERE string_col='b' GROUP BY bool_col"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Description
===
Support syntax `AGG_FUN(...) FILTER (WHERE ...)`, such as: `SELECT sum(val) FILTER (WHERE col > 10) FROM tbl`

Follow ups
===
Major
-----
1. `IS NULL` and `IS NOT NULL` as agg filter is not supported
    - related to https://github.com/apache/pinot/pull/10423
    - due to nullable field handling, we will also need coalesce some times to ensure the results are nullable compatible.
2. SQL basic call-binding and Aggregate call-binding has mismatched info regarding filterArg and thus some time create unsupported nullable/non-nullable type during inferReturnType method.
    - this looks like a calcite bug, will do more research 
3. mixed/conflict filter is not supported, for example `SELECT COUNT(*) FILTER (WHERE a = 1 OR a = 2) FROM tbl WHERE a = 2` will result in a compilation error
    - occurred on v1 engine as well (specifically, FilterAggregateOperator), can be individually fixed
4. Pinot behavior is to not return any rows if all of the aggregate filter function has no matches --> this conflicts with standard behavior, which should return a null.
    - require changes in nullability handling in v1 aggregate function behavior

Minor
-----
1. `ServerPlanRequestVisitor`: agg with filter and group-by causes conversion issue on v1 if the group-by field is not in the select list -- work around: selecting out all the group-by fields
2. `IN` clause not supported: FILTER WHERE clause with IN hard-wired to translate into subquery in calcite for some reason -- work around: use OR and equal