### PR TITLE
[Multi-stage] Limit groups for group-by executor

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
+import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.JoinOverFlowMode;
 
 
 /**
@@ -196,7 +197,8 @@ public class QueryOptionsUtils {
   }
 
   @Nullable
-  public static String getJoinOverflowMode(Map<String, String> queryOptions) {
-    return queryOptions.get(QueryOptionKey.JOIN_OVERFLOW_MODE);
+  public static JoinOverFlowMode getJoinOverflowMode(Map<String, String> queryOptions) {
+    String joinOverflowModeStr = queryOptions.get(QueryOptionKey.JOIN_OVERFLOW_MODE);
+    return joinOverflowModeStr != null ? JoinOverFlowMode.valueOf(joinOverflowModeStr) : null;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintOptions.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/hint/PinotHintOptions.java
@@ -61,6 +61,9 @@ public class PinotHintOptions {
   public static class AggregateOptions {
     public static final String IS_PARTITIONED_BY_GROUP_BY_KEYS = "is_partitioned_by_group_by_keys";
     public static final String SKIP_LEAF_STAGE_GROUP_BY_AGGREGATION = "is_skip_leaf_stage_group_by";
+
+    public static final String NUM_GROUPS_LIMIT = "num_groups_limit";
+    public static final String MAX_INITIAL_RESULT_HOLDER_CAPACITY = "max_initial_result_holder_capacity";
   }
 
   public static class JoinHintOptions {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
@@ -24,17 +24,20 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.calcite.rel.hint.PinotHintOptions;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.data.table.Key;
 import org.apache.pinot.core.plan.maker.InstancePlanMakerImplV2;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.core.query.aggregation.groupby.GroupKeyGenerator;
+import org.apache.pinot.query.planner.plannode.AbstractPlanNode;
 import org.apache.pinot.query.planner.plannode.AggregateNode.AggType;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.operator.utils.TypeUtils;
-
 
 
 /**
@@ -59,9 +62,14 @@ public class MultistageGroupByExecutor {
   // because they use the zero based integer indexes to store results.
   private final Map<Key, Integer> _groupKeyToIdMap;
 
+  private final int _numGroupsLimit;
+  private final int _maxInitialResultHolderCapacity;
+
+  private boolean _numGroupsLimitReached;
+
   public MultistageGroupByExecutor(List<ExpressionContext> groupByExpr, AggregationFunction[] aggFunctions,
       @Nullable int[] filterArgIndices, AggType aggType, Map<String, Integer> colNameToIndexMap,
-      DataSchema resultSchema) {
+      DataSchema resultSchema, Map<String, String> customProperties, @Nullable AbstractPlanNode.NodeHint nodeHint) {
     _aggType = aggType;
     _colNameToIndexMap = colNameToIndexMap;
     _groupSet = groupByExpr;
@@ -74,11 +82,48 @@ public class MultistageGroupByExecutor {
 
     _groupKeyToIdMap = new HashMap<>();
 
+    _numGroupsLimit = getNumGroupsLimit(customProperties, nodeHint);
+    _maxInitialResultHolderCapacity = getMaxInitialResultHolderCapacity(customProperties, nodeHint);
+
     for (int i = 0; i < _aggFunctions.length; i++) {
-      _aggregateResultHolders[i] = _aggFunctions[i].createGroupByResultHolder(
-          InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY,
-          InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT);
+      _aggregateResultHolders[i] =
+          _aggFunctions[i].createGroupByResultHolder(_maxInitialResultHolderCapacity, _numGroupsLimit);
     }
+  }
+
+  private int getNumGroupsLimit(Map<String, String> customProperties, @Nullable AbstractPlanNode.NodeHint nodeHint) {
+    if (nodeHint != null) {
+      Map<String, String> aggregateOptions = nodeHint._hintOptions.get(PinotHintOptions.AGGREGATE_HINT_OPTIONS);
+      if (aggregateOptions != null) {
+        String numGroupsLimitStr = aggregateOptions.get(PinotHintOptions.AggregateOptions.NUM_GROUPS_LIMIT);
+        if (numGroupsLimitStr != null) {
+          return Integer.parseInt(numGroupsLimitStr);
+        }
+      }
+    }
+    Integer numGroupsLimit = QueryOptionsUtils.getNumGroupsLimit(customProperties);
+    return numGroupsLimit != null ? numGroupsLimit : InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT;
+  }
+
+  private int getMaxInitialResultHolderCapacity(Map<String, String> customProperties,
+      @Nullable AbstractPlanNode.NodeHint nodeHint) {
+    if (nodeHint != null) {
+      Map<String, String> aggregateOptions = nodeHint._hintOptions.get(PinotHintOptions.AGGREGATE_HINT_OPTIONS);
+      if (aggregateOptions != null) {
+        String maxInitialResultHolderCapacityStr =
+            aggregateOptions.get(PinotHintOptions.AggregateOptions.MAX_INITIAL_RESULT_HOLDER_CAPACITY);
+        if (maxInitialResultHolderCapacityStr != null) {
+          return Integer.parseInt(maxInitialResultHolderCapacityStr);
+        }
+      }
+    }
+    Integer maxInitialResultHolderCapacity = QueryOptionsUtils.getMaxInitialResultHolderCapacity(customProperties);
+    return maxInitialResultHolderCapacity != null ? maxInitialResultHolderCapacity
+        : InstancePlanMakerImplV2.DEFAULT_MAX_INITIAL_RESULT_HOLDER_CAPACITY;
+  }
+
+  public int getNumGroupsLimit() {
+    return _numGroupsLimit;
   }
 
   /**
@@ -131,6 +176,10 @@ public class MultistageGroupByExecutor {
       rows.add(TypeUtils.canonicalizeRow(row, _resultSchema));
     }
     return rows;
+  }
+
+  public boolean isNumGroupsLimitReached() {
+    return _numGroupsLimitReached;
   }
 
   private void processAggregate(TransferableBlock block, DataSchema inputDataSchema) {
@@ -205,8 +254,7 @@ public class MultistageGroupByExecutor {
       for (int j = 0; j < numKeys; j++) {
         keyValues[j] = row[_colNameToIndexMap.get(_groupSet.get(j).getIdentifier())];
       }
-      Key rowKey = new Key(keyValues);
-      rowIntKeys[i] = _groupKeyToIdMap.computeIfAbsent(rowKey, k -> _groupKeyToIdMap.size());
+      rowIntKeys[i] = getGroupId(new Key(keyValues));
     }
     return rowIntKeys;
   }
@@ -228,8 +276,7 @@ public class MultistageGroupByExecutor {
         for (int j = 0; j < numKeys; j++) {
           keyValues[j] = row[_colNameToIndexMap.get(_groupSet.get(j).getIdentifier())];
         }
-        Key rowKey = new Key(keyValues);
-        rowIntKeys[rowId] = _groupKeyToIdMap.computeIfAbsent(rowKey, k -> _groupKeyToIdMap.size());
+        rowIntKeys[rowId] = getGroupId(new Key(keyValues));
       }
       return rowIntKeys;
     } else {
@@ -241,11 +288,23 @@ public class MultistageGroupByExecutor {
           for (int j = 0; j < numKeys; j++) {
             keyValues[j] = row[_colNameToIndexMap.get(_groupSet.get(j).getIdentifier())];
           }
-          Key rowKey = new Key(keyValues);
-          rowIntKeys[outRowId++] = _groupKeyToIdMap.computeIfAbsent(rowKey, k -> _groupKeyToIdMap.size());
+          rowIntKeys[outRowId++] = getGroupId(new Key(keyValues));
         }
       }
       return Arrays.copyOfRange(rowIntKeys, 0, outRowId);
     }
+  }
+
+  private int getGroupId(Key key) {
+    Integer groupKey = _groupKeyToIdMap.computeIfAbsent(key, k -> {
+      int numGroupKeys = _groupKeyToIdMap.size();
+      if (numGroupKeys == _numGroupsLimit) {
+        _numGroupsLimitReached = true;
+        return null;
+      } else {
+        return numGroupKeys;
+      }
+    });
+    return groupKey != null ? groupKey : GroupKeyGenerator.INVALID_ID;
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/QueryRunnerTest.java
@@ -271,6 +271,19 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
         // test queries with special query options attached
         //   - when leaf limit is set, each server returns multiStageLeafLimit number of rows only.
         new Object[]{"SET multiStageLeafLimit = 1; SELECT * FROM a", 2},
+
+        // test groups limit in both leaf and intermediate stage
+        new Object[]{"SET numGroupsLimit = 1; SELECT col1, COUNT(*) FROM a GROUP BY col1", 1},
+        new Object[]{"SET numGroupsLimit = 2; SELECT col1, COUNT(*) FROM a GROUP BY col1", 2},
+        new Object[]{"SET numGroupsLimit = 1; "
+            + "SELECT a.col2, b.col2, COUNT(*) FROM a JOIN b USING (col1) GROUP BY a.col2, b.col2", 1},
+        new Object[]{"SET numGroupsLimit = 2; "
+            + "SELECT a.col2, b.col2, COUNT(*) FROM a JOIN b USING (col1) GROUP BY a.col2, b.col2", 2},
+        // TODO: Consider pushing down hint to the leaf stage
+        new Object[]{"SET numGroupsLimit = 2; SELECT /*+ aggOptions(num_groups_limit='1') */ "
+            + "col1, COUNT(*) FROM a GROUP BY col1", 2},
+        new Object[]{"SET numGroupsLimit = 2; SELECT /*+ aggOptions(num_groups_limit='1') */ "
+            + "a.col2, b.col2, COUNT(*) FROM a JOIN b USING (col1) GROUP BY a.col2, b.col2", 1}
     };
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -498,6 +498,10 @@ public class CommonConstants {
     public static final String CONFIG_OF_QUERY_EXECUTOR_PLAN_MAKER_CLASS =
         "pinot.server.query.executor.plan.maker.class";
     public static final String CONFIG_OF_QUERY_EXECUTOR_TIMEOUT = "pinot.server.query.executor.timeout";
+    public static final String CONFIG_OF_QUERY_EXECUTOR_NUM_GROUPS_LIMIT =
+        "pinot.server.query.executor.num.groups.limit";
+    public static final String CONFIG_OF_QUERY_EXECUTOR_MAX_INITIAL_RESULT_HOLDER_CAPACITY =
+        "pinot.server.query.executor.max.init.group.holder.capacity";
     public static final String CONFIG_OF_TRANSFORM_FUNCTIONS = "pinot.server.transforms";
     public static final String CONFIG_OF_SERVER_QUERY_REWRITER_CLASS_NAMES = "pinot.server.query.rewriter.class.names";
     public static final String CONFIG_OF_ENABLE_QUERY_CANCELLATION = "pinot.server.enable.query.cancellation";
@@ -1053,7 +1057,11 @@ public class CommonConstants {
     /**
      * Configuration for join overflow.
      */
-    public static final String KEY_OF_JOIN_OVERFLOW_MODE = "pinot.query.join.overflow.mode";
     public static final String KEY_OF_MAX_ROWS_IN_JOIN = "pinot.query.join.max.rows";
+    public static final String KEY_OF_JOIN_OVERFLOW_MODE = "pinot.query.join.overflow.mode";
+
+    public enum JoinOverFlowMode {
+      THROW, BREAK
+    }
   }
 }


### PR DESCRIPTION
- Fix the exception when intermediate group-by executor reaches the groups limit (100K currently)
- Honor the groups limit and stop adding new keys when the limit is hit
- Return an exception when the limit is hit along with the response (similar to the join rows limit)
- Make `numGroupsLimit` and `maxInitialResultHolderCapacity` configurable through server config, query option and query hint
- Make the handling for JOIN and GROUP-BY limit consistent

# Release-notes
Added 2 `AggregateOptions` hint:
- num_groups_limit
- max_initial_result_holder_capacity