### PR TITLE
Fix a bug in BaseFilterOperator.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseFilterOperator.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.operator.BaseOperator;
 import org.apache.pinot.core.operator.blocks.FilterBlock;
+import org.apache.pinot.core.operator.docidsets.EmptyDocIdSet;
 import org.apache.pinot.core.operator.docidsets.NotDocIdSet;
 import org.apache.pinot.core.operator.docidsets.OrDocIdSet;
 
@@ -94,7 +95,7 @@ public abstract class BaseFilterOperator extends BaseOperator<FilterBlock> {
    * @return document IDs in which the predicate evaluates to NULL.
    */
   protected BlockDocIdSet getNulls() {
-    throw new UnsupportedOperationException();
+    return EmptyDocIdSet.getInstance();
   }
 
   /**


### PR DESCRIPTION
Fix a bug introduced in https://github.com/apache/pinot/pull/11185.

Without the change in this PR, if `enableNullHandling` is true and a subclass of BaseFilterOperator does not override `getNulls` and the subclass is a child of a `NotFilterOperator`, we throw a exception. This is a regression.