### PR TITLE
[multistage] Retain timestampAdd and timestampDiff functions during SqlNode to RexNode conversion

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql2rel/PinotConvertletTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql2rel/PinotConvertletTable.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.calcite.sql2rel;
+
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.fun.SqlStdOperatorTable;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+
+/**
+ * PinotConvertletTable is a wrapper of {@link StandardConvertletTable} with the customizations of not converting
+ * certain SqlCalls, e.g. TIMESTAMPADD, TIMESTAMPDIFF.
+ */
+public class PinotConvertletTable implements SqlRexConvertletTable {
+
+  public static final PinotConvertletTable INSTANCE = new PinotConvertletTable();
+
+  private PinotConvertletTable() {
+  }
+
+  @Override
+  public @Nullable SqlRexConvertlet get(SqlCall call) {
+    switch (call.getKind()) {
+      case TIMESTAMP_ADD:
+        return TimestampAddConvertlet.INSTANCE;
+      case TIMESTAMP_DIFF:
+        return TimestampDiffConvertlet.INSTANCE;
+      default:
+        return StandardConvertletTable.INSTANCE.get(call);
+    }
+  }
+
+  /**
+   * Override {@link org.apache.calcite.sql2rel.StandardConvertletTable.TimestampAddConvertlet} to not convert the
+   * SqlCall to arithmetic time expression.
+   */
+  private static class TimestampAddConvertlet implements SqlRexConvertlet {
+    private static final TimestampAddConvertlet INSTANCE = new TimestampAddConvertlet();
+
+    @Override
+    public RexNode convertCall(SqlRexContext cx, SqlCall call) {
+      final RexBuilder rexBuilder = cx.getRexBuilder();
+      return rexBuilder.makeCall(SqlStdOperatorTable.TIMESTAMP_ADD,
+          cx.convertExpression(call.operand(0)),
+          cx.convertExpression(call.operand(1)),
+          cx.convertExpression(call.operand(2)));
+    }
+  }
+
+  /**
+   * Override {@link org.apache.calcite.sql2rel.StandardConvertletTable.TimestampDiffConvertlet} to not convert the
+   * SqlCall to arithmetic time expression.
+   */
+  private static class TimestampDiffConvertlet implements SqlRexConvertlet {
+    private static final TimestampDiffConvertlet INSTANCE = new TimestampDiffConvertlet();
+
+    @Override
+    public RexNode convertCall(SqlRexContext cx, SqlCall call) {
+      final RexBuilder rexBuilder = cx.getRexBuilder();
+      return rexBuilder.makeCall(SqlStdOperatorTable.TIMESTAMP_DIFF,
+          cx.convertExpression(call.operand(0)),
+          cx.convertExpression(call.operand(1)),
+          cx.convertExpression(call.operand(2)));
+    }
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/calcite/sql2rel/PinotConvertletTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/sql2rel/PinotConvertletTable.java
@@ -36,8 +36,9 @@ public class PinotConvertletTable implements SqlRexConvertletTable {
   private PinotConvertletTable() {
   }
 
+  @Nullable
   @Override
-  public @Nullable SqlRexConvertlet get(SqlCall call) {
+  public SqlRexConvertlet get(SqlCall call) {
     switch (call.getKind()) {
       case TIMESTAMP_ADD:
         return TimestampAddConvertlet.INSTANCE;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -52,9 +52,9 @@ import org.apache.calcite.sql.SqlKind;
 import org.apache.calcite.sql.SqlNode;
 import org.apache.calcite.sql.fun.PinotOperatorTable;
 import org.apache.calcite.sql.util.PinotChainedSqlOperatorTable;
+import org.apache.calcite.sql2rel.PinotConvertletTable;
 import org.apache.calcite.sql2rel.RelDecorrelator;
 import org.apache.calcite.sql2rel.SqlToRelConverter;
-import org.apache.calcite.sql2rel.StandardConvertletTable;
 import org.apache.calcite.tools.FrameworkConfig;
 import org.apache.calcite.tools.Frameworks;
 import org.apache.calcite.tools.RelBuilder;
@@ -326,7 +326,7 @@ public class QueryEnvironment {
     RelOptCluster cluster = RelOptCluster.create(plannerContext.getRelOptPlanner(), rexBuilder);
     SqlToRelConverter sqlToRelConverter =
         new SqlToRelConverter(plannerContext.getPlanner(), plannerContext.getValidator(), _catalogReader, cluster,
-            StandardConvertletTable.INSTANCE, _config.getSqlToRelConverterConfig());
+            PinotConvertletTable.INSTANCE, _config.getSqlToRelConverterConfig());
     RelRoot relRoot = sqlToRelConverter.convertQuery(parsed, false, true);
     return relRoot.withRel(sqlToRelConverter.trimUnusedFields(false, relRoot.rel));
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -217,19 +217,6 @@ public final class RelToPlanNodeConverter {
       case INTEGER:
         return isArray ? DataSchema.ColumnDataType.INT_ARRAY : DataSchema.ColumnDataType.INT;
       case BIGINT:
-      case INTERVAL_DAY:
-      case INTERVAL_DAY_HOUR:
-      case INTERVAL_DAY_MINUTE:
-      case INTERVAL_DAY_SECOND:
-      case INTERVAL_HOUR:
-      case INTERVAL_HOUR_MINUTE:
-      case INTERVAL_HOUR_SECOND:
-      case INTERVAL_MINUTE:
-      case INTERVAL_MINUTE_SECOND:
-      case INTERVAL_SECOND:
-      case INTERVAL_MONTH:
-      case INTERVAL_YEAR:
-      case INTERVAL_YEAR_MONTH:
         return isArray ? DataSchema.ColumnDataType.LONG_ARRAY : DataSchema.ColumnDataType.LONG;
       case DECIMAL:
         return resolveDecimal(relDataType, isArray);


### PR DESCRIPTION
### Background

CalciteSqlParser uses StandardConvertletTable to do series conversions for `SqlCall` -> `RexNode`.
One optimization it does is to convert `TimestampAdd` and `TimestampDiff` method to arithmetic timestamp and interval expression.
The problem we are facing here is that the literal expression of Interval is not supported which means the query is optimized to the form of Pinot doesn't recognize.
Hence the PR to not perform certain conversion in `org.apache.calcite.sql2rel.StandardConvertletTable`

### Changes
   - Add `PinotConvertletTable` which is a wrapper of `StandardConvertletTable` just override certain `SqlRexConvertlet`
   - Implements Pinot `TimestampAddConvertlet` and `TimestampDiffConvertlet` to keep the SqlCall as a function call format.
   - Refine `TimestampTests` to include more columns and coverage for `day`, `week`, `month`, `quarter`, `year` coverage.
   - Remove all `INTERVAL_*` types support in `RelToPlanNodeConverter` to avoid the confusion in v2