### PR TITLE
Error detected in base64 query when using multi stage engine

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -291,6 +291,25 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   }
 
   @Test
+  public void testIncorrectBase64()
+      throws Exception {
+    String sqlQuery = "SELECT AirlineID as originalCol, toBase64(toUtf8(AirlineID)) as encoded, "
+        + "fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))) as decoded FROM mytable "
+        + "GROUP BY AirlineID, toBase64(toUtf8(AirlineID)), fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))) "
+        + "ORDER BY fromUtf8(fromBase64(toBase64(toUtf8(AirlineID)))) LIMIT 10";
+
+    setUseMultiStageQueryEngine(false);
+    JsonNode jsonNode = postQuery(sqlQuery);
+    JsonNode exceptions = jsonNode.get("exceptions");
+    Assert.assertTrue(exceptions.isEmpty());
+
+    setUseMultiStageQueryEngine(true);
+    jsonNode = postQuery(sqlQuery);
+    exceptions = jsonNode.get("exceptions");
+    Assert.assertTrue(exceptions.isEmpty());
+  }
+
+  @Test
   public void testRefreshTableConfigAndQueryTimeout()
       throws Exception {
     // Set timeout as 5ms so that query will timeout


### PR DESCRIPTION
Trying to improve the coverage on multi stage engine I've found that this query fails while doesn't fail in V1. It may be the case that this is not an actual error and V1 was too generous with it, but just in case, I'm creating this PR in order to make it easier for @xiangfu0 or @Jackie-Jiang to verify that.

The error shown is:
```
QueryExecutionError:
  java.lang.RuntimeException: Error executing query: [0]@192.168.1.34:52432 MAIL_RECEIVE(RANDOM_DISTRIBUTED)
  └── [1]@localhost:52440 MAIL_SEND(RANDOM_DISTRIBUTED)->{[0]@192.168.1.34@{52432,52432}|[0]}
    └── [1]@localhost:52440 SORT LIMIT 10
      └── [1]@localhost:52440 MAIL_RECEIVE(HASH_DISTRIBUTED)
        └── [2]@localhost:52440 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{52440,52441}|[0]}
    ...
Caused by: java.lang.RuntimeException: 
Received error query execution result block: {1000=Unable to extract from container with type: METADATA
  java.lang.UnsupportedOperationException: Unable to extract from container with type: METADATA
    at org.apache.pinot.query.runtime.blocks.TransferableBlock.getContainer(TransferableBlock.java:94)
    at org.apache.pinot.query.runtime.operator.SortOperator.consumeInputBlocks(SortOperator.java:156)
    at org.apache.pinot.query.runtime.operator.SortOperator.getNextBlock(SortOperator.java:114)
```