### PR TITLE
Fix the data type handling in multi-stage engine

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ObjectFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ObjectFunctions.java
@@ -20,7 +20,6 @@ package org.apache.pinot.common.function.scalar;
 
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.annotations.ScalarFunction;
-import org.apache.pinot.spi.utils.BooleanUtils;
 
 
 public class ObjectFunctions {
@@ -96,42 +95,43 @@ public class ObjectFunctions {
 
   @Nullable
   @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
-  public static Object caseWhen(boolean c1, @Nullable Object o1, @Nullable Object oe) {
+  public static Object caseWhen(@Nullable Boolean c1, @Nullable Object o1, @Nullable Object oe) {
     return caseWhenVar(c1, o1, oe);
   }
 
   @Nullable
   @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
-  public static Object caseWhen(boolean c1, @Nullable Object o1, boolean c2, @Nullable Object o2, @Nullable Object oe) {
+  public static Object caseWhen(@Nullable Boolean c1, @Nullable Object o1, @Nullable Boolean c2, @Nullable Object o2,
+      @Nullable Object oe) {
     return caseWhenVar(c1, o1, c2, o2, oe);
   }
 
   @Nullable
   @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
-  public static Object caseWhen(boolean c1, @Nullable Object o1, boolean c2, @Nullable Object o2, boolean c3,
-                                @Nullable Object o3, @Nullable Object oe) {
+  public static Object caseWhen(@Nullable Boolean c1, @Nullable Object o1, @Nullable Boolean c2, @Nullable Object o2,
+      @Nullable Boolean c3, @Nullable Object o3, @Nullable Object oe) {
     return caseWhenVar(c1, o1, c2, o2, c3, o3, oe);
   }
 
   @Nullable
   @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
-  public static Object caseWhen(boolean c1, @Nullable Object o1, boolean c2, @Nullable Object o2, boolean c3,
-                                @Nullable Object o3, boolean c4, @Nullable Object o4, @Nullable Object oe) {
+  public static Object caseWhen(@Nullable Boolean c1, @Nullable Object o1, @Nullable Boolean c2, @Nullable Object o2,
+      @Nullable Boolean c3, @Nullable Object o3, @Nullable Boolean c4, @Nullable Object o4, @Nullable Object oe) {
     return caseWhenVar(c1, o1, c2, o2, c3, o3, c4, o4, oe);
   }
 
   @Nullable
   @ScalarFunction(nullableParameters = true, names = {"case", "caseWhen", "case_when"})
-  public static Object caseWhen(boolean c1, @Nullable Object o1, boolean c2, @Nullable Object o2, boolean c3,
-                                @Nullable Object o3, boolean c4, @Nullable Object o4, boolean c5, @Nullable Object o5,
-                                @Nullable Object oe) {
+  public static Object caseWhen(@Nullable Boolean c1, @Nullable Object o1, @Nullable Boolean c2, @Nullable Object o2,
+      @Nullable Boolean c3, @Nullable Object o3, @Nullable Boolean c4, @Nullable Object o4, @Nullable Boolean c5,
+      @Nullable Object o5, @Nullable Object oe) {
     return caseWhenVar(c1, o1, c2, o2, c3, o3, c4, o4, c5, o5, oe);
   }
 
   @Nullable
   private static Object caseWhenVar(Object... objs) {
     for (int i = 0; i < objs.length - 1; i += 2) {
-      if (BooleanUtils.toBoolean(objs[i])) {
+      if (Boolean.TRUE.equals(objs[i])) {
         return objs[i + 1];
       }
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
@@ -95,6 +95,11 @@ public class LiteralContext {
         _value = literal.getFieldValue();
         _bigDecimalValue = PinotDataType.BOOLEAN.toBigDecimal(_value);
         break;
+      case INT_VALUE:
+        _type = FieldSpec.DataType.INT;
+        _value = literal.getIntValue();
+        _bigDecimalValue = new BigDecimal((int) _value);
+        break;
       case LONG_VALUE:
         long longValue = literal.getLongValue();
         if (longValue == (int) longValue) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -343,9 +343,27 @@ public class DataSchema {
           return new ByteArray((byte[]) value);
         case BOOLEAN_ARRAY:
           return fromBooleanArray((boolean[]) value);
-        case TIMESTAMP_ARRAY: {
+        case TIMESTAMP_ARRAY:
           return fromTimestampArray((Timestamp[]) value);
-        }
+        case OBJECT:
+          // For OBJECT type, we need to convert based on the actual type of the value. This can happen when the scalar
+          // function returns Object type, e.g. cast function.
+          if (value instanceof Boolean) {
+            return ((boolean) value) ? 1 : 0;
+          }
+          if (value instanceof Timestamp) {
+            return ((Timestamp) value).getTime();
+          }
+          if (value instanceof byte[]) {
+            return new ByteArray((byte[]) value);
+          }
+          if (value instanceof boolean[]) {
+            return fromBooleanArray((boolean[]) value);
+          }
+          if (value instanceof Timestamp[]) {
+            return fromTimestampArray((Timestamp[]) value);
+          }
+          return value;
         default:
           return value;
       }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/DataSchema.java
@@ -312,7 +312,19 @@ public class DataSchema {
     }
 
     /**
-     * Converts to the internal representation of the value.
+     * Converts the value from external value type to the internal value type.
+     *
+     * <p>External value type is used in the following places:
+     * <ul>
+     *   <li>Data ingestion</li>
+     *   <li>Scalar function arguments (UDF)</li>
+     *   <li>Query response</li>
+     * </ul>
+     *
+     * <p>Internal value type is used within the storage and query engine, where value is always of the stored type. For
+     * BYTES type, we use a wrapper class {@link ByteArray} to make it comparable.
+     *
+     * <p>The conversion applies to the following types:
      * <ul>
      *   <li>BOOLEAN: boolean -> int</li>
      *   <li>TIMESTAMP: Timestamp -> long</li>
@@ -340,7 +352,9 @@ public class DataSchema {
     }
 
     /**
-     * Converts to the external representation of the value.
+     * Converts the value from internal value type to the external value type.
+     *
+     * <p>The conversion applies to the following types:
      * <ul>
      *   <li>BOOLEAN: int -> boolean</li>
      *   <li>TIMESTAMP: long -> Timestamp</li>

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/DataSchemaTest.java
@@ -19,8 +19,6 @@
 package org.apache.pinot.common.utils;
 
 import java.nio.ByteBuffer;
-import java.util.Arrays;
-import java.util.List;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -64,39 +62,6 @@ public class DataSchemaTest {
     DataSchema dataSchemaAfterSerDe = DataSchema.fromBytes(ByteBuffer.wrap(dataSchema.toBytes()));
     Assert.assertEquals(dataSchema, dataSchemaAfterSerDe);
     Assert.assertEquals(dataSchema.hashCode(), dataSchemaAfterSerDe.hashCode());
-  }
-
-  @Test
-  public void testSuperTypeCheckers() {
-    List<DataSchema.ColumnDataType> numberTypeToTest = Arrays.asList(INT, LONG, FLOAT, DOUBLE);
-
-    for (DataSchema.ColumnDataType testType : DataSchema.ColumnDataType.values()) {
-      for (DataSchema.ColumnDataType candidateType : DataSchema.ColumnDataType.values()) {
-        if (testType == candidateType) {
-          // all type should be sub-type of themselves.
-          Assert.assertTrue(testType.isSuperTypeOf(candidateType));
-        } else if (!numberTypeToTest.contains(testType)) {
-          // other than number type, nothing should be sub-type of another type.
-          Assert.assertFalse(testType.isSuperTypeOf(candidateType));
-        }
-      }
-    }
-
-    // number super type relationship should be in exactly the order in the list above.
-    for (int idx = 0; idx < numberTypeToTest.size(); idx++) {
-      for (int subTypeIdx = 0; subTypeIdx <= idx; subTypeIdx++) {
-        Assert.assertTrue(numberTypeToTest.get(idx).isSuperTypeOf(numberTypeToTest.get(subTypeIdx)));
-      }
-      for (int subTypeIdx = idx + 1; subTypeIdx < numberTypeToTest.size(); subTypeIdx++) {
-        Assert.assertFalse(numberTypeToTest.get(idx).isSuperTypeOf(numberTypeToTest.get(subTypeIdx)));
-      }
-    }
-
-    // Boolean can be converted by any number type, but not the other way around
-    for (int idx = 0; idx < numberTypeToTest.size(); idx++) {
-      Assert.assertTrue(numberTypeToTest.get(idx).isSuperTypeOf(BOOLEAN));
-      Assert.assertFalse(BOOLEAN.isSuperTypeOf(numberTypeToTest.get(idx)));
-    }
   }
 
   @Test

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
@@ -24,7 +24,6 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
-import java.sql.Timestamp;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.commons.io.output.UnsynchronizedByteArrayOutputStream;
@@ -34,9 +33,9 @@ import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.RowDataBlock;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.ObjectSerDeUtils;
-import org.apache.pinot.spi.utils.ArrayCopyUtils;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.RoaringBitmap;
@@ -45,28 +44,26 @@ import org.roaringbitmap.RoaringBitmap;
 public class DataBlockBuilder {
   private final DataSchema _dataSchema;
   private final DataBlock.Type _blockType;
-  private final DataSchema.ColumnDataType[] _columnDataTypes;
+  private final int _numRows;
+  private final int _numColumns;
 
   private int[] _columnOffsets;
   private int _rowSizeInBytes;
   private int[] _cumulativeColumnOffsetSizeInBytes;
   private int[] _columnSizeInBytes;
 
-  private int _numRows;
-  private int _numColumns;
-
   private final Object2IntOpenHashMap<String> _dictionary = new Object2IntOpenHashMap<>();
   private final UnsynchronizedByteArrayOutputStream _fixedSizeDataByteArrayOutputStream;
   private final DataOutputStream _fixedSizeDataOutputStream;
-  private final UnsynchronizedByteArrayOutputStream _variableSizeDataByteArrayOutputStream
-      = new UnsynchronizedByteArrayOutputStream(8192);
+  private final UnsynchronizedByteArrayOutputStream _variableSizeDataByteArrayOutputStream =
+      new UnsynchronizedByteArrayOutputStream(8192);
   private final DataOutputStream _variableSizeDataOutputStream =
       new DataOutputStream(_variableSizeDataByteArrayOutputStream);
 
   private DataBlockBuilder(DataSchema dataSchema, DataBlock.Type blockType, int numRows) {
     _dataSchema = dataSchema;
-    _columnDataTypes = dataSchema.getColumnDataTypes();
     _blockType = blockType;
+    _numRows = numRows;
     _numColumns = dataSchema.size();
     if (_blockType == DataBlock.Type.ROW) {
       _columnOffsets = new int[_numColumns];
@@ -107,144 +104,83 @@ public class DataBlockBuilder {
 
   public static RowDataBlock buildFromRows(List<Object[]> rows, DataSchema dataSchema)
       throws IOException {
-    DataBlockBuilder rowBuilder = new DataBlockBuilder(dataSchema, DataBlock.Type.ROW, rows.size());
+    int numRows = rows.size();
+    DataBlockBuilder rowBuilder = new DataBlockBuilder(dataSchema, DataBlock.Type.ROW, numRows);
     // TODO: consolidate these null utils into data table utils.
     // Selection / Agg / Distinct all have similar code.
-    int numColumns = rowBuilder._numColumns;
+    ColumnDataType[] storedTypes = dataSchema.getStoredColumnDataTypes();
+    int numColumns = storedTypes.length;
     RoaringBitmap[] nullBitmaps = new RoaringBitmap[numColumns];
-    DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
-    DataSchema.ColumnDataType[] storedColumnDataTypes = dataSchema.getStoredColumnDataTypes();
     Object[] nullPlaceholders = new Object[numColumns];
     for (int colId = 0; colId < numColumns; colId++) {
       nullBitmaps[colId] = new RoaringBitmap();
-      nullPlaceholders[colId] = columnDataTypes[colId].convert(storedColumnDataTypes[colId].getNullPlaceholder());
+      nullPlaceholders[colId] = storedTypes[colId].getNullPlaceholder();
     }
-    rowBuilder._numRows = rows.size();
     ByteBuffer byteBuffer = ByteBuffer.allocate(rowBuilder._rowSizeInBytes);
-    for (int rowId = 0; rowId < rows.size(); rowId++) {
+    for (int rowId = 0; rowId < numRows; rowId++) {
       byteBuffer.clear();
       Object[] row = rows.get(rowId);
-      for (int colId = 0; colId < rowBuilder._numColumns; colId++) {
+      for (int colId = 0; colId < numColumns; colId++) {
         Object value = row[colId];
         if (value == null) {
           nullBitmaps[colId].add(rowId);
           value = nullPlaceholders[colId];
         }
-        switch (rowBuilder._columnDataTypes[colId]) {
+        switch (storedTypes[colId]) {
           // Single-value column
           case INT:
-            byteBuffer.putInt(((Number) value).intValue());
+            byteBuffer.putInt((int) value);
             break;
           case LONG:
-            byteBuffer.putLong(((Number) value).longValue());
+            byteBuffer.putLong((long) value);
             break;
           case FLOAT:
-            byteBuffer.putFloat(((Number) value).floatValue());
+            byteBuffer.putFloat((float) value);
             break;
           case DOUBLE:
-            byteBuffer.putDouble(((Number) value).doubleValue());
+            byteBuffer.putDouble((double) value);
             break;
           case BIG_DECIMAL:
             setColumn(rowBuilder, byteBuffer, (BigDecimal) value);
-            break;
-          case BOOLEAN:
-            if (value instanceof Boolean) {
-              byteBuffer.putInt(((Boolean) value) ? 1 : 0);
-            } else {
-              byteBuffer.putInt(((Number) value).intValue() > 0 ? 1 : 0);
-            }
-            break;
-          case TIMESTAMP:
-            // Certain non strong typed functions in v2 might return long value instead of Timestamp.
-            if (value instanceof Long) {
-              byteBuffer.putLong((long) value);
-            } else {
-              byteBuffer.putLong(((Timestamp) value).getTime());
-            }
             break;
           case STRING:
             setColumn(rowBuilder, byteBuffer, (String) value);
             break;
           case BYTES:
-            if (value instanceof byte[]) {
-              setColumn(rowBuilder, byteBuffer, new ByteArray((byte[]) value));
-            } else {
-              setColumn(rowBuilder, byteBuffer, (ByteArray) value);
-            }
+            setColumn(rowBuilder, byteBuffer, (ByteArray) value);
             break;
-          case OBJECT:
-            setColumn(rowBuilder, byteBuffer, value);
-            break;
+
           // Multi-value column
           case INT_ARRAY:
             setColumn(rowBuilder, byteBuffer, (int[]) value);
             break;
           case LONG_ARRAY:
-            // LONG_ARRAY type covers INT_ARRAY and LONG_ARRAY
-            if (value instanceof int[]) {
-              int[] ints = (int[]) value;
-              int length = ints.length;
-              long[] longs = new long[length];
-              ArrayCopyUtils.copy(ints, longs, length);
-              setColumn(rowBuilder, byteBuffer, longs);
-            } else {
-              setColumn(rowBuilder, byteBuffer, (long[]) value);
-            }
+            setColumn(rowBuilder, byteBuffer, (long[]) value);
             break;
           case FLOAT_ARRAY:
             setColumn(rowBuilder, byteBuffer, (float[]) value);
             break;
           case DOUBLE_ARRAY:
-            // DOUBLE_ARRAY type covers INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY and DOUBLE_ARRAY
-            if (value instanceof int[]) {
-              int[] ints = (int[]) value;
-              int length = ints.length;
-              double[] doubles = new double[length];
-              ArrayCopyUtils.copy(ints, doubles, length);
-              setColumn(rowBuilder, byteBuffer, doubles);
-            } else if (value instanceof long[]) {
-              long[] longs = (long[]) value;
-              int length = longs.length;
-              double[] doubles = new double[length];
-              ArrayCopyUtils.copy(longs, doubles, length);
-              setColumn(rowBuilder, byteBuffer, doubles);
-            } else if (value instanceof float[]) {
-              float[] floats = (float[]) value;
-              int length = floats.length;
-              double[] doubles = new double[length];
-              ArrayCopyUtils.copy(floats, doubles, length);
-              setColumn(rowBuilder, byteBuffer, doubles);
-            } else {
-              setColumn(rowBuilder, byteBuffer, (double[]) value);
-            }
-            break;
-          case BYTES_ARRAY:
-            setColumn(rowBuilder, byteBuffer, (byte[][]) value);
+            setColumn(rowBuilder, byteBuffer, (double[]) value);
             break;
           case STRING_ARRAY:
             setColumn(rowBuilder, byteBuffer, (String[]) value);
             break;
-          case BOOLEAN_ARRAY:
-            boolean[] booleans = (boolean[]) value;
-            int length = booleans.length;
-            int[] ints = new int[length];
-            ArrayCopyUtils.copy(booleans, ints, length);
-            setColumn(rowBuilder, byteBuffer, ints);
+
+          // Special intermediate result for aggregation function
+          case OBJECT:
+            setColumn(rowBuilder, byteBuffer, value);
             break;
-          case TIMESTAMP_ARRAY:
-            Timestamp[] timestamps = (Timestamp[]) value;
-            length = timestamps.length;
-            long[] longs = new long[length];
-            ArrayCopyUtils.copy(timestamps, longs, length);
-            setColumn(rowBuilder, byteBuffer, longs);
-            break;
+
+          // Null
           case UNKNOWN:
             setColumn(rowBuilder, byteBuffer, (Object) null);
             break;
+
           default:
             throw new IllegalStateException(
-                String.format("Unsupported data type: %s for column: %s", rowBuilder._columnDataTypes[colId],
-                    rowBuilder._dataSchema.getColumnName(colId)));
+                String.format("Unsupported stored type: %s for column: %s", storedTypes[colId],
+                    dataSchema.getColumnName(colId)));
         }
       }
       rowBuilder._fixedSizeDataByteArrayOutputStream.write(byteBuffer.array(), 0, byteBuffer.position());
@@ -260,67 +196,64 @@ public class DataBlockBuilder {
       throws IOException {
     int numRows = columns.isEmpty() ? 0 : columns.get(0).length;
     DataBlockBuilder columnarBuilder = new DataBlockBuilder(dataSchema, DataBlock.Type.COLUMNAR, numRows);
-
     // TODO: consolidate these null utils into data table utils.
     // Selection / Agg / Distinct all have similar code.
-    int numColumns = columnarBuilder._numColumns;
+    ColumnDataType[] storedTypes = dataSchema.getStoredColumnDataTypes();
+    int numColumns = storedTypes.length;
     RoaringBitmap[] nullBitmaps = new RoaringBitmap[numColumns];
-    DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
-    DataSchema.ColumnDataType[] storedColumnDataTypes = dataSchema.getStoredColumnDataTypes();
     Object[] nullPlaceholders = new Object[numColumns];
     for (int colId = 0; colId < numColumns; colId++) {
       nullBitmaps[colId] = new RoaringBitmap();
-      nullPlaceholders[colId] = columnDataTypes[colId].convert(storedColumnDataTypes[colId].getNullPlaceholder());
+      nullPlaceholders[colId] = storedTypes[colId].getNullPlaceholder();
     }
-    for (int colId = 0; colId < columns.size(); colId++) {
+    for (int colId = 0; colId < numColumns; colId++) {
       Object[] column = columns.get(colId);
-      columnarBuilder._numRows = column.length;
-      ByteBuffer byteBuffer = ByteBuffer.allocate(columnarBuilder._numRows * columnarBuilder._columnSizeInBytes[colId]);
+      ByteBuffer byteBuffer = ByteBuffer.allocate(numRows * columnarBuilder._columnSizeInBytes[colId]);
       Object value;
-      switch (columnarBuilder._columnDataTypes[colId]) {
+      switch (storedTypes[colId]) {
         // Single-value column
         case INT:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+          for (int rowId = 0; rowId < numRows; rowId++) {
             value = column[rowId];
             if (value == null) {
               nullBitmaps[colId].add(rowId);
               value = nullPlaceholders[colId];
             }
-            byteBuffer.putInt(((Number) value).intValue());
+            byteBuffer.putInt((int) value);
           }
           break;
         case LONG:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+          for (int rowId = 0; rowId < numRows; rowId++) {
             value = column[rowId];
             if (value == null) {
               nullBitmaps[colId].add(rowId);
               value = nullPlaceholders[colId];
             }
-            byteBuffer.putLong(((Number) value).longValue());
+            byteBuffer.putLong((long) value);
           }
           break;
         case FLOAT:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+          for (int rowId = 0; rowId < numRows; rowId++) {
             value = column[rowId];
             if (value == null) {
               nullBitmaps[colId].add(rowId);
               value = nullPlaceholders[colId];
             }
-            byteBuffer.putFloat(((Number) value).floatValue());
+            byteBuffer.putFloat((float) value);
           }
           break;
         case DOUBLE:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+          for (int rowId = 0; rowId < numRows; rowId++) {
             value = column[rowId];
             if (value == null) {
               nullBitmaps[colId].add(rowId);
               value = nullPlaceholders[colId];
             }
-            byteBuffer.putDouble(((Number) value).doubleValue());
+            byteBuffer.putDouble((double) value);
           }
           break;
         case BIG_DECIMAL:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+          for (int rowId = 0; rowId < numRows; rowId++) {
             value = column[rowId];
             if (value == null) {
               nullBitmaps[colId].add(rowId);
@@ -329,28 +262,8 @@ public class DataBlockBuilder {
             setColumn(columnarBuilder, byteBuffer, (BigDecimal) value);
           }
           break;
-        case BOOLEAN:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
-            value = column[rowId];
-            if (value == null) {
-              nullBitmaps[colId].add(rowId);
-              value = nullPlaceholders[colId];
-            }
-            byteBuffer.putInt(((Boolean) value) ? 1 : 0);
-          }
-          break;
-        case TIMESTAMP:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
-            value = column[rowId];
-            if (value == null) {
-              nullBitmaps[colId].add(rowId);
-              value = nullPlaceholders[colId];
-            }
-            byteBuffer.putLong(((Timestamp) value).getTime());
-          }
-          break;
         case STRING:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+          for (int rowId = 0; rowId < numRows; rowId++) {
             value = column[rowId];
             if (value == null) {
               nullBitmaps[colId].add(rowId);
@@ -360,7 +273,7 @@ public class DataBlockBuilder {
           }
           break;
         case BYTES:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+          for (int rowId = 0; rowId < numRows; rowId++) {
             value = column[rowId];
             if (value == null) {
               nullBitmaps[colId].add(rowId);
@@ -369,19 +282,10 @@ public class DataBlockBuilder {
             setColumn(columnarBuilder, byteBuffer, (ByteArray) value);
           }
           break;
-        case OBJECT:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
-            value = column[rowId];
-            if (value == null) {
-              nullBitmaps[colId].add(rowId);
-              value = nullPlaceholders[colId];
-            }
-            setColumn(columnarBuilder, byteBuffer, value);
-          }
-          break;
+
         // Multi-value column
         case INT_ARRAY:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+          for (int rowId = 0; rowId < numRows; rowId++) {
             value = column[rowId];
             if (value == null) {
               nullBitmaps[colId].add(rowId);
@@ -391,26 +295,17 @@ public class DataBlockBuilder {
           }
           break;
         case LONG_ARRAY:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+          for (int rowId = 0; rowId < numRows; rowId++) {
             value = column[rowId];
             if (value == null) {
               nullBitmaps[colId].add(rowId);
               value = nullPlaceholders[colId];
             }
-            if (value instanceof int[]) {
-              // LONG_ARRAY type covers INT_ARRAY and LONG_ARRAY
-              int[] ints = (int[]) value;
-              int length = ints.length;
-              long[] longs = new long[length];
-              ArrayCopyUtils.copy(ints, longs, length);
-              setColumn(columnarBuilder, byteBuffer, longs);
-            } else {
-              setColumn(columnarBuilder, byteBuffer, (long[]) value);
-            }
+            setColumn(columnarBuilder, byteBuffer, (long[]) value);
           }
           break;
         case FLOAT_ARRAY:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+          for (int rowId = 0; rowId < numRows; rowId++) {
             value = column[rowId];
             if (value == null) {
               nullBitmaps[colId].add(rowId);
@@ -420,65 +315,17 @@ public class DataBlockBuilder {
           }
           break;
         case DOUBLE_ARRAY:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+          for (int rowId = 0; rowId < numRows; rowId++) {
             value = column[rowId];
             if (value == null) {
               nullBitmaps[colId].add(rowId);
               value = nullPlaceholders[colId];
             }
-            // DOUBLE_ARRAY type covers INT_ARRAY, LONG_ARRAY, FLOAT_ARRAY and DOUBLE_ARRAY
-            if (value instanceof int[]) {
-              int[] ints = (int[]) value;
-              int length = ints.length;
-              double[] doubles = new double[length];
-              ArrayCopyUtils.copy(ints, doubles, length);
-              setColumn(columnarBuilder, byteBuffer, doubles);
-            } else if (value instanceof long[]) {
-              long[] longs = (long[]) value;
-              int length = longs.length;
-              double[] doubles = new double[length];
-              ArrayCopyUtils.copy(longs, doubles, length);
-              setColumn(columnarBuilder, byteBuffer, doubles);
-            } else if (value instanceof float[]) {
-              float[] floats = (float[]) value;
-              int length = floats.length;
-              double[] doubles = new double[length];
-              ArrayCopyUtils.copy(floats, doubles, length);
-              setColumn(columnarBuilder, byteBuffer, doubles);
-            } else {
-              setColumn(columnarBuilder, byteBuffer, (double[]) value);
-            }
+            setColumn(columnarBuilder, byteBuffer, (double[]) value);
           }
           break;
-        case BOOLEAN_ARRAY:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
-            value = column[rowId];
-            if (value == null) {
-              nullBitmaps[colId].add(rowId);
-              value = nullPlaceholders[colId];
-            }
-            int length = ((boolean[]) value).length;
-            int[] ints = new int[length];
-            ArrayCopyUtils.copy((boolean[]) value, ints, length);
-            setColumn(columnarBuilder, byteBuffer, ints);
-          }
-          break;
-        case TIMESTAMP_ARRAY:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
-            value = column[rowId];
-            if (value == null) {
-              nullBitmaps[colId].add(rowId);
-              value = nullPlaceholders[colId];
-            }
-            int length = ((Timestamp[]) value).length;
-            long[] longs = new long[length];
-            ArrayCopyUtils.copy((Timestamp[]) value, longs, length);
-            setColumn(columnarBuilder, byteBuffer, longs);
-          }
-          break;
-        case BYTES_ARRAY:
         case STRING_ARRAY:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+          for (int rowId = 0; rowId < numRows; rowId++) {
             value = column[rowId];
             if (value == null) {
               nullBitmaps[colId].add(rowId);
@@ -487,15 +334,25 @@ public class DataBlockBuilder {
             setColumn(columnarBuilder, byteBuffer, (String[]) value);
           }
           break;
+
+        // Special intermediate result for aggregation function
+        case OBJECT:
+          for (int rowId = 0; rowId < numRows; rowId++) {
+            setColumn(columnarBuilder, byteBuffer, column[rowId]);
+          }
+          break;
+
+        // Null
         case UNKNOWN:
-          for (int rowId = 0; rowId < columnarBuilder._numRows; rowId++) {
+          for (int rowId = 0; rowId < numRows; rowId++) {
             setColumn(columnarBuilder, byteBuffer, (Object) null);
           }
           break;
+
         default:
           throw new IllegalStateException(
-              String.format("Unsupported data type: %s for column: %s", columnarBuilder._columnDataTypes[colId],
-                  columnarBuilder._dataSchema.getColumnName(colId)));
+              String.format("Unsupported stored type: %s for column: %s", storedTypes[colId],
+                  dataSchema.getColumnName(colId)));
       }
       columnarBuilder._fixedSizeDataByteArrayOutputStream.write(byteBuffer.array(), 0, byteBuffer.position());
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/datablock/DataBlockBuilder.java
@@ -126,6 +126,10 @@ public class DataBlockBuilder {
           nullBitmaps[colId].add(rowId);
           value = nullPlaceholders[colId];
         }
+
+        // NOTE:
+        // We intentionally make the type casting very strict here (e.g. only accepting Integer for INT) to ensure the
+        // rows conform to the data schema. This can help catch the unexpected data type issues early.
         switch (storedTypes[colId]) {
           // Single-value column
           case INT:
@@ -210,6 +214,10 @@ public class DataBlockBuilder {
       Object[] column = columns.get(colId);
       ByteBuffer byteBuffer = ByteBuffer.allocate(numRows * columnarBuilder._columnSizeInBytes[colId]);
       Object value;
+
+      // NOTE:
+      // We intentionally make the type casting very strict here (e.g. only accepting Integer for INT) to ensure the
+      // rows conform to the data schema. This can help catch the unexpected data type issues early.
       switch (storedTypes[colId]) {
         // Single-value column
         case INT:

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseBlock.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.operator.blocks;
 
 import java.io.IOException;
-import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -112,7 +111,7 @@ public class InstanceResponseBlock implements Block {
   }
 
   @Nullable
-  public Collection<Object[]> getRows() {
+  public List<Object[]> getRows() {
     return _resultsBlock != null ? _resultsBlock.getRows(_queryContext) : null;
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/datablock/DataBlockTestUtils.java
@@ -19,13 +19,13 @@
 package org.apache.pinot.core.common.datablock;
 
 import java.math.BigDecimal;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
 import org.apache.commons.lang.RandomStringUtils;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -40,7 +40,7 @@ public class DataBlockTestUtils {
 
   public static Object[] getRandomRow(DataSchema dataSchema, int nullPercentile) {
     final int numColumns = dataSchema.getColumnNames().length;
-    DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
+    ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
     Object[] row = new Object[numColumns];
     for (int colId = 0; colId < numColumns; colId++) {
       switch (columnDataTypes[colId]) {
@@ -60,10 +60,10 @@ public class DataBlockTestUtils {
           row[colId] = BigDecimal.valueOf(RANDOM.nextDouble());
           break;
         case BOOLEAN:
-          row[colId] = RANDOM.nextBoolean();
+          row[colId] = RANDOM.nextBoolean() ? 1 : 0;
           break;
         case TIMESTAMP:
-          row[colId] = new Timestamp(RANDOM.nextLong());
+          row[colId] = RANDOM.nextLong();
           break;
         case STRING:
           row[colId] = RandomStringUtils.random(RANDOM.nextInt(20));
@@ -113,17 +113,17 @@ public class DataBlockTestUtils {
           break;
         case BOOLEAN_ARRAY:
           length = RANDOM.nextInt(ARRAY_SIZE);
-          boolean[] booleanArray = new boolean[length];
+          int[] booleanArray = new int[length];
           for (int i = 0; i < length; i++) {
-            booleanArray[i] = RANDOM.nextBoolean();
+            booleanArray[i] = RANDOM.nextBoolean() ? 1 : 0;
           }
           row[colId] = booleanArray;
           break;
         case TIMESTAMP_ARRAY:
           length = RANDOM.nextInt(ARRAY_SIZE);
-          Timestamp[] timestampArray = new Timestamp[length];
+          long[] timestampArray = new long[length];
           for (int i = 0; i < length; i++) {
-            timestampArray[i] = new Timestamp(RANDOM.nextLong());
+            timestampArray[i] = RANDOM.nextLong();
           }
           row[colId] = timestampArray;
           break;
@@ -134,15 +134,14 @@ public class DataBlockTestUtils {
           throw new UnsupportedOperationException("Can't fill random data for column type: " + columnDataTypes[colId]);
       }
       // randomly set some entry to null
-      if (columnDataTypes[colId].getStoredType() != DataSchema.ColumnDataType.OBJECT) {
+      if (columnDataTypes[colId].getStoredType() != ColumnDataType.OBJECT) {
         row[colId] = randomlySettingNull(nullPercentile) ? null : row[colId];
       }
     }
     return row;
   }
 
-  public static Object getElement(DataBlock dataBlock, int rowId, int colId,
-      DataSchema.ColumnDataType columnDataType) {
+  public static Object getElement(DataBlock dataBlock, int rowId, int colId, ColumnDataType columnDataType) {
     RoaringBitmap nullBitmap = dataBlock.getNullRowIds(colId);
     if (nullBitmap != null) {
       if (nullBitmap.contains(rowId)) {
@@ -164,10 +163,8 @@ public class DataBlockTestUtils {
         return dataBlock.getString(rowId, colId);
       case BYTES:
         return dataBlock.getBytes(rowId, colId);
-      case BOOLEAN_ARRAY:
       case INT_ARRAY:
         return dataBlock.getIntArray(rowId, colId);
-      case TIMESTAMP_ARRAY:
       case LONG_ARRAY:
         return dataBlock.getLongArray(rowId, colId);
       case FLOAT_ARRAY:

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BigDecimalQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BigDecimalQueriesTest.java
@@ -329,7 +329,7 @@ public class BigDecimalQueriesTest extends BaseQueriesTest {
           // Null values are inserted at: index % 4 == 3. All null values are grouped into a single null.
           i++;
         }
-        assertEquals(row[1], BASE_BIG_DECIMAL.add(BigDecimal.valueOf(NUM_RECORDS - i - 1)).toPlainString());
+        assertEquals(row[1], BASE_BIG_DECIMAL.add(BigDecimal.valueOf(NUM_RECORDS - i - 1)));
         i++;
       }
     }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExprMinMaxTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExprMinMaxTest.java
@@ -58,7 +58,6 @@ import static org.testng.Assert.fail;
 /**
  * Queries test for argMin/argMax functions.
  */
-@SuppressWarnings({"rawtypes", "unchecked"})
 public class ExprMinMaxTest extends BaseQueriesTest {
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "ExprMinMaxTest");
   private static final String RAW_TABLE_NAME = "testTable";
@@ -257,8 +256,8 @@ public class ExprMinMaxTest extends BaseQueriesTest {
     assertEquals(rows.get(1)[4], new String[]{"a0", "a01", "a02"});
     assertEquals(rows.get(0)[5], 0);
     assertEquals(rows.get(1)[5], 0);
-    assertEquals(rows.get(0)[6], "360000");
-    assertEquals(rows.get(1)[6], "360000");
+    assertEquals(rows.get(0)[6], new BigDecimal(360000));
+    assertEquals(rows.get(1)[6], new BigDecimal(360000));
     assertEquals(rows.get(0)[7], 600D);
     assertEquals(rows.get(1)[7], 600D);
     assertEquals(rows.get(0)[8], 1683138373879L - 1999L);
@@ -362,11 +361,10 @@ public class ExprMinMaxTest extends BaseQueriesTest {
     query = "SELECT expr_min(mvBytesColumn, intColumn) FROM testTable";
 
     try {
-      brokerResponse = getBrokerResponse(query);
+      getBrokerResponse(query);
       fail("remove this test case, now mvBytesColumn works correctly in serialization");
     } catch (Exception e) {
-      assertTrue(e.getMessage()
-          .contains("java.lang.IllegalArgumentException: Unsupported type of value: byte[][]"));
+      assertTrue(e.getMessage().contains("Unsupported stored type: BYTES_ARRAY"));
     }
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotAggregateLiteralAttachmentRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotAggregateLiteralAttachmentRule.java
@@ -36,9 +36,10 @@ import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.tools.RelBuilderFactory;
 import org.apache.calcite.util.Pair;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.LiteralHintUtils;
 import org.apache.pinot.query.planner.logical.RexExpression;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.query.planner.logical.RexExpressionUtils;
 
 
 /**
@@ -89,12 +90,12 @@ public class PinotAggregateLiteralAttachmentRule extends RelOptRule {
       int argSize = aggCall.getArgList().size();
       if (argSize > 1) {
         // use -1 argIdx to indicate size of the agg operands.
-        rexLiteralMap.put(new Pair<>(aggIdx, -1), new RexExpression.Literal(FieldSpec.DataType.INT, argSize));
+        rexLiteralMap.put(new Pair<>(aggIdx, -1), new RexExpression.Literal(ColumnDataType.INT, argSize));
         // put the literals in to the map.
         for (int argIdx = 0; argIdx < argSize; argIdx++) {
           RexNode field = rexNodes.get(aggCall.getArgList().get(argIdx));
           if (field instanceof RexLiteral) {
-            rexLiteralMap.put(new Pair<>(aggIdx, argIdx), LiteralHintUtils.rexLiteralToLiteral((RexLiteral) field));
+            rexLiteralMap.put(new Pair<>(aggIdx, argIdx), RexExpressionUtils.fromRexLiteral((RexLiteral) field));
           }
         }
       }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/CalciteRexExpressionParser.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/parser/CalciteRexExpressionParser.java
@@ -20,7 +20,6 @@ package org.apache.pinot.query.parser;
 
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.GregorianCalendar;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -36,7 +35,6 @@ import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.plannode.SortNode;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.SqlCompilationException;
 import org.slf4j.Logger;
@@ -187,19 +185,10 @@ public class CalciteRexExpressionParser {
       case INPUT_REF:
         return inputRefToIdentifier((RexExpression.InputRef) rexNode, pinotQuery);
       case LITERAL:
-        return rexLiteralToExpression((RexExpression.Literal) rexNode);
+        return RequestUtils.getLiteralExpression(((RexExpression.Literal) rexNode).getValue());
       default:
         return compileFunctionExpression((RexExpression.FunctionCall) rexNode, pinotQuery);
     }
-  }
-
-  private static Expression rexLiteralToExpression(RexExpression.Literal rexLiteral) {
-    // TODO: currently literals are encoded as strings for V1, remove this and use directly literal type when it
-    // supports strong-type in V1.
-    if (rexLiteral.getDataType() == FieldSpec.DataType.TIMESTAMP) {
-      return RequestUtils.getLiteralExpression(((GregorianCalendar) rexLiteral.getValue()).getTimeInMillis());
-    }
-    return RequestUtils.getLiteralExpression(rexLiteral.getValue());
   }
 
   private static Expression inputRefToIdentifier(RexExpression.InputRef inputRef, PinotQuery pinotQuery) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RexExpressionUtils.java
@@ -20,67 +20,134 @@ package org.apache.pinot.query.planner.logical;
 
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Range;
+import java.math.BigDecimal;
 import java.util.ArrayList;
+import java.util.GregorianCalendar;
 import java.util.List;
 import java.util.Set;
 import java.util.stream.Collectors;
+import org.apache.calcite.rel.core.AggregateCall;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rex.RexCall;
 import org.apache.calcite.rex.RexInputRef;
 import org.apache.calcite.rex.RexLiteral;
 import org.apache.calcite.rex.RexNode;
 import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.util.NlsString;
 import org.apache.calcite.util.Sarg;
 import org.apache.commons.lang3.NotImplementedException;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 
 public class RexExpressionUtils {
-
   private RexExpressionUtils() {
   }
 
-  static RexExpression handleCase(RexCall rexCall) {
-    List<RexExpression> operands =
-        rexCall.getOperands().stream().map(RexExpression::toRexExpression).collect(Collectors.toList());
-    return new RexExpression.FunctionCall(rexCall.getKind(),
-        RelToPlanNodeConverter.convertToFieldSpecDataType(rexCall.getType()),
-        "caseWhen", operands);
+  public static RexExpression fromRexNode(RexNode rexNode) {
+    if (rexNode instanceof RexInputRef) {
+      return fromRexInputRef((RexInputRef) rexNode);
+    } else if (rexNode instanceof RexLiteral) {
+      return fromRexLiteral((RexLiteral) rexNode);
+    } else if (rexNode instanceof RexCall) {
+      return fromRexCall((RexCall) rexNode);
+    } else {
+      throw new IllegalArgumentException("Unsupported RexNode type with SqlKind: " + rexNode.getKind());
+    }
   }
 
-  static RexExpression handleCast(RexCall rexCall) {
+  public static RexExpression.InputRef fromRexInputRef(RexInputRef rexInputRef) {
+    return new RexExpression.InputRef(rexInputRef.getIndex());
+  }
+
+  public static RexExpression.Literal fromRexLiteral(RexLiteral rexLiteral) {
+    ColumnDataType dataType = RelToPlanNodeConverter.convertToColumnDataType(rexLiteral.getType());
+    return new RexExpression.Literal(dataType, convertValue(dataType, rexLiteral.getValue()));
+  }
+
+  @Nullable
+  private static Object convertValue(ColumnDataType dataType, @Nullable Comparable<?> value) {
+    if (value == null) {
+      return null;
+    }
+    switch (dataType) {
+      case INT:
+        return ((BigDecimal) value).intValue();
+      case LONG:
+        return ((BigDecimal) value).longValue();
+      case FLOAT:
+        return ((BigDecimal) value).floatValue();
+      case DOUBLE:
+        return ((BigDecimal) value).doubleValue();
+      case BOOLEAN:
+        return ((Boolean) value) ? 1 : 0;
+      case TIMESTAMP:
+        return ((GregorianCalendar) value).getTimeInMillis();
+      case STRING:
+        return ((NlsString) value).getValue();
+      default:
+        return value;
+    }
+  }
+
+  public static RexExpression fromRexCall(RexCall rexCall) {
+    switch (rexCall.getKind()) {
+      case CASE:
+        return handleCase(rexCall);
+      case CAST:
+        return handleCast(rexCall);
+      case REINTERPRET:
+        return handleReinterpret(rexCall);
+      case SEARCH:
+        return handleSearch(rexCall);
+      default:
+        List<RexExpression> operands =
+            rexCall.getOperands().stream().map(RexExpressionUtils::fromRexNode).collect(Collectors.toList());
+        return new RexExpression.FunctionCall(rexCall.getKind(),
+            RelToPlanNodeConverter.convertToColumnDataType(rexCall.getType()), rexCall.getOperator().getName(),
+            operands);
+    }
+  }
+
+  private static RexExpression.FunctionCall handleCase(RexCall rexCall) {
+    List<RexExpression> operands =
+        rexCall.getOperands().stream().map(RexExpressionUtils::fromRexNode).collect(Collectors.toList());
+    return new RexExpression.FunctionCall(SqlKind.CASE,
+        RelToPlanNodeConverter.convertToColumnDataType(rexCall.getType()), "caseWhen", operands);
+  }
+
+  private static RexExpression.FunctionCall handleCast(RexCall rexCall) {
     // CAST is being rewritten into "rexCall.CAST<targetType>(inputValue)",
     //   - e.g. result type has already been converted into the CAST RexCall, so we assert single operand.
     List<RexExpression> operands =
-        rexCall.getOperands().stream().map(RexExpression::toRexExpression).collect(Collectors.toList());
+        rexCall.getOperands().stream().map(RexExpressionUtils::fromRexNode).collect(Collectors.toList());
     Preconditions.checkState(operands.size() == 1, "CAST takes exactly 2 arguments");
     RelDataType castType = rexCall.getType();
-    operands.add(new RexExpression.Literal(FieldSpec.DataType.STRING,
-        RelToPlanNodeConverter.convertToFieldSpecDataType(castType).name()));
-    return new RexExpression.FunctionCall(rexCall.getKind(),
-        RelToPlanNodeConverter.convertToFieldSpecDataType(castType),
+    operands.add(new RexExpression.Literal(ColumnDataType.STRING,
+        RelToPlanNodeConverter.convertToColumnDataType(castType).name()));
+    return new RexExpression.FunctionCall(SqlKind.CAST, RelToPlanNodeConverter.convertToColumnDataType(castType),
         "CAST", operands);
   }
 
   /**
    * Reinterpret is a pass-through function that does not change the type of the input.
    */
-  static RexExpression handleReinterpret(RexCall rexCall) {
+  private static RexExpression handleReinterpret(RexCall rexCall) {
     List<RexNode> operands = rexCall.getOperands();
     Preconditions.checkState(operands.size() == 1, "REINTERPRET takes only 1 argument");
-    return RexExpression.toRexExpression(operands.get(0));
+    return fromRexNode(operands.get(0));
   }
 
   // TODO: Add support for range filter expressions (e.g. a > 0 and a < 30)
-  static RexExpression handleSearch(RexCall rexCall) {
+  private static RexExpression.FunctionCall handleSearch(RexCall rexCall) {
     List<RexNode> operands = rexCall.getOperands();
     RexInputRef rexInputRef = (RexInputRef) operands.get(0);
     RexLiteral rexLiteral = (RexLiteral) operands.get(1);
-    FieldSpec.DataType dataType = RelToPlanNodeConverter.convertToFieldSpecDataType(rexLiteral.getType());
+    ColumnDataType dataType = RelToPlanNodeConverter.convertToColumnDataType(rexLiteral.getType());
     Sarg sarg = rexLiteral.getValueAs(Sarg.class);
     if (sarg.isPoints()) {
-      return new RexExpression.FunctionCall(SqlKind.IN, dataType, SqlKind.IN.name(), toFunctionOperands(rexInputRef,
-          sarg.rangeSet.asRanges(), dataType));
+      return new RexExpression.FunctionCall(SqlKind.IN, dataType, SqlKind.IN.name(),
+          toFunctionOperands(rexInputRef, sarg.rangeSet.asRanges(), dataType));
     } else if (sarg.isComplementedPoints()) {
       return new RexExpression.FunctionCall(SqlKind.NOT_IN, dataType, SqlKind.NOT_IN.name(),
           toFunctionOperands(rexInputRef, sarg.rangeSet.complement().asRanges(), dataType));
@@ -90,13 +157,27 @@ public class RexExpressionUtils {
   }
 
   private static List<RexExpression> toFunctionOperands(RexInputRef rexInputRef, Set<Range> ranges,
-      FieldSpec.DataType dataType) {
+      ColumnDataType dataType) {
     List<RexExpression> result = new ArrayList<>(ranges.size() + 1);
-    result.add(RexExpression.toRexExpression(rexInputRef));
+    result.add(fromRexInputRef(rexInputRef));
     for (Range range : ranges) {
-      result.add(new RexExpression.Literal(dataType, RexExpression.toRexValue(dataType, range.lowerEndpoint())));
+      result.add(new RexExpression.Literal(dataType, convertValue(dataType, range.lowerEndpoint())));
     }
     return result;
+  }
+
+  public static RexExpression fromAggregateCall(AggregateCall aggregateCall) {
+    List<RexExpression> operands =
+        aggregateCall.getArgList().stream().map(RexExpression.InputRef::new).collect(Collectors.toList());
+    return new RexExpression.FunctionCall(aggregateCall.getAggregation().getKind(),
+        RelToPlanNodeConverter.convertToColumnDataType(aggregateCall.getType()),
+        aggregateCall.getAggregation().getName(), operands);
+  }
+
+  public static List<RexExpression> fromInputRefs(Iterable<Integer> inputRefs) {
+    List<RexExpression> rexExpressionInputRefs = new ArrayList<>();
+    inputRefs.forEach(k -> rexExpressionInputRefs.add(new RexExpression.InputRef(k)));
+    return rexExpressionInputRefs;
   }
 
   public static Integer getValueAsInt(RexNode in) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/AggregateNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/AggregateNode.java
@@ -27,6 +27,7 @@ import org.apache.calcite.rel.hint.PinotHintStrategyTable;
 import org.apache.calcite.rel.hint.RelHint;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.planner.logical.RexExpressionUtils;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
 
 
@@ -50,7 +51,7 @@ public class AggregateNode extends AbstractPlanNode {
       List<RexExpression> groupSet, List<RelHint> relHints) {
     super(planFragmentId, dataSchema);
     Preconditions.checkState(areHintsValid(relHints), "invalid sql hint for agg node: {}", relHints);
-    _aggCalls = aggCalls.stream().map(RexExpression::toRexExpression).collect(Collectors.toList());
+    _aggCalls = aggCalls.stream().map(RexExpressionUtils::fromAggregateCall).collect(Collectors.toList());
     _filterArgIndices = aggCalls.stream().map(c -> c.filterArg).collect(Collectors.toList());
     _groupSet = groupSet;
     _nodeHint = new NodeHint(relHints);

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/FilterNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/FilterNode.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.planner.plannode;
 import org.apache.calcite.rex.RexNode;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.planner.logical.RexExpressionUtils;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
 
 
@@ -34,7 +35,7 @@ public class FilterNode extends AbstractPlanNode {
 
   public FilterNode(int currentStageId, DataSchema dataSchema, RexNode condition) {
     super(currentStageId, dataSchema);
-    _condition = RexExpression.toRexExpression(condition);
+    _condition = RexExpressionUtils.fromRexNode(condition);
   }
 
   public RexExpression getCondition() {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/ProjectNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/ProjectNode.java
@@ -23,6 +23,7 @@ import java.util.stream.Collectors;
 import org.apache.calcite.rex.RexNode;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.planner.logical.RexExpressionUtils;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
 
 
@@ -33,9 +34,10 @@ public class ProjectNode extends AbstractPlanNode {
   public ProjectNode(int planFragmentId) {
     super(planFragmentId);
   }
+
   public ProjectNode(int currentStageId, DataSchema dataSchema, List<RexNode> projects) {
     super(currentStageId, dataSchema);
-    _projects = projects.stream().map(RexExpression::toRexExpression).collect(Collectors.toList());
+    _projects = projects.stream().map(RexExpressionUtils::fromRexNode).collect(Collectors.toList());
   }
 
   public List<RexExpression> getProjects() {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/ValueNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/ValueNode.java
@@ -20,14 +20,12 @@ package org.apache.pinot.query.planner.plannode;
 
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
-import java.util.GregorianCalendar;
 import java.util.List;
 import org.apache.calcite.rex.RexLiteral;
-import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.planner.logical.RexExpressionUtils;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
-import org.apache.pinot.spi.data.FieldSpec;
 
 
 public class ValueNode extends AbstractPlanNode {
@@ -38,8 +36,7 @@ public class ValueNode extends AbstractPlanNode {
     super(planFragmentId);
   }
 
-  public ValueNode(int currentStageId, DataSchema dataSchema,
-      ImmutableList<ImmutableList<RexLiteral>> literalTuples) {
+  public ValueNode(int currentStageId, DataSchema dataSchema, ImmutableList<ImmutableList<RexLiteral>> literalTuples) {
     super(currentStageId, dataSchema);
     _literalRows = new ArrayList<>();
     for (List<RexLiteral> literalTuple : literalTuples) {
@@ -49,12 +46,7 @@ public class ValueNode extends AbstractPlanNode {
           literalRow.add(null);
           continue;
         }
-        if (literal.getTypeName() == SqlTypeName.TIMESTAMP) {
-          GregorianCalendar tsLiteral = (GregorianCalendar) literal.getValue();
-          literalRow.add(new RexExpression.Literal(FieldSpec.DataType.TIMESTAMP, tsLiteral.getTimeInMillis()));
-          continue;
-        }
-        literalRow.add(RexExpression.toRexExpression(literal));
+        literalRow.add(RexExpressionUtils.fromRexLiteral(literal));
       }
       _literalRows.add(literalRow);
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -35,6 +35,7 @@ import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionFactory;
@@ -46,6 +47,7 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.block.DataBlockValSet;
 import org.apache.pinot.query.runtime.operator.block.FilteredDataBlockValSet;
+import org.apache.pinot.query.runtime.operator.utils.TypeUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.query.runtime.plan.StageMetadata;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -191,6 +193,8 @@ public class AggregateOperator extends MultiStageOperator {
       if (rows.isEmpty()) {
         return TransferableBlockUtils.getEndOfStreamTransferableBlock();
       } else {
+        ColumnDataType[] storedTypes = _resultSchema.getStoredColumnDataTypes();
+        rows.forEach(row -> TypeUtils.convertRow(row, storedTypes));
         TransferableBlock dataBlock = new TransferableBlock(rows, _resultSchema, DataBlock.Type.ROW);
         if (_groupByExecutor.isNumGroupsLimitReached()) {
           dataBlock.addException(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE,
@@ -200,7 +204,10 @@ public class AggregateOperator extends MultiStageOperator {
         return dataBlock;
       }
     } else {
-      return new TransferableBlock(_aggregationExecutor.getResult(), _resultSchema, DataBlock.Type.ROW);
+      ColumnDataType[] storedTypes = _resultSchema.getStoredColumnDataTypes();
+      List<Object[]> rows = _aggregationExecutor.getResult();
+      rows.forEach(row -> TypeUtils.convertRow(row, storedTypes));
+      return new TransferableBlock(rows, _resultSchema, DataBlock.Type.ROW);
     }
   }
 
@@ -317,7 +324,7 @@ public class AggregateOperator extends MultiStageOperator {
       case LITERAL: {
         RexExpression.Literal literalRexExp = (RexExpression.Literal) rexExpr;
         Object value = literalRexExp.getValue();
-        exprContext = ExpressionContext.forLiteralContext(literalRexExp.getDataType(), value);
+        exprContext = ExpressionContext.forLiteralContext(literalRexExp.getDataType().toDataType(), value);
         break;
       }
       default:
@@ -343,7 +350,7 @@ public class AggregateOperator extends MultiStageOperator {
       if (expression.getType().equals(ExpressionContext.Type.IDENTIFIER) && !"__PLACEHOLDER__".equals(
           expression.getIdentifier())) {
         int index = colNameToIndexMap.get(expression.getIdentifier());
-        DataSchema.ColumnDataType dataType = inputDataSchema.getColumnDataType(index);
+        ColumnDataType dataType = inputDataSchema.getColumnDataType(index);
         Preconditions.checkState(block.getType().equals(DataBlock.Type.ROW), "Datablock type is not ROW");
         if (filterArgIdx == -1) {
           blockValSetMap.put(expression, new DataBlockValSet(dataType, block.getDataBlock(), index));

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -31,6 +31,7 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.spi.utils.BooleanUtils;
 
 
 /*
@@ -83,7 +84,7 @@ public class FilterOperator extends MultiStageOperator {
     List<Object[]> resultRows = new ArrayList<>();
     for (Object[] row : block.getContainer()) {
       Object filterResult = _filterOperand.apply(row);
-      if (filterResult != null && (int) filterResult == 1) {
+      if (BooleanUtils.isTrueInternalValue(filterResult)) {
         resultRows.add(row);
       }
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -18,20 +18,19 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
+import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
-import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
-import org.apache.pinot.query.runtime.operator.utils.TypeUtils;
+import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /*
@@ -49,19 +48,19 @@ import org.slf4j.LoggerFactory;
  */
 public class FilterOperator extends MultiStageOperator {
   private static final String EXPLAIN_NAME = "FILTER";
+
   private final MultiStageOperator _upstreamOperator;
-  private static final Logger LOGGER = LoggerFactory.getLogger(AggregateOperator.class);
   private final TransformOperand _filterOperand;
   private final DataSchema _dataSchema;
-  private TransferableBlock _upstreamErrorBlock;
 
   public FilterOperator(OpChainExecutionContext context, MultiStageOperator upstreamOperator, DataSchema dataSchema,
       RexExpression filter) {
     super(context);
     _upstreamOperator = upstreamOperator;
     _dataSchema = dataSchema;
-    _filterOperand = TransformOperand.toTransformOperand(filter, dataSchema);
-    _upstreamErrorBlock = null;
+    _filterOperand = TransformOperandFactory.getTransformOperand(filter, dataSchema);
+    Preconditions.checkState(_filterOperand.getResultType() == ColumnDataType.BOOLEAN,
+        "Filter operand must return BOOLEAN, got: %s", _filterOperand.getResultType());
   }
 
   @Override
@@ -77,30 +76,14 @@ public class FilterOperator extends MultiStageOperator {
 
   @Override
   protected TransferableBlock getNextBlock() {
-    try {
-      TransferableBlock block = _upstreamOperator.nextBlock();
-      return transform(block);
-    } catch (Exception e) {
-      return TransferableBlockUtils.getErrorTransferableBlock(e);
-    }
-  }
-
-  @SuppressWarnings("ConstantConditions")
-  private TransferableBlock transform(TransferableBlock block)
-      throws Exception {
-    if (_upstreamErrorBlock != null) {
-      return _upstreamErrorBlock;
-    } else if (block.isErrorBlock()) {
-      _upstreamErrorBlock = block;
-      return _upstreamErrorBlock;
-    } else if (TransferableBlockUtils.isEndOfStream(block)) {
+    TransferableBlock block = _upstreamOperator.nextBlock();
+    if (block.isEndOfStreamBlock()) {
       return block;
     }
-
     List<Object[]> resultRows = new ArrayList<>();
-    List<Object[]> container = block.getContainer();
-    for (Object[] row : container) {
-      if ((Boolean) TypeUtils.convert(_filterOperand.apply(row), DataSchema.ColumnDataType.BOOLEAN)) {
+    for (Object[] row : block.getContainer()) {
+      Object filterResult = _filterOperand.apply(row);
+      if (filterResult != null && (int) filterResult == 1) {
         resultRows.add(row);
       }
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -44,7 +44,7 @@ import org.apache.pinot.query.planner.plannode.JoinNode;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
-import org.apache.pinot.query.runtime.operator.utils.TypeUtils;
+import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.query.runtime.plan.StageMetadata;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.JoinOverFlowMode;
@@ -135,7 +135,7 @@ public class HashJoinOperator extends MultiStageOperator {
     _rightTableOperator = rightTableOperator;
     _joinClauseEvaluators = new ArrayList<>(node.getJoinClauses().size());
     for (RexExpression joinClause : node.getJoinClauses()) {
-      _joinClauseEvaluators.add(TransformOperand.toTransformOperand(joinClause, _resultSchema));
+      _joinClauseEvaluators.add(TransformOperandFactory.getTransformOperand(joinClause, _resultSchema));
     }
     _isHashTableBuilt = false;
     _broadcastRightTable = new HashMap<>();
@@ -263,14 +263,11 @@ public class HashJoinOperator extends MultiStageOperator {
       _upstreamErrorBlock = leftBlock;
       return _upstreamErrorBlock;
     }
-    if (leftBlock.isSuccessfulEndOfStreamBlock() && !needUnmatchedRightRows()) {
-      if (leftBlock.isSuccessfulEndOfStreamBlock()) {
-        return TransferableBlockUtils.getEndOfStreamTransferableBlock();
+    if (leftBlock.isSuccessfulEndOfStreamBlock()) {
+      if (!needUnmatchedRightRows()) {
+        return leftBlock;
       }
-      return leftBlock;
-    }
-    // TODO: Moved to a different function.
-    if (leftBlock.isSuccessfulEndOfStreamBlock() && needUnmatchedRightRows()) {
+      // TODO: Moved to a different function.
       // Return remaining non-matched rows for non-inner join.
       List<Object[]> returnRows = new ArrayList<>();
       for (Map.Entry<Key, ArrayList<Object[]>> entry : _broadcastRightTable.entrySet()) {
@@ -289,24 +286,21 @@ public class HashJoinOperator extends MultiStageOperator {
       return new TransferableBlock(returnRows, _resultSchema, DataBlock.Type.ROW);
     }
     List<Object[]> rows;
-    if (leftBlock.isEndOfStreamBlock()) {
-      rows = new ArrayList<>();
-    } else {
-      switch (_joinType) {
-        case SEMI: {
-          rows = buildJoinedDataBlockSemi(leftBlock);
-          break;
-        }
-        case ANTI: {
-          rows = buildJoinedDataBlockAnti(leftBlock);
-          break;
-        }
-        default: { // INNER, LEFT, RIGHT, FULL
-          rows = buildJoinedDataBlockDefault(leftBlock);
-          break;
-        }
+    switch (_joinType) {
+      case SEMI: {
+        rows = buildJoinedDataBlockSemi(leftBlock);
+        break;
+      }
+      case ANTI: {
+        rows = buildJoinedDataBlockAnti(leftBlock);
+        break;
+      }
+      default: { // INNER, LEFT, RIGHT, FULL
+        rows = buildJoinedDataBlockDefault(leftBlock);
+        break;
       }
     }
+    // TODO: Rows can be empty here. Consider fetching another left block instead of returning empty block.
     return new TransferableBlock(rows, _resultSchema, DataBlock.Type.ROW);
   }
 
@@ -352,8 +346,10 @@ public class HashJoinOperator extends MultiStageOperator {
         Object[] rightRow = matchedRightRows.get(i);
         // TODO: Optimize this to avoid unnecessary object copy.
         Object[] resultRow = joinRow(leftRow, rightRow);
-        if (_joinClauseEvaluators.isEmpty() || _joinClauseEvaluators.stream().allMatch(
-            evaluator -> (Boolean) TypeUtils.convert(evaluator.apply(resultRow), DataSchema.ColumnDataType.BOOLEAN))) {
+        if (_joinClauseEvaluators.isEmpty() || _joinClauseEvaluators.stream().allMatch(evaluator -> {
+          Object result = evaluator.apply(resultRow);
+          return result != null && (int) result == 1;
+        })) {
           rows.add(resultRow);
           hasMatchForLeftRow = true;
           if (_matchedRightRows != null) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -47,6 +47,7 @@ import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.query.runtime.plan.StageMetadata;
+import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.JoinOverFlowMode;
 
 
@@ -346,10 +347,8 @@ public class HashJoinOperator extends MultiStageOperator {
         Object[] rightRow = matchedRightRows.get(i);
         // TODO: Optimize this to avoid unnecessary object copy.
         Object[] resultRow = joinRow(leftRow, rightRow);
-        if (_joinClauseEvaluators.isEmpty() || _joinClauseEvaluators.stream().allMatch(evaluator -> {
-          Object result = evaluator.apply(resultRow);
-          return result != null && (int) result == 1;
-        })) {
+        if (_joinClauseEvaluators.isEmpty() || _joinClauseEvaluators.stream()
+            .allMatch(evaluator -> BooleanUtils.isTrueInternalValue(evaluator.apply(resultRow)))) {
           rows.add(resultRow);
           hasMatchForLeftRow = true;
           if (_matchedRightRows != null) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageAggregationExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageAggregationExecutor.java
@@ -115,7 +115,8 @@ public class MultistageAggregationExecutor {
       }
       row[i] = value;
     }
-    return Collections.singletonList(TypeUtils.canonicalizeRow(row, _resultSchema));
+    TypeUtils.convertRow(row, _resultSchema.getColumnDataTypes());
+    return Collections.singletonList(row);
   }
 
   private void processAggregate(TransferableBlock block, DataSchema inputDataSchema) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageAggregationExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageAggregationExecutor.java
@@ -115,7 +115,8 @@ public class MultistageAggregationExecutor {
       }
       row[i] = value;
     }
-    TypeUtils.convertRow(row, _resultSchema.getColumnDataTypes());
+    // Convert the results from AggregationFunction to the desired type
+    TypeUtils.convertRow(row, _resultSchema.getStoredColumnDataTypes());
     return Collections.singletonList(row);
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -30,7 +30,6 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
-import org.apache.pinot.query.runtime.operator.utils.TypeUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 
 
@@ -109,10 +108,7 @@ public class TransformOperator extends MultiStageOperator {
     for (Object[] row : container) {
       Object[] resultRow = new Object[_resultColumnSize];
       for (int i = 0; i < _resultColumnSize; i++) {
-        Object value = _transformOperandsList.get(i).apply(row);
-        if (value != null) {
-          resultRow[i] = TypeUtils.convert(value, _resultSchema.getColumnDataType(i));
-        }
+        resultRow[i] = _transformOperandsList.get(i).apply(row);
       }
       resultRows.add(resultRow);
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -29,10 +29,9 @@ import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
+import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
 import org.apache.pinot.query.runtime.operator.utils.TypeUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -47,8 +46,8 @@ import org.slf4j.LoggerFactory;
  */
 public class TransformOperator extends MultiStageOperator {
   private static final String EXPLAIN_NAME = "TRANSFORM";
+
   private final MultiStageOperator _upstreamOperator;
-  private static final Logger LOGGER = LoggerFactory.getLogger(TransformOperator.class);
   private final List<TransformOperand> _transformOperandsList;
   private final int _resultColumnSize;
   // TODO: Check type matching between resultSchema and the actual result.
@@ -65,7 +64,7 @@ public class TransformOperator extends MultiStageOperator {
     _resultColumnSize = transforms.size();
     _transformOperandsList = new ArrayList<>(_resultColumnSize);
     for (RexExpression rexExpression : transforms) {
-      _transformOperandsList.add(TransformOperand.toTransformOperand(rexExpression, upstreamDataSchema));
+      _transformOperandsList.add(TransformOperandFactory.getTransformOperand(rexExpression, upstreamDataSchema));
     }
     _resultSchema = resultSchema;
   }
@@ -110,7 +109,10 @@ public class TransformOperator extends MultiStageOperator {
     for (Object[] row : container) {
       Object[] resultRow = new Object[_resultColumnSize];
       for (int i = 0; i < _resultColumnSize; i++) {
-        resultRow[i] = TypeUtils.convert(_transformOperandsList.get(i).apply(row), _resultSchema.getColumnDataType(i));
+        Object value = _transformOperandsList.get(i).apply(row);
+        if (value != null) {
+          resultRow[i] = TypeUtils.convert(value, _resultSchema.getColumnDataType(i));
+        }
       }
       resultRows.add(resultRow);
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
@@ -219,7 +219,7 @@ public class WindowAggregateOperator extends MultiStageOperator {
 
   private TransferableBlock produceWindowAggregatedBlock() {
     Key emptyOrderKey = AggregationUtils.extractEmptyKey();
-    ColumnDataType[] storedTypes = _resultSchema.getStoredColumnDataTypes();
+    ColumnDataType[] resultStoredTypes = _resultSchema.getStoredColumnDataTypes();
     List<Object[]> rows = new ArrayList<>(_numRows);
     if (_windowFrame.getWindowFrameType() == WindowNode.WindowFrameType.RANGE) {
       // All aggregation window functions only support RANGE type today (SUM/AVG/MIN/MAX/COUNT/BOOL_AND/BOOL_OR)
@@ -235,7 +235,8 @@ public class WindowAggregateOperator extends MultiStageOperator {
           for (int i = 0; i < _windowAccumulators.length; i++) {
             row[i + existingRow.length] = _windowAccumulators[i].getRangeResultForKeys(partitionKey, orderKey);
           }
-          TypeUtils.convertRow(row, storedTypes);
+          // Convert the results from Accumulator to the desired type
+          TypeUtils.convertRow(row, resultStoredTypes);
           rows.add(row);
         }
       }
@@ -258,7 +259,8 @@ public class WindowAggregateOperator extends MultiStageOperator {
                     previousRowValues[i]);
             previousRowValues[i] = row[i + existingRow.length];
           }
-          TypeUtils.convertRow(row, storedTypes);
+          // Convert the results from Accumulator to the desired type
+          TypeUtils.convertRow(row, resultStoredTypes);
           rows.add(row);
           previousPartitionKey = partitionKey;
         }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/LiteralOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/LiteralOperand.java
@@ -18,16 +18,22 @@
  */
 package org.apache.pinot.query.runtime.operator.operands;
 
-import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 
 
-public class LiteralOperand extends TransformOperand {
+public class LiteralOperand implements TransformOperand {
+  private final ColumnDataType _resultType;
   private final Object _value;
 
   public LiteralOperand(RexExpression.Literal rexExpression) {
+    _resultType = rexExpression.getDataType();
     _value = rexExpression.getValue();
-    _resultType = DataSchema.ColumnDataType.fromDataType(rexExpression.getDataType(), true);
+  }
+
+  @Override
+  public ColumnDataType getResultType() {
+    return _resultType;
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/ReferenceOperand.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/ReferenceOperand.java
@@ -18,21 +18,28 @@
  */
 package org.apache.pinot.query.runtime.operator.operands;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 
 
-public class ReferenceOperand extends TransformOperand {
-  private final int _refIndex;
+public class ReferenceOperand implements TransformOperand {
+  private final int _index;
+  private final ColumnDataType _resultType;
 
-  public ReferenceOperand(RexExpression.InputRef inputRef, DataSchema dataSchema) {
-    _refIndex = inputRef.getIndex();
-    _resultType = dataSchema.getColumnDataType(_refIndex);
-    _resultName = dataSchema.getColumnName(_refIndex);
+  public ReferenceOperand(int index, DataSchema dataSchema) {
+    _index = index;
+    _resultType = dataSchema.getColumnDataType(index);
   }
 
   @Override
+  public ColumnDataType getResultType() {
+    return _resultType;
+  }
+
+  @Nullable
+  @Override
   public Object apply(Object[] row) {
-    return row[_refIndex];
+    return row[_index];
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/TransformOperandFactory.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/TransformOperandFactory.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.runtime.operator.operands;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.query.planner.logical.RexExpression;
+import org.apache.pinot.query.runtime.operator.utils.OperatorUtils;
+
+
+public class TransformOperandFactory {
+  private TransformOperandFactory() {
+  }
+
+  public static TransformOperand getTransformOperand(RexExpression rexExpression, DataSchema dataSchema) {
+    if (rexExpression instanceof RexExpression.FunctionCall) {
+      return getTransformOperand((RexExpression.FunctionCall) rexExpression, dataSchema);
+    } else if (rexExpression instanceof RexExpression.InputRef) {
+      return new ReferenceOperand(((RexExpression.InputRef) rexExpression).getIndex(), dataSchema);
+    } else if (rexExpression instanceof RexExpression.Literal) {
+      return new LiteralOperand((RexExpression.Literal) rexExpression);
+    } else {
+      throw new UnsupportedOperationException("Unsupported RexExpression: " + rexExpression);
+    }
+  }
+
+  private static TransformOperand getTransformOperand(RexExpression.FunctionCall functionCall, DataSchema dataSchema) {
+    List<RexExpression> operands = functionCall.getFunctionOperands();
+    int numOperands = operands.size();
+    String canonicalName = OperatorUtils.canonicalizeFunctionName(functionCall.getFunctionName());
+    switch (canonicalName) {
+      case "AND":
+        Preconditions.checkState(numOperands >= 2, "AND takes >=2 arguments, got: %s", numOperands);
+        return new FilterOperand.And(operands, dataSchema);
+      case "OR":
+        Preconditions.checkState(numOperands >= 2, "OR takes >=2 arguments, got: %s", numOperands);
+        return new FilterOperand.Or(operands, dataSchema);
+      case "NOT":
+        Preconditions.checkState(numOperands == 1, "NOT takes one argument, got: %s", numOperands);
+        return new FilterOperand.Not(operands.get(0), dataSchema);
+      case "ISTRUE":
+        Preconditions.checkState(numOperands == 1, "IS_TRUE takes one argument, got: %s", numOperands);
+        return new FilterOperand.IsTrue(operands.get(0), dataSchema);
+      case "ISNOTTRUE":
+        Preconditions.checkState(numOperands == 1, "IS_NOT_TRUE takes one argument, got: %s", numOperands);
+        return new FilterOperand.IsNotTrue(operands.get(0), dataSchema);
+      case "equals":
+        return new FilterOperand.Predicate(operands, dataSchema, v -> v == 0);
+      case "notEquals":
+        return new FilterOperand.Predicate(operands, dataSchema, v -> v != 0);
+      case "greaterThan":
+        return new FilterOperand.Predicate(operands, dataSchema, v -> v > 0);
+      case "greaterThanOrEqual":
+        return new FilterOperand.Predicate(operands, dataSchema, v -> v >= 0);
+      case "lessThan":
+        return new FilterOperand.Predicate(operands, dataSchema, v -> v < 0);
+      case "lessThanOrEqual":
+        return new FilterOperand.Predicate(operands, dataSchema, v -> v <= 0);
+      default:
+        return new FunctionOperand(functionCall, canonicalName, dataSchema);
+    }
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/TypeUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/TypeUtils.java
@@ -18,6 +18,8 @@
  */
 package org.apache.pinot.query.runtime.operator.utils;
 
+import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 
 
@@ -28,6 +30,7 @@ public class TypeUtils {
   /**
    * Converts value to the desired stored {@link ColumnDataType}. This is used to convert rows generated from
    * single-stage engine to be used in multi-stage engine.
+   * TODO: Revisit to see if we should use original type instead of stored type
    */
   public static Object convert(Object value, ColumnDataType storedType) {
     switch (storedType) {
@@ -39,8 +42,23 @@ public class TypeUtils {
         return ((Number) value).floatValue();
       case DOUBLE:
         return ((Number) value).doubleValue();
+      // For AggregationFunctions that return serialized custom object, e.g. DistinctCountRawHLLAggregationFunction
       case STRING:
         return value.toString();
+      case LONG_ARRAY:
+        if (value instanceof LongArrayList) {
+          // For FunnelCountAggregationFunction
+          return ((LongArrayList) value).elements();
+        } else {
+          return value;
+        }
+      case DOUBLE_ARRAY:
+        if (value instanceof DoubleArrayList) {
+          // For HistogramAggregationFunction
+          return ((DoubleArrayList) value).elements();
+        } else {
+          return value;
+        }
       // TODO: Add more conversions
       default:
         return value;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/SubmissionService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/SubmissionService.java
@@ -21,12 +21,9 @@ package org.apache.pinot.query.service;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -34,8 +31,6 @@ import org.slf4j.LoggerFactory;
  * or any failure occurs.
  */
 public class SubmissionService {
-  private static final Logger LOGGER = LoggerFactory.getLogger(SubmissionService.class);
-
   private final ExecutorService _executor;
   private final List<CompletableFuture<Void>> _futures = new ArrayList<>();
 
@@ -47,13 +42,11 @@ public class SubmissionService {
     _futures.add(CompletableFuture.runAsync(runnable, _executor));
   }
 
-  public void awaitFinish(long deadlineMs) throws ExecutionException {
+  public void awaitFinish(long deadlineMs)
+      throws Exception {
     CompletableFuture<Void> completableFuture = CompletableFuture.allOf(_futures.toArray(new CompletableFuture[]{}));
     try {
       completableFuture.get(deadlineMs - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
-    } catch (Throwable t) {
-      LOGGER.error("error occurred during submission", t);
-      throw new ExecutionException("error occurred during submission", t);
     } finally {
       // Cancel all ongoing submission
       for (CompletableFuture<Void> future : _futures) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
@@ -68,9 +68,8 @@ public class QueryServerEnclosure {
   private final HelixManager _helixManager;
 
   private final QueryRunner _queryRunner;
-  private final ExecutorService _executor = Executors.newCachedThreadPool(
-      new NamedThreadFactory("QueryServerTest_Server"));
-
+  private final ExecutorService _executor =
+      Executors.newCachedThreadPool(new NamedThreadFactory("QueryServerTest_Server"));
 
   public QueryServerEnclosure(MockInstanceDataManagerFactory factory) {
     try {
@@ -133,6 +132,9 @@ public class QueryServerEnclosure {
       try {
         _queryRunner.processQuery(distributedStagePlan, requestMetadataMap);
       } catch (Exception e) {
+        // TODO: Find a way to propagate the exception and fail the test
+        System.err.println("Caught exception while executing query");
+        e.printStackTrace(System.err);
         throw new RuntimeException("Error executing query!", e);
       }
     });

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtilsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtilsTest.java
@@ -34,26 +34,26 @@ import org.testng.Assert;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+
 
 public class TransferableBlockUtilsTest {
   private static final int TOTAL_ROW_COUNT = 50;
   private static final int TEST_EST_BYTES_PER_COLUMN = 8;
-  private static final List<DataSchema.ColumnDataType> EXCLUDE_DATA_TYPES = ImmutableList.of(
-      DataSchema.ColumnDataType.OBJECT, DataSchema.ColumnDataType.JSON, DataSchema.ColumnDataType.BYTES,
-      DataSchema.ColumnDataType.BYTES_ARRAY);
+  private static final List<ColumnDataType> EXCLUDE_DATA_TYPES =
+      ImmutableList.of(ColumnDataType.OBJECT, ColumnDataType.JSON, ColumnDataType.BYTES, ColumnDataType.BYTES_ARRAY);
 
   private static DataSchema getDataSchema() {
-    DataSchema.ColumnDataType[] allDataTypes = DataSchema.ColumnDataType.values();
-    List<DataSchema.ColumnDataType> columnDataTypes = new ArrayList<DataSchema.ColumnDataType>();
-    List<String> columnNames = new ArrayList<String>();
+    ColumnDataType[] allDataTypes = ColumnDataType.values();
+    List<ColumnDataType> columnDataTypes = new ArrayList<>();
+    List<String> columnNames = new ArrayList<>();
     for (int i = 0; i < allDataTypes.length; i++) {
       if (!EXCLUDE_DATA_TYPES.contains(allDataTypes[i])) {
         columnNames.add(allDataTypes[i].name());
         columnDataTypes.add(allDataTypes[i]);
       }
     }
-    return new DataSchema(columnNames.toArray(new String[0]),
-        columnDataTypes.toArray(new DataSchema.ColumnDataType[0]));
+    return new DataSchema(columnNames.toArray(new String[0]), columnDataTypes.toArray(new ColumnDataType[0]));
   }
 
   @DataProvider
@@ -71,8 +71,8 @@ public class TransferableBlockUtilsTest {
     int estRowSizeInBytes = dataSchema.size() * TEST_EST_BYTES_PER_COLUMN;
     List<Object[]> rows = DataBlockTestUtils.getRandomRows(dataSchema, TOTAL_ROW_COUNT, 1);
     RowDataBlock rowBlock = DataBlockBuilder.buildFromRows(rows, dataSchema);
-    validateBlocks(TransferableBlockUtils.splitBlock(new TransferableBlock(rowBlock),
-        DataBlock.Type.ROW, estRowSizeInBytes * splitRowCount + 1), rows, dataSchema);
+    validateBlocks(TransferableBlockUtils.splitBlock(new TransferableBlock(rowBlock), DataBlock.Type.ROW,
+        estRowSizeInBytes * splitRowCount + 1), rows, dataSchema);
     // compare non-serialized split
     validateBlocks(TransferableBlockUtils.splitBlock(new TransferableBlock(rows, dataSchema, DataBlock.Type.ROW),
         DataBlock.Type.ROW, estRowSizeInBytes * splitRowCount + 1), rows, dataSchema);
@@ -113,11 +113,12 @@ public class TransferableBlockUtilsTest {
           if (row[colId] == null && rows.get(rowId)[colId] == null) {
             continue;
           }
-          DataSchema.ColumnDataType columnDataType = dataSchema.getColumnDataType(colId);
+          ColumnDataType columnDataType = dataSchema.getColumnDataType(colId);
           Object actualVal = row[colId];
           Object expectedVal = rows.get(rowId)[colId];
-          Assert.assertEquals(actualVal, expectedVal, "Error comparing split Block at (" + rowId + "," + colId + ")"
-              + " of Type: " + columnDataType + "! expected: [" + expectedVal + "], actual: [" + actualVal + "]");
+          Assert.assertEquals(actualVal, expectedVal,
+              "Error comparing split Block at (" + rowId + "," + colId + ")" + " of Type: " + columnDataType
+                  + "! expected: [" + expectedVal + "], actual: [" + actualVal + "]");
         }
         rowId++;
       }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
@@ -29,7 +29,6 @@ import org.apache.pinot.query.planner.plannode.AggregateNode.AggType;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.mockito.Mock;
 import org.mockito.Mockito;
@@ -43,6 +42,7 @@ import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.DOUBLE;
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.INT;
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.LONG;
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.STRING;
+
 
 public class AggregateOperatorTest {
 
@@ -140,7 +140,7 @@ public class AggregateOperatorTest {
   @Test
   public void shouldAggregateSingleInputBlockWithLiteralInput() {
     // Given:
-    List<RexExpression> calls = ImmutableList.of(getSum(new RexExpression.Literal(FieldSpec.DataType.DOUBLE, 1.0)));
+    List<RexExpression> calls = ImmutableList.of(getSum(new RexExpression.Literal(ColumnDataType.DOUBLE, 1.0)));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, DOUBLE});
@@ -171,9 +171,10 @@ public class AggregateOperatorTest {
     RexExpression.FunctionCall agg = getSum(new RexExpression.InputRef(0));
     DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{STRING, INT});
     DataSchema outSchema = new DataSchema(new String[]{"group", "sum"}, new ColumnDataType[]{STRING, DOUBLE});
-    AggregateOperator sum0GroupBy1 = new AggregateOperator(OperatorTestUtil.getDefaultContext(), upstreamOperator,
-        outSchema, inSchema, Collections.singletonList(agg),
-        Collections.singletonList(new RexExpression.InputRef(1)), AggType.LEAF, null, null);
+    AggregateOperator sum0GroupBy1 =
+        new AggregateOperator(OperatorTestUtil.getDefaultContext(), upstreamOperator, outSchema, inSchema,
+            Collections.singletonList(agg), Collections.singletonList(new RexExpression.InputRef(1)), AggType.LEAF,
+            null, null);
     TransferableBlock result = sum0GroupBy1.getNextBlock();
     List<Object[]> resultRows = result.getContainer();
     Assert.assertEquals(resultRows.size(), 2);
@@ -190,7 +191,7 @@ public class AggregateOperatorTest {
   public void shouldThrowOnUnknownAggFunction() {
     // Given:
     List<RexExpression> calls = ImmutableList.of(
-        new RexExpression.FunctionCall(SqlKind.AVG, FieldSpec.DataType.INT, "AVERAGE", ImmutableList.of()));
+        new RexExpression.FunctionCall(SqlKind.AVG, ColumnDataType.INT, "AVERAGE", ImmutableList.of()));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
     DataSchema outSchema = new DataSchema(new String[]{"unknown"}, new ColumnDataType[]{DOUBLE});
     DataSchema inSchema = new DataSchema(new String[]{"unknown"}, new ColumnDataType[]{DOUBLE});
@@ -229,6 +230,6 @@ public class AggregateOperatorTest {
   }
 
   private static RexExpression.FunctionCall getSum(RexExpression arg) {
-    return new RexExpression.FunctionCall(SqlKind.SUM, FieldSpec.DataType.INT, "SUM", ImmutableList.of(arg));
+    return new RexExpression.FunctionCall(SqlKind.SUM, ColumnDataType.INT, "SUM", ImmutableList.of(arg));
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/FilterOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/FilterOperatorTest.java
@@ -23,10 +23,10 @@ import java.util.List;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -56,9 +56,9 @@ public class FilterOperatorTest {
   public void shouldPropagateUpstreamErrorBlock() {
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(TransferableBlockUtils.getErrorTransferableBlock(new Exception("filterError")));
-    RexExpression booleanLiteral = new RexExpression.Literal(FieldSpec.DataType.BOOLEAN, true);
-    DataSchema inputSchema = new DataSchema(new String[]{"boolCol"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.BOOLEAN
+    RexExpression booleanLiteral = new RexExpression.Literal(ColumnDataType.BOOLEAN, 1);
+    DataSchema inputSchema = new DataSchema(new String[]{"boolCol"}, new ColumnDataType[]{
+        ColumnDataType.BOOLEAN
     });
     FilterOperator op =
         new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, booleanLiteral);
@@ -69,10 +69,9 @@ public class FilterOperatorTest {
 
   @Test
   public void shouldPropagateUpstreamEOS() {
-    RexExpression booleanLiteral = new RexExpression.Literal(FieldSpec.DataType.BOOLEAN, true);
-
-    DataSchema inputSchema = new DataSchema(new String[]{"intCol"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT
+    RexExpression booleanLiteral = new RexExpression.Literal(ColumnDataType.BOOLEAN, 1);
+    DataSchema inputSchema = new DataSchema(new String[]{"intCol"}, new ColumnDataType[]{
+        ColumnDataType.INT
     });
     Mockito.when(_upstreamOperator.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
     FilterOperator op =
@@ -83,10 +82,9 @@ public class FilterOperatorTest {
 
   @Test
   public void shouldHandleTrueBooleanLiteralFilter() {
-    RexExpression booleanLiteral = new RexExpression.Literal(FieldSpec.DataType.BOOLEAN, true);
-
-    DataSchema inputSchema = new DataSchema(new String[]{"intCol"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT
+    RexExpression booleanLiteral = new RexExpression.Literal(ColumnDataType.BOOLEAN, 1);
+    DataSchema inputSchema = new DataSchema(new String[]{"intCol"}, new ColumnDataType[]{
+        ColumnDataType.INT
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{0}, new Object[]{1}))
@@ -103,10 +101,9 @@ public class FilterOperatorTest {
 
   @Test
   public void shouldHandleFalseBooleanLiteralFilter() {
-    RexExpression booleanLiteral = new RexExpression.Literal(FieldSpec.DataType.BOOLEAN, false);
-
-    DataSchema inputSchema = new DataSchema(new String[]{"intCol"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT
+    RexExpression booleanLiteral = new RexExpression.Literal(ColumnDataType.BOOLEAN, 0);
+    DataSchema inputSchema = new DataSchema(new String[]{"intCol"}, new ColumnDataType[]{
+        ColumnDataType.INT
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
@@ -118,61 +115,58 @@ public class FilterOperatorTest {
     Assert.assertTrue(result.isEmpty());
   }
 
-  @Test
+  @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Filter operand must "
+      + "return BOOLEAN, got: STRING")
   public void shouldThrowOnNonBooleanTypeBooleanLiteral() {
-    RexExpression booleanLiteral = new RexExpression.Literal(FieldSpec.DataType.STRING, "false");
-    DataSchema inputSchema = new DataSchema(new String[]{"intCol"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT
+    RexExpression booleanLiteral = new RexExpression.Literal(ColumnDataType.STRING, "false");
+    DataSchema inputSchema = new DataSchema(new String[]{"intCol"}, new ColumnDataType[]{
+        ColumnDataType.INT
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
     FilterOperator op =
         new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, booleanLiteral);
-    TransferableBlock errorBlock = op.getNextBlock();
-    Assert.assertTrue(errorBlock.isErrorBlock());
-    Assert.assertTrue(errorBlock.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("cast"));
+    op.getNextBlock();
   }
 
-  @Test
+  @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Filter operand must "
+      + "return BOOLEAN, got: INT")
   public void shouldThrowOnNonBooleanTypeInputRef() {
     RexExpression ref0 = new RexExpression.InputRef(0);
-    DataSchema inputSchema = new DataSchema(new String[]{"intCol"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT
+    DataSchema inputSchema = new DataSchema(new String[]{"intCol"}, new ColumnDataType[]{
+        ColumnDataType.INT
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1}, new Object[]{2}));
     FilterOperator op = new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, ref0);
-    TransferableBlock errorBlock = op.getNextBlock();
-    Assert.assertTrue(errorBlock.isErrorBlock());
-    Assert.assertTrue(errorBlock.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("cast"));
+    op.getNextBlock();
   }
 
   @Test
   public void shouldHandleBooleanInputRef() {
     RexExpression ref1 = new RexExpression.InputRef(1);
-    DataSchema inputSchema = new DataSchema(new String[]{"intCol", "boolCol"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.BOOLEAN
+    DataSchema inputSchema = new DataSchema(new String[]{"intCol", "boolCol"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.BOOLEAN
     });
     Mockito.when(_upstreamOperator.nextBlock())
-        .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1, true}, new Object[]{2, false}));
+        .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1, 1}, new Object[]{2, 0}));
     FilterOperator op = new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, ref1);
     TransferableBlock dataBlock = op.getNextBlock();
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
     Assert.assertEquals(result.size(), 1);
     Assert.assertEquals(result.get(0)[0], 1);
-    Assert.assertEquals(result.get(0)[1], true);
+    Assert.assertEquals(result.get(0)[1], 1);
   }
 
   @Test
   public void shouldHandleAndFilter() {
-    DataSchema inputSchema = new DataSchema(new String[]{"boolCol0", "boolCol1"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.BOOLEAN
+    DataSchema inputSchema = new DataSchema(new String[]{"boolCol0", "boolCol1"}, new ColumnDataType[]{
+        ColumnDataType.BOOLEAN, ColumnDataType.BOOLEAN
     });
-    Mockito.when(_upstreamOperator.nextBlock()).thenReturn(
-        OperatorTestUtil.block(inputSchema, new Object[]{true, true}, new Object[]{false, false},
-            new Object[]{true, false}));
-    RexExpression.FunctionCall andCall = new RexExpression.FunctionCall(SqlKind.AND, FieldSpec.DataType.BOOLEAN, "AND",
+    Mockito.when(_upstreamOperator.nextBlock())
+        .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1, 1}, new Object[]{0, 0}, new Object[]{1, 0}));
+    RexExpression.FunctionCall andCall = new RexExpression.FunctionCall(SqlKind.AND, ColumnDataType.BOOLEAN, "AND",
         ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
 
     FilterOperator op =
@@ -181,19 +175,18 @@ public class FilterOperatorTest {
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
     Assert.assertEquals(result.size(), 1);
-    Assert.assertEquals(result.get(0)[0], true);
-    Assert.assertEquals(result.get(0)[1], true);
+    Assert.assertEquals(result.get(0)[0], 1);
+    Assert.assertEquals(result.get(0)[1], 1);
   }
 
   @Test
   public void shouldHandleOrFilter() {
-    DataSchema inputSchema = new DataSchema(new String[]{"boolCol0", "boolCol1"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.BOOLEAN
+    DataSchema inputSchema = new DataSchema(new String[]{"boolCol0", "boolCol1"}, new ColumnDataType[]{
+        ColumnDataType.BOOLEAN, ColumnDataType.BOOLEAN
     });
-    Mockito.when(_upstreamOperator.nextBlock()).thenReturn(
-        OperatorTestUtil.block(inputSchema, new Object[]{true, true}, new Object[]{false, false},
-            new Object[]{true, false}));
-    RexExpression.FunctionCall orCall = new RexExpression.FunctionCall(SqlKind.OR, FieldSpec.DataType.BOOLEAN, "OR",
+    Mockito.when(_upstreamOperator.nextBlock())
+        .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1, 1}, new Object[]{0, 0}, new Object[]{1, 0}));
+    RexExpression.FunctionCall orCall = new RexExpression.FunctionCall(SqlKind.OR, ColumnDataType.BOOLEAN, "OR",
         ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
 
     FilterOperator op =
@@ -202,21 +195,20 @@ public class FilterOperatorTest {
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
     Assert.assertEquals(result.size(), 2);
-    Assert.assertEquals(result.get(0)[0], true);
-    Assert.assertEquals(result.get(0)[1], true);
-    Assert.assertEquals(result.get(1)[0], true);
-    Assert.assertEquals(result.get(1)[1], false);
+    Assert.assertEquals(result.get(0)[0], 1);
+    Assert.assertEquals(result.get(0)[1], 1);
+    Assert.assertEquals(result.get(1)[0], 1);
+    Assert.assertEquals(result.get(1)[1], 0);
   }
 
   @Test
   public void shouldHandleNotFilter() {
-    DataSchema inputSchema = new DataSchema(new String[]{"boolCol0", "boolCol1"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.BOOLEAN
+    DataSchema inputSchema = new DataSchema(new String[]{"boolCol0", "boolCol1"}, new ColumnDataType[]{
+        ColumnDataType.BOOLEAN, ColumnDataType.BOOLEAN
     });
-    Mockito.when(_upstreamOperator.nextBlock()).thenReturn(
-        OperatorTestUtil.block(inputSchema, new Object[]{true, true}, new Object[]{false, false},
-            new Object[]{true, false}));
-    RexExpression.FunctionCall notCall = new RexExpression.FunctionCall(SqlKind.NOT, FieldSpec.DataType.BOOLEAN, "NOT",
+    Mockito.when(_upstreamOperator.nextBlock())
+        .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1, 1}, new Object[]{0, 0}, new Object[]{1, 0}));
+    RexExpression.FunctionCall notCall = new RexExpression.FunctionCall(SqlKind.NOT, ColumnDataType.BOOLEAN, "NOT",
         ImmutableList.of(new RexExpression.InputRef(0)));
 
     FilterOperator op =
@@ -225,19 +217,19 @@ public class FilterOperatorTest {
     Assert.assertFalse(dataBlock.isErrorBlock());
     List<Object[]> result = dataBlock.getContainer();
     Assert.assertEquals(result.size(), 1);
-    Assert.assertEquals(result.get(0)[0], false);
-    Assert.assertEquals(result.get(0)[1], false);
+    Assert.assertEquals(result.get(0)[0], 0);
+    Assert.assertEquals(result.get(0)[1], 0);
   }
 
   @Test
   public void shouldHandleGreaterThanFilter() {
-    DataSchema inputSchema = new DataSchema(new String[]{"int0", "int1"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT
+    DataSchema inputSchema = new DataSchema(new String[]{"int0", "int1"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.INT
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{1, 2}, new Object[]{3, 2}, new Object[]{1, 1}));
     RexExpression.FunctionCall greaterThan =
-        new RexExpression.FunctionCall(SqlKind.GREATER_THAN, FieldSpec.DataType.BOOLEAN, "greaterThan",
+        new RexExpression.FunctionCall(SqlKind.GREATER_THAN, ColumnDataType.BOOLEAN, "greaterThan",
             ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.InputRef(1)));
     FilterOperator op =
         new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, greaterThan);
@@ -251,15 +243,14 @@ public class FilterOperatorTest {
 
   @Test
   public void shouldHandleBooleanFunction() {
-    DataSchema inputSchema = new DataSchema(new String[]{"string1"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.STRING
+    DataSchema inputSchema = new DataSchema(new String[]{"string1"}, new ColumnDataType[]{
+        ColumnDataType.STRING
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{"starTree"}, new Object[]{"treeStar"}));
     RexExpression.FunctionCall startsWith =
-        new RexExpression.FunctionCall(SqlKind.OTHER, FieldSpec.DataType.BOOLEAN, "startsWith",
-            ImmutableList.of(new RexExpression.InputRef(0),
-                new RexExpression.Literal(FieldSpec.DataType.STRING, "star")));
+        new RexExpression.FunctionCall(SqlKind.OTHER, ColumnDataType.BOOLEAN, "startsWith",
+            ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.Literal(ColumnDataType.STRING, "star")));
     FilterOperator op =
         new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, startsWith);
     TransferableBlock dataBlock = op.getNextBlock();
@@ -270,19 +261,17 @@ public class FilterOperatorTest {
     Assert.assertEquals(result.get(0), expectedResult.get(0));
   }
 
-  @Test(expectedExceptions = NullPointerException.class, expectedExceptionsMessageRegExp = ".*Cannot find function "
-      + "with Name: startsWithError.*")
+  @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = "Cannot find function "
+      + "with name: startsWithError")
   public void shouldThrowOnUnfoundFunction() {
-    DataSchema inputSchema = new DataSchema(new String[]{"string1"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.STRING
+    DataSchema inputSchema = new DataSchema(new String[]{"string1"}, new ColumnDataType[]{
+        ColumnDataType.STRING
     });
     Mockito.when(_upstreamOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(inputSchema, new Object[]{"starTree"}, new Object[]{"treeStar"}));
     RexExpression.FunctionCall startsWith =
-        new RexExpression.FunctionCall(SqlKind.OTHER, FieldSpec.DataType.BOOLEAN, "startsWithError",
-            ImmutableList.of(new RexExpression.InputRef(0),
-                new RexExpression.Literal(FieldSpec.DataType.STRING, "star")));
-    FilterOperator op =
-        new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, startsWith);
+        new RexExpression.FunctionCall(SqlKind.OTHER, ColumnDataType.BOOLEAN, "startsWithError",
+            ImmutableList.of(new RexExpression.InputRef(0), new RexExpression.Literal(ColumnDataType.STRING, "star")));
+    new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, startsWith);
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -31,13 +31,13 @@ import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.partitioning.FieldSelectionKeySelector;
 import org.apache.pinot.query.planner.plannode.JoinNode;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -85,11 +85,11 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldHandleHashJoinKeyCollisionInnerJoin() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     List<RexExpression> joinClauses = new ArrayList<>();
     Mockito.when(_leftOperator.nextBlock())
@@ -98,10 +98,9 @@ public class HashJoinOperatorTest {
     Mockito.when(_rightOperator.nextBlock()).thenReturn(
             OperatorTestUtil.block(rightSchema, new Object[]{2, "Aa"}, new Object[]{2, "BB"}, new Object[]{3, "BB"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
-    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_col2", "string_col2"},
-        new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_col2", "string_col2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, Collections.emptyList());
@@ -120,11 +119,11 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldHandleInnerJoinOnInt() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}))
@@ -133,10 +132,9 @@ public class HashJoinOperatorTest {
             OperatorTestUtil.block(rightSchema, new Object[]{2, "Aa"}, new Object[]{2, "BB"}, new Object[]{3, "BB"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
     List<RexExpression> joinClauses = new ArrayList<>();
-    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_col2", "string_co2"},
-        new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_col2", "string_co2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, Collections.emptyList());
@@ -152,11 +150,11 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldHandleJoinOnEmptySelector() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}))
@@ -165,10 +163,9 @@ public class HashJoinOperatorTest {
             OperatorTestUtil.block(rightSchema, new Object[]{2, "Aa"}, new Object[]{2, "BB"}, new Object[]{3, "BB"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
     List<RexExpression> joinClauses = new ArrayList<>();
-    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_col2", "string_co2"},
-        new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_col2", "string_co2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses, Collections.emptyList());
@@ -190,11 +187,11 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldHandleLeftJoin() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "CC"}))
@@ -204,10 +201,9 @@ public class HashJoinOperatorTest {
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     List<RexExpression> joinClauses = new ArrayList<>();
-    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
-        new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.LEFT,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, Collections.emptyList());
@@ -224,21 +220,20 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldPassLeftTableEOS() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
     Mockito.when(_rightOperator.nextBlock()).thenReturn(
             OperatorTestUtil.block(rightSchema, new Object[]{1, "BB"}, new Object[]{1, "CC"}, new Object[]{3, "BB"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
-        new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
         });
     List<RexExpression> joinClauses = new ArrayList<>();
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
@@ -252,11 +247,11 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldHandleLeftJoinOneToN() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock()).thenReturn(OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
@@ -265,10 +260,9 @@ public class HashJoinOperatorTest {
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     List<RexExpression> joinClauses = new ArrayList<>();
-    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
-        new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.LEFT,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, Collections.emptyList());
@@ -285,11 +279,11 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldPassRightTableEOS() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock()).thenReturn(
             OperatorTestUtil.block(rightSchema, new Object[]{1, "BB"}, new Object[]{1, "CC"}, new Object[]{3, "BB"}))
@@ -297,10 +291,9 @@ public class HashJoinOperatorTest {
     Mockito.when(_rightOperator.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     List<RexExpression> joinClauses = new ArrayList<>();
-    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
-        new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
         });
 
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
@@ -315,11 +308,11 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldHandleInequiJoinOnString() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}))
@@ -332,29 +325,32 @@ public class HashJoinOperatorTest {
     List<RexExpression> functionOperands = new ArrayList<>();
     functionOperands.add(new RexExpression.InputRef(1));
     functionOperands.add(new RexExpression.InputRef(3));
-    joinClauses.add(
-        new RexExpression.FunctionCall(SqlKind.NOT_EQUALS, FieldSpec.DataType.STRING, "NOT_EQUALS", functionOperands));
-    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
-        new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.STRING
+    joinClauses.add(new RexExpression.FunctionCall(SqlKind.NOT_EQUALS, ColumnDataType.BOOLEAN, "<>", functionOperands));
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_col2", "string_col2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses, Collections.emptyList());
     HashJoinOperator join =
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
-    Assert.assertTrue(result.isErrorBlock());
-    Assert.assertTrue(result.getExceptions().get(1000).contains("notEquals"));
+    List<Object[]> resultRows = result.getContainer();
+    List<Object[]> expectedRows =
+        Arrays.asList(new Object[]{1, "Aa", 2, "BB"}, new Object[]{1, "Aa", 3, "BB"}, new Object[]{2, "BB", 2, "Aa"});
+    Assert.assertEquals(resultRows.size(), expectedRows.size());
+    for (int i = 0; i < expectedRows.size(); i++) {
+      Assert.assertEquals(resultRows.get(i), expectedRows.get(i));
+    }
   }
 
   @Test
   public void shouldHandleInequiJoinOnInt() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}))
@@ -367,12 +363,10 @@ public class HashJoinOperatorTest {
     List<RexExpression> functionOperands = new ArrayList<>();
     functionOperands.add(new RexExpression.InputRef(0));
     functionOperands.add(new RexExpression.InputRef(2));
-    joinClauses.add(
-        new RexExpression.FunctionCall(SqlKind.NOT_EQUALS, FieldSpec.DataType.STRING, "NOT_EQUALS", functionOperands));
-    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
-        new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.STRING
+    joinClauses.add(new RexExpression.FunctionCall(SqlKind.NOT_EQUALS, ColumnDataType.BOOLEAN, "<>", functionOperands));
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(new ArrayList<>(), new ArrayList<>()), joinClauses, Collections.emptyList());
@@ -382,17 +376,18 @@ public class HashJoinOperatorTest {
     List<Object[]> resultRows = result.getContainer();
     List<Object[]> expectedRows = Arrays.asList(new Object[]{1, "Aa", 2, "Aa"}, new Object[]{2, "BB", 1, "BB"});
     Assert.assertEquals(resultRows.size(), expectedRows.size());
-    Assert.assertEquals(resultRows.get(0), expectedRows.get(0));
-    Assert.assertEquals(resultRows.get(1), expectedRows.get(1));
+    for (int i = 0; i < expectedRows.size(); i++) {
+      Assert.assertEquals(resultRows.get(i), expectedRows.get(i));
+    }
   }
 
   @Test
   public void shouldHandleRightJoin() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}))
@@ -402,9 +397,8 @@ public class HashJoinOperatorTest {
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     List<RexExpression> joinClauses = new ArrayList<>();
-    DataSchema resultSchema = new DataSchema(new String[]{"foo", "bar", "foo", "bar"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-        DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema = new DataSchema(new String[]{"foo", "bar", "foo", "bar"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.RIGHT,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, Collections.emptyList());
@@ -429,11 +423,11 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldHandleSemiJoin() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock()).thenReturn(
             OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}, new Object[]{4, "CC"}))
@@ -443,9 +437,8 @@ public class HashJoinOperatorTest {
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     List<RexExpression> joinClauses = new ArrayList<>();
-    DataSchema resultSchema = new DataSchema(new String[]{"foo", "bar", "foo", "bar"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-        DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema = new DataSchema(new String[]{"foo", "bar", "foo", "bar"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.SEMI,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, Collections.emptyList());
@@ -464,11 +457,11 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldHandleFullJoin() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock()).thenReturn(
             OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}, new Object[]{4, "CC"}))
@@ -477,9 +470,8 @@ public class HashJoinOperatorTest {
             OperatorTestUtil.block(rightSchema, new Object[]{2, "Aa"}, new Object[]{2, "BB"}, new Object[]{3, "BB"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
     List<RexExpression> joinClauses = new ArrayList<>();
-    DataSchema resultSchema = new DataSchema(new String[]{"foo", "bar", "foo", "bar"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-        DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema = new DataSchema(new String[]{"foo", "bar", "foo", "bar"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.FULL,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, Collections.emptyList());
@@ -507,11 +499,11 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldHandleAntiJoin() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock()).thenReturn(
             OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}, new Object[]{4, "CC"}))
@@ -521,9 +513,8 @@ public class HashJoinOperatorTest {
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     List<RexExpression> joinClauses = new ArrayList<>();
-    DataSchema resultSchema = new DataSchema(new String[]{"foo", "bar", "foo", "bar"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-        DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema = new DataSchema(new String[]{"foo", "bar", "foo", "bar"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
     });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.ANTI,
         getJoinKeys(Arrays.asList(1), Arrays.asList(1)), joinClauses, Collections.emptyList());
@@ -540,11 +531,11 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldPropagateRightTableError() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock()).thenReturn(
             OperatorTestUtil.block(rightSchema, new Object[]{1, "BB"}, new Object[]{1, "CC"}, new Object[]{3, "BB"}))
@@ -553,10 +544,9 @@ public class HashJoinOperatorTest {
         .thenReturn(TransferableBlockUtils.getErrorTransferableBlock(new Exception("testInnerJoinRightError")));
 
     List<RexExpression> joinClauses = new ArrayList<>();
-    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
-        new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, Collections.emptyList());
@@ -571,11 +561,11 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldPropagateLeftTableError() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_rightOperator.nextBlock()).thenReturn(
             OperatorTestUtil.block(rightSchema, new Object[]{1, "BB"}, new Object[]{1, "CC"}, new Object[]{3, "BB"}))
@@ -584,10 +574,9 @@ public class HashJoinOperatorTest {
         .thenReturn(TransferableBlockUtils.getErrorTransferableBlock(new Exception("testInnerJoinLeftError")));
 
     List<RexExpression> joinClauses = new ArrayList<>();
-    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
-        new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
         });
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, Collections.emptyList());
@@ -601,11 +590,11 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldPropagateJoinLimitError() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}))
@@ -615,15 +604,12 @@ public class HashJoinOperatorTest {
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     List<RexExpression> joinClauses = new ArrayList<>();
-    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
-        new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
         });
-    Map<String, String> hintsMap = ImmutableMap.of(
-        PinotHintOptions.JoinHintOptions.JOIN_OVERFLOW_MODE, "THROW",
-        PinotHintOptions.JoinHintOptions.MAX_ROWS_IN_JOIN, "1"
-    );
+    Map<String, String> hintsMap = ImmutableMap.of(PinotHintOptions.JoinHintOptions.JOIN_OVERFLOW_MODE, "THROW",
+        PinotHintOptions.JoinHintOptions.MAX_ROWS_IN_JOIN, "1");
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, getJoinHints(hintsMap));
     HashJoinOperator join =
@@ -637,11 +623,11 @@ public class HashJoinOperatorTest {
 
   @Test
   public void shouldHandleJoinWithPartialResultsWhenHitDataRowsLimit() {
-    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema leftSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
-    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema rightSchema = new DataSchema(new String[]{"int_col", "string_col"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     Mockito.when(_leftOperator.nextBlock())
         .thenReturn(OperatorTestUtil.block(leftSchema, new Object[]{1, "Aa"}, new Object[]{2, "BB"}))
@@ -651,15 +637,12 @@ public class HashJoinOperatorTest {
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     List<RexExpression> joinClauses = new ArrayList<>();
-    DataSchema resultSchema = new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"},
-        new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.STRING
+    DataSchema resultSchema =
+        new DataSchema(new String[]{"int_col1", "string_col1", "int_co2", "string_col2"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.STRING, ColumnDataType.INT, ColumnDataType.STRING
         });
-    Map<String, String> hintsMap = ImmutableMap.of(
-        PinotHintOptions.JoinHintOptions.JOIN_OVERFLOW_MODE, "BREAK",
-        PinotHintOptions.JoinHintOptions.MAX_ROWS_IN_JOIN, "1"
-    );
+    Map<String, String> hintsMap = ImmutableMap.of(PinotHintOptions.JoinHintOptions.JOIN_OVERFLOW_MODE, "BREAK",
+        PinotHintOptions.JoinHintOptions.MAX_ROWS_IN_JOIN, "1");
     JoinNode node = new JoinNode(1, resultSchema, leftSchema, rightSchema, JoinRelType.INNER,
         getJoinKeys(Arrays.asList(0), Arrays.asList(0)), joinClauses, getJoinHints(hintsMap));
     HashJoinOperator join =

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperatorTest.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.sql.Timestamp;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -113,31 +112,8 @@ public class LeafStageTransferableBlockOperatorTest {
     TransferableBlock resultBlock = operator.nextBlock();
 
     // Then:
-    Assert.assertEquals(resultBlock.getContainer().get(0), new Object[]{true, new Timestamp(1660000000000L), true});
-    Assert.assertEquals(resultBlock.getContainer().get(1), new Object[]{false, new Timestamp(1600000000000L), false});
-    Assert.assertTrue(operator.nextBlock().isEndOfStreamBlock(), "Expected EOS after reading two rows");
-  }
-
-  @Test
-  public void shouldHandleCanonicalizationCorrectly() {
-    // TODO: not all stored types are supported, add additional datatype when they are supported.
-    // Given:
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT boolCol, tsCol FROM tbl");
-    DataSchema schema = new DataSchema(new String[]{"boolCol", "tsCol"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.TIMESTAMP});
-    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
-        new SelectionResultsBlock(schema,
-            Arrays.asList(new Object[]{1, 1660000000000L}, new Object[]{0, 1600000000000L})), queryContext));
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(),
-            getStaticBlockProcessor(resultsBlockList), getStaticServerQueryRequests(resultsBlockList.size()), schema);
-
-    // When:
-    TransferableBlock resultBlock = operator.nextBlock();
-
-    // Then:
-    Assert.assertEquals(resultBlock.getContainer().get(0), new Object[]{true, new Timestamp(1660000000000L)});
-    Assert.assertEquals(resultBlock.getContainer().get(1), new Object[]{false, new Timestamp(1600000000000L)});
+    Assert.assertEquals(resultBlock.getContainer().get(0), new Object[]{1, 1660000000000L, 1});
+    Assert.assertEquals(resultBlock.getContainer().get(1), new Object[]{0, 1600000000000L, 0});
     Assert.assertTrue(operator.nextBlock().isEndOfStreamBlock(), "Expected EOS after reading two rows");
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LiteralValueOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LiteralValueOperatorTest.java
@@ -25,7 +25,6 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
-import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -60,8 +59,10 @@ public class LiteralValueOperatorTest {
     DataSchema schema = new DataSchema(new String[]{"sLiteral", "iLiteral"},
         new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.INT});
     List<List<RexExpression>> literals = ImmutableList.of(
-        ImmutableList.of(new RexExpression.Literal(DataType.STRING, "foo"), new RexExpression.Literal(DataType.INT, 1)),
-        ImmutableList.of(new RexExpression.Literal(DataType.STRING, ""), new RexExpression.Literal(DataType.INT, 2)));
+        ImmutableList.of(new RexExpression.Literal(ColumnDataType.STRING, "foo"),
+            new RexExpression.Literal(ColumnDataType.INT, 1)),
+        ImmutableList.of(new RexExpression.Literal(ColumnDataType.STRING, ""),
+            new RexExpression.Literal(ColumnDataType.INT, 2)));
     LiteralValueOperator operator = new LiteralValueOperator(OperatorTestUtil.getDefaultContext(), schema, literals);
 
     // When:

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
@@ -32,6 +32,7 @@ import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
@@ -49,7 +50,6 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.exchange.BlockExchange;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 import org.apache.pinot.query.runtime.plan.StageMetadata;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -271,8 +271,7 @@ public class OpChainTest {
   private Stack<MultiStageOperator> getFullOpchain(int receivedStageId, int senderStageId,
       OpChainExecutionContext context, long waitTimeInMillis) {
     Stack<MultiStageOperator> operators = new Stack<>();
-    DataSchema upStreamSchema =
-        new DataSchema(new String[]{"intCol"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT});
+    DataSchema upStreamSchema = new DataSchema(new String[]{"intCol"}, new ColumnDataType[]{ColumnDataType.INT});
     //Mailbox Receive Operator
     try {
       when(_mailbox1.poll()).thenReturn(OperatorTestUtil.block(upStreamSchema, new Object[]{1}),
@@ -294,7 +293,7 @@ public class OpChainTest {
         new TransformOperator(context, leafOp, upStreamSchema, Collections.singletonList(ref0), upStreamSchema);
 
     //Filter operator
-    RexExpression booleanLiteral = new RexExpression.Literal(FieldSpec.DataType.BOOLEAN, true);
+    RexExpression booleanLiteral = new RexExpression.Literal(ColumnDataType.BOOLEAN, 1);
     FilterOperator filterOp = new FilterOperator(context, transformOp, upStreamSchema, booleanLiteral);
 
     // Dummy operator

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
@@ -24,10 +24,10 @@ import java.util.Arrays;
 import java.util.List;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -59,19 +59,18 @@ public class TransformOperatorTest {
 
   @Test
   public void shouldHandleRefTransform() {
-    DataSchema upStreamSchema = new DataSchema(new String[]{"intCol", "strCol"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING
+    DataSchema upStreamSchema = new DataSchema(new String[]{"intCol", "strCol"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.STRING
     });
     DataSchema resultSchema = new DataSchema(new String[]{"inCol", "strCol"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
+        new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.STRING});
     Mockito.when(_upstreamOp.nextBlock())
         .thenReturn(OperatorTestUtil.block(upStreamSchema, new Object[]{1, "a"}, new Object[]{2, "b"}));
     // Output column value
     RexExpression.InputRef ref0 = new RexExpression.InputRef(0);
     RexExpression.InputRef ref1 = new RexExpression.InputRef(1);
-    TransformOperator op =
-        new TransformOperator(OperatorTestUtil.getDefaultContext(),
-            _upstreamOp, resultSchema, ImmutableList.of(ref0, ref1), upStreamSchema);
+    TransformOperator op = new TransformOperator(OperatorTestUtil.getDefaultContext(), _upstreamOp, resultSchema,
+        ImmutableList.of(ref0, ref1), upStreamSchema);
     TransferableBlock result = op.nextBlock();
 
     Assert.assertTrue(!result.isErrorBlock());
@@ -84,24 +83,23 @@ public class TransformOperatorTest {
 
   @Test
   public void shouldHandleLiteralTransform() {
-    DataSchema upStreamSchema = new DataSchema(new String[]{"boolCol", "strCol"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.STRING
+    DataSchema upStreamSchema = new DataSchema(new String[]{"boolCol", "strCol"}, new ColumnDataType[]{
+        ColumnDataType.BOOLEAN, ColumnDataType.STRING
     });
     DataSchema resultSchema = new DataSchema(new String[]{"boolCol", "strCol"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.STRING});
+        new ColumnDataType[]{ColumnDataType.BOOLEAN, ColumnDataType.STRING});
     Mockito.when(_upstreamOp.nextBlock())
         .thenReturn(OperatorTestUtil.block(upStreamSchema, new Object[]{1, "a"}, new Object[]{2, "b"}));
     // Set up literal operands
-    RexExpression.Literal boolLiteral = new RexExpression.Literal(FieldSpec.DataType.BOOLEAN, true);
-    RexExpression.Literal strLiteral = new RexExpression.Literal(FieldSpec.DataType.STRING, "str");
-    TransformOperator op =
-        new TransformOperator(OperatorTestUtil.getDefaultContext(),
-            _upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema);
+    RexExpression.Literal boolLiteral = new RexExpression.Literal(ColumnDataType.BOOLEAN, 1);
+    RexExpression.Literal strLiteral = new RexExpression.Literal(ColumnDataType.STRING, "str");
+    TransformOperator op = new TransformOperator(OperatorTestUtil.getDefaultContext(), _upstreamOp, resultSchema,
+        ImmutableList.of(boolLiteral, strLiteral), upStreamSchema);
     TransferableBlock result = op.nextBlock();
     // Literal operands should just output original literals.
     Assert.assertTrue(!result.isErrorBlock());
     List<Object[]> resultRows = result.getContainer();
-    List<Object[]> expectedRows = Arrays.asList(new Object[]{true, "str"}, new Object[]{true, "str"});
+    List<Object[]> expectedRows = Arrays.asList(new Object[]{1, "str"}, new Object[]{1, "str"});
     Assert.assertEquals(resultRows.size(), expectedRows.size());
     Assert.assertEquals(resultRows.get(0), expectedRows.get(0));
     Assert.assertEquals(resultRows.get(1), expectedRows.get(1));
@@ -109,10 +107,9 @@ public class TransformOperatorTest {
 
   @Test
   public void shouldHandlePlusMinusFuncTransform() {
-    DataSchema upStreamSchema =
-        new DataSchema(new String[]{"doubleCol1", "doubleCol2"}, new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE
-        });
+    DataSchema upStreamSchema = new DataSchema(new String[]{"doubleCol1", "doubleCol2"}, new ColumnDataType[]{
+        ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
+    });
     Mockito.when(_upstreamOp.nextBlock())
         .thenReturn(OperatorTestUtil.block(upStreamSchema, new Object[]{1.0, 1.0}, new Object[]{2.0, 3.0}));
     // Run a plus and minus function operand on double columns.
@@ -120,14 +117,13 @@ public class TransformOperatorTest {
     RexExpression.InputRef ref1 = new RexExpression.InputRef(1);
     List<RexExpression> functionOperands = ImmutableList.of(ref0, ref1);
     RexExpression.FunctionCall plus01 =
-        new RexExpression.FunctionCall(PLUS, FieldSpec.DataType.DOUBLE, "plus", functionOperands);
+        new RexExpression.FunctionCall(PLUS, ColumnDataType.DOUBLE, "plus", functionOperands);
     RexExpression.FunctionCall minus01 =
-        new RexExpression.FunctionCall(MINUS, FieldSpec.DataType.DOUBLE, "minus", functionOperands);
+        new RexExpression.FunctionCall(MINUS, ColumnDataType.DOUBLE, "minus", functionOperands);
     DataSchema resultSchema = new DataSchema(new String[]{"plusR", "minusR"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
-    TransformOperator op =
-        new TransformOperator(OperatorTestUtil.getDefaultContext(),
-            _upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema);
+        new ColumnDataType[]{ColumnDataType.DOUBLE, ColumnDataType.DOUBLE});
+    TransformOperator op = new TransformOperator(OperatorTestUtil.getDefaultContext(), _upstreamOp, resultSchema,
+        ImmutableList.of(plus01, minus01), upStreamSchema);
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(!result.isErrorBlock());
     List<Object[]> resultRows = result.getContainer();
@@ -139,44 +135,42 @@ public class TransformOperatorTest {
 
   @Test
   public void shouldThrowOnTypeMismatchFuncTransform() {
-    DataSchema upStreamSchema = new DataSchema(new String[]{"string1", "string2"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING
+    DataSchema upStreamSchema = new DataSchema(new String[]{"string1", "string2"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING
     });
     Mockito.when(_upstreamOp.nextBlock())
-        .thenReturn(OperatorTestUtil.block(upStreamSchema, new Object[]{"1.0", "1.0"}, new Object[]{"2.0", "3.0"}));
+        .thenReturn(OperatorTestUtil.block(upStreamSchema, new Object[]{"str1", "str1"}, new Object[]{"str2", "str3"}));
     // Run a plus and minus function operand on string columns.
     RexExpression.InputRef ref0 = new RexExpression.InputRef(0);
     RexExpression.InputRef ref1 = new RexExpression.InputRef(1);
     List<RexExpression> functionOperands = ImmutableList.of(ref0, ref1);
     RexExpression.FunctionCall plus01 =
-        new RexExpression.FunctionCall(PLUS, FieldSpec.DataType.DOUBLE, "plus", functionOperands);
+        new RexExpression.FunctionCall(PLUS, ColumnDataType.DOUBLE, "plus", functionOperands);
     RexExpression.FunctionCall minus01 =
-        new RexExpression.FunctionCall(MINUS, FieldSpec.DataType.DOUBLE, "minus", functionOperands);
+        new RexExpression.FunctionCall(MINUS, ColumnDataType.DOUBLE, "minus", functionOperands);
     DataSchema resultSchema = new DataSchema(new String[]{"plusR", "minusR"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.DOUBLE, DataSchema.ColumnDataType.DOUBLE});
-    TransformOperator op =
-        new TransformOperator(OperatorTestUtil.getDefaultContext(),
-            _upstreamOp, resultSchema, ImmutableList.of(plus01, minus01), upStreamSchema);
+        new ColumnDataType[]{ColumnDataType.DOUBLE, ColumnDataType.DOUBLE});
+    TransformOperator op = new TransformOperator(OperatorTestUtil.getDefaultContext(), _upstreamOp, resultSchema,
+        ImmutableList.of(plus01, minus01), upStreamSchema);
 
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
-    Assert.assertTrue(result.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("ArithmeticFunctions"));
+    Assert.assertTrue(result.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("NumberFormatException"));
   }
 
   @Test
   public void shouldPropagateUpstreamError() {
-    DataSchema upStreamSchema = new DataSchema(new String[]{"string1", "string2"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING
+    DataSchema upStreamSchema = new DataSchema(new String[]{"string1", "string2"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING
     });
     Mockito.when(_upstreamOp.nextBlock())
         .thenReturn(TransferableBlockUtils.getErrorTransferableBlock(new Exception("transformError")));
-    RexExpression.Literal boolLiteral = new RexExpression.Literal(FieldSpec.DataType.BOOLEAN, true);
-    RexExpression.Literal strLiteral = new RexExpression.Literal(FieldSpec.DataType.STRING, "str");
+    RexExpression.Literal boolLiteral = new RexExpression.Literal(ColumnDataType.BOOLEAN, 1);
+    RexExpression.Literal strLiteral = new RexExpression.Literal(ColumnDataType.STRING, "str");
     DataSchema resultSchema = new DataSchema(new String[]{"inCol", "strCol"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
-    TransformOperator op =
-        new TransformOperator(OperatorTestUtil.getDefaultContext(),
-            _upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema);
+        new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.STRING});
+    TransformOperator op = new TransformOperator(OperatorTestUtil.getDefaultContext(), _upstreamOp, resultSchema,
+        ImmutableList.of(boolLiteral, strLiteral), upStreamSchema);
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
     Assert.assertTrue(result.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("transformError"));
@@ -184,26 +178,25 @@ public class TransformOperatorTest {
 
   @Test
   public void testNoopBlock() {
-    DataSchema upStreamSchema = new DataSchema(new String[]{"string1", "string2"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING
+    DataSchema upStreamSchema = new DataSchema(new String[]{"string1", "string2"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING
     });
     Mockito.when(_upstreamOp.nextBlock())
         .thenReturn(OperatorTestUtil.block(upStreamSchema, new Object[]{"a", "a"}, new Object[]{"b", "b"}))
         .thenReturn(OperatorTestUtil.block(upStreamSchema, new Object[]{"c", "c"}, new Object[]{"d", "d"}, new Object[]{
             "e", "e"
         }));
-    RexExpression.Literal boolLiteral = new RexExpression.Literal(FieldSpec.DataType.BOOLEAN, true);
-    RexExpression.Literal strLiteral = new RexExpression.Literal(FieldSpec.DataType.STRING, "str");
+    RexExpression.Literal boolLiteral = new RexExpression.Literal(ColumnDataType.BOOLEAN, 1);
+    RexExpression.Literal strLiteral = new RexExpression.Literal(ColumnDataType.STRING, "str");
     DataSchema resultSchema = new DataSchema(new String[]{"boolCol", "strCol"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.STRING});
-    TransformOperator op =
-        new TransformOperator(OperatorTestUtil.getDefaultContext(),
-            _upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema);
+        new ColumnDataType[]{ColumnDataType.BOOLEAN, ColumnDataType.STRING});
+    TransformOperator op = new TransformOperator(OperatorTestUtil.getDefaultContext(), _upstreamOp, resultSchema,
+        ImmutableList.of(boolLiteral, strLiteral), upStreamSchema);
     TransferableBlock result = op.nextBlock();
     // First block has two rows
     Assert.assertFalse(result.isErrorBlock());
     List<Object[]> resultRows = result.getContainer();
-    List<Object[]> expectedRows = Arrays.asList(new Object[]{true, "str"}, new Object[]{true, "str"});
+    List<Object[]> expectedRows = Arrays.asList(new Object[]{1, "str"}, new Object[]{1, "str"});
     Assert.assertEquals(resultRows.size(), expectedRows.size());
     Assert.assertEquals(resultRows.get(0), expectedRows.get(0));
     Assert.assertEquals(resultRows.get(1), expectedRows.get(1));
@@ -211,7 +204,7 @@ public class TransformOperatorTest {
     result = op.nextBlock();
     Assert.assertFalse(result.isErrorBlock());
     resultRows = result.getContainer();
-    expectedRows = Arrays.asList(new Object[]{true, "str"}, new Object[]{true, "str"}, new Object[]{true, "str"});
+    expectedRows = Arrays.asList(new Object[]{1, "str"}, new Object[]{1, "str"}, new Object[]{1, "str"});
     Assert.assertEquals(resultRows.size(), expectedRows.size());
     Assert.assertEquals(resultRows.get(0), expectedRows.get(0));
     Assert.assertEquals(resultRows.get(1), expectedRows.get(1));
@@ -222,26 +215,24 @@ public class TransformOperatorTest {
       + "should not be empty.*")
   public void testWrongNumTransform() {
     DataSchema resultSchema = new DataSchema(new String[]{"inCol", "strCol"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
-    DataSchema upStreamSchema = new DataSchema(new String[]{"string1", "string2"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING
+        new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.STRING});
+    DataSchema upStreamSchema = new DataSchema(new String[]{"string1", "string2"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING
     });
-    TransformOperator transform =
-        new TransformOperator(OperatorTestUtil.getDefaultContext(), _upstreamOp, resultSchema, new ArrayList<>(),
-            upStreamSchema);
+    new TransformOperator(OperatorTestUtil.getDefaultContext(), _upstreamOp, resultSchema, new ArrayList<>(),
+        upStreamSchema);
   }
 
   @Test(expectedExceptions = IllegalStateException.class, expectedExceptionsMessageRegExp = ".*doesn't match "
       + "transform operand size.*")
   public void testMismatchedSchemaOperandSize() {
     DataSchema resultSchema = new DataSchema(new String[]{"inCol", "strCol"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
-    DataSchema upStreamSchema = new DataSchema(new String[]{"string1", "string2"}, new DataSchema.ColumnDataType[]{
-        DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING
+        new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.STRING});
+    DataSchema upStreamSchema = new DataSchema(new String[]{"string1", "string2"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING
     });
     RexExpression.InputRef ref0 = new RexExpression.InputRef(0);
-    TransformOperator transform =
-        new TransformOperator(OperatorTestUtil.getDefaultContext(), _upstreamOp, resultSchema, ImmutableList.of(ref0),
-            upStreamSchema);
+    new TransformOperator(OperatorTestUtil.getDefaultContext(), _upstreamOp, resultSchema, ImmutableList.of(ref0),
+        upStreamSchema);
   }
 };

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
@@ -29,13 +29,13 @@ import java.util.Map;
 import org.apache.calcite.rel.RelFieldCollation;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.planner.plannode.WindowNode;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.utils.AggregationUtils;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -81,9 +81,8 @@ public class WindowAggregateOperatorTest {
     Mockito.when(_input.nextBlock())
         .thenReturn(TransferableBlockUtils.getErrorTransferableBlock(new Exception("foo!")));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, INT});
-    DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
+    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
         new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
             Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
@@ -105,9 +104,8 @@ public class WindowAggregateOperatorTest {
 
     Mockito.when(_input.nextBlock()).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, INT});
-    DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
+    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
         new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
             Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
@@ -127,12 +125,11 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> calls = ImmutableList.of(getSum(new RexExpression.InputRef(1)));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, INT});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
     Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, 1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
         new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
             Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
@@ -144,7 +141,7 @@ public class WindowAggregateOperatorTest {
 
     // Then:
     Assert.assertTrue(block1.getNumRows() > 0, "First block is the result");
-    Assert.assertEquals(block1.getContainer().get(0), new Object[]{2, 1, 1},
+    Assert.assertEquals(block1.getContainer().get(0), new Object[]{2, 1, 1.0},
         "Expected three columns (original two columns, agg value)");
     Assert.assertTrue(block2.isEndOfStreamBlock(), "Second block is EOS (done processing)");
   }
@@ -156,12 +153,11 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
     List<RexExpression> order = ImmutableList.of(new RexExpression.InputRef(0));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, INT});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
     Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, 1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
         new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, order,
             Arrays.asList(RelFieldCollation.Direction.ASCENDING), Arrays.asList(RelFieldCollation.NullDirection.LAST),
@@ -174,7 +170,7 @@ public class WindowAggregateOperatorTest {
 
     // Then:
     Assert.assertTrue(block1.getNumRows() > 0, "First block is the result");
-    Assert.assertEquals(block1.getContainer().get(0), new Object[]{2, 1, 1},
+    Assert.assertEquals(block1.getContainer().get(0), new Object[]{2, 1, 1.0},
         "Expected three columns (original two columns, agg value)");
     Assert.assertTrue(block2.isEndOfStreamBlock(), "Second block is EOS (done processing)");
   }
@@ -184,12 +180,11 @@ public class WindowAggregateOperatorTest {
     // Given:
     List<RexExpression> calls = ImmutableList.of(getSum(new RexExpression.InputRef(1)));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, INT});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
     Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, 1}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
         new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, Collections.emptyList(),
             Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE,
@@ -201,7 +196,7 @@ public class WindowAggregateOperatorTest {
 
     // Then:
     Assert.assertTrue(block1.getNumRows() > 0, "First block is the result");
-    Assert.assertEquals(block1.getContainer().get(0), new Object[]{2, 1, 1},
+    Assert.assertEquals(block1.getContainer().get(0), new Object[]{2, 1, 1.0},
         "Expected three columns (original two columns, agg value)");
     Assert.assertTrue(block2.isEndOfStreamBlock(), "Second block is EOS (done processing)");
   }
@@ -209,15 +204,14 @@ public class WindowAggregateOperatorTest {
   @Test
   public void testShouldWindowAggregateOverSingleInputBlockWithLiteralInput() {
     // Given:
-    List<RexExpression> calls = ImmutableList.of(getSum(new RexExpression.Literal(FieldSpec.DataType.INT, 42)));
+    List<RexExpression> calls = ImmutableList.of(getSum(new RexExpression.Literal(ColumnDataType.INT, 42)));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, INT});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
     Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, 3}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
-    DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
         new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
             Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
@@ -230,7 +224,7 @@ public class WindowAggregateOperatorTest {
     // Then:
     Assert.assertTrue(block1.getNumRows() > 0, "First block is the result");
     // second value is 1 (the literal) instead of 3 (the col val)
-    Assert.assertEquals(block1.getContainer().get(0), new Object[]{2, 3, 42},
+    Assert.assertEquals(block1.getContainer().get(0), new Object[]{2, 3, 42.0},
         "Expected three columns (original two columns, agg literal value)");
     Assert.assertTrue(block2.isEndOfStreamBlock(), "Second block is EOS (done processing)");
   }
@@ -241,7 +235,7 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> calls = ImmutableList.of(getSum(new RexExpression.InputRef(1)));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, INT});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, INT});
     Mockito.when(_input.nextBlock())
         .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{1, 1}, new Object[]{1, 2}))
         .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{1, 3}))
@@ -250,8 +244,7 @@ public class WindowAggregateOperatorTest {
     AggregationUtils.Merger merger = Mockito.mock(AggregationUtils.Merger.class);
     Mockito.when(merger.merge(Mockito.any(), Mockito.any())).thenReturn(12d);
     Mockito.when(merger.init(Mockito.any(), Mockito.any())).thenReturn(1d);
-    DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+    DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, INT, DOUBLE});
     WindowAggregateOperator operator =
         new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
             Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
@@ -278,20 +271,20 @@ public class WindowAggregateOperatorTest {
   public void testPartitionByWindowAggregateWithHashCollision() {
     MultiStageOperator upstreamOperator = OperatorTestUtil.getOperator(OperatorTestUtil.OP_1);
     // Create an aggregation call with sum for first column and group by second column.
-    RexExpression.FunctionCall agg = getSum(new RexExpression.InputRef(0));
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, INT});
+    List<RexExpression> calls = ImmutableList.of(getSum(new RexExpression.InputRef(0)));
+    List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(1));
+    DataSchema inSchema = new DataSchema(new String[]{"arg", "group"}, new ColumnDataType[]{INT, STRING});
     DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, INT, DOUBLE});
+        new DataSchema(new String[]{"arg", "group", "sum"}, new ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator sum0PartitionBy1 =
-        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), upstreamOperator,
-            Arrays.asList(new RexExpression.InputRef(1)), Collections.emptyList(), Collections.emptyList(),
-            Collections.emptyList(), Arrays.asList(agg), Integer.MIN_VALUE, Integer.MAX_VALUE,
-            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), upstreamOperator, group,
+            Collections.emptyList(), Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE,
+            Integer.MAX_VALUE, WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
 
     TransferableBlock result = sum0PartitionBy1.getNextBlock();
     List<Object[]> resultRows = result.getContainer();
     List<Object[]> expectedRows =
-        Arrays.asList(new Object[]{2, "BB", 5.0}, new Object[]{3, "BB", 5.0}, new Object[]{1, "Aa", 1});
+        Arrays.asList(new Object[]{2, "BB", 5.0}, new Object[]{3, "BB", 5.0}, new Object[]{1, "Aa", 1.0});
     Assert.assertEquals(resultRows.size(), expectedRows.size());
     Assert.assertEquals(resultRows.get(0), expectedRows.get(0));
     Assert.assertEquals(resultRows.get(1), expectedRows.get(1));
@@ -303,10 +296,10 @@ public class WindowAggregateOperatorTest {
   public void testShouldThrowOnUnknownAggFunction() {
     // Given:
     List<RexExpression> calls = ImmutableList.of(
-        new RexExpression.FunctionCall(SqlKind.AVG, FieldSpec.DataType.INT, "AVERAGE", ImmutableList.of()));
+        new RexExpression.FunctionCall(SqlKind.AVG, ColumnDataType.INT, "AVERAGE", ImmutableList.of()));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
-    DataSchema outSchema = new DataSchema(new String[]{"unknown"}, new DataSchema.ColumnDataType[]{DOUBLE});
-    DataSchema inSchema = new DataSchema(new String[]{"unknown"}, new DataSchema.ColumnDataType[]{DOUBLE});
+    DataSchema outSchema = new DataSchema(new String[]{"unknown"}, new ColumnDataType[]{DOUBLE});
+    DataSchema inSchema = new DataSchema(new String[]{"unknown"}, new ColumnDataType[]{DOUBLE});
 
     // When:
     WindowAggregateOperator operator =
@@ -320,11 +313,11 @@ public class WindowAggregateOperatorTest {
   public void testShouldThrowOnUnknownRankAggFunction() {
     // TODO: Remove this test when support is added for NTILE function
     // Given:
-    List<RexExpression> calls = ImmutableList.of(
-        new RexExpression.FunctionCall(SqlKind.RANK, FieldSpec.DataType.INT, "NTILE", ImmutableList.of()));
+    List<RexExpression> calls =
+        ImmutableList.of(new RexExpression.FunctionCall(SqlKind.RANK, ColumnDataType.INT, "NTILE", ImmutableList.of()));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
-    DataSchema outSchema = new DataSchema(new String[]{"unknown"}, new DataSchema.ColumnDataType[]{DOUBLE});
-    DataSchema inSchema = new DataSchema(new String[]{"unknown"}, new DataSchema.ColumnDataType[]{DOUBLE});
+    DataSchema outSchema = new DataSchema(new String[]{"unknown"}, new ColumnDataType[]{DOUBLE});
+    DataSchema inSchema = new DataSchema(new String[]{"unknown"}, new ColumnDataType[]{DOUBLE});
 
     // When:
     WindowAggregateOperator operator =
@@ -336,38 +329,39 @@ public class WindowAggregateOperatorTest {
   @Test
   public void testRankDenseRankRankingFunctions() {
     // Given:
-    List<RexExpression> calls = ImmutableList.of(
-        new RexExpression.FunctionCall(SqlKind.RANK, FieldSpec.DataType.INT, "RANK", ImmutableList.of()),
-        new RexExpression.FunctionCall(SqlKind.DENSE_RANK, FieldSpec.DataType.INT, "DENSE_RANK", ImmutableList.of()));
+    List<RexExpression> calls =
+        ImmutableList.of(new RexExpression.FunctionCall(SqlKind.RANK, ColumnDataType.INT, "RANK", ImmutableList.of()),
+            new RexExpression.FunctionCall(SqlKind.DENSE_RANK, ColumnDataType.INT, "DENSE_RANK", ImmutableList.of()));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
     List<RexExpression> order = ImmutableList.of(new RexExpression.InputRef(1));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, STRING});
     // Input should be in sorted order on the order by key as SortExchange will handle pre-sorting the data
-    Mockito.when(_input.nextBlock())
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{3, "and"}, new Object[]{2, "bar"},
-            new Object[]{2, "foo"}, new Object[]{1, "foo"}))
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{1, "foo"}, new Object[]{2, "foo"},
-            new Object[]{1, "numb"}, new Object[]{2, "the"}, new Object[]{3, "true"}))
+    Mockito.when(_input.nextBlock()).thenReturn(
+            OperatorTestUtil.block(inSchema, new Object[]{3, "and"}, new Object[]{2, "bar"}, new Object[]{2, "foo"},
+                new Object[]{1, "foo"})).thenReturn(
+            OperatorTestUtil.block(inSchema, new Object[]{1, "foo"}, new Object[]{2, "foo"}, new Object[]{1, "numb"},
+                new Object[]{2, "the"}, new Object[]{3, "true"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema = new DataSchema(new String[]{"group", "arg", "rank", "dense_rank"},
-        new DataSchema.ColumnDataType[]{INT, STRING, LONG, LONG});
+        new ColumnDataType[]{INT, STRING, LONG, LONG});
 
     // When:
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, order,
-            Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, 0,
-            WindowNode.WindowFrameType.RANGE, Collections.emptyList(), outSchema, inSchema);
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, order, Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, 0, WindowNode.WindowFrameType.RANGE,
+            Collections.emptyList(), outSchema, inSchema);
 
     TransferableBlock result = operator.getNextBlock();
     TransferableBlock eosBlock = operator.getNextBlock();
     List<Object[]> resultRows = result.getContainer();
     Map<Integer, List<Object[]>> expectedPartitionToRowsMap = new HashMap<>();
-    expectedPartitionToRowsMap.put(1, Arrays.asList(new Object[]{1, "foo", 1L, 1L}, new Object[]{1, "foo", 1L, 1L},
-        new Object[]{1, "numb", 3L, 2L}));
-    expectedPartitionToRowsMap.put(2, Arrays.asList(new Object[]{2, "bar", 1L, 1L}, new Object[]{2, "foo", 2L, 2L},
-        new Object[]{2, "foo", 2L, 2L}, new Object[]{2, "the", 4L, 3L}));
+    expectedPartitionToRowsMap.put(1,
+        Arrays.asList(new Object[]{1, "foo", 1L, 1L}, new Object[]{1, "foo", 1L, 1L}, new Object[]{1, "numb", 3L, 2L}));
+    expectedPartitionToRowsMap.put(2,
+        Arrays.asList(new Object[]{2, "bar", 1L, 1L}, new Object[]{2, "foo", 2L, 2L}, new Object[]{2, "foo", 2L, 2L},
+            new Object[]{2, "the", 4L, 3L}));
     expectedPartitionToRowsMap.put(3, Arrays.asList(new Object[]{3, "and", 1L, 1L}, new Object[]{3, "true", 2L, 2L}));
 
     Integer previousPartitionKey = null;
@@ -395,35 +389,35 @@ public class WindowAggregateOperatorTest {
   public void testRowNumberRankingFunction() {
     // Given:
     List<RexExpression> calls = ImmutableList.of(
-        new RexExpression.FunctionCall(SqlKind.ROW_NUMBER, FieldSpec.DataType.INT, "ROW_NUMBER", ImmutableList.of()));
+        new RexExpression.FunctionCall(SqlKind.ROW_NUMBER, ColumnDataType.INT, "ROW_NUMBER", ImmutableList.of()));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
     List<RexExpression> order = ImmutableList.of(new RexExpression.InputRef(1));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, STRING});
     // Input should be in sorted order on the order by key as SortExchange will handle pre-sorting the data
-    Mockito.when(_input.nextBlock())
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{3, "and"}, new Object[]{2, "bar"},
-            new Object[]{2, "foo"}))
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{1, "foo"}, new Object[]{2, "foo"},
-            new Object[]{2, "the"}, new Object[]{3, "true"}))
-        .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
+    Mockito.when(_input.nextBlock()).thenReturn(
+            OperatorTestUtil.block(inSchema, new Object[]{3, "and"}, new Object[]{2, "bar"}, new Object[]{2, "foo"}))
+        .thenReturn(
+            OperatorTestUtil.block(inSchema, new Object[]{1, "foo"}, new Object[]{2, "foo"}, new Object[]{2, "the"},
+                new Object[]{3, "true"})).thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "row_number"}, new DataSchema.ColumnDataType[]{INT, STRING, LONG});
+        new DataSchema(new String[]{"group", "arg", "row_number"}, new ColumnDataType[]{INT, STRING, LONG});
 
     // When:
     WindowAggregateOperator operator =
-        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, order,
-            Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, 0,
-            WindowNode.WindowFrameType.ROWS, Collections.emptyList(), outSchema, inSchema);
+        new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, order, Collections.emptyList(),
+            Collections.emptyList(), calls, Integer.MIN_VALUE, 0, WindowNode.WindowFrameType.ROWS,
+            Collections.emptyList(), outSchema, inSchema);
 
     TransferableBlock result = operator.getNextBlock();
     TransferableBlock eosBlock = operator.getNextBlock();
     List<Object[]> resultRows = result.getContainer();
     Map<Integer, List<Object[]>> expectedPartitionToRowsMap = new HashMap<>();
     expectedPartitionToRowsMap.put(1, Collections.singletonList(new Object[]{1, "foo", 1L}));
-    expectedPartitionToRowsMap.put(2, Arrays.asList(new Object[]{2, "bar", 1L}, new Object[]{2, "foo", 2L},
-        new Object[]{2, "foo", 3L}, new Object[]{2, "the", 4L}));
+    expectedPartitionToRowsMap.put(2,
+        Arrays.asList(new Object[]{2, "bar", 1L}, new Object[]{2, "foo", 2L}, new Object[]{2, "foo", 3L},
+            new Object[]{2, "the", 4L}));
     expectedPartitionToRowsMap.put(3, Arrays.asList(new Object[]{3, "and", 1L}, new Object[]{3, "true", 2L}));
 
     Integer previousPartitionKey = null;
@@ -454,17 +448,16 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
     List<RexExpression> order = ImmutableList.of(new RexExpression.InputRef(1));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, STRING});
     // Input should be in sorted order on the order by key as SortExchange will handle pre-sorting the data
-    Mockito.when(_input.nextBlock())
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{3, "and"}, new Object[]{2, "bar"},
-            new Object[]{2, "foo"}))
-        .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{1, "foo"}, new Object[]{2, "foo"},
-            new Object[]{3, "true"}))
+    Mockito.when(_input.nextBlock()).thenReturn(
+            OperatorTestUtil.block(inSchema, new Object[]{3, "and"}, new Object[]{2, "bar"}, new Object[]{2, "foo"}))
+        .thenReturn(
+            OperatorTestUtil.block(inSchema, new Object[]{1, "foo"}, new Object[]{2, "foo"}, new Object[]{3, "true"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
+        new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator operator =
         new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, order,
             Arrays.asList(RelFieldCollation.Direction.ASCENDING), Arrays.asList(RelFieldCollation.NullDirection.LAST),
@@ -474,9 +467,9 @@ public class WindowAggregateOperatorTest {
     TransferableBlock result = operator.getNextBlock();
     TransferableBlock eosBlock = operator.getNextBlock();
     List<Object[]> resultRows = result.getContainer();
-    List<Object[]> expectedRows = Arrays.asList(new Object[]{1, "foo", 1}, new Object[]{2, "bar", 2},
-        new Object[]{2, "foo", 6.0}, new Object[]{2, "foo", 6.0}, new Object[]{3, "and", 3},
-        new Object[]{3, "true", 6.0});
+    List<Object[]> expectedRows =
+        Arrays.asList(new Object[]{1, "foo", 1.0}, new Object[]{2, "bar", 2.0}, new Object[]{2, "foo", 6.0},
+            new Object[]{2, "foo", 6.0}, new Object[]{3, "and", 3.0}, new Object[]{3, "true", 6.0});
     Assert.assertEquals(resultRows.size(), expectedRows.size());
     Assert.assertEquals(resultRows.get(0), expectedRows.get(0));
     Assert.assertEquals(resultRows.get(1), expectedRows.get(1));
@@ -497,14 +490,14 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(1));
     List<RexExpression> order = ImmutableList.of(new RexExpression.InputRef(1));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, STRING});
     Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
         .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "bar"}))
         .thenReturn(OperatorTestUtil.block(inSchema, new Object[]{3, "foo"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
+        new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator operator =
         new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, order,
             Arrays.asList(RelFieldCollation.Direction.DESCENDING), Arrays.asList(RelFieldCollation.NullDirection.LAST),
@@ -515,7 +508,7 @@ public class WindowAggregateOperatorTest {
     TransferableBlock resultBlock = operator.nextBlock(); // (output result)
 
     // Then:
-    Assert.assertEquals(resultBlock.getContainer().get(0), new Object[]{2, "bar", 2},
+    Assert.assertEquals(resultBlock.getContainer().get(0), new Object[]{2, "bar", 2.0},
         "Expected three columns (original two columns, agg literal value)");
     Assert.assertEquals(resultBlock.getContainer().get(1), new Object[]{2, "foo", 5.0},
         "Expected three columns (original two columns, agg literal value)");
@@ -531,12 +524,12 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> calls = ImmutableList.of(getSum(new RexExpression.InputRef(1)));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, STRING});
     Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
+        new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator operator =
         new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
             Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
@@ -550,12 +543,12 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(1));
     List<RexExpression> order = ImmutableList.of(new RexExpression.InputRef(1));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, STRING});
     Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
+        new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator operator =
         new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, order,
             Arrays.asList(RelFieldCollation.Direction.ASCENDING), Arrays.asList(RelFieldCollation.NullDirection.LAST),
@@ -568,7 +561,7 @@ public class WindowAggregateOperatorTest {
 
     // Then:
     Assert.assertTrue(block1.getNumRows() > 0, "First block is the result");
-    Assert.assertEquals(block1.getContainer().get(0), new Object[]{2, "foo", 2},
+    Assert.assertEquals(block1.getContainer().get(0), new Object[]{2, "foo", 2.0},
         "Expected three columns (original two columns, agg value)");
     Assert.assertTrue(block2.isEndOfStreamBlock(), "Second block is EOS (done processing)");
   }
@@ -581,12 +574,12 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> calls = ImmutableList.of(getSum(new RexExpression.InputRef(1)));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, STRING});
     Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
+        new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator operator =
         new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
             Collections.emptyList(), Collections.emptyList(), calls, 5, Integer.MAX_VALUE,
@@ -601,12 +594,12 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> calls = ImmutableList.of(getSum(new RexExpression.InputRef(1)));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, STRING});
     Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "foo"}))
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
+        new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator operator =
         new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
             Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, 5,
@@ -619,7 +612,7 @@ public class WindowAggregateOperatorTest {
     List<RexExpression> calls = ImmutableList.of(getSum(new RexExpression.InputRef(1)));
     List<RexExpression> group = ImmutableList.of(new RexExpression.InputRef(0));
 
-    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new DataSchema.ColumnDataType[]{INT, STRING});
+    DataSchema inSchema = new DataSchema(new String[]{"group", "arg"}, new ColumnDataType[]{INT, STRING});
     // TODO: it is necessary to produce two values here, the operator only throws on second
     // (see the comment in WindowAggregate operator)
     Mockito.when(_input.nextBlock()).thenReturn(OperatorTestUtil.block(inSchema, new Object[]{2, "metallica"}))
@@ -627,7 +620,7 @@ public class WindowAggregateOperatorTest {
         .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
 
     DataSchema outSchema =
-        new DataSchema(new String[]{"group", "arg", "sum"}, new DataSchema.ColumnDataType[]{INT, STRING, DOUBLE});
+        new DataSchema(new String[]{"group", "arg", "sum"}, new ColumnDataType[]{INT, STRING, DOUBLE});
     WindowAggregateOperator operator =
         new WindowAggregateOperator(OperatorTestUtil.getDefaultContext(), _input, group, Collections.emptyList(),
             Collections.emptyList(), Collections.emptyList(), calls, Integer.MIN_VALUE, Integer.MAX_VALUE,
@@ -643,6 +636,6 @@ public class WindowAggregateOperatorTest {
   }
 
   private static RexExpression.FunctionCall getSum(RexExpression arg) {
-    return new RexExpression.FunctionCall(SqlKind.SUM, FieldSpec.DataType.INT, "SUM", ImmutableList.of(arg));
+    return new RexExpression.FunctionCall(SqlKind.SUM, ColumnDataType.INT, "SUM", ImmutableList.of(arg));
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BooleanUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BooleanUtils.java
@@ -18,9 +18,15 @@
  */
 package org.apache.pinot.spi.utils;
 
+import javax.annotation.Nullable;
+
+
 public class BooleanUtils {
   private BooleanUtils() {
   }
+
+  public static final int INTERNAL_TRUE = 1;
+  public static final int INTERNAL_FALSE = 0;
 
   /**
    * Returns the boolean value for the given boolean string.
@@ -39,7 +45,7 @@ public class BooleanUtils {
     } else if (booleanObject instanceof String) {
       return BooleanUtils.toBoolean((String) booleanObject);
     } else if (booleanObject instanceof Number) {
-      return ((Number) booleanObject).intValue() == 1;
+      return ((Number) booleanObject).intValue() == INTERNAL_TRUE;
     } else if (booleanObject instanceof Boolean) {
       return (boolean) booleanObject;
     } else {
@@ -55,6 +61,27 @@ public class BooleanUtils {
    * </ul>
    */
   public static int toInt(String booleanString) {
-    return toBoolean(booleanString) ? 1 : 0;
+    return toBoolean(booleanString) ? INTERNAL_TRUE : INTERNAL_FALSE;
+  }
+
+  /**
+   * Returns the boolean value for the given non-null Integer object (internal value for BOOLEAN).
+   */
+  public static boolean fromNonNullInternalValue(Object value) {
+    return (int) value == INTERNAL_TRUE;
+  }
+
+  /**
+   * Returns whether the given nullable Integer object (internal value for BOOLEAN) represents true.
+   */
+  public static boolean isTrueInternalValue(@Nullable Object value) {
+    return value != null && (int) value == INTERNAL_TRUE;
+  }
+
+  /**
+   * Returns whether the given nullable Integer object (internal value for BOOLEAN) represents false.
+   */
+  public static boolean isFalseInternalValue(@Nullable Object value) {
+    return value != null && (int) value == INTERNAL_FALSE;
   }
 }


### PR DESCRIPTION
- Fix the wiring issue for value passing:
  - Use internal stored value type within the engine (same as single-stage engine):
    - BOOLEAN: int
    - TIMESTAMP: long
    - BYTES: ByteArray
    - BOOLEAN_ARRAY: int[]
    - TIMESTAMP_ARRAY: long[]
  - Only convert the value to external value type when used in UDF
- Enhance leaf stage to only convert data types when necessary
- Fix the wiring issue for `null` values
- Correctly handle `null` in `FilterOperand`