### PR TITLE
Fix Java8 compat in Vector Transform tests

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/VectorTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/VectorTransformFunctionTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.testng.annotations.DataProvider;
@@ -60,7 +61,7 @@ public class VectorTransformFunctionTest extends BaseTransformFunctionTest {
   @DataProvider(name = "testVectorTransformFunctionDataProvider")
   public Object[][] testVectorTransformFunctionDataProvider() {
     String zeroVectorLiteral = "ARRAY[0.0"
-        + ",0.0".repeat(VECTOR_DIM_SIZE - 1)
+        + StringUtils.repeat(",0.0", VECTOR_DIM_SIZE - 1)
         + "]";
     return new Object[][]{
         new Object[]{"cosineDistance(vector1, vector2)", 0.1, 0.4},

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/VectorIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/VectorIntegrationTest.java
@@ -32,6 +32,7 @@ import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -131,10 +132,10 @@ public class VectorIntegrationTest extends BaseClusterIntegrationTest {
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
     String zeroVectorStringLiteral = "ARRAY[0.0"
-        + ", 0.0".repeat(VECTOR_DIM_SIZE - 1)
+        + StringUtils.repeat(", 0.0", VECTOR_DIM_SIZE - 1)
         + "]";
     String oneVectorStringLiteral = "ARRAY[1.0"
-        + ", 1.0".repeat(VECTOR_DIM_SIZE - 1)
+        + StringUtils.repeat(", 1.0", VECTOR_DIM_SIZE - 1)
         + "]";
     String query =
         String.format("SELECT "


### PR DESCRIPTION
This commit replaces the usage of `"".repeat(...)` added in #11268 with java8 compatible invocations