### PR TITLE
[multistage] Enable some ignored queries in pinot-query-runtime

### DIFF
--- a/pinot-query-runtime/src/test/resources/queries/Aggregates.json
+++ b/pinot-query-runtime/src/test/resources/queries/Aggregates.json
@@ -85,8 +85,6 @@
       },
       {
         "psql": "4.2.7",
-        "ignored": true,
-        "comments": "TODO(Sonam): Remove ignore check. Test fails with existing code because existing code returns INT 0. But H2 returns a double.",
         "description": "aggregate int column and filter by int column",
         "sql": "SELECT sum(1 / int_col) FROM {tbl} WHERE int_col > 0",
         "h2Sql": "SELECT sum(1.0 / int_col) FROM {tbl} WHERE int_col > 0"
@@ -98,8 +96,6 @@
       },
       {
         "psql": "4.2.7",
-        "ignored": true,
-        "comments": "TODO(Sonam): Remove ignore check. Test fails with existing code but is fixed with this patch",
         "description": "aggregations on double column with filters",
         "sql": "SELECT min(double_col), max(double_col), avg(double_col), sum(double_col), count(double_col), count(distinct(double_col)), count(*) FROM {tbl} WHERE int_col > 100 and double_col = 1.75"
       },
@@ -160,8 +156,6 @@
       },
       {
         "psql": "4.2.7",
-        "ignored": true,
-        "comments": "TODO(Sonam): Remove ignore check. Test fails with existing code but is fixed with this patch.",
         "description": "aggregations on string column with filters",
         "sql": "SELECT count(string_col), count(distinct(string_col)), count(*) FROM {tbl} WHERE int_col > 100 and double_col = 1.75"
       }
@@ -427,15 +421,11 @@
     "queries": [
       {
         "psql": "9.21.0",
-        "ignored": true,
-        "comments": "TODO(Sonam): Remove ignore check. Test fails with existing code but is fixed with this patch",
         "description": "JOIN with simple aggregations on int and double columns",
         "sql": "SELECT min(double_col), min(int_col), min(double_col2), min(int_col2), max(double_col), max(int_col), max(double_col2), max(int_col2), avg(int_col), avg(double_col), avg(double_col2), avg(int_col2), sum(int_col), sum(double_col), sum(double_col2), sum(int_col2), count(*), count(distinct int_col), count(distinct double_col), count(distinct int_col2), count(distinct double_col2) from {tbl1} JOIN {tbl2} ON string_col = string_col2"
       },
       {
         "psql": "9.21.0",
-        "ignored": true,
-        "comments": "TODO(Sonam): Remove ignore check. Test fails with existing code but is fixed with this patch",
         "description": "JOIN with simple aggregations on boolean columns",
         "sql": "SELECT count(bool_col), count(distinct bool_col), bool_and(bool_col), bool_or(bool_col) from {tbl1} JOIN {tbl2} ON string_col = string_col2"
       },
@@ -446,15 +436,11 @@
       },
       {
         "psql": "9.21.0",
-        "ignored": true,
-        "comments": "TODO(Sonam): Remove ignore check. Test fails with existing code but is fixed with this patch",
         "description": "JOIN with simple aggregations on int and double columns and group by on bool_col",
         "sql": "SELECT bool_col, min(double_col), min(int_col), min(double_col2), min(int_col2), max(double_col), max(int_col), max(double_col2), max(int_col2), avg(int_col), avg(double_col), avg(double_col2), avg(int_col2), sum(int_col), sum(double_col), sum(double_col2), sum(int_col2), count(*), count(distinct int_col), count(distinct double_col), count(distinct int_col2), count(distinct double_col2) from {tbl1} JOIN {tbl2} ON string_col = string_col2 GROUP BY bool_col"
       },
       {
         "psql": "9.21.0",
-        "ignored": true,
-        "comments": "TODO(Sonam): Remove ignore check. Test fails with existing code but is fixed with this patch",
         "description": "JOIN with aggregations on int and double columns and group by on bool_col and string_col",
         "sql": "SELECT bool_col, string_col, min(double_col), min(int_col), min(double_col2), min(int_col2), max(double_col), max(int_col), max(double_col2), max(int_col2), avg(int_col), avg(double_col), avg(double_col2), avg(int_col2), sum(int_col), sum(double_col), sum(double_col2), sum(int_col2), count(*), count(distinct int_col), count(distinct double_col), count(distinct int_col2), count(distinct double_col2) from {tbl1} JOIN {tbl2} ON string_col = string_col2 GROUP BY bool_col, string_col"
       },
@@ -465,8 +451,6 @@
       },
       {
         "psql": "9.21.0",
-        "ignored": true,
-        "comments": "TODO(Sonam): Remove ignore check. Test fails with existing code but is fixed with this patch",
         "description": "JOIN with  aggregations on boolean columns and group by on string and int",
         "sql": "SELECT string_col, int_col, count(bool_col), count(distinct bool_col), bool_and(bool_col), bool_or(bool_col) from {tbl1} JOIN {tbl2} ON string_col = string_col2 GROUP BY string_col, int_col"
       },
@@ -682,17 +666,15 @@
         "sql": "SELECT min(bool_col) FROM {tbl}"
       },
       {
-        "ignored": true,
-        "comment": "issue with converting data types:  Unexpected RelDataTypeField: ANY for column: EXPR$0",
         "psql": "9.21.0",
         "description": "aggregate boolean column no group by with inner function",
-        "sql": "SELECT bool_and(startsWith(string_col, 'a')), bool_or(startsWith(string_col, 'a')) FROM {tbl}"
+        "sql": "SELECT bool_and(startsWith(string_col, 'a')), bool_or(startsWith(string_col, 'a')) FROM {tbl}",
+        "h2Sql": "SELECT bool_and(CASE WHEN string_col LIKE 'a%' THEN TRUE ELSE FALSE END), bool_or(CASE WHEN string_col LIKE 'a%' THEN TRUE ELSE FALSE END) FROM {tbl}"
       },
       {
-        "ignored": true,
-        "comment": "issue with converting data types:  Unexpected RelDataTypeField: ANY for column: EXPR$0",
         "description": "sum with inner function",
-        "sql": "SELECT sum(pow(int_col, 2)) FROM {tbl}"
+        "sql": "SELECT sum(pow(int_col, 2)) FROM {tbl}",
+        "h2Sql": "SELECT sum(int_col * int_col) FROM {tbl}"
       },
       {
         "psql": "4.2.7",
@@ -739,8 +721,6 @@
     },
     "queries": [
       {
-        "ignored": true,
-        "comment": "sum empty returns [0] instead of [null] at the moment when leaf aggregation is performed by v1 engine.",
         "description": "Return empty for sum",
         "sql": "SELECT sum(int_col) FROM {tbl} WHERE string_col IN ('foo', 'bar')"
       },
@@ -800,8 +780,6 @@
         "sql": "SELECT bool_and(bool_col) FROM {tbl} WHERE string_col IN ('foo', 'bar')"
       },
       {
-        "ignored": true,
-        "comment": "bool_and empty returns [0 which gets converted to false] instead of [null] when leaf aggregation is performed by Intermediate Stage",
         "description": "Return empty for bool_and with subquery",
         "sql": "SELECT bool_and(bool_col) FROM {tbl} WHERE string_col IN ( SELECT string_col FROM {tbl} WHERE int_col BETWEEN 1 AND 0 GROUP BY string_col )"
       },
@@ -812,8 +790,6 @@
         "sql": "SELECT bool_or(bool_col) FROM {tbl} WHERE string_col IN ('foo', 'bar')"
       },
       {
-        "ignored": true,
-        "comment": "bool_or empty returns [false] instead of [null] at the moment when leaf aggregation is performed by Intermediate Stage",
         "description": "Return empty for bool_or with subquery",
         "sql": "SELECT bool_or(bool_col) FROM {tbl} WHERE string_col IN ( SELECT string_col FROM {tbl} WHERE int_col BETWEEN 1 AND 0 GROUP BY string_col )"
       },
@@ -822,8 +798,6 @@
         "sql": "SELECT count(distinct int_col) FROM {tbl} WHERE string_col IN ('foo', 'bar')"
       },
       {
-        "ignored": true,
-        "comments": "TODO(Sonam): Remove ignore check. Test fails with existing code because H2 expects 0. But we return null",
         "description": "Return empty for count distinct with subquery",
         "sql": "SELECT count(distinct int_col) FROM {tbl} WHERE string_col IN ( SELECT string_col FROM {tbl} WHERE int_col BETWEEN 1 AND 0 GROUP BY string_col )"
       },
@@ -912,8 +886,6 @@
         "sql": "SELECT /*+ aggOptions(is_skip_leaf_stage_group_by='true') */ bool_and(bool_col), bool_or(bool_col) FROM {tbl}"
       },
       {
-        "ignored": true,
-        "comment": "sum empty returns [0] instead of [null] at the moment",
         "description": "sum empty input after filter with subquery",
         "sql": "SELECT /*+ aggOptions(is_skip_leaf_stage_group_by='true') */ sum(int_col) FROM {tbl} WHERE string_col IN ( SELECT string_col FROM {tbl} WHERE int_col BETWEEN 1 AND 0 GROUP BY string_col )"
       },

--- a/pinot-query-runtime/src/test/resources/queries/Comparisons.json
+++ b/pinot-query-runtime/src/test/resources/queries/Comparisons.json
@@ -171,8 +171,6 @@
     ]
   },
   "timestamps_comp": {
-    "ignored": true,
-    "comment": "we don't support timestamp comparisons",
     "psql": "9.2",
     "tables": {
       "tbl": {
@@ -410,13 +408,9 @@
       { "sql": "SELECT val NOT BETWEEN 3 AND 2 FROM {tbl}" },
       { "sql": "SELECT 3 NOT BETWEEN small AND big FROM {tbl}" },
       {
-        "ignored": true,
-        "comment": "SYMMETRIC not supported",
         "sql": "SELECT val BETWEEN SYMMETRIC small AND big FROM {tbl}"
       },
       {
-        "ignored": true,
-        "comment": "SYMMETRIC not supported",
         "sql": "SELECT val BETWEEN SYMMETRIC big AND small FROM {tbl}"
       }
     ]

--- a/pinot-query-runtime/src/test/resources/queries/FilterAggregates.json
+++ b/pinot-query-runtime/src/test/resources/queries/FilterAggregates.json
@@ -115,8 +115,6 @@
         "sql": "SELECT min(double_col) FILTER (WHERE string_col IN ('a', 'b')), count(*) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2"
       },
       {
-        "ignored": true,
-        "comments": "IS NULL and IS NOT NULL is not yet supported in filter conversion.",
         "sql": "SELECT min(double_col) FILTER (WHERE string_col IS NOT NULL), count(*) FROM {tbl1} JOIN {tbl2} ON string_col = string_col2"
       },
       {

--- a/pinot-query-runtime/src/test/resources/queries/OrderBy.json
+++ b/pinot-query-runtime/src/test/resources/queries/OrderBy.json
@@ -340,8 +340,6 @@
     ]
   },
   "order_by_boolean": {
-    "ignored": true,
-    "comment": "fails when we try to canonicalizeRow with ClassCastException - value is already in memory as boolean but DataSchema expects it to be an int",
     "tables": {
       "bools": {
         "schema": [

--- a/pinot-query-runtime/src/test/resources/queries/StringFunctions.json
+++ b/pinot-query-runtime/src/test/resources/queries/StringFunctions.json
@@ -23,8 +23,6 @@
       { "sql": "SELECT concat(strCol, strCol) FROM {stringTbl}" },
       { "sql": "SELECT concat_ws(',', strCol, strCol) FROM {stringTbl} WHERE strCol <> ''" },
       {
-        "ignored": true,
-        "comment": "standard SQL treats '' as null and ignores it, but pinot does not",
         "sql": "SELECT concat_ws(',', strCol, strCol) FROM {stringTbl}"
       },
       {

--- a/pinot-query-runtime/src/test/resources/queries/TableExpressions.json
+++ b/pinot-query-runtime/src/test/resources/queries/TableExpressions.json
@@ -35,8 +35,6 @@
       { "sql": "SELECT * FROM {tbl} WHERE intCol BETWEEN 0 AND 100 AND strCol BETWEEN 'bar' AND 'foo'" },
       { "sql": "SELECT * FROM {tbl} WHERE intCol IN (SELECT a.intCol FROM {tbl} AS a JOIN {tbl} AS b ON a.strCol = b.strCol WHERE MOD(a.intCol, 2) = MOD(b.intCol, 2))" },
       {
-        "ignored": true,
-        "comments": "Relation Decorrelator not supported",
         "sql": "SELECT * FROM {tbl} AS a WHERE a.strCol IN (SELECT b.strCol FROM {tbl} AS b WHERE b.intCol = a.intCol + 1)"
       },
       {
@@ -45,18 +43,12 @@
         "sql": "SELECT * FROM {tbl} AS a WHERE a.intCol BETWEEN (SELECT b.intCol FROM {tbl} AS b WHERE b.intCol = a.intCol + 1) AND 100"
       },
       {
-        "ignored": true,
-        "comments": "Relation Decorrelator not supported",
         "sql": "SELECT * FROM {tbl} AS a WHERE a.intCol BETWEEN (SELECT MIN(b.intCol) FROM {tbl} AS b WHERE b.intCol = a.intCol + 1) AND 100"
       },
       {
-        "ignored": true,
-        "comments": "Relation Decorrelator not supported",
         "sql": "SELECT * FROM {tbl} AS a WHERE EXISTS (SELECT strCol FROM {tbl} AS b WHERE b.intCol = a.intCol + 1)"
       },
       {
-        "ignored": true,
-        "comments": "Relation Decorrelator not supported",
         "sql": "SELECT * FROM {tbl} AS a WHERE NOT EXISTS (SELECT strCol FROM {tbl} AS b WHERE b.intCol = a.intCol + 1)"
       },
       {

--- a/pinot-query-runtime/src/test/resources/queries/ValueExpressions.json
+++ b/pinot-query-runtime/src/test/resources/queries/ValueExpressions.json
@@ -45,8 +45,6 @@
   },
   "scalar_subqueries": {
     "psql": "4.2.11",
-    "ignored": true,
-    "comment": "can't compile the logical plan",
     "tables": {
       "cities": {
         "schema": [


### PR DESCRIPTION
Since the recent enhancement and improvement, we can re-enable a few tests.