### PR TITLE
Test OfflineClusterIntegrationTest.testDistinctCountHll in both engines

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -98,7 +98,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
         Integer.parseInt(config.getProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT));
     _queryEnvironment = new QueryEnvironment(new TypeFactory(new TypeSystem()),
         CalciteSchemaBuilder.asRootSchema(new PinotCatalog(tableCache)),
-        new WorkerManager(reducerHostname, reducerPort, routingManager), _tableCache);
+        new WorkerManager(reducerHostname, reducerPort, routingManager), _tableCache, config);
     _mailboxService = new MailboxService(reducerHostname, reducerPort, config);
     _queryDispatcher = new QueryDispatcher(_mailboxService);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotQueryResource.java
@@ -202,7 +202,8 @@ public class PinotQueryResource {
     }
 
     QueryEnvironment queryEnvironment = new QueryEnvironment(new TypeFactory(new TypeSystem()),
-        CalciteSchemaBuilder.asRootSchema(new PinotCatalog(_pinotHelixResourceManager.getTableCache())), null, null);
+        CalciteSchemaBuilder.asRootSchema(new PinotCatalog(_pinotHelixResourceManager.getTableCache())), null, null,
+        null);
     List<String> tableNames = queryEnvironment.getTableNamesForQuery(query);
     List<String> instanceIds;
     if (tableNames.size() != 0) {
@@ -244,7 +245,7 @@ public class PinotQueryResource {
         LOGGER.info("Trying to compile query {} using multi-stage engine", query);
         QueryEnvironment queryEnvironment = new QueryEnvironment(new TypeFactory(new TypeSystem()),
             CalciteSchemaBuilder.asRootSchema(new PinotCatalog(_pinotHelixResourceManager.getTableCache())), null,
-            null);
+            null, null);
         queryEnvironment.getTableNamesForQuery(query);
         LOGGER.info("Successfully compiled query using multi-stage engine: {}", query);
         return QueryException.getException(QueryException.SQL_PARSING_ERROR, new Exception(

--- a/pinot-query-planner/pom.xml
+++ b/pinot-query-planner/pom.xml
@@ -77,6 +77,11 @@
       <artifactId>commons-compiler</artifactId>
       <version>3.1.6</version>
     </dependency>
+    <!-- Official documentation recommends to use this library to create RelRules -->
+    <dependency>
+      <groupId>org.immutables</groupId>
+      <artifactId>value</artifactId>
+    </dependency>
 
     <dependency>
       <groupId>org.testng</groupId>

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/DefaultHllLog2mRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/DefaultHllLog2mRule.java
@@ -1,0 +1,214 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import com.google.common.collect.ImmutableList;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.plan.RelRule;
+import org.apache.calcite.rel.RelNode;
+import org.apache.calcite.rel.core.Aggregate;
+import org.apache.calcite.rel.core.AggregateCall;
+import org.apache.calcite.rel.logical.LogicalAggregate;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexLiteral;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.sql.SqlAggFunction;
+import org.apache.calcite.tools.RelBuilder;
+import org.apache.calcite.util.CompositeList;
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.immutables.value.Value;
+
+
+/**
+ * Sets HyperLogLog log2m for DistinctCountHLL functions if not explicitly set for the given query.
+ */
+@Value.Enclosing
+public class DefaultHllLog2mRule extends RelRule<DefaultHllLog2mRule.Config> {
+
+  private final int _defaultHllLog2m;
+  private final BigDecimal _defaultHllLog2mBigDecimal;
+
+  private DefaultHllLog2mRule(DefaultHllLog2mRule.Config config) {
+    super(config);
+    _defaultHllLog2m = config.defaultHllLog2m();
+    _defaultHllLog2mBigDecimal = BigDecimal.valueOf(_defaultHllLog2m);
+  }
+
+  @Override
+  public boolean matches(RelOptRuleCall call) {
+    if (_defaultHllLog2m <= 0) {
+      return false;
+    }
+    if (call.rels.length < 1) {
+      return false;
+    }
+    final Aggregate aggregate = call.rel(0);
+    final List<AggregateCall> originalAggCalls = aggregate.getAggCallList();
+
+    for (AggregateCall originalCall : originalAggCalls) {
+      SqlAggFunction originalFunction = originalCall.getAggregation();
+      if (isAffectedFunctionCall(originalFunction.getName(), originalCall.getArgList().size())) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  @Override
+  public void onMatch(RelOptRuleCall ruleCall) {
+    Aggregate oldAggRel = (Aggregate) ruleCall.rels[0];
+
+    List<AggregateCall> oldCalls = oldAggRel.getAggCallList();
+
+    final List<AggregateCall> newCalls = new ArrayList<>();
+    final Map<AggregateCall, RexNode> aggCallMapping = new HashMap<>();
+
+    // List of input expressions. If a particular aggregate needs more, it
+    // will add an expression to the end, and we will create an extra
+    // project.
+    final RelBuilder relBuilder = ruleCall.builder();
+    relBuilder.push(oldAggRel.getInput());
+    final List<RexNode> inputExprs = new ArrayList<>(relBuilder.fields());
+
+    // create new aggregate function calls and rest of project list together
+    for (AggregateCall oldCall : oldCalls) {
+      reduceAgg(oldAggRel, oldCall, newCalls, aggCallMapping, inputExprs);
+    }
+
+    final int extraArgCount =
+        inputExprs.size() - relBuilder.peek().getRowType().getFieldCount();
+    if (extraArgCount > 0) {
+      relBuilder.project(inputExprs,
+          CompositeList.of(
+              relBuilder.peek().getRowType().getFieldNames(),
+              Collections.nCopies(extraArgCount, null)));
+      // New plan is absolutely better than old plan.
+      // In fact old plan is semantically incorrect
+      ruleCall.getPlanner().prune(oldAggRel);
+    }
+    newAggregateRel(relBuilder, oldAggRel, newCalls);
+    RelNode build = relBuilder.build();
+    ruleCall.transformTo(build);
+  }
+
+  private void reduceAgg(
+      Aggregate oldAggRel,
+      AggregateCall oldCall,
+      List<AggregateCall> newCalls,
+      Map<AggregateCall, RexNode> aggCallMapping,
+      List<RexNode> inputExprs) {
+    SqlAggFunction oldFunc = oldCall.getAggregation();
+
+    RexBuilder rexBuilder = oldAggRel.getCluster().getRexBuilder();
+
+    // Check if the aggregation function and arguments match your criteria
+    RelNode oldInput = oldAggRel.getInput();
+    int nGroups = oldAggRel.getGroupCount();
+    if (isAffectedFunctionCall(oldFunc.getName(), oldCall.getArgList().size())) {
+      Integer originalFieldIndex = oldCall.getArgList().get(0);
+
+      RexLiteral log2mRexLiteral = rexBuilder.makeExactLiteral(_defaultHllLog2mBigDecimal);
+      int log2mIdx = lookupOrAdd(inputExprs, log2mRexLiteral);
+
+      AggregateCall newCall = AggregateCall.create(oldFunc,
+          oldCall.isDistinct(),
+          oldCall.isApproximate(),
+          oldCall.ignoreNulls(),
+          ImmutableList.of(originalFieldIndex, log2mIdx),
+          oldCall.filterArg,
+          oldCall.distinctKeys,
+          oldCall.collation,
+          nGroups,
+          oldAggRel,
+          null,
+          null);
+
+      rexBuilder.addAggCall(newCall, nGroups, newCalls, aggCallMapping, oldAggRel::fieldIsNullable);
+    } else {
+      // anything else:  preserve original call
+      rexBuilder.addAggCall(oldCall, nGroups, newCalls, aggCallMapping, oldInput::fieldIsNullable);
+    }
+  }
+
+  private static <T> int lookupOrAdd(List<T> list, T element) {
+    int ordinal = list.indexOf(element);
+    if (ordinal == -1) {
+      ordinal = list.size();
+      list.add(element);
+    }
+    return ordinal;
+  }
+
+  protected void newAggregateRel(RelBuilder relBuilder,
+      Aggregate oldAggregate,
+      List<AggregateCall> newCalls) {
+    relBuilder.aggregate(
+        relBuilder.groupKey(oldAggregate.getGroupSet(), oldAggregate.getGroupSets()),
+        newCalls);
+  }
+
+  private boolean isAffectedFunctionCall(String functionName, int argSize) {
+    switch (functionName.toLowerCase()) {
+      case "distinctcounthll":
+      case "distinctcounthllmv":
+      case "distinctcountrawhll":
+      case "distinctcountrawhllmv":
+        return argSize == 1;
+      default:
+        return false;
+    }
+  }
+
+  @Value.Immutable
+  public interface Config extends RelRule.Config {
+    @Override
+    @Value.Default
+    default OperandTransform operandSupplier() {
+      return (OperandBuilder b0) -> b0.operand(LogicalAggregate.class).anyInputs();
+    }
+
+    @Override
+    default DefaultHllLog2mRule toRule() {
+      return new DefaultHllLog2mRule(this);
+    }
+
+    /** Returns defaultHllLog2m. */
+    @Value.Default
+    default int defaultHllLog2m() {
+      return CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M;
+    }
+
+    Config withDefaultHllLog2m(int newDefault);
+
+    static Config fromPinotConfig(PinotConfiguration config) {
+      int defaultLog2m = config.getProperty(
+          CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M_KEY,
+          CommonConstants.Helix.DEFAULT_HYPERLOGLOG_LOG2M);
+      return ImmutableDefaultHllLog2mRule.Config.builder().withDefaultHllLog2m(defaultLog2m).build();
+    }
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
@@ -21,8 +21,10 @@ package org.apache.calcite.rel.rules;
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
 import java.util.Collection;
+import javax.annotation.Nullable;
 import org.apache.calcite.adapter.enumerable.EnumerableRules;
 import org.apache.calcite.plan.RelOptRule;
+import org.apache.pinot.spi.env.PinotConfiguration;
 
 
 /**
@@ -110,6 +112,17 @@ public class PinotQueryRuleSets {
   public static final Collection<RelOptRule> PINOT_PRE_RULES = ImmutableList.of(
       PinotAggregateLiteralAttachmentRule.INSTANCE
   );
+
+  public static Collection<RelOptRule> getPinotPreRules(@Nullable PinotConfiguration config) {
+    ImmutableList.Builder<RelOptRule> builder = new ImmutableList.Builder<>();
+    builder.addAll(PINOT_PRE_RULES);
+    if (config == null) {
+      builder.add(ImmutableDefaultHllLog2mRule.Config.builder().build().toRule());
+    } else {
+      builder.add(DefaultHllLog2mRule.Config.fromPinotConfig(config).toRule());
+    }
+    return builder.build();
+  }
 
 
   // Pinot specific rules that should be run AFTER all other rules

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -70,6 +70,7 @@ import org.apache.pinot.query.planner.logical.RelToPlanNodeConverter;
 import org.apache.pinot.query.planner.physical.PinotDispatchPlanner;
 import org.apache.pinot.query.routing.WorkerManager;
 import org.apache.pinot.query.type.TypeFactory;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.apache.pinot.sql.parsers.parser.SqlPhysicalExplain;
@@ -96,7 +97,7 @@ public class QueryEnvironment {
   private final TableCache _tableCache;
 
   public QueryEnvironment(TypeFactory typeFactory, CalciteSchema rootSchema, WorkerManager workerManager,
-      TableCache tableCache) {
+      TableCache tableCache, @Nullable PinotConfiguration config) {
     _typeFactory = typeFactory;
     _rootSchema = rootSchema;
     _workerManager = workerManager;
@@ -129,7 +130,7 @@ public class QueryEnvironment {
 
     // ----
     // Run Pinot specific pre-rules
-    hepProgramBuilder.addRuleCollection(PinotQueryRuleSets.PINOT_PRE_RULES);
+    hepProgramBuilder.addRuleCollection(PinotQueryRuleSets.getPinotPreRules(config));
 
     // ----
     // Run the Calcite CORE rules using 1 HepInstruction per rule. We use 1 HepInstruction per rule for simplicity:

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -210,7 +210,7 @@ public class QueryEnvironmentTestBase {
     TableCache tableCache = factory.buildTableCache();
     return new QueryEnvironment(new TypeFactory(new TypeSystem()),
         CalciteSchemaBuilder.asRootSchema(new PinotCatalog(tableCache)),
-        new WorkerManager("localhost", reducerPort, routingManager), tableCache);
+        new WorkerManager("localhost", reducerPort, routingManager), tableCache, null);
   }
 
   /**

--- a/pom.xml
+++ b/pom.xml
@@ -432,6 +432,13 @@
         <optional>true</optional> <!-- This is only needed at compilation time as an annotation processor -->
       </dependency>
       <dependency>
+        <groupId>org.immutables</groupId>
+        <artifactId>bom</artifactId>
+        <version>2.9.3</version>
+        <scope>import</scope>
+        <type>pom</type>
+      </dependency>
+      <dependency>
         <groupId>commons-cli</groupId>
         <artifactId>commons-cli</artifactId>
         <version>1.5.0</version>


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

V2 engine now uses config default log2m for HLL via Calcite rule rewrite

```mermaid
flowchart TD
  N0["Create QueryEnvironment with config #40;F1#41;"]:::stAdded
  N1["Get Pinot pre#45;rules using config #40;F5#41;"]:::stModified
  N2["Return rule set with DefaultHllLog2mRule #40;F4#41;"]:::stModified
  N3["Match HLL aggregate call with one arg #40;F3#41;"]:::stAdded
  N4["Rewrite aggregate call to add default log2m #40;F3#41;"]:::stAdded
  N0 -->|"passes config"| N1
  N1 -->|"calls getPinotPreRules"| N2
  N2 -->|"includes rule"| N3
  N3 -->|"on match#44; rewrites"| N4
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler\.java — [before](https://github.com/apache/pinot/blob/5bee13a68a15cea0acf445dd4f04ae0fd33b9734/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java) · [after](https://github.com/apache/pinot/blob/372c3ba47a856975360afb4532c742780169f335/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java)
- F3: pinot\-query\-planner/src/main/java/org/apache/calcite/rel/rules/DefaultHllLog2mRule\.java — [after](https://github.com/apache/pinot/blob/372c3ba47a856975360afb4532c742780169f335/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/DefaultHllLog2mRule.java)
- F4: pinot\-query\-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets\.java — [before](https://github.com/apache/pinot/blob/5bee13a68a15cea0acf445dd4f04ae0fd33b9734/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java) · [after](https://github.com/apache/pinot/blob/372c3ba47a856975360afb4532c742780169f335/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java)
- F5: pinot\-query\-planner/src/main/java/org/apache/pinot/query/QueryEnvironment\.java — [before](https://github.com/apache/pinot/blob/5bee13a68a15cea0acf445dd4f04ae0fd33b9734/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java) · [after](https://github.com/apache/pinot/blob/372c3ba47a856975360afb4532c742780169f335/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjViZWUxM2E2OGExNWNlYTBhY2Y0NDVkZDRmMDRhZTBmZDMzYjk3MzQiLCJjb250ZXh0X2hhc2giOiI3ZjhiMzNkYWI3NDY0OTUwMDI5Y2IzMjNjNDZiZjNjMjZlOGU1MmU5YTQ2OTk1YjFjNWQxYTA1YjUwMjU2ZDJmIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MjcwMzcxLCJoZWFkX3NoYSI6IjM3MmMzYmE0N2E4NTY5NzUzNjBhZmI0NTMyYzc0Mjc4MDE2OWYzMzUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJiM2IwYjllYThhYjk5ZTY2Y2I3N2FmZGQ4ZWFiYzFiYjAzY2I0NDhiIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature bf4d4f588333cedcd29faba5bd468348ad11a1ae75bee9d1a7f43813db0d94b0 -->
<!-- pinot-pr-flow:end -->

This PR executes OfflineClusterIntegrationTest.testDistinctCountHll in both single and multi stage query engine.

While doing that, I found that V1 and V2 returned different values when the default `log2m` was used. The reason was that while V1 picked the default value from `default.hyperloglog.log2m` config, V2 was using the default value without reading that config. And the reason for that is that the implementation in V1 does a rewrite in the broker. While V2 doesn't have anything like that.

Ideally we should change the implementation of all different HLL operations in order to correctly use the value specified in the configuration. But I assume V1 doesn't do that for some reason (probably because operation implementation is static and cannot read the configuration). Therefore I decided to follow the same approach in V2 and do a rewrite.

In order to do so, I created a calcite RelRule.