### PR TITLE
Make task MaxAttemptsPerTask configurable

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -205,7 +205,8 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       _controllerMetrics.addMeteredTableValue(taskType, ControllerMeter.NUMBER_ADHOC_TASKS_SUBMITTED, 1);
       responseMap.put(tableNameWithType,
           _helixTaskResourceManager.submitTask(parentTaskName, pinotTaskConfigs, minionInstanceTag,
-              taskGenerator.getTaskTimeoutMs(), taskGenerator.getNumConcurrentTasksPerInstance()));
+              taskGenerator.getTaskTimeoutMs(), taskGenerator.getNumConcurrentTasksPerInstance(),
+              taskGenerator.getMaxAttemptsPerTask()));
     }
     if (responseMap.isEmpty()) {
       throw new NoTaskScheduledException("No task scheduled for 'tableName': " + tableName);
@@ -579,7 +580,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       LOGGER.info("Submitting {} tasks for task type: {} with task configs: {}", numTasks, taskType, pinotTaskConfigs);
       _controllerMetrics.addMeteredTableValue(taskType, ControllerMeter.NUMBER_TASKS_SUBMITTED, numTasks);
       return _helixTaskResourceManager.submitTask(pinotTaskConfigs, taskGenerator.getTaskTimeoutMs(),
-          taskGenerator.getNumConcurrentTasksPerInstance());
+          taskGenerator.getNumConcurrentTasksPerInstance(), taskGenerator.getMaxAttemptsPerTask());
     }
     LOGGER.info("No task to schedule for task type: {}", taskType);
     return null;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/BaseTaskGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/BaseTaskGenerator.java
@@ -31,8 +31,8 @@ import org.slf4j.LoggerFactory;
 
 
 /**
- * Base implementation of the {@link PinotTaskGenerator} which reads the 'taskTimeoutMs' and
- * 'numConcurrentTasksPerInstance' from the cluster config.
+ * Base implementation of the {@link PinotTaskGenerator} which reads the 'taskTimeoutMs',
+ * 'numConcurrentTasksPerInstance' and 'maxAttemptsPerTask' from the cluster config.
  */
 public abstract class BaseTaskGenerator implements PinotTaskGenerator {
   protected static final Logger LOGGER = LoggerFactory.getLogger(BaseTaskGenerator.class);
@@ -72,6 +72,21 @@ public abstract class BaseTaskGenerator implements PinotTaskGenerator {
       }
     }
     return JobConfig.DEFAULT_NUM_CONCURRENT_TASKS_PER_INSTANCE;
+  }
+
+  @Override
+  public int getMaxAttemptsPerTask() {
+    String taskType = getTaskType();
+    String configKey = taskType + MinionConstants.MAX_ATTEMPTS_PER_TASK_KEY_SUFFIX;
+    String configValue = _clusterInfoAccessor.getClusterConfig(configKey);
+    if (configValue != null) {
+      try {
+        return Integer.parseInt(configValue);
+      } catch (Exception e) {
+        LOGGER.error("Invalid config {}: '{}'", configKey, configValue, e);
+      }
+    }
+    return MinionConstants.DEFAULT_MAX_ATTEMPTS_PER_TASK;
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/PinotTaskGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/generator/PinotTaskGenerator.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.helix.task.JobConfig;
 import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
+import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 
@@ -64,6 +65,13 @@ public interface PinotTaskGenerator {
    */
   default int getNumConcurrentTasksPerInstance() {
     return JobConfig.DEFAULT_NUM_CONCURRENT_TASKS_PER_INSTANCE;
+  }
+
+  /**
+   * Returns the maximum number of attempts per task, 1 by default.
+   */
+  default int getMaxAttemptsPerTask() {
+    return MinionConstants.DEFAULT_MAX_ATTEMPTS_PER_TASK;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -52,12 +52,18 @@ public class MinionConstants {
    */
   public static final String TIMEOUT_MS_KEY_SUFFIX = ".timeoutMs";
   public static final String NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY_SUFFIX = ".numConcurrentTasksPerInstance";
+  public static final String MAX_ATTEMPTS_PER_TASK_KEY_SUFFIX = ".maxAttemptsPerTask";
 
   /**
    * Table level configs
    */
   public static final String TABLE_MAX_NUM_TASKS_KEY = "tableMaxNumTasks";
   public static final String ENABLE_REPLACE_SEGMENTS_KEY = "enableReplaceSegments";
+
+  /**
+   * Job configs
+   */
+  public static final int DEFAULT_MAX_ATTEMPTS_PER_TASK = 1;
 
   // Purges rows inside segment that match chosen criteria
   public static class PurgeTask {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -20,6 +20,8 @@ package org.apache.pinot.integration.tests;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.helix.model.HelixConfigScope;
 import org.apache.helix.model.builder.HelixConfigScopeBuilder;
@@ -79,10 +81,13 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
 
     // Set task timeout in cluster config
     PinotHelixResourceManager helixResourceManager = _controllerStarter.getHelixResourceManager();
+    Map<String, String> properties = new HashMap<>();
+    properties.put(TASK_TYPE + MinionConstants.TIMEOUT_MS_KEY_SUFFIX, Long.toString(600_000L));
+    properties.put(TASK_TYPE + MinionConstants.MAX_ATTEMPTS_PER_TASK_KEY_SUFFIX, "2");
+
     helixResourceManager.getHelixAdmin().setConfig(
         new HelixConfigScopeBuilder(HelixConfigScope.ConfigScopeProperty.CLUSTER)
-            .forCluster(helixResourceManager.getHelixClusterName()).build(),
-        Collections.singletonMap(TASK_TYPE + MinionConstants.TIMEOUT_MS_KEY_SUFFIX, Long.toString(600_000L)));
+            .forCluster(helixResourceManager.getHelixClusterName()).build(), properties);
 
     // Add 3 offline tables, where 2 of them have TestTask enabled
     TableTaskConfig taskConfig = new TableTaskConfig(Collections.singletonMap(TASK_TYPE, Collections.emptyMap()));
@@ -101,6 +106,13 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     PinotTaskGenerator taskGenerator = _taskManager.getTaskGeneratorRegistry().getTaskGenerator(TASK_TYPE);
     assertNotNull(taskGenerator);
     assertEquals(taskGenerator.getTaskTimeoutMs(), 600_000L);
+  }
+
+  @Test
+  public void testTaskMaxAttempts() {
+    PinotTaskGenerator taskGenerator = _taskManager.getTaskGeneratorRegistry().getTaskGenerator(TASK_TYPE);
+    assertNotNull(taskGenerator);
+    assertEquals(taskGenerator.getMaxAttemptsPerTask(), 2);
   }
 
   private void verifyTaskCount(String task, int errors, int waiting, int running, int total) {


### PR DESCRIPTION
This PR makes task MaxAttemptsPerTask configurable. Right now the `MaxAttemptsPerTask` setting is hard coded as 1. This change would allow applications to configure different MaxAttemptsPerTask for tasks.
