### PR TITLE
Add instrumentation for dcount merge. Release bitmaps for and/or doc id set to save memory. `performance`

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -86,6 +86,7 @@ public final class AndDocIdSet implements BlockDocIdSet {
       if (docIdIterator instanceof SortedDocIdIterator) {
         sortedDocIdIterators.add((SortedDocIdIterator) docIdIterator);
         // do not keep holding on to the _docIdRanges since they will occupy heap space during the query execution
+        _numEntriesScannedInFilter += blockDocIdSet.getNumEntriesScannedInFilter();
         iterator.remove();
       } else if (docIdIterator instanceof BitmapBasedDocIdIterator) {
         bitmapBasedDocIdIterators.add((BitmapBasedDocIdIterator) docIdIterator);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -92,6 +92,8 @@ public final class AndDocIdSet implements BlockDocIdSet {
       } else if (docIdIterator instanceof BitmapBasedDocIdIterator) {
         bitmapBasedDocIdIterators.add((BitmapBasedDocIdIterator) docIdIterator);
         // aggregate the number of entries scanned in filter before removing the iterator
+        // some BitmapBasedDocIdIterator may be generated from underlying index types (e.g. H3Index) that actually
+        // scans documents, so we need to aggregate them here
         _numEntriesScannedInFilter += blockDocIdSet.getNumEntriesScannedInFilter();
         // do not keep holding on to the _docIdRanges since they will occupy heap space during the query execution
         iterator.remove();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -85,13 +85,15 @@ public final class AndDocIdSet implements BlockDocIdSet {
       allDocIdIterators[i] = docIdIterator;
       if (docIdIterator instanceof SortedDocIdIterator) {
         sortedDocIdIterators.add((SortedDocIdIterator) docIdIterator);
-        // do not keep holding on to the _docIdRanges since they will occupy heap space during the query execution
+        // aggregate the number of entries scanned in filter before removing the iterator
         _numEntriesScannedInFilter += blockDocIdSet.getNumEntriesScannedInFilter();
+        // do not keep holding on to the _docIdRanges since they will occupy heap space during the query execution
         iterator.remove();
       } else if (docIdIterator instanceof BitmapBasedDocIdIterator) {
         bitmapBasedDocIdIterators.add((BitmapBasedDocIdIterator) docIdIterator);
-        // do not keep holding on to the bitmaps since they will occupy heap space during the query execution
+        // aggregate the number of entries scanned in filter before removing the iterator
         _numEntriesScannedInFilter += blockDocIdSet.getNumEntriesScannedInFilter();
+        // do not keep holding on to the _docIdRanges since they will occupy heap space during the query execution
         iterator.remove();
       } else if (docIdIterator instanceof ScanBasedDocIdIterator) {
         scanBasedDocIdIterators.add((ScanBasedDocIdIterator) docIdIterator);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/AndDocIdSet.java
@@ -61,7 +61,7 @@ public final class AndDocIdSet implements BlockDocIdSet {
   private final boolean _cardinalityBasedRankingForScan;
 
   public AndDocIdSet(List<BlockDocIdSet> docIdSets, @Nullable Map<String, String> queryOptions) {
-    _docIdSets = docIdSets;
+    _docIdSets = docIdSets instanceof ArrayList ? docIdSets : new ArrayList<>(docIdSets);
     _cardinalityBasedRankingForScan =
         !MapUtils.isEmpty(queryOptions) && QueryOptionsUtils.isAndScanReorderingEnabled(queryOptions);
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/OrDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/OrDocIdSet.java
@@ -52,7 +52,7 @@ public final class OrDocIdSet implements BlockDocIdSet {
   private final int _numDocs;
 
   public OrDocIdSet(List<BlockDocIdSet> docIdSets, int numDocs) {
-    _docIdSets = docIdSets;
+    _docIdSets = docIdSets instanceof ArrayList ? docIdSets : new ArrayList<>(docIdSets);
     _numDocs = numDocs;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/OrDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/OrDocIdSet.java
@@ -73,6 +73,7 @@ public final class OrDocIdSet implements BlockDocIdSet {
       if (docIdIterator instanceof SortedDocIdIterator) {
         sortedDocIdIterators.add((SortedDocIdIterator) docIdIterator);
         // do not keep holding on to the _docIdRanges since they will occupy heap space during the query execution
+        _numEntriesScannedInFilter += blockDocIdSet.getNumEntriesScannedInFilter();
         iterator.remove();
       } else if (docIdIterator instanceof BitmapBasedDocIdIterator) {
         bitmapBasedDocIdIterators.add((BitmapBasedDocIdIterator) docIdIterator);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/OrDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/OrDocIdSet.java
@@ -72,13 +72,15 @@ public final class OrDocIdSet implements BlockDocIdSet {
       allDocIdIterators[i] = docIdIterator;
       if (docIdIterator instanceof SortedDocIdIterator) {
         sortedDocIdIterators.add((SortedDocIdIterator) docIdIterator);
-        // do not keep holding on to the _docIdRanges since they will occupy heap space during the query execution
+        // aggregate the number of entries scanned in filter before removing the iterator
         _numEntriesScannedInFilter += blockDocIdSet.getNumEntriesScannedInFilter();
+        // do not keep holding on to the _docIdRanges since they will occupy heap space during the query execution
         iterator.remove();
       } else if (docIdIterator instanceof BitmapBasedDocIdIterator) {
         bitmapBasedDocIdIterators.add((BitmapBasedDocIdIterator) docIdIterator);
-        // do not keep holding on to the bitmaps since they will occupy heap space during the query execution
+        // aggregate the number of entries scanned in filter before removing the iterator
         _numEntriesScannedInFilter += blockDocIdSet.getNumEntriesScannedInFilter();
+        // do not keep holding on to the bitmaps since they will occupy heap space during the query execution
         iterator.remove();
       } else {
         remainingDocIdIterators.add(docIdIterator);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/OrDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/OrDocIdSet.java
@@ -79,6 +79,8 @@ public final class OrDocIdSet implements BlockDocIdSet {
       } else if (docIdIterator instanceof BitmapBasedDocIdIterator) {
         bitmapBasedDocIdIterators.add((BitmapBasedDocIdIterator) docIdIterator);
         // aggregate the number of entries scanned in filter before removing the iterator
+        // some BitmapBasedDocIdIterator may be generated from underlying index types (e.g. H3Index) that actually
+        // scans documents, so we need to aggregate them here
         _numEntriesScannedInFilter += blockDocIdSet.getNumEntriesScannedInFilter();
         // do not keep holding on to the bitmaps since they will occupy heap space during the query execution
         iterator.remove();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/OrDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/OrDocIdSet.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.operator.docidsets;
 
 import java.util.ArrayList;
+import java.util.Iterator;
 import java.util.List;
 import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.core.common.BlockDocIdSet;
@@ -62,13 +63,19 @@ public final class OrDocIdSet implements BlockDocIdSet {
     List<SortedDocIdIterator> sortedDocIdIterators = new ArrayList<>();
     List<BitmapBasedDocIdIterator> bitmapBasedDocIdIterators = new ArrayList<>();
     List<BlockDocIdIterator> remainingDocIdIterators = new ArrayList<>();
-    for (int i = 0; i < numDocIdSets; i++) {
-      BlockDocIdIterator docIdIterator = _docIdSets.get(i).iterator();
+
+    Iterator<BlockDocIdSet> iterator = _docIdSets.iterator();
+    for (int i = 0; iterator.hasNext(); i++) {
+      BlockDocIdIterator docIdIterator = iterator.next().iterator();
       allDocIdIterators[i] = docIdIterator;
       if (docIdIterator instanceof SortedDocIdIterator) {
         sortedDocIdIterators.add((SortedDocIdIterator) docIdIterator);
+        // do not keep holding on to the _docIdRanges since they will occupy heap space during the query execution
+        iterator.remove();
       } else if (docIdIterator instanceof BitmapBasedDocIdIterator) {
         bitmapBasedDocIdIterators.add((BitmapBasedDocIdIterator) docIdIterator);
+        // do not keep holding on to the bitmaps since they will occupy heap space during the query execution
+        iterator.remove();
       } else {
         remainingDocIdIterators.add(docIdIterator);
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctAggregateAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctAggregateAggregationFunction.java
@@ -35,6 +35,7 @@ import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.PeekableIntIterator;
 import org.roaringbitmap.RoaringBitmap;
@@ -112,6 +113,9 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
     if (intermediateResult2.isEmpty()) {
       return intermediateResult1;
     }
+
+    Tracing.ThreadAccountantOps.sampleAndCheckInterruption();
+
     intermediateResult1.addAll(intermediateResult2);
     return intermediateResult1;
   }


### PR DESCRIPTION
We have seen a case the following tree comes up at the top of a few heap dumps

This basically indicates we are still holding on to the bitmaps during the execution of query. This will impact the performance of queries with long filter chains.
```
 ↖java.nio.HeapLongBuffer.hb
↖org.roaringbitmap.buffer.MappeableBitmapContainer.bitmap
↖org.roaringbitmap.buffer.MappeableContainer[]
↖org.roaringbitmap.buffer.MutableRoaringArray.values
↖org.roaringbitmap.buffer.MutableRoaringBitmap.highLowContainer
↖org.apache.pinot.core.operator.dociditerators.BitmapDocIdIterator._docIds
↖org.apache.pinot.core.operator.docidsets.BitmapDocIdSet._iterator
↖{j.u.ArrayList}
↖org.apache.pinot.core.operator.docidsets.AndDocIdSet._docIdSets
↖org.apache.pinot.core.operator.DocIdSetOperator._blockDocIdSet
↖org.apache.pinot.core.operator.ProjectionOperator._docIdSetOperator
↖org.apache.pinot.core.operator.query.GroupByOperator._projectOperator
↖{j.u.ArrayList}
↖org.apache.pinot.core.operator.combine.GroupByCombineOperator._operators
↖org.apache.pinot.core.operator.combine.BaseCombineOperator$1.this$0
↖j.u.concurrent.Executors$RunnableAdapter.task
↖j.u.concurrent.FutureTask.callable
↖j.u.concurrent.Executors$RunnableAdapter.task
↖com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.callable
↖com.google.common.util.concurrent.TrustedListenableFutureTask.task
↖{j.u.concurrent.LinkedBlockingQueue}
↖j.u.concurrent.ThreadPoolExecutor.workQueue
↖j.u.concurrent.ThreadPoolExecutor$Worker.this$0
```

Testing:
Before:
<img width="1792" alt="Screenshot 2023-07-27 at 9 24 25 PM" src="https://github.com/apache/pinot/assets/10736840/de32e185-d3b7-48e3-b5d1-a3f3fcbfbf94">
After:
<img width="1792" alt="Screenshot 2023-07-27 at 9 23 38 PM" src="https://github.com/apache/pinot/assets/10736840/72c79c1c-5f27-4f72-9f76-34b25a90c567">