### PR TITLE
Add new broker query point for querying multi-stage engine

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -179,8 +179,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
     }
 
     boolean traceEnabled = Boolean.parseBoolean(
-        request.has(CommonConstants.Broker.Request.TRACE) ? request.get(CommonConstants.Broker.Request.TRACE).asText()
-            : "false");
+        sqlNodeAndOptions.getOptions().getOrDefault(CommonConstants.Broker.Request.TRACE, "false"));
 
     ResultTable queryResults;
     Map<Integer, ExecutionStatsAggregator> stageIdStatsMap = new HashMap<>();

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
@@ -24,7 +24,6 @@ import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.JdkSslContext;
-import io.netty.handler.ssl.SslContext;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
@@ -61,6 +60,7 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport<C
   private final int _brokerReadTimeout;
   private final AsyncHttpClient _httpClient;
   private final String _extraOptionStr;
+  private final boolean _useMultiStageEngine;
 
   public JsonAsyncHttpPinotClientTransport() {
     _brokerReadTimeout = 60000;
@@ -68,41 +68,21 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport<C
     _scheme = CommonConstants.HTTP_PROTOCOL;
     _extraOptionStr = DEFAULT_EXTRA_QUERY_OPTION_STRING;
     _httpClient = Dsl.asyncHttpClient(Dsl.config().setRequestTimeout(_brokerReadTimeout));
+    _useMultiStageEngine = false;
   }
 
   public JsonAsyncHttpPinotClientTransport(Map<String, String> headers, String scheme, String extraOptionString,
-      @Nullable SSLContext sslContext, ConnectionTimeouts connectionTimeouts, TlsProtocols tlsProtocols,
-      @Nullable String appId) {
+      boolean useMultiStageEngine, @Nullable SSLContext sslContext, ConnectionTimeouts connectionTimeouts,
+      TlsProtocols tlsProtocols, @Nullable String appId) {
     _brokerReadTimeout = connectionTimeouts.getReadTimeoutMs();
     _headers = headers;
     _scheme = scheme;
     _extraOptionStr = StringUtils.isEmpty(extraOptionString) ? DEFAULT_EXTRA_QUERY_OPTION_STRING : extraOptionString;
+    _useMultiStageEngine = useMultiStageEngine;
 
     Builder builder = Dsl.config();
     if (sslContext != null) {
       builder.setSslContext(new JdkSslContext(sslContext, true, ClientAuth.OPTIONAL));
-    }
-
-    builder.setRequestTimeout(_brokerReadTimeout)
-        .setReadTimeout(connectionTimeouts.getReadTimeoutMs())
-        .setConnectTimeout(connectionTimeouts.getConnectTimeoutMs())
-        .setHandshakeTimeout(connectionTimeouts.getHandshakeTimeoutMs())
-        .setUserAgent(ConnectionUtils.getUserAgentVersionFromClassPath("ua", appId))
-        .setEnabledProtocols(tlsProtocols.getEnabledProtocols().toArray(new String[0]));
-    _httpClient = Dsl.asyncHttpClient(builder.build());
-  }
-
-  public JsonAsyncHttpPinotClientTransport(Map<String, String> headers, String scheme, String extraOptionStr,
-      @Nullable SslContext sslContext, ConnectionTimeouts connectionTimeouts, TlsProtocols tlsProtocols,
-      @Nullable String appId) {
-    _brokerReadTimeout = connectionTimeouts.getReadTimeoutMs();
-    _headers = headers;
-    _scheme = scheme;
-    _extraOptionStr = StringUtils.isEmpty(extraOptionStr) ? DEFAULT_EXTRA_QUERY_OPTION_STRING : extraOptionStr;
-
-    Builder builder = Dsl.config();
-    if (sslContext != null) {
-      builder.setSslContext(sslContext);
     }
 
     builder.setRequestTimeout(_brokerReadTimeout)
@@ -131,7 +111,7 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport<C
       json.put("sql", query);
       json.put("queryOptions", _extraOptionStr);
 
-      String url = _scheme + "://" + brokerAddress + "/query/sql";
+      String url = String.format("%s://%s%s", _scheme, brokerAddress, _useMultiStageEngine ? "/query" : "/query/sql");
       BoundRequestBuilder requestBuilder = _httpClient.preparePost(url);
 
       if (_headers != null) {
@@ -139,21 +119,21 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport<C
       }
       LOGGER.debug("Sending query {} to {}", query, url);
       return requestBuilder.addHeader("Content-Type", "application/json; charset=utf-8").setBody(json.toString())
-              .execute().toCompletableFuture().thenApply(httpResponse -> {
-        LOGGER.debug("Completed query, HTTP status is {}", httpResponse.getStatusCode());
+          .execute().toCompletableFuture().thenApply(httpResponse -> {
+            LOGGER.debug("Completed query, HTTP status is {}", httpResponse.getStatusCode());
 
-        if (httpResponse.getStatusCode() != 200) {
-          throw new PinotClientException(
+            if (httpResponse.getStatusCode() != 200) {
+              throw new PinotClientException(
                   "Pinot returned HTTP status " + httpResponse.getStatusCode() + ", expected 200");
-        }
+            }
 
-        String responseBody = httpResponse.getResponseBody(StandardCharsets.UTF_8);
-        try {
-          return BrokerResponse.fromJson(OBJECT_READER.readTree(responseBody));
-        } catch (JsonProcessingException e) {
-          throw new CompletionException(e);
-        }
-      });
+            String responseBody = httpResponse.getResponseBody(StandardCharsets.UTF_8);
+            try {
+              return BrokerResponse.fromJson(OBJECT_READER.readTree(responseBody));
+            } catch (JsonProcessingException e) {
+              throw new CompletionException(e);
+            }
+          });
     } catch (Exception e) {
       throw new PinotClientException(e);
     }

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportFactory.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportFactory.java
@@ -45,14 +45,15 @@ public class JsonAsyncHttpPinotClientTransportFactory implements PinotClientTran
   private int _handshakeTimeoutMs = Integer.parseInt(DEFAULT_BROKER_HANDSHAKE_TIMEOUT_MS);
   private String _appId = null;
   private String _extraOptionString;
+  private boolean _useMultiStageEngine;
 
   @Override
   public PinotClientTransport buildTransport() {
     ConnectionTimeouts connectionTimeouts =
         ConnectionTimeouts.create(_readTimeoutMs, _connectTimeoutMs, _handshakeTimeoutMs);
     TlsProtocols tlsProtocols = TlsProtocols.defaultProtocols(_tlsV10Enabled);
-    return new JsonAsyncHttpPinotClientTransport(_headers, _scheme, _extraOptionString, _sslContext, connectionTimeouts,
-        tlsProtocols, _appId);
+    return new JsonAsyncHttpPinotClientTransport(_headers, _scheme, _extraOptionString, _useMultiStageEngine,
+        _sslContext, connectionTimeouts, tlsProtocols, _appId);
   }
 
   public Map<String, String> getHeaders() {
@@ -103,6 +104,7 @@ public class JsonAsyncHttpPinotClientTransportFactory implements PinotClientTran
         System.getProperties().getProperty("broker.tlsV10Enabled", DEFAULT_BROKER_TLS_V10_ENABLED));
 
     _extraOptionString = properties.getProperty("queryOptions", "");
+    _useMultiStageEngine = Boolean.parseBoolean(properties.getProperty("useMultiStageEngine", "false"));
     return this;
   }
 }

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -103,6 +103,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   protected List<StreamDataServerStartable> _kafkaStarters;
 
   protected org.apache.pinot.client.Connection _pinotConnection;
+  protected org.apache.pinot.client.Connection _pinotConnectionV2;
   protected Connection _h2Connection;
   protected QueryGenerator _queryGenerator;
 
@@ -506,6 +507,14 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
    * @return Pinot connection
    */
   protected org.apache.pinot.client.Connection getPinotConnection() {
+    if (useMultiStageQueryEngine()) {
+      if (_pinotConnectionV2 == null) {
+        Properties properties = getPinotConnectionProperties();
+        properties.put("useMultiStageEngine", "true");
+        _pinotConnectionV2 = ConnectionFactory.fromZookeeper(properties, getZkUrl() + "/" + getHelixClusterName());
+      }
+      return _pinotConnectionV2;
+    }
     if (_pinotConnection == null) {
       _pinotConnection =
           ConnectionFactory.fromZookeeper(getPinotConnectionProperties(), getZkUrl() + "/" + getHelixClusterName());
@@ -753,7 +762,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   protected void testQuery(String pinotQuery, String h2Query)
       throws Exception {
     ClusterIntegrationTestUtils.testQuery(pinotQuery, getBrokerBaseApiUrl(), getPinotConnection(), h2Query,
-        getH2Connection(), null, getExtraQueryProperties());
+        getH2Connection(), null, getExtraQueryProperties(), useMultiStageQueryEngine());
   }
 
   /**
@@ -762,6 +771,6 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   protected void testQueryWithMatchingRowCount(String pinotQuery, String h2Query)
       throws Exception {
     ClusterIntegrationTestUtils.testQueryWithMatchingRowCount(pinotQuery, getBrokerBaseApiUrl(), getPinotConnection(),
-        h2Query, getH2Connection(), null, getExtraQueryProperties());
+        h2Query, getH2Connection(), null, getExtraQueryProperties(), useMultiStageQueryEngine());
   }
 }


### PR DESCRIPTION
Per #11251 , create two new Broker API endpoints for multi-stage query engine.
```
GET /query
POST /query
```

Make Integration tests to use new endpoint for testing multi-stage engine.
