### PR TITLE
[CI]use 16 core ubuntu instances for ci

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -70,7 +70,7 @@ jobs:
         run: .github/workflows/scripts/.pinot_linter.sh
   unit-test:
     if: github.repository == 'apache/pinot'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8core
     strategy:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false
@@ -122,7 +122,7 @@ jobs:
 
   integration-test:
     if: github.repository == 'apache/pinot'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8core
     strategy:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false
@@ -174,7 +174,7 @@ jobs:
 
   compatibility-verifier:
     if: github.repository == 'apache/pinot'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8core
     strategy:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false
@@ -229,7 +229,7 @@ jobs:
 
   quickstarts:
     if: github.repository == 'apache/pinot'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8core
     strategy:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false


### PR DESCRIPTION
Use bigger instances to speed up CI

https://docs.github.com/en/actions/using-github-hosted-runners/about-larger-runners