### PR TITLE
Fix a flaky test PinotFSSegmentUploaderTest.

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/PinotFSSegmentUploaderTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/manager/realtime/PinotFSSegmentUploaderTest.java
@@ -41,7 +41,7 @@ import org.testng.annotations.Test;
 
 
 public class PinotFSSegmentUploaderTest {
-  private static final int TIMEOUT_IN_MS = 100;
+  private static final int TIMEOUT_IN_MS = 1000;
   private File _file;
   private LLCSegmentName _llcSegmentName;
   private ServerMetrics _serverMetrics = Mockito.mock(ServerMetrics.class);


### PR DESCRIPTION
The test might fail because uploading segment times out.

```
WARN [PinotFSSegmentUploader] [main] Timed out waiting to upload segment: test_REALTIME__1__0__20230816T0414Z for table: test
Error:  Tests run: 4, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 3.226 s <<< FAILURE! - in org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploaderTest
Error:  org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploaderTest.testNoSegmentStoreConfigured  Time elapsed: 0.021 s
Error:  org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploaderTest.testSegmentAlreadyExist  Time elapsed: 0.147 s  <<< FAILURE!
java.lang.NullPointerException: Cannot invoke "java.net.URI.toString()" because "segmentURI" is null
	at org.apache.pinot.core.data.manager.realtime.PinotFSSegmentUploaderTest.testSegmentAlreadyExist(PinotFSSegmentUploaderTest.java:77)
	at java.base/jdk.internal.reflect.DirectMethodHandleAccessor.invoke(DirectMethodHandleAccessor.java:104)
	at java.base/java.lang.reflect.Method.invoke(Method.java:578)
	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:108)
	at org.testng.internal.Invoker.invokeMethod(Invoker.java:661)
	at org.testng.internal.Invoker.invokeTestMethod(Invoker.java:869)
	at org.testng.internal.Invoker.invokeTestMethods(Invoker.java:1193)
	at org.testng.internal.TestMethodWorker.invokeTestMethods(TestMethodWorker.java:126)
	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:109)
	at org.testng.TestRunner.privateRun(TestRunner.java:744)
	at org.testng.TestRunner.run(TestRunner.java:602)
	at org.testng.SuiteRunner.runTest(SuiteRunner.java:380)
	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:375)
	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:340)
	at org.testng.SuiteRunner.run(SuiteRunner.java:289)
	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1301)
	at org.testng.TestNG.runSuitesLocally(TestNG.java:1226)
	at org.testng.TestNG.runSuites(TestNG.java:1144)
	at org.testng.TestNG.run(TestNG.java:1115)
	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:136)
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeSingleClass(TestNGDirectoryTestSuite.java:112)
	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:99)
	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:145)
	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:428)
	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:562)
	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:548)
```