### PR TITLE
[multistage] Fixing the stale pinot ServerInstance in BrokerRoutingMananger tableTenantServersMap

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
@@ -837,8 +837,12 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
 
       Map<String, ServerInstance> tenantServerMap = entry.getValue();
 
-      if (!tenantServerMap.containsKey(instanceId) && tags.contains(tableServerTag)) {
+      if (tags.contains(tableServerTag)) {
+        // ServerInstance might got updated for internal fields like queryServicePort, queryMailboxPort, etc,
+        // so always update the tenantServerMap with the latest serverInstance
         tenantServerMap.put(instanceId, serverInstance);
+      } else {
+        tenantServerMap.remove(instanceId);
       }
     }
   }


### PR DESCRIPTION
For `BrokerRoutingMananger`, the `ServerInstance` inside `_tableTenantServersMap` is not updated during a server restart. The stale `ServerInstance` was still kept.

How to reproduce:
0. Start 1 controller, 1 broker, 3 servers (0, 1, 2)
1. bring down broker, server 0
2. start broker 
3. start server 0
4. all query failed due to grpc connection refused issue, which turns out that it tries to use to server0's previous life `_queryServicePort` and `_queryMailboxPort`.


What happened:
1. One running server is down
2. Broker got restarted, read the old ServerInstance to form `_tableTenantServersMap`
3. When the server coming back online, it updates its own `ServerInstance`, which triggers the `BrokerRoutingMananger` to `processClusterChange`, and updated `_enabledServerInstanceMap`, however due to old `ServerInstance` already kept in `_tableTenantServersMap`, so it won't update the `ServerInstance` with new fields like `_queryServicePort` or `_queryMailboxPort`.


Fix:
Always update `ServerInstance` when possible for `_tableTenantServersMap`, also proactively remove `ServerInstance` if possible.