### PR TITLE
Allow adding exception to TransferableBlock without converting it to DataBlock

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -161,7 +161,7 @@ public class QueryRunner {
     if (pipelineBreakerResult != null && pipelineBreakerResult.getErrorBlock() != null) {
       TransferableBlock errorBlock = pipelineBreakerResult.getErrorBlock();
       LOGGER.error("Error executing pipeline breaker for request: {}, stage: {}, sending error block: {}", requestId,
-          distributedStagePlan.getStageId(), errorBlock.getDataBlock().getExceptions());
+          distributedStagePlan.getStageId(), errorBlock.getExceptions());
       int receiverStageId = ((MailboxSendNode) distributedStagePlan.getStageRoot()).getReceiverStageId();
       MailboxMetadata mailboxMetadata = distributedStagePlan.getStageMetadata().getWorkerMetadataList()
           .get(distributedStagePlan.getServer().workerId()).getMailBoxInfosMap().get(receiverStageId);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/executor/OpChainSchedulerService.java
@@ -60,7 +60,7 @@ public class OpChainSchedulerService {
           if (result.isErrorBlock()) {
             returnedErrorBlock = result;
             LOGGER.error("({}): Completed erroneously {} {}", operatorChain, operatorChain.getStats(),
-                result.getDataBlock().getExceptions());
+                result.getExceptions());
           } else {
             LOGGER.debug("({}): Completed {}", operatorChain, operatorChain.getStats());
           }
@@ -71,7 +71,7 @@ public class OpChainSchedulerService {
           _submittedOpChainMap.remove(operatorChain.getId());
           if (returnedErrorBlock != null || thrown != null) {
             if (thrown == null) {
-              thrown = new RuntimeException("Error block " + returnedErrorBlock.getDataBlock().getExceptions());
+              thrown = new RuntimeException("Error block " + returnedErrorBlock.getExceptions());
             }
             operatorChain.cancel(thrown);
           } else if (isFinished) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -34,7 +34,6 @@ import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
-import org.apache.pinot.common.response.ProcessingException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
@@ -194,12 +193,9 @@ public class AggregateOperator extends MultiStageOperator {
       } else {
         TransferableBlock dataBlock = new TransferableBlock(rows, _resultSchema, DataBlock.Type.ROW);
         if (_groupByExecutor.isNumGroupsLimitReached()) {
-          ProcessingException resourceLimitExceededException =
-              new ProcessingException(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE);
-          resourceLimitExceededException.setMessage(
+          dataBlock.addException(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE,
               String.format("Reached numGroupsLimit of: %d for group-by, ignoring the extra groups",
                   _groupByExecutor.getNumGroupsLimit()));
-          dataBlock.getDataBlock().addException(resourceLimitExceededException);
         }
         return dataBlock;
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -312,7 +312,7 @@ public class HashJoinOperator extends MultiStageOperator {
 
   private TransferableBlock setPartialResultExceptionToBlock(TransferableBlock block) {
     if (_resourceLimitExceededException != null) {
-      block.getDataBlock().addException(_resourceLimitExceededException);
+      block.addException(_resourceLimitExceededException);
     }
     return block;
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtilsTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/blocks/TransferableBlockUtilsTest.java
@@ -99,7 +99,7 @@ public class TransferableBlockUtilsTest {
         TransferableBlockUtils.splitBlock(new TransferableBlock(nonSplittableBlock), DataBlock.Type.METADATA,
             4 * 1024 * 1024);
     Assert.assertTrue(transferableBlocks.hasNext());
-    Assert.assertEquals(transferableBlocks.next().getDataBlock(), nonSplittableBlock);
+    Assert.assertSame(transferableBlocks.next().getDataBlock(), nonSplittableBlock);
     Assert.assertFalse(transferableBlocks.hasNext());
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/AggregateOperatorTest.java
@@ -224,7 +224,7 @@ public class AggregateOperatorTest {
 
     // Then:
     Assert.assertTrue(block.isErrorBlock(), "expected ERROR block from invalid computation");
-    Assert.assertTrue(block.getDataBlock().getExceptions().get(1000).contains("String cannot be cast to class"),
+    Assert.assertTrue(block.getExceptions().get(1000).contains("String cannot be cast to class"),
         "expected it to fail with class cast exception");
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/FilterOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/FilterOperatorTest.java
@@ -21,7 +21,6 @@ package org.apache.pinot.query.runtime.operator;
 import com.google.common.collect.ImmutableList;
 import java.util.List;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
@@ -65,8 +64,7 @@ public class FilterOperatorTest {
         new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, booleanLiteral);
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
-    DataBlock error = errorBlock.getDataBlock();
-    Assert.assertTrue(error.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("filterError"));
+    Assert.assertTrue(errorBlock.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("filterError"));
   }
 
   @Test
@@ -132,8 +130,7 @@ public class FilterOperatorTest {
         new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, booleanLiteral);
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
-    DataBlock data = errorBlock.getDataBlock();
-    Assert.assertTrue(data.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("cast"));
+    Assert.assertTrue(errorBlock.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("cast"));
   }
 
   @Test
@@ -147,8 +144,7 @@ public class FilterOperatorTest {
     FilterOperator op = new FilterOperator(OperatorTestUtil.getDefaultContext(), _upstreamOperator, inputSchema, ref0);
     TransferableBlock errorBlock = op.getNextBlock();
     Assert.assertTrue(errorBlock.isErrorBlock());
-    DataBlock data = errorBlock.getDataBlock();
-    Assert.assertTrue(data.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("cast"));
+    Assert.assertTrue(errorBlock.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("cast"));
   }
 
   @Test

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -29,7 +29,6 @@ import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.hint.PinotHintOptions;
 import org.apache.calcite.rel.hint.RelHint;
 import org.apache.calcite.sql.SqlKind;
-import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
@@ -346,8 +345,7 @@ public class HashJoinOperatorTest {
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
     TransferableBlock result = join.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
-    MetadataBlock errorBlock = (MetadataBlock) result.getDataBlock();
-    Assert.assertTrue(errorBlock.getExceptions().get(1000).contains("notEquals"));
+    Assert.assertTrue(result.getExceptions().get(1000).contains("notEquals"));
   }
 
   @Test
@@ -567,8 +565,8 @@ public class HashJoinOperatorTest {
 
     TransferableBlock result = join.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
-    Assert.assertTrue(result.getDataBlock().getExceptions().get(QueryException.UNKNOWN_ERROR_CODE)
-        .contains("testInnerJoinRightError"));
+    Assert.assertTrue(
+        result.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("testInnerJoinRightError"));
   }
 
   @Test
@@ -598,8 +596,7 @@ public class HashJoinOperatorTest {
 
     TransferableBlock result = join.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
-    Assert.assertTrue(result.getDataBlock().getExceptions().get(QueryException.UNKNOWN_ERROR_CODE)
-        .contains("testInnerJoinLeftError"));
+    Assert.assertTrue(result.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("testInnerJoinLeftError"));
   }
 
   @Test
@@ -634,9 +631,8 @@ public class HashJoinOperatorTest {
 
     TransferableBlock result = join.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
-    Assert.assertTrue(
-        result.getDataBlock().getExceptions().get(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE)
-            .contains("reach number of rows limit"));
+    Assert.assertTrue(result.getExceptions().get(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE)
+        .contains("reach number of rows limit"));
   }
 
   @Test
@@ -672,9 +668,8 @@ public class HashJoinOperatorTest {
     TransferableBlock result = join.nextBlock();
     Assert.assertFalse(result.isErrorBlock());
     Assert.assertEquals(result.getNumRows(), 1);
-    Assert.assertTrue(
-        result.getDataBlock().getExceptions().get(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE)
-            .contains("reach number of rows limit"));
+    Assert.assertTrue(result.getExceptions().get(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE)
+        .contains("reach number of rows limit"));
   }
 }
 // TODO: Add more inequi join tests.

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.calcite.rel.RelDistribution;
-import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.MailboxIdUtils;
@@ -120,10 +119,9 @@ public class MailboxReceiveOperatorTest {
             _stageMetadata1);
     try (MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(context, RelDistribution.Type.SINGLETON, 1)) {
       Thread.sleep(100L);
-      TransferableBlock mailbox = receiveOp.nextBlock();
-      assertTrue(mailbox.isErrorBlock());
-      MetadataBlock errorBlock = (MetadataBlock) mailbox.getDataBlock();
-      assertTrue(errorBlock.getExceptions().containsKey(QueryException.EXECUTION_TIMEOUT_ERROR_CODE));
+      TransferableBlock block = receiveOp.nextBlock();
+      assertTrue(block.isErrorBlock());
+      assertTrue(block.getExceptions().containsKey(QueryException.EXECUTION_TIMEOUT_ERROR_CODE));
     }
   }
 
@@ -168,7 +166,7 @@ public class MailboxReceiveOperatorTest {
     try (MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(context, RelDistribution.Type.SINGLETON, 1)) {
       TransferableBlock block = receiveOp.nextBlock();
       assertTrue(block.isErrorBlock());
-      assertTrue(block.getDataBlock().getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains(errorMessage));
+      assertTrue(block.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains(errorMessage));
     }
   }
 
@@ -235,7 +233,7 @@ public class MailboxReceiveOperatorTest {
         1)) {
       TransferableBlock block = receiveOp.nextBlock();
       assertTrue(block.isErrorBlock());
-      assertTrue(block.getDataBlock().getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains(errorMessage));
+      assertTrue(block.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains(errorMessage));
     }
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortedMailboxReceiveOperatorTest.java
@@ -28,7 +28,6 @@ import java.util.stream.Stream;
 import org.apache.calcite.rel.RelDistribution;
 import org.apache.calcite.rel.RelFieldCollation.Direction;
 import org.apache.calcite.rel.RelFieldCollation.NullDirection;
-import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.mailbox.MailboxIdUtils;
@@ -143,10 +142,9 @@ public class SortedMailboxReceiveOperatorTest {
         RelDistribution.Type.SINGLETON, DATA_SCHEMA, COLLATION_KEYS, COLLATION_DIRECTIONS, COLLATION_NULL_DIRECTIONS,
         false, 1)) {
       Thread.sleep(100L);
-      TransferableBlock mailbox = receiveOp.nextBlock();
-      assertTrue(mailbox.isErrorBlock());
-      MetadataBlock errorBlock = (MetadataBlock) mailbox.getDataBlock();
-      assertTrue(errorBlock.getExceptions().containsKey(QueryException.EXECUTION_TIMEOUT_ERROR_CODE));
+      TransferableBlock block = receiveOp.nextBlock();
+      assertTrue(block.isErrorBlock());
+      assertTrue(block.getExceptions().containsKey(QueryException.EXECUTION_TIMEOUT_ERROR_CODE));
     }
   }
 
@@ -194,7 +192,7 @@ public class SortedMailboxReceiveOperatorTest {
         false, 1)) {
       TransferableBlock block = receiveOp.nextBlock();
       assertTrue(block.isErrorBlock());
-      assertTrue(block.getDataBlock().getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains(errorMessage));
+      assertTrue(block.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains(errorMessage));
     }
   }
 
@@ -238,7 +236,7 @@ public class SortedMailboxReceiveOperatorTest {
         COLLATION_NULL_DIRECTIONS, false, 1)) {
       TransferableBlock block = receiveOp.nextBlock();
       assertTrue(block.isErrorBlock());
-      assertTrue(block.getDataBlock().getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains(errorMessage));
+      assertTrue(block.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains(errorMessage));
     }
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/TransformOperatorTest.java
@@ -22,7 +22,6 @@ import com.google.common.collect.ImmutableList;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
@@ -161,8 +160,7 @@ public class TransformOperatorTest {
 
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
-    DataBlock data = result.getDataBlock();
-    Assert.assertTrue(data.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("ArithmeticFunctions"));
+    Assert.assertTrue(result.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("ArithmeticFunctions"));
   }
 
   @Test
@@ -181,8 +179,7 @@ public class TransformOperatorTest {
             _upstreamOp, resultSchema, ImmutableList.of(boolLiteral, strLiteral), upStreamSchema);
     TransferableBlock result = op.nextBlock();
     Assert.assertTrue(result.isErrorBlock());
-    DataBlock data = result.getDataBlock();
-    Assert.assertTrue(data.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("transformError"));
+    Assert.assertTrue(result.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains("transformError"));
   }
 
   @Test

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperatorTest.java
@@ -638,7 +638,7 @@ public class WindowAggregateOperatorTest {
 
     // Then:
     Assert.assertTrue(block.isErrorBlock(), "expected ERROR block from invalid computation");
-    Assert.assertTrue(block.getDataBlock().getExceptions().get(1000).contains("String cannot be cast to class"),
+    Assert.assertTrue(block.getExceptions().get(1000).contains("String cannot be cast to class"),
         "expected it to fail with class cast exception");
   }
 


### PR DESCRIPTION
When resource limit is exceeded, we add an exception to the `TransferableBlock` along with the data. This PR allows us to add exception without converting the underlying data into a `DataBlock`. This is critical because we don't need to do the conversion without sending the data cross nodes.