### PR TITLE
Add spotbugs to detect some cases when plugins use forbidden apis

### DIFF
--- a/contrib/pinot-spotbugs-plugin/pom.xml
+++ b/contrib/pinot-spotbugs-plugin/pom.xml
@@ -1,0 +1,113 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>pinot</artifactId>
+    <groupId>org.apache.pinot</groupId>
+    <version>0.13.0-SNAPSHOT</version>
+    <relativePath>../..</relativePath>
+  </parent>
+
+  <artifactId>pinot-spotbugs-plugin</artifactId>
+
+  <properties>
+    <pinot.root>${basedir}/../..</pinot.root>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+  </properties>
+
+  <description>Apache Pinot SpotBugs plugin project</description>
+  <dependencies>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>spotbugs</artifactId>
+      <version>${spotBugsVersion}</version>
+      <scope>provided</scope>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <version>4.13</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.github.spotbugs</groupId>
+      <artifactId>test-harness</artifactId>
+      <version>${spotBugsVersion}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-spi</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>com.google.guava</groupId>
+      <artifactId>guava</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>xml-maven-plugin</artifactId>
+        <version>1.0.2</version>
+        <executions>
+          <execution>
+            <id>validate-spotbugs-configuration</id>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+            <configuration>
+              <validationSets>
+                <validationSet>
+                  <dir>src/main/resources</dir>
+                  <includes>
+                    <include>findbugs.xml</include>
+                  </includes>
+                  <systemId>findbugsplugin.xsd</systemId>
+                </validationSet>
+                <validationSet>
+                  <dir>src/main/resources</dir>
+                  <includes>
+                    <include>messages.xml</include>
+                  </includes>
+                  <systemId>messagecollection.xsd</systemId>
+                </validationSet>
+              </validationSets>
+            </configuration>
+          </execution>
+        </executions>
+        <dependencies>
+          <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>${spotBugsVersion}</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/contrib/pinot-spotbugs-plugin/src/main/java/org/apache/pinot/spotbugs/plugin/ShadedTypesUsedOnSpiDetector.java
+++ b/contrib/pinot-spotbugs-plugin/src/main/java/org/apache/pinot/spotbugs/plugin/ShadedTypesUsedOnSpiDetector.java
@@ -1,0 +1,89 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spotbugs.plugin;
+
+import edu.umd.cs.findbugs.BugInstance;
+import edu.umd.cs.findbugs.BugReporter;
+import edu.umd.cs.findbugs.bcel.OpcodeStackDetector;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.bcel.Const;
+import org.apache.bcel.classfile.Utility;
+
+
+public class ShadedTypesUsedOnSpiDetector extends OpcodeStackDetector {
+  private final BugReporter _bugReporter;
+  private final List<String> _shadedPackages;
+  private final List<String> _spiPackages;
+
+
+  public static final String BUG_TYPE = "SHADED_TYPES_IN_SPI";
+
+  public ShadedTypesUsedOnSpiDetector(BugReporter bugReporter) {
+    _bugReporter = bugReporter;
+    _shadedPackages = Arrays.asList("com.fasterxml.jackson", "com.google.common");
+    _spiPackages = Arrays.asList("org.apache.pinot.segment.spi", "org.apache.pinot.spi");
+  }
+
+  @Override
+  public void sawOpcode(int seen) {
+    if (seen != Const.INVOKESTATIC && seen != Const.INVOKEVIRTUAL && seen != Const.INVOKESPECIAL) {
+      return;
+    }
+
+    if (!isSpiClass(getDottedClassConstantOperand())) {
+      return;
+    }
+
+    String sigConstantOperand = getSigConstantOperand();
+    String returnClass = Utility.methodSignatureReturnType(sigConstantOperand, false);
+    String[] argClasses = Utility.methodSignatureArgumentTypes(sigConstantOperand, false);
+    if (isShadedType(returnClass)) {
+      _bugReporter.reportBug(
+          new BugInstance(this, BUG_TYPE, NORMAL_PRIORITY)
+              .addClassAndMethod(this)
+              .addSourceLine(this, getPC())
+      );
+    }
+    for (String argClass : argClasses) {
+      if (isShadedType(argClass)) {
+        _bugReporter.reportBug(
+            new BugInstance(this, BUG_TYPE, NORMAL_PRIORITY)
+                .addClassAndMethod(this)
+                .addSourceLine(this, getPC()));
+      }
+    }
+
+    if (getClassConstantOperand().equals("java/lang/System") && getNameConstantOperand().equals("out")) {
+      // report bug when System.out is used in code
+      BugInstance bug = new BugInstance(this, "MY_BUG", NORMAL_PRIORITY)
+          .addClassAndMethod(this)
+          .addSourceLine(this, getPC());
+      _bugReporter.reportBug(bug);
+    }
+  }
+
+  private boolean isShadedType(String className) {
+    return _shadedPackages.stream().anyMatch(className::startsWith);
+  }
+
+  private boolean isSpiClass(String className) {
+    return _spiPackages.stream().anyMatch(className::startsWith);
+  }
+}

--- a/contrib/pinot-spotbugs-plugin/src/main/resources/findbugs.xml
+++ b/contrib/pinot-spotbugs-plugin/src/main/resources/findbugs.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<FindbugsPlugin xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="findbugsplugin.xsd"
+        pluginid="org.apache.pinot.pinot-spotbugs-plugin">
+
+        <Detector class="org.apache.pinot.spotbugs.plugin.ShadedTypesUsedOnSpiDetector" reports="SHADED_TYPES_IN_SPI" />
+
+        <BugPattern abbrev="PL" type="SHADED_TYPES_IN_SPI" category="PINOT_PLUGINS" />
+</FindbugsPlugin>

--- a/contrib/pinot-spotbugs-plugin/src/main/resources/messages.xml
+++ b/contrib/pinot-spotbugs-plugin/src/main/resources/messages.xml
@@ -1,0 +1,57 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<MessageCollection xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:noNamespaceSchemaLocation="messagecollection.xsd">
+
+  <Plugin>
+    <ShortDescription>Apache Pinot Spotbugs Plugin</ShortDescription>
+    <Details>This plugin provides original detectors defined to contribute to Apache Pinot</Details>
+  </Plugin>
+
+  <Detector class="org.apache.pinot.spotbugs.plugin.ShadedTypesUsedOnSpiDetector">
+    <Details>
+      Detector used to detect usages of shaded libraries when calling SPI code.
+    </Details>
+  </Detector>
+
+  <BugPattern type="SHADED_TYPES_IN_SPI">
+    <ShortDescription>Using shaded APIs when calling SPI methods.</ShortDescription>
+    <LongDescription>
+      At least one call to an SPI method using shaded libraries has been detected.
+      This can produce problems in runtime when the shaded classes are repackaged.
+      For example, you may be trying to call a method that receives an argument whose static type is a Jackson package.
+      Given that Jackson should be shaded, your plugin will actually try to call that method using its shaded version
+      of Jackson, which would produce a MethodNotFound at runtime.
+    </LongDescription>
+    <Details>
+<![CDATA[
+<p>At least one call to an SPI method using shaded libraries has been detected.
+This can produce problems in runtime when the shaded classes are repackaged.
+For example, you may be trying to call a method that receives an argument whose static type is a Jackson package.
+Given that Jackson should be shaded, your plugin will actually try to call that method using its shaded version
+of Jackson, which would produce a MethodNotFound at runtime.</p>
+]]>
+    </Details>
+  </BugPattern>
+
+  <BugCode abbrev="PL">Shaded types in SPI</BugCode>
+</MessageCollection>

--- a/contrib/pinot-spotbugs-plugin/src/test/java/org/apache/pinot/spotbugs/plugin/BadSpecialCase.java
+++ b/contrib/pinot-spotbugs-plugin/src/test/java/org/apache/pinot/spotbugs/plugin/BadSpecialCase.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spotbugs.plugin;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.IOException;
+import java.util.Collections;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TimestampConfig;
+
+/**
+ * This is an invalid case where a constructor that requires a jackson argument is called
+ */
+class BadSpecialCase {
+  void method()
+      throws IOException {
+    new FieldConfig("asd", FieldConfig.EncodingType.RAW, (FieldConfig.IndexType) null, Collections.emptyList(),
+        FieldConfig.CompressionCodec.LZ4, (TimestampConfig) null, (JsonNode) null, Collections.emptyMap(),
+        (JsonNode) null);
+  }
+}

--- a/contrib/pinot-spotbugs-plugin/src/test/java/org/apache/pinot/spotbugs/plugin/BadStaticArgCase.java
+++ b/contrib/pinot-spotbugs-plugin/src/test/java/org/apache/pinot/spotbugs/plugin/BadStaticArgCase.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spotbugs.plugin;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import java.io.IOException;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+
+/**
+ * This is an invalid case where a static method that requires a jackson argument is called
+ */
+class BadStaticArgCase {
+  void method()
+      throws IOException {
+    JsonUtils.stringToObject((String) null, (TypeReference<Object>) null);
+  }
+}

--- a/contrib/pinot-spotbugs-plugin/src/test/java/org/apache/pinot/spotbugs/plugin/BadStaticResultCase.java
+++ b/contrib/pinot-spotbugs-plugin/src/test/java/org/apache/pinot/spotbugs/plugin/BadStaticResultCase.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spotbugs.plugin;
+
+import java.io.IOException;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+
+/**
+ * This is an invalid case where a static method that returns a jackson object is called
+ */
+class BadStaticResultCase {
+  void method()
+      throws IOException {
+    JsonUtils.newArrayNode();
+  }
+}

--- a/contrib/pinot-spotbugs-plugin/src/test/java/org/apache/pinot/spotbugs/plugin/BadVirtualArgCase.java
+++ b/contrib/pinot-spotbugs-plugin/src/test/java/org/apache/pinot/spotbugs/plugin/BadVirtualArgCase.java
@@ -1,0 +1,33 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spotbugs.plugin;
+
+import java.io.IOException;
+import org.apache.pinot.spi.config.table.FieldConfig;
+
+
+/**
+ * This is an invalid case where a virtual method that requires a jackson argument is called
+ */
+class BadVirtualArgCase {
+  void method()
+      throws IOException {
+    new FieldConfig.Builder("someName").withTierOverwrites(null);
+  }
+}

--- a/contrib/pinot-spotbugs-plugin/src/test/java/org/apache/pinot/spotbugs/plugin/BadVirtualResultCase.java
+++ b/contrib/pinot-spotbugs-plugin/src/test/java/org/apache/pinot/spotbugs/plugin/BadVirtualResultCase.java
@@ -1,0 +1,35 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spotbugs.plugin;
+
+import java.io.IOException;
+import org.apache.pinot.spi.config.table.FieldConfig;
+
+
+/**
+ * This is an invalid case where a virtual method that returns a jackson object is called
+ */
+class BadVirtualResultCase {
+  FieldConfig _config = null;
+
+  void method()
+      throws IOException {
+    _config.getTierOverwrites();
+  }
+}

--- a/contrib/pinot-spotbugs-plugin/src/test/java/org/apache/pinot/spotbugs/plugin/GoodCase.java
+++ b/contrib/pinot-spotbugs-plugin/src/test/java/org/apache/pinot/spotbugs/plugin/GoodCase.java
@@ -1,0 +1,30 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spotbugs.plugin;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import org.apache.pinot.spi.utils.JsonUtils;
+
+
+class GoodCase {
+  void method()
+      throws JsonProcessingException {
+    JsonUtils.stringToObject((String) null, (Class<?>) null);
+  }
+}

--- a/contrib/pinot-spotbugs-plugin/src/test/java/org/apache/pinot/spotbugs/plugin/ShadedTypesUsedOnSpiDetectorTest.java
+++ b/contrib/pinot-spotbugs-plugin/src/test/java/org/apache/pinot/spotbugs/plugin/ShadedTypesUsedOnSpiDetectorTest.java
@@ -1,0 +1,103 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.spotbugs.plugin;
+
+import edu.umd.cs.findbugs.BugCollection;
+import edu.umd.cs.findbugs.test.SpotBugsRule;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcher;
+import edu.umd.cs.findbugs.test.matcher.BugInstanceMatcherBuilder;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import org.junit.Rule;
+import org.junit.Test;
+
+import static edu.umd.cs.findbugs.test.CountMatcher.containsExactly;
+import static org.junit.Assert.assertThat;
+
+
+public class ShadedTypesUsedOnSpiDetectorTest {
+  @Rule
+  public SpotBugsRule _spotbugs = new SpotBugsRule();
+
+  @Test
+  public void testGoodCase() {
+    Path path =
+        Paths.get("target/test-classes", "org.apache.pinot.spotbugs.plugin".replace('.', '/'), "GoodCase.class");
+    BugCollection bugCollection = _spotbugs.performAnalysis(path);
+
+    BugInstanceMatcher bugTypeMatcher =
+        new BugInstanceMatcherBuilder().bugType(ShadedTypesUsedOnSpiDetector.BUG_TYPE).build();
+    assertThat(bugCollection, containsExactly(0, bugTypeMatcher));
+  }
+
+  @Test
+  public void testBadStaticArgCase() {
+    Path path = Paths.get("target/test-classes", "org.apache.pinot.spotbugs.plugin".replace('.', '/'),
+        "BadStaticArgCase.class");
+    BugCollection bugCollection = _spotbugs.performAnalysis(path);
+
+    BugInstanceMatcher bugTypeMatcher =
+        new BugInstanceMatcherBuilder().bugType(ShadedTypesUsedOnSpiDetector.BUG_TYPE).build();
+    assertThat(bugCollection, containsExactly(1, bugTypeMatcher));
+  }
+
+  @Test
+  public void testBadStaticResultCase() {
+    Path path = Paths.get("target/test-classes", "org.apache.pinot.spotbugs.plugin".replace('.', '/'),
+        "BadStaticResultCase.class");
+    BugCollection bugCollection = _spotbugs.performAnalysis(path);
+
+    BugInstanceMatcher bugTypeMatcher =
+        new BugInstanceMatcherBuilder().bugType(ShadedTypesUsedOnSpiDetector.BUG_TYPE).build();
+    assertThat(bugCollection, containsExactly(1, bugTypeMatcher));
+  }
+
+  @Test
+  public void testBadVirtualResultCase() {
+    Path path = Paths.get("target/test-classes", "org.apache.pinot.spotbugs.plugin".replace('.', '/'),
+        "BadVirtualResultCase.class");
+    BugCollection bugCollection = _spotbugs.performAnalysis(path);
+
+    BugInstanceMatcher bugTypeMatcher =
+        new BugInstanceMatcherBuilder().bugType(ShadedTypesUsedOnSpiDetector.BUG_TYPE).build();
+    assertThat(bugCollection, containsExactly(1, bugTypeMatcher));
+  }
+
+  @Test
+  public void testBadVirtualArgCase() {
+    Path path = Paths.get("target/test-classes", "org.apache.pinot.spotbugs.plugin".replace('.', '/'),
+        "BadVirtualArgCase.class");
+    BugCollection bugCollection = _spotbugs.performAnalysis(path);
+
+    BugInstanceMatcher bugTypeMatcher =
+        new BugInstanceMatcherBuilder().bugType(ShadedTypesUsedOnSpiDetector.BUG_TYPE).build();
+    assertThat(bugCollection, containsExactly(1, bugTypeMatcher));
+  }
+
+  @Test
+  public void testBadSpecialCase() {
+    Path path = Paths.get("target/test-classes", "org.apache.pinot.spotbugs.plugin".replace('.', '/'),
+        "BadSpecialCase.class");
+    BugCollection bugCollection = _spotbugs.performAnalysis(path);
+
+    BugInstanceMatcher bugTypeMatcher =
+        new BugInstanceMatcherBuilder().bugType(ShadedTypesUsedOnSpiDetector.BUG_TYPE).build();
+    assertThat(bugCollection, containsExactly(1, bugTypeMatcher));
+  }
+}

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -52,7 +52,49 @@
     <module>pinot-environment</module>
   </modules>
 
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <version>4.7.3.2</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>check</goal>
+            </goals>
+            <phase>test</phase>
+          </execution>
+        </executions>
+        <configuration>
+          <includeFilterFile>${pinot.root}/pinot-plugins/spotbugs-include.xml</includeFilterFile>
+          <plugins>
+            <plugin>
+              <groupId>org.apache.pinot</groupId>
+              <artifactId>pinot-spotbugs-plugin</artifactId>
+              <version>${project.version}</version>
+            </plugin>
+          </plugins>
+        </configuration>
+        <dependencies>
+          <!-- overwrite dependency on spotbugs if you want to specify the version of spotbugs -->
+          <dependency>
+            <groupId>com.github.spotbugs</groupId>
+            <artifactId>spotbugs</artifactId>
+            <version>4.7.3</version>
+          </dependency>
+        </dependencies>
+      </plugin>
+    </plugins>
+  </build>
+
   <dependencies>
+    <dependency>
+      <groupId>org.apache.pinot</groupId>
+      <artifactId>pinot-spotbugs-plugin</artifactId>
+      <version>${project.version}</version>
+      <scope>provided</scope>
+    </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-spi</artifactId>

--- a/pinot-plugins/spotbugs-include.xml
+++ b/pinot-plugins/spotbugs-include.xml
@@ -1,0 +1,31 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+
+-->
+<FindBugsFilter
+    xmlns="https://github.com/spotbugs/filter/3.0.0"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="https://github.com/spotbugs/filter/3.0.0 https://raw.githubusercontent.com/spotbugs/spotbugs/3.1.0/spotbugs/etc/findbugsfilter.xsd">
+
+  <Match>
+    <Bug category="PINOT_PLUGINS"/>
+  </Match>
+
+</FindBugsFilter>

--- a/pom.xml
+++ b/pom.xml
@@ -57,6 +57,7 @@
     <module>pinot-segment-local</module>
     <module>pinot-compatibility-verifier</module>
     <module>contrib/pinot-fmpp-maven-plugin</module>
+    <module>contrib/pinot-spotbugs-plugin</module>
 
     <module>pinot-query-planner</module>
     <module>pinot-query-runtime</module>
@@ -179,6 +180,8 @@
 
     <!-- Configuration for Packaging -->
     <shade.prefix>org.apache.pinot.shaded</shade.prefix>
+
+    <spotBugsVersion>4.0.0</spotBugsVersion>
   </properties>
 
   <profiles>


### PR DESCRIPTION
This PR includes adds spotbugs execution in the plugin section. The spotbugs configuration ignores all default detectors (we can discuss later if we want to use them in future) but enables a new detector specifically created to detect when we are calling a SPI method using as argument or receiving as result some object defined in a shaded library.

Right now the spotbugs plugin includes two simplifications:
1. _calling a SPI_ means calling constructors, static or virtual methods defined in a class whose package starts with  `org.apache.pinot.segment.spi` or `org.apache.pinot.spi`.
2. _object defined in a shared library_ means an object whose package starts with `com.fasterxml.jackson` or `com.google.common`

This means that this system has false negatives (there are more shaded libraries and there may be more SPI classes) but should not have false positives.