### PR TITLE
Support stage parallelism for partitioned table scan

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintOptions.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintOptions.java
@@ -83,5 +83,6 @@ public class PinotHintOptions {
   public static class TableHintOptions {
     public static final String PARTITION_KEY = "partition_key";
     public static final String PARTITION_SIZE = "partition_size";
+    public static final String PARTITION_PARALLELISM = "partition_parallelism";
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanMetadata.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/DispatchablePlanMetadata.java
@@ -70,6 +70,7 @@ public class DispatchablePlanMetadata implements Serializable {
 
   // whether a stage is partitioned table scan
   private boolean _isPartitionedTableScan;
+  private int _partitionParallelism;
 
   public DispatchablePlanMetadata() {
     _scannedTables = new ArrayList<>();
@@ -141,6 +142,14 @@ public class DispatchablePlanMetadata implements Serializable {
 
   public void setPartitionedTableScan(boolean isPartitionedTableScan) {
     _isPartitionedTableScan = isPartitionedTableScan;
+  }
+
+  public int getPartitionParallelism() {
+    return _partitionParallelism;
+  }
+
+  public void setPartitionParallelism(int partitionParallelism) {
+    _partitionParallelism = partitionParallelism;
   }
 
   public Map<String, Set<String>> getTableToUnavailableSegmentsMap() {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -102,21 +102,22 @@ public class WorkerManager {
 
     DispatchablePlanMetadata metadata = context.getDispatchablePlanMetadataMap().get(fragment.getFragmentId());
     Map<String, String> tableOptions = metadata.getTableOptions();
-    String partitionKey = null;
-    int numPartitions = 0;
-    if (tableOptions != null) {
-      partitionKey = tableOptions.get(PinotHintOptions.TableHintOptions.PARTITION_KEY);
-      String partitionSize = tableOptions.get(PinotHintOptions.TableHintOptions.PARTITION_SIZE);
-      if (partitionSize != null) {
-        numPartitions = Integer.parseInt(partitionSize);
-      }
-    }
+    String partitionKey =
+        tableOptions != null ? tableOptions.get(PinotHintOptions.TableHintOptions.PARTITION_KEY) : null;
     if (partitionKey == null) {
       assignWorkersToNonPartitionedLeafFragment(metadata, context);
     } else {
-      Preconditions.checkState(numPartitions > 0, "'%s' must be provided for partition key: %s",
+      String numPartitionsStr = tableOptions.get(PinotHintOptions.TableHintOptions.PARTITION_SIZE);
+      Preconditions.checkState(numPartitionsStr != null, "'%s' must be provided for partition key: %s",
           PinotHintOptions.TableHintOptions.PARTITION_SIZE, partitionKey);
-      assignWorkersToPartitionedLeafFragment(metadata, context, partitionKey, numPartitions);
+      int numPartitions = Integer.parseInt(numPartitionsStr);
+      Preconditions.checkState(numPartitions > 0, "'%s' must be positive, got: %s",
+          PinotHintOptions.TableHintOptions.PARTITION_SIZE, numPartitions);
+      String partitionParallelismStr = tableOptions.get(PinotHintOptions.TableHintOptions.PARTITION_PARALLELISM);
+      int partitionParallelism = partitionParallelismStr != null ? Integer.parseInt(partitionParallelismStr) : 1;
+      Preconditions.checkState(partitionParallelism > 0, "'%s' must be positive: %s, got: %s",
+          PinotHintOptions.TableHintOptions.PARTITION_PARALLELISM, partitionParallelism);
+      assignWorkersToPartitionedLeafFragment(metadata, context, partitionKey, numPartitions, partitionParallelism);
     }
   }
 
@@ -207,7 +208,7 @@ public class WorkerManager {
   }
 
   private void assignWorkersToPartitionedLeafFragment(DispatchablePlanMetadata metadata,
-      DispatchablePlanContext context, String partitionKey, int numPartitions) {
+      DispatchablePlanContext context, String partitionKey, int numPartitions, int partitionParallelism) {
     String tableName = metadata.getScannedTables().get(0);
     ColocatedTableInfo colocatedTableInfo = getColocatedTableInfo(tableName, partitionKey, numPartitions);
 
@@ -238,6 +239,7 @@ public class WorkerManager {
     metadata.setWorkerIdToSegmentsMap(workerIdToSegmentsMap);
     metadata.setTimeBoundaryInfo(colocatedTableInfo._timeBoundaryInfo);
     metadata.setPartitionedTableScan(true);
+    metadata.setPartitionParallelism(partitionParallelism);
   }
 
   private void assignWorkersToIntermediateFragment(PlanFragment fragment, DispatchablePlanContext context) {
@@ -249,12 +251,29 @@ public class WorkerManager {
     Map<Integer, DispatchablePlanMetadata> metadataMap = context.getDispatchablePlanMetadataMap();
     DispatchablePlanMetadata metadata = metadataMap.get(fragment.getFragmentId());
 
-    // If the first child is partitioned table scan, use the same worker assignment to avoid shuffling data
-    // TODO: Introduce a hint to control this
-    if (children.size() > 0) {
+    // If the first child is partitioned table scan, use the same worker assignment to avoid shuffling data. When
+    // partition parallelism is configured, create multiple intermediate stage workers on the same instance for each
+    // worker in the first child.
+    if (!children.isEmpty()) {
       DispatchablePlanMetadata firstChildMetadata = metadataMap.get(children.get(0).getFragmentId());
       if (firstChildMetadata.isPartitionedTableScan()) {
-        metadata.setWorkerIdToServerInstanceMap(firstChildMetadata.getWorkerIdToServerInstanceMap());
+        int partitionParallelism = firstChildMetadata.getPartitionParallelism();
+        Map<Integer, QueryServerInstance> childWorkerIdToServerInstanceMap =
+            firstChildMetadata.getWorkerIdToServerInstanceMap();
+        if (partitionParallelism == 1) {
+          metadata.setWorkerIdToServerInstanceMap(childWorkerIdToServerInstanceMap);
+        } else {
+          int numChildWorkers = childWorkerIdToServerInstanceMap.size();
+          Map<Integer, QueryServerInstance> workerIdToServerInstanceMap = new HashMap<>();
+          int workerId = 0;
+          for (int i = 0; i < numChildWorkers; i++) {
+            QueryServerInstance serverInstance = childWorkerIdToServerInstanceMap.get(i);
+            for (int j = 0; j < partitionParallelism; j++) {
+              workerIdToServerInstanceMap.put(workerId++, serverInstance);
+            }
+          }
+          metadata.setWorkerIdToServerInstanceMap(workerIdToServerInstanceMap);
+        }
         return;
       }
     }
@@ -308,13 +327,13 @@ public class WorkerManager {
       throw new IllegalStateException(
           "No server instance found for intermediate stage for tables: " + Arrays.toString(tableNames.toArray()));
     }
-    Map<String, String> options = context.getPlannerContext().getOptions();
-    int stageParallelism = Integer.parseInt(options.getOrDefault(QueryOptionKey.STAGE_PARALLELISM, "1"));
     if (metadata.isRequiresSingletonInstance()) {
       // require singleton should return a single global worker ID with 0;
       metadata.setWorkerIdToServerInstanceMap(Collections.singletonMap(0,
           new QueryServerInstance(serverInstances.get(RANDOM.nextInt(serverInstances.size())))));
     } else {
+      Map<String, String> options = context.getPlannerContext().getOptions();
+      int stageParallelism = Integer.parseInt(options.getOrDefault(QueryOptionKey.STAGE_PARALLELISM, "1"));
       Map<Integer, QueryServerInstance> workerIdToServerInstanceMap = new HashMap<>();
       int workerId = 0;
       for (ServerInstance serverInstance : serverInstances) {

--- a/pinot-query-runtime/src/test/resources/queries/QueryHints.json
+++ b/pinot-query-runtime/src/test/resources/queries/QueryHints.json
@@ -66,8 +66,20 @@
         "sql": "SELECT {tbl1}.num, COUNT(*) FROM {tbl1} /*+ tableOptions(partition_key='num', partition_size='4') */ GROUP BY {tbl1}.num"
       },
       {
+        "description": "Group by partition column with partition parallelism",
+        "sql": "SELECT {tbl1}.num, COUNT(*) FROM {tbl1} /*+ tableOptions(partition_key='num', partition_size='4', partition_parallelism='2') */ GROUP BY {tbl1}.num"
+      },
+      {
         "description": "Colocated JOIN with partition column",
         "sql": "SELECT {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} /*+ tableOptions(partition_key='num', partition_size='4') */ JOIN {tbl2} /*+ tableOptions(partition_key='num', partition_size='4') */ ON {tbl1}.num = {tbl2}.num"
+      },
+      {
+        "description": "Colocated JOIN with partition column with partition parallelism",
+        "sql": "SELECT {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} /*+ tableOptions(partition_key='num', partition_size='4', partition_parallelism='2') */ JOIN {tbl2} /*+ tableOptions(partition_key='num', partition_size='4', partition_parallelism='2') */ ON {tbl1}.num = {tbl2}.num"
+      },
+      {
+        "description": "Colocated JOIN with partition column with partition parallelism in first table",
+        "sql": "SELECT {tbl1}.num, {tbl1}.name, {tbl2}.num, {tbl2}.val FROM {tbl1} /*+ tableOptions(partition_key='num', partition_size='4', partition_parallelism='2') */ JOIN {tbl2} /*+ tableOptions(partition_key='num', partition_size='4') */ ON {tbl1}.num = {tbl2}.num"
       },
       {
         "description": "Colocated JOIN with partition column and group by partition column",


### PR DESCRIPTION
Added `partition_parallelism` as TableHintOptions so that we can increase parallelism per partition for intermediate stage after partitioned table scan stage