### PR TITLE
[multistage] Derive SUM return type to be PostgreSQL compatible

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -139,18 +139,14 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     String query;
     String h2Query;
 
-    // SUM result will overflow INTEGER
+    // SUM INTEGER result will be BIGINT
     query = "SELECT SUM(ActualElapsedTime) FROM mytable";
-
-    // SUM result will overflow INTEGER
+    testQuery(query);
+    // SUM FLOAT result will be FLOAT
     query = "SELECT SUM(CAST(ActualElapsedTime AS FLOAT)) FROM mytable";
-
-    // SUM result will overflow INTEGER
-    query = "SELECT SUM(CAST(ActualElapsedTime AS BIGINT)) FROM mytable";
-
-    // SUM result will overflow INTEGER
+    testQuery(query);
+    // SUM DOUBLE result will be DOUBLE
     query = "SELECT SUM(CAST(ActualElapsedTime AS DOUBLE)) FROM mytable";
-
     testQuery(query);
     query = "SELECT COUNT(*) FROM mytable WHERE CarrierDelay=15 AND ArrDelay > CarrierDelay LIMIT 1";
     testQuery(query);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -139,6 +139,19 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     String query;
     String h2Query;
 
+    // SUM result will overflow INTEGER
+    query = "SELECT SUM(ActualElapsedTime) FROM mytable";
+
+    // SUM result will overflow INTEGER
+    query = "SELECT SUM(CAST(ActualElapsedTime AS FLOAT)) FROM mytable";
+
+    // SUM result will overflow INTEGER
+    query = "SELECT SUM(CAST(ActualElapsedTime AS BIGINT)) FROM mytable";
+
+    // SUM result will overflow INTEGER
+    query = "SELECT SUM(CAST(ActualElapsedTime AS DOUBLE)) FROM mytable";
+
+    testQuery(query);
     query = "SELECT COUNT(*) FROM mytable WHERE CarrierDelay=15 AND ArrDelay > CarrierDelay LIMIT 1";
     testQuery(query);
     query = "SELECT ArrDelay, CarrierDelay, (ArrDelay - CarrierDelay) AS diff FROM mytable WHERE CarrierDelay=15 AND "

--- a/pinot-integration-tests/src/test/resources/tpch/22.sql
+++ b/pinot-integration-tests/src/test/resources/tpch/22.sql
@@ -21,7 +21,7 @@ where
       )
       and ps_availqty > (
         select
-          CAST(0.5 * SUM(l_quantity) AS DOUBLE)
+          0.5 * sum(l_quantity)
         from
           lineitem
         where

--- a/pinot-integration-tests/src/test/resources/tpch/22.sql
+++ b/pinot-integration-tests/src/test/resources/tpch/22.sql
@@ -21,7 +21,7 @@ where
       )
       and ps_availqty > (
         select
-          0.5 * sum(l_quantity)
+          CAST(0.5 * SUM(l_quantity) AS DOUBLE)
         from
           lineitem
         where

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -287,7 +287,12 @@ public class QueryEnvironment {
 
   private RelRoot decorrelateIfNeeded(RelRoot relRoot) {
     if (hasCorrelateNode(relRoot.rel)) {
-      relRoot = relRoot.withRel(RelDecorrelator.decorrelateQuery(relRoot.rel, RelBuilder.create(_config)));
+      try {
+        relRoot = relRoot.withRel(RelDecorrelator.decorrelateQuery(relRoot.rel, RelBuilder.create(_config)));
+      } catch (Throwable e) {
+        throw new UnsupportedOperationException(
+            "Failed to de-correlate the given query to a valid execution plan: " + RelOptUtil.toString(relRoot.rel), e);
+      }
     }
     return relRoot;
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeSystem.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeSystem.java
@@ -82,12 +82,8 @@ public class TypeSystem extends RelDataTypeSystemImpl {
       case BIGINT:
         return typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.BIGINT),
             argumentType.isNullable());
-      case FLOAT:
-      case DOUBLE:
-        return typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DOUBLE),
-            argumentType.isNullable());
       default:
-        return super.deriveSumType(typeFactory, argumentType);
+        return argumentType;
     }
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeSystem.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeSystem.java
@@ -29,8 +29,20 @@ import org.apache.calcite.sql.type.SqlTypeUtil;
  * The {@code TypeSystem} overwrites Calcite type system with Pinot specific logics.
  */
 public class TypeSystem extends RelDataTypeSystemImpl {
-  private static final int MAX_DECIMAL_SCALE_DIGIT = 1000;
-  private static final int MAX_DECIMAL_PRECISION_DIGIT = 1000;
+  private static final int MAX_DECIMAL_SCALE = 1000;
+  private static final int MAX_DECIMAL_PRECISION = 1000;
+
+  /**
+   * Default precision for derived arithmetic decimal types(plus/multiply/divide/mod). We won't allow the return
+   * precision to be larger than this value majorly due to the following reasons:
+   * <ul><li>1. Precision computation is very costly, it should be explicitly specified</li>
+   * <li>2. Work around the type hoist issue when doing de-correlation decimal type mismatch. See:
+   * <a href="https://github.com/apache/pinot/pull/11151">Derive SUM return type to be PostgreSQL compatible</a>
+   * for more details
+   * </li></ul>
+   */
+  private static final int DERIVED_DECIMAL_PRECISION = 19;
+  private static final int DERIVED_DECIMAL_SCALE = 1;
 
   @Override
   public boolean shouldConvertRaggedUnionTypesToVarying() {
@@ -47,12 +59,12 @@ public class TypeSystem extends RelDataTypeSystemImpl {
 
   @Override
   public int getMaxNumericScale() {
-    return MAX_DECIMAL_SCALE_DIGIT;
+    return MAX_DECIMAL_SCALE;
   }
 
   @Override
   public int getMaxNumericPrecision() {
-    return MAX_DECIMAL_PRECISION_DIGIT;
+    return MAX_DECIMAL_PRECISION;
   }
 
   @Override
@@ -85,5 +97,49 @@ public class TypeSystem extends RelDataTypeSystemImpl {
       default:
         return argumentType;
     }
+  }
+
+  @Override
+  public RelDataType deriveDecimalPlusType(RelDataTypeFactory typeFactory,
+      RelDataType type1, RelDataType type2) {
+    RelDataType dataType = super.deriveDecimalPlusType(typeFactory, type1, type2);
+    if (dataType != null && SqlTypeUtil.isExactNumeric(dataType) && SqlTypeUtil.isDecimal(dataType)
+        && (dataType.getPrecision() > DERIVED_DECIMAL_PRECISION)) {
+      return typeFactory.createSqlType(SqlTypeName.DECIMAL, DERIVED_DECIMAL_PRECISION, DERIVED_DECIMAL_SCALE);
+    }
+    return dataType;
+  }
+
+  @Override
+  public RelDataType deriveDecimalMultiplyType(RelDataTypeFactory typeFactory,
+      RelDataType type1, RelDataType type2) {
+    RelDataType dataType = super.deriveDecimalMultiplyType(typeFactory, type1, type2);
+    if (dataType != null && SqlTypeUtil.isExactNumeric(dataType) && SqlTypeUtil.isDecimal(dataType)
+        && (dataType.getPrecision() > DERIVED_DECIMAL_PRECISION)) {
+      return typeFactory.createSqlType(SqlTypeName.DECIMAL, DERIVED_DECIMAL_PRECISION, DERIVED_DECIMAL_SCALE);
+    }
+    return dataType;
+  }
+
+  @Override
+  public RelDataType deriveDecimalDivideType(RelDataTypeFactory typeFactory,
+      RelDataType type1, RelDataType type2) {
+    RelDataType dataType = super.deriveDecimalDivideType(typeFactory, type1, type2);
+    if (dataType != null && SqlTypeUtil.isExactNumeric(dataType) && SqlTypeUtil.isDecimal(dataType)
+        && (dataType.getPrecision() > DERIVED_DECIMAL_PRECISION)) {
+      return typeFactory.createSqlType(SqlTypeName.DECIMAL, DERIVED_DECIMAL_PRECISION, DERIVED_DECIMAL_SCALE);
+    }
+    return dataType;
+  }
+
+  @Override
+  public RelDataType deriveDecimalModType(RelDataTypeFactory typeFactory,
+      RelDataType type1, RelDataType type2) {
+    RelDataType dataType = super.deriveDecimalModType(typeFactory, type1, type2);
+    if (dataType != null && SqlTypeUtil.isExactNumeric(dataType) && SqlTypeUtil.isDecimal(dataType)
+        && (dataType.getPrecision() > DERIVED_DECIMAL_PRECISION)) {
+      return typeFactory.createSqlType(SqlTypeName.DECIMAL, DERIVED_DECIMAL_PRECISION, DERIVED_DECIMAL_SCALE);
+    }
+    return dataType;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeSystem.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeSystem.java
@@ -70,4 +70,24 @@ public class TypeSystem extends RelDataTypeSystemImpl {
       }
     }
   }
+
+  @Override
+  public RelDataType deriveSumType(RelDataTypeFactory typeFactory,
+      RelDataType argumentType) {
+    assert SqlTypeUtil.isNumeric(argumentType);
+    switch (argumentType.getSqlTypeName()) {
+      case TINYINT:
+      case SMALLINT:
+      case INTEGER:
+      case BIGINT:
+        return typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.BIGINT),
+            argumentType.isNullable());
+      case FLOAT:
+      case DOUBLE:
+        return typeFactory.createTypeWithNullability(typeFactory.createSqlType(SqlTypeName.DOUBLE),
+            argumentType.isNullable());
+      default:
+        return super.deriveSumType(typeFactory, argumentType);
+    }
+  }
 }

--- a/pinot-query-planner/src/test/resources/queries/AggregatePlans.json
+++ b/pinot-query-planner/src/test/resources/queries/AggregatePlans.json
@@ -36,7 +36,7 @@
         "sql": "EXPLAIN PLAN FOR SELECT AVG(a.col3) as avg, COUNT(*) as count FROM a WHERE a.col3 >= 0 AND a.col2 = 'pink floyd'",
         "output": [
           "Execution Plan",
-          "\nLogicalProject(avg=[/(CAST(CASE(=($1, 0), null:INTEGER, $0)):DOUBLE, $1)], count=[$1])",
+          "\nLogicalProject(avg=[/(CAST(CASE(=($1, 0), null:BIGINT, $0)):DOUBLE, $1)], count=[$1])",
           "\n  LogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalAggregate(group=[{}], agg#0=[$SUM0($1)], agg#1=[COUNT()])",
@@ -51,7 +51,7 @@
         "sql": "EXPLAIN PLAN FOR SELECT SUM(a.col3), COUNT(a.col1) FROM a",
         "output": [
           "Execution Plan",
-          "\nLogicalProject(EXPR$0=[CASE(=($1, 0), null:INTEGER, $0)], EXPR$1=[$1])",
+          "\nLogicalProject(EXPR$0=[CASE(=($1, 0), null:BIGINT, $0)], EXPR$1=[$1])",
           "\n  LogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalAggregate(group=[{}], agg#0=[$SUM0($2)], agg#1=[COUNT()])",
@@ -64,7 +64,7 @@
         "sql": "EXPLAIN PLAN FOR SELECT SUM(a.col3), COUNT(*) FROM a WHERE a.col3 >= 0 AND a.col2 = 'a'",
         "output": [
           "Execution Plan",
-          "\nLogicalProject(EXPR$0=[CASE(=($1, 0), null:INTEGER, $0)], EXPR$1=[$1])",
+          "\nLogicalProject(EXPR$0=[CASE(=($1, 0), null:BIGINT, $0)], EXPR$1=[$1])",
           "\n  LogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalAggregate(group=[{}], agg#0=[$SUM0($1)], agg#1=[COUNT()])",
@@ -79,7 +79,7 @@
         "sql": "EXPLAIN PLAN FOR SELECT SUM(a.col3) as sum, COUNT(*) as count FROM a WHERE a.col3 >= 0 AND a.col2 = 'pink floyd'",
         "output": [
           "Execution Plan",
-          "\nLogicalProject(sum=[CASE(=($1, 0), null:INTEGER, $0)], count=[$1])",
+          "\nLogicalProject(sum=[CASE(=($1, 0), null:BIGINT, $0)], count=[$1])",
           "\n  LogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalAggregate(group=[{}], agg#0=[$SUM0($1)], agg#1=[COUNT()])",
@@ -94,7 +94,7 @@
         "sql": "EXPLAIN PLAN FOR SELECT /*+ aggOptions(is_skip_leaf_stage_group_by='true') */ AVG(a.col3) as avg, COUNT(*) as count FROM a WHERE a.col3 >= 0 AND a.col2 = 'pink floyd'",
         "output": [
           "Execution Plan",
-          "\nLogicalProject(avg=[/(CAST(CASE(=($1, 0), null:INTEGER, $0)):DOUBLE, $1)], count=[$1])",
+          "\nLogicalProject(avg=[/(CAST(CASE(=($1, 0), null:BIGINT, $0)):DOUBLE, $1)], count=[$1])",
           "\n  LogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalAggregate(group=[{}], agg#0=[$SUM0($1)], agg#1=[COUNT()])",
@@ -109,7 +109,7 @@
         "sql": "EXPLAIN PLAN FOR SELECT /*+ aggOptions(is_skip_leaf_stage_group_by='true') */ SUM(a.col3) as sum, COUNT(*) as count FROM a WHERE a.col3 >= 0 AND a.col2 = 'pink floyd'",
         "output": [
           "Execution Plan",
-          "\nLogicalProject(sum=[CASE(=($1, 0), null:INTEGER, $0)], count=[$1])",
+          "\nLogicalProject(sum=[CASE(=($1, 0), null:BIGINT, $0)], count=[$1])",
           "\n  LogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalAggregate(group=[{}], agg#0=[$SUM0($1)], agg#1=[COUNT()])",

--- a/pinot-query-planner/src/test/resources/queries/AggregatePlans.json
+++ b/pinot-query-planner/src/test/resources/queries/AggregatePlans.json
@@ -2,11 +2,11 @@
   "aggregates_planning_tests": {
     "queries": [
       {
-        "description": "Select AVG aggregation for a BIG_DECIMAL column",
+        "description": "Select AVG aggregation for a BIG_DECIMAL column, TODO:(No need to cast in LogicalProject)",
         "sql": "EXPLAIN PLAN FOR SELECT AVG(a.col4) as avg FROM a WHERE a.col3 >= 0 AND a.col2 = 'pink floyd'",
         "output": [
           "Execution Plan",
-          "\nLogicalProject(avg=[/(CASE(=($1, 0), null:DECIMAL(1000, 0), $0), $1)])",
+          "\nLogicalProject(avg=[CAST(/(CASE(=($1, 0), null:DECIMAL(1000, 0), $0), $1)):DECIMAL(1000, 0)])",
           "\n  LogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalAggregate(group=[{}], agg#0=[$SUM0($2)], agg#1=[COUNT()])",
@@ -17,11 +17,11 @@
         ]
       },
       {
-        "description": "Select many aggregations for a BIG_DECIMAL column",
+        "description": "Select many aggregations for a BIG_DECIMAL column, TODO:(No need to cast in LogicalProject)",
         "sql": "EXPLAIN PLAN FOR SELECT AVG(a.col4) as avg, SUM(a.col4) as sum, MAX(a.col4) as max FROM a WHERE a.col3 >= 0 AND a.col2 = 'pink floyd'",
         "output": [
           "Execution Plan",
-          "\nLogicalProject(avg=[/(CASE(=($1, 0), null:DECIMAL(1000, 0), $0), $1)], sum=[CASE(=($1, 0), null:DECIMAL(1000, 0), $0)], max=[$2])",
+          "\nLogicalProject(avg=[CAST(/(CASE(=($1, 0), null:DECIMAL(1000, 0), $0), $1)):DECIMAL(1000, 0)], sum=[CASE(=($1, 0), null:DECIMAL(1000, 0), $0)], max=[$2])",
           "\n  LogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)], agg#2=[MAX($2)])",
           "\n    PinotLogicalExchange(distribution=[hash])",
           "\n      LogicalAggregate(group=[{}], agg#0=[$SUM0($2)], agg#1=[COUNT()], agg#2=[MAX($2)])",

--- a/pinot-query-planner/src/test/resources/queries/JoinPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/JoinPlans.json
@@ -339,7 +339,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalTableScan(table=[[a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
-          "\n      LogicalProject(col1=[$0], col2=[$1], EXPR$0=[$2], col10=[CAST($0):VARCHAR], col20=[CAST($1):VARCHAR], EXPR$05=[CAST($2):DECIMAL(1000, 1)])",
+          "\n      LogicalProject(col1=[$0], col2=[$1], EXPR$0=[$2], col10=[CAST($0):VARCHAR], col20=[CAST($1):VARCHAR], EXPR$05=[CAST($2):DECIMAL(12, 1)])",
           "\n        LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)])",
           "\n          PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n            LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)])",
@@ -358,7 +358,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalTableScan(table=[[a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
-          "\n      LogicalProject(col1=[$0], col2=[$1], EXPR$0=[CAST(/(CAST($2):DECIMAL(12, 1) NOT NULL, $3)):DECIMAL(12, 1) NOT NULL], col10=[CAST($0):VARCHAR], col20=[CAST($1):VARCHAR], EXPR$05=[CAST(CAST(/(CAST($2):DECIMAL(12, 1) NOT NULL, $3)):DECIMAL(12, 1) NOT NULL):DECIMAL(12, 1)])",
+          "\n      LogicalProject(col1=[$0], col2=[$1], EXPR$0=[CAST(/($2, $3)):DECIMAL(12, 1) NOT NULL], col10=[CAST($0):VARCHAR], col20=[CAST($1):VARCHAR], EXPR$05=[CAST(CAST(/($2, $3)):DECIMAL(12, 1) NOT NULL):DECIMAL(12, 1)])",
           "\n        LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], agg#1=[COUNT($3)])",
           "\n          PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n            LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], agg#1=[COUNT()])",
@@ -410,6 +410,15 @@
       {
         "description": "Incorrect table",
         "sql": "EXPLAIN PLAN FOR SELECT b.col1 - a.col3 FROM a JOIN c ON a.col1 = c.col3",
+        "expectedException": "Error explain query plan for.*"
+      }
+    ]
+  },
+  "failed_to_decorrelate_due_to_type_mismatch": {
+    "queries": [
+      {
+        "description": "Decorrelation failed due to DECIMAL type mismatch",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1 FROM a WHERE a.col4 > (SELECT 0.5 * SUM(b.col3) FROM b WHERE b.col1 = a.col1)",
         "expectedException": "Error explain query plan for.*"
       }
     ]

--- a/pinot-query-planner/src/test/resources/queries/JoinPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/JoinPlans.json
@@ -312,8 +312,8 @@
         ]
       },
       {
-        "description": "Correlated join",
-        "sql": "EXPLAIN PLAN FOR SELECT a.col1 FROM a WHERE a.col4 > (SELECT 0.5 * SUM(b.col3) FROM b WHERE b.col2 = a.col2 AND b.col1 = a.col1)",
+        "description": "Correlated join, TODO: fix the CAST for auto hoisting the datatype",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1 FROM a WHERE a.col4 > (SELECT CAST(0.5 * SUM(b.col3) AS DOUBLE) FROM b WHERE b.col2 = a.col2 AND b.col1 = a.col1)",
         "output": [
           "Execution Plan",
           "\nLogicalProject(col1=[$0])",
@@ -321,10 +321,66 @@
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalTableScan(table=[[a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
-          "\n      LogicalProject(col1=[$0], col2=[$1], col10=[CAST($0):VARCHAR], col20=[CAST($1):VARCHAR], $f2=[CAST($2):INTEGER], EXPR$3=[*(0.5:DECIMAL(2, 1), $2)])",
+          "\n      LogicalProject(col1=[$0], col2=[$1], col10=[CAST($0):VARCHAR], col20=[CAST($1):VARCHAR], $f2=[CAST($2):BIGINT], EXPR$3=[CAST(*(0.5:DECIMAL(2, 1), $2)):DOUBLE])",
           "\n        LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)])",
           "\n          PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n            LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)])",
+          "\n              LogicalTableScan(table=[[b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Correlated join 2",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1 FROM a WHERE a.col4 > (SELECT SUM(0.5 * b.col3) FROM b WHERE b.col2 = a.col2 AND b.col1 = a.col1)",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0])",
+          "\n  LogicalJoin(condition=[AND(=($0, $7), =($1, $8), >($3, $9))], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
+          "\n      LogicalTableScan(table=[[a]])",
+          "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
+          "\n      LogicalProject(col1=[$0], col2=[$1], EXPR$0=[$2], col10=[CAST($0):VARCHAR], col20=[CAST($1):VARCHAR], EXPR$05=[CAST($2):DECIMAL(1000, 1)])",
+          "\n        LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)])",
+          "\n          PinotLogicalExchange(distribution=[hash[0, 1]])",
+          "\n            LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)])",
+          "\n              LogicalProject(col1=[$0], col2=[$1], $f0=[*(0.5:DECIMAL(2, 1), $2)])",
+          "\n                LogicalTableScan(table=[[b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Correlated join 3",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1 FROM a WHERE a.col4 > (SELECT AVG(0.5 * b.col3) FROM b WHERE b.col2 = a.col2 AND b.col1 = a.col1)",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0])",
+          "\n  LogicalJoin(condition=[AND(=($0, $7), =($1, $8), >($3, $9))], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
+          "\n      LogicalTableScan(table=[[a]])",
+          "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
+          "\n      LogicalProject(col1=[$0], col2=[$1], EXPR$0=[CAST(/(CAST($2):DECIMAL(12, 1) NOT NULL, $3)):DECIMAL(12, 1) NOT NULL], col10=[CAST($0):VARCHAR], col20=[CAST($1):VARCHAR], EXPR$05=[CAST(CAST(/(CAST($2):DECIMAL(12, 1) NOT NULL, $3)):DECIMAL(12, 1) NOT NULL):DECIMAL(12, 1)])",
+          "\n        LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], agg#1=[COUNT($3)])",
+          "\n          PinotLogicalExchange(distribution=[hash[0, 1]])",
+          "\n            LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], agg#1=[COUNT()])",
+          "\n              LogicalProject(col1=[$0], col2=[$1], $f0=[*(0.5:DECIMAL(2, 1), $2)])",
+          "\n                LogicalTableScan(table=[[b]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Correlated join 4",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1 FROM a WHERE a.col4 > (SELECT  0.5 * AVG(b.col3) FROM b WHERE b.col2 = a.col2 AND b.col1 = a.col1)",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(col1=[$0])",
+          "\n  LogicalJoin(condition=[AND(=($0, $7), =($1, $8), >($3, $12))], joinType=[inner])",
+          "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
+          "\n      LogicalTableScan(table=[[a]])",
+          "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
+          "\n      LogicalProject(col1=[$0], col2=[$1], col10=[CAST($0):VARCHAR], col20=[CAST($1):VARCHAR], $f2=[CAST(/(CAST($2):DOUBLE NOT NULL, $3)):DOUBLE], EXPR$3=[*(0.5:DECIMAL(2, 1), /(CAST($2):DOUBLE NOT NULL, $3))])",
+          "\n        LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], agg#1=[COUNT($3)])",
+          "\n          PinotLogicalExchange(distribution=[hash[0, 1]])",
+          "\n            LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)], agg#1=[COUNT()])",
           "\n              LogicalTableScan(table=[[b]])",
           "\n"
         ]

--- a/pinot-query-planner/src/test/resources/queries/JoinPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/JoinPlans.json
@@ -312,8 +312,8 @@
         ]
       },
       {
-        "description": "Correlated join, TODO: fix the CAST for auto hoisting the datatype",
-        "sql": "EXPLAIN PLAN FOR SELECT a.col1 FROM a WHERE a.col4 > (SELECT CAST(0.5 * SUM(b.col3) AS DOUBLE) FROM b WHERE b.col2 = a.col2 AND b.col1 = a.col1)",
+        "description": "Correlated join",
+        "sql": "EXPLAIN PLAN FOR SELECT a.col1 FROM a WHERE a.col4 > (SELECT 0.5 * SUM(b.col3) FROM b WHERE b.col2 = a.col2 AND b.col1 = a.col1)",
         "output": [
           "Execution Plan",
           "\nLogicalProject(col1=[$0])",
@@ -321,7 +321,7 @@
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n      LogicalTableScan(table=[[a]])",
           "\n    PinotLogicalExchange(distribution=[hash[0, 1]])",
-          "\n      LogicalProject(col1=[$0], col2=[$1], col10=[CAST($0):VARCHAR], col20=[CAST($1):VARCHAR], $f2=[CAST($2):BIGINT], EXPR$3=[CAST(*(0.5:DECIMAL(2, 1), $2)):DOUBLE])",
+          "\n      LogicalProject(col1=[$0], col2=[$1], col10=[CAST($0):VARCHAR], col20=[CAST($1):VARCHAR], $f2=[CAST($2):BIGINT], EXPR$3=[*(0.5:DECIMAL(2, 1), $2)])",
           "\n        LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)])",
           "\n          PinotLogicalExchange(distribution=[hash[0, 1]])",
           "\n            LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)])",
@@ -410,15 +410,6 @@
       {
         "description": "Incorrect table",
         "sql": "EXPLAIN PLAN FOR SELECT b.col1 - a.col3 FROM a JOIN c ON a.col1 = c.col3",
-        "expectedException": "Error explain query plan for.*"
-      }
-    ]
-  },
-  "failed_to_decorrelate_due_to_type_mismatch": {
-    "queries": [
-      {
-        "description": "Decorrelation failed due to DECIMAL type mismatch",
-        "sql": "EXPLAIN PLAN FOR SELECT a.col1 FROM a WHERE a.col4 > (SELECT 0.5 * SUM(b.col3) FROM b WHERE b.col1 = a.col1)",
         "expectedException": "Error explain query plan for.*"
       }
     ]


### PR DESCRIPTION
Derive sum return type for v2.
Based on https://www.postgresql.org/docs/current/functions-aggregate.html#FUNCTIONS-AGGREGATE-TABLE

for query:
```
SELECT SUM(DestAirportSeqID) FROM airlineStats
```
Before:
![image](https://github.com/apache/pinot/assets/1202120/278dbb4a-baaa-44d2-a116-4d7d258014a0)

After:
<img width="504" alt="image" src="https://github.com/apache/pinot/assets/1202120/314b9c12-b046-4112-83f2-7bf32c57e64a">
