### PR TITLE
ForwardIndexHandler should only refer to columns in schema

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
@@ -221,8 +221,7 @@ public class ForwardIndexHandler extends BaseIndexHandler {
     for (String column : existingAllColumns) {
       if (_schema != null && !_schema.hasColumn(column)) {
         // _schema will be null only in tests
-        LOGGER.info("Column {} is not in schema, removing forward index", column);
-        columnOperationsMap.put(column, List.of(Operation.DISABLE_FORWARD_INDEX));
+        LOGGER.info("Column {} is not in schema, skipping updating forward index", column);
         continue;
       }
       FieldIndexConfigs newConf = _fieldIndexConfigs.get(column);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/ForwardIndexHandler.java
@@ -219,6 +219,12 @@ public class ForwardIndexHandler extends BaseIndexHandler {
     }
 
     for (String column : existingAllColumns) {
+      if (_schema != null && !_schema.hasColumn(column)) {
+        // _schema will be null only in tests
+        LOGGER.info("Column {} is not in schema, removing forward index", column);
+        columnOperationsMap.put(column, List.of(Operation.DISABLE_FORWARD_INDEX));
+        continue;
+      }
       FieldIndexConfigs newConf = _fieldIndexConfigs.get(column);
       boolean newIsFwd = newConf.getConfig(StandardIndexes.forward()).isEnabled();
       boolean newIsDict = newConf.getConfig(StandardIndexes.dictionary()).isEnabled();


### PR DESCRIPTION
If a noDictionary column has been removed from the schema, loading existing segments (where column is still present) fails with 

```
java.lang.IllegalArgumentException: Failed to find column: column_name

	at com.google.common.base.Preconditions.checkArgument(Preconditions.java:218)
	at org.apache.pinot.segment.local.segment.creator.impl.stats.AbstractColumnStatisticsCollector.<init>(AbstractColumnStatisticsCollector.java:60)
	at org.apache.pinot.segment.local.segment.creator.impl.stats.LongColumnPreIndexStatsCollector.<init>(LongColumnPreIndexStatsCollector.java:34)
	at org.apache.pinot.segment.local.segment.index.loader.ForwardIndexHandler.getStatsCollector(ForwardIndexHandler.java:1013)
	at org.apache.pinot.segment.local.segment.index.loader.ForwardIndexHandler.createDictBasedForwardIndex(ForwardIndexHandler.java:803)
	at org.apache.pinot.segment.local.segment.index.loader.ForwardIndexHandler.updateIndices(ForwardIndexHandler.java:175)
```

This is due to handler assuming the column still exists and tries to create a dictionary by default for it. This PR fixes it