### PR TITLE
Remove dedicated executor for exchange

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
@@ -60,11 +60,11 @@ public class GrpcSendingMailbox implements SendingMailbox {
   @Override
   public void send(TransferableBlock block)
       throws IOException {
-    if (LOGGER.isDebugEnabled()) {
-      LOGGER.debug("==[GRPC SEND]== sending data to: " + _id);
-    }
     if (isTerminated()) {
       return;
+    }
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("==[GRPC SEND]== sending data to: " + _id);
     }
     if (_contentObserver == null) {
       _contentObserver = getContentObserver();
@@ -91,9 +91,9 @@ public class GrpcSendingMailbox implements SendingMailbox {
     }
     try {
       String msg = t != null ? t.getMessage() : "Unknown";
-        // NOTE: DO NOT use onError() because it will terminate the stream, and receiver might not get the callback
-        _contentObserver.onNext(toMailboxContent(TransferableBlockUtils.getErrorTransferableBlock(
-            new RuntimeException("Cancelled by sender with exception: " + msg, t))));
+      // NOTE: DO NOT use onError() because it will terminate the stream, and receiver might not get the callback
+      _contentObserver.onNext(toMailboxContent(TransferableBlockUtils.getErrorTransferableBlock(
+          new RuntimeException("Cancelled by sender with exception: " + msg, t))));
       _contentObserver.onCompleted();
     } catch (Exception e) {
       // Exception can be thrown if the stream is already closed, so we simply ignore it

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.mailbox;
 
+import java.util.concurrent.TimeoutException;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.slf4j.Logger;
@@ -41,7 +42,8 @@ public class InMemorySendingMailbox implements SendingMailbox {
   }
 
   @Override
-  public void send(TransferableBlock block) {
+  public void send(TransferableBlock block)
+      throws TimeoutException {
     if (_isTerminated) {
       return;
     }
@@ -56,7 +58,7 @@ public class InMemorySendingMailbox implements SendingMailbox {
       case ERROR:
         throw new RuntimeException(String.format("Mailbox: %s already errored out (received error block before)", _id));
       case TIMEOUT:
-        throw new RuntimeException(
+        throw new TimeoutException(
             String.format("Timed out adding block into mailbox: %s with timeout: %dms", _id, timeoutMs));
       case EARLY_TERMINATED:
         _isTerminated = true;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/MailboxIdUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/MailboxIdUtils.java
@@ -21,9 +21,7 @@ package org.apache.pinot.query.mailbox;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import java.util.stream.Collectors;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.query.routing.MailboxMetadata;
-import org.apache.pinot.query.runtime.operator.OpChainId;
 
 
 // TODO: De-couple mailbox id from query information
@@ -40,13 +38,8 @@ public class MailboxIdUtils {
         + receiverStageId + SEPARATOR + receiverWorkerId;
   }
 
-  public static OpChainId toOpChainId(String mailboxId) {
-    String[] parts = StringUtils.split(mailboxId, SEPARATOR);
-    return new OpChainId(Long.parseLong(parts[0]), Integer.parseInt(parts[4]), Integer.parseInt(parts[3]));
-  }
-
-  public static List<String> toMailboxIds(long requestId, MailboxMetadata senderMailBoxMetadata) {
-    return toMailboxIds(requestId, senderMailBoxMetadata.getMailBoxIdList());
+  public static List<String> toMailboxIds(long requestId, MailboxMetadata mailBoxMetadata) {
+    return toMailboxIds(requestId, mailBoxMetadata.getMailBoxIdList());
   }
 
   public static List<String> toMailboxIds(long requestId, List<String> mailboxMetadataIdList) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/MailboxService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/MailboxService.java
@@ -23,17 +23,9 @@ import com.google.common.cache.Cache;
 import com.google.common.cache.CacheBuilder;
 import com.google.common.cache.RemovalListener;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
-import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import java.util.function.Consumer;
 import org.apache.pinot.query.mailbox.channel.ChannelManager;
 import org.apache.pinot.query.mailbox.channel.GrpcMailboxServer;
-import org.apache.pinot.query.runtime.blocks.TransferableBlock;
-import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.operator.OpChainId;
-import org.apache.pinot.query.runtime.operator.exchange.BlockExchange;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -45,7 +37,6 @@ import org.slf4j.LoggerFactory;
 public class MailboxService {
   private static final Logger LOGGER = LoggerFactory.getLogger(MailboxService.class);
   private static final int DANGLING_RECEIVING_MAILBOX_EXPIRY_SECONDS = 300;
-  private static final int DANGLING_EXCHANGE_EXPIRY_SECONDS = 300;
 
   /**
    * Cached receiving mailboxes that contains the received blocks queue.
@@ -64,46 +55,19 @@ public class MailboxService {
               }
             }
           }).build();
-  /**
-   * Cached the executing thread that send blocks from {@link BlockExchange}.
-   *
-   * There's the  executor service used to run the actual underlying connection and data transfer on a separate thread
-   * so that the query stage execution can properly decoupled with the data transfer mechanism.
-   */
-  private final Cache<OpChainId, Future<?>> _submittedExchangeCache =
-      CacheBuilder.newBuilder().expireAfterAccess(DANGLING_EXCHANGE_EXPIRY_SECONDS, TimeUnit.SECONDS)
-          .removalListener((RemovalListener<OpChainId, Future<?>>) notification -> {
-            if (notification.wasEvicted()) {
-              Future<?> future = notification.getValue();
-              if (!future.isDone()) {
-                LOGGER.warn("Evicting dangling exchange request for {}}", notification.getKey());
-                future.cancel(true);
-              }
-            }
-          }).build();
 
   private final String _hostname;
   private final int _port;
   private final PinotConfiguration _config;
-  private final Consumer<OpChainId> _unblockOpChainCallback;
-  private final ExecutorService _exchangeExecutor;
   private final ChannelManager _channelManager = new ChannelManager();
 
   private GrpcMailboxServer _grpcMailboxServer;
 
-  public MailboxService(String hostname, int port, PinotConfiguration config,
-      Consumer<OpChainId> unblockOpChainCallback) {
+  public MailboxService(String hostname, int port, PinotConfiguration config) {
     _hostname = hostname;
     _port = port;
     _config = config;
-    _unblockOpChainCallback = unblockOpChainCallback;
-    _exchangeExecutor = Executors.newCachedThreadPool();
     LOGGER.info("Initialized MailboxService with hostname: {}, port: {}", hostname, port);
-  }
-
-  public MailboxService(String hostname, int port, PinotConfiguration config) {
-    this(hostname, port, config, ignoreMe -> {
-    });
   }
 
   /**
@@ -131,10 +95,6 @@ public class MailboxService {
     return _port;
   }
 
-  public Consumer<OpChainId> getCallback() {
-    return _unblockOpChainCallback;
-  }
-
   /**
    * Returns a sending mailbox for the given mailbox id. The returned sending mailbox is uninitialized, i.e. it will
    * not open the underlying channel or acquire any additional resources. Instead, it will initialize lazily when the
@@ -154,7 +114,7 @@ public class MailboxService {
    */
   public ReceivingMailbox getReceivingMailbox(String mailboxId) {
     try {
-      return _receivingMailboxCache.get(mailboxId, () -> new ReceivingMailbox(mailboxId, _unblockOpChainCallback));
+      return _receivingMailboxCache.get(mailboxId, () -> new ReceivingMailbox(mailboxId));
     } catch (ExecutionException e) {
       throw new RuntimeException(e);
     }
@@ -173,26 +133,5 @@ public class MailboxService {
    */
   public void releaseReceivingMailbox(ReceivingMailbox mailbox) {
     _receivingMailboxCache.invalidate(mailbox.getId());
-  }
-
-  /**
-   * submit a block exchange to sending service for a single OpChain.
-   *
-   * Notice that the logic inside the {@link BlockExchange#send()} should guarantee the submitted Runnable object
-   *     to be terminated successfully or after opChain timeout.
-   *
-   * @param blockExchange the exchange object of the OpChain with all the pending data to be sent.
-   */
-  public void submitExchangeRequest(OpChainId opChainId, BlockExchange blockExchange) {
-    _submittedExchangeCache.put(opChainId, _exchangeExecutor.submit(() -> {
-      TransferableBlock block = blockExchange.send();
-      while (!TransferableBlockUtils.isEndOfStream(block)) {
-        block = blockExchange.send();
-      }
-    }));
-  }
-
-  public void cancelExchangeRequest(OpChainId opChainId, Throwable t) {
-    _submittedExchangeCache.invalidate(opChainId);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/SendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/SendingMailbox.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.query.mailbox;
 
 import java.io.IOException;
+import java.util.concurrent.TimeoutException;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.operator.exchange.BlockExchange;
 
@@ -34,7 +35,7 @@ public interface SendingMailbox {
    * sending the data, since that would allow {@link BlockExchange} to exit early.
    */
   void send(TransferableBlock block)
-      throws IOException;
+      throws IOException, TimeoutException;
 
   /**
    * Called when there is no more data to be sent by the {@link BlockExchange}. This is also a signal for the

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -90,8 +90,6 @@ public class QueryRunner {
     _port = config.getProperty(QueryConfig.KEY_OF_QUERY_RUNNER_PORT, QueryConfig.DEFAULT_QUERY_RUNNER_PORT);
     _helixManager = helixManager;
     try {
-      long releaseMs = config.getProperty(QueryConfig.KEY_OF_SCHEDULER_RELEASE_TIMEOUT_MS,
-          QueryConfig.DEFAULT_SCHEDULER_RELEASE_TIMEOUT_MS);
       //TODO: make this configurable
       _opChainExecutor = ExecutorServiceUtils.create(config, "pinot.query.runner.opchain",
           "op_chain_worker_on_" + _port + "_port");

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
@@ -59,18 +59,18 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
 
     long requestId = context.getRequestId();
     int workerId = context.getServer().workerId();
-    MailboxMetadata senderMailBoxMetadatas =
+    MailboxMetadata mailboxMetadata =
         context.getStageMetadata().getWorkerMetadataList().get(workerId).getMailBoxInfosMap().get(senderStageId);
-    if (senderMailBoxMetadatas != null && !senderMailBoxMetadatas.getMailBoxIdList().isEmpty()) {
-      _mailboxIds = MailboxIdUtils.toMailboxIds(requestId, senderMailBoxMetadatas);
+    if (mailboxMetadata != null && !mailboxMetadata.getMailBoxIdList().isEmpty()) {
+      _mailboxIds = MailboxIdUtils.toMailboxIds(requestId, mailboxMetadata);
     } else {
       _mailboxIds = Collections.emptyList();
     }
     List<ReadMailboxAsyncStream> asyncStreams = _mailboxIds.stream()
         .map(mailboxId -> new ReadMailboxAsyncStream(_mailboxService.getReceivingMailbox(mailboxId), this))
         .collect(Collectors.toList());
-    _multiConsumer = new BlockingMultiStreamConsumer.OfTransferableBlock(
-        context.getId(), context.getDeadlineMs(), asyncStreams);
+    _multiConsumer =
+        new BlockingMultiStreamConsumer.OfTransferableBlock(context.getId(), context.getDeadlineMs(), asyncStreams);
   }
 
   protected BlockingMultiStreamConsumer.OfTransferableBlock getMultiConsumer() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchange.java
@@ -20,62 +20,37 @@ package org.apache.pinot.query.runtime.operator.exchange;
 
 import java.util.Iterator;
 import java.util.List;
-import java.util.concurrent.ArrayBlockingQueue;
-import java.util.concurrent.BlockingQueue;
-import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
-import java.util.concurrent.atomic.AtomicReference;
-import java.util.function.Consumer;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.common.datablock.DataBlock;
-import org.apache.pinot.common.utils.ExceptionUtils;
 import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.runtime.blocks.BlockSplitter;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
-import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.operator.OpChainId;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
- * This class contains the shared logic across all different exchange types for
- * exchanging data across different servers.
- *
- * {@link BlockExchange} is used by {@link org.apache.pinot.query.runtime.operator.MailboxSendOperator} to
- * exchange data between underlying {@link org.apache.pinot.query.mailbox.MailboxService} and the query stage execution
- * engine running the actual {@link org.apache.pinot.query.runtime.operator.OpChain}.
+ * This class contains the shared logic across all different exchange types for exchanging data across servers.
  */
 public abstract class BlockExchange {
-  public static final int DEFAULT_MAX_PENDING_BLOCKS = 5;
-  private static final Logger LOGGER = LoggerFactory.getLogger(BlockExchange.class);
   // TODO: Deduct this value via grpc config maximum byte size; and make it configurable with override.
   // TODO: Max block size is a soft limit. only counts fixedSize datatable byte buffer
   private static final int MAX_MAILBOX_CONTENT_SIZE_BYTES = 4 * 1024 * 1024;
 
-  private final OpChainId _opChainId;
   private final List<SendingMailbox> _sendingMailboxes;
   private final BlockSplitter _splitter;
-  private final Consumer<OpChainId> _callback;
-  private final long _deadlineMs;
 
-  private final BlockingQueue<TransferableBlock> _queue = new ArrayBlockingQueue<>(DEFAULT_MAX_PENDING_BLOCKS);
-  private final AtomicReference<TransferableBlock> _errorBlock = new AtomicReference<>();
-
-  public static BlockExchange getExchange(OpChainId opChainId, List<SendingMailbox> sendingMailboxes,
-      RelDistribution.Type exchangeType, KeySelector<Object[], Object[]> selector, BlockSplitter splitter,
-      Consumer<OpChainId> callback, long deadlineMs) {
+  public static BlockExchange getExchange(List<SendingMailbox> sendingMailboxes, RelDistribution.Type exchangeType,
+      KeySelector<Object[], Object[]> selector, BlockSplitter splitter) {
     switch (exchangeType) {
       case SINGLETON:
-        return new SingletonExchange(opChainId, sendingMailboxes, splitter, callback, deadlineMs);
+        return new SingletonExchange(sendingMailboxes, splitter);
       case HASH_DISTRIBUTED:
-        return new HashExchange(opChainId, sendingMailboxes, selector, splitter, callback, deadlineMs);
+        return new HashExchange(sendingMailboxes, selector, splitter);
       case RANDOM_DISTRIBUTED:
-        return new RandomExchange(opChainId, sendingMailboxes, splitter, callback, deadlineMs);
+        return new RandomExchange(sendingMailboxes, splitter);
       case BROADCAST_DISTRIBUTED:
-        return new BroadcastExchange(opChainId, sendingMailboxes, splitter, callback, deadlineMs);
+        return new BroadcastExchange(sendingMailboxes, splitter);
       case ROUND_ROBIN_DISTRIBUTED:
       case RANGE_DISTRIBUTED:
       case ANY:
@@ -84,16 +59,12 @@ public abstract class BlockExchange {
     }
   }
 
-  protected BlockExchange(OpChainId opChainId, List<SendingMailbox> sendingMailboxes, BlockSplitter splitter,
-      Consumer<OpChainId> callback, long deadlineMs) {
-    _opChainId = opChainId;
+  protected BlockExchange(List<SendingMailbox> sendingMailboxes, BlockSplitter splitter) {
     _sendingMailboxes = sendingMailboxes;
     _splitter = splitter;
-    _callback = callback;
-    _deadlineMs = deadlineMs;
   }
 
-  public boolean offerBlock(TransferableBlock block, long timeoutMs)
+  public void send(TransferableBlock block)
       throws Exception {
     boolean isEarlyTerminated = true;
     for (SendingMailbox sendingMailbox : _sendingMailboxes) {
@@ -105,43 +76,12 @@ public abstract class BlockExchange {
     if (isEarlyTerminated) {
       throw new EarlyTerminationException();
     }
-    return _queue.offer(block, timeoutMs, TimeUnit.MILLISECONDS);
-  }
-
-  public int getRemainingCapacity() {
-    return _queue.remainingCapacity();
-  }
-
-  public TransferableBlock send() {
-    try {
-      TransferableBlock block;
-      long timeoutMs = _deadlineMs - System.currentTimeMillis();
-      if (_errorBlock.get() != null) {
-        LOGGER.debug("Exchange: {} is already cancelled or errored out internally, ignore the late block", _opChainId);
-        return _errorBlock.get();
+    if (block.isEndOfStreamBlock()) {
+      for (SendingMailbox sendingMailbox : _sendingMailboxes) {
+        sendBlock(sendingMailbox, block);
       }
-      block = _queue.poll(timeoutMs, TimeUnit.MILLISECONDS);
-      if (block == null) {
-        block = TransferableBlockUtils.getErrorTransferableBlock(new TimeoutException(
-            String.format("Timed out polling block for opChain: %s after %dms", _opChainId, timeoutMs)));
-      } else {
-        // Notify that the block exchange can now accept more blocks.
-        _callback.accept(_opChainId);
-        if (block.isEndOfStreamBlock()) {
-          for (SendingMailbox sendingMailbox : _sendingMailboxes) {
-            sendBlock(sendingMailbox, block);
-          }
-        } else {
-          route(_sendingMailboxes, block);
-        }
-      }
-      return block;
-    } catch (Exception e) {
-      TransferableBlock errorBlock = TransferableBlockUtils.getErrorTransferableBlock(
-          new RuntimeException("Exception while sending data via exchange for opChain: " + _opChainId + "\n"
-              + ExceptionUtils.consolidateExceptionMessages(e)));
-      setErrorBlock(errorBlock);
-      return errorBlock;
+    } else {
+      route(_sendingMailboxes, block);
     }
   }
 
@@ -157,19 +97,6 @@ public abstract class BlockExchange {
     Iterator<TransferableBlock> splits = _splitter.split(block, type, MAX_MAILBOX_CONTENT_SIZE_BYTES);
     while (splits.hasNext()) {
       sendingMailbox.send(splits.next());
-    }
-  }
-
-  private void setErrorBlock(TransferableBlock errorBlock) {
-    if (_errorBlock.compareAndSet(null, errorBlock)) {
-      try {
-        for (SendingMailbox sendingMailbox : _sendingMailboxes) {
-          sendBlock(sendingMailbox, errorBlock);
-        }
-      } catch (Exception e) {
-        LOGGER.error("error while sending exception block via exchange for opChain: " + _opChainId, e);
-      }
-      _queue.clear();
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchange.java
@@ -19,11 +19,9 @@
 package org.apache.pinot.query.runtime.operator.exchange;
 
 import java.util.List;
-import java.util.function.Consumer;
 import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.runtime.blocks.BlockSplitter;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
-import org.apache.pinot.query.runtime.operator.OpChainId;
 
 
 /**
@@ -31,9 +29,8 @@ import org.apache.pinot.query.runtime.operator.OpChainId;
  */
 class BroadcastExchange extends BlockExchange {
 
-  protected BroadcastExchange(OpChainId opChainId, List<SendingMailbox> sendingMailboxes, BlockSplitter splitter,
-      Consumer<OpChainId> callback, long deadlineMs) {
-    super(opChainId, sendingMailboxes, splitter, callback, deadlineMs);
+  protected BroadcastExchange(List<SendingMailbox> sendingMailboxes, BlockSplitter splitter) {
+    super(sendingMailboxes, splitter);
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/HashExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/HashExchange.java
@@ -20,12 +20,10 @@ package org.apache.pinot.query.runtime.operator.exchange;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.function.Consumer;
 import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.runtime.blocks.BlockSplitter;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
-import org.apache.pinot.query.runtime.operator.OpChainId;
 
 
 /**
@@ -38,9 +36,9 @@ class HashExchange extends BlockExchange {
   // TODO: ensure that server instance list is sorted using same function in sender.
   private final KeySelector<Object[], Object[]> _keySelector;
 
-  HashExchange(OpChainId opChainId, List<SendingMailbox> sendingMailboxes, KeySelector<Object[], Object[]> selector,
-      BlockSplitter splitter, Consumer<OpChainId> callback, long deadlineMs) {
-    super(opChainId, sendingMailboxes, splitter, callback, deadlineMs);
+  HashExchange(List<SendingMailbox> sendingMailboxes, KeySelector<Object[], Object[]> selector,
+      BlockSplitter splitter) {
+    super(sendingMailboxes, splitter);
     _keySelector = selector;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/RandomExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/RandomExchange.java
@@ -21,12 +21,10 @@ package org.apache.pinot.query.runtime.operator.exchange;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.List;
 import java.util.Random;
-import java.util.function.Consumer;
 import java.util.function.IntFunction;
 import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.runtime.blocks.BlockSplitter;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
-import org.apache.pinot.query.runtime.operator.OpChainId;
 
 
 /**
@@ -38,15 +36,13 @@ class RandomExchange extends BlockExchange {
 
   private final IntFunction<Integer> _rand;
 
-  RandomExchange(OpChainId opChainId, List<SendingMailbox> sendingMailboxes, BlockSplitter splitter,
-      Consumer<OpChainId> callback, long deadlineMs) {
-    this(opChainId, sendingMailboxes, RANDOM::nextInt, splitter, callback, deadlineMs);
+  RandomExchange(List<SendingMailbox> sendingMailboxes, BlockSplitter splitter) {
+    this(sendingMailboxes, RANDOM::nextInt, splitter);
   }
 
   @VisibleForTesting
-  RandomExchange(OpChainId opChainId, List<SendingMailbox> sendingMailboxes, IntFunction<Integer> rand,
-      BlockSplitter splitter, Consumer<OpChainId> callback, long deadlineMs) {
-    super(opChainId, sendingMailboxes, splitter, callback, deadlineMs);
+  RandomExchange(List<SendingMailbox> sendingMailboxes, IntFunction<Integer> rand, BlockSplitter splitter) {
+    super(sendingMailboxes, splitter);
     _rand = rand;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/SingletonExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/SingletonExchange.java
@@ -20,12 +20,10 @@ package org.apache.pinot.query.runtime.operator.exchange;
 
 import com.google.common.base.Preconditions;
 import java.util.List;
-import java.util.function.Consumer;
 import org.apache.pinot.query.mailbox.InMemorySendingMailbox;
 import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.runtime.blocks.BlockSplitter;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
-import org.apache.pinot.query.runtime.operator.OpChainId;
 
 
 /**
@@ -34,9 +32,8 @@ import org.apache.pinot.query.runtime.operator.OpChainId;
  */
 class SingletonExchange extends BlockExchange {
 
-  SingletonExchange(OpChainId opChainId, List<SendingMailbox> sendingMailboxes, BlockSplitter splitter,
-      Consumer<OpChainId> callback, long deadlineMs) {
-    super(opChainId, sendingMailboxes, splitter, callback, deadlineMs);
+  SingletonExchange(List<SendingMailbox> sendingMailboxes, BlockSplitter splitter) {
+    super(sendingMailboxes, splitter);
     Preconditions.checkArgument(
         sendingMailboxes.size() == 1 && sendingMailboxes.get(0) instanceof InMemorySendingMailbox,
         "Expect single InMemorySendingMailbox for SingletonExchange");

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.query.runtime.plan;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.function.Consumer;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.operator.OpChainId;
@@ -70,10 +69,6 @@ public class OpChainExecutionContext {
 
   public MailboxService getMailboxService() {
     return _mailboxService;
-  }
-
-  public Consumer<OpChainId> getCallback() {
-    return _mailboxService.getCallback();
   }
 
   public long getRequestId() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
@@ -22,14 +22,14 @@ package org.apache.pinot.query.service;
  * Configuration for setting up query runtime.
  */
 public class QueryConfig {
+  private QueryConfig() {
+  }
+
   /**
    * Configuration for mailbox data block size
    */
   public static final String KEY_OF_MAX_INBOUND_QUERY_DATA_BLOCK_SIZE_BYTES = "pinot.query.runner.max.msg.size.bytes";
   public static final int DEFAULT_MAX_INBOUND_QUERY_DATA_BLOCK_SIZE_BYTES = 16 * 1024 * 1024;
-
-  public static final String KEY_OF_MAILBOX_TIMEOUT_MS = "pinot.query.runner.mailbox.timeout.ms";
-  public static final long DEFAULT_MAILBOX_TIMEOUT_MS = 10_000L;
 
   /**
    * Configuration for server port, port that opens and accepts
@@ -58,21 +58,4 @@ public class QueryConfig {
    */
   public static final String KEY_OF_SERVER_RESPONSE_STATUS_ERROR = "ERROR";
   public static final String KEY_OF_SERVER_RESPONSE_STATUS_OK = "OK";
-
-  /**
-   * Configuration keys for managing the scheduler
-   */
-
-  /**
-   * The maximum time that a operator chain will be held in the queue without being scheduled for execution.
-   * This is intended as a defensive measure for situations where we notice that an operator is not being
-   * scheduled when it otherwise should be. The default value, -1, indicates that we should never release
-   * an operator chain despite any amount of time elapsed.
-   */
-  public static final String KEY_OF_SCHEDULER_RELEASE_TIMEOUT_MS = "pinot.query.scheduler.release.timeout.ms";
-  public static final long DEFAULT_SCHEDULER_RELEASE_TIMEOUT_MS = 10_000;
-
-  private QueryConfig() {
-    // do not instantiate.
-  }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
@@ -80,7 +80,6 @@ public class QueryServerEnclosure {
       _runnerConfig.put(QueryConfig.KEY_OF_QUERY_RUNNER_PORT, _queryRunnerPort);
       _runnerConfig.put(QueryConfig.KEY_OF_QUERY_RUNNER_HOSTNAME,
           String.format("Server_%s", QueryConfig.DEFAULT_QUERY_RUNNER_HOSTNAME));
-      _runnerConfig.put(QueryConfig.KEY_OF_SCHEDULER_RELEASE_TIMEOUT_MS, 100);
       _queryRunner = new QueryRunner();
     } catch (Exception e) {
       throw new RuntimeException("Test Failed!", e);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
@@ -57,7 +57,6 @@ import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -108,8 +107,7 @@ public class OpChainTest {
         TransferableBlock arg = invocation.getArgument(0);
         _blockList.add(arg);
         return true;
-      }).when(_exchange).offerBlock(any(TransferableBlock.class), anyLong());
-      when(_exchange.getRemainingCapacity()).thenReturn(1);
+      }).when(_exchange).send(any(TransferableBlock.class));
       when(_mailbox2.poll()).then(x -> {
         if (_blockList.isEmpty()) {
           return TransferableBlockUtils.getEndOfStreamTransferableBlock();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchangeTest.java
@@ -20,7 +20,6 @@ package org.apache.pinot.query.runtime.operator.exchange;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.Iterators;
-import java.io.IOException;
 import java.util.List;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
@@ -29,7 +28,6 @@ import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.runtime.blocks.BlockSplitter;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.operator.OpChainId;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -65,9 +63,9 @@ public class BlockExchangeTest {
     // Given:
     List<SendingMailbox> destinations = ImmutableList.of(_mailbox1, _mailbox2);
     BlockExchange exchange = new TestBlockExchange(destinations);
+
     // When:
-    exchange.offerBlock(TransferableBlockUtils.getEndOfStreamTransferableBlock(), Long.MAX_VALUE);
-    exchange.send();
+    exchange.send(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     // Then:
     ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
@@ -91,8 +89,7 @@ public class BlockExchangeTest {
         new DataSchema(new String[]{"foo"}, new ColumnDataType[]{ColumnDataType.STRING}), DataBlock.Type.ROW);
 
     // When:
-    exchange.offerBlock(block, Long.MAX_VALUE);
-    exchange.send();
+    exchange.send(block);
 
     // Then:
     ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
@@ -100,30 +97,6 @@ public class BlockExchangeTest {
     Assert.assertEquals(captor.getValue().getContainer(), block.getContainer());
 
     Mockito.verify(_mailbox2, Mockito.never()).send(Mockito.any());
-  }
-
-  @Test
-  public void shouldSendErrorBlockIfExchangeInternalThrowException()
-      throws Exception {
-    // Given:
-    List<SendingMailbox> destinations = ImmutableList.of(_mailbox1, _mailbox2);
-    BlockExchange exchange = new ThrowingBlockExchange(destinations);
-    TransferableBlock block = new TransferableBlock(ImmutableList.of(new Object[]{"val"}),
-        new DataSchema(new String[]{"foo"}, new ColumnDataType[]{ColumnDataType.STRING}), DataBlock.Type.ROW);
-
-    // When:
-    exchange.offerBlock(block, Long.MAX_VALUE);
-    exchange.send();
-
-    // Then:
-    ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
-    Mockito.verify(_mailbox1).complete();
-    Mockito.verify(_mailbox1, Mockito.times(1)).send(captor.capture());
-    Assert.assertTrue(captor.getValue().isErrorBlock());
-
-    Mockito.verify(_mailbox2).complete();
-    Mockito.verify(_mailbox2, Mockito.times(1)).send(captor.capture());
-    Assert.assertTrue(captor.getValue().isErrorBlock());
   }
 
   @Test
@@ -147,8 +120,7 @@ public class BlockExchangeTest {
         (block, type, maxSize) -> ImmutableList.of(outBlockOne, outBlockTwo).iterator());
 
     // When:
-    exchange.offerBlock(inBlock, Long.MAX_VALUE);
-    exchange.send();
+    exchange.send(inBlock);
 
     // Then:
     ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
@@ -166,7 +138,7 @@ public class BlockExchangeTest {
     }
 
     protected TestBlockExchange(List<SendingMailbox> destinations, BlockSplitter splitter) {
-      super(new OpChainId(1, 2, 3), destinations, splitter, (opChainId) -> { }, Long.MAX_VALUE);
+      super(destinations, splitter);
     }
 
     @Override
@@ -175,22 +147,6 @@ public class BlockExchangeTest {
       for (SendingMailbox mailbox : destinations) {
         sendBlock(mailbox, block);
       }
-    }
-  }
-
-  private static class ThrowingBlockExchange extends BlockExchange {
-    protected ThrowingBlockExchange(List<SendingMailbox> destinations) {
-      this(destinations, (block, type, size) -> Iterators.singletonIterator(block));
-    }
-
-    protected ThrowingBlockExchange(List<SendingMailbox> destinations, BlockSplitter splitter) {
-      super(new OpChainId(1, 2, 3), destinations, splitter, (opChainId) -> { }, Long.MAX_VALUE);
-    }
-
-    @Override
-    protected void route(List<SendingMailbox> destinations, TransferableBlock block)
-        throws Exception {
-      throw new IOException("Deliberate I/O Exception routing");
     }
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/BroadcastExchangeTest.java
@@ -23,7 +23,6 @@ import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.operator.OpChainId;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -63,8 +62,7 @@ public class BroadcastExchangeTest {
     ImmutableList<SendingMailbox> destinations = ImmutableList.of(_mailbox1, _mailbox2);
 
     // When:
-    new BroadcastExchange(new OpChainId(1, 2, 3), destinations, TransferableBlockUtils::splitBlock,
-        (opChainId) -> { }, System.currentTimeMillis() + 10_000L).route(destinations, _block);
+    new BroadcastExchange(destinations, TransferableBlockUtils::splitBlock).route(destinations, _block);
 
     ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/HashExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/HashExchangeTest.java
@@ -27,7 +27,6 @@ import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.operator.OpChainId;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -71,8 +70,7 @@ public class HashExchangeTest {
     ImmutableList<SendingMailbox> destinations = ImmutableList.of(_mailbox1, _mailbox2);
 
     // When:
-    new HashExchange(new OpChainId(1, 2, 3), destinations, selector, TransferableBlockUtils::splitBlock,
-        (opChainId) -> { }, System.currentTimeMillis() + 10_000L).route(destinations, _block);
+    new HashExchange(destinations, selector, TransferableBlockUtils::splitBlock).route(destinations, _block);
 
     // Then:
     ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/RandomExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/RandomExchangeTest.java
@@ -23,7 +23,6 @@ import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.operator.OpChainId;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -63,8 +62,7 @@ public class RandomExchangeTest {
     ImmutableList<SendingMailbox> destinations = ImmutableList.of(_mailbox1, _mailbox2);
 
     // When:
-    new RandomExchange(new OpChainId(1, 2, 3), destinations, size -> 1, TransferableBlockUtils::splitBlock,
-        (opChainId) -> { }, System.currentTimeMillis() + 10_000L).route(destinations, _block);
+    new RandomExchange(destinations, size -> 1, TransferableBlockUtils::splitBlock).route(destinations, _block);
 
     ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
     // Then:

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/SingletonExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/SingletonExchangeTest.java
@@ -25,7 +25,6 @@ import org.apache.pinot.query.mailbox.InMemorySendingMailbox;
 import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.query.runtime.operator.OpChainId;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -67,8 +66,7 @@ public class SingletonExchangeTest {
     ImmutableList<SendingMailbox> destinations = ImmutableList.of(_mailbox1);
 
     // When:
-    new SingletonExchange(new OpChainId(1, 2, 3), destinations, TransferableBlockUtils::splitBlock, (opChainId) -> {
-    }, System.currentTimeMillis() + 10_000L).route(destinations, _block);
+    new SingletonExchange(destinations, TransferableBlockUtils::splitBlock).route(destinations, _block);
 
     // Then:
     ArgumentCaptor<TransferableBlock> captor = ArgumentCaptor.forClass(TransferableBlock.class);
@@ -84,8 +82,7 @@ public class SingletonExchangeTest {
     ImmutableList<SendingMailbox> destinations = ImmutableList.of(_mailbox2);
 
     // When:
-    new SingletonExchange(new OpChainId(1, 2, 3), destinations, TransferableBlockUtils::splitBlock, (opChainId) -> {
-    }, System.currentTimeMillis() + 10_000L).route(destinations, _block);
+    new SingletonExchange(destinations, TransferableBlockUtils::splitBlock).route(destinations, _block);
   }
 
   @Test(expectedExceptions = IllegalArgumentException.class)
@@ -95,7 +92,6 @@ public class SingletonExchangeTest {
     ImmutableList<SendingMailbox> destinations = ImmutableList.of(_mailbox1, _mailbox3);
 
     // When:
-    new SingletonExchange(new OpChainId(1, 2, 3), destinations, TransferableBlockUtils::splitBlock, (opChainId) -> {
-    }, System.currentTimeMillis() + 10_000L).route(destinations, _block);
+    new SingletonExchange(destinations, TransferableBlockUtils::splitBlock).route(destinations, _block);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -190,8 +190,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
     reducerConfig.put(QueryConfig.KEY_OF_QUERY_RUNNER_HOSTNAME, _reducerHostname);
     _reducerScheduler = new OpChainSchedulerService(EXECUTOR);
     _mailboxService = new MailboxService(QueryConfig.DEFAULT_QUERY_RUNNER_HOSTNAME, _reducerGrpcPort,
-        new PinotConfiguration(reducerConfig), ignoreMe -> {
-    });
+        new PinotConfiguration(reducerConfig));
     _mailboxService.start();
 
     Map<String, List<String>> tableToSegmentMap1 = factory1.buildTableSegmentNameMap();


### PR DESCRIPTION
After #11205, the issue in #10761 no longer exists and we don't need an extra cached thread pool for exchange.
- Revert the changes from #10761 
- Remove the receive mail callback which is also no longer needed after #11205