### PR TITLE
[multistage] Adding rule to skip SINGLE_VALUE aggregation function

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -102,6 +102,21 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
   }
 
   @Test
+  public void testSingleValueQuery()
+      throws Exception {
+    String query = "select sum(ActualElapsedTime) from mytable WHERE ActualElapsedTime > "
+        + "(select avg(ActualElapsedTime) as avg_profit from mytable)";
+    JsonNode jsonNode = postQuery(query);
+    long joinResult = jsonNode.get("resultTable").get("rows").get(0).get(0).asLong();
+
+    // The query of `SELECT avg(ActualElapsedTime) FROM mytable` is -1412.435033969449
+    query = "select sum(ActualElapsedTime) as profit from mytable WHERE ActualElapsedTime > -1412.435033969449";
+    jsonNode = postQuery(query);
+    long expectedResult = jsonNode.get("resultTable").get("rows").get(0).get(0).asLong();
+    assertEquals(joinResult, expectedResult);
+  }
+
+  @Test
   @Override
   public void testGeneratedQueries()
       throws Exception {

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
@@ -124,6 +124,7 @@ public class PinotQueryRuleSets {
       // copy exchanges down, this must be done after SortExchangeNodeInsertRule
       PinotSortExchangeCopyRule.SORT_EXCHANGE_COPY,
 
+      PinotSingleValueAggregateRemoveRule.INSTANCE,
       PinotJoinExchangeNodeInsertRule.INSTANCE,
       PinotAggregateExchangeNodeInsertRule.INSTANCE,
       PinotWindowExchangeNodeInsertRule.INSTANCE,

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotSingleValueAggregateRemoveRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotSingleValueAggregateRemoveRule.java
@@ -1,0 +1,59 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.hep.HepRelVertex;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.tools.RelBuilderFactory;
+
+
+/**
+ * SingleValueAggregateRemoveRule that matches an Aggregate function SINGLE_VALUE and remove it
+ *
+ */
+public class PinotSingleValueAggregateRemoveRule extends RelOptRule {
+  public static final PinotSingleValueAggregateRemoveRule INSTANCE =
+      new PinotSingleValueAggregateRemoveRule(PinotRuleUtils.PINOT_REL_FACTORY);
+
+  public PinotSingleValueAggregateRemoveRule(RelBuilderFactory factory) {
+    super(operand(LogicalAggregate.class, any()), factory, null);
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    final Aggregate agg = call.rel(0);
+    if (agg.getAggCallList().size() != 1) {
+      return false;
+    }
+    final AggregateCall aggCall = agg.getAggCallList().get(0);
+    return aggCall.getAggregation().getName().equals("SINGLE_VALUE");
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall call) {
+    final Aggregate agg = call.rel(0);
+    final RelNode input = ((HepRelVertex) agg.getInput()).getCurrentRel();
+    call.transformTo(input);
+  }
+}

--- a/pinot-query-planner/src/test/resources/queries/AggregatePlans.json
+++ b/pinot-query-planner/src/test/resources/queries/AggregatePlans.json
@@ -3,6 +3,28 @@
     "queries": [
       {
         "description": "Select AVG aggregation for a BIG_DECIMAL column, TODO:(No need to cast in LogicalProject)",
+        "sql": "EXPLAIN PLAN FOR SELECT AVG(a.col4) as avg FROM a WHERE a.col3 >= (SELECT AVG(a.col4) FROM a)",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(avg=[CAST(/(CASE(=($1, 0), null:DECIMAL(1000, 0), $0), $1)):DECIMAL(1000, 0)])",
+          "\n  LogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)])",
+          "\n    PinotLogicalExchange(distribution=[hash])",
+          "\n      LogicalAggregate(group=[{}], agg#0=[$SUM0($1)], agg#1=[COUNT()])",
+          "\n        LogicalJoin(condition=[>=($0, $2)], joinType=[inner])",
+          "\n          PinotLogicalExchange(distribution=[random])",
+          "\n            LogicalProject(col3=[$2], col4=[$3])",
+          "\n              LogicalTableScan(table=[[a]])",
+          "\n          PinotLogicalExchange(distribution=[broadcast])",
+          "\n            LogicalProject(EXPR$0=[CAST(/(CASE(=($1, 0), null:DECIMAL(1000, 0), $0), $1)):DECIMAL(1000, 0)])",
+          "\n              LogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)])",
+          "\n                PinotLogicalExchange(distribution=[hash])",
+          "\n                  LogicalAggregate(group=[{}], agg#0=[$SUM0($3)], agg#1=[COUNT()])",
+          "\n                    LogicalTableScan(table=[[a]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Select AVG aggregation for a BIG_DECIMAL column, TODO:(No need to cast in LogicalProject)",
         "sql": "EXPLAIN PLAN FOR SELECT AVG(a.col4) as avg FROM a WHERE a.col3 >= 0 AND a.col2 = 'pink floyd'",
         "output": [
           "Execution Plan",


### PR DESCRIPTION
`SINGLE_VALUE` is a data integrity check, so we can skip it.

Attached the current exceptions/stacktrace for query:
`select  sum(ActualElapsedTime) from mytable WHERE ActualElapsedTime > (select avg(ActualElapsedTime) as avg_profit from mytable)`

```
Caught exception while compiling SQL request 95713964000000001: select  sum(ActualElapsedTime) from mytable WHERE ActualElapsedTime > 
(select avg(ActualElapsedTime) as avg_profit from mytable) 
, Error composing query plan for: select  sum(ActualElapsedTime) from mytable WHERE ActualElapsedTime > 
(select avg(ActualElapsedTime) as avg_profit from mytable) 

org.apache.pinot.query.QueryEnvironment.planQuery(QueryEnvironment.java:182)
org.apache.pinot.broker.requesthandler.MultiStageBrokerRequestHandler.handleRequest(MultiStageBrokerRequestHandler.java:152)
org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:263)
org.apache.pinot.broker.requesthandler.BrokerRequestHandler.handleRequest(BrokerRequestHandler.java:48)
Cannot generate a valid execution plan for the given query: LogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
  LogicalProject(ActualElapsedTime=[$0])
    LogicalFilter(condition=[>($0, $1)])
      LogicalJoin(condition=[true], joinType=[left])
        LogicalProject(ActualElapsedTime=[$3])
          LogicalTableScan(table=[[mytable]])
        LogicalAggregate(group=[{}], agg#0=[SINGLE_VALUE($0)])
          LogicalAggregate(group=[{}], avg_profit=[AVG($0)])
            LogicalProject(ActualElapsedTime=[$3])
              LogicalTableScan(table=[[mytable]])

org.apache.pinot.query.QueryEnvironment.optimize(QueryEnvironment.java:342)
org.apache.pinot.query.QueryEnvironment.compileQuery(QueryEnvironment.java:284)
org.apache.pinot.query.QueryEnvironment.planQuery(QueryEnvironment.java:173)
org.apache.pinot.broker.requesthandler.MultiStageBrokerRequestHandler.handleRequest(MultiStageBrokerRequestHandler.java:152)
Invalid aggregation function name: SINGLE_VALUE
org.apache.pinot.segment.spi.AggregationFunctionType.getAggregationFunctionType(AggregationFunctionType.java:454)
org.apache.calcite.rel.rules.PinotAggregateExchangeNodeInsertRule.buildAggregateCall(PinotAggregateExchangeNodeInsertRule.java:295)
org.apache.calcite.rel.rules.PinotAggregateExchangeNodeInsertRule.convertAggForLeafInput(PinotAggregateExchangeNodeInsertRule.java:243)
org.apache.calcite.rel.rules.PinotAggregateExchangeNodeInsertRule.createPlanWithLeafExchangeFinalAggregate(PinotAggregateExchangeNodeInsertRule.java:147)

jsonNode = {"requestId":"95713964000000001","brokerId":"Broker_192.168.86.250_18099","exceptions":[{"message":"SQLParsingError:
Error composing query plan for: select  sum(ActualElapsedTime) from mytable WHERE ActualElapsedTime > 
(select avg(ActualElapsedTime) as avg_profit from mytable) 

org.apache.pinot.query.QueryEnvironment.planQuery(QueryEnvironment.java:182)
org.apache.pinot.broker.requesthandler.MultiStageBrokerRequestHandler.handleRequest(MultiStageBrokerRequestHandler.java:152)
org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:263)
org.apache.pinot.broker.requesthandler.BrokerRequestHandler.handleRequest(BrokerRequestHandler.java:48)
Cannot generate a valid execution plan for the given query: LogicalAggregate(group=[{}], EXPR$0=[SUM($0)])
  LogicalProject(ActualElapsedTime=[$0])
    LogicalFilter(condition=[>($0, $1)])
      LogicalJoin(condition=[true], joinType=[left])
        LogicalProject(ActualElapsedTime=[$3])
          LogicalTableScan(table=[[mytable]])
        LogicalAggregate(group=[{}], agg#0=[SINGLE_VALUE($0)])
          LogicalAggregate(group=[{}], avg_profit=[AVG($0)])
            LogicalProject(ActualElapsedTime=[$3])
              LogicalTableScan(table=[[mytable]])

org.apache.pinot.query.QueryEnvironment.optimize(QueryEnvironment.java:342)
org.apache.pinot.query.QueryEnvironment.compileQuery(QueryEnvironment.java:284)
org.apache.pinot.query.QueryEnvironment.planQuery(QueryEnvironment.java:173)
org.apache.pinot.broker.requesthandler.MultiStageBrokerRequestHandler.handleRequest(MultiStageBrokerRequestHandler.java:152)
Invalid aggregation function name: SINGLE_VALUE
org.apache.pinot.segment.spi.AggregationFunctionType.getAggregationFunctionType(AggregationFunctionType.java:454)
org.apache.calcite.rel.rules.PinotAggregateExchangeNodeInsertRule.buildAggregateCall(PinotAggregateExchangeNodeInsertRule.java:295)
org.apache.calcite.rel.rules.PinotAggregateExchangeNodeInsertRule.convertAggForLeafInput(PinotAggregateExchangeNodeInsertRule.java:243)
org.apache.calcite.rel.rules.PinotAggregateExchangeNodeInsertRule.createPlanWithLeafExchangeFinalAggregate(PinotAggregateExchangeNodeInsertRule.java:147)
","errorCode":150}],"numServersQueried":0,"numServersResponded":0,"numSegmentsQueried":0,"numSegmentsProcessed":0,"numSegmentsMatched":0,"numConsumingSegmentsQueried":0,"numConsumingSegmentsProcessed":0,"numConsumingSegmentsMatched":0,"numDocsScanned":0,"numEntriesScannedInFilter":0,"numEntriesScannedPostFilter":0,"numGroupsLimitReached":false,"totalDocs":0,"timeUsedMs":0,"offlineThreadCpuTimeNs":0,"realtimeThreadCpuTimeNs":0,"offlineSystemActivitiesCpuTimeNs":0,"realtimeSystemActivitiesCpuTimeNs":0,"offlineResponseSerializationCpuTimeNs":0,"realtimeResponseSerializationCpuTimeNs":0,"offlineTotalCpuTimeNs":0,"realtimeTotalCpuTimeNs":0,"brokerReduceTimeMs":0,"segmentStatistics":[],"traceInfo":{},"numRowsResultSet":0,"minConsumingFreshnessTimeMs":0,"numSegmentsPrunedByBroker":0,"numSegmentsPrunedByServer":0,"numSegmentsPrunedInvalid":0,"numSegmentsPrunedByLimit":0,"numSegmentsPrunedByValue":0,"explainPlanNumEmptyFilterSegments":0,"explainPlanNumMatchAllFilterSegments":0}
```