### PR TITLE
add configuration to fail server startup on non-good status checker

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -502,8 +502,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
       }
     }
 
-    boolean exitServerOnIncompleteStartup = _serverConf.getProperty(Server.CONFIG_OF_EXIT_SERVER_ON_INCOMPLETE_STARTUP,
-        Server.DEFAULT_EXIT_SERVER_ON_INCOMPLETE_STARTUP);
+    boolean exitServerOnIncompleteStartup = _serverConf.getProperty(Server.CONFIG_OF_EXIT_ON_SERVICE_STATUS_CHECK_FAILURE,
+        Server.DEFAULT_EXIT_ON_SERVICE_STATUS_CHECK_FAILURE);
     if (exitServerOnIncompleteStartup) {
       String errorMessage = String.format("Service status %s has not turned GOOD within %dms: %s. Exiting server.",
           serviceStatus, System.currentTimeMillis() - startTimeMs, ServiceStatus.getStatusDescription());

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -502,7 +502,8 @@ public abstract class BaseServerStarter implements ServiceStartable {
       }
     }
 
-    boolean exitServerOnIncompleteStartup = _serverConf.getProperty(Server.CONFIG_OF_EXIT_ON_SERVICE_STATUS_CHECK_FAILURE,
+    boolean exitServerOnIncompleteStartup = _serverConf.getProperty(
+        Server.CONFIG_OF_EXIT_ON_SERVICE_STATUS_CHECK_FAILURE,
         Server.DEFAULT_EXIT_ON_SERVICE_STATUS_CHECK_FAILURE);
     if (exitServerOnIncompleteStartup) {
       String errorMessage = String.format("Service status %s has not turned GOOD within %dms: %s. Exiting server.",

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -663,7 +663,6 @@ public abstract class BaseServerStarter implements ServiceStartable {
         Server.DEFAULT_SHUTDOWN_ENABLE_RESOURCE_CHECK)) {
       shutdownResourceCheck(endTimeMs);
     }
-    // If the server stops while waiting for GOOD status, these will not have been setup yet.
     if (_serverQueriesDisabledTracker != null) {
       _serverQueriesDisabledTracker.stop();
     }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -478,7 +478,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
     long checkIntervalMs = _serverConf.getProperty(Server.CONFIG_OF_STARTUP_SERVICE_STATUS_CHECK_INTERVAL_MS,
         Server.DEFAULT_STARTUP_SERVICE_STATUS_CHECK_INTERVAL_MS);
 
-    Status serviceStatus = ServiceStatus.getServiceStatus(_instanceId);
+    Status serviceStatus = null;
     while (System.currentTimeMillis() < endTimeMs) {
       serviceStatus = ServiceStatus.getServiceStatus(_instanceId);
       long currentTimeMs = System.currentTimeMillis();
@@ -508,8 +508,9 @@ public abstract class BaseServerStarter implements ServiceStartable {
       String errorMessage = String.format("Service status %s has not turned GOOD within %dms: %s. Exiting server.",
           serviceStatus, System.currentTimeMillis() - startTimeMs, ServiceStatus.getStatusDescription());
       LOGGER.error(errorMessage);
-      // Stop the server so that it will be removed from the Helix cluster
-      stop();
+      // If we exit here, only the _adminApiApplication and _helixManager are initialized, so we only stop them
+      _adminApiApplication.stop();
+      _helixManager.disconnect();
       throw new IllegalStateException(errorMessage);
     }
     LOGGER.warn("Service status has not turned GOOD within {}ms: {}", System.currentTimeMillis() - startTimeMs,

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -555,15 +555,6 @@ public class CommonConstants {
     // Use 10 seconds by default so high volume stream are able to catch up.
     // This is also the default in the case a user misconfigures this by setting to <= 0.
     public static final int DEFAULT_STARTUP_REALTIME_MIN_FRESHNESS_MS = 10000;
-    // The timeouts above determine how long servers will poll their status before giving up.
-    // This configuration determines what we do when we give up. By default, we will mark the
-    // server as healthy and start the query server. If this is set to true, we instead throw
-    // an exception and exit the server. This is useful if you want to ensure that the server
-    // is always fully ready before accepting queries. But note that this can cause the server
-    // to never be healthy if there is some reason that it can never reach a GOOD status.
-    public static final String CONFIG_OF_EXIT_SERVER_ON_INCOMPLETE_STARTUP =
-        "pinot.server.starter.exitServerOnStartupStatusFailure";
-    public static final boolean DEFAULT_EXIT_SERVER_ON_INCOMPLETE_STARTUP = false;
 
     public static final String DEFAULT_READ_MODE = "mmap";
     // Whether to reload consuming segment on scheme update
@@ -594,6 +585,15 @@ public class CommonConstants {
     public static final String CONFIG_OF_STARTUP_ENABLE_SERVICE_STATUS_CHECK =
         "pinot.server.startup.enableServiceStatusCheck";
     public static final boolean DEFAULT_STARTUP_ENABLE_SERVICE_STATUS_CHECK = true;
+    // The timeouts above determine how long servers will poll their status before giving up.
+    // This configuration determines what we do when we give up. By default, we will mark the
+    // server as healthy and start the query server. If this is set to true, we instead throw
+    // an exception and exit the server. This is useful if you want to ensure that the server
+    // is always fully ready before accepting queries. But note that this can cause the server
+    // to never be healthy if there is some reason that it can never reach a GOOD status.
+    public static final String CONFIG_OF_EXIT_SERVER_ON_INCOMPLETE_STARTUP =
+        "pinot.server.starter.exitServerOnStartupStatusFailure";
+    public static final boolean DEFAULT_EXIT_SERVER_ON_INCOMPLETE_STARTUP = false;
     public static final String CONFIG_OF_STARTUP_SERVICE_STATUS_CHECK_INTERVAL_MS =
         "pinot.server.startup.serviceStatusCheckIntervalMs";
     public static final long DEFAULT_STARTUP_SERVICE_STATUS_CHECK_INTERVAL_MS = 10_000L;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -591,9 +591,9 @@ public class CommonConstants {
     // an exception and exit the server. This is useful if you want to ensure that the server
     // is always fully ready before accepting queries. But note that this can cause the server
     // to never be healthy if there is some reason that it can never reach a GOOD status.
-    public static final String CONFIG_OF_EXIT_SERVER_ON_INCOMPLETE_STARTUP =
-        "pinot.server.starter.exitServerOnStartupStatusFailure";
-    public static final boolean DEFAULT_EXIT_SERVER_ON_INCOMPLETE_STARTUP = false;
+    public static final String CONFIG_OF_EXIT_ON_SERVICE_STATUS_CHECK_FAILURE =
+        "pinot.server.startup.exitOnServiceStatusCheckFailure";
+    public static final boolean DEFAULT_EXIT_ON_SERVICE_STATUS_CHECK_FAILURE = false;
     public static final String CONFIG_OF_STARTUP_SERVICE_STATUS_CHECK_INTERVAL_MS =
         "pinot.server.startup.serviceStatusCheckIntervalMs";
     public static final long DEFAULT_STARTUP_SERVICE_STATUS_CHECK_INTERVAL_MS = 10_000L;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -555,6 +555,15 @@ public class CommonConstants {
     // Use 10 seconds by default so high volume stream are able to catch up.
     // This is also the default in the case a user misconfigures this by setting to <= 0.
     public static final int DEFAULT_STARTUP_REALTIME_MIN_FRESHNESS_MS = 10000;
+    // The timeouts above determine how long servers will poll their status before giving up.
+    // This configuration determines what we do when we give up. By default, we will mark the
+    // server as healthy and start the query server. If this is set to true, we instead throw
+    // an exception and exit the server. This is useful if you want to ensure that the server
+    // is always fully ready before accepting queries. But note that this can cause the server
+    // to never be healthy if there is some reason that it can never reach a GOOD status.
+    public static final String CONFIG_OF_EXIT_SERVER_ON_INCOMPLETE_STARTUP =
+        "pinot.server.starter.exitServerOnStartupStatusFailure";
+    public static final boolean DEFAULT_EXIT_SERVER_ON_INCOMPLETE_STARTUP = false;
 
     public static final String DEFAULT_READ_MODE = "mmap";
     // Whether to reload consuming segment on scheme update


### PR DESCRIPTION
This is a small feature addition to allow servers to stop if they have no reach `GOOD` status by the end of their startup timeout. This is off by default, so it should not have any affect on existing deployments.

We have several instances per day in our production clusters where new servers start but they are not fully caught up. We plan to use this in the future to prevent those servers from starting.

This was tested on internal clusters with a very small timeout. We observed the server attempt to start, poll status, then quickly destroy segments and deregister from helix.

Once this and #11345 are merged, I plan to add a new documentation page outlining the many server startup configurations and what is best to set for high availability and accuracy.