### PR TITLE
Fix the NPE when query response error stream is null

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -401,8 +401,10 @@ public class PinotQueryResource {
       if (responseCode == HttpURLConnection.HTTP_FORBIDDEN) {
         throw new WebApplicationException("Permission denied", Response.Status.FORBIDDEN);
       } else if (responseCode != HttpURLConnection.HTTP_OK) {
-        throw new IOException("Failed : HTTP error code : " + responseCode + ". Root Cause: "
-            + IOUtils.toString(conn.getErrorStream(), StandardCharsets.UTF_8));
+        InputStream errorStream = conn.getErrorStream();
+        throw new IOException(
+            "Failed : HTTP error code : " + responseCode + ". Root Cause: " + (errorStream != null ? IOUtils.toString(
+                errorStream, StandardCharsets.UTF_8) : "Unknown"));
       }
       final byte[] bytes = drain(new BufferedInputStream(conn.getInputStream()));
 


### PR DESCRIPTION
This can happen when there is no error message sent back from the server (e.g. server hit NPE)