### PR TITLE
Fix a bug in NULL ordering using ordinal.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -32,6 +32,7 @@ import java.util.Map;
 import java.util.Set;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 import org.apache.calcite.avatica.util.Casing;
 import org.apache.calcite.sql.SqlBasicCall;
 import org.apache.calcite.sql.SqlDataTypeSpec;
@@ -973,5 +974,24 @@ public class CalciteSqlParser {
       expression = expression.getFunctionCall().getOperands().get(0);
     }
     return expression;
+  }
+
+  @Nullable
+  public static Boolean isNullsLast(Expression expression) {
+    String operator = expression.getFunctionCall().getOperator();
+    if (operator.equals(CalciteSqlParser.NULLS_LAST)) {
+      return true;
+    } else if (operator.equals(CalciteSqlParser.NULLS_FIRST)) {
+      return false;
+    } else {
+      return null;
+    }
+  }
+
+  public static boolean isAsc(Expression expression, Boolean isNullsLast) {
+    if (isNullsLast != null) {
+      expression = expression.getFunctionCall().getOperands().get(0);
+    }
+    return expression.getFunctionCall().getOperator().equals(CalciteSqlParser.ASC);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/utils/QueryContextConverterUtils.java
@@ -24,7 +24,6 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.common.request.DataSource;
 import org.apache.pinot.common.request.Expression;
@@ -116,8 +115,8 @@ public class QueryContextConverterUtils {
       orderByExpressions = new ArrayList<>(orderByList.size());
       Set<Expression> seen = new HashSet<>();
       for (Expression orderBy : orderByList) {
-        Boolean isNullsLast = isNullsLast(orderBy);
-        boolean isAsc = isAsc(orderBy, isNullsLast);
+        Boolean isNullsLast = CalciteSqlParser.isNullsLast(orderBy);
+        boolean isAsc = CalciteSqlParser.isAsc(orderBy, isNullsLast);
         Expression orderByFunctionsRemoved = CalciteSqlParser.removeOrderByFunctions(orderBy);
         // Deduplicate the order-by expressions
         if (seen.add(orderByFunctionsRemoved)) {
@@ -154,24 +153,5 @@ public class QueryContextConverterUtils {
         .setHavingFilter(havingFilter).setLimit(pinotQuery.getLimit()).setOffset(pinotQuery.getOffset())
         .setQueryOptions(pinotQuery.getQueryOptions()).setExpressionOverrideHints(expressionContextOverrideHints)
         .setExplain(pinotQuery.isExplain()).build();
-  }
-
-  @Nullable
-  private static Boolean isNullsLast(Expression expression) {
-    String operator = expression.getFunctionCall().getOperator();
-    if (operator.equals(CalciteSqlParser.NULLS_LAST)) {
-      return true;
-    } else if (operator.equals(CalciteSqlParser.NULLS_FIRST)) {
-      return false;
-    } else {
-      return null;
-    }
-  }
-
-  private static boolean isAsc(Expression expression, Boolean isNullsLast) {
-    if (isNullsLast != null) {
-      expression = expression.getFunctionCall().getOperands().get(0);
-    }
-    return expression.getFunctionCall().getOperator().equals(CalciteSqlParser.ASC);
   }
 }


### PR DESCRIPTION
After https://github.com/apache/pinot/pull/10805, there can be either one (ASC/DESC) or two (NULLS FIRST/NULLS LAST + ASC/DESC) levels of functions wrapping the ORDER BY expression. The `OrdinalsUpdater` still assumed only one level of function.
