### PR TITLE
Remove the redundant OrderByExpressionContext::isDesc.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/OrderByExpressionContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/OrderByExpressionContext.java
@@ -51,10 +51,6 @@ public class OrderByExpressionContext {
     return _isAsc;
   }
 
-  public boolean isDesc() {
-    return !_isAsc;
-  }
-
   public boolean isNullsLast() {
     // By default, null values sort as if larger than any non-null value; that is, NULLS FIRST is the default for DESC
     // order, and NULLS LAST otherwise.

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionPartiallyOrderedByDescOperation.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionPartiallyOrderedByDescOperation.java
@@ -47,9 +47,9 @@ public class SelectionPartiallyOrderedByDescOperation extends LinearSelectionOrd
       List<ExpressionContext> expressions, BaseProjectOperator<?> projectOperator, int numSortedExpressions) {
     super(indexSegment, queryContext, expressions, projectOperator, numSortedExpressions);
     assert queryContext.getOrderByExpressions() != null;
-    Preconditions.checkArgument(queryContext.getOrderByExpressions().stream()
+    Preconditions.checkArgument(!queryContext.getOrderByExpressions().stream()
             .filter(expr -> expr.getExpression().getType() == ExpressionContext.Type.IDENTIFIER).findFirst()
-            .orElseThrow(() -> new IllegalArgumentException("The query is not order by identifiers")).isDesc(),
+            .orElseThrow(() -> new IllegalArgumentException("The query is not order by identifiers")).isAsc(),
         "%s can only be used when the first column in order by is DESC", EXPLAIN_NAME);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
@@ -676,7 +676,7 @@ public class BrokerRequestToQueryContextConverterTest {
     List<OrderByExpressionContext> orderByExpressionContexts = queryContext.getOrderByExpressions();
     assertEquals(orderByExpressionContexts.size(), 1);
     OrderByExpressionContext orderByExpressionContext = orderByExpressionContexts.get(0);
-    assertTrue(orderByExpressionContext.isDesc());
+    assertFalse(orderByExpressionContext.isAsc());
     assertTrue(orderByExpressionContext.isNullsLast());
     assertEquals(orderByExpressionContext.getExpression().getFunction().getFunctionName(), "datetrunc");
     assertEquals(orderByExpressionContext.getExpression().getFunction().getArguments().get(0).getIdentifier(), "A");
@@ -762,7 +762,7 @@ public class BrokerRequestToQueryContextConverterTest {
     List<OrderByExpressionContext> orderByExpressionContexts = queryContext.getOrderByExpressions();
     assertEquals(orderByExpressionContexts.size(), 1);
     OrderByExpressionContext orderByExpressionContext = orderByExpressionContexts.get(0);
-    assertTrue(orderByExpressionContext.isDesc());
+    assertFalse(orderByExpressionContext.isAsc());
     assertFalse(orderByExpressionContext.isNullsLast());
   }
 
@@ -776,7 +776,7 @@ public class BrokerRequestToQueryContextConverterTest {
     List<OrderByExpressionContext> orderByExpressionContexts = queryContext.getOrderByExpressions();
     assertEquals(orderByExpressionContexts.size(), 1);
     OrderByExpressionContext orderByExpressionContext = orderByExpressionContexts.get(0);
-    assertTrue(orderByExpressionContext.isDesc());
+    assertFalse(orderByExpressionContext.isAsc());
     assertTrue(orderByExpressionContext.isNullsLast());
   }
 
@@ -790,7 +790,7 @@ public class BrokerRequestToQueryContextConverterTest {
     List<OrderByExpressionContext> orderByExpressionContexts = queryContext.getOrderByExpressions();
     assertEquals(orderByExpressionContexts.size(), 1);
     OrderByExpressionContext orderByExpressionContext = orderByExpressionContexts.get(0);
-    assertFalse(orderByExpressionContext.isDesc());
+    assertTrue(orderByExpressionContext.isAsc());
     assertTrue(orderByExpressionContext.isNullsLast());
   }
 }


### PR DESCRIPTION
This method is only used in precondition checks and tests.