### PR TITLE
separate tags with commas as indicated in action doc

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -115,7 +115,7 @@ jobs:
         continue-on-error: true
         timeout-minutes: 5
         with:
-          flags: unittests${{ matrix.testset }}${{matrix.distribution}}${{matrix.java}}
+          flags: unittests${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-unit-tests
           fail_ci_if_error: false
           verbose: true
@@ -167,7 +167,7 @@ jobs:
         continue-on-error: true
         timeout-minutes: 5
         with:
-          flags: integration${{ matrix.testset }}${{matrix.distribution}}${{matrix.java}}
+          flags: integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-integration-tests
           fail_ci_if_error: false
           verbose: true

--- a/pom.xml
+++ b/pom.xml
@@ -1405,7 +1405,6 @@
           <artifactId>maven-surefire-plugin</artifactId>
           <version>3.0.0-M5</version>
           <configuration>
-            <!-- Do not set argLine here, it will break the code coverage plugin. Set it in the properties section. -->
             <forkCount>1</forkCount>
             <reuseForks>false</reuseForks>
             <!-- 60 minutes -->
@@ -1417,7 +1416,7 @@
             <trimStackTrace>false</trimStackTrace>
             <reportFormat>plain</reportFormat>
             <argLine>
-              ${argLine}
+              @{argLine}
               --add-opens=java.base/java.nio=ALL-UNNAMED
               --add-opens=java.base/sun.nio.ch=ALL-UNNAMED
               --add-opens=java.base/java.lang=ALL-UNNAMED


### PR DESCRIPTION
@erichgess found that https://github.com/apache/pinot/pull/10528 broke the codecov coverate.

There were two issues:
- Metadata was wrong. Instead of separating tags, it created huge tags that concatenated all properties. That is being fixed as indicated in https://github.com/codecov/codecov-action (tags should be separated by commas).
- Jacoco wasn't actually added to surefire because `$argLine` expression indicates that `argLine` should be eagerly evaluated before applying previous plugins. By changing that to `@argLine`, it can be evaluated after jacoco plugin modifies the property, as explained [in the official doc](https://maven.apache.org/surefire/maven-surefire-plugin/faq.html#late-property-evaluation).