### PR TITLE
[logging] fix consume rate logging bug to respect 1 minute threshold

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1652,11 +1652,11 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     // Log every minute or 100k events
     if (now - prevTime > TimeUnit.MINUTES.toMillis(TIME_THRESHOLD_FOR_LOG_MINUTES)
         || rowsConsumed >= MSG_COUNT_THRESHOLD_FOR_LOG) {
+      // multiply by 1000 to get events/sec. now and prevTime are in milliseconds.
+      float consumedRate = ((float) rowsConsumed) * 1000 / (now - prevTime);
       _segmentLogger.info(
           "Consumed {} events from (rate:{}/s), currentOffset={}, numRowsConsumedSoFar={}, numRowsIndexedSoFar={}",
-          // multiply by 1000 to get events/sec. now and prevTime are in milliseconds.
-          rowsConsumed, (float) (rowsConsumed) * 1000 / (now - prevTime), _currentOffset, _numRowsConsumed,
-          _numRowsIndexed);
+          rowsConsumed, consumedRate, _currentOffset, _numRowsConsumed, _numRowsIndexed);
       _lastConsumedCount = _numRowsConsumed;
       _lastLogTime = now;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1648,12 +1648,13 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
     _lastUpdatedRowsIndexed.set(_numRowsIndexed);
     final long now = now();
     final int rowsConsumed = _numRowsConsumed - _lastConsumedCount;
-    final long prevTime = _lastConsumedCount == 0 ? _consumeStartTime : _lastLogTime;
+    final long prevTime = _lastLogTime == 0 ? _consumeStartTime : _lastLogTime;
     // Log every minute or 100k events
     if (now - prevTime > TimeUnit.MINUTES.toMillis(TIME_THRESHOLD_FOR_LOG_MINUTES)
         || rowsConsumed >= MSG_COUNT_THRESHOLD_FOR_LOG) {
       _segmentLogger.info(
           "Consumed {} events from (rate:{}/s), currentOffset={}, numRowsConsumedSoFar={}, numRowsIndexedSoFar={}",
+          // multiply by 1000 to get events/sec. now and prevTime are in milliseconds.
           rowsConsumed, (float) (rowsConsumed) * 1000 / (now - prevTime), _currentOffset, _numRowsConsumed,
           _numRowsIndexed);
       _lastConsumedCount = _numRowsConsumed;


### PR DESCRIPTION
This is a small `fix` in realtime servers to avoid excessive logging. This will now correctly log at most once per minute or 100k events.

We should have been logging consume rate + other metadata every minute or every 100k events. But for some reason the code uses `lastConsumeCount` to check if we should use `consumeStartTime` or `lastLogTime` as previous time. Since we have partitions with low to no event volume (QA and such), `lastConsumeCount` is often 0, so this causes emits a log on every consume loop. Now we always use `lastLogTime` as `prevTime` when it's not 0.