### PR TITLE
add multi-value support for native text index

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableTextIndex.java
@@ -121,8 +121,8 @@ public class NativeMutableTextIndex implements MutableTextIndex {
   private List<String> analyze(String document) {
     List<String> tokens = new ArrayList<>();
     try (TokenStream tokenStream = _analyzer.tokenStream(_column, document)) {
-      tokenStream.reset();
       CharTermAttribute attribute = tokenStream.getAttribute(CharTermAttribute.class);
+      tokenStream.reset();
       while (tokenStream.incrementToken()) {
         tokens.add(attribute.toString());
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableTextIndex.java
@@ -76,9 +76,7 @@ public class NativeMutableTextIndex implements MutableTextIndex {
   }
 
   private void addHelper(String document) {
-    Iterable<String> tokens;
-    tokens = analyze(document);
-
+    Iterable<String> tokens = analyze(document);
     _writeLock.lock();
     try {
       for (String token : tokens) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeMutableTextIndex.java
@@ -63,9 +63,22 @@ public class NativeMutableTextIndex implements MutableTextIndex {
 
   @Override
   public void add(String document) {
-    Iterable<String> tokens;
+    addHelper(document);
+    _nextDocId++;
+  }
 
+  @Override
+  public void add(String[] documents) {
+    for (String document : documents) {
+      addHelper(document);
+    }
+    _nextDocId++;
+  }
+
+  private void addHelper(String document) {
+    Iterable<String> tokens;
     tokens = analyze(document);
+
     _writeLock.lock();
     try {
       for (String token : tokens) {
@@ -76,15 +89,9 @@ public class NativeMutableTextIndex implements MutableTextIndex {
         });
         _invertedIndex.add(currentDictId, _nextDocId);
       }
-      _nextDocId++;
     } finally {
       _writeLock.unlock();
     }
-  }
-
-  @Override
-  public void add(String[] documents) {
-    throw new UnsupportedOperationException("Mutable native text indexes are not supported for multi-valued columns");
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/NativeTextIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/NativeTextIndexCreator.java
@@ -67,7 +67,7 @@ public class NativeTextIndexCreator extends AbstractTextIndexCreator {
   private final File _tempDir;
   private final File _fstIndexFile;
   private final File _invertedIndexFile;
-  private Analyzer _analyzer;
+  private final Analyzer _analyzer;
   private final Map<String, RoaringBitmapWriter<RoaringBitmap>> _postingListMap = new TreeMap<>();
   private final RoaringBitmapWriter.Wizard<Container, RoaringBitmap> _bitmapWriterWizard = RoaringBitmapWriter.writer();
   private int _nextDocId = 0;
@@ -107,7 +107,7 @@ public class NativeTextIndexCreator extends AbstractTextIndexCreator {
   private void addHelper(String document) {
     List<String> tokens;
     try {
-      tokens = analyze(document, _analyzer);
+      tokens = analyze(document);
     } catch (IOException e) {
       throw new RuntimeException(e.getMessage());
     }
@@ -144,10 +144,10 @@ public class NativeTextIndexCreator extends AbstractTextIndexCreator {
     FileUtils.deleteDirectory(_tempDir);
   }
 
-  public List<String> analyze(String text, Analyzer analyzer)
+  public List<String> analyze(String text)
       throws IOException {
     List<String> result = new ArrayList<>();
-    try (TokenStream tokenStream = analyzer.tokenStream(_columnName, text)) {
+    try (TokenStream tokenStream = _analyzer.tokenStream(_columnName, text)) {
       CharTermAttribute attr = tokenStream.addAttribute(CharTermAttribute.class);
       tokenStream.reset();
       while (tokenStream.incrementToken()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/NativeTextIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/NativeTextIndexCreator.java
@@ -90,6 +90,19 @@ public class NativeTextIndexCreator extends AbstractTextIndexCreator {
 
   @Override
   public void add(String document) {
+    addHelper(document);
+    _nextDocId++;
+  }
+
+  @Override
+  public void add(String[] documents, int length) {
+    for (int i = 0; i < length; i++) {
+      addHelper(documents[i]);
+    }
+    _nextDocId++;
+  }
+
+  private void addHelper(String document) {
     List<String> tokens;
     try {
       tokens = analyze(document, new StandardAnalyzer(LuceneTextIndexCreator.ENGLISH_STOP_WORDS_SET));
@@ -100,13 +113,6 @@ public class NativeTextIndexCreator extends AbstractTextIndexCreator {
     for (String token : tokens) {
       addToPostingList(token);
     }
-
-    _nextDocId++;
-  }
-
-  @Override
-  public void add(String[] documents, int length) {
-    throw new UnsupportedOperationException("Native text index is not supported on MV column: " + _columnName);
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/NativeTextIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/NativeTextIndexReader.java
@@ -59,7 +59,7 @@ public class NativeTextIndexReader implements TextIndexReader {
           PinotDataBuffer.mapFile(indexFile, /* readOnly */ true, 0, indexFile.length(), ByteOrder.BIG_ENDIAN, desc);
       populateIndexes();
     } catch (Exception e) {
-      LOGGER.error("Failed to instantiate Lucene text index reader for column {}, exception {}", column,
+      LOGGER.error("Failed to instantiate native text index reader for column {}, exception {}", column,
           e.getMessage());
       throw new RuntimeException(e);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
@@ -184,9 +184,6 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
       return null;
     }
     if (config.getFstType() == FSTType.NATIVE) {
-      if (!context.getFieldSpec().isSingleValueField()) {
-        return null;
-      }
       return new NativeMutableTextIndex(context.getFieldSpec().getName());
     }
     if (context.getConsumerDir() == null) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
@@ -19,7 +19,7 @@
 package org.apache.pinot.segment.local.realtime.impl.invertedindex;
 
 import java.io.File;
-import java.util.Arrays;
+import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.search.SearcherManager;
@@ -33,38 +33,66 @@ import static org.testng.Assert.assertEquals;
 public class NativeAndLuceneMutableTextIndexTest {
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "RealTimeNativeVsLuceneTest");
   private static final String TEXT_COLUMN_NAME = "testColumnName";
+  private static final String MV_TEXT_COLUMN_NAME = "testMVColumnName";
 
   private RealtimeLuceneTextIndex _realtimeLuceneTextIndex;
   private NativeMutableTextIndex _nativeMutableTextIndex;
 
-  private List<String> getTextData() {
-    return Arrays.asList("Prince Andrew kept looking with an amused smile from Pierre",
-        "vicomte and from the vicomte to their hostess. In the first moment of",
-        "Pierre’s outburst Anna Pávlovna, despite her social experience, was",
-        "horror-struck. But when she saw that Pierre’s sacrilegious words",
-        "had not exasperated the vicomte, and had convinced herself that it was",
-        "impossible to stop him, she rallied her forces and joined the vicomte in", "a vigorous attack on the orator",
-        "horror-struck. But when she", "she rallied her forces and joined", "outburst Anna Pávlovna",
-        "she rallied her forces and", "despite her social experience", "had not exasperated the vicomte",
-        " despite her social experience", "impossible to stop him", "despite her social experience");
+  private RealtimeLuceneTextIndex _realtimeLuceneMVTextIndex;
+  private NativeMutableTextIndex _nativeMutableMVTextIndex;
+
+  private String[] getTextData() {
+    return new String[]{"Prince Andrew kept looking with an amused smile from Pierre",
+      "vicomte and from the vicomte to their hostess. In the first moment of",
+      "Pierre’s outburst Anna Pávlovna, despite her social experience, was",
+      "horror-struck. But when she saw that Pierre’s sacrilegious words",
+      "had not exasperated the vicomte, and had convinced herself that it was",
+      "impossible to stop him, she rallied her forces and joined the vicomte in", "a vigorous attack on the orator",
+      "horror-struck. But when she", "she rallied her forces and joined", "outburst Anna Pávlovna",
+      "she rallied her forces and", "despite her social experience", "had not exasperated the vicomte",
+      " despite her social experience", "impossible to stop him", "despite her social experience"};
+  }
+
+  private String[][] getMVTextData() {
+    return new String[][]{{"Prince Andrew kept looking with an amused smile from Pierre",
+        "vicomte and from the vicomte to their hostess. In the first moment of"}, {
+      "Pierre’s outburst Anna Pávlovna, despite her social experience, was",
+        "horror-struck. But when she saw that Pierre’s sacrilegious words"}, {
+      "had not exasperated the vicomte, and had convinced herself that it was"}, {
+      "impossible to stop him, she rallied her forces and joined the vicomte in", "a vigorous attack on the orator",
+        "horror-struck. But when she", "she rallied her forces and joined", "outburst Anna Pávlovna"}, {
+      "she rallied her forces and", "despite her social experience", "had not exasperated the vicomte",
+        " despite her social experience", "impossible to stop him", "despite her social experience"}};
   }
 
   @BeforeClass
   public void setUp()
       throws Exception {
-    _realtimeLuceneTextIndex = new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null,
-        null);
+    _realtimeLuceneTextIndex = new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null);
     _nativeMutableTextIndex = new NativeMutableTextIndex(TEXT_COLUMN_NAME);
-    List<String> documents = getTextData();
 
+    _realtimeLuceneMVTextIndex = new RealtimeLuceneTextIndex(MV_TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null);
+    _nativeMutableMVTextIndex = new NativeMutableTextIndex(MV_TEXT_COLUMN_NAME);
+
+    String[] documents = getTextData();
     for (String doc : documents) {
       _realtimeLuceneTextIndex.add(doc);
       _nativeMutableTextIndex.add(doc);
     }
 
-    SearcherManager searcherManager = _realtimeLuceneTextIndex.getSearcherManager();
+    String[][] mvDocuments = getMVTextData();
+    for (String[] mvDoc : mvDocuments) {
+      _realtimeLuceneMVTextIndex.add(mvDoc);
+      _nativeMutableMVTextIndex.add(mvDoc);
+    }
+
+    List<SearcherManager> searcherManagers = new ArrayList<>();
+    searcherManagers.add(_realtimeLuceneTextIndex.getSearcherManager());
+    searcherManagers.add(_realtimeLuceneMVTextIndex.getSearcherManager());
     try {
-      searcherManager.maybeRefresh();
+      for (SearcherManager searcherManager : searcherManagers) {
+        searcherManager.maybeRefresh();
+      }
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -100,5 +128,6 @@ public class NativeAndLuceneMutableTextIndexTest {
 
   private void testSelectionResults(String nativeQuery, String luceneQuery) {
     assertEquals(_nativeMutableTextIndex.getDocIds(nativeQuery), _realtimeLuceneTextIndex.getDocIds(luceneQuery));
+    assertEquals(_nativeMutableMVTextIndex.getDocIds(nativeQuery), _realtimeLuceneMVTextIndex.getDocIds(luceneQuery));
   }
 }


### PR DESCRIPTION
This change adds native text index support for multi-value columns. Tested via HybridQuickstart on MV String column, against consuming + sealed segments.


tag: `feature`