### PR TITLE
[multistage]: Removing the format support in explain physical plan sql queries.

### DIFF
--- a/pinot-common/src/main/codegen/includes/parserImpls.ftl
+++ b/pinot-common/src/main/codegen/includes/parserImpls.ftl
@@ -125,22 +125,11 @@ SqlNode SqlPhysicalExplain() :
     SqlNode stmt;
     SqlExplainLevel detailLevel = SqlExplainLevel.EXPPLAN_ATTRIBUTES;
     SqlExplain.Depth depth = SqlExplain.Depth.PHYSICAL;
-    final SqlExplainFormat format;
+    final SqlExplainFormat format = SqlExplainFormat.TEXT;
 }
 {
     <EXPLAIN> <IMPLEMENTATION> <PLAN>
     [ detailLevel = ExplainDetailLevel() ]
-    (
-        LOOKAHEAD(2)
-        <AS> <XML> { format = SqlExplainFormat.XML; }
-    |
-        LOOKAHEAD(2)
-        <AS> <JSON> { format = SqlExplainFormat.JSON; }
-    |
-        <AS> <DOT_FORMAT> { format = SqlExplainFormat.DOT; }
-    |
-        { format = SqlExplainFormat.TEXT; }
-    )
     <FOR> stmt = SqlQueryOrDml() {
         return new SqlPhysicalExplain(getPos(),
             stmt,

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -476,7 +476,7 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
   private Object[][] provideQueriesWithExplainedPhysicalPlan() {
     //@formatter:off
     return new Object[][] {
-new Object[]{"EXPLAIN IMPLEMENTATION PLAN INCLUDING ALL ATTRIBUTES AS JSON FOR SELECT col1, col3 FROM a",
+new Object[]{"EXPLAIN IMPLEMENTATION PLAN INCLUDING ALL ATTRIBUTES FOR SELECT col1, col3 FROM a",
   "[0]@localhost:3 MAIL_RECEIVE(RANDOM_DISTRIBUTED)\n"
   + "├── [1]@localhost:2 MAIL_SEND(RANDOM_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n"
   + "│   └── [1]@localhost:2 PROJECT\n"
@@ -484,7 +484,7 @@ new Object[]{"EXPLAIN IMPLEMENTATION PLAN INCLUDING ALL ATTRIBUTES AS JSON FOR S
   + "└── [1]@localhost:1 MAIL_SEND(RANDOM_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n"
   + "   └── [1]@localhost:1 PROJECT\n"
   + "      └── [1]@localhost:1 TABLE SCAN (a) null\n"},
-new Object[]{"EXPLAIN IMPLEMENTATION PLAN EXCLUDING ATTRIBUTES AS DOT FOR "
+new Object[]{"EXPLAIN IMPLEMENTATION PLAN EXCLUDING ATTRIBUTES FOR "
     + "SELECT col1, COUNT(*) FROM a GROUP BY col1",
   "[0]@localhost:3 MAIL_RECEIVE(RANDOM_DISTRIBUTED)\n"
   + "├── [1]@localhost:2 MAIL_SEND(RANDOM_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]} (Subtree Omitted)\n"


### PR DESCRIPTION
As per the [issue](https://github.com/apache/pinot/issues/11178), a minor change for removing the support of `FORMAT` in `EXPLAIN IMPLEMENTATION PLAN`  queries.

cc: @walterddr 