### PR TITLE
[multistage] Fixing pinot client resolve table name

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/Connection.java
@@ -24,8 +24,6 @@ import java.util.Properties;
 import java.util.concurrent.CompletableFuture;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.request.RequestUtils;
-import org.apache.pinot.sql.parsers.CalciteSqlParser;
-import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -191,9 +189,7 @@ public class Connection {
   @Nullable
   private static String[] resolveTableName(String query) {
     try {
-      SqlNodeAndOptions sqlNodeAndOptions = CalciteSqlParser.compileToSqlNodeAndOptions(query);
-      return RequestUtils.getTableNames(CalciteSqlParser.compileSqlNodeToPinotQuery(sqlNodeAndOptions.getSqlNode()))
-          .toArray(new String[0]);
+      return RequestUtils.getTableNames(query).toArray(new String[0]);
     } catch (Exception e) {
       LOGGER.error("Cannot parse table name from query: {}. Fallback to broker selector default.", query, e);
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -304,6 +304,55 @@ public class RequestUtils {
     return Splitter.on(';').omitEmptyStrings().trimResults().withKeyValueSeparator('=').split(optionStr);
   }
 
+  /**
+   * Returns all the table names from a given {@link SqlNode}.
+   * <pre>
+   * 1. FROM Clause (FromNode): The main location where the table name is specified.
+   * </pre>
+   * {@code
+   *     SELECT * FROM table_name;
+   * }
+   * <pre>
+   * 2. JOIN Clauses (JoinNode): Table names will be part of INNER JOIN, LEFT JOIN, RIGHT JOIN, FULL JOIN, etc.
+   * </pre>
+   * {@code
+   *     SELECT * FROM table_name1 JOIN table_name2 ON table_name1.column_name = table_name2.column_name;
+   * }
+   * <pre>
+   * 3. SubQueries in FROM Clause (SubQueryNode): Subqueries in the FROM clause might contain additional table names.
+   * </pre>
+   * {@code
+   *     SELECT * FROM (SELECT * FROM table_name) WHERE column_name = value;
+   * }
+   * <pre>
+   * 4. WITH Clause (WithNode): Common Table Expressions (CTEs) may contain table names.
+   * </pre>
+   * {@code
+   *     WITH table_name1 AS (SELECT * FROM table_name2) SELECT * FROM table_name1;
+   * }
+   * <pre>
+   * 5. LATERAL or APPLY Operators (LateralNode, ApplyNode): These operators allow you to reference columns of
+   *    preceding tables in FROM clause sub-queries.
+   * </pre>
+   * {@code
+   *     SELECT * FROM table_name1, LATERAL (SELECT * FROM table_name2) AS table_name2;
+   * }
+   * <pre>
+   * 6. UNION, INTERSECT, EXCEPT Clauses (SetOperationNode): These set operations between multiple SELECT statements
+   *    can also contain table names.
+   * </pre>
+   * {@code
+   *     SELECT * FROM table_name1 UNION SELECT * FROM table_name2;
+   * }
+   * <pre>
+   * 7. WHERE Clause (WhereNode): WHERE clause can contain table names in subqueries.
+   * </pre>
+   * {@code
+   *     SELECT * FROM table_name WHERE column_name IN (SELECT * FROM table_name2);
+   * }
+   * @param sqlNode Sql Query Node
+   * @return Set of table names
+   */
   public static Set<String> getTableNames(SqlNode sqlNode) {
     Set<String> tableNames = new HashSet<>();
     if (sqlNode instanceof SqlSelect) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -49,7 +49,6 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.Context;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.Response;
-import org.apache.calcite.jdbc.CalciteSchemaBuilder;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.commons.io.IOUtils;
 import org.apache.commons.lang3.tuple.Pair;
@@ -66,10 +65,6 @@ import org.apache.pinot.controller.api.access.AccessType;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.auth.ManualAuthorization;
 import org.apache.pinot.core.query.executor.sql.SqlQueryExecutor;
-import org.apache.pinot.query.QueryEnvironment;
-import org.apache.pinot.query.catalog.PinotCatalog;
-import org.apache.pinot.query.type.TypeFactory;
-import org.apache.pinot.query.type.TypeSystem;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
@@ -201,9 +196,7 @@ public class PinotQueryResource {
       throw new WebApplicationException("Permission denied", Response.Status.FORBIDDEN);
     }
 
-    QueryEnvironment queryEnvironment = new QueryEnvironment(new TypeFactory(new TypeSystem()),
-        CalciteSchemaBuilder.asRootSchema(new PinotCatalog(_pinotHelixResourceManager.getTableCache())), null, null);
-    List<String> tableNames = queryEnvironment.getTableNamesForQuery(query);
+    Set<String> tableNames = RequestUtils.getTableNames(query);
     List<String> instanceIds;
     if (tableNames.size() != 0) {
       List<TableConfig> tableConfigList = getListTableConfigs(tableNames);
@@ -255,7 +248,7 @@ public class PinotQueryResource {
   }
 
   // given a list of tables, returns the list of tableConfigs
-  private List<TableConfig> getListTableConfigs(List<String> tableNames) {
+  private List<TableConfig> getListTableConfigs(Set<String> tableNames) {
     List<TableConfig> allTableConfigList = new ArrayList<>();
     for (String tableName : tableNames) {
       List<TableConfig> tableConfigList = new ArrayList<>();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -233,9 +233,8 @@ public class PinotQueryResource {
     // Get resource table name.
     String tableName;
     try {
-      String inputTableName =
-          sqlNode != null ? RequestUtils.getTableNames(CalciteSqlParser.compileSqlNodeToPinotQuery(sqlNode)).iterator()
-              .next() : CalciteSqlCompiler.compileToBrokerRequest(query).getQuerySource().getTableName();
+      String inputTableName = sqlNode != null ? RequestUtils.getTableNames(sqlNode).iterator().next()
+          : CalciteSqlCompiler.compileToBrokerRequest(query).getQuerySource().getTableName();
       tableName = _pinotHelixResourceManager.getActualTableName(inputTableName);
     } catch (Exception e) {
       LOGGER.error("Caught exception while compiling query: {}", query, e);

--- a/pinot-core/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.utils.request;
 
+import com.google.common.collect.ImmutableSet;
 import org.apache.calcite.sql.SqlLiteral;
 import org.apache.calcite.sql.parser.SqlParserPos;
 import org.apache.pinot.common.request.Expression;
@@ -33,5 +34,121 @@ public class RequestUtilsTest {
     Expression nullExpr = RequestUtils.getLiteralExpression(nullLiteral);
     Assert.assertEquals(nullExpr.getType(), ExpressionType.LITERAL);
     Assert.assertEquals(nullExpr.getLiteral().getNullValue(), true);
+  }
+
+  @Test
+  public void testExtractTableName() {
+    String query = "select * from myTable";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable"));
+
+    query = "select * from myTable where foo = 'bar'";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable"));
+
+    query = "select * from default.myTable where foo = 'bar'";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable"));
+
+    query = "explain plan for select * from default.myTable where foo = 'bar'";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable"));
+
+    query = "select * from myTable JOIN myTable2 ON myTable.foo = myTable2.bar";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable", "myTable2"));
+
+    query = "select * from myTable,myTable2,myTable3 WHERE myTable.foo = myTable2.bar AND myTable3.foo = 'bar'";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable", "myTable2", "myTable3"));
+
+    query = "select s_acctbal, s_name, n_name, p_partkey, p_mfgr, s_address, s_phone, s_comment\n"
+        + "from part, supplier, partsupp, nation, region\n"
+        + "where p_partkey = ps_partkey and s_suppkey = ps_suppkey and p_size = 15 and p_type like '%BRASS'\n"
+        + "  and s_nationkey = n_nationkey and n_regionkey = r_regionkey and r_name = 'EUROPE' and ps_supplycost = (\n"
+        + "    select min(ps_supplycost)\n"
+        + "    from partsupp, supplier, nation, region\n"
+        + "    where\n"
+        + "      p_partkey = ps_partkey and s_suppkey = ps_suppkey and s_nationkey = n_nationkey\n"
+        + "      and n_regionkey = r_regionkey and r_name = 'EUROPE')\n"
+        + "    order by s_acctbal desc, n_name, s_name, p_partkey;";
+    Assert.assertEquals(RequestUtils.getTableNames(query),
+        ImmutableSet.of("part", "supplier", "partsupp", "nation", "region"));
+
+    query = "select * from myTable UNION select * from myTable2 INTERSECT select * from myTable3";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable", "myTable2", "myTable3"));
+
+    query =
+        "WITH t1 AS (SELECT * FROM myTable), t2 AS (SELECT * FROM myTable2) SELECT * FROM t1 JOIN t2 ON t1.foo = t2"
+            + ".bar";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable", "myTable2"));
+
+    query =
+        "WITH t1 AS (SELECT * FROM myTable), t2 AS (SELECT * FROM myTable2) SELECT * FROM t1 JOIN t2 ON t1.foo = t2"
+            + ".bar JOIN myTable3 ON t1.foo = myTable3.bar";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable", "myTable2", "myTable3"));
+
+    // A simple filter query with one table
+    query = "Select * from tbl1 where condition1 = filter1";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1"));
+
+    // query with IN / NOT IN clause
+    query = "SELECT COUNT(*) FROM tbl1 WHERE userUUID IN (SELECT userUUID FROM tbl2) "
+        + "and uuid NOT IN (SELECT uuid from tbl3)";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1", "tbl2", "tbl3"));
+
+    // query with two level IN / NOT IN clause
+    query = "SELECT COUNT(*) FROM tbl1 WHERE userUUID IN "
+        + "(SELECT userUUID FROM tbl2 WHERE uuid NOT IN (SELECT uuid from tbl3)) ";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1", "tbl2", "tbl3"));
+
+    // query with JOIN clause
+    query = "SELECT tbl1.col1, tbl2.col2 FROM tbl1 JOIN tbl2 ON tbl1.key = tbl2.key WHERE tbl1.col1 = value1";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1", "tbl2"));
+
+    // query with WHERE clause JOIN
+    query = "SELECT tbl1.col1, tbl2.col2 FROM tbl1, tbl2 WHERE tbl1.key = tbl2.key AND tbl1.col1 = value1";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1", "tbl2"));
+
+    // query with JOIN clause and table alias
+    query = "SELECT A.col1, B.col2 FROM tbl1 AS A JOIN tbl2 AS B ON A.key = B.key WHERE A.col1 = value1";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1", "tbl2"));
+
+    // query with UNION clause
+    query = "SELECT * FROM tbl1 UNION ALL SELECT * FROM tbl2 UNION ALL SELECT * FROM tbl3";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1", "tbl2", "tbl3"));
+
+    // query with UNION clause and table alias
+    query = "SELECT * FROM (SELECT * FROM tbl1) AS t1 UNION SELECT * FROM ( SELECT * FROM tbl2) AS t2";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1", "tbl2"));
+
+    // query with UNION clause and table alias using WITH clause
+    query = "WITH tmp1 AS (SELECT * FROM tbl1), \n"
+        + "tmp2 AS (SELECT * FROM tbl2) \n"
+        + "SELECT * FROM tmp1 UNION ALL SELECT * FROM tmp2";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1", "tbl2"));
+
+    // query with UNION clause and table alias using WITH clause
+    query = "WITH tmp1 AS (SELECT * FROM tbl1), \n"
+        + "tmp2 AS (SELECT * FROM tbl2) \n"
+        + "SELECT * FROM tmp1 UNION ALL SELECT * FROM tmp2 UNION ALL SELECT * FROM tbl3";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1", "tbl2", "tbl3"));
+
+    // query with aliases, JOIN, IN/NOT-IN, group-by
+    query = "with tmp as (select col1, count(*) from tbl1 where condition1 = filter1 group by col1), "
+        + "tmp2 as (select A.col1, B.col2 from tbl2 as A JOIN tbl3 AS B on A.key = B.key) "
+        + "select sum(col1) from tmp where col1 in (select col1 from tmp2) and col1 not in (select col1 from tbl4)";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1", "tbl2", "tbl3", "tbl4"));
+
+    // query with aliases, JOIN, IN/NOT-IN, group-by
+    query = "with tmp as (select col1, count(*) from tbl1 where condition1 = filter1 group by col1 order by col2), "
+        + "tmp2 as (select A.col1, B.col2 from tbl2 as A JOIN tbl3 AS B on A.key = B.key) "
+        + "select sum(col1) from tmp where col1 in (select col1 from tmp2) and col1 not in (select col1 from tbl4) "
+        + "order by A.col1";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1", "tbl2", "tbl3", "tbl4"));
+
+    // query with aliases, JOIN, IN/NOT-IN, group-by and explain
+    query = "explain plan for with tmp as (select col1, count(*) from tbl1 where condition1 = filter1 group by col1), "
+        + "tmp2 as (select A.col1, B.col2 from tbl2 as A JOIN tbl3 AS B on A.key = B.key) "
+        + "select sum(col1) from tmp where col1 in (select col1 from tmp2) and col1 not in (select col1 from tbl4)";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1", "tbl2", "tbl3", "tbl4"));
+
+    // test for self join queries
+    query = "SELECT tbl1.a FROM tbl1 JOIN(SELECT a FROM tbl1) as self ON tbl1.a=self.a ";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1"));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
@@ -53,6 +53,12 @@ public class RequestUtilsTest {
     query = "select * from myTable JOIN myTable2 ON myTable.foo = myTable2.bar";
     Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable", "myTable2"));
 
+    query = "SELECT e.employee_id, e.name, d.department_name "
+        + "FROM employees AS e "
+        + "INNER JOIN departments AS d ON e.department_id = d.department_id "
+        + "WHERE e.salary > 50000 ";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("employees", "departments"));
+
     query = "select * from myTable,myTable2,myTable3 WHERE myTable.foo = myTable2.bar AND myTable3.foo = 'bar'";
     Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable", "myTable2", "myTable3"));
 
@@ -159,5 +165,23 @@ public class RequestUtilsTest {
     query = "SELECT a.col1, newb.sum_col3 FROM a JOIN LATERAL "
         + "(SELECT SUM(col3) as sum_col3 FROM b WHERE col2 = a.col2) AS newb ON TRUE";
     Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("a", "b"));
+
+    // test from with AS clause
+    query = "SELECT * FROM myTable AS T1 WHERE col1 IN (SELECT col2 FROM T2)";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable", "T2"));
+
+    // test from with AS clause
+    query = "SELECT * FROM (select * from myTable As T3) AS T1 WHERE col1 = (SELECT col2 FROM T2 LIMIT 1)";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable", "T2"));
+
+    // test from with AS clause
+    query = "SELECT * FROM (select * from myTable As T4 WHERE col4 = (SELECT col2 FROM T3 LIMIT 1)) AS T1 "
+        + "WHERE col1 IN (SELECT col2 FROM T2)";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable", "T2", "T3"));
+
+    // test from with AS clause
+    query = "SELECT * FROM (select * from myTable As T4 WHERE col4 = (SELECT col2 FROM T4 LIMIT 1)) AS T1 "
+        + "WHERE col1 IN (SELECT col2 FROM T2)";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("myTable", "T2"));
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
@@ -150,5 +150,14 @@ public class RequestUtilsTest {
     // test for self join queries
     query = "SELECT tbl1.a FROM tbl1 JOIN(SELECT a FROM tbl1) as self ON tbl1.a=self.a ";
     Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("tbl1"));
+
+    // test for sub query
+    query = "SELECT * FROM (SELECT column1 FROM table_name) AS alias_name";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("table_name"));
+
+    // test for lateral join
+    query = "SELECT a.col1, newb.sum_col3 FROM a JOIN LATERAL "
+        + "(SELECT SUM(col3) as sum_col3 FROM b WHERE col2 = a.col2) AS newb ON TRUE";
+    Assert.assertEquals(RequestUtils.getTableNames(query), ImmutableSet.of("a", "b"));
   }
 }


### PR DESCRIPTION
https://github.com/apache/pinot/issues/11313 
Extract table name from SqlNode.

Some background:
we got rid of a similar function before in this PR: https://github.com/apache/pinot/pull/10873/files#diff-5bdf53db08d67e2823f300f3db3af05dc704f4ef5319299cc3233f9b55aba059L150

However there is a need for `pinot-java-client`, which depends on `pinot-common` to get all the table names, then decide which Pinot broker to route the query to.

Since `pinot-common` doesn't depend on `pinot-query-planner`, the table name extraction logic there only works for v1 query and some simple v2 queries.

There are 2 possible options to solve this:

1. Let `pinot-java-client` depends `pinot-query-planner`, use v2 `QueryEnvironment` from `pinot-query-planner` to compile `SqlNode` -> `RelNode`, then extract table names. But it requires the full initialization of Calcite `PlannerContext` with `FrameworkConfig`, `Prepare.CatalogReader`, `RelDataTypeFactory`, `HepProgram`. And the compilation time might take 10+ms, which is 10-100x than extracting from SqlNode.

2. Considering the perf, this PR re-implemented a separated `getTableNames` logic in `pinot-common`.

Here are the cases that table names may occur:

1. **FROM Clause (FromNode)**: The main location where the table name is specified.
   ```sql
   SELECT * FROM table_name;
   ```

2. **JOIN Clauses (JoinNode)**: Table names will be part of INNER JOIN, LEFT JOIN, RIGHT JOIN, FULL JOIN, etc.
   ```sql
   SELECT * FROM table_name INNER JOIN another_table ON condition;
   ```

3. **Subqueries in FROM Clause (SubqueryNode)**: Subqueries in the FROM clause might contain additional table names.
   ```sql
   SELECT * FROM (SELECT column1 FROM table_name) AS alias_name;
   ```

4. **WITH Clause (WithNode)**: Common Table Expressions (CTEs) may contain table names.
   ```sql
   WITH cte_name AS (SELECT column1 FROM table_name) SELECT * FROM cte_name;
   ```

5. **LATERAL or APPLY Operators (LateralNode, ApplyNode)**: These operators allow you to reference columns of preceding tables in FROM clause subqueries.
   ```sql
   SELECT * FROM table_name LATERAL (SELECT column1 FROM another_table WHERE condition);
   ```

6. **UNION, INTERSECT, EXCEPT Clauses (SetOperationNode)**: These set operations between multiple SELECT statements can also contain table names.
   ```sql
   SELECT column1 FROM table_name UNION SELECT column1 FROM another_table;
   ```
