### PR TITLE
Stop table data manager before shutdown

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -184,6 +184,15 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected abstract void doStart();
 
   @Override
+  public void stop() {
+    _logger.info("Stopping table data manager for table: {}", _tableNameWithType);
+    doStop();
+    _logger.info("Stopped table data manager for table: {}", _tableNameWithType);
+  }
+
+  protected abstract void doStop();
+
+  @Override
   public void shutDown() {
     _logger.info("Shutting down table data manager for table: {}", _tableNameWithType);
     _shutDown = true;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineTableDataManager.java
@@ -37,6 +37,10 @@ public class OfflineTableDataManager extends BaseTableDataManager {
   }
 
   @Override
+  protected void doStop() {
+  }
+
+  @Override
   protected void doShutdown() {
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -244,10 +244,16 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   }
 
   @Override
-  protected void doShutdown() {
+  protected void doStop() {
     if (_tableUpsertMetadataManager != null) {
       // Stop the upsert metadata manager first to prevent removing metadata when destroying segments
       _tableUpsertMetadataManager.stop();
+    }
+  }
+
+  @Override
+  protected void doShutdown() {
+    if (_tableUpsertMetadataManager != null) {
       for (SegmentDataManager segmentDataManager : _segmentDataManagerMap.values()) {
         segmentDataManager.destroy();
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -57,6 +57,11 @@ public interface TableDataManager {
   void start();
 
   /**
+   * Stops the table data manager. Should be called to signal no more segment operations will be performed on the table.
+   */
+  void stop();
+
+  /**
    * Shuts down the table data manager. Should be called only once. After calling shut down, no other method should be
    * called.
    */


### PR DESCRIPTION
Currently when a table is deleted we wait for all segments to be removed via state transition. This can cause deletion to be slow in case of upsert tables where a lot of keys need to be removed from the state. 

The solution is to add a stop method in table data manager which calls partitionUpsertMetadataManager.stop. 
This will prevent further unnecessary removal of the segments from the primary key state.