### PR TITLE
[multistage]use all servers if no server instance found for intermediate stage

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -20,7 +20,6 @@ package org.apache.pinot.query.routing;
 
 import com.google.common.base.Preconditions;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -322,10 +322,9 @@ public class WorkerManager {
       }
     }
     if (serverInstances.isEmpty()) {
-      LOGGER.error("[RequestId: {}] No server instance found for intermediate stage for tables: {}",
+      LOGGER.info("[RequestId: {}] No server instance found for intermediate stage for tables: {}, fall back to all",
           context.getRequestId(), tableNames);
-      throw new IllegalStateException(
-          "No server instance found for intermediate stage for tables: " + Arrays.toString(tableNames.toArray()));
+      serverInstances = new ArrayList<>(enabledServerInstanceMap.values());
     }
     if (metadata.isRequiresSingletonInstance()) {
       // require singleton should return a single global worker ID with 0;


### PR DESCRIPTION
With the current logic, if no server instance found for intermediate stage, the query engine throws an exception. See the following figure (the table has no data):

<img width="1239" alt="Screenshot 2023-08-28 at 5 41 40 PM" src="https://github.com/apache/pinot/assets/9796617/5c08ce4a-0c30-49b9-9f35-88eb7c170f92">

This PR tries to fix this problem by using all servers. After fixing this issue, the query runs correctly:

<img width="1239" alt="Screenshot 2023-08-28 at 5 45 00 PM" src="https://github.com/apache/pinot/assets/9796617/b9635e5b-493a-479f-ba0a-1f37ac688804">
