### PR TITLE
Adding query function override for Aggregate functions of multi valued column

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -958,8 +958,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
    * Retrieve multivalued columns for a table.
    * From the table Schema , we get the multi valued columns of dimension fields.
    *
-   * @param tableCache
-   * @param tableName
+   * @param tableSchema
+   * @param columnName
    * @return multivalued columns of the table .
    */
   private static boolean checkIfColumnIsMultiValued(@Nonnull Schema tableSchema, @Nonnull String columnName) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -89,7 +89,6 @@ import org.apache.pinot.spi.config.table.QueryConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.exception.BadQueryRequestException;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1131,14 +1131,14 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       return;
     }
 
-    String _operator = DISTINCT_MV_COL_FUNCTION_OVERRIDE_MAP.get(function.getOperator());
-    if (_operator != null) {
+    String overrideOperator = DISTINCT_MV_COL_FUNCTION_OVERRIDE_MAP.get(function.getOperator());
+    if (overrideOperator != null) {
       List<Expression> operands = function.getOperands();
       if (operands.size() >= 1 && operands.get(0).isSetIdentifier() && isMultiValueColumn(tableSchema,
           operands.get(0).getIdentifier().getName())) {
         // we are only checking the first operand that if its a MV column as all the overriding agg. fn.'s have
         // first operator is column name
-        function.setOperator(_operator);
+        function.setOperator(overrideOperator);
       }
     } else {
       for (Expression operand : function.getOperands()) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryOverrideTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryOverrideTest.java
@@ -69,7 +69,7 @@ public class QueryOverrideTest {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
     BaseBrokerRequestHandler.handleDistinctMultiValuedOverride(pinotQuery, ImmutableSet.of("col2", "col3"));
     assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcount");
-    BaseBrokerRequestHandler.handleSegmentPartitionedDistinctCountOverride(pinotQuery,
+    BaseBrokerRequestHandler.handleDistinctMultiValuedOverride(pinotQuery,
         ImmutableSet.of("col1", "col2", "col3"));
     assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcountmv");
   }

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryOverrideTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryOverrideTest.java
@@ -19,9 +19,11 @@
 package org.apache.pinot.broker.requesthandler;
 
 import com.google.common.collect.ImmutableSet;
+import java.io.IOException;
 import java.util.Arrays;
 import org.apache.pinot.common.request.PinotQuery;
 import org.apache.pinot.common.utils.request.RequestUtils;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.testng.annotations.Test;
 
@@ -64,14 +66,21 @@ public class QueryOverrideTest {
   }
 
   @Test
-  public void testDistinctMultiValuedOverride() {
-    String query = "SELECT DISTINCT_COUNT(col1) FROM myTable";
-    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
-    BaseBrokerRequestHandler.handleDistinctMultiValuedOverride(pinotQuery, ImmutableSet.of("col2", "col3"));
-    assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcount");
-    BaseBrokerRequestHandler.handleDistinctMultiValuedOverride(pinotQuery,
-        ImmutableSet.of("col1", "col2", "col3"));
-    assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcountmv");
+  public void testDistinctMultiValuedOverride()
+      throws IOException {
+    String query1 = "SELECT DISTINCT_COUNT(col1) FROM myTable";
+    PinotQuery pinotQuery1 = CalciteSqlParser.compileToPinotQuery(query1);
+    String query2 = "SELECT DISTINCT_COUNT(col2) FROM myTable";
+    PinotQuery pinotQuery2 = CalciteSqlParser.compileToPinotQuery(query2);
+    Schema tableSchema = Schema.fromString("{\"schemaName\":\"testSchema\","
+        + "\"dimensionFieldSpecs\":[ {\"name\":\"col2\",\"dataType\":\"LONG\",\"singleValueField\":\"false\"},"
+        + "{\"name\":\"col3\",\"dataType\":\"LONG\",\"singleValueField\":\"false\"}],"
+        + "\"dateTimeFieldSpecs\":[{\"name\":\"dt1\",\"dataType\":\"INT\",\"format\":\"x:HOURS:EPOCH\","
+        + "\"granularity\":\"1:HOURS\"}]}");
+    BaseBrokerRequestHandler.handleDistinctMultiValuedOverride(pinotQuery1, tableSchema);
+    assertEquals(pinotQuery1.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcount");
+    BaseBrokerRequestHandler.handleDistinctMultiValuedOverride(pinotQuery2, tableSchema);
+    assertEquals(pinotQuery2.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcountmv");
   }
 
   @Test

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryOverrideTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/QueryOverrideTest.java
@@ -64,6 +64,17 @@ public class QueryOverrideTest {
   }
 
   @Test
+  public void testDistinctMultiValuedOverride() {
+    String query = "SELECT DISTINCT_COUNT(col1) FROM myTable";
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
+    BaseBrokerRequestHandler.handleDistinctMultiValuedOverride(pinotQuery, ImmutableSet.of("col2", "col3"));
+    assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcount");
+    BaseBrokerRequestHandler.handleSegmentPartitionedDistinctCountOverride(pinotQuery,
+        ImmutableSet.of("col1", "col2", "col3"));
+    assertEquals(pinotQuery.getSelectList().get(0).getFunctionCall().getOperator(), "distinctcountmv");
+  }
+
+  @Test
   public void testApproximateFunctionOverride() {
     {
       String query = "SELECT DISTINCT_COUNT(col1) FROM myTable GROUP BY col2 HAVING DISTINCT_COUNT(col1) > 10 "


### PR DESCRIPTION
Adding query function override for distinct functions of multi valued column .

`DISTINCTCOUNT` & Other distinct aggregate functions have a different behaviour when queried over a multivalued column with Dict enabled & disabled.  This PR fixes that by overriding the function names to use multivalued Aggragation functions.

**Fixes :** https://github.com/apache/pinot/issues/11292 

