### PR TITLE
Reload Table API to reload table data

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/messages/TableReloadMessage.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/messages/TableReloadMessage.java
@@ -1,0 +1,71 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.common.messages;
+
+import java.util.UUID;
+import org.apache.helix.model.Message;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+
+
+/**
+ * This (Helix) message is sent from the controller to brokers when a request is received to reload the table.
+ *
+ * NOTE: We keep the table name as a separate key instead of using the Helix PARTITION_NAME so that this message can be
+ *       used for any resource.
+ */
+public class TableReloadMessage extends Message {
+  public static final String RELOAD_TABLE_MSG_SUB_TYPE = "RELOAD_TABLE";
+
+  private static final String TABLE_NAME_KEY = "tableName";
+  private static final String FORCE_KEY = "force";
+
+  /**
+   * Constructor for the sender.
+   */
+  public TableReloadMessage(String tableNameWithType, boolean force) {
+    super(MessageType.USER_DEFINE_MSG, UUID.randomUUID().toString());
+    setMsgSubType(RELOAD_TABLE_MSG_SUB_TYPE);
+    // Give it infinite time to process the message, as long as session is alive
+    setExecutionTimeout(-1);
+    // Set the Pinot specific fields
+    // NOTE: DO NOT use Helix field "PARTITION_NAME" because it can be overridden by Helix while sending the message
+    ZNRecord znRecord = getRecord();
+    znRecord.setSimpleField(TABLE_NAME_KEY, tableNameWithType);
+    znRecord.setBooleanField(FORCE_KEY, force);
+  }
+
+  /**
+   * Constructor for the receiver.
+   */
+  public TableReloadMessage(Message message) {
+    super(message.getRecord());
+    if (!message.getMsgSubType().equals(RELOAD_TABLE_MSG_SUB_TYPE)) {
+      throw new IllegalArgumentException("Invalid message subtype:" + message.getMsgSubType());
+    }
+  }
+
+  public String getTableNameWithType() {
+    return getRecord().getSimpleField(TABLE_NAME_KEY);
+  }
+
+  public boolean isForce() {
+    return getRecord().getBooleanField(FORCE_KEY, false);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metadata/ZKMetadataProvider.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.AccessOption;
 import org.apache.helix.store.HelixPropertyStore;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -315,6 +316,15 @@ public class ZKMetadataProvider {
   public static TableConfig getTableConfig(ZkHelixPropertyStore<ZNRecord> propertyStore, String tableNameWithType) {
     return toTableConfig(propertyStore.get(constructPropertyStorePathForResourceConfig(tableNameWithType), null,
         AccessOption.PERSISTENT));
+  }
+
+  public static Pair<TableConfig, ZNRecord> getTableConfigWithZNRecord(ZkHelixPropertyStore<ZNRecord> propertyStore,
+      String tableNameWithType) {
+    Stat stat = new Stat();
+    ZNRecord znRecord = propertyStore.get(constructPropertyStorePathForResourceConfig(tableNameWithType), stat,
+        AccessOption.PERSISTENT);
+    znRecord.setVersion(stat.getVersion());
+    return Pair.of(toTableConfig(znRecord), znRecord);
   }
 
   @Nullable

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ServerReloadTableControllerJobStatusResponse.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/ServerReloadTableControllerJobStatusResponse.java
@@ -1,0 +1,62 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.api.resources;
+
+import java.util.Map;
+
+
+public class ServerReloadTableControllerJobStatusResponse {
+  private boolean _completed;
+  private int _totalServersQueried;
+  private int _totalServerCallsFailed;
+  private Map<String, String> _metadata;
+
+  public boolean isCompleted() {
+    return _completed;
+  }
+
+  public void setCompleted(boolean completed) {
+    _completed = completed;
+  }
+
+  public int getTotalServersQueried() {
+    return _totalServersQueried;
+  }
+
+  public void setTotalServersQueried(int totalServersQueried) {
+    _totalServersQueried = totalServersQueried;
+  }
+
+  public int getTotalServerCallsFailed() {
+    return _totalServerCallsFailed;
+  }
+
+  public void setTotalServerCallsFailed(int totalServerCallsFailed) {
+    _totalServerCallsFailed = totalServerCallsFailed;
+  }
+
+  public Map<String, String> getMetadata() {
+    return _metadata;
+  }
+
+  public void setMetadata(Map<String, String> metadata) {
+    _metadata = metadata;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -106,6 +106,7 @@ import org.apache.pinot.common.messages.SegmentRefreshMessage;
 import org.apache.pinot.common.messages.SegmentReloadMessage;
 import org.apache.pinot.common.messages.TableConfigRefreshMessage;
 import org.apache.pinot.common.messages.TableDeletionMessage;
+import org.apache.pinot.common.messages.TableReloadMessage;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.controllerjob.ControllerJobType;
 import org.apache.pinot.common.metadata.instance.InstanceZKMetadata;
@@ -2031,6 +2032,24 @@ public class PinotHelixResourceManager {
         ZKMetadataProvider.constructPropertyStorePathForControllerJob(ControllerJobType.RELOAD_SEGMENT));
   }
 
+  /**
+   *
+   * @param tableNameWithType Table for which job is to be added
+   * @param jobId job's UUID
+   * @param numMessagesSent number of messages that were sent to servers. Saved as metadata
+   * @return boolean representing success / failure of the ZK write step
+   */
+  public boolean addNewReloadTableJob(String tableNameWithType, String jobId, int numMessagesSent) {
+    Map<String, String> jobMetadata = new HashMap<>();
+    jobMetadata.put(CommonConstants.ControllerJob.JOB_ID, jobId);
+    jobMetadata.put(CommonConstants.ControllerJob.TABLE_NAME_WITH_TYPE, tableNameWithType);
+    jobMetadata.put(CommonConstants.ControllerJob.JOB_TYPE, ControllerJobType.RELOAD_TABLE.toString());
+    jobMetadata.put(CommonConstants.ControllerJob.SUBMISSION_TIME_MS, Long.toString(System.currentTimeMillis()));
+    jobMetadata.put(CommonConstants.ControllerJob.MESSAGE_COUNT, Integer.toString(numMessagesSent));
+    return addControllerJobToZK(jobId, jobMetadata,
+        ZKMetadataProvider.constructPropertyStorePathForControllerJob(ControllerJobType.RELOAD_TABLE));
+  }
+
   public boolean addNewForceCommitJob(String tableNameWithType, String jobId, Set<String> consumingSegmentsCommitted)
       throws JsonProcessingException {
     Map<String, String> jobMetadata = new HashMap<>();
@@ -2363,6 +2382,28 @@ public class PinotHelixResourceManager {
       LOGGER.warn("No reload message sent for segment: {} in table: {}", segmentName, tableNameWithType);
     }
     return Pair.of(numMessagesSent, segmentReloadMessage.getMsgId());
+  }
+
+  public Pair<Integer, String> reloadTable(String tableNameWithType, boolean force) {
+    LOGGER.info("Sending reload message for table: {}", tableNameWithType);
+
+    Criteria recipientCriteria = new Criteria();
+    recipientCriteria.setRecipientInstanceType(InstanceType.PARTICIPANT);
+    recipientCriteria.setInstanceName("%");
+    recipientCriteria.setResource(tableNameWithType);
+    recipientCriteria.setSessionSpecific(true);
+    TableReloadMessage tableReloadMessage = new TableReloadMessage(tableNameWithType, force);
+    ClusterMessagingService messagingService = _helixZkManager.getMessagingService();
+
+    // Infinite timeout on the recipient
+    int timeoutMs = -1;
+    int numMessagesSent = messagingService.send(recipientCriteria, tableReloadMessage, null, timeoutMs);
+    if (numMessagesSent > 0) {
+      LOGGER.info("Sent {} reload messages for table: {}", numMessagesSent, tableNameWithType);
+    } else {
+      LOGGER.warn("No reload message sent for table: {}", tableNameWithType);
+    }
+    return Pair.of(numMessagesSent, tableReloadMessage.getMsgId());
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/auth/Actions.java
@@ -113,6 +113,7 @@ public class Actions {
     public static final String GET_INSTANCE_PARTITIONS = "GetInstancePartitions";
     public static final String GET_METADATA = "GetMetadata";
     public static final String GET_PAUSE_STATUS = "GetPauseStatus";
+    public static final String GET_TABLE_RELOAD_STATUS = "GetTableReloadStatus";
     public static final String GET_ROUTING_TABLE = "GetRoutingTable";
     public static final String GET_SCHEMA = "GetSchema";
     public static final String GET_SEGMENT = "GetSegment";
@@ -132,6 +133,7 @@ public class Actions {
     public static final String REBUILD_BROKER_RESOURCE = "RebuildBrokerResource";
     public static final String REFRESH_ROUTING = "RefreshRouting";
     public static final String RELOAD_SEGMENT = "ReloadSegment";
+    public static final String RELOAD_TABLE = "ReloadTable";
     public static final String REPLACE_SEGMENT = "ReplaceSegment";
     public static final String RESUME_CONSUMPTION = "ResumeConsumption";
     public static final String UPDATE_INSTANCE_PARTITIONS = "UpdateInstancePartitions";

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -88,6 +88,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected static final Logger LOGGER = LoggerFactory.getLogger(BaseTableDataManager.class);
 
   protected final ConcurrentHashMap<String, SegmentDataManager> _segmentDataManagerMap = new ConcurrentHashMap<>();
+  private final long _loadTimeMs = System.currentTimeMillis();
+
   // Semaphore to restrict the maximum number of parallel segment downloads for a table.
   private Semaphore _segmentDownloadSemaphore;
 
@@ -459,6 +461,11 @@ public abstract class BaseTableDataManager implements TableDataManager {
       }
       throw reloadFailureException;
     }
+  }
+
+  @Override
+  public long getLoadTimeMs() {
+    return _loadTimeMs;
   }
 
   private boolean canReuseExistingDirectoryForReload(SegmentZKMetadata segmentZKMetadata, String currentSegmentTier,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -127,6 +127,13 @@ public interface InstanceDataManager {
   void addOrReplaceSegment(String tableNameWithType, String segmentName)
       throws Exception;
 
+
+  /**
+   * Reloads the table metadata in the servers. One of the things it does it reconstruct
+   * the table metadata manager.
+   */
+  void reloadTable(String tableNameWithType, boolean force, SegmentRefreshSemaphore segmentRefreshSemaphore);
+
   /**
    * Returns all tables served by the instance.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildTimeLeaseExtender.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildTimeLeaseExtender.java
@@ -85,7 +85,7 @@ public class SegmentBuildTimeLeaseExtender {
         LOGGER.info("Created lease extender for table: {}", tableNameWithType);
         return leaseExtender;
       } else {
-        LOGGER.warn("Lease extender for table: {} already exists", tableNameWithType);
+        LOGGER.debug("Lease extender for table: {} already exists", tableNameWithType);
         return v;
       }
     });

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ReloadTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ReloadTableIntegrationTest.java
@@ -1,0 +1,117 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.integration.tests;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.List;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.controller.api.resources.ServerReloadTableControllerJobStatusResponse;
+import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.StringUtil;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+public class ReloadTableIntegrationTest extends BaseClusterIntegrationTest {
+
+  @BeforeClass
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir);
+
+    // Start the Pinot cluster
+    startZk();
+    startController();
+    startBroker();
+    startServer();
+
+    // Start Kafka
+    startKafka();
+
+    // Unpack the Avro files
+    List<File> avroFiles = unpackAvroData(_tempDir);
+
+    // Create and upload the schema and table config
+    Schema schema = createSchema();
+    addSchema(schema);
+    TableConfig tableConfig = createRealtimeTableConfig(avroFiles.get(0));
+    addTableConfig(tableConfig);
+
+    // Push data into Kafka
+    pushAvroIntoKafka(avroFiles);
+
+    // Set up the H2 connection
+    setUpH2Connection(avroFiles);
+
+    // Initialize the query generator
+    setUpQueryGenerator(avroFiles);
+
+    // Wait for all documents loaded
+    waitForAllDocsLoaded(600_000L);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    dropRealtimeTable(getTableName());
+    stopServer();
+    stopBroker();
+    stopController();
+    stopKafka();
+    stopZk();
+    FileUtils.deleteDirectory(_tempDir);
+  }
+
+  @Test
+  public void testTableReload()
+      throws Exception {
+    String responseStr = ControllerTest.sendPostRequest(
+        StringUtil.join("/", getControllerBaseApiUrl(), "tables", getTableName(), "reload?force=true"), null);
+    assertTrue(responseStr.contains("Submitted reload table job"));
+
+    // TODO fix this once SuccessResponse has a top-level field for returning job IDs
+    final String jobId = responseStr.split("with id: ")[1].split(",")[0];
+    final int maxDelay = 10_000;
+    int delay = 1_000;
+
+    // wait for reload to finish
+    ServerReloadTableControllerJobStatusResponse response;
+    do {
+      Thread.sleep(delay);
+      responseStr = ControllerTest.sendGetRequest(
+          StringUtil.join("/", getControllerBaseApiUrl(), "tables", "tableReloadStatus", jobId), null);
+
+      response = JsonUtils.stringToObject(responseStr, ServerReloadTableControllerJobStatusResponse.class);
+      delay = Math.min(delay * 2, maxDelay);
+    } while (!response.isCompleted());
+
+    // Validate no change
+    assertEquals(getCurrentCountStarResult(), getCountStarResult());
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/ReadOnlyTableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/ReadOnlyTableDataManager.java
@@ -1,0 +1,168 @@
+package org.apache.pinot.segment.local.data.manager;
+
+import com.google.common.cache.LoadingCache;
+import java.io.File;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.HelixManager;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.SegmentMetadata;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+
+
+/**
+ * A read-only wrapper for an existing table data manager
+ */
+public class ReadOnlyTableDataManager implements TableDataManager {
+  // underlying table data manager
+  private final TableDataManager _tableDataManager;
+  private final String readOnlyReason;
+
+  public ReadOnlyTableDataManager(TableDataManager tableDataManager, String readOnlyReason) {
+    this._tableDataManager = tableDataManager;
+    this.readOnlyReason = readOnlyReason;
+  }
+
+  @Override
+  public void init(TableDataManagerConfig tableDataManagerConfig, String instanceId,
+      ZkHelixPropertyStore<ZNRecord> propertyStore, ServerMetrics serverMetrics, HelixManager helixManager,
+      @Nullable ExecutorService segmentPreloadExecutor,
+      @Nullable LoadingCache<Pair<String, String>, SegmentErrorInfo> errorCache,
+      TableDataManagerParams tableDataManagerParams) {
+    _tableDataManager.init(tableDataManagerConfig, instanceId, propertyStore, serverMetrics, helixManager,
+        segmentPreloadExecutor, errorCache, tableDataManagerParams);
+  }
+
+  @Override
+  public void start() {
+    _tableDataManager.start();
+  }
+
+  @Override
+  public void shutDown() {
+    throw new ReadOnlyTableDataManagerException(readOnlyReason, "shutDown");
+  }
+
+  @Override
+  public boolean isShutDown() {
+    return _tableDataManager.isShutDown();
+  }
+
+  @Override
+  public void addSegment(ImmutableSegment immutableSegment) {
+    throw new ReadOnlyTableDataManagerException(readOnlyReason, "addSegment");
+  }
+
+  @Override
+  public void addSegment(File indexDir, IndexLoadingConfig indexLoadingConfig)
+      throws Exception {
+    throw new ReadOnlyTableDataManagerException(readOnlyReason, "addSegment");
+  }
+
+  @Override
+  public void addSegment(String segmentName, IndexLoadingConfig indexLoadingConfig, SegmentZKMetadata zkMetadata)
+      throws Exception {
+    throw new ReadOnlyTableDataManagerException(readOnlyReason, "addSegment");
+  }
+
+  @Override
+  public void reloadSegment(String segmentName, IndexLoadingConfig indexLoadingConfig, SegmentZKMetadata zkMetadata,
+      SegmentMetadata localMetadata, @Nullable Schema schema, boolean forceDownload)
+      throws Exception {
+    throw new ReadOnlyTableDataManagerException(readOnlyReason, "reloadSegment");
+  }
+
+  @Override
+  public void addOrReplaceSegment(String segmentName, IndexLoadingConfig indexLoadingConfig,
+      SegmentZKMetadata zkMetadata, @Nullable SegmentMetadata localMetadata)
+      throws Exception {
+    throw new ReadOnlyTableDataManagerException(readOnlyReason, "addOrReplaceSegment");
+  }
+
+  @Override
+  public void removeSegment(String segmentName) {
+    throw new ReadOnlyTableDataManagerException(readOnlyReason, "removeSegment");
+  }
+
+  @Override
+  public boolean tryLoadExistingSegment(String segmentName, IndexLoadingConfig indexLoadingConfig,
+      SegmentZKMetadata zkMetadata) {
+    throw new ReadOnlyTableDataManagerException(readOnlyReason, "tryLoadExistingSegment");
+  }
+
+  @Override
+  public File getSegmentDataDir(String segmentName, @Nullable String segmentTier, TableConfig tableConfig) {
+    return _tableDataManager.getSegmentDataDir(segmentTier, segmentTier, tableConfig);
+  }
+
+  @Override
+  public boolean isSegmentDeletedRecently(String segmentName) {
+    return _tableDataManager.isSegmentDeletedRecently(segmentName);
+  }
+
+  @Override
+  public List<SegmentDataManager> acquireAllSegments() {
+    return _tableDataManager.acquireAllSegments();
+  }
+
+  @Override
+  public List<SegmentDataManager> acquireSegments(List<String> segmentNames, List<String> missingSegments) {
+    return _tableDataManager.acquireSegments(segmentNames, missingSegments);
+  }
+
+  @Nullable
+  @Override
+  public SegmentDataManager acquireSegment(String segmentName) {
+    return _tableDataManager.acquireSegment(segmentName);
+  }
+
+  @Override
+  public void releaseSegment(SegmentDataManager segmentDataManager) {
+    _tableDataManager.releaseSegment(segmentDataManager);
+  }
+
+  @Override
+  public int getNumSegments() {
+    return _tableDataManager.getNumSegments();
+  }
+
+  @Override
+  public String getTableName() {
+    return _tableDataManager.getTableName();
+  }
+
+  @Override
+  public File getTableDataDir() {
+    return _tableDataManager.getTableDataDir();
+  }
+
+  @Override
+  public TableDataManagerConfig getTableDataManagerConfig() {
+    return _tableDataManager.getTableDataManagerConfig();
+  }
+
+  @Override
+  public void addSegmentError(String segmentName, SegmentErrorInfo segmentErrorInfo) {
+    _tableDataManager.addSegmentError(segmentName, segmentErrorInfo);
+  }
+
+  @Override
+  public Map<String, SegmentErrorInfo> getSegmentErrors() {
+    return _tableDataManager.getSegmentErrors();
+  }
+
+  @Override
+  public long getLoadTimeMs() {
+    return _tableDataManager.getLoadTimeMs();
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/ReadOnlyTableDataManagerException.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/ReadOnlyTableDataManagerException.java
@@ -1,7 +1,0 @@
-package org.apache.pinot.segment.local.data.manager;
-
-public class ReadOnlyTableDataManagerException extends UnsupportedOperationException {
-  public ReadOnlyTableDataManagerException(String readOnlyReason, String operation) {
-    super("cannot " + operation + " during " + readOnlyReason);
-  }
-}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/ReadOnlyTableDataManagerException.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/ReadOnlyTableDataManagerException.java
@@ -1,0 +1,7 @@
+package org.apache.pinot.segment.local.data.manager;
+
+public class ReadOnlyTableDataManagerException extends UnsupportedOperationException {
+  public ReadOnlyTableDataManagerException(String readOnlyReason, String operation) {
+    super("cannot " + operation + " during " + readOnlyReason);
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -237,4 +237,10 @@ public interface TableDataManager {
    */
   default void onConsumingToOnline(String segmentNameStr) {
   };
+
+  /**
+   * Returns the load time of this table data manager (in milliseconds).
+   * @return load time in ms
+   */
+  long getLoadTimeMs();
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerConfig.java
@@ -40,10 +40,13 @@ public class TableDataManagerConfig {
 
   private final InstanceDataManagerConfig _instanceDataManagerConfig;
   private final TableConfig _tableConfig;
+  private final int _tableConfigZNRecordVersion;
 
-  public TableDataManagerConfig(InstanceDataManagerConfig instanceDataManagerConfig, TableConfig tableConfig) {
+  public TableDataManagerConfig(InstanceDataManagerConfig instanceDataManagerConfig,
+      TableConfig tableConfig, int tableConfigZNRecordVersion) {
     _instanceDataManagerConfig = instanceDataManagerConfig;
     _tableConfig = tableConfig;
+    _tableConfigZNRecordVersion = tableConfigZNRecordVersion;
   }
 
   public InstanceDataManagerConfig getInstanceDataManagerConfig() {
@@ -52,6 +55,10 @@ public class TableDataManagerConfig {
 
   public TableConfig getTableConfig() {
     return _tableConfig;
+  }
+
+  public int getTableConfigZNRecordVersion() {
+    return _tableConfigZNRecordVersion;
   }
 
   public String getTableName() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerDelegate.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManagerDelegate.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.segment.local.data.manager;
 
 import com.google.common.cache.LoadingCache;
@@ -33,7 +51,7 @@ public class TableDataManagerDelegate implements TableDataManager {
   }
 
   public TableDataManagerDelegate(Supplier<TableDataManager> getTableDataManager) {
-    this._getTableDataManager = getTableDataManager;
+    _getTableDataManager = getTableDataManager;
   }
 
   @Override

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ControllerJobStatusResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/ControllerJobStatusResource.java
@@ -89,4 +89,20 @@ public class ControllerJobStatusResource {
       }
     }
   }
+
+  @GET
+  @Path("/controllerJob/reloadTableStatus/{tableNameWithType}")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Task status", notes = "Return the status of a given reload job")
+  public String reloadTableStatus(@PathParam("tableNameWithType") String tableNameWithType,
+          @QueryParam("reloadJobTimestamp") long reloadJobSubmissionTimestamp)
+          throws Exception {
+    TableDataManager tableDataManager =
+            ServerResourceUtils.checkGetTableDataManager(_serverInstance, tableNameWithType);
+    long loadTimeMs = tableDataManager.getLoadTimeMs();
+    boolean completed = loadTimeMs >= reloadJobSubmissionTimestamp;
+    TableReloadStatusValue value = new TableReloadStatusValue();
+    value.setCompleted(completed);
+    return JsonUtils.objectToString(value);
+  }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableReloadStatusValue.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableReloadStatusValue.java
@@ -16,8 +16,16 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.common.metadata.controllerjob;
+package org.apache.pinot.server.api.resources;
 
-public enum ControllerJobType {
-  RELOAD_SEGMENT, RELOAD_TABLE, FORCE_COMMIT, TABLE_REBALANCE, TENANT_REBALANCE
+public class TableReloadStatusValue {
+  private boolean _completed;
+
+  public boolean isCompleted() {
+    return _completed;
+  }
+
+  public void setCompleted(boolean completed) {
+    _completed = completed;
+  }
 }


### PR DESCRIPTION
Fixes #10916.

**Approach**: This PR adds a new Reload Table API to reload table configurations to the Pinot Controller. The Controller would send a Helix message to all servers to signal the reload. The TableDataManager has a new in-memory state called loadTime to denote when it was loaded. For reload table status checks, a new controller API is added which polls all the servers that host the table and checks if the loadTime of that table data manager > reload job submission time.

More details can be found in #10916.

**Test plan**:
- Added an integration test for reloading table and validating if it is successful.
- Tested locally taking an upsert table and converting that to a partial upsert table - verified that there were no reduction in row counts, no query errors during the reload time frame.