### PR TITLE
Make PinotTableRestletResourceTest java8 compatible

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTableRestletResourceTest.java
@@ -58,8 +58,7 @@ public class PinotTableRestletResourceTest extends ControllerTest {
   private static final String OFFLINE_TABLE_NAME = "testOfflineTable";
   private static final String REALTIME_TABLE_NAME = "testRealtimeTable";
   private final TableConfigBuilder _offlineBuilder = new TableConfigBuilder(TableType.OFFLINE);
-  private final TableConfigBuilder _realtimeBuilder = new TableConfigBuilder(TableType.REALTIME)
-      .setStreamConfigs(Map.of("stream.type", "foo", "consumer.type", "lowlevel"));
+  private final TableConfigBuilder _realtimeBuilder = new TableConfigBuilder(TableType.REALTIME);
   private String _createTableUrl;
 
   @BeforeClass


### PR DESCRIPTION
This commit fixes java8 build compatibility that is broken in #11017

Specifically, `Map.of` is only available in java 9+.

In this case, this code:

```java
TableConfigBuilder(TableType.REALTIME)
      .setStreamConfigs(Map.of("stream.type", "foo", "consumer.type", "lowlevel"));
```

Is actually not used since we are later calling the following in setup:

```java
StreamConfig streamConfig = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs();
_realtimeBuilder...setStreamConfigs(streamConfig.getStreamConfigsMap());
```
