### PR TITLE
Register single value columns as nullable.

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -293,7 +293,7 @@ public class ClusterIntegrationTestUtils {
       throws Exception {
     int numAvroFiles = avroFiles.size();
     if (numAvroFiles == 1) {
-      buildSegmentFromAvro(avroFiles.get(0), tableConfig, schema, baseSegmentIndex, segmentDir, tarDir);
+      buildSegmentFromAvro(avroFiles.get(0), tableConfig, schema, baseSegmentIndex, segmentDir, tarDir, false);
     } else {
       ExecutorService executorService = Executors.newFixedThreadPool(numAvroFiles);
       List<Future<Void>> futures = new ArrayList<>(numAvroFiles);
@@ -301,7 +301,7 @@ public class ClusterIntegrationTestUtils {
         File avroFile = avroFiles.get(i);
         int segmentIndex = i + baseSegmentIndex;
         futures.add(executorService.submit(() -> {
-          buildSegmentFromAvro(avroFile, tableConfig, schema, segmentIndex, segmentDir, tarDir);
+          buildSegmentFromAvro(avroFile, tableConfig, schema, segmentIndex, segmentDir, tarDir, false);
           return null;
         }));
       }
@@ -321,12 +321,14 @@ public class ClusterIntegrationTestUtils {
    * @param segmentIndex Segment index number
    * @param segmentDir Output directory for the un-tarred segments
    * @param tarDir Output directory for the tarred segments
+   * @param nullHandlingEnabled whether to enable null handling for the segment
    */
   public static void buildSegmentFromAvro(File avroFile, TableConfig tableConfig,
-      org.apache.pinot.spi.data.Schema schema, int segmentIndex, File segmentDir, File tarDir)
+      org.apache.pinot.spi.data.Schema schema, int segmentIndex, File segmentDir, File tarDir,
+      boolean nullHandlingEnabled)
       throws Exception {
     // Test segment with space and special character in the file name
-    buildSegmentFromAvro(avroFile, tableConfig, schema, segmentIndex + " %", segmentDir, tarDir);
+    buildSegmentFromAvro(avroFile, tableConfig, schema, segmentIndex + " %", segmentDir, tarDir, nullHandlingEnabled);
   }
 
   /**
@@ -338,15 +340,18 @@ public class ClusterIntegrationTestUtils {
    * @param segmentNamePostfix Segment name postfix
    * @param segmentDir Output directory for the un-tarred segments
    * @param tarDir Output directory for the tarred segments
+   * @param nullHandlingEnabled whether to enable null handling for the segment
    */
   public static void buildSegmentFromAvro(File avroFile, TableConfig tableConfig,
-      org.apache.pinot.spi.data.Schema schema, String segmentNamePostfix, File segmentDir, File tarDir)
+      org.apache.pinot.spi.data.Schema schema, String segmentNamePostfix, File segmentDir, File tarDir,
+      boolean nullHandlingEnabled)
       throws Exception {
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setInputFilePath(avroFile.getPath());
     segmentGeneratorConfig.setOutDir(segmentDir.getPath());
     segmentGeneratorConfig.setTableName(tableConfig.getTableName());
     segmentGeneratorConfig.setSegmentNamePostfix(segmentNamePostfix);
+    segmentGeneratorConfig.setNullHandlingEnabled(nullHandlingEnabled);
 
     // Build the segment
     SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
@@ -122,7 +122,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
 
     // Create 1 segment, for METADATA push WITH move to final location
     ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(0), offlineTableConfig, schema, "_with_move",
-        _segmentDir, _tarDir);
+        _segmentDir, _tarDir, getNullHandlingEnabled());
 
     SegmentMetadataPushJobRunner runner = new SegmentMetadataPushJobRunner();
     SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
@@ -176,7 +176,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
 
     // Create 1 segment, for METADATA push WITHOUT move to final location
     ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(1), offlineTableConfig, schema, "_without_move",
-        _segmentDir, _tarDir);
+        _segmentDir, _tarDir, getNullHandlingEnabled());
     jobSpec.setPushJobSpec(new PushJobSpec());
     runner = new SegmentMetadataPushJobRunner();
 
@@ -223,7 +223,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     String firstTimeStamp = Long.toString(System.currentTimeMillis());
 
     ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(0), offlineTableConfig, schema, firstTimeStamp,
-        _segmentDir, _tarDir);
+        _segmentDir, _tarDir, getNullHandlingEnabled());
 
     // First test standalone metadata push job runner
     BaseSegmentPushJobRunner runner = new SegmentMetadataPushJobRunner();
@@ -287,7 +287,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     String secondTimeStamp = Long.toString(System.currentTimeMillis());
 
     ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(1), offlineTableConfig, schema, secondTimeStamp,
-        _segmentDir, _tarDir);
+        _segmentDir, _tarDir, getNullHandlingEnabled());
     jobSpec.setPushJobSpec(new PushJobSpec());
 
     // Now test standalone tar push job runner

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/CustomDataQueryClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/CustomDataQueryClusterIntegrationTest.java
@@ -84,7 +84,8 @@ public abstract class CustomDataQueryClusterIntegrationTest extends BaseClusterI
 
     // create & upload segments
     File avroFile = createAvroFile();
-    ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFile, tableConfig, schema, 0, _segmentDir, _tarDir);
+    ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFile, tableConfig, schema, 0, _segmentDir, _tarDir,
+        getNullHandlingEnabled());
     uploadSegments(getTableName(), _tarDir);
 
     waitForAllDocsLoaded(60_000);
@@ -117,7 +118,8 @@ public abstract class CustomDataQueryClusterIntegrationTest extends BaseClusterI
 
   @Override
   public TableConfig createOfflineTableConfig() {
-    return new TableConfigBuilder(TableType.OFFLINE).setTableName(getTableName()).build();
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName(getTableName())
+        .setNullHandlingEnabled(getNullHandlingEnabled()).build();
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/MultiStageNullHandlingTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/MultiStageNullHandlingTest.java
@@ -1,0 +1,157 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.io.IOException;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+@Test(suiteName = "CustomClusterIntegrationTest")
+public class MultiStageNullHandlingTest extends CustomDataQueryClusterIntegrationTest {
+  private static final String DEFAULT_TABLE_NAME = "testTable";
+  private static final String INT_COLUMN = "int1";
+  private static final String BOOL_COLUMN = "bool1";
+
+  @Override
+  public String getTableName() {
+    return DEFAULT_TABLE_NAME;
+  }
+
+  @Override
+  public Schema createSchema() {
+    return new Schema.SchemaBuilder().setSchemaName(getTableName())
+        .addSingleValueDimension(INT_COLUMN, FieldSpec.DataType.INT)
+        .addSingleValueDimension(BOOL_COLUMN, FieldSpec.DataType.BOOLEAN).build();
+  }
+
+  @Override
+  protected boolean getNullHandlingEnabled() {
+    return true;
+  }
+
+  @Override
+  protected long getCountStarResult() {
+    /*
+    Uploaded table content:
+
+    row#  int1  bool1
+    ----  ====  =====
+    1     1     true
+    2     2     false
+    3     3     null
+    4     null  null
+     */
+    return 4;
+  }
+
+  @Override
+  public File createAvroFile()
+      throws IOException {
+
+    // create avro schema
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("myRecord", null, null, false);
+
+    avroSchema.setFields(ImmutableList.of(new org.apache.avro.Schema.Field(INT_COLUMN,
+            org.apache.avro.Schema.createUnion(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT),
+                org.apache.avro.Schema.create(org.apache.avro.Schema.Type.NULL)), null, null),
+        new org.apache.avro.Schema.Field(BOOL_COLUMN,
+            org.apache.avro.Schema.createUnion(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BOOLEAN),
+                org.apache.avro.Schema.create(org.apache.avro.Schema.Type.NULL)), null, null)));
+
+    // create avro file
+    File avroFile = new File(_tempDir, "data.avro");
+    try (DataFileWriter<GenericData.Record> fileWriter = new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
+      fileWriter.create(avroSchema, avroFile);
+      GenericData.Record record = new GenericData.Record(avroSchema);
+      record.put(INT_COLUMN, 1);
+      record.put(BOOL_COLUMN, true);
+      fileWriter.append(record);
+
+      record = new GenericData.Record(avroSchema);
+      record.put(INT_COLUMN, 2);
+      record.put(BOOL_COLUMN, false);
+      fileWriter.append(record);
+
+      record = new GenericData.Record(avroSchema);
+      record.put(INT_COLUMN, 3);
+      record.put(BOOL_COLUMN, null);
+      fileWriter.append(record);
+
+      record = new GenericData.Record(avroSchema);
+      record.put(INT_COLUMN, null);
+      record.put(BOOL_COLUMN, null);
+      fileWriter.append(record);
+    }
+
+    return avroFile;
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testFilterIsNull(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query =
+        "SET enableNullHandling = true; SELECT int1 FROM testTable WHERE bool1 IS NULL ORDER BY int1 NULLS LAST";
+
+    JsonNode jsonNode = postQuery(query);
+
+    assertEquals(getRowSize(jsonNode), 2);
+    assertEquals(getRowZeroColumnZero(jsonNode), 3);
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testFilterIsNotNull(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SET enableNullHandling = true; SELECT int1 FROM testTable WHERE bool1 IS NOT NULL";
+
+    JsonNode jsonNode = postQuery(query);
+
+    assertEquals(getRowSize(jsonNode), 2);
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testCount(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SET enableNullHandling = true; SELECT COUNT(int1) FROM testTable";
+
+    JsonNode jsonNode = postQuery(query);
+
+    assertEquals(getRowZeroColumnZero(jsonNode), 3);
+  }
+
+  private int getRowSize(JsonNode jsonNode) {
+    return jsonNode.get("resultTable").get("rows").size();
+  }
+
+  private int getRowZeroColumnZero(JsonNode jsonNode) {
+    return Integer.parseInt(jsonNode.get("resultTable").get("rows").get(0).get(0).asText());
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
@@ -31,6 +31,7 @@ import org.apache.calcite.schema.SchemaVersion;
 import org.apache.calcite.schema.Schemas;
 import org.apache.calcite.schema.Table;
 import org.apache.pinot.common.config.provider.TableCache;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 import static java.util.Objects.requireNonNull;
@@ -66,7 +67,14 @@ public class PinotCatalog implements Schema {
     if (schema == null) {
       throw new IllegalArgumentException(String.format("Could not find schema for table: '%s'", tableName));
     }
-    return new PinotTable(schema);
+    TableConfig tableConfig = _tableCache.getTableConfig(TableNameBuilder.OFFLINE.tableNameWithType(tableName));
+    if (tableConfig == null) {
+      tableConfig = _tableCache.getTableConfig(TableNameBuilder.REALTIME.tableNameWithType(tableName));
+    }
+    if (tableConfig == null) {
+      throw new IllegalArgumentException(String.format("Could not find table config for table: '%s'", tableName));
+    }
+    return new PinotTable(schema, tableConfig.getIndexingConfig().isNullHandlingEnabled());
   }
 
   /**

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotTable.java
@@ -36,17 +36,19 @@ import org.apache.pinot.spi.data.Schema;
  * {@link RelDataType} of the table to the planner.
  */
 public class PinotTable extends AbstractTable implements ScannableTable {
-  private Schema _schema;
+  private final Schema _schema;
+  private final boolean _nullHandlingEnabled;
 
-  public PinotTable(Schema schema) {
+  public PinotTable(Schema schema, boolean nullHandlingEnabled) {
     _schema = schema;
+    _nullHandlingEnabled = nullHandlingEnabled;
   }
 
   @Override
   public RelDataType getRowType(RelDataTypeFactory relDataTypeFactory) {
     Preconditions.checkState(relDataTypeFactory instanceof TypeFactory);
     TypeFactory typeFactory = (TypeFactory) relDataTypeFactory;
-    return typeFactory.createRelDataTypeFromSchema(_schema);
+    return typeFactory.createRelDataTypeFromSchema(_schema, _nullHandlingEnabled);
   }
 
   @Override

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/testutils/MockRoutingManagerFactory.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/testutils/MockRoutingManagerFactory.java
@@ -36,6 +36,8 @@ import org.apache.pinot.core.routing.RoutingTable;
 import org.apache.pinot.core.routing.TablePartitionInfo;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
 import org.apache.pinot.core.transport.ServerInstance;
+import org.apache.pinot.spi.config.table.IndexingConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
@@ -107,6 +109,11 @@ public class MockRoutingManagerFactory {
       String schemaName = invocationOnMock.getArgument(0);
       return _schemaMap.get(schemaName);
     });
+    IndexingConfig mockIndexingConfig = mock(IndexingConfig.class);
+    when(mockIndexingConfig.isNullHandlingEnabled()).thenReturn(false);
+    TableConfig mockTableConfig = mock(TableConfig.class);
+    when(mockTableConfig.getIndexingConfig()).thenReturn(mockIndexingConfig);
+    when(mock.getTableConfig(anyString())).thenReturn(mockTableConfig);
     return mock;
   }
 

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/type/TypeFactoryTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/type/TypeFactoryTest.java
@@ -51,7 +51,7 @@ public class TypeFactoryTest {
         .addMultiValueDimension("STRING_ARRAY_COL", FieldSpec.DataType.STRING)
         .addMultiValueDimension("BYTES_ARRAY_COL", FieldSpec.DataType.BYTES)
         .build();
-    RelDataType relDataTypeFromSchema = typeFactory.createRelDataTypeFromSchema(testSchema);
+    RelDataType relDataTypeFromSchema = typeFactory.createRelDataTypeFromSchema(testSchema, false);
     List<RelDataTypeField> fieldList = relDataTypeFromSchema.getFieldList();
     for (RelDataTypeField field : fieldList) {
       switch (field.getName()) {


### PR DESCRIPTION
Register single value columns as nullable in V2 if the table has null handling enabled.

This PR fixes the following NULL related queries in V2.

- `SELECT col IS NULL FROM mytable`
- `SELECT COUNT(col) FROM mytable`

Without this PR, the above queries would be incorrectly parsed as:

- `SELECT FALSE FROM mytable`
- `SELECT COUNT(*) FROM mytable`