### PR TITLE
Upgrade jacoco plugin to use the new includeCurrentProject flag

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -115,7 +115,7 @@ jobs:
         continue-on-error: true
         timeout-minutes: 5
         with:
-          flags: unittests${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
+          flags: unittests,unittests${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-unit-tests
           fail_ci_if_error: false
           verbose: true
@@ -167,7 +167,7 @@ jobs:
         continue-on-error: true
         timeout-minutes: 5
         with:
-          flags: integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
+          flags: integration,integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
           name: codecov-integration-tests
           fail_ci_if_error: false
           verbose: true

--- a/pom.xml
+++ b/pom.xml
@@ -1520,7 +1520,7 @@
       <plugin>
         <groupId>org.jacoco</groupId>
         <artifactId>jacoco-maven-plugin</artifactId>
-        <version>0.8.6</version>
+        <version>0.8.9</version>
         <executions>
           <execution>
             <goals>
@@ -1533,6 +1533,9 @@
             <goals>
               <goal>report-aggregate</goal>
             </goals>
+            <configuration>
+              <includeCurrentProject>true</includeCurrentProject>
+            </configuration>
           </execution>
         </executions>
         <configuration>


### PR DESCRIPTION
This PR solves #11382 by upgrading jacoco maven plugin in order to set `includeCurrentProject` to true. The problem it fixes is explained in the issue. Some other alternatives are shown there, but it seems clear this brings the best results and it is very easy to implement