### PR TITLE
[multistage] Make join operator more resilient

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
@@ -61,6 +61,7 @@ public class QueryException {
   public static final int SERVER_TABLE_MISSING_ERROR_CODE = 230;
   public static final int SERVER_SEGMENT_MISSING_ERROR_CODE = 235;
   public static final int QUERY_SCHEDULING_TIMEOUT_ERROR_CODE = 240;
+  public static final int SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE = 245;
   public static final int EXECUTION_TIMEOUT_ERROR_CODE = 250;
   public static final int DATA_TABLE_SERIALIZATION_ERROR_CODE = 260;
   public static final int BROKER_GATHER_ERROR_CODE = 300;
@@ -105,6 +106,8 @@ public class QueryException {
       new ProcessingException(SERVER_SEGMENT_MISSING_ERROR_CODE);
   public static final ProcessingException QUERY_SCHEDULING_TIMEOUT_ERROR =
       new ProcessingException(QUERY_SCHEDULING_TIMEOUT_ERROR_CODE);
+  public static final ProcessingException SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR =
+      new ProcessingException(SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE);
   public static final ProcessingException EXECUTION_TIMEOUT_ERROR =
       new ProcessingException(EXECUTION_TIMEOUT_ERROR_CODE);
   public static final ProcessingException DATA_TABLE_SERIALIZATION_ERROR =
@@ -147,6 +150,7 @@ public class QueryException {
     SERVER_TABLE_MISSING_ERROR.setMessage("ServerTableMissing");
     SERVER_SEGMENT_MISSING_ERROR.setMessage("ServerSegmentMissing");
     QUERY_SCHEDULING_TIMEOUT_ERROR.setMessage("QuerySchedulingTimeoutError");
+    SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR.setMessage("ServerResourceLimitExceededError");
     EXECUTION_TIMEOUT_ERROR.setMessage("ExecutionTimeoutError");
     DATA_TABLE_DESERIALIZATION_ERROR.setMessage("DataTableSerializationError");
     BROKER_GATHER_ERROR.setMessage("BrokerGatherError");

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -36,7 +36,6 @@ public class QueryOptionsUtils {
   private QueryOptionsUtils() {
   }
 
-
   private static final Map<String, String> CONFIG_RESOLVER;
   private static final RuntimeException CLASS_LOAD_ERROR;
 
@@ -188,5 +187,16 @@ public class QueryOptionsUtils {
 
   public static boolean shouldDropResults(Map<String, String> queryOptions) {
     return Boolean.parseBoolean(queryOptions.get(CommonConstants.Broker.Request.QueryOptionKey.DROP_RESULTS));
+  }
+
+  @Nullable
+  public static Integer getMaxRowsInJoin(Map<String, String> queryOptions) {
+    String maxRowsInJoin = queryOptions.get(QueryOptionKey.MAX_ROWS_IN_JOIN);
+    return maxRowsInJoin != null ? Integer.parseInt(maxRowsInJoin) : null;
+  }
+
+  @Nullable
+  public static String getJoinOverflowMode(Map<String, String> queryOptions) {
+    return queryOptions.get(QueryOptionKey.JOIN_OVERFLOW_MODE);
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintOptions.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintOptions.java
@@ -65,6 +65,16 @@ public class PinotHintOptions {
 
   public static class JoinHintOptions {
     public static final String JOIN_STRATEGY = "join_strategy";
+    /**
+     * Max rows allowed to build the right table hash collection.
+     */
+    public static final String MAX_ROWS_IN_JOIN = "max_rows_in_join";
+    /**
+     * Mode when join overflow happens, supported values: THROW or BREAK.
+     *   THROW(default): Break right table build process, and throw exception, no JOIN with left table performed.
+     *   BREAK: Break right table build process, continue to perform JOIN operation, results might be partial.
+     */
+    public static final String JOIN_OVERFLOW_MODE = "join_overflow_mode";
   }
 
   public static class TableHintOptions {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -186,7 +186,7 @@ public final class RelToPlanNodeConverter {
     List<RexExpression> joinClause =
         joinInfo.nonEquiConditions.stream().map(RexExpression::toRexExpression).collect(Collectors.toList());
     return new JoinNode(currentStageId, toDataSchema(node.getRowType()), toDataSchema(node.getLeft().getRowType()),
-        toDataSchema(node.getRight().getRowType()), joinType, joinKeys, joinClause);
+        toDataSchema(node.getRight().getRowType()), joinType, joinKeys, joinClause, node.getHints());
   }
 
   private static DataSchema toDataSchema(RelDataType rowType) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/AbstractPlanNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/AbstractPlanNode.java
@@ -89,6 +89,7 @@ public abstract class AbstractPlanNode implements PlanNode, ProtoSerializable {
   public static class NodeHint {
     @ProtoProperties
     public Map<String, Map<String, String>> _hintOptions;
+
     public NodeHint() {
     }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/JoinNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/JoinNode.java
@@ -18,9 +18,7 @@
  */
 package org.apache.pinot.query.planner.plannode;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.hint.RelHint;
@@ -47,13 +45,6 @@ public class JoinNode extends AbstractPlanNode {
 
   public JoinNode(int planFragmentId) {
     super(planFragmentId);
-  }
-
-  @VisibleForTesting
-  public JoinNode(int planFragmentId, DataSchema dataSchema, DataSchema leftSchema, DataSchema rightSchema,
-      JoinRelType joinRelType, JoinKeys joinKeys, List<RexExpression> joinClause) {
-    this(planFragmentId, dataSchema, leftSchema, rightSchema, joinRelType, joinKeys, joinClause,
-        Collections.emptyList());
   }
 
   public JoinNode(int planFragmentId, DataSchema dataSchema, DataSchema leftSchema, DataSchema rightSchema,

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/JoinNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/JoinNode.java
@@ -18,9 +18,12 @@
  */
 package org.apache.pinot.query.planner.plannode;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.hint.RelHint;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.partitioning.FieldSelectionKeySelector;
@@ -36,6 +39,8 @@ public class JoinNode extends AbstractPlanNode {
   @ProtoProperties
   private List<RexExpression> _joinClause;
   @ProtoProperties
+  private NodeHint _joinHints;
+  @ProtoProperties
   private List<String> _leftColumnNames;
   @ProtoProperties
   private List<String> _rightColumnNames;
@@ -44,14 +49,22 @@ public class JoinNode extends AbstractPlanNode {
     super(planFragmentId);
   }
 
+  @VisibleForTesting
   public JoinNode(int planFragmentId, DataSchema dataSchema, DataSchema leftSchema, DataSchema rightSchema,
       JoinRelType joinRelType, JoinKeys joinKeys, List<RexExpression> joinClause) {
+    this(planFragmentId, dataSchema, leftSchema, rightSchema, joinRelType, joinKeys, joinClause,
+        Collections.emptyList());
+  }
+
+  public JoinNode(int planFragmentId, DataSchema dataSchema, DataSchema leftSchema, DataSchema rightSchema,
+      JoinRelType joinRelType, JoinKeys joinKeys, List<RexExpression> joinClause, List<RelHint> joinHints) {
     super(planFragmentId, dataSchema);
     _leftColumnNames = Arrays.asList(leftSchema.getColumnNames());
     _rightColumnNames = Arrays.asList(rightSchema.getColumnNames());
     _joinRelType = joinRelType;
     _joinKeys = joinKeys;
     _joinClause = joinClause;
+    _joinHints = new NodeHint(joinHints);
   }
 
   public JoinRelType getJoinRelType() {
@@ -64,6 +77,10 @@ public class JoinNode extends AbstractPlanNode {
 
   public List<RexExpression> getJoinClauses() {
     return _joinClause;
+  }
+
+  public NodeHint getJoinHints() {
+    return _joinHints;
   }
 
   public List<String> getLeftColumnNames() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -29,17 +29,23 @@ import java.util.Map;
 import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.core.JoinRelType;
+import org.apache.calcite.rel.hint.PinotHintOptions;
 import org.apache.pinot.common.datablock.DataBlock;
+import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.partitioning.KeySelector;
+import org.apache.pinot.query.planner.plannode.AbstractPlanNode;
 import org.apache.pinot.query.planner.plannode.JoinNode;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.utils.TypeUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.query.runtime.plan.StageMetadata;
+import org.apache.pinot.spi.utils.CommonConstants;
 
 
 /**
@@ -58,6 +64,8 @@ import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 public class HashJoinOperator extends MultiStageOperator {
   private static final String EXPLAIN_NAME = "HASH_JOIN";
   private static final int INITIAL_HEURISTIC_SIZE = 16;
+  private static final int DEFAULT_MAX_ROWS_IN_JOIN = 1024 * 1024; // 2^20, around 1MM rows
+  private static final JoinOverFlowMode DEFAULT_JOIN_OVERFLOW_MODE = JoinOverFlowMode.THROW;
 
   private static final Set<JoinRelType> SUPPORTED_JOIN_TYPES = ImmutableSet.of(
       JoinRelType.INNER, JoinRelType.LEFT, JoinRelType.RIGHT, JoinRelType.FULL, JoinRelType.SEMI, JoinRelType.ANTI);
@@ -83,14 +91,32 @@ public class HashJoinOperator extends MultiStageOperator {
   // TODO: Remove this special handling by fixing data block EOS abstraction or operator's invariant.
   private boolean _isTerminated;
   private TransferableBlock _upstreamErrorBlock;
-  private KeySelector<Object[], Object[]> _leftKeySelector;
-  private KeySelector<Object[], Object[]> _rightKeySelector;
+  private final KeySelector<Object[], Object[]> _leftKeySelector;
+  private final KeySelector<Object[], Object[]> _rightKeySelector;
+
+  // Below are specific parameters to protect the hash table from growing too large.
+  // Once the hash table reaches the limit, we will throw exception or break the right table build process.
+  /**
+   * Max rows allowed to build the right table hash collection.
+   */
+  private final int _maxRowsInHashTable;
+  /**
+   * Mode when join overflow happens, supported values: THROW or BREAK.
+   *   THROW(default): Break right table build process, and throw exception, no JOIN with left table performed.
+   *   BREAK: Break right table build process, continue to perform JOIN operation, results might be partial.
+   */
+  private final JoinOverFlowMode _joinOverflowMode;
+
+  private int _currentRowsInHashTable = 0;
+  private ProcessingException _partialResultException = null;
 
   public HashJoinOperator(OpChainExecutionContext context, MultiStageOperator leftTableOperator,
       MultiStageOperator rightTableOperator, DataSchema leftSchema, JoinNode node) {
     super(context);
     Preconditions.checkState(SUPPORTED_JOIN_TYPES.contains(node.getJoinRelType()),
         "Join type: " + node.getJoinRelType() + " is not supported!");
+    _maxRowsInHashTable = getMaxRowInJoin(context.getStageMetadata(), node.getJoinHints());
+    _joinOverflowMode = getJoinOverflowMode(context.getStageMetadata(), node.getJoinHints());
     _joinType = node.getJoinRelType();
     _leftKeySelector = node.getJoinKeys().getLeftJoinKeySelector();
     _rightKeySelector = node.getJoinKeys().getRightJoinKeySelector();
@@ -119,6 +145,38 @@ public class HashJoinOperator extends MultiStageOperator {
     _upstreamErrorBlock = null;
   }
 
+  private JoinOverFlowMode getJoinOverflowMode(StageMetadata stageMetadata, AbstractPlanNode.NodeHint joinHints) {
+    if (joinHints != null && joinHints._hintOptions != null && joinHints._hintOptions
+        .containsKey(PinotHintOptions.JOIN_HINT_OPTIONS) && joinHints._hintOptions.get(
+            PinotHintOptions.JOIN_HINT_OPTIONS)
+        .containsKey(PinotHintOptions.JoinHintOptions.JOIN_OVERFLOW_MODE)) {
+      return JoinOverFlowMode.valueOf(joinHints._hintOptions.get(PinotHintOptions.JOIN_HINT_OPTIONS)
+          .get(PinotHintOptions.JoinHintOptions.JOIN_OVERFLOW_MODE));
+    }
+    if (stageMetadata != null && stageMetadata.getCustomProperties() != null && stageMetadata.getCustomProperties()
+        .containsKey(CommonConstants.Broker.Request.QueryOptionKey.JOIN_OVERFLOW_MODE)) {
+      return JoinOverFlowMode.valueOf(
+          stageMetadata.getCustomProperties().get(CommonConstants.Broker.Request.QueryOptionKey.JOIN_OVERFLOW_MODE));
+    }
+    return DEFAULT_JOIN_OVERFLOW_MODE;
+  }
+
+  private int getMaxRowInJoin(StageMetadata stageMetadata, AbstractPlanNode.NodeHint joinHints) {
+    if (joinHints != null && joinHints._hintOptions != null && joinHints._hintOptions
+        .containsKey(PinotHintOptions.JOIN_HINT_OPTIONS) && joinHints._hintOptions.get(
+            PinotHintOptions.JOIN_HINT_OPTIONS)
+        .containsKey(PinotHintOptions.JoinHintOptions.MAX_ROWS_IN_JOIN)) {
+      return Integer.parseInt(joinHints._hintOptions.get(PinotHintOptions.JOIN_HINT_OPTIONS)
+          .get(PinotHintOptions.JoinHintOptions.MAX_ROWS_IN_JOIN));
+    }
+    if (stageMetadata != null && stageMetadata.getCustomProperties() != null && stageMetadata.getCustomProperties()
+        .containsKey(CommonConstants.Broker.Request.QueryOptionKey.MAX_ROWS_IN_JOIN)) {
+      return Integer.parseInt(
+          stageMetadata.getCustomProperties().get(CommonConstants.Broker.Request.QueryOptionKey.MAX_ROWS_IN_JOIN));
+    }
+    return DEFAULT_MAX_ROWS_IN_JOIN;
+  }
+
   // TODO: Separate left and right table operator.
   @Override
   public List<MultiStageOperator> getChildOperators() {
@@ -135,7 +193,7 @@ public class HashJoinOperator extends MultiStageOperator {
   protected TransferableBlock getNextBlock() {
     try {
       if (_isTerminated) {
-        return TransferableBlockUtils.getEndOfStreamTransferableBlock();
+        return setPartialResultExceptionToBlock(TransferableBlockUtils.getEndOfStreamTransferableBlock());
       }
       if (!_isHashTableBuilt) {
         // Build JOIN hash table
@@ -146,25 +204,45 @@ public class HashJoinOperator extends MultiStageOperator {
       }
       TransferableBlock leftBlock = _leftTableOperator.nextBlock();
       // JOIN each left block with the right block.
-      return buildJoinedDataBlock(leftBlock);
+      return setPartialResultExceptionToBlock(buildJoinedDataBlock(leftBlock));
     } catch (Exception e) {
       return TransferableBlockUtils.getErrorTransferableBlock(e);
     }
   }
 
-  private void buildBroadcastHashTable() {
+  private void buildBroadcastHashTable()
+      throws ProcessingException {
     TransferableBlock rightBlock = _rightTableOperator.nextBlock();
     while (!TransferableBlockUtils.isEndOfStream(rightBlock)) {
       List<Object[]> container = rightBlock.getContainer();
+      // Row based overflow check.
+      if (container.size() + _currentRowsInHashTable > _maxRowsInHashTable) {
+        _partialResultException = new ProcessingException(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE);
+        _partialResultException.setMessage(
+            "Cannot build in memory hash table for join operator, reach number of rows limit: "
+                + _maxRowsInHashTable);
+        if (_joinOverflowMode == JoinOverFlowMode.THROW) {
+          throw _partialResultException;
+        } else {
+          // Just fill up the buffer.
+          int remainingRows = _maxRowsInHashTable - _currentRowsInHashTable;
+          container = container.subList(0, remainingRows);
+        }
+      }
       // put all the rows into corresponding hash collections keyed by the key selector function.
       for (Object[] row : container) {
         ArrayList<Object[]> hashCollection = _broadcastRightTable.computeIfAbsent(
             new Key(_rightKeySelector.getKey(row)), k -> new ArrayList<>(INITIAL_HEURISTIC_SIZE));
         int size = hashCollection.size();
-        if ((size & size - 1) == 0 && size < Integer.MAX_VALUE / 2) { // is power of 2
-          hashCollection.ensureCapacity(size << 1);
+        if ((size & size - 1) == 0 && size < _maxRowsInHashTable && size < Integer.MAX_VALUE / 2) { // is power of 2
+          hashCollection.ensureCapacity(Math.min(size << 1, _maxRowsInHashTable));
         }
+        // TODO: Support size based overflow.
         hashCollection.add(row);
+      }
+      _currentRowsInHashTable += container.size();
+      if (_currentRowsInHashTable == _maxRowsInHashTable) {
+        break;
       }
       rightBlock = _rightTableOperator.nextBlock();
     }
@@ -175,8 +253,7 @@ public class HashJoinOperator extends MultiStageOperator {
     }
   }
 
-  private TransferableBlock buildJoinedDataBlock(TransferableBlock leftBlock)
-      throws Exception {
+  private TransferableBlock buildJoinedDataBlock(TransferableBlock leftBlock) {
     if (leftBlock.isErrorBlock()) {
       _upstreamErrorBlock = leftBlock;
       return _upstreamErrorBlock;
@@ -226,6 +303,13 @@ public class HashJoinOperator extends MultiStageOperator {
       }
     }
     return new TransferableBlock(rows, _resultSchema, DataBlock.Type.ROW);
+  }
+
+  private TransferableBlock setPartialResultExceptionToBlock(TransferableBlock block) {
+    if (_partialResultException != null) {
+      block.getDataBlock().addException(_partialResultException);
+    }
+    return block;
   }
 
   private List<Object[]> buildJoinedDataBlockSemi(TransferableBlock leftBlock) {
@@ -320,5 +404,9 @@ public class HashJoinOperator extends MultiStageOperator {
 
   private boolean needUnmatchedLeftRows() {
     return _joinType == JoinRelType.LEFT || _joinType == JoinRelType.FULL;
+  }
+
+  enum JoinOverFlowMode {
+    THROW, BREAK
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/QueryConfig.java
@@ -58,4 +58,10 @@ public class QueryConfig {
    */
   public static final String KEY_OF_SERVER_RESPONSE_STATUS_ERROR = "ERROR";
   public static final String KEY_OF_SERVER_RESPONSE_STATUS_OK = "OK";
+
+  /**
+   * Configuration for join overflow.
+   */
+  public static final String KEY_OF_JOIN_OVERFLOW_MODE = "pinot.query.join.overflow.mode";
+  public static final String KEY_OF_MAX_ROWS_IN_JOIN = "pinot.query.join.max.rows";
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -22,6 +22,7 @@ import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.calcite.rel.core.JoinRelType;
@@ -104,7 +105,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
+        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, Collections.emptyList());
     HashJoinOperator joinOnString =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
@@ -139,7 +140,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, Collections.emptyList());
     HashJoinOperator joinOnInt =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = joinOnInt.nextBlock();
@@ -171,7 +172,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses);
+        getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses, Collections.emptyList());
     HashJoinOperator joinOnInt =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = joinOnInt.nextBlock();
@@ -210,7 +211,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.LEFT,
-        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
+        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, Collections.emptyList());
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
@@ -242,7 +243,7 @@ public class HashJoinOperatorTest {
         });
     List<RexExpression> joinClauses = new ArrayList<>();
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, Collections.emptyList());
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
@@ -271,7 +272,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.LEFT,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, Collections.emptyList());
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
@@ -304,7 +305,7 @@ public class HashJoinOperatorTest {
         });
 
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, Collections.emptyList());
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
@@ -340,7 +341,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses);
+        getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses, Collections.emptyList());
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
@@ -376,7 +377,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses);
+        getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses, Collections.emptyList());
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
@@ -408,7 +409,7 @@ public class HashJoinOperatorTest {
         DataSchema.ColumnDataType.STRING
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.RIGHT,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, Collections.emptyList());
     HashJoinOperator joinOnNum =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = joinOnNum.nextBlock();
@@ -449,7 +450,7 @@ public class HashJoinOperatorTest {
         DataSchema.ColumnDataType.STRING
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.SEMI,
-        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
+        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, Collections.emptyList());
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
@@ -483,7 +484,7 @@ public class HashJoinOperatorTest {
         DataSchema.ColumnDataType.STRING
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.FULL,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, Collections.emptyList());
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
@@ -527,7 +528,7 @@ public class HashJoinOperatorTest {
         DataSchema.ColumnDataType.STRING
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.ANTI,
-        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses);
+        getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, Collections.emptyList());
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
@@ -560,7 +561,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, Collections.emptyList());
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
@@ -591,7 +592,7 @@ public class HashJoinOperatorTest {
             DataSchema.ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
-        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses);
+        getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, Collections.emptyList());
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerExecutorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerExecutorTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.runtime.plan.pipeline;
 
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableMap;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
@@ -91,7 +92,6 @@ public class PipelineBreakerExecutorTest {
               ImmutableList.of(_server), ImmutableMap.of()))
           .build()).collect(Collectors.toList())).build();
 
-
   @AfterClass
   public void tearDownClass() {
     ExecutorServiceUtils.close(_executor);
@@ -152,7 +152,8 @@ public class PipelineBreakerExecutorTest {
     MailboxReceiveNode mailboxReceiveNode2 =
         new MailboxReceiveNode(0, DATA_SCHEMA, 2, RelDistribution.Type.SINGLETON, PinotRelExchangeType.PIPELINE_BREAKER,
             null, null, false, false, null);
-    JoinNode joinNode = new JoinNode(0, DATA_SCHEMA, DATA_SCHEMA, DATA_SCHEMA, JoinRelType.INNER, null, null);
+    JoinNode joinNode =
+        new JoinNode(0, DATA_SCHEMA, DATA_SCHEMA, DATA_SCHEMA, JoinRelType.INNER, null, null, Collections.emptyList());
     joinNode.addInput(mailboxReceiveNode1);
     joinNode.addInput(mailboxReceiveNode2);
     DistributedStagePlan distributedStagePlan =
@@ -247,7 +248,8 @@ public class PipelineBreakerExecutorTest {
     MailboxReceiveNode incorrectlyConfiguredMailboxNode =
         new MailboxReceiveNode(0, DATA_SCHEMA, 3, RelDistribution.Type.SINGLETON, PinotRelExchangeType.PIPELINE_BREAKER,
             null, null, false, false, null);
-    JoinNode joinNode = new JoinNode(0, DATA_SCHEMA, DATA_SCHEMA, DATA_SCHEMA, JoinRelType.INNER, null, null);
+    JoinNode joinNode =
+        new JoinNode(0, DATA_SCHEMA, DATA_SCHEMA, DATA_SCHEMA, JoinRelType.INNER, null, null, Collections.emptyList());
     joinNode.addInput(mailboxReceiveNode1);
     joinNode.addInput(incorrectlyConfiguredMailboxNode);
     DistributedStagePlan distributedStagePlan =
@@ -285,7 +287,8 @@ public class PipelineBreakerExecutorTest {
     MailboxReceiveNode incorrectlyConfiguredMailboxNode =
         new MailboxReceiveNode(0, DATA_SCHEMA, 2, RelDistribution.Type.SINGLETON, PinotRelExchangeType.PIPELINE_BREAKER,
             null, null, false, false, null);
-    JoinNode joinNode = new JoinNode(0, DATA_SCHEMA, DATA_SCHEMA, DATA_SCHEMA, JoinRelType.INNER, null, null);
+    JoinNode joinNode =
+        new JoinNode(0, DATA_SCHEMA, DATA_SCHEMA, DATA_SCHEMA, JoinRelType.INNER, null, null, Collections.emptyList());
     joinNode.addInput(mailboxReceiveNode1);
     joinNode.addInput(incorrectlyConfiguredMailboxNode);
     DistributedStagePlan distributedStagePlan =

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -96,7 +96,6 @@ public class CommonConstants {
     // https://datasketches.apache.org/docs/Theta/ThetaErrorTable.html
     public static final int DEFAULT_THETA_SKETCH_NOMINAL_ENTRIES = 65536;
 
-
     public static final int DEFAULT_TUPLE_SKETCH_LGK = 16;
 
     // Whether to rewrite DistinctCount to DistinctCountBitmap
@@ -250,19 +249,19 @@ public class CommonConstants {
     // By default, Jersey uses the default unbounded thread pool to process queries.
     // By enabling it, BrokerManagedAsyncExecutorProvider will be used to create a bounded thread pool.
     public static final String CONFIG_OF_ENABLE_BOUNDED_JERSEY_THREADPOOL_EXECUTOR =
-            "pinot.broker.enable.bounded.jersey.threadpool.executor";
+        "pinot.broker.enable.bounded.jersey.threadpool.executor";
     public static final boolean DEFAULT_ENABLE_BOUNDED_JERSEY_THREADPOOL_EXECUTOR = false;
     // Default capacities for the bounded thread pool
     public static final String CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_MAX_POOL_SIZE =
-            "pinot.broker.jersey.threadpool.executor.max.pool.size";
+        "pinot.broker.jersey.threadpool.executor.max.pool.size";
     public static final int DEFAULT_JERSEY_THREADPOOL_EXECUTOR_MAX_POOL_SIZE =
-            Runtime.getRuntime().availableProcessors() * 2;
+        Runtime.getRuntime().availableProcessors() * 2;
     public static final String CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_CORE_POOL_SIZE =
-            "pinot.broker.jersey.threadpool.executor.core.pool.size";
+        "pinot.broker.jersey.threadpool.executor.core.pool.size";
     public static final int DEFAULT_JERSEY_THREADPOOL_EXECUTOR_CORE_POOL_SIZE =
-            Runtime.getRuntime().availableProcessors() * 2;
+        Runtime.getRuntime().availableProcessors() * 2;
     public static final String CONFIG_OF_JERSEY_THREADPOOL_EXECUTOR_QUEUE_SIZE =
-            "pinot.broker.jersey.threadpool.executor.queue.size";
+        "pinot.broker.jersey.threadpool.executor.queue.size";
     public static final int DEFAULT_JERSEY_THREADPOOL_EXECUTOR_QUEUE_SIZE = Integer.MAX_VALUE;
 
     // used for SQL GROUP BY during broker reduce
@@ -349,6 +348,10 @@ public class CommonConstants {
         public static final String IN_PREDICATE_SORT_THRESHOLD = "inPredicateSortThreshold";
 
         public static final String DROP_RESULTS = "dropResults";
+
+        // Handle JOIN Overflow
+        public static final String MAX_ROWS_IN_JOIN = "maxRowsInJoin";
+        public static final String JOIN_OVERFLOW_MODE = "joinOverflowMode";
 
         // TODO: Remove these keys (only apply to PQL) after releasing 0.11.0
         @Deprecated


### PR DESCRIPTION
To protect the server from OOM, this PR introduces the limit for join operator to ensure the memory consumption is limited.

1. Add new query options for join operator right table size limit:
- joinOverflowMode(string) : Overflow mode, allowed value are: `THROW`/`BREAK`
  - Server config: `pinot.query.join.overflow.mode=THROW`
  - Session level: `SET joinOverflowMode='THROW'`
  - QueryHint level: `join_overflow_mode='THROW'`
- maxRowsInJoin(integer) :   the number of rows allowed for right table cache in a join operator
  - Server config: `pinot.query.join.max.rows=100000`
  - Session level: `SET maxRowsInJoin=1000000`
  - QueryHint level: `max_rows_in_join='1000000'`

2. Add server partial result exception
3. Support continuous processing when `joinOverflowMode = BREAK`;

TODO: Support size based limit.

Examples:
```
SET joinOverflowMode='BREAK';
SET maxRowsInJoin=10;
SELECT a.playerName, a.teamID, b.teamName 
FROM baseballStats_OFFLINE AS a
JOIN dimBaseballTeams_OFFLINE AS b
ON a.teamID = b.teamID
```


```
SELECT /*+ joinOptions(join_overflow_mode='BREAK', max_rows_in_join='10') */ a.playerName, a.teamID, b.teamName 
FROM baseballStats_OFFLINE AS a
JOIN dimBaseballTeams_OFFLINE AS b
ON a.teamID = b.teamID
```

Sample screenshot for:
0. Normal run without limit hit: (Joined result is 47735)
<img width="791" alt="image" src="https://github.com/apache/pinot/assets/1202120/32c24dda-3e28-40cf-9797-0d726ac2401a">
1. Query option: Throw exception when row limit hit:
<img width="1287" alt="image" src="https://github.com/apache/pinot/assets/1202120/2555e984-b8f3-4418-9a0b-defe0dd070a8">
2. Query option: Continue when row limit hit: (Joined result is 29884)
<img width="1126" alt="image" src="https://github.com/apache/pinot/assets/1202120/81584ccb-3ea5-44e2-bf0e-96776d89a5e2">

3. JoinHints: Throw exception when row limit hit:
<img width="1290" alt="image" src="https://github.com/apache/pinot/assets/1202120/965c038a-19fd-4ae2-8bbe-b733c6345dce">

4. JoinHints: Continue when row limit hit: (Joined result is 29884) 
<img width="756" alt="image" src="https://github.com/apache/pinot/assets/1202120/af1a61f8-eacf-4313-b39f-519908e94519">

More examples of difference between the threshold, and overflow mode:
<img width="783" alt="image" src="https://github.com/apache/pinot/assets/1202120/5e54f128-5fed-44d2-893b-8d1e3489b5a2">
<img width="1291" alt="image" src="https://github.com/apache/pinot/assets/1202120/b1015597-050a-4ce9-b69d-31e16af3dc2b">
<img width="1289" alt="image" src="https://github.com/apache/pinot/assets/1202120/ef130f25-63b3-4714-b5f5-f1b4ec8396e0">
