### PR TITLE
Add Server API to get tenant pools

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/InstanceResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/InstanceResource.java
@@ -29,6 +29,7 @@ import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.ws.rs.GET;
@@ -38,6 +39,7 @@ import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import org.apache.helix.HelixManager;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.utils.config.InstanceUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.server.api.AdminApiApplication;
 
@@ -72,5 +74,21 @@ public class InstanceResource {
       return config.getTags();
     }
     return Collections.emptyList();
+  }
+
+  @GET
+  @Path("pools")
+  @ApiOperation(value = "Tenant pools for current instance")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error")
+  })
+  @Produces(MediaType.APPLICATION_JSON)
+  public Map<String, String> getInstancePools() {
+    InstanceConfig instanceConfig = HelixHelper.getInstanceConfig(_helixManager, _instanceId);
+    if (instanceConfig == null || instanceConfig.getRecord() == null) {
+      return Collections.emptyMap();
+    }
+    Map<String, String> pools = instanceConfig.getRecord().getMapField(InstanceUtils.POOL_KEY);
+    return pools == null ? Collections.emptyMap() : pools;
   }
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/InstanceResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/InstanceResource.java
@@ -76,6 +76,10 @@ public class InstanceResource {
     return Collections.emptyList();
   }
 
+  /**
+   * Retrieve instance pools in the Helix InstanceConfig: https://docs.pinot.apache.org/operators/operating-pinot/instance-assignment#pool-based-instance-assignment.
+   * Returns an empty Map if poolBased config is not enabled or the instance is not assigned to any pool.
+   */
   @GET
   @Path("pools")
   @ApiOperation(value = "Tenant pools for current instance")

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/InstanceResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/InstanceResource.java
@@ -77,7 +77,8 @@ public class InstanceResource {
   }
 
   /**
-   * Retrieve instance pools in the Helix InstanceConfig: https://docs.pinot.apache.org/operators/operating-pinot/instance-assignment#pool-based-instance-assignment.
+   * Retrieve instance pools in the Helix InstanceConfig:
+   * https://docs.pinot.apache.org/operators/operating-pinot/instance-assignment#pool-based-instance-assignment.
    * Returns an empty Map if poolBased config is not enabled or the instance is not assigned to any pool.
    */
   @GET


### PR DESCRIPTION
Add a new Server API GET /instance/pools in InstanceResource to get server pools. `feature` 

It returns an empty map if the server is not assigned to any pool number

Tested locally:
1. server is not assigned to any pool number
```
❯ curl localhost:7500/instance/pools | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100     2  100     2    0     0    153      0 --:--:-- --:--:-- --:--:--   333
{}
```
2. server is assigned to pool numbers                                                                                                                                                                              
```
❯ curl localhost:7500/instance/pools | jq
  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
                                 Dload  Upload   Total   Spent    Left  Speed
100    58  100    58    0     0   5070      0 --:--:-- --:--:-- --:--:-- 11600
{
  "DefaultTenant_OFFLINE": "0",
  "DefaultTenant_REALTIME": "0"
}
```
