### PR TITLE
Fix the issue of consuming segment entering ERROR state due to stream connection errors

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1480,6 +1480,10 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       _partitionGroupConsumerSemaphore.release();
       _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(),
           "Failed to initialize segment data manager", e));
+      _segmentLogger.warn(
+          "Calling controller to mark the segment as OFFLINE in Ideal State because of initialization error: '{}'",
+          e.getMessage());
+      postStopConsumedMsg("Consuming segment initialization error");
       throw e;
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -234,7 +234,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private final ServerMetrics _serverMetrics;
   private final PartitionUpsertMetadataManager _partitionUpsertMetadataManager;
   private final BooleanSupplier _isReadyToConsumeData;
-  private MutableSegmentImpl _realtimeSegment;
+  private final MutableSegmentImpl _realtimeSegment;
   private volatile StreamPartitionMsgOffset _currentOffset;
   private volatile State _state;
   private volatile int _numRowsConsumed = 0;
@@ -293,10 +293,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   private final SegmentCommitterFactory _segmentCommitterFactory;
   private final ConsumptionRateLimiter _rateLimiter;
 
-  private StreamPartitionMsgOffset _latestStreamOffsetAtStartupTime;
+  private final StreamPartitionMsgOffset _latestStreamOffsetAtStartupTime;
   private final CompletionMode _segmentCompletionMode;
-
-  private RealtimeSegmentConfig.Builder _realtimeSegmentConfigBuilder;
 
   // TODO each time this method is called, we print reason for stop. Good to print only once.
   private boolean endCriteriaReached() {
@@ -652,24 +650,6 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   }
 
   public class PartitionConsumer implements Runnable {
-
-    @VisibleForTesting
-    void init() {
-      // create stream consumer and partition metadata provider
-      makeStreamConsumer("Starting");
-      createPartitionMetadataProvider("Starting");
-
-      // set latest stream offset at startup time
-      _latestStreamOffsetAtStartupTime = fetchLatestStreamOffset(5000);
-
-      // adjust partition count in partitioning config based on the actual number of stream partitions
-      SegmentPartitionConfig partitionConfig = _tableConfig.getIndexingConfig().getSegmentPartitionConfig();
-      setPartitionParameters(_realtimeSegmentConfigBuilder, partitionConfig);
-
-      // create mutable segment
-      _realtimeSegment = new MutableSegmentImpl(_realtimeSegmentConfigBuilder.build(), _serverMetrics);
-    }
-
     public void run() {
       long initialConsumptionEnd = 0L;
       long lastCatchUpStart = 0L;
@@ -699,7 +679,6 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
           _partitionUpsertMetadataManager.removeExpiredPrimaryKeys();
         }
 
-        init();
         while (!_state.isFinal()) {
           if (_state.shouldConsume()) {
             consumeLoop();  // Consume until we reached the end criteria, or we are stopped.
@@ -810,10 +789,6 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
         _realtimeTableDataManager
             .addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
         _serverMetrics.setValueOfTableGauge(_clientId, ServerGauge.LLC_PARTITION_CONSUMING, 0);
-
-        // At this point, we are done consuming from the stream using this consuming segment.
-        // We need to close the stream consumer and release the consumer semaphore.
-        closeStreamConsumers();
         return;
       }
 
@@ -1437,24 +1412,18 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
 
     // Start new realtime segment
     String consumerDir = realtimeTableDataManager.getConsumerDir();
-    _realtimeSegmentConfigBuilder =
-        new RealtimeSegmentConfig.Builder(indexLoadingConfig)
-            .setTableNameWithType(_tableNameWithType)
+    RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
+        new RealtimeSegmentConfig.Builder(indexLoadingConfig).setTableNameWithType(_tableNameWithType)
             .setSegmentName(_segmentNameStr)
-            .setStreamName(streamTopic)
-            .setSchema(_schema)
-            .setTimeColumnName(timeColumnName)
-            .setCapacity(_segmentMaxRowCount)
-            .setAvgNumMultiValues(indexLoadingConfig.getRealtimeAvgMultiValueCount())
+            .setStreamName(streamTopic).setSchema(_schema).setTimeColumnName(timeColumnName)
+            .setCapacity(_segmentMaxRowCount).setAvgNumMultiValues(indexLoadingConfig.getRealtimeAvgMultiValueCount())
             .setSegmentZKMetadata(segmentZKMetadata)
-            .setOffHeap(_isOffHeap)
-            .setMemoryManager(_memoryManager)
+            .setOffHeap(_isOffHeap).setMemoryManager(_memoryManager)
             .setStatsHistory(realtimeTableDataManager.getStatsHistory())
             .setAggregateMetrics(indexingConfig.isAggregateMetrics())
             .setIngestionAggregationConfigs(IngestionConfigUtils.getAggregationConfigs(tableConfig))
             .setNullHandlingEnabled(_nullHandlingEnabled)
-            .setConsumerDir(consumerDir)
-            .setUpsertMode(tableConfig.getUpsertMode())
+            .setConsumerDir(consumerDir).setUpsertMode(tableConfig.getUpsertMode())
             .setPartitionUpsertMetadataManager(partitionUpsertMetadataManager)
             .setPartitionDedupMetadataManager(partitionDedupMetadataManager)
             .setUpsertComparisonColumns(tableConfig.getUpsertComparisonColumns())
@@ -1486,11 +1455,16 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     try {
       _startOffset = _partitionGroupConsumptionStatus.getStartOffset();
       _currentOffset = _streamPartitionMsgOffsetFactory.create(_startOffset);
+      makeStreamConsumer("Starting");
+      createPartitionMetadataProvider("Starting");
+      setPartitionParameters(realtimeSegmentConfigBuilder, indexingConfig.getSegmentPartitionConfig());
+      _realtimeSegment = new MutableSegmentImpl(realtimeSegmentConfigBuilder.build(), serverMetrics);
       _resourceTmpDir = new File(resourceDataDir, RESOURCE_TEMP_DIR_NAME);
       if (!_resourceTmpDir.exists()) {
         _resourceTmpDir.mkdirs();
       }
       _state = State.INITIAL_CONSUMING;
+      _latestStreamOffsetAtStartupTime = fetchLatestStreamOffset(5000);
       _consumeStartTime = now();
       setConsumeEndTime(segmentZKMetadata, _consumeStartTime);
       _segmentCommitterFactory =

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -169,6 +169,7 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     final String offset = "34";
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+    segmentDataManager.createPartitionConsumer().init();
     {
       //  Controller sends catchup response with both offset and streamPartitionMsgOffset
       String responseStr =
@@ -267,6 +268,7 @@ public class LLRealtimeSegmentDataManagerTest {
   public void testSegmentBuildException()
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+    segmentDataManager.createPartitionConsumer().init();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
     final LongMsgOffset endOffset = new LongMsgOffset(START_OFFSET_VALUE + 500);
     // We should consume initially...
@@ -526,6 +528,7 @@ public class LLRealtimeSegmentDataManagerTest {
 
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.COMMITTED);
       segmentDataManager.goOnlineFromConsuming(metadata);
@@ -536,6 +539,7 @@ public class LLRealtimeSegmentDataManagerTest {
 
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.RETAINED);
       segmentDataManager.goOnlineFromConsuming(metadata);
@@ -546,6 +550,7 @@ public class LLRealtimeSegmentDataManagerTest {
 
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.DISCARDED);
       segmentDataManager.goOnlineFromConsuming(metadata);
@@ -556,6 +561,7 @@ public class LLRealtimeSegmentDataManagerTest {
 
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.ERROR);
       segmentDataManager.goOnlineFromConsuming(metadata);
@@ -567,6 +573,7 @@ public class LLRealtimeSegmentDataManagerTest {
     // If holding, but we have overshot the expected final offset, the download and replace
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.HOLDING);
       segmentDataManager.setCurrentOffset(finalOffsetValue + 1);
@@ -579,6 +586,7 @@ public class LLRealtimeSegmentDataManagerTest {
     // If catching up, but we have overshot the expected final offset, the download and replace
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
       segmentDataManager.setCurrentOffset(finalOffsetValue + 1);
@@ -591,6 +599,7 @@ public class LLRealtimeSegmentDataManagerTest {
     // If catching up, but we did not get to the final offset, then download and replace
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
       segmentDataManager._consumeOffsets.add(new LongMsgOffset(finalOffsetValue - 1));
@@ -603,6 +612,7 @@ public class LLRealtimeSegmentDataManagerTest {
     // But then if we get to the exact offset, we get to build and replace, not download
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
       segmentDataManager._consumeOffsets.add(finalOffset);
@@ -619,6 +629,7 @@ public class LLRealtimeSegmentDataManagerTest {
     // test reaching max row limit
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.INITIAL_CONSUMING);
       Assert.assertFalse(segmentDataManager.invokeEndCriteriaReached());
       segmentDataManager.setNumRowsIndexed(Fixtures.MAX_ROWS_IN_SEGMENT - 1);
@@ -631,6 +642,7 @@ public class LLRealtimeSegmentDataManagerTest {
     // test reaching max time limit
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.INITIAL_CONSUMING);
       Assert.assertFalse(segmentDataManager.invokeEndCriteriaReached());
       // We should still get false because there is no messages fetched
@@ -646,6 +658,7 @@ public class LLRealtimeSegmentDataManagerTest {
     // In catching up state, test reaching final offset
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
       final long finalOffset = START_OFFSET_VALUE + 100;
       segmentDataManager.setFinalOffset(finalOffset);
@@ -658,6 +671,7 @@ public class LLRealtimeSegmentDataManagerTest {
     // In catching up state, test reaching final offset ignoring time
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._timeSupplier.add(Fixtures.MAX_TIME_FOR_SEGMENT_CLOSE_MS);
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
       final long finalOffset = START_OFFSET_VALUE + 100;
@@ -672,6 +686,7 @@ public class LLRealtimeSegmentDataManagerTest {
     // Case 1. We have reached final offset.
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._timeSupplier.add(1);
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CONSUMING_TO_ONLINE);
       segmentDataManager.setConsumeEndTime(segmentDataManager._timeSupplier.get() + 10);
@@ -686,6 +701,7 @@ public class LLRealtimeSegmentDataManagerTest {
     // Case 2. We have reached time limit.
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CONSUMING_TO_ONLINE);
       final long endTime = segmentDataManager._timeSupplier.get() + 10;
       segmentDataManager.setConsumeEndTime(endTime);
@@ -712,6 +728,7 @@ public class LLRealtimeSegmentDataManagerTest {
   public void testReuseOfBuiltSegment()
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+    segmentDataManager.createPartitionConsumer().init();
 
     SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params();
     params.withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
@@ -749,6 +766,7 @@ public class LLRealtimeSegmentDataManagerTest {
   public void testFileRemovedDuringOnlineTransition()
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+    segmentDataManager.createPartitionConsumer().init();
 
     SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params();
     params.withStatus(SegmentCompletionProtocol.ControllerResponseStatus.FAILED);
@@ -782,17 +800,20 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     long timeout = 10_000L;
     FakeLLRealtimeSegmentDataManager firstSegmentDataManager = createFakeSegmentManager();
+    firstSegmentDataManager.createPartitionConsumer().init();
     Assert.assertTrue(firstSegmentDataManager.getAcquiredConsumerSemaphore().get());
     Semaphore firstSemaphore = firstSegmentDataManager.getPartitionGroupConsumerSemaphore();
     Assert.assertEquals(firstSemaphore.availablePermits(), 0);
     Assert.assertFalse(firstSemaphore.hasQueuedThreads());
 
-    AtomicReference<FakeLLRealtimeSegmentDataManager> secondSegmentDataManager = new AtomicReference<>(null);
+    AtomicReference<FakeLLRealtimeSegmentDataManager> secondSegmentDataManagerRef = new AtomicReference<>(null);
 
     // Construct the second segment manager, which will be blocked on the semaphore.
     Thread constructSecondSegmentManager = new Thread(() -> {
       try {
-        secondSegmentDataManager.set(createFakeSegmentManager());
+        FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
+        segmentDataManager.createPartitionConsumer().init();
+        secondSegmentDataManagerRef.set(segmentDataManager);
       } catch (Exception e) {
         throw new RuntimeException("Exception when sleeping for " + timeout + "ms", e);
       }
@@ -811,11 +832,11 @@ public class LLRealtimeSegmentDataManagerTest {
     }, timeout, "Failed to wait for the second segment blocked on semaphore");
 
     // Wait for the second segment manager finished the construction.
-    TestUtils.waitForCondition(aVoid -> secondSegmentDataManager.get() != null, timeout,
+    TestUtils.waitForCondition(aVoid -> secondSegmentDataManagerRef.get() != null, timeout,
         "Failed to acquire the semaphore for the second segment manager in " + timeout + "ms");
 
-    Assert.assertTrue(secondSegmentDataManager.get().getAcquiredConsumerSemaphore().get());
-    Semaphore secondSemaphore = secondSegmentDataManager.get().getPartitionGroupConsumerSemaphore();
+    Assert.assertTrue(secondSegmentDataManagerRef.get().getAcquiredConsumerSemaphore().get());
+    Semaphore secondSemaphore = secondSegmentDataManagerRef.get().getPartitionGroupConsumerSemaphore();
     Assert.assertEquals(firstSemaphore, secondSemaphore);
     Assert.assertEquals(secondSemaphore.availablePermits(), 0);
     Assert.assertFalse(secondSemaphore.hasQueuedThreads());
@@ -825,8 +846,8 @@ public class LLRealtimeSegmentDataManagerTest {
     Assert.assertEquals(firstSegmentDataManager.getPartitionGroupConsumerSemaphore().availablePermits(), 0);
 
     // The permit finally gets released in the Semaphore.
-    secondSegmentDataManager.get().destroy();
-    Assert.assertEquals(secondSegmentDataManager.get().getPartitionGroupConsumerSemaphore().availablePermits(), 1);
+    secondSegmentDataManagerRef.get().destroy();
+    Assert.assertEquals(secondSegmentDataManagerRef.get().getPartitionGroupConsumerSemaphore().availablePermits(), 1);
   }
 
   @Test

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -169,7 +169,6 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     final String offset = "34";
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-    segmentDataManager.createPartitionConsumer().init();
     {
       //  Controller sends catchup response with both offset and streamPartitionMsgOffset
       String responseStr =
@@ -268,7 +267,6 @@ public class LLRealtimeSegmentDataManagerTest {
   public void testSegmentBuildException()
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-    segmentDataManager.createPartitionConsumer().init();
     LLRealtimeSegmentDataManager.PartitionConsumer consumer = segmentDataManager.createPartitionConsumer();
     final LongMsgOffset endOffset = new LongMsgOffset(START_OFFSET_VALUE + 500);
     // We should consume initially...
@@ -528,7 +526,6 @@ public class LLRealtimeSegmentDataManagerTest {
 
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.COMMITTED);
       segmentDataManager.goOnlineFromConsuming(metadata);
@@ -539,7 +536,6 @@ public class LLRealtimeSegmentDataManagerTest {
 
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.RETAINED);
       segmentDataManager.goOnlineFromConsuming(metadata);
@@ -550,7 +546,6 @@ public class LLRealtimeSegmentDataManagerTest {
 
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.DISCARDED);
       segmentDataManager.goOnlineFromConsuming(metadata);
@@ -561,7 +556,6 @@ public class LLRealtimeSegmentDataManagerTest {
 
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.ERROR);
       segmentDataManager.goOnlineFromConsuming(metadata);
@@ -573,7 +567,6 @@ public class LLRealtimeSegmentDataManagerTest {
     // If holding, but we have overshot the expected final offset, the download and replace
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.HOLDING);
       segmentDataManager.setCurrentOffset(finalOffsetValue + 1);
@@ -586,7 +579,6 @@ public class LLRealtimeSegmentDataManagerTest {
     // If catching up, but we have overshot the expected final offset, the download and replace
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
       segmentDataManager.setCurrentOffset(finalOffsetValue + 1);
@@ -599,7 +591,6 @@ public class LLRealtimeSegmentDataManagerTest {
     // If catching up, but we did not get to the final offset, then download and replace
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
       segmentDataManager._consumeOffsets.add(new LongMsgOffset(finalOffsetValue - 1));
@@ -612,7 +603,6 @@ public class LLRealtimeSegmentDataManagerTest {
     // But then if we get to the exact offset, we get to build and replace, not download
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._stopWaitTimeMs = 0;
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
       segmentDataManager._consumeOffsets.add(finalOffset);
@@ -629,7 +619,6 @@ public class LLRealtimeSegmentDataManagerTest {
     // test reaching max row limit
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.INITIAL_CONSUMING);
       Assert.assertFalse(segmentDataManager.invokeEndCriteriaReached());
       segmentDataManager.setNumRowsIndexed(Fixtures.MAX_ROWS_IN_SEGMENT - 1);
@@ -642,7 +631,6 @@ public class LLRealtimeSegmentDataManagerTest {
     // test reaching max time limit
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.INITIAL_CONSUMING);
       Assert.assertFalse(segmentDataManager.invokeEndCriteriaReached());
       // We should still get false because there is no messages fetched
@@ -658,7 +646,6 @@ public class LLRealtimeSegmentDataManagerTest {
     // In catching up state, test reaching final offset
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
       final long finalOffset = START_OFFSET_VALUE + 100;
       segmentDataManager.setFinalOffset(finalOffset);
@@ -671,7 +658,6 @@ public class LLRealtimeSegmentDataManagerTest {
     // In catching up state, test reaching final offset ignoring time
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._timeSupplier.add(Fixtures.MAX_TIME_FOR_SEGMENT_CLOSE_MS);
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CATCHING_UP);
       final long finalOffset = START_OFFSET_VALUE + 100;
@@ -686,7 +672,6 @@ public class LLRealtimeSegmentDataManagerTest {
     // Case 1. We have reached final offset.
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._timeSupplier.add(1);
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CONSUMING_TO_ONLINE);
       segmentDataManager.setConsumeEndTime(segmentDataManager._timeSupplier.get() + 10);
@@ -701,7 +686,6 @@ public class LLRealtimeSegmentDataManagerTest {
     // Case 2. We have reached time limit.
     {
       FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-      segmentDataManager.createPartitionConsumer().init();
       segmentDataManager._state.set(segmentDataManager, LLRealtimeSegmentDataManager.State.CONSUMING_TO_ONLINE);
       final long endTime = segmentDataManager._timeSupplier.get() + 10;
       segmentDataManager.setConsumeEndTime(endTime);
@@ -728,7 +712,6 @@ public class LLRealtimeSegmentDataManagerTest {
   public void testReuseOfBuiltSegment()
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-    segmentDataManager.createPartitionConsumer().init();
 
     SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params();
     params.withStatus(SegmentCompletionProtocol.ControllerResponseStatus.COMMIT_SUCCESS);
@@ -766,7 +749,6 @@ public class LLRealtimeSegmentDataManagerTest {
   public void testFileRemovedDuringOnlineTransition()
       throws Exception {
     FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-    segmentDataManager.createPartitionConsumer().init();
 
     SegmentCompletionProtocol.Response.Params params = new SegmentCompletionProtocol.Response.Params();
     params.withStatus(SegmentCompletionProtocol.ControllerResponseStatus.FAILED);
@@ -800,20 +782,17 @@ public class LLRealtimeSegmentDataManagerTest {
       throws Exception {
     long timeout = 10_000L;
     FakeLLRealtimeSegmentDataManager firstSegmentDataManager = createFakeSegmentManager();
-    firstSegmentDataManager.createPartitionConsumer().init();
     Assert.assertTrue(firstSegmentDataManager.getAcquiredConsumerSemaphore().get());
     Semaphore firstSemaphore = firstSegmentDataManager.getPartitionGroupConsumerSemaphore();
     Assert.assertEquals(firstSemaphore.availablePermits(), 0);
     Assert.assertFalse(firstSemaphore.hasQueuedThreads());
 
-    AtomicReference<FakeLLRealtimeSegmentDataManager> secondSegmentDataManagerRef = new AtomicReference<>(null);
+    AtomicReference<FakeLLRealtimeSegmentDataManager> secondSegmentDataManager = new AtomicReference<>(null);
 
     // Construct the second segment manager, which will be blocked on the semaphore.
     Thread constructSecondSegmentManager = new Thread(() -> {
       try {
-        FakeLLRealtimeSegmentDataManager segmentDataManager = createFakeSegmentManager();
-        segmentDataManager.createPartitionConsumer().init();
-        secondSegmentDataManagerRef.set(segmentDataManager);
+        secondSegmentDataManager.set(createFakeSegmentManager());
       } catch (Exception e) {
         throw new RuntimeException("Exception when sleeping for " + timeout + "ms", e);
       }
@@ -832,11 +811,11 @@ public class LLRealtimeSegmentDataManagerTest {
     }, timeout, "Failed to wait for the second segment blocked on semaphore");
 
     // Wait for the second segment manager finished the construction.
-    TestUtils.waitForCondition(aVoid -> secondSegmentDataManagerRef.get() != null, timeout,
+    TestUtils.waitForCondition(aVoid -> secondSegmentDataManager.get() != null, timeout,
         "Failed to acquire the semaphore for the second segment manager in " + timeout + "ms");
 
-    Assert.assertTrue(secondSegmentDataManagerRef.get().getAcquiredConsumerSemaphore().get());
-    Semaphore secondSemaphore = secondSegmentDataManagerRef.get().getPartitionGroupConsumerSemaphore();
+    Assert.assertTrue(secondSegmentDataManager.get().getAcquiredConsumerSemaphore().get());
+    Semaphore secondSemaphore = secondSegmentDataManager.get().getPartitionGroupConsumerSemaphore();
     Assert.assertEquals(firstSemaphore, secondSemaphore);
     Assert.assertEquals(secondSemaphore.availablePermits(), 0);
     Assert.assertFalse(secondSemaphore.hasQueuedThreads());
@@ -846,8 +825,8 @@ public class LLRealtimeSegmentDataManagerTest {
     Assert.assertEquals(firstSegmentDataManager.getPartitionGroupConsumerSemaphore().availablePermits(), 0);
 
     // The permit finally gets released in the Semaphore.
-    secondSegmentDataManagerRef.get().destroy();
-    Assert.assertEquals(secondSegmentDataManagerRef.get().getPartitionGroupConsumerSemaphore().availablePermits(), 1);
+    secondSegmentDataManager.get().destroy();
+    Assert.assertEquals(secondSegmentDataManager.get().getPartitionGroupConsumerSemaphore().availablePermits(), 1);
   }
 
   @Test


### PR DESCRIPTION
## Description

This PR fixes the issue described in #11165 by calling controller to mark the Ideal State for the segment as OFFLINE when there's error in consumer setup (or in general LLRealtimeSegmentDataManager initialization).

## Testing Done
Ran an integration test locally and simulated an exception during initial stream consumer setup: 
Before the problematic segment goes to ERROR state, the IS is marked as OFFLINE for the segment. For a very short period of time, the EV was in ERROR state till Helix kicks off ERROR -> OFFLINE transition for that segment. Then it became OFFLINE. After that kicking off RealtimeSegmentValidationManager created a new consuming segment for the partition.