### PR TITLE
Properly handle shutdown of TableDataManager

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -28,6 +28,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -179,7 +180,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected abstract void doInit();
 
   @Override
-  public void start() {
+  public synchronized void start() {
     _logger.info("Starting table data manager for table: {}", _tableNameWithType);
     doStart();
     _logger.info("Started table data manager for table: {}", _tableNameWithType);
@@ -188,7 +189,11 @@ public abstract class BaseTableDataManager implements TableDataManager {
   protected abstract void doStart();
 
   @Override
-  public void shutDown() {
+  public synchronized void shutDown() {
+    if (_shutDown) {
+      _logger.info("Table data manager for table: {} is already shut down", _tableNameWithType);
+      return;
+    }
     _logger.info("Shutting down table data manager for table: {}", _tableNameWithType);
     _shutDown = true;
     doShutdown();
@@ -196,6 +201,18 @@ public abstract class BaseTableDataManager implements TableDataManager {
   }
 
   protected abstract void doShutdown();
+
+  /**
+   * Releases and removes all segments tracked by the table data manager.
+   */
+  protected void releaseAndRemoveAllSegments() {
+    Iterator<SegmentDataManager> iterator = _segmentDataManagerMap.values().iterator();
+    while (iterator.hasNext()) {
+      SegmentDataManager segmentDataManager = iterator.next();
+      iterator.remove();
+      releaseSegment(segmentDataManager);
+    }
+  }
 
   @Override
   public boolean isShutDown() {
@@ -214,6 +231,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
   @Override
   public void addSegment(ImmutableSegment immutableSegment) {
     String segmentName = immutableSegment.getSegmentName();
+    Preconditions.checkState(!_shutDown, "Table data manager is already shut down, cannot add segment: %s to table: %s",
+        segmentName, _tableNameWithType);
     _logger.info("Adding immutable segment: {} to table: {}", segmentName, _tableNameWithType);
     _serverMetrics.addValueToTableGauge(_tableNameWithType, ServerGauge.DOCUMENT_COUNT,
         immutableSegment.getSegmentMetadata().getTotalDocs());
@@ -232,6 +251,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
   @Override
   public void addSegment(File indexDir, IndexLoadingConfig indexLoadingConfig)
       throws Exception {
+    Preconditions.checkState(!_shutDown, "Table data manager is already shut down, cannot add segment: %s to table: %s",
+        indexDir.getName(), _tableNameWithType);
     indexLoadingConfig.setTableDataDir(_tableDataDir);
     indexLoadingConfig.setInstanceTierConfigs(_tableDataManagerConfig.getInstanceTierConfigs());
     addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, indexLoadingConfig.getSchema()));
@@ -251,6 +272,12 @@ public abstract class BaseTableDataManager implements TableDataManager {
    */
   @Override
   public void removeSegment(String segmentName) {
+    // Allow removing segment after shutdown so that we can remove the segment when the table is deleted
+    if (_shutDown) {
+      _logger.info("Table data manager is already shut down, skip removing segment: {} from table: {}", segmentName,
+          _tableNameWithType);
+      return;
+    }
     _logger.info("Removing segment: {} from table: {}", segmentName, _tableNameWithType);
     SegmentDataManager segmentDataManager = unregisterSegment(segmentName);
     if (segmentDataManager != null) {
@@ -364,6 +391,9 @@ public abstract class BaseTableDataManager implements TableDataManager {
   public void reloadSegment(String segmentName, IndexLoadingConfig indexLoadingConfig, SegmentZKMetadata zkMetadata,
       SegmentMetadata localMetadata, @Nullable Schema schema, boolean forceDownload)
       throws Exception {
+    Preconditions.checkState(!_shutDown,
+        "Table data manager is already shut down, cannot reload segment: %s of table: %s", segmentName,
+        _tableNameWithType);
     String segmentTier = getSegmentCurrentTier(segmentName);
     indexLoadingConfig.setSegmentTier(segmentTier);
     indexLoadingConfig.setTableDataDir(_tableDataDir);
@@ -390,8 +420,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
         SegmentDirectory segmentDirectory =
             initSegmentDirectory(segmentName, String.valueOf(zkMetadata.getCrc()), indexLoadingConfig);
         // We should first try to reuse existing segment directory
-        if (canReuseExistingDirectoryForReload(zkMetadata, segmentTier, segmentDirectory, indexLoadingConfig,
-            schema)) {
+        if (canReuseExistingDirectoryForReload(zkMetadata, segmentTier, segmentDirectory, indexLoadingConfig, schema)) {
           LOGGER.info("Reloading segment: {} of table: {} using existing segment directory as no reprocessing needed",
               segmentName, _tableNameWithType);
           // No reprocessing needed, reuse the same segment
@@ -432,9 +461,8 @@ public abstract class BaseTableDataManager implements TableDataManager {
     }
   }
 
-  private boolean canReuseExistingDirectoryForReload(SegmentZKMetadata segmentZKMetadata,
-      String currentSegmentTier, SegmentDirectory segmentDirectory, IndexLoadingConfig indexLoadingConfig,
-      Schema schema)
+  private boolean canReuseExistingDirectoryForReload(SegmentZKMetadata segmentZKMetadata, String currentSegmentTier,
+      SegmentDirectory segmentDirectory, IndexLoadingConfig indexLoadingConfig, Schema schema)
       throws Exception {
     SegmentDirectoryLoader segmentDirectoryLoader =
         SegmentDirectoryLoaderRegistry.getSegmentDirectoryLoader(indexLoadingConfig.getSegmentDirectoryLoader());
@@ -446,6 +474,9 @@ public abstract class BaseTableDataManager implements TableDataManager {
   public void addOrReplaceSegment(String segmentName, IndexLoadingConfig indexLoadingConfig,
       SegmentZKMetadata zkMetadata, @Nullable SegmentMetadata localMetadata)
       throws Exception {
+    Preconditions.checkState(!_shutDown,
+        "Table data manager is already shut down, cannot add/replace segment: %s of table: %s", segmentName,
+        _tableNameWithType);
     if (localMetadata != null && hasSameCRC(zkMetadata, localMetadata)) {
       LOGGER.info("Segment: {} of table: {} has crc: {} same as before, already loaded, do nothing", segmentName,
           _tableNameWithType, localMetadata.getCrc());
@@ -595,12 +626,13 @@ public abstract class BaseTableDataManager implements TableDataManager {
   }
 
   // not thread safe. Caller should invoke it with safe concurrency control.
-  protected void downloadFromPeersWithoutStreaming(String segmentName, SegmentZKMetadata zkMetadata,
-      File destTarFile) throws Exception {
+  protected void downloadFromPeersWithoutStreaming(String segmentName, SegmentZKMetadata zkMetadata, File destTarFile)
+      throws Exception {
     Preconditions.checkArgument(_tableDataManagerConfig.getTablePeerDownloadScheme() != null,
-            "Download peers require non null peer download scheme");
-    List<URI> peerSegmentURIs = PeerServerSegmentFinder.getPeerServerURIs(segmentName,
-        _tableDataManagerConfig.getTablePeerDownloadScheme(), _helixManager, _tableNameWithType);
+        "Download peers require non null peer download scheme");
+    List<URI> peerSegmentURIs =
+        PeerServerSegmentFinder.getPeerServerURIs(segmentName, _tableDataManagerConfig.getTablePeerDownloadScheme(),
+            _helixManager, _tableNameWithType);
     if (peerSegmentURIs.isEmpty()) {
       String msg = String.format("segment %s doesn't have any peers", segmentName);
       LOGGER.warn(msg);
@@ -611,10 +643,10 @@ public abstract class BaseTableDataManager implements TableDataManager {
       // Next download the segment from a randomly chosen server using configured scheme.
       SegmentFetcherFactory.fetchAndDecryptSegmentToLocal(peerSegmentURIs, destTarFile, zkMetadata.getCrypterName());
       LOGGER.info("Fetched segment {} from peers: {} to: {} of size: {}", segmentName, peerSegmentURIs, destTarFile,
-              destTarFile.length());
+          destTarFile.length());
     } catch (AttemptsExceededException e) {
       LOGGER.error("Attempts exceeded when downloading segment: {} for table: {} from peers {} to: {}", segmentName,
-              _tableNameWithType, peerSegmentURIs, destTarFile);
+          _tableNameWithType, peerSegmentURIs, destTarFile);
       _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.SEGMENT_DOWNLOAD_FROM_PEERS_FAILURES, 1L);
       throw e;
     }
@@ -636,12 +668,12 @@ public abstract class BaseTableDataManager implements TableDataManager {
     String uri = zkMetadata.getDownloadUrl();
     AtomicInteger attempts = new AtomicInteger(0);
     try {
-        File ret = SegmentFetcherFactory.fetchAndStreamUntarToLocal(uri, tempRootDir, maxStreamRateInByte, attempts);
-        _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.SEGMENT_STREAMED_DOWNLOAD_UNTAR_FAILURES,
-            attempts.get());
-        LOGGER.info("Downloaded and untarred segment: {} for table: {} from: {} attempts: {}", segmentName,
-            _tableNameWithType, uri, attempts.get());
-        return ret;
+      File ret = SegmentFetcherFactory.fetchAndStreamUntarToLocal(uri, tempRootDir, maxStreamRateInByte, attempts);
+      _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.SEGMENT_STREAMED_DOWNLOAD_UNTAR_FAILURES,
+          attempts.get());
+      LOGGER.info("Downloaded and untarred segment: {} for table: {} from: {} attempts: {}", segmentName,
+          _tableNameWithType, uri, attempts.get());
+      return ret;
     } catch (Exception e) {
       _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.SEGMENT_STREAMED_DOWNLOAD_UNTAR_FAILURES,
           attempts.get());
@@ -771,6 +803,10 @@ public abstract class BaseTableDataManager implements TableDataManager {
   @Override
   public boolean tryLoadExistingSegment(String segmentName, IndexLoadingConfig indexLoadingConfig,
       SegmentZKMetadata zkMetadata) {
+    Preconditions.checkState(!_shutDown,
+        "Table data manager is already shut down, cannot load existing segment: %s of table: %s", segmentName,
+        _tableNameWithType);
+
     // Try to recover the segment from potential segment reloading failure.
     String segmentTier = zkMetadata.getTier();
     File indexDir = getSegmentDataDir(segmentName, segmentTier, indexLoadingConfig.getTableConfig());

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/InstanceDataManager.java
@@ -75,12 +75,6 @@ public interface InstanceDataManager {
       throws Exception;
 
   /**
-   * Adds a segment from local disk into an OFFLINE table.
-   */
-  void addOfflineSegment(String offlineTableName, String segmentName, File indexDir)
-      throws Exception;
-
-  /**
    * Adds a segment into an REALTIME table.
    * <p>The segment might be committed or under consuming.
    */

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/offline/OfflineTableDataManager.java
@@ -38,5 +38,6 @@ public class OfflineTableDataManager extends BaseTableDataManager {
 
   @Override
   protected void doShutdown() {
+    releaseAndRemoveAllSegments();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -54,7 +54,6 @@ import org.apache.pinot.segment.local.dedup.PartitionDedupMetadataManager;
 import org.apache.pinot.segment.local.dedup.TableDedupMetadataManager;
 import org.apache.pinot.segment.local.dedup.TableDedupMetadataManagerFactory;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
-import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentStatsHistory;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.index.loader.LoaderUtils;
@@ -251,18 +250,14 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     if (_tableUpsertMetadataManager != null) {
       // Stop the upsert metadata manager first to prevent removing metadata when destroying segments
       _tableUpsertMetadataManager.stop();
-      for (SegmentDataManager segmentDataManager : _segmentDataManagerMap.values()) {
-        segmentDataManager.destroy();
-      }
+      releaseAndRemoveAllSegments();
       try {
         _tableUpsertMetadataManager.close();
       } catch (IOException e) {
         _logger.warn("Cannot close upsert metadata manager properly for table: {}", _tableNameWithType, e);
       }
     } else {
-      for (SegmentDataManager segmentDataManager : _segmentDataManagerMap.values()) {
-        segmentDataManager.destroy();
-      }
+      releaseAndRemoveAllSegments();
     }
     if (_leaseExtender != null) {
       _leaseExtender.shutDown();
@@ -382,6 +377,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   @Override
   public void addSegment(String segmentName, IndexLoadingConfig indexLoadingConfig, SegmentZKMetadata segmentZKMetadata)
       throws Exception {
+    Preconditions.checkState(!_shutDown, "Table data manager is already shut down, cannot add segment: %s to table: %s",
+        segmentName, _tableNameWithType);
     SegmentDataManager segmentDataManager = _segmentDataManagerMap.get(segmentName);
     if (segmentDataManager != null) {
       _logger.warn("Skipping adding existing segment: {} for table: {} with data manager class: {}", segmentName,
@@ -438,8 +435,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     int partitionGroupId = llcSegmentName.getPartitionGroupId();
     Semaphore semaphore = _partitionGroupIdToSemaphoreMap.computeIfAbsent(partitionGroupId, k -> new Semaphore(1));
     PartitionUpsertMetadataManager partitionUpsertMetadataManager =
-        _tableUpsertMetadataManager != null ? _tableUpsertMetadataManager.getOrCreatePartitionManager(
-            partitionGroupId) : null;
+        _tableUpsertMetadataManager != null ? _tableUpsertMetadataManager.getOrCreatePartitionManager(partitionGroupId)
+            : null;
     PartitionDedupMetadataManager partitionDedupMetadataManager =
         _tableDedupMetadataManager != null ? _tableDedupMetadataManager.getOrCreatePartitionManager(partitionGroupId)
             : null;
@@ -488,6 +485,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
 
   @Override
   public void addSegment(ImmutableSegment immutableSegment) {
+    String segmentName = immutableSegment.getSegmentName();
+    Preconditions.checkState(!_shutDown, "Table data manager is already shut down, cannot add segment: %s to table: %s",
+        segmentName, _tableNameWithType);
     if (isUpsertEnabled()) {
       handleUpsert(immutableSegment);
       return;
@@ -646,17 +646,6 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     } finally {
       FileUtils.deleteQuietly(tempRootDir);
     }
-  }
-
-  /**
-   * Replaces a committed HLC REALTIME segment.
-   */
-  public void replaceHLSegment(SegmentZKMetadata segmentZKMetadata, IndexLoadingConfig indexLoadingConfig)
-      throws Exception {
-    ZKMetadataProvider.setSegmentZKMetadata(_propertyStore, _tableNameWithType, segmentZKMetadata);
-    File indexDir = new File(_indexDir, segmentZKMetadata.getSegmentName());
-    Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, _tableNameWithType);
-    addSegment(ImmutableSegmentLoader.load(indexDir, indexLoadingConfig, schema));
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -36,7 +36,6 @@ import org.apache.pinot.client.ResultSetGroup;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.core.query.utils.idset.IdSet;
 import org.apache.pinot.core.query.utils.idset.IdSets;
-import org.apache.pinot.server.starter.helix.BaseServerStarter;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -80,25 +79,6 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
    */
   protected int getNumQueriesToGenerate() {
     return DEFAULT_NUM_QUERIES_TO_GENERATE;
-  }
-
-  /**
-   * Test server table data manager deletion after the table is dropped
-   */
-  protected void cleanupTestTableDataManager(String tableNameWithType) {
-    TestUtils.waitForCondition(aVoid -> {
-      try {
-        for (BaseServerStarter serverStarter : _serverStarters) {
-          if (serverStarter.getServerInstance().getInstanceDataManager().getTableDataManager(tableNameWithType)
-              != null) {
-            return false;
-          }
-        }
-        return true;
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    }, 600_000L, "Failed to delete table data managers");
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseRealtimeClusterIntegrationTest.java
@@ -180,7 +180,7 @@ public abstract class BaseRealtimeClusterIntegrationTest extends BaseClusterInte
   public void tearDown()
       throws Exception {
     dropRealtimeTable(getTableName());
-    cleanupTestTableDataManager(TableNameBuilder.REALTIME.tableNameWithType(getTableName()));
+    waitForTableDataManagerRemoved(TableNameBuilder.REALTIME.tableNameWithType(getTableName()));
     stopServer();
     stopBroker();
     stopController();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -432,7 +432,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     }
     waitForNumOfSegmentsBecomeOnline(offlineTableName, 1);
     dropOfflineTable(SEGMENT_UPLOAD_TEST_TABLE);
-    cleanupTestTableDataManager(offlineTableName);
+    waitForTableDataManagerRemoved(offlineTableName);
   }
 
   private void waitForNumOfSegmentsBecomeOnline(String tableNameWithType, int numSegments)
@@ -2386,15 +2386,13 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     for (int i = 2; i < 20; i++) {
       query = String.format("SELECT distinctCountHLL(FlightNum, %d) FROM mytable ", i);
       assertEquals(postQuery(query).get("resultTable").get("rows").get(0).get(0).asLong(), expectedResults[i - 2]);
-      assertEquals(postQuery(query).get("resultTable").get("rows").get(0).get(0).asLong(),
-          expectedResults[i - 2]);
+      assertEquals(postQuery(query).get("resultTable").get("rows").get(0).get(0).asLong(), expectedResults[i - 2]);
     }
 
     // Default HLL is set as log2m=12
     query = "SELECT distinctCountHLL(FlightNum) FROM mytable ";
     assertEquals(postQuery(query).get("resultTable").get("rows").get(0).get(0).asLong(), expectedResults[10]);
-    assertEquals(postQuery(query).get("resultTable").get("rows").get(0).get(0).asLong(),
-        expectedResults[10]);
+    assertEquals(postQuery(query).get("resultTable").get("rows").get(0).get(0).asLong(), expectedResults[10]);
   }
 
   @Test

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -61,8 +61,8 @@ public interface TableDataManager {
   void start();
 
   /**
-   * Shuts down the table data manager. Should be called only once. After calling shut down, no other method should be
-   * called.
+   * Shuts down the table data manager. After calling shut down, no other method should be called.
+   * NOTE: Shut down might be called multiple times. The implementation should be able to handle that.
    */
   void shutDown();
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -33,7 +33,6 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.function.Supplier;
@@ -42,7 +41,9 @@ import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.tuple.Pair;
+import org.apache.helix.HelixDataAccessor;
 import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
@@ -214,26 +215,6 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   }
 
   @Override
-  public void addOfflineSegment(String offlineTableName, String segmentName, File indexDir)
-      throws Exception {
-    LOGGER.info("Adding segment: {} to table: {}", segmentName, offlineTableName);
-    TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, offlineTableName);
-    Preconditions.checkState(tableConfig != null, "Failed to find table config for table: %s", offlineTableName);
-    Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, tableConfig);
-    SegmentZKMetadata zkMetadata =
-        ZKMetadataProvider.getSegmentZKMetadata(_propertyStore, offlineTableName, segmentName);
-    Preconditions.checkState(zkMetadata != null, "Failed to find ZK metadata for offline segment: %s, table: %s",
-        segmentName, offlineTableName);
-
-    IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(_instanceDataManagerConfig, tableConfig, schema);
-    indexLoadingConfig.setSegmentTier(zkMetadata.getTier());
-
-    _tableDataManagerMap.computeIfAbsent(offlineTableName, k -> createTableDataManager(k, tableConfig))
-        .addSegment(indexDir, indexLoadingConfig);
-    LOGGER.info("Added segment: {} to table: {}", segmentName, offlineTableName);
-  }
-
-  @Override
   public void addRealtimeSegment(String realtimeTableName, String segmentName)
       throws Exception {
     LOGGER.info("Adding segment: {} to table: {}", segmentName, realtimeTableName);
@@ -264,28 +245,43 @@ public class HelixInstanceDataManager implements InstanceDataManager {
   @Override
   public void deleteTable(String tableNameWithType)
       throws Exception {
-    // Wait externalview to converge
-    long endTimeMs = System.currentTimeMillis() + _externalViewDroppedMaxWaitMs;
-    do {
-      ExternalView externalView = _helixManager.getHelixDataAccessor()
-          .getProperty(_helixManager.getHelixDataAccessor().keyBuilder().externalView(tableNameWithType));
-      if (externalView == null) {
-        LOGGER.info("ExternalView converged for the table to delete: {}", tableNameWithType);
-        _tableDataManagerMap.compute(tableNameWithType, (k, v) -> {
-          if (v != null) {
-            v.shutDown();
-            LOGGER.info("Removed table: {}", tableNameWithType);
-          } else {
-            LOGGER.warn("Failed to find table data manager for table: {}, skip removing the table", tableNameWithType);
-          }
-          return null;
-        });
-        return;
-      }
-      Thread.sleep(_externalViewDroppedCheckInternalMs);
-    } while (System.currentTimeMillis() < endTimeMs);
-    throw new TimeoutException(
-        "Timeout while waiting for ExternalView to converge for the table to delete: " + tableNameWithType);
+    TableDataManager tableDataManager = _tableDataManagerMap.get(tableNameWithType);
+    if (tableDataManager == null) {
+      LOGGER.warn("Failed to find table data manager for table: {}, skip deleting the table", tableNameWithType);
+      return;
+    }
+    LOGGER.info("Shutting down table data manager for table: {}", tableNameWithType);
+    tableDataManager.shutDown();
+    LOGGER.info("Finished shutting down table data manager for table: {}", tableNameWithType);
+
+    try {
+      // Wait for external view to disappear or become empty before removing the table data manager.
+      //
+      // When creating the table, controller will check whether the external view exists, and allow table creation only
+      // if it doesn't exist. If the table is recreated just after external view disappeared, there is a small chance
+      // that server won't realize the external view is removed because it is recreated before the server checks it. In
+      // order to handle this scenario, we want to remove the table data manager when the external view exists but is
+      // empty.
+      HelixDataAccessor helixDataAccessor = _helixManager.getHelixDataAccessor();
+      PropertyKey externalViewKey = helixDataAccessor.keyBuilder().externalView(tableNameWithType);
+      long endTimeMs = System.currentTimeMillis() + _externalViewDroppedMaxWaitMs;
+      do {
+        ExternalView externalView = helixDataAccessor.getProperty(externalViewKey);
+        if (externalView == null) {
+          LOGGER.info("ExternalView is dropped for table: {}", tableNameWithType);
+          return;
+        }
+        if (externalView.getRecord().getMapFields().isEmpty()) {
+          LOGGER.info("ExternalView is empty for table: {}", tableNameWithType);
+          return;
+        }
+        Thread.sleep(_externalViewDroppedCheckInternalMs);
+      } while (System.currentTimeMillis() < endTimeMs);
+      LOGGER.warn("ExternalView still exists after {}ms for table: {}", _externalViewDroppedMaxWaitMs,
+          tableNameWithType);
+    } finally {
+      _tableDataManagerMap.remove(tableNameWithType);
+    }
   }
 
   @Override

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -29,8 +29,6 @@ import org.apache.pinot.common.Utils;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
-import org.apache.pinot.common.utils.LLCSegmentName;
-import org.apache.pinot.common.utils.SegmentName;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.LLRealtimeSegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
@@ -75,49 +73,61 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
 
     @Transition(from = "OFFLINE", to = "CONSUMING")
     public void onBecomeConsumingFromOffline(Message message, NotificationContext context) {
-      Preconditions.checkState(SegmentName.isLowLevelConsumerSegmentName(message.getPartitionName()),
-          "Tried to go into CONSUMING state on non-low level segment");
       _logger.info("SegmentOnlineOfflineStateModel.onBecomeConsumingFromOffline() : " + message);
-      // We do the same processing as usual for going to the consuming state, which adds the segment to the table data
-      // manager and starts Kafka consumption
-      onBecomeOnlineFromOffline(message, context);
+      String realtimeTableName = message.getResourceName();
+      String segmentName = message.getPartitionName();
+      try {
+        _instanceDataManager.addRealtimeSegment(realtimeTableName, segmentName);
+      } catch (Exception e) {
+        String errorMessage =
+            String.format("Caught exception in state transition OFFLINE -> CONSUMING for table: %s, segment: %s",
+                realtimeTableName, segmentName);
+        _logger.error(errorMessage, e);
+        TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(realtimeTableName);
+        if (tableDataManager != null) {
+          tableDataManager.addSegmentError(segmentName,
+              new SegmentErrorInfo(System.currentTimeMillis(), errorMessage, e));
+        }
+        Utils.rethrowException(e);
+      }
     }
 
     @Transition(from = "CONSUMING", to = "ONLINE")
     public void onBecomeOnlineFromConsuming(Message message, NotificationContext context) {
+      _logger.info("SegmentOnlineOfflineStateModel.onBecomeOnlineFromConsuming() : " + message);
       String realtimeTableName = message.getResourceName();
-      String segmentNameStr = message.getPartitionName();
-      LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
-
+      String segmentName = message.getPartitionName();
       TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(realtimeTableName);
-      Preconditions.checkNotNull(tableDataManager);
-      tableDataManager.onConsumingToOnline(segmentNameStr);
-      SegmentDataManager acquiredSegment = tableDataManager.acquireSegment(segmentNameStr);
+      Preconditions.checkState(tableDataManager != null, "Failed to find table: %s", realtimeTableName);
+      tableDataManager.onConsumingToOnline(segmentName);
+      SegmentDataManager acquiredSegment = tableDataManager.acquireSegment(segmentName);
       // For this transition to be correct in helix, we should already have a segment that is consuming
-      if (acquiredSegment == null) {
-        throw new RuntimeException("Segment " + segmentNameStr + " + not present ");
-      }
+      Preconditions.checkState(acquiredSegment != null, "Failed to find segment: %s in table: %s", segmentName,
+          realtimeTableName);
 
       // TODO: https://github.com/apache/pinot/issues/10049
       try {
         if (!(acquiredSegment instanceof LLRealtimeSegmentDataManager)) {
           // We found an LLC segment that is not consuming right now, must be that we already swapped it with a
           // segment that has been built. Nothing to do for this state transition.
-          _logger
-              .info("Segment {} not an instance of LLRealtimeSegmentDataManager. Reporting success for the transition",
-                  acquiredSegment.getSegmentName());
+          _logger.info(
+              "Segment {} not an instance of LLRealtimeSegmentDataManager. Reporting success for the transition",
+              acquiredSegment.getSegmentName());
           return;
         }
         LLRealtimeSegmentDataManager segmentDataManager = (LLRealtimeSegmentDataManager) acquiredSegment;
-        SegmentZKMetadata segmentZKMetadata = ZKMetadataProvider
-            .getSegmentZKMetadata(_instanceDataManager.getPropertyStore(), realtimeTableName, segmentNameStr);
+        SegmentZKMetadata segmentZKMetadata =
+            ZKMetadataProvider.getSegmentZKMetadata(_instanceDataManager.getPropertyStore(), realtimeTableName,
+                segmentName);
         segmentDataManager.goOnlineFromConsuming(segmentZKMetadata);
-      } catch (InterruptedException e) {
-        String errorMessage = String.format("State transition interrupted for segment %s.", segmentNameStr);
-        _logger.warn(errorMessage, e);
-        tableDataManager
-            .addSegmentError(segmentNameStr, new SegmentErrorInfo(System.currentTimeMillis(), errorMessage, e));
-        throw new RuntimeException(e);
+      } catch (Exception e) {
+        String errorMessage =
+            String.format("Caught exception in state transition CONSUMING -> ONLINE for table: %s, segment: %s",
+                realtimeTableName, segmentName);
+        _logger.error(errorMessage, e);
+        tableDataManager.addSegmentError(segmentName,
+            new SegmentErrorInfo(System.currentTimeMillis(), errorMessage, e));
+        Utils.rethrowException(e);
       } finally {
         tableDataManager.releaseSegment(acquiredSegment);
       }
@@ -131,7 +141,7 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
       try {
         _instanceDataManager.offloadSegment(realtimeTableName, segmentName);
       } catch (Exception e) {
-        _logger.error("Caught exception in state transition from CONSUMING -> OFFLINE for resource: {}, partition: {}",
+        _logger.error("Caught exception in state transition CONSUMING -> OFFLINE for table: {}, segment: {}",
             realtimeTableName, segmentName, e);
         Utils.rethrowException(e);
       }
@@ -141,15 +151,16 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
     public void onBecomeDroppedFromConsuming(Message message, NotificationContext context) {
       _logger.info("SegmentOnlineOfflineStateModel.onBecomeDroppedFromConsuming() : " + message);
       String realtimeTableName = message.getResourceName();
-      String segmentNameStr = message.getPartitionName();
+      String segmentName = message.getPartitionName();
       TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(realtimeTableName);
-      Preconditions.checkNotNull(tableDataManager);
-      tableDataManager.onConsumingToDropped(segmentNameStr);
+      Preconditions.checkState(tableDataManager != null, "Failed to find table: %s", realtimeTableName);
+      tableDataManager.onConsumingToDropped(segmentName);
       try {
-        onBecomeOfflineFromConsuming(message, context);
-        onBecomeDroppedFromOffline(message, context);
-      } catch (final Exception e) {
-        _logger.error("Caught exception on CONSUMING -> DROPPED state transition", e);
+        _instanceDataManager.offloadSegment(realtimeTableName, segmentName);
+        _instanceDataManager.deleteSegment(realtimeTableName, segmentName);
+      } catch (Exception e) {
+        _logger.error("Caught exception in state transition CONSUMING -> DROPPED for table: {}, segment: {}",
+            realtimeTableName, segmentName, e);
         Utils.rethrowException(e);
       }
     }
@@ -160,7 +171,7 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
       String tableNameWithType = message.getResourceName();
       String segmentName = message.getPartitionName();
       try {
-        TableType tableType = TableNameBuilder.getTableTypeFromTableName(message.getResourceName());
+        TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
         Preconditions.checkNotNull(tableType);
         if (tableType == TableType.OFFLINE) {
           _instanceDataManager.addOrReplaceSegment(tableNameWithType, segmentName);
@@ -168,14 +179,14 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
           _instanceDataManager.addRealtimeSegment(tableNameWithType, segmentName);
         }
       } catch (Exception e) {
-        String errorMessage = String
-            .format("Caught exception in state transition from OFFLINE -> ONLINE for resource: %s, partition: %s",
+        String errorMessage =
+            String.format("Caught exception in state transition OFFLINE -> ONLINE for table: %s, segment: %s",
                 tableNameWithType, segmentName);
         _logger.error(errorMessage, e);
         TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(tableNameWithType);
         if (tableDataManager != null) {
-          tableDataManager
-              .addSegmentError(segmentName, new SegmentErrorInfo(System.currentTimeMillis(), errorMessage, e));
+          tableDataManager.addSegmentError(segmentName,
+              new SegmentErrorInfo(System.currentTimeMillis(), errorMessage, e));
         }
         Utils.rethrowException(e);
       }
@@ -191,7 +202,7 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
       try {
         _instanceDataManager.offloadSegment(tableNameWithType, segmentName);
       } catch (Exception e) {
-        _logger.error("Caught exception in state transition from ONLINE -> OFFLINE for resource: {}, partition: {}",
+        _logger.error("Caught exception in state transition ONLINE -> OFFLINE for table: {}, segment: {}",
             tableNameWithType, segmentName, e);
         Utils.rethrowException(e);
       }
@@ -205,8 +216,9 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
       String segmentName = message.getPartitionName();
       try {
         _instanceDataManager.deleteSegment(tableNameWithType, segmentName);
-      } catch (final Exception e) {
-        _logger.error("Cannot drop the segment : " + segmentName + " from server!\n" + e.getMessage(), e);
+      } catch (Exception e) {
+        _logger.error("Caught exception in state transition OFFLINE -> DROPPED for table: {}, segment: {}",
+            tableNameWithType, segmentName, e);
         Utils.rethrowException(e);
       }
     }
@@ -214,18 +226,35 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
     @Transition(from = "ONLINE", to = "DROPPED")
     public void onBecomeDroppedFromOnline(Message message, NotificationContext context) {
       _logger.info("SegmentOnlineOfflineStateModel.onBecomeDroppedFromOnline() : " + message);
+      String tableNameWithType = message.getResourceName();
+      String segmentName = message.getPartitionName();
       try {
-        onBecomeOfflineFromOnline(message, context);
-        onBecomeDroppedFromOffline(message, context);
-      } catch (final Exception e) {
-        _logger.error("Caught exception on ONLINE -> DROPPED state transition", e);
+        _instanceDataManager.offloadSegment(tableNameWithType, segmentName);
+        _instanceDataManager.deleteSegment(tableNameWithType, segmentName);
+      } catch (Exception e) {
+        _logger.error("Caught exception in state transition ONLINE -> DROPPED for table: {}, segment: {}",
+            tableNameWithType, segmentName, e);
         Utils.rethrowException(e);
       }
     }
 
     @Transition(from = "ERROR", to = "OFFLINE")
     public void onBecomeOfflineFromError(Message message, NotificationContext context) {
-      _logger.info("Resetting the state for segment:{} from ERROR to OFFLINE", message.getPartitionName());
+      _logger.info("SegmentOnlineOfflineStateModel.onBecomeOfflineFromError() : " + message);
+    }
+
+    @Transition(from = "ERROR", to = "DROPPED")
+    public void onBecomeDroppedFromError(Message message, NotificationContext context) {
+      _logger.info("SegmentOnlineOfflineStateModel.onBecomeDroppedFromError() : " + message);
+      String tableNameWithType = message.getResourceName();
+      String segmentName = message.getPartitionName();
+      try {
+        _instanceDataManager.deleteSegment(tableNameWithType, segmentName);
+      } catch (Exception e) {
+        _logger.error("Caught exception in state transition ERROR -> DROPPED for table: {}, segment: {}",
+            tableNameWithType, segmentName, e);
+        Utils.rethrowException(e);
+      }
     }
   }
 }


### PR DESCRIPTION
- Enhance `TableDataManager.shutdown()` to handle:
  - Active queries (decrease ref count instead of directly destroy the segment)
  - Block adding/replacing/refreshing/removing segment after shutdown
  - Destroy all segments
- Properly handle table deletion by first shutting down the table data manager, then wait for EV to disappear or empty
- This can also solve the slow segment removal problem for upsert tables
- Other bug fixes/cleanups:
  - In `SegmentOnlineOfflineStateModelFactory`, add ERROR -> DROPPED state transition to delete errored segment locally. Also clean up the logs to avoid one state transition causing multiple events to be logged
  - Fix `SegmentUploadIntegrationTest` which doesn't drop table properly