### PR TITLE
Fix RawStringDistinctExecutor integer overflow

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBigDecimalSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBigDecimalSingleColumnDistinctExecutor.java
@@ -68,7 +68,7 @@ public abstract class BaseRawBigDecimalSingleColumnDistinctExecutor implements D
     if (_hasNull) {
       records.add(new Record(new Object[]{null}));
     }
-    assert records.size() <= _limit + 1;
+    assert (records.size() - _limit) <= 1;
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBytesSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBytesSingleColumnDistinctExecutor.java
@@ -68,7 +68,7 @@ abstract class BaseRawBytesSingleColumnDistinctExecutor implements DistinctExecu
     if (_hasNull) {
       records.add(new Record(new Object[]{null}));
     }
-    assert records.size() <= _limit + 1;
+    assert (records.size() - _limit) <= 1;
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawStringSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawStringSingleColumnDistinctExecutor.java
@@ -67,7 +67,7 @@ abstract class BaseRawStringSingleColumnDistinctExecutor implements DistinctExec
     if (_hasNull) {
       records.add(new Record(new Object[]{null}));
     }
-    assert records.size() <= _limit + 1;
+    assert (records.size() - _limit) <= 1;
     return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
   }
 


### PR DESCRIPTION
```
select DISTINCT(n_comment) from nation limit 10
```
on tpc-h dataset fails on v2 engine due to integer overflow

```
[
  {
    "errorCode": 200,
    "message": "QueryExecutionError:\njava.lang.RuntimeException: Error executing query: [0]@100.94.5.107:49954 MAIL_RECEIVE(RANDOM_DISTRIBUTED)\n└── [1]@localhost:49966 MAIL_SEND(RANDOM_DISTRIBUTED)->{[0]@100.94.5.107@{49954,49954}|[0]}\n   └── [1]@localhost:49966 AGGREGATE_FINAL\n      └── [1]@localhost:49966 MAIL_RECEIVE(HASH_DISTRIBUTED)\n         └── [2]@localhost:49966 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{49966,49967}|[0]}\n...\nCaused by: java.lang.RuntimeException: Received error query execution result block: {200=QueryExecutionError:\njava.lang.AssertionError\n\tat org.apache.pinot.core.query.distinct.raw.BaseRawStringSingleColumnDistinctExecutor.getResult(BaseRawStringSingleColumnDistinctExecutor.java:70)\n\tat org.apache.pinot.core.query.distinct.raw.RawStringSingleColumnDistinctOnlyExecutor.getResult(RawStringSingleColumnDistinctOnlyExecutor.java:29)\n\tat org.apache.pinot.core.operator.query.DistinctOperator.getNextBlock(DistinctOperator.java:64)"
  }
]
```