### PR TITLE
[pinot-core] Start consumption after creating segment data manager

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/HLRealtimeSegmentDataManager.java
@@ -417,6 +417,11 @@ public class HLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
   }
 
   @Override
+  public void startConsumption() {
+    // no-op
+  }
+
+  @Override
   public ConsumerState getConsumerState() {
     throw new UnsupportedOperationException();
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1285,7 +1285,8 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     cleanupMetrics();
   }
 
-  protected void startConsumerThread() {
+  @Override
+  public void startConsumption() {
     _consumerThread = new Thread(new PartitionConsumer(), _segmentNameStr);
     _segmentLogger.info("Created new consumer thread {} for {}", _consumerThread, this);
     _consumerThread.start();
@@ -1472,7 +1473,6 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
       _segmentLogger
           .info("Starting consumption on realtime consuming segment {} maxRowCount {} maxEndTime {}", llcSegmentName,
               _segmentMaxRowCount, new DateTime(_consumeEndTime, DateTimeZone.UTC));
-      startConsumerThread();
     } catch (Exception e) {
       // In case of exception thrown here, segment goes to ERROR state. Then any attempt to reset the segment from
       // ERROR -> OFFLINE -> CONSUMING via Helix Admin fails because the semaphore is acquired, but not released.

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -53,6 +53,12 @@ public abstract class RealtimeSegmentDataManager extends SegmentDataManager {
   public abstract Map<String, String> getPartitionToCurrentOffset();
 
   /**
+   * Starts the consumption of the underlying realtime segments.
+   * In some cases, it is helpful to not do this inside the constructor itself.
+   */
+  public abstract void startConsumption();
+
+  /**
    * Get the state of the consumer
    */
   public abstract ConsumerState getConsumerState();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -453,8 +453,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       segmentDataManager = llRealtimeSegmentDataManager;
     } else {
       InstanceZKMetadata instanceZKMetadata = ZKMetadataProvider.getInstanceZKMetadata(_propertyStore, _instanceId);
-      HLRealtimeSegmentDataManager hlRealtimeSegmentDataManager = new HLRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, instanceZKMetadata, this,
-          _indexDir.getAbsolutePath(), indexLoadingConfig, schema, _serverMetrics);
+      HLRealtimeSegmentDataManager hlRealtimeSegmentDataManager = new HLRealtimeSegmentDataManager(segmentZKMetadata,
+              tableConfig, instanceZKMetadata, this, _indexDir.getAbsolutePath(),
+              indexLoadingConfig, schema, _serverMetrics);
       hlRealtimeSegmentDataManager.startConsumption();
       segmentDataManager = hlRealtimeSegmentDataManager;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -445,14 +445,18 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       PartitionDedupMetadataManager partitionDedupMetadataManager =
           _tableDedupMetadataManager != null ? _tableDedupMetadataManager.getOrCreatePartitionManager(partitionGroupId)
               : null;
-      segmentDataManager =
+      LLRealtimeSegmentDataManager llRealtimeSegmentDataManager =
           new LLRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, this, _indexDir.getAbsolutePath(),
               indexLoadingConfig, schema, llcSegmentName, semaphore, _serverMetrics, partitionUpsertMetadataManager,
               partitionDedupMetadataManager, _isTableReadyToConsumeData);
+      llRealtimeSegmentDataManager.startConsumption();
+      segmentDataManager = llRealtimeSegmentDataManager;
     } else {
       InstanceZKMetadata instanceZKMetadata = ZKMetadataProvider.getInstanceZKMetadata(_propertyStore, _instanceId);
-      segmentDataManager = new HLRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, instanceZKMetadata, this,
+      HLRealtimeSegmentDataManager hlRealtimeSegmentDataManager = new HLRealtimeSegmentDataManager(segmentZKMetadata, tableConfig, instanceZKMetadata, this,
           _indexDir.getAbsolutePath(), indexLoadingConfig, schema, _serverMetrics);
+      hlRealtimeSegmentDataManager.startConsumption();
+      segmentDataManager = hlRealtimeSegmentDataManager;
     }
 
     _logger.info("Initialized RealtimeSegmentDataManager - " + segmentName);

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManagerTest.java
@@ -1052,7 +1052,7 @@ public class LLRealtimeSegmentDataManagerTest {
     }
 
     @Override
-    protected void startConsumerThread() {
+    public void startConsumption() {
       // Do nothing.
     }
 


### PR DESCRIPTION
Fixes #11207.

**Approach**: Starting a new thread inside the constructor escapes "this" object and results in data races as the object is not completely initialized while it gets shared with another thread. So, moved this logic to another function that gets invoked immediately after the constructor in all the usages (there's only one usage in the entire code + one no-op usage in test).

**Test plan**:
* Existing unit tests pass.
* Verified e2e query runs by running a few queries: select *, select count(*) locally when the table has > 2 segments.