### PR TITLE
Replace jacoco report-aggregate with report

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1589,7 +1589,7 @@
             <id>report</id>
             <phase>test</phase>
             <goals>
-              <goal>report-aggregate</goal>
+              <goal>report</goal>
             </goals>
           </execution>
         </executions>


### PR DESCRIPTION
The reason is that report-aggregate includes the coverage of the project dependencies and not the project itself. As explained https://stackoverflow.com/a/53559994 this goal is designed to be executed in a project that has dependencies to the others and not in the projects that declares the tests.
