### PR TITLE
Fix for escape/unescape issue for segment min/max values.

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -140,7 +140,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   private static final String COLUMN_LENGTH_MAP_KEY = "columnLengthMap";
   private static final String COLUMN_CARDINALITY_MAP_KEY = "columnCardinalityMap";
   private static final String MAX_NUM_MULTI_VALUES_MAP_KEY = "maxNumMultiValuesMap";
-  private static final int DISK_SIZE_IN_BYTES = 20798304;
+  private static final int DISK_SIZE_IN_BYTES = 20800512;
   private static final int NUM_ROWS = 115545;
 
   private final List<ServiceStatus.ServiceStatusCallback> _serviceStatusCallbacks =

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -574,14 +574,16 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       String maxValue, DataType dataType) {
     String validMinValue = getValidPropertyValue(minValue, false, dataType);
     properties.setProperty(getKeyFor(column, MIN_VALUE), validMinValue);
+    // setting the property for signifying that the min value is escaped.
+    if (validMinValue.compareTo(minValue) != 0) {
+      properties.setProperty(getKeyFor(column, IS_MIN_VALUE_ESCAPED), true);
+    }
 
     String validMaxValue = getValidPropertyValue(maxValue, true, dataType);
     properties.setProperty(getKeyFor(column, MAX_VALUE), validMaxValue);
-
-    // setting the property for signifying that the mon or max value is escaped.
-    if (validMinValue.compareTo(minValue) != 0
-        || validMaxValue.compareTo(maxValue) != 0) {
-      properties.setProperty(getKeyFor(column, IS_MIN_MAX_VALUE_ESCAPED), true);
+    // setting the property for signifying that the max value is escaped.
+    if (validMaxValue.compareTo(maxValue) != 0) {
+      properties.setProperty(getKeyFor(column, IS_MAX_VALUE_ESCAPED), true);
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreatorTest.java
@@ -215,7 +215,8 @@ public class SegmentColumnarIndexCreatorTest {
     SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", ",bar", "foo", FieldSpec.DataType.STRING);
     Assert.assertFalse(Boolean.parseBoolean(
         String.valueOf(props.getProperty(getKeyFor("colA", Column.MIN_MAX_VALUE_INVALID)))));
-    Assert.assertEquals(String.valueOf(props.getProperty(getKeyFor("colA", MIN_VALUE))), ",bar");
+    Assert.assertEquals(
+        getEscapedValidPropertyValue(String.valueOf(props.getProperty(getKeyFor("colA", MIN_VALUE)))), ",bar");
 
     props = new PropertiesConfiguration();
     SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", "bar", "  ", FieldSpec.DataType.STRING);
@@ -228,17 +229,19 @@ public class SegmentColumnarIndexCreatorTest {
     Assert.assertFalse(Boolean.parseBoolean(
         String.valueOf(props.getProperty(getKeyFor("colA", Column.MIN_MAX_VALUE_INVALID)))));
     Assert.assertEquals(
-        StringEscapeUtils.unescapeJava(String.valueOf(props.getProperty(getKeyFor("colA", MIN_VALUE)))), "a\t");
+        getEscapedValidPropertyValue(String.valueOf(props.getProperty(getKeyFor("colA", MIN_VALUE)))), "a\t");
     Assert.assertEquals(
-        StringEscapeUtils.unescapeJava(String.valueOf(props.getProperty(getKeyFor("colA", MAX_VALUE)))), "\nb");
+        getEscapedValidPropertyValue((String.valueOf(props.getProperty(getKeyFor("colA", MAX_VALUE))))), "\nb");
 
     // test for values with 'v'.
     props = new PropertiesConfiguration();
     SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", "aa,bb", "aa,bb,", FieldSpec.DataType.STRING);
     Assert.assertFalse(Boolean.parseBoolean(
         String.valueOf(props.getProperty(getKeyFor("colA", Column.MIN_MAX_VALUE_INVALID)))));
-    Assert.assertEquals(String.valueOf(props.getProperty(getKeyFor("colA", MIN_VALUE))), "aa,bb");
-    Assert.assertEquals(String.valueOf(props.getProperty(getKeyFor("colA", MAX_VALUE))), "aa,bb,");
+    Assert.assertEquals(
+        getEscapedValidPropertyValue(String.valueOf(props.getProperty(getKeyFor("colA", MIN_VALUE)))), "aa,bb");
+    Assert.assertEquals(
+        getEscapedValidPropertyValue(String.valueOf(props.getProperty(getKeyFor("colA", MAX_VALUE)))), "aa,bb,");
 
     // test for value length grater than METADATA_PROPERTY_LENGTH_LIMIT
     props = new PropertiesConfiguration();
@@ -249,6 +252,16 @@ public class SegmentColumnarIndexCreatorTest {
     SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", stringMinValue,
         stringMaxValue, FieldSpec.DataType.STRING);
     compareLongValuesWithColumnMinMax(stringMinValue, stringMaxValue, props, FieldSpec.DataType.STRING);
+
+    // test for value length grater than METADATA_PROPERTY_LENGTH_LIMIT with random string having ascii characters.
+    props = new PropertiesConfiguration();
+    String stringAsciiMinValue = RandomStringUtils.
+        randomAlphanumeric(SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT + 3);
+    String stringAsciiMaxValue = RandomStringUtils.
+        randomAlphanumeric(SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT + 3);
+    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", stringAsciiMinValue,
+        stringAsciiMaxValue, FieldSpec.DataType.STRING);
+    compareLongValuesWithColumnMinMax(stringAsciiMinValue, stringAsciiMaxValue, props, FieldSpec.DataType.STRING);
 
     // long value test
     props = new PropertiesConfiguration();
@@ -301,7 +314,6 @@ public class SegmentColumnarIndexCreatorTest {
     PropertiesConfiguration props = new PropertiesConfiguration();
 
     // test for value length grater than METADATA_PROPERTY_LENGTH_LIMIT with last characters as '\uFFFF'
-    props = new PropertiesConfiguration();
     String stringMinValue = RandomStringUtils.
         randomAlphanumeric(SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT + 3);
     String stringMaxValue = RandomStringUtils.

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -101,6 +101,7 @@ public class V1Constants {
       public static final String DEFAULT_NULL_VALUE = "defaultNullValue";
       public static final String MIN_VALUE = "minValue";
       public static final String MAX_VALUE = "maxValue";
+      public static final String IS_MIN_MAX_VALUE_ESCAPED = "isMinMaxValueEscaped";
       public static final String MIN_MAX_VALUE_INVALID = "minMaxValueInvalid";
       public static final String PARTITION_FUNCTION = "partitionFunction";
       public static final String PARTITION_FUNCTION_CONFIG = "partitionFunctionConfig";

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/V1Constants.java
@@ -101,7 +101,8 @@ public class V1Constants {
       public static final String DEFAULT_NULL_VALUE = "defaultNullValue";
       public static final String MIN_VALUE = "minValue";
       public static final String MAX_VALUE = "maxValue";
-      public static final String IS_MIN_MAX_VALUE_ESCAPED = "isMinMaxValueEscaped";
+      public static final String IS_MIN_VALUE_ESCAPED = "isMinValueEscaped";
+      public static final String IS_MAX_VALUE_ESCAPED = "isMaxValueEscaped";
       public static final String MIN_MAX_VALUE_INVALID = "minMaxValueInvalid";
       public static final String PARTITION_FUNCTION = "partitionFunction";
       public static final String PARTITION_FUNCTION_CONFIG = "partitionFunctionConfig";

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
@@ -251,10 +251,15 @@ public class ColumnMetadataImpl implements ColumnMetadata {
     // NOTE: Use getProperty() instead of getString() to avoid variable substitution ('${anotherKey}'), which can cause
     //       problem for special values such as '$${' where the first '$' is identified as escape character.
     // TODO: Use getProperty() for other properties as well to avoid the overhead of variable substitution
-    String minString = StringEscapeUtils.unescapeJava((String)
-        config.getProperty(Column.getKeyFor(column, Column.MIN_VALUE)));
-    String maxString = StringEscapeUtils.unescapeJava((String)
-        config.getProperty(Column.getKeyFor(column, Column.MAX_VALUE)));
+    String minString = (String) config.getProperty(Column.getKeyFor(column, Column.MIN_VALUE));
+    String maxString = (String) config.getProperty(Column.getKeyFor(column, Column.MAX_VALUE));
+    // check whether the mim/max values are escaped or not, if yes get the unescaped value.
+    boolean isMinMaxValueEscaped = config.getBoolean(
+        Column.getKeyFor(column, Column.IS_MIN_MAX_VALUE_ESCAPED), false);
+    if (isMinMaxValueEscaped) {
+      minString = StringEscapeUtils.unescapeJava(minString);
+      maxString = StringEscapeUtils.unescapeJava(maxString);
+    }
     if (minString != null && maxString != null) {
       switch (dataType.getStoredType()) {
         case INT:

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
@@ -252,14 +252,22 @@ public class ColumnMetadataImpl implements ColumnMetadata {
     //       problem for special values such as '$${' where the first '$' is identified as escape character.
     // TODO: Use getProperty() for other properties as well to avoid the overhead of variable substitution
     String minString = (String) config.getProperty(Column.getKeyFor(column, Column.MIN_VALUE));
-    String maxString = (String) config.getProperty(Column.getKeyFor(column, Column.MAX_VALUE));
     // check whether the mim/max values are escaped or not, if yes get the unescaped value.
-    boolean isMinMaxValueEscaped = config.getBoolean(
-        Column.getKeyFor(column, Column.IS_MIN_MAX_VALUE_ESCAPED), false);
-    if (isMinMaxValueEscaped) {
+    boolean isMinValueEscaped = config.getBoolean(
+        Column.getKeyFor(column, Column.IS_MIN_VALUE_ESCAPED), false);
+    if (isMinValueEscaped) {
       minString = StringEscapeUtils.unescapeJava(minString);
+    }
+
+    String maxString = (String) config.getProperty(Column.getKeyFor(column, Column.MAX_VALUE));
+    maxString = StringEscapeUtils.unescapeJava(maxString);
+    // check whether the mim/max values are escaped or not, if yes get the unescaped value.
+    boolean isMaxValueEscaped = config.getBoolean(
+        Column.getKeyFor(column, Column.IS_MAX_VALUE_ESCAPED), false);
+    if (isMaxValueEscaped) {
       maxString = StringEscapeUtils.unescapeJava(maxString);
     }
+
     if (minString != null && maxString != null) {
       switch (dataType.getStoredType()) {
         case INT:


### PR DESCRIPTION
- This is a follow-up PR for fixing the [issue](https://github.com/apache/pinot/pull/10990/files#r1277977517) related to the introduction of `unescapeJava` while reading the data from the property file. 
- The fix is based on escaping the value while writing to handle the cases if some characters are present in the original value, adding the flag in the property file to signal that the values are escaped. 
- Default value of the flag is false.
- Added unit test case based on random ASCII value to test such possible issues.

cc @Jackie-Jiang 