### PR TITLE
Add extract(quarter/dow/doy) support

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunction.java
@@ -36,7 +36,7 @@ public class ExtractTransformFunction extends BaseTransformFunction {
   protected Chronology _chronology = ISOChronology.getInstanceUTC();
 
   private enum Field {
-    YEAR, MONTH, DAY, DOW, HOUR, MINUTE, SECOND, QUARTER
+    YEAR, MONTH, DAY, DOY, DOW, HOUR, MINUTE, SECOND, QUARTER
   }
 
   @Override
@@ -90,6 +90,10 @@ public class ExtractTransformFunction extends BaseTransformFunction {
           break;
         case DOW:
           accessor = _chronology.dayOfWeek();
+          output[i] = accessor.get(timestamps[i]);
+          break;
+        case DOY:
+          accessor = _chronology.dayOfYear();
           output[i] = accessor.get(timestamps[i]);
           break;
         case HOUR:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunction.java
@@ -36,7 +36,7 @@ public class ExtractTransformFunction extends BaseTransformFunction {
   protected Chronology _chronology = ISOChronology.getInstanceUTC();
 
   private enum Field {
-    YEAR, MONTH, DAY, HOUR, MINUTE, SECOND
+    YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, QUARTER
   }
 
   @Override
@@ -75,6 +75,10 @@ public class ExtractTransformFunction extends BaseTransformFunction {
         case YEAR:
           accessor = _chronology.year();
           output[i] = accessor.get(timestamps[i]);
+          break;
+        case QUARTER:
+          accessor = _chronology.monthOfYear();
+          output[i] = (accessor.get(timestamps[i]) - 1) / 3 + 1;
           break;
         case MONTH:
           accessor = _chronology.monthOfYear();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunction.java
@@ -36,7 +36,7 @@ public class ExtractTransformFunction extends BaseTransformFunction {
   protected Chronology _chronology = ISOChronology.getInstanceUTC();
 
   private enum Field {
-    YEAR, MONTH, DAY, DOY, DOW, HOUR, MINUTE, SECOND, QUARTER
+    YEAR, QUARTER, MONTH, DAY, DOY, DOW, HOUR, MINUTE, SECOND
   }
 
   @Override
@@ -88,12 +88,12 @@ public class ExtractTransformFunction extends BaseTransformFunction {
           accessor = _chronology.dayOfMonth();
           output[i] = accessor.get(timestamps[i]);
           break;
-        case DOW:
-          accessor = _chronology.dayOfWeek();
-          output[i] = accessor.get(timestamps[i]);
-          break;
         case DOY:
           accessor = _chronology.dayOfYear();
+          output[i] = accessor.get(timestamps[i]);
+          break;
+        case DOW:
+          accessor = _chronology.dayOfWeek();
           output[i] = accessor.get(timestamps[i]);
           break;
         case HOUR:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ExtractTransformFunction.java
@@ -36,7 +36,7 @@ public class ExtractTransformFunction extends BaseTransformFunction {
   protected Chronology _chronology = ISOChronology.getInstanceUTC();
 
   private enum Field {
-    YEAR, MONTH, DAY, HOUR, MINUTE, SECOND, QUARTER
+    YEAR, MONTH, DAY, DOW, HOUR, MINUTE, SECOND, QUARTER
   }
 
   @Override
@@ -86,6 +86,10 @@ public class ExtractTransformFunction extends BaseTransformFunction {
           break;
         case DAY:
           accessor = _chronology.dayOfMonth();
+          output[i] = accessor.get(timestamps[i]);
+          break;
+        case DOW:
+          accessor = _chronology.dayOfWeek();
           output[i] = accessor.get(timestamps[i]);
           break;
         case HOUR:

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/TimestampTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/TimestampTest.java
@@ -138,7 +138,10 @@ public class TimestampTest extends CustomDataQueryClusterIntegrationTest {
         + "WEEK_OF_YEAR(ts1), WEEK_OF_YEAR(ts2),\n"
         + "DAY_OF_YEAR(ts1), DAY_OF_YEAR(ts2),\n"
         + "DAY_OF_MONTH(ts1), DAY_OF_MONTH(ts2),\n"
-        + "DAY_OF_WEEK(ts1), DAY_OF_WEEK(ts2)\n"
+        + "DAY_OF_WEEK(ts1), DAY_OF_WEEK(ts2),\n"
+        + "DOY(ts1), DOY(ts2),\n"
+        + "DOW(ts1), DOW(ts2),\n"
+        + "QUARTER(ts1), QUARTER(ts2)\n"
         + "FROM %s\n"
         + "LIMIT %d\n", getTableName(), getCountStarResult());
     JsonNode jsonNode = postQuery(query);
@@ -165,6 +168,12 @@ public class TimestampTest extends CustomDataQueryClusterIntegrationTest {
           jsonNode.get("resultTable").get("rows").get(i).get(19).asInt());
       assertEquals(jsonNode.get("resultTable").get("rows").get(i).get(20).asInt(),
           jsonNode.get("resultTable").get("rows").get(i).get(21).asInt());
+      assertEquals(jsonNode.get("resultTable").get("rows").get(i).get(22).asInt(),
+          jsonNode.get("resultTable").get("rows").get(i).get(23).asInt());
+      assertEquals(jsonNode.get("resultTable").get("rows").get(i).get(24).asInt(),
+          jsonNode.get("resultTable").get("rows").get(i).get(25).asInt());
+      assertEquals(jsonNode.get("resultTable").get("rows").get(i).get(26).asInt(),
+          jsonNode.get("resultTable").get("rows").get(i).get(27).asInt());
     }
   }
 


### PR DESCRIPTION
```
SELECT quarter(date2) FROM "Calcs"
```
 fails on V2 with

```
Caused by: java.lang.IllegalArgumentException: No enum constant org.apache.pinot.core.operator.transform.function.ExtractTransformFunction.Field.QUARTER\
```
because calcite rewriter implicitly converts it to a extract query