### PR TITLE
UI: use new PUT api's to enable/disable table/instance state

### DIFF
--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -247,4 +247,14 @@ declare module 'Models' {
     GOOD = "GOOD",
     UPDATING = "UPDATING",
   }
+
+  export const enum InstanceState {
+    ENABLE = "enable",
+    DISABLE = "disable"
+  }
+
+  export const enum TableType {
+    REALTIME = "realtime",
+    OFFLINE = "offline"
+  }
 }

--- a/pinot-controller/src/main/resources/app/pages/InstanceDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/InstanceDetails.tsx
@@ -23,7 +23,7 @@ import { UnControlled as CodeMirror } from 'react-codemirror2';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/material.css';
 import 'codemirror/mode/javascript/javascript';
-import { TableData } from 'Models';
+import { InstanceState, TableData } from 'Models';
 import { RouteComponentProps } from 'react-router-dom';
 import PinotMethodUtils from '../utils/PinotMethodUtils';
 import AppLoader from '../components/AppLoader';
@@ -256,7 +256,7 @@ const InstanceDetails = ({ match }: RouteComponentProps<Props>) => {
   };
 
   const toggleInstanceState = async () => {
-    const result = await PinotMethodUtils.toggleInstanceState(instanceName, state.enabled ? 'DISABLE' : 'ENABLE');
+    const result = await PinotMethodUtils.toggleInstanceState(instanceName, state.enabled ? InstanceState.DISABLE : InstanceState.ENABLE);
     if(result.status){
       dispatch({type: 'success', message: result.status, show: true});
       fetchData();

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -22,7 +22,7 @@ import { makeStyles } from '@material-ui/core/styles';
 import { Box, Button, FormControlLabel, Grid, Switch, Tooltip, Typography } from '@material-ui/core';
 import { RouteComponentProps, useHistory, useLocation } from 'react-router-dom';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
-import { DISPLAY_SEGMENT_STATUS, TableData, TableSegmentJobs } from 'Models';
+import { DISPLAY_SEGMENT_STATUS, InstanceState, TableData, TableSegmentJobs, TableType } from 'Models';
 import AppLoader from '../components/AppLoader';
 import CustomizedTables from '../components/Table';
 import TableToolbar from '../components/TableToolbar';
@@ -246,19 +246,8 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
   };
 
   const toggleTableState = async () => {
-    const result = await PinotMethodUtils.toggleTableState(tableName, state.enabled ? 'disable' : 'enable', tableType.toLowerCase());
-    if(!result.error && result[0].state){
-      if(result[0].state.successful){
-        dispatch({type: 'success', message: result[0].state.message, show: true});
-        setState({ enabled: !state.enabled });
-        fetchTableData();
-      } else {
-        dispatch({type: 'error', message: result[0].state.message, show: true});
-      }
-      closeDialog();
-    } else {
-      syncResponse(result);
-    }
+    const result = await PinotMethodUtils.toggleTableState(tableName, state.enabled ? InstanceState.DISABLE : InstanceState.ENABLE, tableType.toLowerCase() as TableType);
+    syncResponse(result);
   };
 
   const handleConfigChange = (value: string) => {

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -21,7 +21,7 @@ import { AxiosResponse } from 'axios';
 import { TableData, Instances, Instance, Tenants, ClusterConfig, TableName, TableSize,
   IdealState, QueryTables, TableSchema, SQLResult, ClusterName, ZKGetList, ZKConfig, OperationResponse,
   BrokerList, ServerList, UserList, TableList, UserObject, TaskProgressResponse, TableSegmentJobs, TaskRuntimeConfig,
-  SegmentDebugDetails, QuerySchemas
+  SegmentDebugDetails, QuerySchemas, TableType, InstanceState
 } from 'Models';
 
 const headers = {
@@ -86,11 +86,11 @@ export const putInstance = (name: string, params: string): Promise<AxiosResponse
 export const updateInstanceTags = (name: string, params: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.put(`/instances/${name}/updateTags?tags=${params}`, null, { headers });
 
-export const setInstanceState = (name: string, stateName: string): Promise<AxiosResponse<OperationResponse>> =>
-  baseApi.post(`/instances/${name}/state`, stateName, { headers: {'Content-Type': 'text/plain', 'Accept': 'application/json'} });
+export const setInstanceState = (name: string, state: InstanceState): Promise<AxiosResponse<OperationResponse>> =>
+  baseApi.put(`/instances/${name}/state?state=${state}`, { headers: {'Content-Type': 'text/plain', 'Accept': 'application/json'} });
 
-export const setTableState = (name: string, stateName: string, tableType: string): Promise<AxiosResponse<OperationResponse>> =>
-  baseApi.get(`/tables/${name}?state=${stateName}&type=${tableType}`);
+export const setTableState = (tableName: string, state: InstanceState, tableType: TableType): Promise<AxiosResponse<OperationResponse>> =>
+  baseApi.put(`/tables/${tableName}/state?state=${state}&type=${tableType}`);
 
 export const dropInstance = (name: string): Promise<AxiosResponse<OperationResponse>> =>
   baseApi.delete(`instances/${name}`, { headers });


### PR DESCRIPTION
labels - `ui`
Resolves - #11224 


Now UI is using new PUT api's 

- Enable/disable Instance 

<img width="672" alt="image" src="https://github.com/apache/pinot/assets/41536903/f026eba4-8fc7-4d02-98d4-f1572dc05b0b">

- Enable/isable table
<img width="717" alt="image" src="https://github.com/apache/pinot/assets/41536903/22404595-7b73-469c-a0c0-974ba5eb532c">

- No UX change 
<img width="1728" alt="image" src="https://github.com/apache/pinot/assets/41536903/b264e813-d8d5-40aa-83e6-be110cecbd4c">
