### PR TITLE
Turn on expand identifier in SqlValidator config

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -529,6 +529,28 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
       assertEquals(encoded, toBase64(toUtf8(original)));
       assertEquals(decoded, fromUtf8(fromBase64(toBase64(toUtf8(original)))));
     }
+
+    // Test select with group by order by limit
+    sqlQuery = "SELECT toBase64(toUtf8(AirlineID)) "
+        + "FROM mytable "
+        + "GROUP BY toBase64(toUtf8(AirlineID)) "
+        + "ORDER BY toBase64(toUtf8(AirlineID)) DESC "
+        + "LIMIT 10";
+    response = postQuery(sqlQuery);
+    resultTable = response.get("resultTable");
+    dataSchema = resultTable.get("dataSchema");
+    assertEquals(dataSchema.get("columnDataTypes").toString(), "[\"STRING\"]");
+    rows = response.get("resultTable").get("rows");
+    assertEquals(rows.get(0).get(0).asText(), "MjExNzE=");
+    assertEquals(rows.get(1).get(0).asText(), "MjAzOTg=");
+    assertEquals(rows.get(2).get(0).asText(), "MjAzNjY=");
+    assertEquals(rows.get(3).get(0).asText(), "MjAzNTU=");
+    assertEquals(rows.get(4).get(0).asText(), "MjAzMDQ=");
+    assertEquals(rows.get(5).get(0).asText(), "MjA0Mzc=");
+    assertEquals(rows.get(6).get(0).asText(), "MjA0MzY=");
+    assertEquals(rows.get(7).get(0).asText(), "MjA0MDk=");
+    assertEquals(rows.get(8).get(0).asText(), "MTkzOTM=");
+    assertEquals(rows.get(9).get(0).asText(), "MTk5Nzc=");
   }
 
   @Test

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/Validator.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/Validator.java
@@ -40,7 +40,8 @@ public class Validator extends SqlValidatorImpl {
 
   public Validator(SqlOperatorTable opTab, SqlValidatorCatalogReader catalogReader, RelDataTypeFactory typeFactory) {
     // TODO: support BABEL validator. Currently parser conformance is set to use BABEL.
-    super(opTab, catalogReader, typeFactory, Config.DEFAULT.withSqlConformance(SqlConformanceEnum.LENIENT));
+    super(opTab, catalogReader, typeFactory,
+        Config.DEFAULT.withSqlConformance(SqlConformanceEnum.LENIENT).withIdentifierExpansion(true));
   }
 
   /**

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -407,11 +407,6 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
         new Object[]{"SELECT a.col1 FROM a WHERE a.col1 IN ()", "Encountered \"\" at line"},
         // AT TIME ZONE should fail
         new Object[]{"SELECT a.col1 AT TIME ZONE 'PST' FROM a", "No match found for function signature AT_TIME_ZONE"},
-        // CASE WHEN with non-consolidated result type at compile time.
-        new Object[]{
-            "SELECT SUM(CASE WHEN col3 > 10 THEN 1 WHEN col3 > 20 THEN 2 WHEN col3 > 30 THEN 3 "
-                + "WHEN col3 > 40 THEN 4 WHEN col3 > 50 THEN '5' ELSE 0 END) FROM a", "while converting CASE WHEN"
-        },
     };
   }
 

--- a/pinot-query-planner/src/test/resources/queries/BasicQueryPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/BasicQueryPlans.json
@@ -57,6 +57,20 @@
           "\n        LogicalTableScan(table=[[a]])",
           "\n"
         ]
+      },
+      {
+        "description": "",
+        "sql": "EXPLAIN PLAN FOR SELECT SUM(CASE WHEN col3 > 10 THEN 1 WHEN col3 > 20 THEN 2 WHEN col3 > 30 THEN 3 WHEN col3 > 40 THEN 4 WHEN col3 > 50 THEN '5' ELSE 0 END) FROM a",
+        "output": [
+          "Execution Plan",
+          "\nLogicalProject(EXPR$0=[CASE(=($1, 0), null:DECIMAL(1000, 500), $0)])",
+          "\n  LogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT($1)])",
+          "\n    PinotLogicalExchange(distribution=[hash])",
+          "\n      LogicalAggregate(group=[{}], agg#0=[$SUM0($0)], agg#1=[COUNT()])",
+          "\n        LogicalProject($f0=[CAST(CASE(>($2, 10), '1':VARCHAR, >($2, 20), '2':VARCHAR, >($2, 30), '3':VARCHAR, >($2, 40), '4':VARCHAR, >($2, 50), '5':VARCHAR, '0':VARCHAR)):DECIMAL(1000, 500) NOT NULL])",
+          "\n          LogicalTableScan(table=[[a]])",
+          "\n"
+        ]
       }
     ]
   }


### PR DESCRIPTION
Fix for https://github.com/apache/pinot/pull/11447
For sql:
```
SELECT toBase64(toUtf8(AirlineID)) as encoded
FROM mytable
GROUP BY toBase64(toUtf8(AirlineID))
LIMIT 10
```

The issue is that calcite expand group by `toBase64(toUtf8(AirlineID))` to `toBase64(toUtf8(CAST(mytable.AirlineID AS VARCHAR CHARACTER SET ISO-8859-1)))` but not the expression in SELECT.


Enabling identifier expansion is useful in situations where you want to be explicit about the source of each column or table. It can help in reducing ambiguity and making the query more self-describing.
