### PR TITLE
Make test Java 8 compatible

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreatorTest.java
@@ -171,12 +171,12 @@ public class SegmentColumnarIndexCreatorTest {
     minValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, false, DataType.BYTES);
     byte[] minBytes = BytesUtils.toBytes(minValue);
     assertEquals(minBytes.length, numBytes - 1);
-    assertTrue(Arrays.equals(minBytes, 0, numBytes - 1, bytes, 0, numBytes - 1));
+    assertEquals(Arrays.copyOfRange(minBytes, 0, numBytes - 1), Arrays.copyOfRange(bytes, 0, numBytes - 1));
     assertTrue(ByteArray.compare(minBytes, bytes) < 0);
     maxValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, true, DataType.BYTES);
     byte[] maxBytes = BytesUtils.toBytes(maxValue);
     assertEquals(maxBytes.length, numBytes - 1);
-    assertTrue(Arrays.equals(maxBytes, 0, numBytes - 2, bytes, 0, numBytes - 2));
+    assertEquals(Arrays.copyOfRange(maxBytes, 0, numBytes - 2), Arrays.copyOfRange(bytes, 0, numBytes - 2));
     assertEquals(maxBytes[numBytes - 2], (byte) 0xFF);
     assertTrue(ByteArray.compare(maxBytes, bytes) > 0);
 
@@ -187,7 +187,7 @@ public class SegmentColumnarIndexCreatorTest {
     minValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, false, DataType.BYTES);
     minBytes = BytesUtils.toBytes(minValue);
     assertEquals(minBytes.length, numBytes - 1);
-    assertTrue(Arrays.equals(minBytes, 0, numBytes - 1, bytes, 0, numBytes - 1));
+    assertEquals(Arrays.copyOfRange(minBytes, 0, numBytes - 1), Arrays.copyOfRange(bytes, 0, numBytes - 1));
     assertTrue(ByteArray.compare(minBytes, bytes) < 0);
     maxValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, true, DataType.BYTES);
     assertEquals(maxValue, value);
@@ -198,12 +198,12 @@ public class SegmentColumnarIndexCreatorTest {
     minValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, false, DataType.BYTES);
     minBytes = BytesUtils.toBytes(minValue);
     assertEquals(minBytes.length, numBytes - 1);
-    assertTrue(Arrays.equals(minBytes, 0, numBytes - 1, bytes, 0, numBytes - 1));
+    assertEquals(Arrays.copyOfRange(minBytes, 0, numBytes - 1), Arrays.copyOfRange(bytes, 0, numBytes - 1));
     assertTrue(ByteArray.compare(minBytes, bytes) < 0);
     maxValue = SegmentColumnarIndexCreator.getValueWithinLengthLimit(value, true, DataType.BYTES);
     maxBytes = BytesUtils.toBytes(maxValue);
     assertEquals(maxBytes.length, numBytes);
-    assertTrue(Arrays.equals(maxBytes, 0, numBytes - 1, bytes, 0, numBytes - 1));
+    assertEquals(Arrays.copyOfRange(maxBytes, 0, numBytes - 1), Arrays.copyOfRange(bytes, 0, numBytes - 1));
     assertEquals(maxBytes[numBytes - 1], (byte) 0xFF);
     assertTrue(ByteArray.compare(maxBytes, bytes) > 0);
   }


### PR DESCRIPTION
 Removes use of `Arrays.equals(boolean[] a, int aFromIndex, int aToIndex, boolean[] b, int bFromIndex, int bToIndex)` that is only available in https://docs.oracle.com/javase%2F9%2Fdocs%2Fapi%2F%2F/java/util/Arrays.html JDK9 for the same reason being highlighted in https://github.com/apache/pinot/pull/11197 with JDK8 incompatibility. 

"We are not able to run in java-11 at this time due to some downstream dependencies. We are working on a short and long term solution for this."
