### PR TITLE
Fix the thread safety issue for mutable forward index

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.local.realtime.impl.forward;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.pinot.segment.local.io.reader.impl.FixedByteSingleValueMultiColReader;
 import org.apache.pinot.segment.local.io.writer.impl.FixedByteSingleValueMultiColWriter;
 import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
@@ -89,7 +90,6 @@ import org.slf4j.LoggerFactory;
  * </code>
  *
  */
-// TODO: Fix thread-safety issue for ArrayList
 // TODO: Optimize it
 public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
   private static final Logger LOGGER = LoggerFactory.getLogger(FixedByteMVMutableForwardIndex.class);
@@ -104,10 +104,11 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
   private static final int INCREMENT_PERCENTAGE = 100;
   //Increments the Initial size by 100% of initial capacity every time we runs out of capacity
 
+  // For single writer multiple readers setup, use ArrayList for writer and CopyOnWriteArrayList for reader
   private final List<FixedByteSingleValueMultiColWriter> _headerWriters = new ArrayList<>();
-  private final List<FixedByteSingleValueMultiColReader> _headerReaders = new ArrayList<>();
+  private final List<FixedByteSingleValueMultiColReader> _headerReaders = new CopyOnWriteArrayList<>();
   private final List<FixedByteSingleValueMultiColWriter> _dataWriters = new ArrayList<>();
-  private final List<FixedByteSingleValueMultiColReader> _dataReaders = new ArrayList<>();
+  private final List<FixedByteSingleValueMultiColReader> _dataReaders = new CopyOnWriteArrayList<>();
   private final int _headerSize;
   private final int _incrementalCapacity;
   private final int _columnSizeInBytes;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteSVMutableForwardIndex.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
 import org.apache.pinot.segment.local.io.reader.impl.FixedByteSingleValueMultiColReader;
 import org.apache.pinot.segment.local.io.writer.impl.FixedByteSingleValueMultiColWriter;
 import org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex;
@@ -44,13 +45,13 @@ import org.slf4j.LoggerFactory;
  *   are not guaranteed to have a deterministic value. </li>
  * </ul>
  */
-// TODO: Fix thread-safety issue for ArrayList
 // TODO: Optimize it
 public class FixedByteSVMutableForwardIndex implements MutableForwardIndex {
   private static final Logger LOGGER = LoggerFactory.getLogger(FixedByteSVMutableForwardIndex.class);
 
+  // For single writer multiple readers setup, use ArrayList for writer and CopyOnWriteArrayList for reader
   private final List<WriterWithOffset> _writers = new ArrayList<>();
-  private final List<ReaderWithOffset> _readers = new ArrayList<>();
+  private final List<ReaderWithOffset> _readers = new CopyOnWriteArrayList<>();
 
   private final boolean _dictionaryEncoded;
   private final DataType _storedType;


### PR DESCRIPTION
Solve #11311 

Use `CopyOnWriteArrayList` to maintain the reader list.