### PR TITLE
[multistage][draft] histogram agg support

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql/fun/PinotOperatorTable.java
@@ -50,6 +50,8 @@ public class PinotOperatorTable extends SqlStdOperatorTable {
   private static @MonotonicNonNull PinotOperatorTable _instance;
 
   public static final SqlFunction COALESCE = new PinotSqlCoalesceFunction();
+  public static final SqlArrayValueConstructor ARRAY_VALUE_CONSTRUCTOR = new SqlArrayValueConstructor();
+  public static final SqlMapValueConstructor MAP_VALUE_CONSTRUCTOR = new SqlMapValueConstructor();
 
   // TODO: clean up lazy init by using Suppliers.memorized(this::computeInstance) and make getter wrapped around
   // supplier instance. this should replace all lazy init static objects in the codebase

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/AggregationFunctionType.java
@@ -142,8 +142,14 @@ public enum AggregationFunctionType {
   // DEPRECATED in v2
   IDSET("idSet"),
 
-  // TODO: support histogram requires solving ARRAY constructor and multi-function signature without optional ordinal
-  HISTOGRAM("histogram"),
+  // histogram has 2 signatures, either by array or by lower/upper/binCount
+  HISTOGRAM("histogram", null, SqlKind.OTHER_FUNCTION, SqlFunctionCategory.USER_DEFINED_FUNCTION,
+      OperandTypes.or(
+          OperandTypes.family(ImmutableList.of(SqlTypeFamily.NUMERIC, SqlTypeFamily.ARRAY), ordinal -> ordinal > 1),
+          OperandTypes.family(ImmutableList.of(
+              SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC),
+              ordinal -> ordinal > 1)
+      ), ReturnTypes.TO_ARRAY, ReturnTypes.explicit(SqlTypeName.OTHER)),
 
   // TODO: support underscore separated version of the stats functions, resolving conflict in SqlStdOptTable
   // currently Pinot is missing generated agg functions impl from Calcite's AggregateReduceFunctionsRule


### PR DESCRIPTION
Summary
===
first draft to support histogram, supported syntax
```
select Dest, histogram(CAST(AirTime AS DOUBLE), 0, 100, 10) from airlineStats group by Dest limit 1000
select Dest, histogram(CAST(AirTime AS DOUBLE), ARRAY[0, 10, 100]) from airlineStats group by Dest limit 1000
```

Work Items
===
1. make ARRAY_VALUE_CONSTRUCTOR the default association with `ARRAY` keyword (previously it was `ARRAY_QUERY_CONSTRUCTOR`)
2. Histogram can now register 2 different signatures --> (1) array-based and (2) left, right, bin-size based

TODO
===
1. workaround for ArrayLiteral needs to be handled in `LiteralHintUtils` 
    - complication: RexExpressions.Literal now users FieldSpec.DataTye which is not easy to represent array. maybe need to change to use `DataSchema.ColumnDataType`
2. arrayValueConstructor needs to be a signature supported by leaf and intermediate stage:
    - for leaf, register a transform function type `arrayValueConststructor` that returns identical array based on the literal
    - for intermediate stage, register as a real-literal within the operator so when reference to that row index (from the next operator) return that directly.

CC @xiangfu0 