### PR TITLE
Enhance Minion task management

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTaskRestletResource.java
@@ -410,7 +410,7 @@ public class PinotTaskRestletResource {
   @ApiOperation("Get the task state for the given task (deprecated)")
   public StringResultResponse getTaskStateDeprecated(
       @ApiParam(value = "Task name", required = true) @PathParam("taskName") String taskName) {
-    return new StringResultResponse(_pinotHelixTaskResourceManager.getTaskState(taskName).toString());
+    return new StringResultResponse(String.valueOf(_pinotHelixTaskResourceManager.getTaskState(taskName)));
   }
 
   @GET

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SimpleMinionClusterIntegrationTest.java
@@ -130,7 +130,6 @@ public class SimpleMinionClusterIntegrationTest extends ClusterTest {
     HOLD.set(true);
     // No tasks before we start.
     assertEquals(_helixTaskResourceManager.getTasksInProgress(TASK_TYPE).size(), 0);
-    verifyTaskCount("Task_" + TASK_TYPE + "_1624403781879", 0, 0, 0, 0);
 
     // Should create the task queues and generate a task
     String task1 = _taskManager.scheduleTasks().get(TASK_TYPE);


### PR DESCRIPTION
Fix #11282 

- Remove the unnecessary wait after scheduling a task
- Enhance other task status APIs to first read workflow/job config to determine whether the task exists because when task is just created, the context might not be created yet

No new test is added because we already have good coverage on these APIs.