### PR TITLE
[multistage][bugfix] dont duplicate register scalar function in CalciteSchema

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -21,7 +21,6 @@ package org.apache.pinot.common.function;
 import com.google.common.base.Preconditions;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -126,10 +125,6 @@ public class FunctionRegistry {
 
   public static Map<String, List<Function>> getRegisteredCalciteFunctionMap() {
     return FUNCTION_MAP.map();
-  }
-
-  public static Collection<Function> getRegisteredCalciteFunctions(String name) {
-    return FUNCTION_MAP.map().get(name);
   }
 
   public static Set<String> getRegisteredCalciteFunctionNames() {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
@@ -31,7 +31,6 @@ import org.apache.calcite.schema.SchemaVersion;
 import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.schema.Table;
 import org.apache.pinot.common.config.provider.TableCache;
-import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 import static java.util.Objects.requireNonNull;
@@ -92,14 +91,22 @@ public class PinotCatalog implements Schema {
     return Collections.emptySet();
   }
 
+  /**
+   * {@code PinotCatalog} doesn't need to return function collections b/c they are already registered.
+   * see: {@link org.apache.calcite.jdbc.CalciteSchemaBuilder#asRootSchema(Schema)}
+   */
   @Override
   public Collection<Function> getFunctions(String name) {
-    return FunctionRegistry.getRegisteredCalciteFunctions(name);
+    return Collections.emptyList();
   }
 
+  /**
+   * {@code PinotCatalog} doesn't need to return function name set b/c they are already registered.
+   * see: {@link org.apache.calcite.jdbc.CalciteSchemaBuilder#asRootSchema(Schema)}
+   */
   @Override
   public Set<String> getFunctionNames() {
-    return FunctionRegistry.getRegisteredCalciteFunctionNames();
+    return Collections.emptySet();
   }
 
   @Override

--- a/pinot-query-runtime/src/test/resources/queries/SpecialSyntax.json
+++ b/pinot-query-runtime/src/test/resources/queries/SpecialSyntax.json
@@ -41,6 +41,14 @@
         ]
       },
       {
+        "description": "test scalar function with STD SQL operator, and scalar function exactly match should be found properly",
+        "sql": "SELECT upper(col1), roundDecimal(col3_r), add(plus(CAST(col3_l AS DOUBLE), cast(col3_r AS DOUBLE)), cast(10 AS DOUBLE)) FROM (SELECT {tbl1}.col1 AS col1, {tbl1}.col3 AS col3_l, {tbl2}.col3 AS col3_r FROM {tbl1} JOIN {tbl2} USING (col2))",
+        "outputs": [
+          ["BAR", 3, 15.0],
+          ["FOO", 4, 15.0]
+        ]
+      },
+      {
         "description": "test scalar function with STD SQL operator, and scalar function without STD SQL operator can be found properly",
         "sql": "SELECT UpPeR(col1), round_deCiMal(col3_r), aDD(pluS(CAST(col3_l AS DOUBLE), CAST(col3_r AS DOUBLE)), CAST(10 AS DOUBLE)) FROM (SELECT {tbl1}.col1 AS col1, {tbl1}.col3 AS col3_l, {tbl2}.col3 AS col3_r FROM {tbl1} JOIN {tbl2} USING (col2))",
         "outputs": [


### PR DESCRIPTION
this fixes: #11189 

Schema (PinotCatalog) and FunctionMap (CalciteSchema.SchemaPlus) both registers functions from FunctionRegistry. previously we registered in both, thus causes confusion.

the solution is to only do it in SchemaPlus b/c it handles case sensitivity 