### PR TITLE
[UI] Show size of table is with replication

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/TablesListingPage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TablesListingPage.tsx
@@ -46,8 +46,8 @@ const useStyles = makeStyles(() => ({
 
 const TableTooltipData = [
   null,
-  'Uncompressed size of all data segments',
-  'Estimated size of all data segments, in case any servers are not reachable for actual size',
+  'Uncompressed size of all data segments with replication',
+  'Estimated size of all data segments with replication, in case any servers are not reachable for actual size',
   null,
   'GOOD if all replicas of all segments are up',
 ];

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -521,13 +521,13 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
           <Grid item xs={4}>
             <strong>Table Name:</strong> {tableSummary.tableName}
           </Grid>
-          <Tooltip title="Uncompressed size of all data segments"  arrow placement="top-start">
+          <Tooltip title="Uncompressed size of all data segments with replication"  arrow placement="top-start">
           <Grid item xs={2}>
             <strong>Reported Size:</strong> {Utils.formatBytes(tableSummary.reportedSize)}
           </Grid>
           </Tooltip>
           <Grid item xs={2}></Grid>
-          <Tooltip title="Estimated size of all data segments, in case any servers are not reachable for actual size" arrow placement="top-start">
+          <Tooltip title="Estimated size of all data segments with replication, in case any servers are not reachable for actual size" arrow placement="top-start">
             <Grid item xs={2}>
               <strong>Estimated Size: </strong>
               {Utils.formatBytes(tableSummary.estimatedSize)}

--- a/pinot-controller/src/main/resources/app/pages/Tenants.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Tenants.tsx
@@ -41,8 +41,8 @@ type Props = {
 
 const TableTooltipData = [
   null,
-  "Uncompressed size of all data segments",
-  "Estimated size of all data segments, in case any servers are not reachable for actual size",
+  "Uncompressed size of all data segments with replication",
+  "Estimated size of all data segments with replication, in case any servers are not reachable for actual size",
   null,
   "GOOD if all replicas of all segments are up"
 ];


### PR DESCRIPTION
This is 'ui' 'bugfix'

## Screenshot

#### Before 
![image](https://github.com/apache/pinot/assets/41536903/8ae62f76-781a-4be4-8548-c9894b26ffa4)
![image](https://github.com/apache/pinot/assets/41536903/35b14134-15c7-4e88-adf6-dbf74e563262)


#### After
<img width="343" alt="image" src="https://github.com/apache/pinot/assets/41536903/fa4c7566-84cd-4289-89a3-b2aed0b1fe9b">
<img width="395" alt="image" src="https://github.com/apache/pinot/assets/41536903/13e67026-9ea0-4601-be6c-89c9145d0993">
<img width="1728" alt="image" src="https://github.com/apache/pinot/assets/41536903/2743b501-238b-4232-a09e-fdda6c048e4f">
