### PR TITLE
Fix for issue when using MinIO as deep store

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -138,10 +138,8 @@ public class S3PinotFS extends BasePinotFS {
                 .asyncCredentialUpdateEnabled(s3Config.isAsyncSessionUpdateEnabled()).build();
       }
 
-      S3ClientBuilder s3ClientBuilder = S3Client.builder()
-                  .forcePathStyle(true)
-                  .region(Region.of(s3Config.getRegion()))
-                  .credentialsProvider(awsCredentialsProvider);
+      S3ClientBuilder s3ClientBuilder = S3Client.builder().forcePathStyle(true).region(Region.of(s3Config.getRegion()))
+          .credentialsProvider(awsCredentialsProvider);
       if (StringUtils.isNotEmpty(s3Config.getEndpoint())) {
         try {
           s3ClientBuilder.endpointOverride(new URI(s3Config.getEndpoint()));

--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -138,8 +138,10 @@ public class S3PinotFS extends BasePinotFS {
                 .asyncCredentialUpdateEnabled(s3Config.isAsyncSessionUpdateEnabled()).build();
       }
 
-      S3ClientBuilder s3ClientBuilder =
-          S3Client.builder().region(Region.of(s3Config.getRegion())).credentialsProvider(awsCredentialsProvider);
+      S3ClientBuilder s3ClientBuilder = S3Client.builder()
+                  .forcePathStyle(true)
+                  .region(Region.of(s3Config.getRegion()))
+                  .credentialsProvider(awsCredentialsProvider);
       if (StringUtils.isNotEmpty(s3Config.getEndpoint())) {
         try {
           s3ClientBuilder.endpointOverride(new URI(s3Config.getEndpoint()));


### PR DESCRIPTION
This is a bugfix for an issue that was introduced when upgrading the AWS S3 library from version 2.14.28:

```
-    <aws.sdk.version>2.14.28</aws.sdk.version>
+    <aws.sdk.version>2.20.83</aws.sdk.version>
```

This commit:

```
commit 0420414fc2a5408dc7aa32fdb9d359763fc3cb34
Author: Xiaobing <61892277+klsince@users.noreply.github.com>
Date:   Tue Jun 13 10:08:00 2023 -0700

    bump awssdk version for a bugfix on http conn leakage (#10898)

    * bump awssdk version for a bugfix on http conn leakage
    * use latest s3mock and fix S3PinotFSTest
```

This causes a problem when trying to use MinIO, which is S3 API compatible. The default of how URIs are resolved seems to have got messed up for MInIO, resulting in the following exception:

```
Caused by: java.net.UnknownHostException: pinot-controller.minio
    at java.net.InetAddress$CachedAddresses.get(InetAddress.java:797) ~[?:?]
    at java.net.InetAddress.getAllByName0(InetAddress.java:1533) ~[?:?]
    at java.net.InetAddress.getAllByName(InetAddress.java:1386) ~[?:?]
    at java.net.InetAddress.getAllByName(InetAddress.java:1307) ~[?:?]
    at org.apache.http.impl.conn.SystemDefaultDnsResolver.resolve(SystemDefaultDnsResolver.java:45) ~[pinot-s3-0.13.0-SNAPSHOT-shaded.jar:0.13.0-SNAPSHOT-fe2b013a657e1ad6ac508a9a37933961bc4c408b]
    at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:112) ~[pinot-s3-0.13.0-SNAPSHOT-shaded.jar:0.13.0-SNAPSHOT-fe2b013a657e1ad6ac508a9a37933961bc4c408b]
    at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:376) ~[pinot-s3-0.13.0-SNAPSHOT-shaded.jar:0.13.0-SNAPSHOT-fe2b013a657e1ad6ac508a9a37933961bc4c408b]
    at software.amazon.awssdk.http.apache.internal.conn.ClientConnectionManagerFactory$DelegatingHttpClientConnectionManager.connect(ClientConnectionManagerFactory.java:86) ~[pinot-s3-0.13.0-SNAPSHOT-shaded.jar:0.13.0-SNAPSHOT-fe2b013a657e1ad6ac508a9a37933961bc4c408b]
```

This [StackOverflow thread ](https://stackoverflow.com/questions/72205086/amazonss3client-throws-unknownhostexception-if-attempting-to-connect-to-a-local) describes the issue and a way to work around it.

I'm not sure whether setting this flag would cause an issue for other S3 API implementations.

----
In case it's useful, this is my breakdown of which versions MinIO worked/didn't work:


```
0.12.1                                                              2022-12-25 11:50 +0530  Works

0.13.0-SNAPSHOT-f5dba86d5c-20230428-11-ms-openjdk-linux-arm64       2023-04-27 18:56 -0700  Works

0.13.0-SNAPSHOT-c78026da73-20230523-11-amazoncorretto               2023-05-22 10:35 -0700  Works

0.13.0-SNAPSHOT-26e5952d75-20230609-11-amazoncorretto               2023-06-07 20:55 -0700  Works

0.13.0-SNAPSHOT-86b3b3e1c5-20230612-11-amazoncorretto               2023-06-09 18:51 -0700  Works

0.13.0-SNAPSHOT-207036950a-20230613-11-amazoncorretto               2023-06-13 02:08 +0530  Works

0.13.0-SNAPSHOT-14670f49f6-20230614-11-amazoncorretto-linux-arm64   2023-06-13 19:42 -0400  java.net.UnknownHostException: pinot-events.minio

0.13.0-SNAPSHOT-f1966d9fa0-20230615-11-amazoncorretto               2023-06-15 12:28 -0700  java.net.UnknownHostException: pinot-events.minio

0.13.0-SNAPSHOT-61dcea6b71-20230727-11-amazoncorretto               2023-07-26 18:39 -0700  java.net.UnknownHostException: pinot-events.minio
```