### PR TITLE
Enhance hash exchange

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/HashExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/HashExchange.java
@@ -47,16 +47,24 @@ class HashExchange extends BlockExchange {
   @Override
   protected void route(List<SendingMailbox> destinations, TransferableBlock block)
       throws Exception {
-    List<Object[]>[] destIdxToRows = new List[destinations.size()];
+    int numMailboxes = destinations.size();
+    if (numMailboxes == 1) {
+      sendBlock(destinations.get(0), block);
+      return;
+    }
+
+    List<Object[]>[] destIdxToRows = new List[numMailboxes];
     List<Object[]> container = block.getContainer();
     for (Object[] row : container) {
-      int partition = _keySelector.computeHash(row) % destinations.size();
-      if (destIdxToRows[partition] == null) {
-        destIdxToRows[partition] = new ArrayList<>(container.size());
+      int index = _keySelector.computeHash(row) % numMailboxes;
+      List<Object[]> rows = destIdxToRows[index];
+      if (rows == null) {
+        rows = new ArrayList<>();
+        destIdxToRows[index] = rows;
       }
-      destIdxToRows[partition].add(row);
+      rows.add(row);
     }
-    for (int i = 0; i < destinations.size(); i++) {
+    for (int i = 0; i < numMailboxes; i++) {
       if (destIdxToRows[i] != null) {
         sendBlock(destinations.get(i), new TransferableBlock(destIdxToRows[i], block.getDataSchema(), block.getType()));
       }


### PR DESCRIPTION
- When there is only 1 receiver, skip the hashing
- Do not pre-allocate the array because the rows will be re-distributed