### PR TITLE
Try to increase codecov coverage by running all unit tests together

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -75,7 +75,7 @@ jobs:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false
       matrix:
-        testset: [ 1, 2 ]
+        testset: [ 1 ]
         java: [ 11, 17, 20 ]
         distribution: [ "temurin" ]
     name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})

--- a/.github/workflows/scripts/.pinot_test.sh
+++ b/.github/workflows/scripts/.pinot_test.sh
@@ -46,24 +46,10 @@ else
   #     due to the -am flag (include dependency modules)
   if [ "$RUN_TEST_SET" == "1" ]; then
     mvn clean install -DskipTests -am -B -T 16 \
-        -pl 'pinot-spi' \
-        -pl 'pinot-segment-spi' \
-        -pl 'pinot-common' \
-        -pl 'pinot-segment-local' \
-        -pl 'pinot-core' \
-        -pl 'pinot-query-planner' \
-        -pl 'pinot-query-runtime' \
-        -P github-actions,no-integration-tests \
         -Dcheckstyle.skip -Dspotless.skip -Denforcer.skip -Dlicense.skip || exit 1
     mvn test -T 16 \
-        -pl 'pinot-spi' \
-        -pl 'pinot-segment-spi' \
-        -pl 'pinot-common' \
-        -pl 'pinot-segment-local' \
-        -pl 'pinot-core' \
-        -pl 'pinot-query-planner' \
-        -pl 'pinot-query-runtime' \
-        -P github-actions,no-integration-tests && exit 0 || exit 1
+        -P github-actions,no-integration-tests -Dcheckstyle.skip -Dspotless.skip -Denforcer.skip -Dlicense.skip \
+        && exit 0 || exit 1
   fi
   if [ "$RUN_TEST_SET" == "2" ]; then
     mvn clean install -DskipTests -Dcheckstyle.skip -Dspotless.skip -Denforcer.skip -Dlicense.skip -T 16 || exit 1


### PR DESCRIPTION
Coverage in codecov seems to be incorrect. Specifically, there are projects whose coverage is 0 when they have tests.

It seems difficult to understand why. One reason may be due to the way we split unit tests in two different executions. This is a POC PR that tries to verify that by removing that split and executing all junit tests in the same job.