### PR TITLE
Add array functions to v2 fn registry

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -217,5 +217,30 @@ public class FunctionRegistry {
     public static String arrayToMV(Object multiValue) {
       throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
     }
+
+    @ScalarFunction(names = "arrayMin", isPlaceholder = true)
+    public static String arrayMin(Object multiValue) {
+      throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
+    }
+
+    @ScalarFunction(names = "arrayMax", isPlaceholder = true)
+    public static String arrayMax(Object multiValue) {
+      throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
+    }
+
+    @ScalarFunction(names = "arrayLength", isPlaceholder = true)
+    public static String arrayLength(Object multiValue) {
+      throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
+    }
+
+    @ScalarFunction(names = "arrayAverage", isPlaceholder = true)
+    public static String arrayAverage(Object multiValue) {
+      throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
+    }
+
+    @ScalarFunction(names = "arraySum", isPlaceholder = true)
+    public static String arraySum(Object multiValue) {
+      throw new UnsupportedOperationException("Placeholder scalar function, should not reach here");
+    }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -58,7 +58,7 @@ public enum TransformFunctionType {
   FLOOR("floor"),
   LOG("log", "ln"),
   LOG2("log2"),
-  LOG10("log10", "log1"),
+  LOG10("log10"),
   SIGN("sign"),
   ROUND_DECIMAL("roundDecimal"),
   TRUNCATE("truncate"),

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -168,7 +168,7 @@ public enum TransformFunctionType {
       SqlTypeTransforms.FORCE_NULLABLE), OperandTypes.family(SqlTypeFamily.ARRAY)),
   ARRAYMAX("arrayMax", ReturnTypes.cascade(opBinding -> positionalComponentReturnType(opBinding, 0),
       SqlTypeTransforms.FORCE_NULLABLE), OperandTypes.family(SqlTypeFamily.ARRAY)),
-  ARRAYSUM("arraySum", ReturnTypes.DECIMAL_SUM_NULLABLE, OperandTypes.family(SqlTypeFamily.ARRAY)),
+  ARRAYSUM("arraySum", ReturnTypes.DOUBLE, OperandTypes.family(SqlTypeFamily.ARRAY)),
   VALUEIN("valueIn"),
   MAPVALUE("mapValue", ReturnTypes.cascade(opBinding ->
       opBinding.getOperandType(2).getComponentType(), SqlTypeTransforms.FORCE_NULLABLE),

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -58,7 +58,7 @@ public enum TransformFunctionType {
   FLOOR("floor"),
   LOG("log", "ln"),
   LOG2("log2"),
-  LOG10("log10"),
+  LOG10("log10", "log1"),
   SIGN("sign"),
   ROUND_DECIMAL("roundDecimal"),
   TRUNCATE("truncate"),

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -163,10 +163,12 @@ public enum TransformFunctionType {
   // The only column accepted by "cardinality" function is multi-value array, thus putting "cardinality" as alias.
   // TODO: once we support other types of multiset, we should make CARDINALITY its own function
   ARRAYLENGTH("arrayLength", "cardinality"),
-  ARRAYAVERAGE("arrayAverage"),
-  ARRAYMIN("arrayMin"),
-  ARRAYMAX("arrayMax"),
-  ARRAYSUM("arraySum"),
+  ARRAYAVERAGE("arrayAverage", ReturnTypes.DOUBLE, OperandTypes.family(SqlTypeFamily.ARRAY)),
+  ARRAYMIN("arrayMin", ReturnTypes.cascade(opBinding -> positionalComponentReturnType(opBinding, 0),
+      SqlTypeTransforms.FORCE_NULLABLE), OperandTypes.family(SqlTypeFamily.ARRAY)),
+  ARRAYMAX("arrayMax", ReturnTypes.cascade(opBinding -> positionalComponentReturnType(opBinding, 0),
+      SqlTypeTransforms.FORCE_NULLABLE), OperandTypes.family(SqlTypeFamily.ARRAY)),
+  ARRAYSUM("arraySum", ReturnTypes.DECIMAL_SUM_NULLABLE, OperandTypes.family(SqlTypeFamily.ARRAY)),
   VALUEIN("valueIn"),
   MAPVALUE("mapValue", ReturnTypes.cascade(opBinding ->
       opBinding.getOperandType(2).getComponentType(), SqlTypeTransforms.FORCE_NULLABLE),


### PR DESCRIPTION
```select arrayAverage(intMv) as col from transformsAndAggregationsTest```

fails with 

```
[{"errorCode":150,"message":"SQLParsingError:\nError composing query plan for 'SET \"useMultistageEngine\"=true;\nselect col from (select arrayLength(\"t1\".\"floatMv\") as col, \"t1\".\"$docId\" as docId from transformsAndAggregationsTest t1 join transformsAndAggregationsTest t2 on \"t1\".\"$docId\" = \"t2\".\"$docId\") order by docId limit 100': From line 2, column 25 to line 2, column 51: No match found for function signature arrayLength(<REAL ARRAY>)'\norg.apache.pinot.query.QueryEnvironment.planQuery(QueryEnvironment.java:180)\norg.apache.pinot.broker.requesthandler.MultiStageBrokerRequestHandler.handleRequest(MultiStageBrokerRequestHandler.java:137)\norg.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:263)\norg.apache.pinot.broker.requesthandler.BrokerRequestHandler.handleRequest(BrokerRequestHandler.java:48)\nFrom line 2, column 25 to line 2, column 51: No match found for function signature arrayLength(<REAL ARRAY>)\njdk.internal.reflect.GeneratedConstructorAccessor116.newInstance(Unknown Source)\njava.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)\njava.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)\norg.apache.calcite.runtime.Resources$ExInstWithCause.ex(Resources.java:505)\nNo match found for function signature arrayLength(<REAL ARRAY>)\njdk.internal.reflect.GeneratedConstructorAccessor115.newInstance(Unknown Source)\njava.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)\njava.base/java.lang.reflect.Constructor.newInstance(Constructor.java:490)\norg.apache.calcite.runtime.Resources$ExInstWithCause.ex(Resources.java:505)\n"}]
```