### PR TITLE
getMessageAtIndex should actually return the value in the streamMessage for compatibility

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarMessageBatch.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarMessageBatch.java
@@ -59,6 +59,7 @@ public class PulsarMessageBatch implements MessageBatch<PulsarStreamMessage> {
   public byte[] getMessageBytesAtIndex(int index) {
     return getMessageAtIndex(index).getValue();
   }
+
   @Override
   public int getMessageOffsetAtIndex(int index) {
     return ByteBuffer.wrap(_messageList.get(index).getValue()).arrayOffset();


### PR DESCRIPTION
Fixing a bug from https://github.com/apache/pinot/pull/10995 