### PR TITLE
only emit throttling metrics when throttling is allowed

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeConsumptionRateManager.java
@@ -147,9 +147,14 @@ public class RealtimeConsumptionRateManager {
 
     @Override
     public void throttle(int numMsgs) {
-      _metricEmitter.emitMetric(numMsgs, _rate, Clock.systemUTC().instant());
-      if (InstanceHolder.INSTANCE._isThrottlingAllowed && numMsgs > 0) {
-        _rateLimiter.acquire(numMsgs);
+      if (InstanceHolder.INSTANCE._isThrottlingAllowed) {
+        // Only emit metrics when throttling is allowed. Throttling is not enabled.
+        // until the server has passed startup checks. Otherwise, we will see
+        // consumption well over 100% during startup.
+        _metricEmitter.emitMetric(numMsgs, _rate, Clock.systemUTC().instant());
+        if (numMsgs > 0) {
+          _rateLimiter.acquire(numMsgs);
+        }
       }
     }
 


### PR DESCRIPTION
This is arguable a `fix` to metrics in the `RealtimeConsumptionRateManager.java`. Rather than emit metrics every time we call `.throttle`, only emit these metrics when throttling is enabled. I see our servers emit order of magnitude above 100 when they first start up and catch up at an unbounded rate. This makes it hard to understand the chart and write detectors on this metric.

We could also introduce 2 metrics for "quota utilization with throttling on" vs "quota utilization with throttling off", but that feels somewhat counterintuitive to emit the utilization metric when throttling isn't even doing anything.