### PR TITLE
Add and refine tests for ExpressionScanDocIdIterator.

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
@@ -839,11 +839,11 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   public void testExpressionFilterOperatorResultIsInSecondProjectionBlock()
       throws Exception {
     initializeRows();
-    int counter = 0;
-    for (int i = 0; i < DocIdSetPlanNode.MAX_DOC_PER_CALL; i++) {
-      insertRowWithTwoColumns(null, counter++);
+    int i = 0;
+    for (; i < DocIdSetPlanNode.MAX_DOC_PER_CALL; i++) {
+      insertRowWithTwoColumns(null, i);
     }
-    insertRowWithTwoColumns(1, counter);
+    insertRowWithTwoColumns(1, i);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT)
         .addSingleValueDimension(COLUMN2, FieldSpec.DataType.INT).build();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
@@ -839,11 +839,10 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   public void testExpressionFilterOperatorResultIsInSecondProjectionBlock()
       throws Exception {
     initializeRows();
-    int i = 0;
-    for (; i < DocIdSetPlanNode.MAX_DOC_PER_CALL; i++) {
+    for (int i = 0; i < DocIdSetPlanNode.MAX_DOC_PER_CALL; i++) {
       insertRowWithTwoColumns(null, i);
     }
-    insertRowWithTwoColumns(1, i);
+    insertRowWithTwoColumns(1, DocIdSetPlanNode.MAX_DOC_PER_CALL);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT)
         .addSingleValueDimension(COLUMN2, FieldSpec.DataType.INT).build();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
@@ -839,9 +839,9 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
       throws Exception {
     initializeRows();
     insertRowWithTwoColumns(null, null);
-    insertRowWithTwoColumns(Integer.MIN_VALUE, null);
     insertRowWithTwoColumns(1, null);
     insertRowWithTwoColumns(-1, 1);
+    insertRowWithTwoColumns(Integer.MIN_VALUE, null);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.INT)
         .addSingleValueDimension(COLUMN2, FieldSpec.DataType.INT).build();


### PR DESCRIPTION
In `ExpressionScanDocIdIterator::processProjectionBlock`, if we mistakenly add local document IDs (`i` instead of `_docIdBuffer[i]`) to `matchingDocIds`, the `testExpressionFilterOperatorResultIsInSecondProjectionBlock` and `testExpressionFilterOperatorApplyAndForGetFalses` tests will fail.