### PR TITLE
[bugfix] Do not move real-time segments to working dir on restart

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -232,7 +232,9 @@ public abstract class BaseTableDataManager implements TableDataManager {
   @Override
   public void addSegment(File indexDir, IndexLoadingConfig indexLoadingConfig)
       throws Exception {
+
     indexLoadingConfig.setTableDataDir(_tableDataDir);
+    indexLoadingConfig.setInstanceTierConfigs(_tableDataManagerConfig.getInstanceTierConfigs());
     addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, indexLoadingConfig.getSchema()));
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -232,7 +232,6 @@ public abstract class BaseTableDataManager implements TableDataManager {
   @Override
   public void addSegment(File indexDir, IndexLoadingConfig indexLoadingConfig)
       throws Exception {
-
     indexLoadingConfig.setTableDataDir(_tableDataDir);
     indexLoadingConfig.setInstanceTierConfigs(_tableDataManagerConfig.getInstanceTierConfigs());
     addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, indexLoadingConfig.getSchema()));

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -390,6 +390,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       return;
     }
 
+    // Assign table directory to not let the segment be moved during loading/preprocessing
+    indexLoadingConfig.setTableDataDir(_tableDataDir);
+
     File segmentDir = new File(_indexDir, segmentName);
     // Restart during segment reload might leave segment in inconsistent state (index directory might not exist but
     // segment backup directory existed), need to first try to recover from reload failure before checking the existence

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -390,8 +390,10 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       return;
     }
 
-    // Assign table directory to not let the segment be moved during loading/preprocessing
+    // Assign table directory and tier info to not let the segment be moved during loading/preprocessing
     indexLoadingConfig.setTableDataDir(_tableDataDir);
+    indexLoadingConfig.setInstanceTierConfigs(_tableDataManagerConfig.getInstanceTierConfigs());
+    indexLoadingConfig.setSegmentTier(segmentZKMetadata.getTier());
 
     File segmentDir = new File(_indexDir, segmentName);
     // Restart during segment reload might leave segment in inconsistent state (index directory might not exist but

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManagerTest.java
@@ -210,7 +210,6 @@ public class RealtimeTableDataManagerTest {
     assertEquals(llmd.getTotalDocs(), 5);
   }
 
-
   @Test
   public void testAllowDownload() {
     RealtimeTableDataManager mgr = new RealtimeTableDataManager(null);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -220,8 +220,16 @@ public class HelixInstanceDataManager implements InstanceDataManager {
     TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, offlineTableName);
     Preconditions.checkState(tableConfig != null, "Failed to find table config for table: %s", offlineTableName);
     Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, tableConfig);
+    SegmentZKMetadata zkMetadata =
+        ZKMetadataProvider.getSegmentZKMetadata(_propertyStore, offlineTableName, segmentName);
+    Preconditions.checkState(zkMetadata != null, "Failed to find ZK metadata for offline segment: %s, table: %s",
+        segmentName, offlineTableName);
+
+    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(_instanceDataManagerConfig, tableConfig, schema);
+    indexLoadingConfig.setSegmentTier(zkMetadata.getTier());
+
     _tableDataManagerMap.computeIfAbsent(offlineTableName, k -> createTableDataManager(k, tableConfig))
-        .addSegment(indexDir, new IndexLoadingConfig(_instanceDataManagerConfig, tableConfig, schema));
+        .addSegment(indexDir, indexLoadingConfig);
     LOGGER.info("Added segment: {} to table: {}", segmentName, offlineTableName);
   }
 


### PR DESCRIPTION
**Context**
We're running Pinot on K8S in one of the public clouds, with `pinot.server.instance.segment.directory.loader=tierBased` and multiple tiers/volumes and data directories.

We've noticed that working directory of Pinot (located on ephemeral storage) collects plenty of real-time segments that, per configuration, shall reside in the respective data directory for a tier (persistent storage). Further investigation revealed that `RealtimeTableDataManager` doesn't initialize `IndexLoadingConfig` during segment loading, thus forcing the segment to be moved to `<empty>/<segment_dir>`, which results in a folder in the working directory. The latter contributes to the instability of Pinot and longer restart times.

**How to reproduce**:
1. Set `pinot.server.instance.segment.directory.loader=tierBased` 
2. Create a completed real-time segment.
3. Restart pinot-server, observe the relocation of the segment to the working dir.

**Changes**:
- Initialize `indexLoadingConfig` with table data dir, in the same way as `BaseTableDataManager.addSegment` is doing.