### PR TITLE
disable broker query killing test

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedBrokerQueryKillingTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedBrokerQueryKillingTest.java
@@ -56,6 +56,7 @@ import org.testng.annotations.BeforeClass;
 
 /**
  * Integration test for heap size based broker query killing, this works only for xmx4G
+ * TODO: re-enable or remove this after we resolve https://github.com/apache/pinot/issues/11099
  */
 public class OfflineClusterMemBasedBrokerQueryKillingTest extends BaseClusterIntegrationTestSet {
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedBrokerQueryKillingTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedBrokerQueryKillingTest.java
@@ -52,7 +52,6 @@ import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.util.TestUtils;
 import org.junit.Assert;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.Test;
 
 
 /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedBrokerQueryKillingTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterMemBasedBrokerQueryKillingTest.java
@@ -207,8 +207,6 @@ public class OfflineClusterMemBasedBrokerQueryKillingTest extends BaseClusterInt
         .build();
   }
 
-
-  @Test
   public void testDigestOOMMultipleQueries()
       throws Exception {
     AtomicReference<JsonNode> queryResponse1 = new AtomicReference<>();


### PR DESCRIPTION
Test is flaky now https://github.com/apache/pinot/issues/11099, need some further investigation before re-enable/remove.