### PR TITLE
add additional lucene index configs

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
@@ -61,7 +61,7 @@ public class RealtimeLuceneTextIndex implements MutableTextIndex {
    * @param stopWordsExclude stop words to exclude from default stop words
    */
   public RealtimeLuceneTextIndex(String column, File segmentIndexDir, String segmentName,
-      List<String> stopWordsInclude, List<String> stopWordsExclude) {
+      List<String> stopWordsInclude, List<String> stopWordsExclude, boolean useCompoundFile, int maxBufferSizeMB) {
     _column = column;
     _segmentName = segmentName;
     try {
@@ -75,7 +75,7 @@ public class RealtimeLuceneTextIndex implements MutableTextIndex {
       // for realtime
       _indexCreator =
           new LuceneTextIndexCreator(column, new File(segmentIndexDir.getAbsolutePath() + "/" + segmentName),
-              false /* commitOnClose */, stopWordsInclude, stopWordsExclude);
+              false /* commitOnClose */, stopWordsInclude, stopWordsExclude, useCompoundFile, maxBufferSizeMB);
       IndexWriter indexWriter = _indexCreator.getIndexWriter();
       _searcherManager = new SearcherManager(indexWriter, false, false, null);
     } catch (Exception e) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexConfigBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexConfigBuilder.java
@@ -51,6 +51,17 @@ public class TextIndexConfigBuilder extends TextIndexConfig.AbstractBuilder {
       _stopWordsInclude = TextIndexUtils.extractStopWordsInclude(textIndexProperties);
       _stopWordsExclude = TextIndexUtils.extractStopWordsExclude(textIndexProperties);
 
+      if (textIndexProperties.get(FieldConfig.TEXT_INDEX_LUCENE_USE_COMPOUND_FILE) != null) {
+        _luceneUseCompoundFile =
+            Boolean.parseBoolean(textIndexProperties.get(FieldConfig.TEXT_INDEX_LUCENE_USE_COMPOUND_FILE));
+      }
+
+      if (textIndexProperties.get(FieldConfig.TEXT_INDEX_LUCENE_MAX_BUFFER_SIZE_MB) != null) {
+        _luceneMaxBufferSizeMB =
+            Integer.parseInt(textIndexProperties.get(FieldConfig.TEXT_INDEX_LUCENE_MAX_BUFFER_SIZE_MB));
+      }
+
+
       for (Map.Entry<String, String> entry : textIndexProperties.entrySet()) {
         if (entry.getKey().equalsIgnoreCase(FieldConfig.TEXT_FST_TYPE)) {
           _fstType = FSTType.NATIVE;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
@@ -190,6 +190,7 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
       throw new IllegalArgumentException("A consumer directory is required");
     }
     return new RealtimeLuceneTextIndex(context.getFieldSpec().getName(), context.getConsumerDir(),
-        context.getSegmentName(), config.getStopWordsInclude(), config.getStopWordsExclude());
+        context.getSegmentName(), config.getStopWordsInclude(), config.getStopWordsExclude(),
+        config.isLuceneUseCompoundFile(), config.getLuceneMaxBufferSizeMB());
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -44,7 +44,8 @@ public class LuceneMutableTextIndexTest {
   @BeforeClass
   public void setUp()
       throws Exception {
-    _realtimeLuceneTextIndex = new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null);
+    _realtimeLuceneTextIndex =
+        new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500);
     String[][] documents = getTextData();
     for (String[] row : documents) {
       _realtimeLuceneTextIndex.add(row);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
@@ -68,10 +68,12 @@ public class NativeAndLuceneMutableTextIndexTest {
   @BeforeClass
   public void setUp()
       throws Exception {
-    _realtimeLuceneTextIndex = new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null);
+    _realtimeLuceneTextIndex =
+        new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500);
     _nativeMutableTextIndex = new NativeMutableTextIndex(TEXT_COLUMN_NAME);
 
-    _realtimeLuceneMVTextIndex = new RealtimeLuceneTextIndex(MV_TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null);
+    _realtimeLuceneMVTextIndex =
+        new RealtimeLuceneTextIndex(MV_TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500);
     _nativeMutableMVTextIndex = new NativeMutableTextIndex(MV_TEXT_COLUMN_NAME);
 
     String[] documents = getTextData();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
@@ -174,9 +174,9 @@ public class FilePerIndexDirectoryTest {
       throws IOException {
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true,
-            null, null);
+            null, null, true, 500);
         LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true,
-            null, null)) {
+            null, null, true, 500)) {
       PinotDataBuffer buf = fpi.newBuffer("col1", StandardIndexes.forward(), 1024);
       buf.putInt(0, 1);
 
@@ -237,9 +237,9 @@ public class FilePerIndexDirectoryTest {
     // Write sth to buffers and flush them to index files on disk
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true,
-            null, null);
+            null, null, true, 500);
         LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true,
-            null, null)) {
+            null, null, true, 500)) {
       PinotDataBuffer buf = fpi.newBuffer("col1", StandardIndexes.forward(), 1024);
       buf.putInt(0, 111);
       buf = fpi.newBuffer("col2", StandardIndexes.dictionary(), 1024);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
@@ -235,9 +235,9 @@ public class SingleFileIndexDirectoryTest {
       throws IOException, ConfigurationException {
     try (SingleFileIndexDirectory sfd = new SingleFileIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true,
-            null, null);
+            null, null, true, 500);
         LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true,
-            null, null)) {
+            null, null, true, 500)) {
       PinotDataBuffer buf = sfd.newBuffer("col1", StandardIndexes.forward(), 1024);
       buf.putInt(0, 1);
 
@@ -340,9 +340,9 @@ public class SingleFileIndexDirectoryTest {
       throws Exception {
     try (SingleFileIndexDirectory sfd = new SingleFileIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true,
-            null, null);
+            null, null, true, 500);
         LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true,
-            null, null)) {
+            null, null, true, 500)) {
       PinotDataBuffer buf = sfd.newBuffer("col1", StandardIndexes.forward(), 1024);
       buf.putInt(0, 111);
       buf = sfd.newBuffer("col2", StandardIndexes.dictionary(), 1024);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -33,7 +33,7 @@ import org.apache.pinot.spi.config.table.IndexConfig;
 
 public class TextIndexConfig extends IndexConfig {
   private static final int LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB = 500;
-
+  private static final boolean LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE = true;
   public static final TextIndexConfig DISABLED =
       new TextIndexConfig(true, null, null, false, false, Collections.emptyList(), Collections.emptyList(), false,
           LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB);
@@ -65,9 +65,10 @@ public class TextIndexConfig extends IndexConfig {
     _useANDForMultiTermQueries = useANDForMultiTermQueries;
     _stopWordsInclude = stopWordsInclude;
     _stopWordsExclude = stopWordsExclude;
-    _luceneUseCompoundFile = luceneUseCompoundFile == null || luceneUseCompoundFile; // default to useCompoundFile
-    _luceneMaxBufferSizeMB = luceneMaxBufferSizeMB == null ? LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB
-        : luceneMaxBufferSizeMB;
+    _luceneUseCompoundFile =
+        luceneUseCompoundFile == null ? LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE : luceneUseCompoundFile;
+    _luceneMaxBufferSizeMB =
+        luceneMaxBufferSizeMB == null ? LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB : luceneMaxBufferSizeMB;
   }
 
   public FSTType getFstType() {
@@ -123,7 +124,7 @@ public class TextIndexConfig extends IndexConfig {
     protected boolean _useANDForMultiTermQueries = true;
     protected List<String> _stopWordsInclude = new ArrayList<>();
     protected List<String> _stopWordsExclude = new ArrayList<>();
-    protected boolean _luceneUseCompoundFile = true;
+    protected boolean _luceneUseCompoundFile = LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE;
     protected int _luceneMaxBufferSizeMB = LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB;
 
     public AbstractBuilder(@Nullable FSTType fstType) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -32,8 +32,11 @@ import org.apache.pinot.spi.config.table.IndexConfig;
 
 
 public class TextIndexConfig extends IndexConfig {
-  public static final TextIndexConfig DISABLED = new TextIndexConfig(true, null, null, false, false,
-      Collections.emptyList(), Collections.emptyList());
+  private static final int LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB = 500;
+
+  public static final TextIndexConfig DISABLED =
+      new TextIndexConfig(true, null, null, false, false, Collections.emptyList(), Collections.emptyList(), false,
+          LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB);
   private final FSTType _fstType;
   @Nullable
   private final Object _rawValueForTextIndex;
@@ -41,6 +44,8 @@ public class TextIndexConfig extends IndexConfig {
   private final boolean _useANDForMultiTermQueries;
   private final List<String> _stopWordsInclude;
   private final List<String> _stopWordsExclude;
+  private final boolean _luceneUseCompoundFile;
+  private final int _luceneMaxBufferSizeMB;
 
   @JsonCreator
   public TextIndexConfig(
@@ -50,7 +55,9 @@ public class TextIndexConfig extends IndexConfig {
       @JsonProperty("queryCache") boolean enableQueryCache,
       @JsonProperty("useANDForMultiTermQueries") boolean useANDForMultiTermQueries,
       @JsonProperty("stopWordsInclude") List<String> stopWordsInclude,
-      @JsonProperty("stopWordsExclude") List<String> stopWordsExclude) {
+      @JsonProperty("stopWordsExclude") List<String> stopWordsExclude,
+      @JsonProperty("luceneUseCompoundFile") Boolean luceneUseCompoundFile,
+      @JsonProperty("luceneMaxBufferSizeMB") Integer luceneMaxBufferSizeMB) {
     super(disabled);
     _fstType = fstType;
     _rawValueForTextIndex = rawValueForTextIndex;
@@ -58,6 +65,9 @@ public class TextIndexConfig extends IndexConfig {
     _useANDForMultiTermQueries = useANDForMultiTermQueries;
     _stopWordsInclude = stopWordsInclude;
     _stopWordsExclude = stopWordsExclude;
+    _luceneUseCompoundFile = luceneUseCompoundFile == null || luceneUseCompoundFile; // default to useCompoundFile
+    _luceneMaxBufferSizeMB = luceneMaxBufferSizeMB == null ? LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB
+        : luceneMaxBufferSizeMB;
   }
 
   public FSTType getFstType() {
@@ -90,6 +100,20 @@ public class TextIndexConfig extends IndexConfig {
     return _stopWordsExclude;
   }
 
+  /**
+   * Whether Lucene IndexWriter uses compound file format. Improves indexing speed but may cause file descriptor issues
+   */
+  public boolean isLuceneUseCompoundFile() {
+    return _luceneUseCompoundFile;
+  }
+
+  /**
+   * Lucene buffer size. Helps with indexing speed but may cause heap issues
+   */
+  public int getLuceneMaxBufferSizeMB() {
+    return _luceneMaxBufferSizeMB;
+  }
+
   public static abstract class AbstractBuilder {
     @Nullable
     protected FSTType _fstType;
@@ -99,6 +123,8 @@ public class TextIndexConfig extends IndexConfig {
     protected boolean _useANDForMultiTermQueries = true;
     protected List<String> _stopWordsInclude = new ArrayList<>();
     protected List<String> _stopWordsExclude = new ArrayList<>();
+    protected boolean _luceneUseCompoundFile = true;
+    protected int _luceneMaxBufferSizeMB = LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB;
 
     public AbstractBuilder(@Nullable FSTType fstType) {
       _fstType = fstType;
@@ -110,11 +136,13 @@ public class TextIndexConfig extends IndexConfig {
       _useANDForMultiTermQueries = other._useANDForMultiTermQueries;
       _stopWordsInclude = new ArrayList<>(other._stopWordsInclude);
       _stopWordsExclude = new ArrayList<>(other._stopWordsExclude);
+      _luceneUseCompoundFile = other._luceneUseCompoundFile;
+      _luceneMaxBufferSizeMB = other._luceneMaxBufferSizeMB;
     }
 
     public TextIndexConfig build() {
       return new TextIndexConfig(false, _fstType, _rawValueForTextIndex, _enableQueryCache, _useANDForMultiTermQueries,
-          _stopWordsInclude, _stopWordsExclude);
+          _stopWordsInclude, _stopWordsExclude, _luceneUseCompoundFile, _luceneMaxBufferSizeMB);
     }
 
     public abstract AbstractBuilder withProperties(@Nullable Map<String, String> textIndexProperties);
@@ -131,6 +159,16 @@ public class TextIndexConfig extends IndexConfig {
 
     public AbstractBuilder withStopWordsExclude(List<String> stopWordsExclude) {
       _stopWordsExclude = stopWordsExclude;
+      return this;
+    }
+
+    public AbstractBuilder withLuceneUseCompoundFile(boolean useCompoundFile) {
+      _luceneUseCompoundFile = useCompoundFile;
+      return this;
+    }
+
+    public AbstractBuilder withLuceneMaxBufferSizeMB(int maxBufferSizeMB) {
+      _luceneMaxBufferSizeMB = maxBufferSizeMB;
       return this;
     }
   }
@@ -150,12 +188,14 @@ public class TextIndexConfig extends IndexConfig {
     return _enableQueryCache == that._enableQueryCache && _useANDForMultiTermQueries == that._useANDForMultiTermQueries
         && _fstType == that._fstType && Objects.equals(_rawValueForTextIndex, that._rawValueForTextIndex)
         && Objects.equals(_stopWordsInclude, that._stopWordsInclude) && Objects.equals(_stopWordsExclude,
-        that._stopWordsExclude);
+        that._stopWordsExclude) && _luceneUseCompoundFile == that._luceneUseCompoundFile
+        && _luceneMaxBufferSizeMB == that._luceneMaxBufferSizeMB;
   }
 
   @Override
   public int hashCode() {
     return Objects.hash(super.hashCode(), _fstType, _rawValueForTextIndex, _enableQueryCache,
-        _useANDForMultiTermQueries, _stopWordsInclude, _stopWordsExclude);
+        _useANDForMultiTermQueries, _stopWordsInclude, _stopWordsExclude, _luceneUseCompoundFile,
+        _luceneMaxBufferSizeMB);
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/index/TextIndexConfigTest.java
@@ -41,6 +41,8 @@ public class TextIndexConfigTest {
     assertFalse(config.isUseANDForMultiTermQueries(), "Unexpected useANDForMultiTermQueries");
     assertNull(config.getStopWordsInclude(), "Unexpected stopWordsInclude");
     assertNull(config.getStopWordsExclude(), "Unexpected stopWordsExclude");
+    assertTrue(config.isLuceneUseCompoundFile(), "Unexpected luceneUseCompoundFile");
+    assertEquals(config.getLuceneMaxBufferSizeMB(), 500, "Unexpected luceneMaxBufferSize");
   }
 
   @Test
@@ -56,6 +58,8 @@ public class TextIndexConfigTest {
     assertFalse(config.isUseANDForMultiTermQueries(), "Unexpected useANDForMultiTermQueries");
     assertNull(config.getStopWordsInclude(), "Unexpected stopWordsInclude");
     assertNull(config.getStopWordsExclude(), "Unexpected stopWordsExclude");
+    assertTrue(config.isLuceneUseCompoundFile(), "Unexpected luceneUseCompoundFile");
+    assertEquals(config.getLuceneMaxBufferSizeMB(), 500, "Unexpected luceneMaxBufferSize");
   }
 
   @Test
@@ -71,6 +75,8 @@ public class TextIndexConfigTest {
     assertFalse(config.isUseANDForMultiTermQueries(), "Unexpected useANDForMultiTermQueries");
     assertNull(config.getStopWordsInclude(), "Unexpected stopWordsInclude");
     assertNull(config.getStopWordsExclude(), "Unexpected stopWordsExclude");
+    assertTrue(config.isLuceneUseCompoundFile(), "Unexpected luceneUseCompoundFile");
+    assertEquals(config.getLuceneMaxBufferSizeMB(), 500, "Unexpected luceneMaxBufferSize");
   }
 
   @Test
@@ -86,6 +92,8 @@ public class TextIndexConfigTest {
     assertFalse(config.isUseANDForMultiTermQueries(), "Unexpected useANDForMultiTermQueries");
     assertNull(config.getStopWordsInclude(), "Unexpected stopWordsInclude");
     assertNull(config.getStopWordsExclude(), "Unexpected stopWordsExclude");
+    assertTrue(config.isLuceneUseCompoundFile(), "Unexpected luceneUseCompoundFile");
+    assertEquals(config.getLuceneMaxBufferSizeMB(), 500, "Unexpected luceneMaxBufferSize");
   }
 
   @Test
@@ -97,7 +105,9 @@ public class TextIndexConfigTest {
         + "        \"queryCache\": true,\n"
         + "        \"useANDForMultiTermQueries\": true,\n"
         + "        \"stopWordsInclude\": [\"a\"],\n"
-        + "        \"stopWordsExclude\": [\"b\"]\n"
+        + "        \"stopWordsExclude\": [\"b\"],\n"
+        + "        \"luceneUseCompoundFile\": false,\n"
+        + "        \"luceneMaxBufferSizeMB\": 1024\n"
         + "}";
     TextIndexConfig config = JsonUtils.stringToObject(confStr, TextIndexConfig.class);
 
@@ -108,5 +118,7 @@ public class TextIndexConfigTest {
     assertTrue(config.isUseANDForMultiTermQueries(), "Unexpected useANDForMultiTermQueries");
     assertEquals(config.getStopWordsInclude(), Lists.newArrayList("a"), "Unexpected stopWordsInclude");
     assertEquals(config.getStopWordsExclude(), Lists.newArrayList("b"), "Unexpected stopWordsExclude");
+    assertFalse(config.isLuceneUseCompoundFile(), "Unexpected luceneUseCompoundFile");
+    assertEquals(config.getLuceneMaxBufferSizeMB(), 1024, "Unexpected luceneMaxBufferSize");
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -49,6 +49,10 @@ public class FieldConfig extends BaseJsonConfig {
   public static final String TEXT_INDEX_DEFAULT_RAW_VALUE = "n";
   public static final String TEXT_INDEX_STOP_WORD_INCLUDE_KEY = "stopWordInclude";
   public static final String TEXT_INDEX_STOP_WORD_EXCLUDE_KEY = "stopWordExclude";
+  public static final String TEXT_INDEX_LUCENE_USE_COMPOUND_FILE = "luceneUseCompoundFile";
+  public static final boolean TEXT_INDEX_DEFAULT_LUCENE_USE_COMPOUND_FILE = true;
+  public static final String TEXT_INDEX_LUCENE_MAX_BUFFER_SIZE_MB = "luceneMaxBufferSizeMB";
+  public static final int TEXT_INDEX_DEFAULT_LUCENE_MAX_BUFFER_SIZE_MB = 500;
   public static final String TEXT_INDEX_STOP_WORD_SEPERATOR = ",";
   // "native" for native, default is Lucene
   public static final String TEXT_FST_TYPE = "fstType";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -50,9 +50,7 @@ public class FieldConfig extends BaseJsonConfig {
   public static final String TEXT_INDEX_STOP_WORD_INCLUDE_KEY = "stopWordInclude";
   public static final String TEXT_INDEX_STOP_WORD_EXCLUDE_KEY = "stopWordExclude";
   public static final String TEXT_INDEX_LUCENE_USE_COMPOUND_FILE = "luceneUseCompoundFile";
-  public static final boolean TEXT_INDEX_DEFAULT_LUCENE_USE_COMPOUND_FILE = true;
   public static final String TEXT_INDEX_LUCENE_MAX_BUFFER_SIZE_MB = "luceneMaxBufferSizeMB";
-  public static final int TEXT_INDEX_DEFAULT_LUCENE_MAX_BUFFER_SIZE_MB = 500;
   public static final String TEXT_INDEX_STOP_WORD_SEPERATOR = ",";
   // "native" for native, default is Lucene
   public static final String TEXT_FST_TYPE = "fstType";


### PR DESCRIPTION
Adds two configs for Lucene backed text index, both can be used to optimize for index writing time
1. luceneUseCompoundFile: [compound file format](https://lucene.apache.org/core/8_1_1/core/org/apache/lucene/index/IndexWriterConfig.html#setUseCompoundFile-boolean-)
2. luceneMaxBufferSizeMB: [max buffer size](https://lucene.apache.org/core/8_1_1/core/org/apache/lucene/index/IndexWriterConfig.html#setRAMBufferSizeMB-double-)

Internal testing showed tuning these can improve realtime -> offline segment build time by ~30% (~50% for the 'lucene portion' when subtracting out build time for a table w/o text index). Some sample settings are shown below, collected by creating identical (minus lucene configs) tables in the same cluster. Build time is visualized via ingestion delay metrics: 

![image](https://github.com/apache/pinot/assets/27231838/cb089d6c-ae41-488e-b142-88ad9aaf4d1a)
