### PR TITLE
UI: remove V2 Multi-Stage Query Engine warning

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -316,10 +316,6 @@ const QueryPage = () => {
          + `created with an older schema. `
          + `Please reload the table in order to refresh these segments to the new schema.`);
     }
-    if (checked.useMSE) {
-      warnings.push(`Using V2 Multi-Stage Query Engine. This is an experimental feature. Please report any bugs to `
-          + `Apache Pinot Slack channel.`);
-    }
     return warnings;
   }
 


### PR DESCRIPTION
Before 
<img width="1166" alt="image" src="https://github.com/apache/pinot/assets/41536903/ba373814-a83d-4233-98bb-1e22c10102ff">


After
<img width="1164" alt="image" src="https://github.com/apache/pinot/assets/41536903/e5c14c86-381c-48e2-8802-5c581bd7886c">
