### PR TITLE
Fix null pointer exception in segment debug endpoint

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/DebugResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/DebugResource.java
@@ -349,7 +349,7 @@ public class DebugResource {
           Map<String, SegmentServerDebugInfo> segmentServerDebugInfoMap = segmentEntry.getValue();
           SegmentServerDebugInfo segmentServerDebugInfo = segmentServerDebugInfoMap.get(segmentName);
 
-          if (verbosity > 0 || (segmentServerDebugInfo != null) && segmentHasErrors(segmentServerDebugInfo, evState)) {
+          if (segmentServerDebugInfo != null && (verbosity > 0 || segmentHasErrors(segmentServerDebugInfo, evState))) {
             segmentServerState.put(instanceName,
                 new TableDebugInfo.SegmentState(isState, evState, segmentServerDebugInfo.getSegmentSize(),
                     segmentServerDebugInfo.getConsumerInfo(), segmentServerDebugInfo.getErrorInfo()));


### PR DESCRIPTION
Fixes a null pointer exception where `segmentServerDebugInfo` is null.

`bugfix`
