### PR TITLE
Configure V2 to be case insensitive

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -104,7 +104,7 @@ public class QueryEnvironment {
 
     // catalog
     Properties catalogReaderConfigProperties = new Properties();
-    catalogReaderConfigProperties.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), "true");
+    catalogReaderConfigProperties.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), "false");
     _catalogReader = new PinotCalciteCatalogReader(_rootSchema, _rootSchema.path(null), _typeFactory,
         new CalciteConnectionConfigImpl(catalogReaderConfigProperties));
 

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/testutils/MockRoutingManagerFactory.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/testutils/MockRoutingManagerFactory.java
@@ -23,6 +23,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
@@ -80,8 +81,12 @@ public class MockRoutingManagerFactory {
   }
 
   private void registerTableNameWithType(Schema schema, String tableNameWithType) {
-    _tableNameMap.put(tableNameWithType, tableNameWithType);
-    _schemaMap.put(TableNameBuilder.extractRawTableName(tableNameWithType), schema);
+    _tableNameMap.put(tableNameWithType.toLowerCase(Locale.US), tableNameWithType);
+    String rawTableName = TableNameBuilder.extractRawTableName(tableNameWithType);
+    if (!rawTableName.equals(tableNameWithType)) {
+      _tableNameMap.put(rawTableName.toLowerCase(Locale.US), tableNameWithType);
+    }
+    _schemaMap.put(rawTableName, schema);
   }
 
   public void registerSegment(int insertToServerPort, String tableNameWithType, String segmentName) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -83,6 +83,29 @@ public final class Schema implements Serializable {
   // queries or not).
   private boolean _hasJSONColumn;
 
+  public Schema() {
+  }
+
+  private Schema(Schema other) {
+    _schemaName = other._schemaName;
+    _dimensionFieldSpecs.addAll(other._dimensionFieldSpecs);
+    _metricFieldSpecs.addAll(other._metricFieldSpecs);
+    if (other._timeFieldSpec != null) {
+      _timeFieldSpec = new TimeFieldSpec(
+          other._timeFieldSpec.getIncomingGranularitySpec(), other._timeFieldSpec.getOutgoingGranularitySpec());
+    }
+    _dateTimeFieldSpecs.addAll(other._dateTimeFieldSpecs);
+    _complexFieldSpecs.addAll(other._complexFieldSpecs);
+    if (other._primaryKeyColumns != null) {
+      _primaryKeyColumns = new ArrayList<>(other._primaryKeyColumns);
+    }
+    _fieldSpecMap.putAll(other._fieldSpecMap);
+    _dimensionNames.addAll(other._dimensionNames);
+    _metricNames.addAll(other._metricNames);
+    _dateTimeNames.addAll(other._dateTimeNames);
+    _hasJSONColumn = other._hasJSONColumn;
+  }
+
   public static Schema fromFile(File schemaFile)
       throws IOException {
     return JsonUtils.fileToObject(schemaFile, Schema.class);
@@ -648,7 +671,7 @@ public final class Schema implements Serializable {
       } catch (Exception e) {
         throw new RuntimeException("Invalid schema", e);
       }
-      return _schema;
+      return new Schema(_schema);
     }
   }
 


### PR DESCRIPTION
While V1 is case insensitive, V2 is case sensitive.

I'm not sure if we consider this a bug or a feature. This PR assumes it is a bug and therefore changes the V2 behavior to be case insensitive.

I've also modified `OfflineClusterIntegrationTest` to run the case insensitivity tests with V2. Given that these tests were testing the case insensitivity but also the fact that V1 ignores the schema, I had to split them:
* testCaseInsensitivity and testCaseInsensitivityWithColumnNameContainsTableName test case sensibility
* testSchemaIgnoredInV1 and testIgnoresSchemaInColumnNameWithTestNameInV1 test that schema is ignored in V1

In case we consider case sensibility in V2 a feature, feel free to close this PR