### PR TITLE
Fix intermediate stage routing for multi-stage engine

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/BrokerRoutingManager.java
@@ -58,8 +58,6 @@ import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.HashUtil;
-import org.apache.pinot.common.utils.config.TagNameUtils;
-import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.core.routing.RoutingManager;
 import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.TablePartitionInfo;
@@ -109,16 +107,11 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
   private final ServerRoutingStatsManager _serverRoutingStatsManager;
   private final PinotConfiguration _pinotConfig;
 
-  // Map that contains the tableNameWithType as key and the enabled serverInstances that are tagged with the table's
-  // tenant.
-  private final Map<String, Map<String, ServerInstance>> _tableTenantServersMap = new ConcurrentHashMap<>();
-
   private BaseDataAccessor<ZNRecord> _zkDataAccessor;
   private String _externalViewPathPrefix;
   private String _idealStatePathPrefix;
   private String _instanceConfigsPath;
   private ZkHelixPropertyStore<ZNRecord> _propertyStore;
-  private HelixManager _helixManager;
 
   private Set<String> _routableServers;
 
@@ -137,7 +130,6 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     _idealStatePathPrefix = helixDataAccessor.keyBuilder().idealStates().getPath() + "/";
     _instanceConfigsPath = helixDataAccessor.keyBuilder().instanceConfigs().getPath();
     _propertyStore = helixManager.getHelixPropertyStore();
-    _helixManager = helixManager;
   }
 
   @Override
@@ -266,8 +258,6 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
           if (_excludedServers.remove(instanceId)) {
             LOGGER.info("Got excluded server: {} re-enabled, including it into the routing", instanceId);
           }
-
-          addNewServerToTableTenantServerMap(instanceId, serverInstance, instanceConfig);
         }
       }
     }
@@ -275,19 +265,16 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     for (String instance : _enabledServerInstanceMap.keySet()) {
       if (!enabledServers.contains(instance)) {
         newDisabledServers.add(instance);
-        deleteServerFromTableTenantServerMap(instance);
       }
     }
 
     // Calculate the routable servers and the changed routable servers
     List<String> changedServers = new ArrayList<>(newEnabledServers.size() + newDisabledServers.size());
     if (_excludedServers.isEmpty()) {
-      _routableServers = enabledServers;
       changedServers.addAll(newEnabledServers);
       changedServers.addAll(newDisabledServers);
     } else {
       enabledServers.removeAll(_excludedServers);
-      _routableServers = enabledServers;
       // NOTE: All new enabled servers are routable
       changedServers.addAll(newEnabledServers);
       for (String newDisabledServer : newDisabledServers) {
@@ -296,6 +283,7 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
         }
       }
     }
+    _routableServers = enabledServers;
     long calculateChangedServersEndTimeMs = System.currentTimeMillis();
 
     // Early terminate if there is no changed servers
@@ -424,9 +412,6 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
 
     TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
     Preconditions.checkState(tableConfig != null, "Failed to find table config for table: %s", tableNameWithType);
-
-    // Build a mapping from the table to the list of servers assigned to the table's tenant.
-    buildTableTenantServerMap(tableNameWithType, tableConfig);
 
     String idealStatePath = getIdealStatePath(tableNameWithType);
     IdealState idealState = getIdealState(idealStatePath);
@@ -587,10 +572,6 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     } else {
       LOGGER.warn("Routing does not exist for table: {}, skipping removing routing", tableNameWithType);
     }
-
-    if (_tableTenantServersMap.remove(tableNameWithType) != null) {
-      LOGGER.info("Removed tenant servers for table: {}", tableNameWithType);
-    }
   }
 
   /**
@@ -649,11 +630,6 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     return _enabledServerInstanceMap;
   }
 
-  @Override
-  public Map<String, ServerInstance> getEnabledServersForTableTenant(String tableNameWithType) {
-    return _tableTenantServersMap.getOrDefault(tableNameWithType, Collections.emptyMap());
-  }
-
   private String getIdealStatePath(String tableNameWithType) {
     return _idealStatePathPrefix + tableNameWithType;
   }
@@ -687,6 +663,16 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
     }
     SegmentPartitionMetadataManager partitionMetadataManager = routingEntry.getPartitionMetadataManager();
     return partitionMetadataManager != null ? partitionMetadataManager.getTablePartitionInfo() : null;
+  }
+
+  @Nullable
+  @Override
+  public Set<String> getServingInstances(String tableNameWithType) {
+    RoutingEntry routingEntry = _routingEntryMap.get(tableNameWithType);
+    if (routingEntry == null) {
+      return null;
+    }
+    return routingEntry._instanceSelector.getServingInstances();
   }
 
   /**
@@ -810,60 +796,6 @@ public class BrokerRoutingManager implements RoutingManager, ClusterChangeHandle
         return selectionResult;
       } else {
         return new InstanceSelector.SelectionResult(Collections.emptyMap(), Collections.emptyList(), numPrunedSegments);
-      }
-    }
-  }
-
-  private void buildTableTenantServerMap(String tableNameWithType, TableConfig tableConfig) {
-    String serverTag = getServerTagForTable(tableNameWithType, tableConfig);
-    List<InstanceConfig> allInstanceConfigs = HelixHelper.getInstanceConfigs(_helixManager);
-    List<InstanceConfig> instanceConfigsWithTag = HelixHelper.getInstancesConfigsWithTag(allInstanceConfigs, serverTag);
-    Map<String, ServerInstance> serverInstances = new HashMap<>();
-    for (InstanceConfig serverInstanceConfig : instanceConfigsWithTag) {
-      serverInstances.put(serverInstanceConfig.getInstanceName(), new ServerInstance(serverInstanceConfig));
-    }
-    _tableTenantServersMap.put(tableNameWithType, serverInstances);
-    LOGGER.info("Built map for table={} with {} server instances.", tableNameWithType, serverInstances.size());
-  }
-
-  private void addNewServerToTableTenantServerMap(String instanceId, ServerInstance serverInstance,
-      InstanceConfig instanceConfig) {
-    List<String> tags = instanceConfig.getTags();
-
-    for (Map.Entry<String, Map<String, ServerInstance>> entry : _tableTenantServersMap.entrySet()) {
-      String tableNameWithType = entry.getKey();
-      TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
-      String tableServerTag = getServerTagForTable(tableNameWithType, tableConfig);
-
-      Map<String, ServerInstance> tenantServerMap = entry.getValue();
-
-      if (tags.contains(tableServerTag)) {
-        // ServerInstance might got updated for internal fields like queryServicePort, queryMailboxPort, etc,
-        // so always update the tenantServerMap with the latest serverInstance
-        tenantServerMap.put(instanceId, serverInstance);
-      } else {
-        tenantServerMap.remove(instanceId);
-      }
-    }
-  }
-
-  private String getServerTagForTable(String tableNameWithType, TableConfig tableConfig) {
-    String serverTenantName = tableConfig.getTenantConfig().getServer();
-    String serverTag;
-    if (TableNameBuilder.isOfflineTableResource(tableNameWithType)) {
-      serverTag = TagNameUtils.getOfflineTagForTenant(serverTenantName);
-    } else {
-      // Realtime table
-      serverTag = TagNameUtils.getRealtimeTagForTenant(serverTenantName);
-    }
-
-    return serverTag;
-  }
-
-  private void deleteServerFromTableTenantServerMap(String server) {
-    for (Map.Entry<String, Map<String, ServerInstance>> entry : _tableTenantServersMap.entrySet()) {
-      if (entry.getValue().remove(server) != null) {
-        LOGGER.info("Removing entry for server={}, table={}", server, entry.getKey());
       }
     }
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/BaseInstanceSelector.java
@@ -284,7 +284,8 @@ abstract class BaseInstanceSelector implements InstanceSelector {
     for (Map.Entry<String, List<SegmentInstanceCandidate>> entry : _oldSegmentCandidatesMap.entrySet()) {
       String segment = entry.getKey();
       List<SegmentInstanceCandidate> candidates = entry.getValue();
-      List<SegmentInstanceCandidate> enabledCandidates = getEnabledCandidates(candidates, servingInstances);
+      List<SegmentInstanceCandidate> enabledCandidates =
+          getEnabledCandidatesAndAddToServingInstances(candidates, servingInstances);
       if (!enabledCandidates.isEmpty()) {
         instanceCandidatesMap.put(segment, enabledCandidates);
       } else {
@@ -304,7 +305,8 @@ abstract class BaseInstanceSelector implements InstanceSelector {
       String segment = entry.getKey();
       NewSegmentState newSegmentState = entry.getValue();
       List<SegmentInstanceCandidate> candidates = newSegmentState.getCandidates();
-      List<SegmentInstanceCandidate> enabledCandidates = getEnabledCandidates(candidates, servingInstances);
+      List<SegmentInstanceCandidate> enabledCandidates =
+          getEnabledCandidatesAndAddToServingInstances(candidates, servingInstances);
       if (!enabledCandidates.isEmpty()) {
         instanceCandidatesMap.put(segment, enabledCandidates);
       } else {
@@ -322,8 +324,8 @@ abstract class BaseInstanceSelector implements InstanceSelector {
     _segmentStates = new SegmentStates(instanceCandidatesMap, servingInstances, unavailableSegments);
   }
 
-  private List<SegmentInstanceCandidate> getEnabledCandidates(List<SegmentInstanceCandidate> candidates,
-      Set<String> servingInstances) {
+  private List<SegmentInstanceCandidate> getEnabledCandidatesAndAddToServingInstances(
+      List<SegmentInstanceCandidate> candidates, Set<String> servingInstances) {
     List<SegmentInstanceCandidate> enabledCandidates = new ArrayList<>(candidates.size());
     for (SegmentInstanceCandidate candidate : candidates) {
       String instance = candidate.getInstance();

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -69,6 +69,11 @@ public interface InstanceSelector {
    */
   SelectionResult select(BrokerRequest brokerRequest, List<String> segments, long requestId);
 
+  /**
+   * Returns the enabled server instances currently serving the table.
+   */
+  Set<String> getServingInstances();
+
   class SelectionResult {
     private final Map<String, String> _segmentToInstanceMap;
     private final List<String> _unavailableSegments;

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/SegmentStates.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/SegmentStates.java
@@ -38,17 +38,23 @@ import javax.annotation.concurrent.Immutable;
 @Immutable
 public class SegmentStates {
   private final Map<String, List<SegmentInstanceCandidate>> _instanceCandidatesMap;
+  private final Set<String> _servingInstances;
   private final Set<String> _unavailableSegments;
 
-  public SegmentStates(Map<String, List<SegmentInstanceCandidate>> instanceCandidatesMap,
+  public SegmentStates(Map<String, List<SegmentInstanceCandidate>> instanceCandidatesMap, Set<String> servingInstances,
       Set<String> unavailableSegments) {
     _instanceCandidatesMap = instanceCandidatesMap;
+    _servingInstances = servingInstances;
     _unavailableSegments = unavailableSegments;
   }
 
   @Nullable
   public List<SegmentInstanceCandidate> getCandidates(String segment) {
     return _instanceCandidatesMap.get(segment);
+  }
+
+  public Set<String> getServingInstances() {
+    return _servingInstances;
   }
 
   public Set<String> getUnavailableSegments() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/RoutingManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/RoutingManager.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.routing;
 
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.core.transport.ServerInstance;
@@ -78,10 +79,8 @@ public interface RoutingManager {
   TablePartitionInfo getTablePartitionInfo(String tableNameWithType);
 
   /**
-   * Returns all enabled server instances for a given table's server tenant.
-   *
-   * @param tableNameWithType name of the table with type
-   * @return all enabled servers for a table's server tenant
+   * Returns the enabled server instances currently serving the given table.
    */
-  Map<String, ServerInstance> getEnabledServersForTableTenant(String tableNameWithType);
+  @Nullable
+  Set<String> getServingInstances(String tableNameWithType);
 }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/testutils/MockRoutingManagerFactory.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/testutils/MockRoutingManagerFactory.java
@@ -173,8 +173,8 @@ public class MockRoutingManagerFactory {
     }
 
     @Override
-    public Map<String, ServerInstance> getEnabledServersForTableTenant(String tableNameWithType) {
-      return _serverInstances;
+    public Set<String> getServingInstances(String tableNameWithType) {
+      return _serverInstances.keySet();
     }
   }
 }


### PR DESCRIPTION
Currently we use server tag to determine the worker for intermediate stage, and it has the following issues:
- Maintaining the table to tag mapping in `BrokerRoutingManager` is super expensive. It reads all table configs for each instance config change (this can result in millions of read when rolling restart all servers for a large cluster)
- It has a bug that only change from new enabled servers can be picked up. Changes to existing servers cannot be picked up
- When instance assignment config is used, server tag is ignored, so the mapping will be wrong

To address the above issues, instead of using tag to determine servers, directly picking the serving servers from the `InstanceSelector`.