### PR TITLE
Upgrade joda-time lib and timezone index

### DIFF
--- a/pinot-common/src/main/resources/zone-index.properties
+++ b/pinot-common/src/main/resources/zone-index.properties
@@ -2196,7 +2196,7 @@
 2171 US/Michigan
 2172 US/Mountain
 2173 US/Pacific
-2174 US/Pacific-New
+# 2174 US/Pacific-New # not in joda-time
 2175 US/Samoa
 2176 CET
 2177 CST6CDT

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -34,6 +34,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import java.util.stream.Collectors;
@@ -76,10 +77,17 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
   private static final int NUM_PARTITIONS = 4;
 
   private final Map<String, Set<String>> _tableToSegmentMap = new HashMap<>();
+  private TimeZone _currentSystemTimeZone;
 
   @BeforeClass
   public void setUp()
       throws Exception {
+    // Save the original default timezone
+    _currentSystemTimeZone = TimeZone.getDefault();
+
+    // Change the default timezone
+    TimeZone.setDefault(TimeZone.getTimeZone("America/Los_Angeles"));
+
     // Setting up mock server factories.
     // All test data are loaded upfront b/c the mock server and brokers needs to be in sync.
     MockInstanceDataManagerFactory factory1 = new MockInstanceDataManagerFactory("server1");
@@ -234,6 +242,8 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
 
   @AfterClass
   public void tearDown() {
+    // Restore the original default timezone
+    TimeZone.setDefault(_currentSystemTimeZone);
     DataTableBuilderFactory.setDataTableVersion(DataTableBuilderFactory.DEFAULT_VERSION);
     for (QueryServerEnclosure server : _servers.values()) {
       server.shutDown();

--- a/pinot-query-runtime/src/test/resources/queries/TypeCasting.json
+++ b/pinot-query-runtime/src/test/resources/queries/TypeCasting.json
@@ -135,27 +135,36 @@
         ]
       },
       {
-        "ignored": true,
-        "comment": "problematic dateTimeConvert with weird exception on leaf stage",
-        "sql": "SELECT dateTimeConvert(timestampStringCol, '1:MILLISECONDS:EPOCH', '1:MINUTES:EPOCH', '30:MINUTES') FROM {tbl}",
+        "sql": "SELECT dateTimeConvert(timestampCol, '1:MILLISECONDS:EPOCH', '1:MINUTES:EPOCH', '30:MINUTES') FROM {tbl}",
         "outputs": [
-          []
+          [450],
+          [540],
+          [15263280],
+          [15264360],
+          [27352050],
+          [1993348080]
         ]
       },
       {
-        "ignored": true,
-        "comment": "problematic round function not producing proper decimal results type",
         "sql": "SELECT ROUND(longCol, 2) FROM {tbl}",
         "outputs": [
-          []
+          [14],
+          [14],
+          [20],
+          [20],
+          [40],
+          [46]
         ]
       },
       {
-        "ignored": true,
-        "comment": "dateTrunc returns round up instead of round down results",
-        "sql": "SELECT dateTrunc('DAY', b.timestampCol) FROM {tbl}",
+        "sql": "SELECT dateTrunc('DAY', timestampCol) FROM {tbl}",
         "outputs": [
-          []
+          [0],
+          [0],
+          [915753600000],
+          [915840000000],
+          [1641081600000],
+          [119600841600000]
         ]
       }
     ]

--- a/pom.xml
+++ b/pom.xml
@@ -160,6 +160,7 @@
     <audienceannotations.version>0.13.0</audienceannotations.version>
     <clp-ffi.version>0.4.3</clp-ffi.version>
     <aws.sdk.version>2.20.94</aws.sdk.version>
+    <joda-time.version>2.12.5</joda-time.version>
     <!-- Sets the VM argument line used when unit tests are run. -->
     <argLine>-Xms4g -Xmx4g</argLine>
 
@@ -557,7 +558,7 @@
       <dependency>
         <groupId>joda-time</groupId>
         <artifactId>joda-time</artifactId>
-        <version>2.11.2</version>
+        <version>${joda-time.version}</version>
       </dependency>
       <dependency>
         <groupId>org.apache.avro</groupId>


### PR DESCRIPTION
- upgrade joda-time from 2.11.2 to 2.12.5
- remove a deprecated time zone `US/Pacific-New`