### PR TITLE
[Multi-stage] Refactor query dispatcher to remove pipeline breaker

### DIFF
--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -477,18 +477,18 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
     //@formatter:off
     return new Object[][] {
 new Object[]{"EXPLAIN IMPLEMENTATION PLAN INCLUDING ALL ATTRIBUTES FOR SELECT col1, col3 FROM a",
-  "[0]@localhost:3 MAIL_RECEIVE(RANDOM_DISTRIBUTED)\n"
-  + "├── [1]@localhost:1 MAIL_SEND(RANDOM_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n"
+  "[0]@localhost:3 MAIL_RECEIVE(BROADCAST_DISTRIBUTED)\n"
+  + "├── [1]@localhost:1 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n"
   + "│   └── [1]@localhost:1 PROJECT\n"
   + "│      └── [1]@localhost:1 TABLE SCAN (a) null\n"
-  + "└── [1]@localhost:2 MAIL_SEND(RANDOM_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n"
+  + "└── [1]@localhost:2 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n"
   + "   └── [1]@localhost:2 PROJECT\n"
   + "      └── [1]@localhost:2 TABLE SCAN (a) null\n"},
 new Object[]{"EXPLAIN IMPLEMENTATION PLAN EXCLUDING ATTRIBUTES FOR "
     + "SELECT col1, COUNT(*) FROM a GROUP BY col1",
-  "[0]@localhost:3 MAIL_RECEIVE(RANDOM_DISTRIBUTED)\n"
-  + "├── [1]@localhost:1 MAIL_SEND(RANDOM_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]} (Subtree Omitted)\n"
-  + "└── [1]@localhost:2 MAIL_SEND(RANDOM_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n"
+  "[0]@localhost:3 MAIL_RECEIVE(BROADCAST_DISTRIBUTED)\n"
+  + "├── [1]@localhost:1 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]} (Subtree Omitted)\n"
+  + "└── [1]@localhost:2 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n"
   + "   └── [1]@localhost:2 AGGREGATE_FINAL\n"
   + "      └── [1]@localhost:2 MAIL_RECEIVE(HASH_DISTRIBUTED)\n"
   + "         ├── [2]@localhost:1 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{1,1}|[1],[1]@localhost@{2,2}|[0]}\n"
@@ -498,9 +498,9 @@ new Object[]{"EXPLAIN IMPLEMENTATION PLAN EXCLUDING ATTRIBUTES FOR "
   + "            └── [2]@localhost:2 AGGREGATE_LEAF\n"
   + "               └── [2]@localhost:2 TABLE SCAN (a) null\n"},
 new Object[]{"EXPLAIN IMPLEMENTATION PLAN FOR SELECT a.col1, b.col3 FROM a JOIN b ON a.col1 = b.col1",
-  "[0]@localhost:3 MAIL_RECEIVE(RANDOM_DISTRIBUTED)\n"
-  + "├── [1]@localhost:1 MAIL_SEND(RANDOM_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]} (Subtree Omitted)\n"
-  + "└── [1]@localhost:2 MAIL_SEND(RANDOM_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n"
+  "[0]@localhost:3 MAIL_RECEIVE(BROADCAST_DISTRIBUTED)\n"
+  + "├── [1]@localhost:1 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]} (Subtree Omitted)\n"
+  + "└── [1]@localhost:2 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n"
   + "   └── [1]@localhost:2 PROJECT\n"
   + "      └── [1]@localhost:2 JOIN\n"
   + "         ├── [1]@localhost:2 MAIL_RECEIVE(HASH_DISTRIBUTED)\n"

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.query.runtime.plan;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.operator.OpChainId;
@@ -42,7 +41,6 @@ public class OpChainExecutionContext {
   private final OpChainStats _stats;
   private final boolean _traceEnabled;
 
-  @VisibleForTesting
   public OpChainExecutionContext(MailboxService mailboxService, long requestId, int stageId,
       VirtualServerAddress server, long deadlineMs, StageMetadata stageMetadata,
       PipelineBreakerResult pipelineBreakerResult, boolean traceEnabled) {
@@ -55,8 +53,7 @@ public class OpChainExecutionContext {
     _id = new OpChainId(requestId, server.workerId(), stageId);
     _stats = new OpChainStats(_id.toString());
     if (pipelineBreakerResult != null && pipelineBreakerResult.getOpChainStats() != null) {
-      _stats.getOperatorStatsMap().putAll(
-          pipelineBreakerResult.getOpChainStats().getOperatorStatsMap());
+      _stats.getOperatorStatsMap().putAll(pipelineBreakerResult.getOpChainStats().getOperatorStatsMap());
     }
     _traceEnabled = traceEnabled;
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTestBase.java
@@ -20,7 +20,6 @@ package org.apache.pinot.query.runtime;
 
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.base.Preconditions;
 import com.google.common.math.DoubleMath;
 import java.math.BigDecimal;
 import java.sql.Connection;
@@ -51,8 +50,8 @@ import org.apache.pinot.query.QueryEnvironment;
 import org.apache.pinot.query.QueryServerEnclosure;
 import org.apache.pinot.query.QueryTestSet;
 import org.apache.pinot.query.mailbox.MailboxService;
+import org.apache.pinot.query.planner.DispatchablePlanFragment;
 import org.apache.pinot.query.planner.DispatchableSubPlan;
-import org.apache.pinot.query.planner.plannode.MailboxReceiveNode;
 import org.apache.pinot.query.routing.QueryServerInstance;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.executor.OpChainSchedulerService;
@@ -116,9 +115,10 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
     DispatchableSubPlan dispatchableSubPlan = queryPlannerResult.getQueryPlan();
     Map<String, String> requestMetadataMap = new HashMap<>();
     requestMetadataMap.put(CommonConstants.Query.Request.MetadataKeys.REQUEST_ID, String.valueOf(requestId));
-    Long timeoutMs = QueryOptionsUtils.getTimeoutMs(sqlNodeAndOptions.getOptions());
-    requestMetadataMap.put(CommonConstants.Broker.Request.QueryOptionKey.TIMEOUT_MS,
-        String.valueOf(timeoutMs != null ? timeoutMs : CommonConstants.Broker.DEFAULT_BROKER_TIMEOUT_MS));
+    Long timeoutMsInQueryOption = QueryOptionsUtils.getTimeoutMs(sqlNodeAndOptions.getOptions());
+    long timeoutMs =
+        timeoutMsInQueryOption != null ? timeoutMsInQueryOption : CommonConstants.Broker.DEFAULT_BROKER_TIMEOUT_MS;
+    requestMetadataMap.put(CommonConstants.Broker.Request.QueryOptionKey.TIMEOUT_MS, String.valueOf(timeoutMs));
     requestMetadataMap.put(CommonConstants.Broker.Request.QueryOptionKey.ENABLE_NULL_HANDLING, "true");
     requestMetadataMap.putAll(sqlNodeAndOptions.getOptions());
 
@@ -127,23 +127,18 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
       requestMetadataMap.put(CommonConstants.Broker.Request.TRACE, "true");
     }
 
-    int reducerStageId = -1;
-    for (int stageId = 0; stageId < dispatchableSubPlan.getQueryStageList().size(); stageId++) {
-      if (dispatchableSubPlan.getQueryStageList().get(stageId).getPlanFragment()
-          .getFragmentRoot() instanceof MailboxReceiveNode) {
-        reducerStageId = stageId;
-      } else {
+    List<DispatchablePlanFragment> stagePlans = dispatchableSubPlan.getQueryStageList();
+    for (int stageId = 0; stageId < stagePlans.size(); stageId++) {
+      if (stageId != 0) {
         processDistributedStagePlans(dispatchableSubPlan, stageId, requestMetadataMap);
       }
       if (executionStatsAggregatorMap != null) {
         executionStatsAggregatorMap.put(stageId, new ExecutionStatsAggregator(true));
       }
     }
-    Preconditions.checkState(reducerStageId != -1);
-    ResultTable resultTable = QueryDispatcher.runReducer(requestId, dispatchableSubPlan, reducerStageId,
-        Long.parseLong(requestMetadataMap.get(CommonConstants.Broker.Request.QueryOptionKey.TIMEOUT_MS)),
-        _mailboxService,
-        _reducerScheduler, executionStatsAggregatorMap, true);
+    ResultTable resultTable =
+        QueryDispatcher.runReducer(requestId, dispatchableSubPlan, timeoutMs, executionStatsAggregatorMap, true,
+            _mailboxService);
     return resultTable.getRows();
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -19,21 +19,22 @@
 package org.apache.pinot.query.service.dispatch;
 
 import io.grpc.stub.StreamObserver;
+import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Random;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.pinot.common.proto.Worker;
 import org.apache.pinot.common.utils.NamedThreadFactory;
 import org.apache.pinot.query.QueryEnvironment;
 import org.apache.pinot.query.QueryEnvironmentTestBase;
 import org.apache.pinot.query.QueryTestSet;
+import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.planner.DispatchableSubPlan;
-import org.apache.pinot.query.planner.PlannerUtils;
 import org.apache.pinot.query.runtime.QueryRunner;
 import org.apache.pinot.query.runtime.executor.ExecutorServiceUtils;
 import org.apache.pinot.query.service.server.QueryServer;
@@ -41,53 +42,46 @@ import org.apache.pinot.query.testutils.QueryTestUtils;
 import org.apache.pinot.spi.trace.DefaultRequestContext;
 import org.apache.pinot.spi.trace.RequestContext;
 import org.mockito.Mockito;
-import org.mockito.invocation.InvocationOnMock;
-import org.mockito.stubbing.Answer;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-import org.testng.collections.Lists;
 
 
 public class QueryDispatcherTest extends QueryTestSet {
-  private static final Random RANDOM_REQUEST_ID_GEN = new Random();
+  private static final AtomicLong REQUEST_ID_GEN = new AtomicLong();
   private static final int QUERY_SERVER_COUNT = 2;
-  private static final ExecutorService EXECUTOR = Executors.newCachedThreadPool(
-      new NamedThreadFactory("worker_on_" + QueryDispatcherTest.class.getSimpleName()));
+  private static final ExecutorService EXECUTOR =
+      Executors.newCachedThreadPool(new NamedThreadFactory("worker_on_" + QueryDispatcherTest.class.getSimpleName()));
 
   private final Map<Integer, QueryServer> _queryServerMap = new HashMap<>();
-  private final Map<Integer, QueryRunner> _queryRunnerMap = new HashMap<>();
 
   private QueryEnvironment _queryEnvironment;
-  private DispatchClient _dispatchClient;
+  private QueryDispatcher _queryDispatcher;
 
   @BeforeClass
   public void setUp()
       throws Exception {
-
     for (int i = 0; i < QUERY_SERVER_COUNT; i++) {
       int availablePort = QueryTestUtils.getAvailablePort();
       QueryRunner queryRunner = Mockito.mock(QueryRunner.class);
       Mockito.when(queryRunner.getOpChainExecutorService()).thenReturn(EXECUTOR);
-      Mockito.when(queryRunner.getOpChainExecutorService()).thenReturn(EXECUTOR);
-      QueryServer queryServer = new QueryServer(availablePort, queryRunner);
-      queryServer = Mockito.spy(queryServer);
+      QueryServer queryServer = Mockito.spy(new QueryServer(availablePort, queryRunner));
       queryServer.start();
       _queryServerMap.put(availablePort, queryServer);
-      _queryRunnerMap.put(availablePort, queryRunner);
     }
-
-    List<Integer> portList = Lists.newArrayList(_queryServerMap.keySet());
+    List<Integer> portList = new ArrayList<>(_queryServerMap.keySet());
 
     // reducer port doesn't matter, we are testing the worker instance not GRPC.
     _queryEnvironment = QueryEnvironmentTestBase.getQueryEnvironment(1, portList.get(0), portList.get(1),
         QueryEnvironmentTestBase.TABLE_SCHEMAS, QueryEnvironmentTestBase.SERVER1_SEGMENTS,
         QueryEnvironmentTestBase.SERVER2_SEGMENTS, null);
+    _queryDispatcher = new QueryDispatcher(Mockito.mock(MailboxService.class));
   }
 
   @AfterClass
   public void tearDown() {
+    _queryDispatcher.shutdown();
     for (QueryServer worker : _queryServerMap.values()) {
       worker.shutdown();
     }
@@ -98,28 +92,22 @@ public class QueryDispatcherTest extends QueryTestSet {
   public void testQueryDispatcherCanSendCorrectPayload(String sql)
       throws Exception {
     DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(sql);
-    QueryDispatcher dispatcher = new QueryDispatcher();
-    int reducerStageId =
-        dispatcher.submit(RANDOM_REQUEST_ID_GEN.nextLong(), dispatchableSubPlan, 10_000L, new HashMap<>());
-    Assert.assertTrue(PlannerUtils.isRootPlanFragment(reducerStageId));
-    dispatcher.shutdown();
+    _queryDispatcher.submit(REQUEST_ID_GEN.getAndIncrement(), dispatchableSubPlan, 10_000L, Collections.emptyMap());
   }
 
   @Test
-  public void testQueryDispatcherThrowsWhenQueryServerThrows()
-      throws Exception {
+  public void testQueryDispatcherThrowsWhenQueryServerThrows() {
     String sql = "SELECT * FROM a WHERE col1 = 'foo'";
     QueryServer failingQueryServer = _queryServerMap.values().iterator().next();
     Mockito.doThrow(new RuntimeException("foo")).when(failingQueryServer).submit(Mockito.any(), Mockito.any());
     DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(sql);
-    QueryDispatcher dispatcher = new QueryDispatcher();
     try {
-      dispatcher.submit(RANDOM_REQUEST_ID_GEN.nextLong(), dispatchableSubPlan, 10_000L, new HashMap<>());
+      _queryDispatcher.submit(REQUEST_ID_GEN.getAndIncrement(), dispatchableSubPlan, 10_000L, Collections.emptyMap());
       Assert.fail("Method call above should have failed");
     } catch (Exception e) {
       Assert.assertTrue(e.getMessage().contains("Error dispatching query"));
     }
-    dispatcher.shutdown();
+    Mockito.reset(failingQueryServer);
   }
 
   @Test
@@ -127,84 +115,70 @@ public class QueryDispatcherTest extends QueryTestSet {
       throws Exception {
     String sql = "SELECT * FROM a WHERE col1 = 'foo'";
     QueryServer failingQueryServer = _queryServerMap.values().iterator().next();
-    Mockito.doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocationOnMock)
-          throws Throwable {
-        StreamObserver<Worker.QueryResponse> observer = invocationOnMock.getArgument(1);
-        observer.onError(new RuntimeException("foo"));
-        return null;
-      }
+    Mockito.doAnswer(invocationOnMock -> {
+      StreamObserver<Worker.QueryResponse> observer = invocationOnMock.getArgument(1);
+      observer.onError(new RuntimeException("foo"));
+      return null;
     }).when(failingQueryServer).submit(Mockito.any(), Mockito.any());
-    DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(sql);
-    QueryDispatcher dispatcher = new QueryDispatcher();
-    long requestId = RANDOM_REQUEST_ID_GEN.nextLong();
+    long requestId = REQUEST_ID_GEN.getAndIncrement();
     RequestContext context = new DefaultRequestContext();
     context.setRequestId(requestId);
+    DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(sql);
     try {
-      dispatcher.submitAndReduce(context, dispatchableSubPlan, null, null, 10_000L, new HashMap<>(), null, false);
+      _queryDispatcher.submitAndReduce(context, dispatchableSubPlan, 10_000L, Collections.emptyMap(), null, false);
       Assert.fail("Method call above should have failed");
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Error executing query"));
+      Assert.assertTrue(e.getMessage().contains("Error dispatching query"));
     }
     // wait just a little, until the cancel is being called.
     Thread.sleep(50);
     for (QueryServer queryServer : _queryServerMap.values()) {
-      Mockito.verify(queryServer, Mockito.times(1)).cancel(Mockito.argThat(a -> a.getRequestId() == requestId),
-          Mockito.any());
+      Mockito.verify(queryServer, Mockito.times(1))
+          .cancel(Mockito.argThat(a -> a.getRequestId() == requestId), Mockito.any());
     }
-    dispatcher.shutdown();
+    Mockito.reset(failingQueryServer);
   }
 
   @Test
   public void testQueryDispatcherCancelWhenQueryReducerThrowsError()
       throws Exception {
     String sql = "SELECT * FROM a";
-    DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(sql);
-    QueryDispatcher dispatcher = new QueryDispatcher();
-    long requestId = RANDOM_REQUEST_ID_GEN.nextLong();
+    long requestId = REQUEST_ID_GEN.getAndIncrement();
     RequestContext context = new DefaultRequestContext();
     context.setRequestId(requestId);
+    DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(sql);
     try {
-      // will throw b/c mailboxService is null
-      dispatcher.submitAndReduce(context, dispatchableSubPlan, null, null, 10_000L, new HashMap<>(), null, false);
+      // will throw b/c mailboxService is mocked
+      _queryDispatcher.submitAndReduce(context, dispatchableSubPlan, 10_000L, Collections.emptyMap(), null, false);
       Assert.fail("Method call above should have failed");
-    } catch (Exception e) {
-      System.out.println("e = " + e);
-      Assert.assertTrue(e.getMessage().contains("Error executing query"));
+    } catch (NullPointerException e) {
+      // Expected
     }
     // wait just a little, until the cancel is being called.
     Thread.sleep(50);
     for (QueryServer queryServer : _queryServerMap.values()) {
-      Mockito.verify(queryServer, Mockito.times(1)).cancel(Mockito.argThat(a -> a.getRequestId() == requestId),
-          Mockito.any());
+      Mockito.verify(queryServer, Mockito.times(1))
+          .cancel(Mockito.argThat(a -> a.getRequestId() == requestId), Mockito.any());
     }
-    dispatcher.shutdown();
   }
 
   @Test
-  public void testQueryDispatcherThrowsWhenQueryServerCallsOnError()
-      throws Exception {
+  public void testQueryDispatcherThrowsWhenQueryServerCallsOnError() {
     String sql = "SELECT * FROM a WHERE col1 = 'foo'";
     QueryServer failingQueryServer = _queryServerMap.values().iterator().next();
-    Mockito.doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocationOnMock)
-          throws Throwable {
-        StreamObserver<Worker.QueryResponse> observer = invocationOnMock.getArgument(1);
-        observer.onError(new RuntimeException("foo"));
-        return null;
-      }
+    Mockito.doAnswer(invocationOnMock -> {
+      StreamObserver<Worker.QueryResponse> observer = invocationOnMock.getArgument(1);
+      observer.onError(new RuntimeException("foo"));
+      return null;
     }).when(failingQueryServer).submit(Mockito.any(), Mockito.any());
     DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(sql);
-    QueryDispatcher dispatcher = new QueryDispatcher();
     try {
-      dispatcher.submit(RANDOM_REQUEST_ID_GEN.nextLong(), dispatchableSubPlan, 10_000L, new HashMap<>());
+      _queryDispatcher.submit(REQUEST_ID_GEN.getAndIncrement(), dispatchableSubPlan, 10_000L, Collections.emptyMap());
       Assert.fail("Method call above should have failed");
     } catch (Exception e) {
       Assert.assertTrue(e.getMessage().contains("Error dispatching query"));
     }
-    dispatcher.shutdown();
+    Mockito.reset(failingQueryServer);
   }
 
   @Test
@@ -212,40 +186,34 @@ public class QueryDispatcherTest extends QueryTestSet {
     String sql = "SELECT * FROM a WHERE col1 = 'foo'";
     QueryServer failingQueryServer = _queryServerMap.values().iterator().next();
     CountDownLatch neverClosingLatch = new CountDownLatch(1);
-    Mockito.doAnswer(new Answer() {
-      @Override
-      public Object answer(InvocationOnMock invocationOnMock)
-          throws Throwable {
-        neverClosingLatch.await(5, TimeUnit.SECONDS);
-        StreamObserver<Worker.QueryResponse> observer = invocationOnMock.getArgument(1);
-        observer.onCompleted();
-        return null;
-      }
+    Mockito.doAnswer(invocationOnMock -> {
+      neverClosingLatch.await();
+      StreamObserver<Worker.QueryResponse> observer = invocationOnMock.getArgument(1);
+      observer.onCompleted();
+      return null;
     }).when(failingQueryServer).submit(Mockito.any(), Mockito.any());
     DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(sql);
-    QueryDispatcher dispatcher = new QueryDispatcher();
     try {
-      dispatcher.submit(RANDOM_REQUEST_ID_GEN.nextLong(), dispatchableSubPlan, 1_000, new HashMap<>());
+      _queryDispatcher.submit(REQUEST_ID_GEN.getAndIncrement(), dispatchableSubPlan, 200L, Collections.emptyMap());
       Assert.fail("Method call above should have failed");
     } catch (Exception e) {
-      Assert.assertTrue(e.getMessage().contains("Timed out waiting for response")
-          || e.getMessage().contains("Error dispatching query"));
+      String message = e.getMessage();
+      Assert.assertTrue(
+          message.contains("Timed out waiting for response") || message.contains("Error dispatching query"));
     }
     neverClosingLatch.countDown();
-    dispatcher.shutdown();
+    Mockito.reset(failingQueryServer);
   }
 
   @Test
   public void testQueryDispatcherThrowsWhenDeadlinePreExpiredAndAsyncResponseNotPolled() {
     String sql = "SELECT * FROM a WHERE col1 = 'foo'";
     DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(sql);
-    QueryDispatcher dispatcher = new QueryDispatcher();
     try {
-      dispatcher.submit(RANDOM_REQUEST_ID_GEN.nextLong(), dispatchableSubPlan, -10_000, new HashMap<>());
+      _queryDispatcher.submit(REQUEST_ID_GEN.getAndIncrement(), dispatchableSubPlan, 0L, Collections.emptyMap());
       Assert.fail("Method call above should have failed");
     } catch (Exception e) {
       Assert.assertTrue(e.getMessage().contains("Timed out waiting"));
     }
-    dispatcher.shutdown();
   }
 }


### PR DESCRIPTION
- Do not use pipeline breaker on broker side
  - It is adding complexity without real benefit
  - It makes the exception message very confusing
- Remove the unnecessary data flow executor and `OpChainSchedulerService` from broker
- Fix a bug in reducer logic where null value index is wrong