### PR TITLE
Integration test exceptions fix

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -717,10 +717,10 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   protected long getCurrentCountStarResult(String tableName) {
-     ResultSetGroup resultSetGroup = getPinotConnection().execute("SELECT COUNT(*) FROM " + tableName);
-     if (resultSetGroup.getResultSetCount() > 0) {
-       return resultSetGroup.getResultSet(0).getLong(0);
-     }
+    ResultSetGroup resultSetGroup = getPinotConnection().execute("SELECT COUNT(*) FROM " + tableName);
+    if (resultSetGroup.getResultSetCount() > 0) {
+      return resultSetGroup.getResultSet(0).getLong(0);
+    }
     return 0;
   }
 

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -35,6 +35,7 @@ import java.util.Properties;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.client.ConnectionFactory;
+import org.apache.pinot.client.ResultSetGroup;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.plugin.inputformat.csv.CSVMessageDecoder;
@@ -716,7 +717,11 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
   }
 
   protected long getCurrentCountStarResult(String tableName) {
-    return getPinotConnection().execute("SELECT COUNT(*) FROM " + tableName).getResultSet(0).getLong(0);
+     ResultSetGroup resultSetGroup = getPinotConnection().execute("SELECT COUNT(*) FROM " + tableName);
+     if (resultSetGroup.getResultSetCount() > 0) {
+       return resultSetGroup.getResultSet(0).getLong(0);
+     }
+    return 0;
   }
 
   /**


### PR DESCRIPTION
 - fixing the `getCurrentCountStarResult` to avoid the `IndexOutOfBoundsException`. Here is the stack trace
    ```java
        20:27:01.720 WARN [CustomDataQueryClusterIntegrationTest] [main] Setting up integration test class: ThetaSketchTest
        20:27:01.991 WARN [TestUtils] [main] Error while waiting for condition
        java.lang.IndexOutOfBoundsException: Index 0 out of bounds for length 0
	        at jdk.internal.util.Preconditions.outOfBounds(Preconditions.java:64) ~[?:?]
	        at jdk.internal.util.Preconditions.outOfBoundsCheckIndex(Preconditions.java:70) ~[?:?]
	        at jdk.internal.util.Preconditions.checkIndex(Preconditions.java:248) ~[?:?]
	        at java.util.Objects.checkIndex(Objects.java:372) ~[?:?]
	        at java.util.ArrayList.get(ArrayList.java:459) ~[?:?]
	        at org.apache.pinot.client.ResultSetGroup.getResultSet(ResultSetGroup.java:90) ~[pinot-java-client-0.13.0-SNAPSHOT.jar:0.13.0-SNAPSHOT-8563d33e1a88d5a3baf22fc8faa1f107685ea904]
	        at org.apache.pinot.integration.tests.BaseClusterIntegrationTest.getCurrentCountStarResult(BaseClusterIntegrationTest.java:719) ~[pinot-integration-test-base-0.13.0-SNAPSHOT-tests.jar:0.13.0-SNAPSHOT-8563d33e1a88d5a3baf22fc8faa1f107685ea904]
	        at org.apache.pinot.integration.tests.BaseClusterIntegrationTest.lambda$waitForDocsLoaded$0(BaseClusterIntegrationTest.java:735) ~[pinot-integration-test-base-0.13.0-SNAPSHOT-tests.jar:0.13.0-SNAPSHOT-8563d33e1a88d5a3baf22fc8faa1f107685ea904]
	        at org.apache.pinot.util.TestUtils.waitForCondition(TestUtils.java:130) [pinot-common-0.13.0-SNAPSHOT-tests.jar:0.13.0-SNAPSHOT-8563d33e1a88d5a3baf22fc8faa1f107685ea904]
	        at org.apache.pinot.integration.tests.BaseClusterIntegrationTest.waitForDocsLoaded(BaseClusterIntegrationTest.java:735) [pinot-integration-test-base-0.13.0-SNAPSHOT-tests.jar:0.13.0-SNAPSHOT-8563d33e1a88d5a3baf22fc8faa1f107685ea904]
	        at org.apache.pinot.integration.tests.BaseClusterIntegrationTest.waitForAllDocsLoaded(BaseClusterIntegrationTest.java:730) [pinot-integration-test-base-0.13.0-SNAPSHOT-tests.jar:0.13.0-SNAPSHOT-8563d33e1a88d5a3baf22fc8faa1f107685ea904]
	        at org.apache.pinot.integration.tests.custom.CustomDataQueryClusterIntegrationTest.setUp(CustomDataQueryClusterIntegrationTest.java:90) [test-classes/:?]
	        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:?]
	        at jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:?]
	        at jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:?]
	        at java.lang.reflect.Method.invoke(Method.java:566) ~[?:?]
	        at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:108) [testng-6.11.jar:?]
	        at org.testng.internal.Invoker.invokeConfigurationMethod(Invoker.java:523) [testng-6.11.jar:?]
	        at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:224) [testng-6.11.jar:?]
	        at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:146) [testng-6.11.jar:?]
	        at org.testng.internal.TestMethodWorker.invokeBeforeClassMethods(TestMethodWorker.java:166) [testng-6.11.jar:?]
	        at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:105) [testng-6.11.jar:?]
	        at org.testng.TestRunner.privateRun(TestRunner.java:744) [testng-6.11.jar:?]
	        at org.testng.TestRunner.run(TestRunner.java:602) [testng-6.11.jar:?]
	        at org.testng.SuiteRunner.runTest(SuiteRunner.java:380) [testng-6.11.jar:?]
	        at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:375) [testng-6.11.jar:?]
	        at org.testng.SuiteRunner.privateRun(SuiteRunner.java:340) [testng-6.11.jar:?]
	        at org.testng.SuiteRunner.run(SuiteRunner.java:289) [testng-6.11.jar:?]
	        at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52) [testng-6.11.jar:?]
	        at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86) [testng-6.11.jar:?]
	        at org.testng.TestNG.runSuitesSequentially(TestNG.java:1301) [testng-6.11.jar:?]
	        at org.testng.TestNG.runSuitesLocally(TestNG.java:1226) [testng-6.11.jar:?]
	        at org.testng.TestNG.runSuites(TestNG.java:1144) [testng-6.11.jar:?]
	        at org.testng.TestNG.run(TestNG.java:1115) [testng-6.11.jar:?]
	        at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:284) [surefire-testng-3.0.0-M5.jar:3.0.0-M5]
	        at org.apache.maven.surefire.testng.TestNGXmlTestSuite.execute(TestNGXmlTestSuite.java:75) [surefire-testng-3.0.0-M5.jar:3.0.0-M5]
	        at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:119) [surefire-testng-3.0.0-M5.jar:3.0.0-M5]
	        at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:428) [surefire-booter-3.0.0-M5.jar:3.0.0-M5]
	        at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162) [surefire-booter-3.0.0-M5.jar:3.0.0-M5]
	        at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:562) [surefire-booter-3.0.0-M5.jar:3.0.0-M5]
	        at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:548) [surefire-booter-3.0.0-M5.jar:3.0.0-M5]
        20:27:02.112 WARN [CustomDataQueryClusterIntegrationTest] [main] Finished setting up integration test class: ThetaSketchTest```