### PR TITLE
Add projection operator utils to unify ProjectionOperator creation and allow plugability

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/ProjectionOperatorUtils.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator;
+
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.pinot.core.operator.blocks.DocIdSetBlock;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+
+
+public class ProjectionOperatorUtils {
+  private static Implementation _instance = new DefaultImplementation();
+
+  private ProjectionOperatorUtils() {
+  }
+
+  public static void setImplementation(Implementation newImplementation) {
+    _instance = newImplementation;
+  }
+
+  public static ProjectionOperator getProjectionOperator(Map<String, DataSource> dataSourceMap,
+      @Nullable BaseOperator<DocIdSetBlock> docIdSetOperator) {
+    return _instance.getProjectionOperator(dataSourceMap, docIdSetOperator);
+  }
+
+  public interface Implementation {
+    /**
+     * Returns the projection operator
+     */
+    ProjectionOperator getProjectionOperator(Map<String, DataSource> dataSourceMap,
+        @Nullable BaseOperator<DocIdSetBlock> docIdSetOperator);
+  }
+
+  public static class DefaultImplementation implements Implementation {
+    @Override
+    public ProjectionOperator getProjectionOperator(Map<String, DataSource> dataSourceMap,
+        @Nullable BaseOperator<DocIdSetBlock> docIdSetOperator) {
+      return new ProjectionOperator(dataSourceMap, docIdSetOperator);
+    }
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -40,6 +40,7 @@ import org.apache.pinot.core.operator.BitmapDocIdSetOperator;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.ProjectionOperator;
+import org.apache.pinot.core.operator.ProjectionOperatorUtils;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.operator.transform.TransformOperator;
@@ -263,7 +264,7 @@ public class SelectionOrderByOperator extends BaseOperator<SelectionResultsBlock
       dataSourceMap.put(column, _indexSegment.getDataSource(column));
     }
     ProjectionOperator projectionOperator =
-        new ProjectionOperator(dataSourceMap, new BitmapDocIdSetOperator(docIds, numRows));
+        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, new BitmapDocIdSetOperator(docIds, numRows));
     TransformOperator transformOperator =
         new TransformOperator(_queryContext, projectionOperator, nonOrderByExpressions);
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.operator.BaseProjectOperator;
 import org.apache.pinot.core.operator.DocIdSetOperator;
 import org.apache.pinot.core.operator.ProjectionOperator;
+import org.apache.pinot.core.operator.ProjectionOperatorUtils;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
@@ -76,7 +77,8 @@ public class ProjectPlanNode implements PlanNode {
     DocIdSetOperator docIdSetOperator =
         _maxDocsPerCall > 0 ? new DocIdSetPlanNode(_indexSegment, _queryContext, _maxDocsPerCall, _filterOperator).run()
             : null;
-    ProjectionOperator projectionOperator = new ProjectionOperator(dataSourceMap, docIdSetOperator);
+    ProjectionOperator projectionOperator =
+        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator);
     return hasNonIdentifierExpression ? new TransformOperator(_queryContext, projectionOperator, _expressions)
         : projectionOperator;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeProjectPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/plan/StarTreeProjectPlanNode.java
@@ -30,6 +30,7 @@ import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.operator.BaseProjectOperator;
 import org.apache.pinot.core.operator.DocIdSetOperator;
 import org.apache.pinot.core.operator.ProjectionOperator;
+import org.apache.pinot.core.operator.ProjectionOperatorUtils;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.core.query.request.context.QueryContext;
@@ -80,7 +81,8 @@ public class StarTreeProjectPlanNode implements PlanNode {
         new StarTreeDocIdSetPlanNode(_queryContext, _starTreeV2, _predicateEvaluatorsMap, groupByColumns).run();
     Map<String, DataSource> dataSourceMap = new HashMap<>(HashUtil.getHashMapCapacity(projectionColumns.size()));
     projectionColumns.forEach(column -> dataSourceMap.put(column, _starTreeV2.getDataSource(column)));
-    ProjectionOperator projectionOperator = new ProjectionOperator(dataSourceMap, docIdSetOperator);
+    ProjectionOperator projectionOperator =
+        ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator);
     // NOTE: Here we do not put aggregation expressions into TransformOperator based on the following assumptions:
     //       - They are all columns (not functions or constants), where no transform is required
     //       - We never call TransformOperator.getResultColumnContext() on them


### PR DESCRIPTION
Refactored projection operator creation inside utils class to unify creation logic and allow pluggability
