### PR TITLE
bugfix: safely multiply integers to prevent overflow

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
@@ -163,7 +163,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
    */
   private void addDataBuffer(int rowCapacity) {
     try {
-      long size = rowCapacity * _columnSizeInBytes;
+      long size = (long) rowCapacity * (long) _columnSizeInBytes;
       LOGGER.info("Allocating data buffer of size {} for column {}", size, _context);
       // NOTE: PinotDataBuffer is tracked in PinotDataBufferMemoryManager. No need to track and close inside the class.
       PinotDataBuffer dataBuffer = _memoryManager.allocate(size, _context);


### PR DESCRIPTION
We've observed this exception, blocking ingestion:
```
j.l.IllegalArgumentException: Illegal memory allocation -2116790016 for segment <table>__0__50__20230724T1340Z column <table>__0__50__20230724T1340Z:message_encodedVars.mv.raw.fwd 
at c.g.common.base.Preconditions.checkArgument(Preconditions.java:135) 
at o.a.p.s.l.i.r.RealtimeIndexOffHeapMemoryManager.allocate(RealtimeIndexOffHeapMemoryManager.java:83) 
at o.a.p.s.l.r.i.f.FixedByteMVMutableForwardIndex.addDataBuffer(FixedByteMVMutableForwardIndex.java:169) 
... 21 common frames omitted 
Wrapped by: java.lang.RuntimeException: Error while expanding the capacity by allocating additional buffer with capacity:272272160 
at o.a.p.s.l.r.i.f.FixedByteMVMutableForwardIndex.addDataBuffer(FixedByteMVMutableForwardIndex.java:176) 
at o.a.p.s.l.r.i.f.FixedByteMVMutableForwardIndex.<init>(FixedByteMVMutableForwardIndex.java:142) 
at o.a.p.s.l.s.i.f.ForwardIndexType.createMutableIndex(ForwardIndexType.java:300) 
at o.a.p.s.l.s.i.f.ForwardIndexType.createMutableIn...
```

The negative size comes from an int overflow from unsafe multiplication of two ints.