### PR TITLE
Make Preload Integration test more extensible

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
@@ -205,7 +205,7 @@ public class UpsertTableSegmentPreloadIntegrationTest extends BaseClusterIntegra
     waitForAllDocsLoaded(600_000L);
   }
 
-  private void waitForSnapshotCreation()
+  protected void waitForSnapshotCreation()
       throws Exception {
     Set<String> consumingSegments = getConsumingSegmentsFromIdealState(getTableName() + "_REALTIME");
     // trigger force commit for snapshots
@@ -246,7 +246,7 @@ public class UpsertTableSegmentPreloadIntegrationTest extends BaseClusterIntegra
       } catch (Exception e) {
         return false;
       }
-    }, 60000L, "Error verifying force commit operation on table!");
+    }, 120000L, "Error verifying force commit operation on table!");
   }
 
   protected void verifyIdealState(int numSegmentsExpected) {


### PR DESCRIPTION
* This will allow us to simply extend this test for more usecases
* The primary difference in most such test is what data is loaded and how to check if data is loaded or not. Hence seperating out these two methods make sense so they can be overwritten by child classes
