### PR TITLE
Fix casting issue when casting compatible types

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -253,7 +253,7 @@ public class DataSchema {
     }
 
     public boolean isNumber() {
-      return NUMERIC_TYPES.contains(this);
+      return NUMERIC_TYPES.contains(this.getStoredType());
     }
 
     public boolean isWholeNumber() {
@@ -288,7 +288,7 @@ public class DataSchema {
     public boolean isSuperTypeOf(ColumnDataType subTypeCandidate) {
       if (this.isNumber() && subTypeCandidate.isNumber() && this != BIG_DECIMAL && subTypeCandidate != BIG_DECIMAL) {
         // NUMBER subtype check using type hoisting rules defined in NUMERIC_TYPE_ORDERING
-        return NUMERIC_TYPE_ORDERING.max(this, subTypeCandidate) == this;
+        return NUMERIC_TYPE_ORDERING.max(this.getStoredType(), subTypeCandidate.getStoredType()) == this;
       } else if (subTypeCandidate == BOOLEAN) {
         // BOOLEAN type is sub-type of any number type, checking whether it is equal to 1.
         return this == subTypeCandidate || (this.isNumber() && this != BIG_DECIMAL);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -253,7 +253,7 @@ public class DataSchema {
     }
 
     public boolean isNumber() {
-      return NUMERIC_TYPES.contains(this.getStoredType());
+      return NUMERIC_TYPES.contains(this);
     }
 
     public boolean isWholeNumber() {
@@ -286,10 +286,17 @@ public class DataSchema {
      * @see DataSchema.ColumnDataType#convert(Object)
      */
     public boolean isSuperTypeOf(ColumnDataType subTypeCandidate) {
+      if (this == subTypeCandidate) {
+        return true;
+      }
+
+      if (subTypeCandidate.getStoredType() != subTypeCandidate) {
+        return this.isSuperTypeOf(subTypeCandidate.getStoredType());
+      }
+
       if (this.isNumber() && subTypeCandidate.isNumber() && this != BIG_DECIMAL && subTypeCandidate != BIG_DECIMAL) {
         // NUMBER subtype check using type hoisting rules defined in NUMERIC_TYPE_ORDERING
-        return NUMERIC_TYPE_ORDERING.max(this.getStoredType(), subTypeCandidate.getStoredType())
-            == this.getStoredType();
+        return NUMERIC_TYPE_ORDERING.max(this, subTypeCandidate) == this;
       } else if (subTypeCandidate == BOOLEAN) {
         // BOOLEAN type is sub-type of any number type, checking whether it is equal to 1.
         return this == subTypeCandidate || (this.isNumber() && this != BIG_DECIMAL);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -288,7 +288,8 @@ public class DataSchema {
     public boolean isSuperTypeOf(ColumnDataType subTypeCandidate) {
       if (this.isNumber() && subTypeCandidate.isNumber() && this != BIG_DECIMAL && subTypeCandidate != BIG_DECIMAL) {
         // NUMBER subtype check using type hoisting rules defined in NUMERIC_TYPE_ORDERING
-        return NUMERIC_TYPE_ORDERING.max(this.getStoredType(), subTypeCandidate.getStoredType()) == this;
+        return NUMERIC_TYPE_ORDERING.max(this.getStoredType(), subTypeCandidate.getStoredType())
+            == this.getStoredType();
       } else if (subTypeCandidate == BOOLEAN) {
         // BOOLEAN type is sub-type of any number type, checking whether it is equal to 1.
         return this == subTypeCandidate || (this.isNumber() && this != BIG_DECIMAL);

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
@@ -74,10 +74,12 @@ public class DataSchemaTest {
       for (DataSchema.ColumnDataType candidateType : DataSchema.ColumnDataType.values()) {
         if (testType == candidateType) {
           // all type should be sub-type of themselves.
-          Assert.assertTrue(testType.isSuperTypeOf(candidateType));
+          Assert.assertTrue(testType.isSuperTypeOf(candidateType),
+              testType + " should be super type of " + candidateType);
         } else if (!numberTypeToTest.contains(testType)) {
           // other than number type, nothing should be sub-type of another type.
-          Assert.assertFalse(testType.isSuperTypeOf(candidateType));
+          Assert.assertFalse(testType.isSuperTypeOf(candidateType),
+              testType + " should not be super type of " + candidateType);
         }
       }
     }

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
@@ -87,10 +87,12 @@ public class DataSchemaTest {
     // number super type relationship should be in exactly the order in the list above.
     for (int idx = 0; idx < numberTypeToTest.size(); idx++) {
       for (int subTypeIdx = 0; subTypeIdx <= idx; subTypeIdx++) {
-        Assert.assertTrue(numberTypeToTest.get(idx).isSuperTypeOf(numberTypeToTest.get(subTypeIdx)));
+        Assert.assertTrue(numberTypeToTest.get(idx).isSuperTypeOf(numberTypeToTest.get(subTypeIdx)),
+            numberTypeToTest.get(idx) + " should be super type of " + numberTypeToTest.get(subTypeIdx));
       }
       for (int subTypeIdx = idx + 1; subTypeIdx < numberTypeToTest.size(); subTypeIdx++) {
-        Assert.assertFalse(numberTypeToTest.get(idx).isSuperTypeOf(numberTypeToTest.get(subTypeIdx)));
+        Assert.assertFalse(numberTypeToTest.get(idx).isSuperTypeOf(numberTypeToTest.get(subTypeIdx)),
+            numberTypeToTest.get(idx) + " should not be super type of " + numberTypeToTest.get(subTypeIdx));
       }
     }
 
@@ -99,6 +101,17 @@ public class DataSchemaTest {
       Assert.assertTrue(numberTypeToTest.get(idx).isSuperTypeOf(BOOLEAN));
       Assert.assertFalse(BOOLEAN.isSuperTypeOf(numberTypeToTest.get(idx)));
     }
+  }
+
+  @Test
+  public void testNonPrimitiveTypeDerivations() {
+    Assert.assertFalse(TIMESTAMP.isSuperTypeOf(INT));
+    Assert.assertFalse(INT.isSuperTypeOf(TIMESTAMP));
+    Assert.assertTrue(LONG.isSuperTypeOf(TIMESTAMP));
+    Assert.assertFalse(TIMESTAMP.isSuperTypeOf(LONG));
+
+    Assert.assertTrue(STRING.isSuperTypeOf(JSON));
+    Assert.assertFalse(JSON.isSuperTypeOf(STRING));
   }
 
   @Test


### PR DESCRIPTION
```
SELECT CAST(TIMESTAMPADD(DAY, 1, "Calcs"."date2") AS TIMESTAMP) AS "TEMP_Test__670684053__0_"
FROM "Calcs"
GROUP BY "TEMP_Test__670684053__0_"

```
seems to fail with 

```
"errorCode": 200,
    "message": "QueryExecutionError:\njava.lang.RuntimeException: Error executing query: [0]@127.0.0.1:64177 MAIL_RECEIVE(RANDOM_DISTRIBUTED)\n└── [1]@127.0.0.1:64185 MAIL_SEND(RANDOM_DISTRIBUTED)->{[0]@127.0.0.1@{64177,64177}|[0]}\n   └── [1]@127.0.0.1:64185 AGGREGATE_FINAL\n      └── [1]@127.0.0.1:64185 MAIL_RECEIVE(HASH_DISTRIBUTED)\n         └── [2]@127.0.0.1:64185 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@127.0.0.1@{64185,64186}|[0]}\n...\nCaused by: java.lang.RuntimeException: Received error query execution result block: {1000=Incompatible selection result data schema:  Expected: [TEMP_Test__670684053__0_(TIMESTAMP)]. Actual: [plus(date2,times('86400000','1'))(DOUBLE)]\njava.lang.IllegalStateException: Incompatible selection result data schema:  Expected: [TEMP_Test__670684053__0_(TIMESTAMP)]. Actual: [plus(date2,times('86400000','1'))(DOUBLE)]\n\tat com.google.common.base.Preconditions.checkState(Preconditions.java:512)\n\tat org.apache.pinot.query.runtime.operator.LeafStageTransferableBlockOperator.composeDistinctTransferableBlock(LeafStageTransferableBlockOperator.java:181)\n\tat org.apache.pinot.query.runtime.operator.LeafStageTransferableBlockOperator.composeTransferableBlock(LeafStageTransferableBlockOperator.java:160)"
    ```