### PR TITLE
Fix a bug in ExpressionScanDocIdIterator for multi-value.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ExpressionScanDocIdIterator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/dociditerators/ExpressionScanDocIdIterator.java
@@ -146,9 +146,9 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
   private void processProjectionBlock(ProjectionBlock projectionBlock, BitmapDataProvider matchingDocIds) {
     int numDocs = projectionBlock.getNumDocs();
     TransformResultMetadata resultMetadata = _transformFunction.getResultMetadata();
+    boolean predicateEvaluationResult = _predicateEvaluationResult == PredicateEvaluationResult.TRUE;
     if (resultMetadata.isSingleValue()) {
       _numEntriesScanned += numDocs;
-      boolean predicateEvaluationResult = _predicateEvaluationResult == PredicateEvaluationResult.TRUE;
       RoaringBitmap nullBitmap = null;
       if (resultMetadata.hasDictionary()) {
         int[] dictIds = _transformFunction.transformToDictIdsSV(projectionBlock);
@@ -321,7 +321,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
           int[] dictIds = dictIdsArray[i];
           int numDictIds = dictIds.length;
           _numEntriesScanned += numDictIds;
-          if (_predicateEvaluator.applyMV(dictIds, numDictIds)) {
+          if (_predicateEvaluator.applyMV(dictIds, numDictIds) == predicateEvaluationResult) {
             matchingDocIds.add(_docIdBuffer[i]);
           }
         }
@@ -333,7 +333,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
               int[] values = intValuesArray[i];
               int numValues = values.length;
               _numEntriesScanned += numValues;
-              if (_predicateEvaluator.applyMV(values, numValues)) {
+              if (_predicateEvaluator.applyMV(values, numValues) == predicateEvaluationResult) {
                 matchingDocIds.add(_docIdBuffer[i]);
               }
             }
@@ -344,7 +344,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
               long[] values = longValuesArray[i];
               int numValues = values.length;
               _numEntriesScanned += numValues;
-              if (_predicateEvaluator.applyMV(values, numValues)) {
+              if (_predicateEvaluator.applyMV(values, numValues) == predicateEvaluationResult) {
                 matchingDocIds.add(_docIdBuffer[i]);
               }
             }
@@ -355,7 +355,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
               float[] values = floatValuesArray[i];
               int numValues = values.length;
               _numEntriesScanned += numValues;
-              if (_predicateEvaluator.applyMV(values, numValues)) {
+              if (_predicateEvaluator.applyMV(values, numValues) == predicateEvaluationResult) {
                 matchingDocIds.add(_docIdBuffer[i]);
               }
             }
@@ -366,7 +366,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
               double[] values = doubleValuesArray[i];
               int numValues = values.length;
               _numEntriesScanned += numValues;
-              if (_predicateEvaluator.applyMV(values, numValues)) {
+              if (_predicateEvaluator.applyMV(values, numValues) == predicateEvaluationResult) {
                 matchingDocIds.add(_docIdBuffer[i]);
               }
             }
@@ -377,7 +377,7 @@ public final class ExpressionScanDocIdIterator implements ScanBasedDocIdIterator
               String[] values = valuesArray[i];
               int numValues = values.length;
               _numEntriesScanned += numValues;
-              if (_predicateEvaluator.applyMV(values, numValues)) {
+              if (_predicateEvaluator.applyMV(values, numValues) == predicateEvaluationResult) {
                 matchingDocIds.add(_docIdBuffer[i]);
               }
             }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
@@ -856,4 +856,21 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     assertEquals(rows.size(), NUM_OF_SEGMENT_COPIES);
     assertArrayEquals(rows.get(0), new Object[]{Integer.MIN_VALUE});
   }
+
+  @Test
+  public void testExpressionFilterOperatorNotFilterOnMultiValue()
+      throws Exception {
+    initializeRows();
+    insertRow(new Integer[]{1, 2, 3});
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    Schema schema = new Schema.SchemaBuilder().addMultiValueDimension(COLUMN1, FieldSpec.DataType.INT).build();
+    setUpSegments(tableConfig, schema);
+    String query = String.format("SELECT * FROM testTable WHERE NOT(VALUEIN(%s, 2, 3) > 2) LIMIT 100", COLUMN1);
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query);
+
+    ResultTable resultTable = brokerResponse.getResultTable();
+    List<Object[]> rows = resultTable.getRows();
+    assertEquals(rows.size(), 0);
+  }
 }


### PR DESCRIPTION
This PR fixes a bug introduced in https://github.com/apache/pinot/pull/11220.

The bug is that filters like `WHERE NOT (func(column) > 0)` would get opposite results when the `column` is multi-value,