### PR TITLE
Preload test fix

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
@@ -217,7 +217,7 @@ public class UpsertTableSegmentPreloadIntegrationTest extends BaseClusterIntegra
       try {
         if (isForceCommitJobCompleted(jobId)) {
           assertTrue(_controllerStarter.getHelixResourceManager()
-              .getOnlineSegmentsFromIdealState(getTableName() + "_REALTIME", false)
+              .getOnlineSegmentsFromExternalView(getTableName() + "_REALTIME")
               .containsAll(finalConsumingSegments));
 
           int snapshotFileCount = 0;
@@ -246,7 +246,7 @@ public class UpsertTableSegmentPreloadIntegrationTest extends BaseClusterIntegra
       } catch (Exception e) {
         return false;
       }
-    }, 120000L, "Error verifying force commit operation on table!");
+    }, 5000L, 120000L, "Error verifying force commit operation on table!");
   }
 
   protected void verifyIdealState(int numSegmentsExpected) {


### PR DESCRIPTION
Solves #11359 
Currently in the test we do not check if all segments even have a valid doc id or not and simply check that all segments should have a snapshot.

This fixes the issue to only ensure the number of snapshots are atleast equal to the number of segments with valid docs.