### PR TITLE
Use fromValue instead of valueOf to parse sse config

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -184,7 +184,7 @@ public class S3PinotFS extends BasePinotFS {
   private void setServerSideEncryption(@Nullable String serverSideEncryption, S3Config s3Config) {
     if (serverSideEncryption != null) {
       try {
-        _serverSideEncryption = ServerSideEncryption.valueOf(serverSideEncryption);
+        _serverSideEncryption = ServerSideEncryption.fromValue(serverSideEncryption);
       } catch (Exception e) {
         throw new UnsupportedOperationException(
             String.format("Unknown value '%s' for S3PinotFS config: 'serverSideEncryption'. Supported values are: %s",


### PR DESCRIPTION
This PR fixes the bug reported in https://github.com/apache/pinot/issues/7596 which prevents users from specifying `aws:kms` as an SSE option.