### PR TITLE
Fix the escape/unescape issue for property value in metadata

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -140,7 +140,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   private static final String COLUMN_LENGTH_MAP_KEY = "columnLengthMap";
   private static final String COLUMN_CARDINALITY_MAP_KEY = "columnCardinalityMap";
   private static final String MAX_NUM_MULTI_VALUES_MAP_KEY = "maxNumMultiValuesMap";
-  private static final int DISK_SIZE_IN_BYTES = 20798304;
+  private static final int DISK_SIZE_IN_BYTES = 20798784;
   private static final int NUM_ROWS = 115545;
 
   private final List<ServiceStatus.ServiceStatusCallback> _serviceStatusCallbacks =

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreatorTest.java
@@ -21,11 +21,11 @@ package org.apache.pinot.segment.local.segment.creator.impl;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Random;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.io.FileUtils;
-import org.apache.commons.lang.StringEscapeUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
@@ -35,106 +35,32 @@ import org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.MAX_VALUE;
-import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.MIN_VALUE;
-import static org.apache.pinot.segment.spi.V1Constants.MetadataKeys.Column.getKeyFor;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
+import static org.testng.Assert.assertTrue;
 
 
 public class SegmentColumnarIndexCreatorTest {
   private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "SegmentColumnarIndexCreatorTest");
   private static final File CONFIG_FILE = new File(TEMP_DIR, "config");
-  private static final String PROPERTY_KEY = "testKey";
   private static final String COLUMN_NAME = "testColumn";
   private static final String COLUMN_PROPERTY_KEY_PREFIX = Column.COLUMN_PROPS_KEY_PREFIX + COLUMN_NAME + ".";
-  private static final int NUM_ROUNDS = 1000;
 
   @BeforeClass
   public void setUp()
       throws IOException {
     FileUtils.deleteDirectory(TEMP_DIR);
-  }
-
-  @Test
-  public void testGetValidPropertyValue()
-      throws Exception {
-    // Leading/trailing whitespace
-    Assert.assertEquals(getEscapedValidPropertyValue(" a"), " a");
-    Assert.assertEquals(getEscapedValidPropertyValue("a\t"), "a\t");
-    Assert.assertEquals(getEscapedValidPropertyValue("\na"), "\na");
-
-    // Whitespace in the middle
-    Assert.assertEquals(getEscapedValidPropertyValue("a\t b"), "a\t b");
-    Assert.assertEquals(getEscapedValidPropertyValue("a \nb"), "a \nb");
-
-    // List separator
-    Assert.assertEquals(getEscapedValidPropertyValue("a,b,c"), "a,b,c");
-    Assert.assertEquals(getEscapedValidPropertyValue(",a b"), ",a b");
-
-    // Empty string
-    Assert.assertEquals(getEscapedValidPropertyValue(""), "");
-
-    // Escape character for variable substitution
-    Assert.assertEquals(getEscapedValidPropertyValue("$${"), "$${");
-  }
-
-  @Test
-  public void testPropertyValueWithSpecialCharacters()
-      throws Exception {
-    // Leading/trailing whitespace
-    Assert.assertFalse(SegmentColumnarIndexCreator.isValidPropertyValue(" a"));
-    Assert.assertFalse(SegmentColumnarIndexCreator.isValidPropertyValue("a\t"));
-    Assert.assertFalse(SegmentColumnarIndexCreator.isValidPropertyValue("\na"));
-
-    // Whitespace in the middle
-    Assert.assertTrue(SegmentColumnarIndexCreator.isValidPropertyValue("a\t b"));
-    testPropertyValueWithSpecialCharacters("a\t b");
-    Assert.assertTrue(SegmentColumnarIndexCreator.isValidPropertyValue("a \nb"));
-    testPropertyValueWithSpecialCharacters("a \nb");
-
-    // List separator
-    Assert.assertFalse(SegmentColumnarIndexCreator.isValidPropertyValue("a,b,c"));
-    Assert.assertFalse(SegmentColumnarIndexCreator.isValidPropertyValue(",a b"));
-
-    // Empty string
-    Assert.assertTrue(SegmentColumnarIndexCreator.isValidPropertyValue(""));
-    testPropertyValueWithSpecialCharacters("");
-
-    // Variable substitution (should be disabled)
-    Assert.assertTrue(SegmentColumnarIndexCreator.isValidPropertyValue("$${testKey}"));
-    testPropertyValueWithSpecialCharacters("$${testKey}");
-
-    // Escape character for variable substitution
-    Assert.assertTrue(SegmentColumnarIndexCreator.isValidPropertyValue("$${"));
-    testPropertyValueWithSpecialCharacters("$${");
-
-    for (int i = 0; i < NUM_ROUNDS; i++) {
-      testPropertyValueWithSpecialCharacters(RandomStringUtils.randomAscii(5));
-      testPropertyValueWithSpecialCharacters(RandomStringUtils.random(5));
-    }
-  }
-
-  private void testPropertyValueWithSpecialCharacters(String value)
-      throws Exception {
-    if (SegmentColumnarIndexCreator.isValidPropertyValue(value)) {
-      PropertiesConfiguration configuration = new PropertiesConfiguration(CONFIG_FILE);
-      configuration.setProperty(PROPERTY_KEY, value);
-      Assert.assertEquals(configuration.getProperty(PROPERTY_KEY), value);
-      configuration.save();
-
-      configuration = new PropertiesConfiguration(CONFIG_FILE);
-      Assert.assertEquals(configuration.getProperty(PROPERTY_KEY), value);
-    }
   }
 
   @Test
@@ -147,19 +73,19 @@ public class SegmentColumnarIndexCreatorTest {
     configuration.save();
 
     configuration = new PropertiesConfiguration(CONFIG_FILE);
-    Assert.assertTrue(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "a"));
-    Assert.assertTrue(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "b"));
-    Assert.assertTrue(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "c"));
+    assertTrue(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "a"));
+    assertTrue(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "b"));
+    assertTrue(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "c"));
     SegmentColumnarIndexCreator.removeColumnMetadataInfo(configuration, COLUMN_NAME);
-    Assert.assertFalse(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "a"));
-    Assert.assertFalse(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "b"));
-    Assert.assertFalse(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "c"));
+    assertFalse(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "a"));
+    assertFalse(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "b"));
+    assertFalse(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "c"));
     configuration.save();
 
     configuration = new PropertiesConfiguration(CONFIG_FILE);
-    Assert.assertFalse(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "a"));
-    Assert.assertFalse(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "b"));
-    Assert.assertFalse(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "c"));
+    assertFalse(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "a"));
+    assertFalse(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "b"));
+    assertFalse(configuration.containsKey(COLUMN_PROPERTY_KEY_PREFIX + "c"));
   }
 
   @Test
@@ -169,15 +95,16 @@ public class SegmentColumnarIndexCreatorTest {
         getStartTimeInSegmentMetadata("1:SECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd'T'HH:mm:ssZ", "2021-07-21T06:48:51Z");
     long withoutTZ =
         getStartTimeInSegmentMetadata("1:SECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd'T'HH:mm:ss", "2021-07-21T06:48:51");
-    Assert.assertEquals(withTZ, 1626850131000L); // as UTC timestamp.
-    Assert.assertEquals(withTZ, withoutTZ);
+    assertEquals(withTZ, 1626850131000L); // as UTC timestamp.
+    assertEquals(withTZ, withoutTZ);
   }
 
   private static long getStartTimeInSegmentMetadata(String testDateTimeFormat, String testDateTime)
       throws Exception {
     String timeColumn = "foo";
-    Schema schema = new Schema.SchemaBuilder().addDateTime(timeColumn, FieldSpec.DataType.STRING, testDateTimeFormat,
-        "1:MILLISECONDS").build();
+    Schema schema =
+        new Schema.SchemaBuilder().addDateTime(timeColumn, DataType.STRING, testDateTimeFormat, "1:MILLISECONDS")
+            .build();
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName("test").setTimeColumnName(timeColumn).build();
 
@@ -205,168 +132,80 @@ public class SegmentColumnarIndexCreatorTest {
   }
 
   @Test
-  public void testAddMinMaxValue() {
-    PropertiesConfiguration props = new PropertiesConfiguration();
-    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", "bar", "foo", FieldSpec.DataType.STRING);
-    Assert.assertFalse(Boolean.parseBoolean(
-        String.valueOf(props.getProperty(getKeyFor("colA", Column.MIN_MAX_VALUE_INVALID)))));
+  public void testGetValueWithinLengthLimit() {
+    // String value without '\uFFFF' suffix
+    String value = RandomStringUtils.randomAscii(SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT + 1);
+    String minValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, false, DataType.STRING);
+    assertEquals(minValue, value.substring(0, SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT));
+    assertTrue(minValue.compareTo(value) < 0);
+    String maxValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, true, DataType.STRING);
+    assertEquals(maxValue,
+        value.substring(0, SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT - 1) + '\uFFFF');
+    assertTrue(maxValue.compareTo(value) > 0);
 
-    props = new PropertiesConfiguration();
-    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", ",bar", "foo", FieldSpec.DataType.STRING);
-    Assert.assertFalse(Boolean.parseBoolean(
-        String.valueOf(props.getProperty(getKeyFor("colA", Column.MIN_MAX_VALUE_INVALID)))));
-    Assert.assertEquals(String.valueOf(props.getProperty(getKeyFor("colA", MIN_VALUE))), ",bar");
+    // String value with '\uFFFF' suffix
+    value =
+        RandomStringUtils.randomAscii(SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT - 1) + "\uFFFF\uFFFF";
+    minValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, false, DataType.STRING);
+    assertEquals(minValue, value.substring(0, SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT));
+    assertTrue(minValue.compareTo(value) < 0);
+    maxValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, true, DataType.STRING);
+    assertEquals(maxValue, value);
 
-    props = new PropertiesConfiguration();
-    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", "bar", "  ", FieldSpec.DataType.STRING);
-    Assert.assertFalse(Boolean.parseBoolean(
-        String.valueOf(props.getProperty(getKeyFor("colA", Column.MIN_MAX_VALUE_INVALID)))));
+    // String value with '\uFFFF' and another character
+    value = RandomStringUtils.randomAscii(SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT - 1) + "\uFFFFa";
+    minValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, false, DataType.STRING);
+    assertEquals(minValue, value.substring(0, SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT));
+    assertTrue(minValue.compareTo(value) < 0);
+    maxValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, true, DataType.STRING);
+    assertEquals(maxValue, value.substring(0, SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT) + '\uFFFF');
+    assertTrue(maxValue.compareTo(value) > 0);
 
-    // test for values with leading or ending whitespace.
-    props = new PropertiesConfiguration();
-    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", "a\t", "\nb", FieldSpec.DataType.STRING);
-    Assert.assertFalse(Boolean.parseBoolean(
-        String.valueOf(props.getProperty(getKeyFor("colA", Column.MIN_MAX_VALUE_INVALID)))));
-    Assert.assertEquals(
-        StringEscapeUtils.unescapeJava(String.valueOf(props.getProperty(getKeyFor("colA", MIN_VALUE)))), "a\t");
-    Assert.assertEquals(
-        StringEscapeUtils.unescapeJava(String.valueOf(props.getProperty(getKeyFor("colA", MAX_VALUE)))), "\nb");
-
-    // test for values with 'v'.
-    props = new PropertiesConfiguration();
-    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", "aa,bb", "aa,bb,", FieldSpec.DataType.STRING);
-    Assert.assertFalse(Boolean.parseBoolean(
-        String.valueOf(props.getProperty(getKeyFor("colA", Column.MIN_MAX_VALUE_INVALID)))));
-    Assert.assertEquals(String.valueOf(props.getProperty(getKeyFor("colA", MIN_VALUE))), "aa,bb");
-    Assert.assertEquals(String.valueOf(props.getProperty(getKeyFor("colA", MAX_VALUE))), "aa,bb,");
-
-    // test for value length grater than METADATA_PROPERTY_LENGTH_LIMIT
-    props = new PropertiesConfiguration();
-    String stringMinValue = RandomStringUtils.
-        randomAlphanumeric(SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT + 3);
-    String stringMaxValue = RandomStringUtils.
-        randomAlphanumeric(SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT + 3);
-    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", stringMinValue,
-        stringMaxValue, FieldSpec.DataType.STRING);
-    compareLongValuesWithColumnMinMax(stringMinValue, stringMaxValue, props, FieldSpec.DataType.STRING);
-
-    // long value test
-    props = new PropertiesConfiguration();
-    String longMinValue = String.valueOf(Long.MIN_VALUE);
-    String longMaxValue = String.valueOf(Long.MAX_VALUE);
-    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", longMinValue,
-        longMaxValue, FieldSpec.DataType.LONG);
-    compareLongValuesWithColumnMinMax(longMinValue, longMaxValue, props, FieldSpec.DataType.LONG);
-
-    // int value test
-    props = new PropertiesConfiguration();
-    String intMinValue = String.valueOf(Integer.MIN_VALUE);
-    String intMaxValue = String.valueOf(Integer.MAX_VALUE);
-    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", intMinValue,
-        intMaxValue, FieldSpec.DataType.INT);
-    compareLongValuesWithColumnMinMax(intMinValue, intMaxValue, props, FieldSpec.DataType.INT);
-
-    // float value test
-    props = new PropertiesConfiguration();
-    String floatMinValue = String.valueOf(Float.MIN_VALUE);
-    String floatMaxValue = String.valueOf(Float.MAX_VALUE);
-    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", floatMinValue,
-        floatMaxValue, FieldSpec.DataType.FLOAT);
-    compareLongValuesWithColumnMinMax(floatMinValue, floatMaxValue, props, FieldSpec.DataType.FLOAT);
-
-    // Double value test
-    props = new PropertiesConfiguration();
-    String doubleMinValue = String.valueOf(Double.MIN_VALUE);
-    String doubleMaxValue = String.valueOf(Double.MAX_VALUE);
-    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", doubleMinValue,
-        doubleMaxValue, FieldSpec.DataType.DOUBLE);
-    compareLongValuesWithColumnMinMax(doubleMinValue, doubleMaxValue, props, FieldSpec.DataType.DOUBLE);
-
-    // Byte value test
-    props = new PropertiesConfiguration();
+    // Bytes value without 0xFF suffix
+    int numBytes = SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT / 2 + 1;
+    byte[] bytes = new byte[numBytes];
     Random random = new Random();
-    byte[] byteMinValue = new byte[SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT + 3];
-    byte[] byteMaxValue = new byte[SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT + 3];
-    random.nextBytes(byteMinValue);
-    random.nextBytes(byteMaxValue);
-    String byteMinValueString = BytesUtils.toHexString(byteMinValue);
-    String byteMaxValueString = BytesUtils.toHexString(byteMaxValue);
-    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", byteMinValueString,
-        byteMaxValueString, FieldSpec.DataType.BYTES);
-    compareLongValuesWithColumnMinMax(byteMinValueString, byteMaxValueString, props, FieldSpec.DataType.BYTES);
-  }
+    random.nextBytes(bytes);
+    bytes[numBytes - 2] = 5;
+    value = BytesUtils.toHexString(bytes);
+    minValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, false, DataType.BYTES);
+    byte[] minBytes = BytesUtils.toBytes(minValue);
+    assertEquals(minBytes.length, numBytes - 1);
+    assertTrue(Arrays.equals(minBytes, 0, numBytes - 1, bytes, 0, numBytes - 1));
+    assertTrue(ByteArray.compare(minBytes, bytes) < 0);
+    maxValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, true, DataType.BYTES);
+    byte[] maxBytes = BytesUtils.toBytes(maxValue);
+    assertEquals(maxBytes.length, numBytes - 1);
+    assertTrue(Arrays.equals(maxBytes, 0, numBytes - 2, bytes, 0, numBytes - 2));
+    assertEquals(maxBytes[numBytes - 2], (byte) 0xFF);
+    assertTrue(ByteArray.compare(maxBytes, bytes) > 0);
 
-  @Test
-  public void testAddMinMaxValueForLongValues() {
-    PropertiesConfiguration props = new PropertiesConfiguration();
+    // Bytes value with 0xFF suffix
+    bytes[numBytes - 2] = (byte) 0xFF;
+    bytes[numBytes - 1] = (byte) 0xFF;
+    value = BytesUtils.toHexString(bytes);
+    minValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, false, DataType.BYTES);
+    minBytes = BytesUtils.toBytes(minValue);
+    assertEquals(minBytes.length, numBytes - 1);
+    assertTrue(Arrays.equals(minBytes, 0, numBytes - 1, bytes, 0, numBytes - 1));
+    assertTrue(ByteArray.compare(minBytes, bytes) < 0);
+    maxValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, true, DataType.BYTES);
+    assertEquals(maxValue, value);
 
-    // test for value length grater than METADATA_PROPERTY_LENGTH_LIMIT with last characters as '\uFFFF'
-    props = new PropertiesConfiguration();
-    String stringMinValue = RandomStringUtils.
-        randomAlphanumeric(SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT + 3);
-    String stringMaxValue = RandomStringUtils.
-        randomAlphanumeric(SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT - 2);
-    stringMaxValue = stringMaxValue + '\uFFFF' + '\uFFFF';
-    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", stringMinValue,
-        stringMaxValue, FieldSpec.DataType.STRING);
-    compareLongValuesWithColumnMinMax(stringMinValue, stringMaxValue, props, FieldSpec.DataType.STRING);
-    String columnMaxValue = getEscapedValidPropertyValue((String) props.getProperty(getKeyFor("colA", MAX_VALUE)));
-    Assert.assertEquals(columnMaxValue.length(), SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT);
-
-
-    // Byte value test with last byte values as 0xFF
-    props = new PropertiesConfiguration();
-    Random random = new Random();
-    byte[] byteMinValue = new byte[SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT];
-    byte[] byteMaxValueWithOverflowCondition = new byte[SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT];
-    random.nextBytes(byteMinValue);
-    random.nextBytes(byteMaxValueWithOverflowCondition);
-    for (int i = (SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT / 2 - 4);
-        i < SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT; i++) {
-      byteMaxValueWithOverflowCondition[i] = (byte) 0xFF;
-    }
-    String byteMinValueString = BytesUtils.toHexString(byteMinValue);
-    String byteMaxValueWithOverflowConditionString = BytesUtils.toHexString(byteMaxValueWithOverflowCondition);
-    SegmentColumnarIndexCreator.addColumnMinMaxValueInfo(props, "colA", byteMinValueString,
-        byteMaxValueWithOverflowConditionString, FieldSpec.DataType.BYTES);
-    compareLongValuesWithColumnMinMax(byteMinValueString, byteMaxValueWithOverflowConditionString,
-        props, FieldSpec.DataType.BYTES);
-    Assert.assertEquals(byteMinValueString.length(), SegmentColumnarIndexCreator.METADATA_PROPERTY_LENGTH_LIMIT * 2);
-  }
-
-  private void compareLongValuesWithColumnMinMax(String longMinValue, String longMaxValue,
-      PropertiesConfiguration props, FieldSpec.DataType dataType) {
-    Assert.assertFalse(Boolean.parseBoolean(
-        String.valueOf(props.getProperty(getKeyFor("colA", Column.MIN_MAX_VALUE_INVALID)))));
-
-    String columnMinValue = getEscapedValidPropertyValue((String) props.getProperty(getKeyFor("colA", MIN_VALUE)));
-    String columnMaxValue = getEscapedValidPropertyValue((String) props.getProperty(getKeyFor("colA", MAX_VALUE)));
-    Assert.assertEquals(columnMinValue,
-        getEscapedValidPropertyValue(
-            SegmentColumnarIndexCreator.getValidPropertyValue(longMinValue, false, dataType)));
-    Assert.assertEquals(columnMaxValue,
-        getEscapedValidPropertyValue(
-            SegmentColumnarIndexCreator.getValidPropertyValue(longMaxValue, true, dataType)));
-
-    // check the original value and reduced value based on the length
-    // if same length than should be equal otherwise smaller
-    if (columnMinValue.length() == longMinValue.length()) {
-      Assert.assertTrue(columnMinValue.compareTo(longMinValue) <= 0);
-    } else {
-      Assert.assertTrue(columnMinValue.compareTo(longMinValue) < 0);
-    }
-
-    // check the original value and reduced value based on the length
-    // if same length than should be equal otherwise larger
-    if (columnMaxValue.length() == longMaxValue.length()) {
-      Assert.assertTrue(columnMaxValue.compareTo(longMaxValue) >= 0);
-    } else {
-      Assert.assertTrue(columnMaxValue.compareTo(longMaxValue) > 0);
-    }
-  }
-
-  private String getEscapedValidPropertyValue(String input) {
-    return StringEscapeUtils.unescapeJava(input);
+    // Bytes value with 0xFF and another byte
+    bytes[numBytes - 1] = 5;
+    value = BytesUtils.toHexString(bytes);
+    minValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, false, DataType.BYTES);
+    minBytes = BytesUtils.toBytes(minValue);
+    assertEquals(minBytes.length, numBytes - 1);
+    assertTrue(Arrays.equals(minBytes, 0, numBytes - 1, bytes, 0, numBytes - 1));
+    assertTrue(ByteArray.compare(minBytes, bytes) < 0);
+    maxValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, true, DataType.BYTES);
+    maxBytes = BytesUtils.toBytes(maxValue);
+    assertEquals(maxBytes.length, numBytes);
+    assertTrue(Arrays.equals(maxBytes, 0, numBytes - 1, bytes, 0, numBytes - 1));
+    assertEquals(maxBytes[numBytes - 1], (byte) 0xFF);
+    assertTrue(ByteArray.compare(maxBytes, bytes) > 0);
   }
 
   @AfterClass

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/metadata/ColumnMetadataImpl.java
@@ -47,6 +47,7 @@ import org.apache.pinot.spi.data.FieldSpec.FieldType;
 import org.apache.pinot.spi.data.MetricFieldSpec;
 import org.apache.pinot.spi.data.TimeFieldSpec;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
 
 
@@ -223,7 +224,11 @@ public class ColumnMetadataImpl implements ColumnMetadata {
     FieldType fieldType =
         FieldType.valueOf(config.getString(Column.getKeyFor(column, Column.COLUMN_TYPE)).toUpperCase());
     DataType dataType = DataType.valueOf(config.getString(Column.getKeyFor(column, Column.DATA_TYPE)).toUpperCase());
+    DataType storedType = dataType.getStoredType();
     String defaultNullValueString = config.getString(Column.getKeyFor(column, Column.DEFAULT_NULL_VALUE), null);
+    if (defaultNullValueString != null && storedType == DataType.STRING) {
+      defaultNullValueString = CommonsConfigurationUtils.recoverSpecialCharacterInPropertyValue(defaultNullValueString);
+    }
     FieldSpec fieldSpec;
     switch (fieldType) {
       case DIMENSION:
@@ -251,12 +256,10 @@ public class ColumnMetadataImpl implements ColumnMetadata {
     // NOTE: Use getProperty() instead of getString() to avoid variable substitution ('${anotherKey}'), which can cause
     //       problem for special values such as '$${' where the first '$' is identified as escape character.
     // TODO: Use getProperty() for other properties as well to avoid the overhead of variable substitution
-    String minString = StringEscapeUtils.unescapeJava((String)
-        config.getProperty(Column.getKeyFor(column, Column.MIN_VALUE)));
-    String maxString = StringEscapeUtils.unescapeJava((String)
-        config.getProperty(Column.getKeyFor(column, Column.MAX_VALUE)));
+    String minString = (String) config.getProperty(Column.getKeyFor(column, Column.MIN_VALUE));
+    String maxString = (String) config.getProperty(Column.getKeyFor(column, Column.MAX_VALUE));
     if (minString != null && maxString != null) {
-      switch (dataType.getStoredType()) {
+      switch (storedType) {
         case INT:
           builder.setMinValue(Integer.valueOf(minString));
           builder.setMaxValue(Integer.valueOf(maxString));
@@ -278,8 +281,8 @@ public class ColumnMetadataImpl implements ColumnMetadata {
           builder.setMaxValue(new BigDecimal(maxString));
           break;
         case STRING:
-          builder.setMinValue(minString);
-          builder.setMaxValue(maxString);
+          builder.setMinValue(CommonsConfigurationUtils.recoverSpecialCharacterInPropertyValue(minString));
+          builder.setMaxValue(CommonsConfigurationUtils.recoverSpecialCharacterInPropertyValue(maxString));
           break;
         case BYTES:
           builder.setMinValue(BytesUtils.toByteArray(minString));

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DimensionFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DimensionFieldSpec.java
@@ -20,7 +20,7 @@ package org.apache.pinot.spi.data;
 
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
-import javax.annotation.Nonnull;
+import javax.annotation.Nullable;
 
 
 @JsonIgnoreProperties(ignoreUnknown = true)
@@ -31,34 +31,33 @@ public final class DimensionFieldSpec extends FieldSpec {
     super();
   }
 
-  public DimensionFieldSpec(@Nonnull String name, @Nonnull DataType dataType, boolean isSingleValueField) {
+  public DimensionFieldSpec(String name, DataType dataType, boolean isSingleValueField) {
     super(name, dataType, isSingleValueField);
   }
 
-  public DimensionFieldSpec(@Nonnull String name, @Nonnull DataType dataType, boolean isSingleValueField,
-      @Nonnull Object defaultNullValue) {
+  public DimensionFieldSpec(String name, DataType dataType, boolean isSingleValueField,
+      @Nullable Object defaultNullValue) {
     super(name, dataType, isSingleValueField, defaultNullValue);
   }
 
-  public DimensionFieldSpec(@Nonnull String name, @Nonnull DataType dataType, boolean isSingleValueField, int maxLength,
-      @Nonnull Object defaultNullValue) {
+  public DimensionFieldSpec(String name, DataType dataType, boolean isSingleValueField, int maxLength,
+      @Nullable Object defaultNullValue) {
     super(name, dataType, isSingleValueField, maxLength, defaultNullValue);
   }
 
-  public DimensionFieldSpec(@Nonnull String name, @Nonnull DataType dataType, boolean isSingleValueField,
+  public DimensionFieldSpec(String name, DataType dataType, boolean isSingleValueField,
       Class virtualColumnProviderClass) {
     super(name, dataType, isSingleValueField);
     _virtualColumnProvider = virtualColumnProviderClass.getName();
   }
 
-  public DimensionFieldSpec(@Nonnull String name, @Nonnull DataType dataType, boolean isSingleValueField,
-      Class virtualColumnProviderClass, Object defaultNullValue) {
+  public DimensionFieldSpec(String name, DataType dataType, boolean isSingleValueField,
+      Class virtualColumnProviderClass, @Nullable Object defaultNullValue) {
     super(name, dataType, isSingleValueField, defaultNullValue);
     _virtualColumnProvider = virtualColumnProviderClass.getName();
   }
 
   @JsonIgnore
-  @Nonnull
   @Override
   public FieldType getFieldType() {
     return FieldType.DIMENSION;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/MetricFieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/MetricFieldSpec.java
@@ -21,6 +21,7 @@ package org.apache.pinot.spi.data;
 import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.google.common.base.Preconditions;
+import javax.annotation.Nullable;
 
 
 /**
@@ -38,7 +39,7 @@ public final class MetricFieldSpec extends FieldSpec {
     super(name, dataType, true);
   }
 
-  public MetricFieldSpec(String name, DataType dataType, Object defaultNullValue) {
+  public MetricFieldSpec(String name, DataType dataType, @Nullable Object defaultNullValue) {
     super(name, dataType, true, defaultNullValue);
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -40,9 +40,11 @@ import org.apache.commons.lang3.StringUtils;
 
 /**
  * Provide utility functions to manipulate Apache Commons {@link Configuration} instances.
- *
  */
-public abstract class CommonsConfigurationUtils {
+public class CommonsConfigurationUtils {
+  private CommonsConfigurationUtils() {
+  }
+
   /**
    * Instantiate a {@link PropertiesConfiguration} from a {@link File}.
    * @param file containing properties
@@ -172,5 +174,44 @@ public abstract class CommonsConfigurationUtils {
     } else {
       throw new IllegalArgumentException(returnType + " is not a supported type for conversion.");
     }
+  }
+
+  /**
+   * Replaces the special character in the given property value.
+   * - Leading/trailing space is prefixed/suffixed with "\0"
+   * - Comma is replaces with "\0\0"
+   *
+   * Note:
+   * - '\0' is not allowed in string values, so we can use it as the replaced character
+   * - Escaping comma with backslash doesn't work when comma is preceded by a backslash
+   */
+  public static String replaceSpecialCharacterInPropertyValue(String value) {
+    if (value.isEmpty()) {
+      return value;
+    }
+    if (value.charAt(0) == ' ') {
+      value = "\0" + value;
+    }
+    if (value.charAt(value.length() - 1) == ' ') {
+      value = value + "\0";
+    }
+    return value.replace(",", "\0\0");
+  }
+
+  /**
+   * Recovers the special character in the given property value that is previous replaced by
+   * {@link #replaceSpecialCharacterInPropertyValue(String)}.
+   */
+  public static String recoverSpecialCharacterInPropertyValue(String value) {
+    if (value.isEmpty()) {
+      return value;
+    }
+    if (value.startsWith("\0 ")) {
+      value = value.substring(1);
+    }
+    if (value.endsWith(" \0")) {
+      value = value.substring(0, value.length() - 1);
+    }
+    return value.replace("\0\0", ",");
   }
 }

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/env/CommonsConfigurationUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/env/CommonsConfigurationUtilsTest.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spi.env;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.io.FileUtils;
+import org.apache.commons.lang3.RandomStringUtils;
+import org.apache.commons.lang3.StringUtils;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class CommonsConfigurationUtilsTest {
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "CommonsConfigurationUtilsTest");
+  private static final File CONFIG_FILE = new File(TEMP_DIR, "config");
+  private static final String PROPERTY_KEY = "testKey";
+  private static final int NUM_ROUNDS = 1000;
+
+  @BeforeClass
+  public void setUp()
+      throws IOException {
+    FileUtils.deleteDirectory(TEMP_DIR);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(TEMP_DIR);
+  }
+
+  @Test
+  public void testPropertyValueWithSpecialCharacters()
+      throws ConfigurationException {
+    // Leading/trailing whitespace
+    testPropertyValueWithSpecialCharacters(" a");
+    testPropertyValueWithSpecialCharacters("a ");
+    testPropertyValueWithSpecialCharacters(" a ");
+    testPropertyValueWithSpecialCharacters("  a  ");
+    testPropertyValueWithSpecialCharacters(" a\t");
+    testPropertyValueWithSpecialCharacters("\na ");
+
+    // Whitespace in the middle
+    testPropertyValueWithSpecialCharacters("a\t b");
+    testPropertyValueWithSpecialCharacters("a \nb");
+
+    // List separator (comma)
+    testPropertyValueWithSpecialCharacters("a,b,c");
+    testPropertyValueWithSpecialCharacters(",a b");
+    testPropertyValueWithSpecialCharacters(",a,,,b,,c,");
+
+    // List separator with backslashes
+    testPropertyValueWithSpecialCharacters("a\\,b,\\c");
+    testPropertyValueWithSpecialCharacters("\\a\\,,b\\, \\c");
+    testPropertyValueWithSpecialCharacters("a\\\\,, ,b");
+    testPropertyValueWithSpecialCharacters("a\\\\\\,b");
+
+    // Empty string
+    testPropertyValueWithSpecialCharacters("");
+
+    // Variable substitution (should be disabled)
+    testPropertyValueWithSpecialCharacters("$${testKey}");
+
+    // Escape character for variable substitution
+    testPropertyValueWithSpecialCharacters("$${");
+
+    for (int i = 0; i < NUM_ROUNDS; i++) {
+      testPropertyValueWithSpecialCharacters(RandomStringUtils.randomAscii(5));
+      testPropertyValueWithSpecialCharacters(StringUtils.remove(RandomStringUtils.random(5), '\0'));
+    }
+  }
+
+  private void testPropertyValueWithSpecialCharacters(String value)
+      throws ConfigurationException {
+    String replacedValue = CommonsConfigurationUtils.replaceSpecialCharacterInPropertyValue(value);
+    PropertiesConfiguration configuration = new PropertiesConfiguration(CONFIG_FILE);
+    configuration.setProperty(PROPERTY_KEY, replacedValue);
+    String recoveredValue = CommonsConfigurationUtils.recoverSpecialCharacterInPropertyValue(
+        (String) configuration.getProperty(PROPERTY_KEY));
+    assertEquals(recoveredValue, value);
+    configuration.save();
+    configuration = new PropertiesConfiguration(CONFIG_FILE);
+    recoveredValue = CommonsConfigurationUtils.recoverSpecialCharacterInPropertyValue(
+        (String) configuration.getProperty(PROPERTY_KEY));
+    assertEquals(recoveredValue, value);
+  }
+}


### PR DESCRIPTION
Another attempt of #11218 

Apache Commons Configuration can already handle the string escape/unescape when writing/reading the property values, so there is no need to explicitly escape/unescape property values again.

Currently 2 special character cannot be properly handled currently: leading/trailing space (will be trimmed) and comma (will be treated as list separator). In order to workaround this, we replace them with the preserved '\0' character which is not allowed in the string value, so it won't collide with the property values.
- Leading space -> `"\0 "`
- Trailing space -> `" \0"`
- Comma -> `"\0\0"`

This PR also fixes the invalid default null value so that it can be included in the metadata.