### PR TITLE
Use getResponseBodyAsStream instead of getResponseBody

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerCache.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerCache.java
@@ -22,7 +22,6 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.core.type.TypeReference;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.JdkSslContext;
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -136,8 +135,7 @@ public class BrokerCache {
 
     Future<Response> responseFuture = getRequest.addHeader("accept", "application/json").execute();
     Response response = responseFuture.get();
-    String responseBody = response.getResponseBody(StandardCharsets.UTF_8);
-    return JsonUtils.stringToObject(responseBody, RESPONSE_TYPE_REF);
+    return JsonUtils.inputStreamToObject(response.getResponseBodyAsStream(), RESPONSE_TYPE_REF);
   }
 
   private BrokerData getBrokerData(Map<String, List<BrokerInstance>> responses) {

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransport.java
@@ -18,14 +18,12 @@
  */
 package org.apache.pinot.client;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectReader;
 import com.fasterxml.jackson.databind.node.JsonNodeFactory;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.JdkSslContext;
 import java.io.IOException;
-import java.nio.charset.StandardCharsets;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -127,10 +125,9 @@ public class JsonAsyncHttpPinotClientTransport implements PinotClientTransport<C
                   "Pinot returned HTTP status " + httpResponse.getStatusCode() + ", expected 200");
             }
 
-            String responseBody = httpResponse.getResponseBody(StandardCharsets.UTF_8);
             try {
-              return BrokerResponse.fromJson(OBJECT_READER.readTree(responseBody));
-            } catch (JsonProcessingException e) {
+              return BrokerResponse.fromJson(OBJECT_READER.readTree(httpResponse.getResponseBodyAsStream()));
+            } catch (IOException e) {
               throw new CompletionException(e);
             }
           });

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/ControllerResponseFuture.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/ControllerResponseFuture.java
@@ -18,10 +18,11 @@
  */
 package org.apache.pinot.client.controller.response;
 
-import java.nio.charset.StandardCharsets;
+import java.io.InputStream;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.pinot.client.PinotClientException;
 import org.asynchttpclient.Response;
 import org.slf4j.Logger;
@@ -62,7 +63,7 @@ abstract class ControllerResponseFuture<T> implements Future<T> {
   abstract public T get(long timeout, TimeUnit unit)
       throws ExecutionException;
 
-  public String getStringResponse(long timeout, TimeUnit unit)
+  public InputStream getStreamResponse(long timeout, TimeUnit unit)
       throws ExecutionException {
     try {
       LOGGER.debug("Sending request to {}", _url);
@@ -75,10 +76,8 @@ abstract class ControllerResponseFuture<T> implements Future<T> {
         throw new PinotClientException("Pinot returned HTTP status " + httpResponse.getStatusCode() + ", expected 200");
       }
 
-      String responseBody = httpResponse.getResponseBody(StandardCharsets.UTF_8);
-
-      return responseBody;
-    } catch (Exception e) {
+      return httpResponse.getResponseBodyAsStream();
+    } catch (TimeoutException | InterruptedException e) {
       throw new ExecutionException(e);
     }
   }

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/ControllerTenantBrokerResponse.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/ControllerTenantBrokerResponse.java
@@ -20,6 +20,7 @@ package org.apache.pinot.client.controller.response;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -74,16 +75,13 @@ public class ControllerTenantBrokerResponse {
     @Override
     public ControllerTenantBrokerResponse get(long timeout, TimeUnit unit)
         throws ExecutionException {
-      String response = getStringResponse(timeout, unit);
       try {
-        JsonNode jsonResponse = JsonUtils.stringToJsonNode(response);
-        ControllerTenantBrokerResponse tableResponse = ControllerTenantBrokerResponse.fromJson(jsonResponse);
-        return tableResponse;
+        InputStream response = getStreamResponse(timeout, unit);
+        JsonNode jsonResponse = JsonUtils.inputStreamToJsonNode(response);
+        return ControllerTenantBrokerResponse.fromJson(jsonResponse);
       } catch (IOException e) {
-        new ExecutionException(e);
+        throw new ExecutionException(e);
       }
-
-      return null;
     }
   }
 }

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/SchemaResponse.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/SchemaResponse.java
@@ -20,6 +20,7 @@ package org.apache.pinot.client.controller.response;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
@@ -75,15 +76,13 @@ public class SchemaResponse {
     @Override
     public SchemaResponse get(long timeout, TimeUnit unit)
         throws ExecutionException {
-      String response = getStringResponse(timeout, unit);
       try {
-        JsonNode jsonResponse = JsonUtils.stringToJsonNode(response);
+        InputStream response = getStreamResponse(timeout, unit);
+        JsonNode jsonResponse = JsonUtils.inputStreamToJsonNode(response);
         return SchemaResponse.fromJson(jsonResponse);
       } catch (IOException e) {
-        new ExecutionException(e);
+        throw new ExecutionException(e);
       }
-
-      return null;
     }
   }
 }

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/TableResponse.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/response/TableResponse.java
@@ -20,6 +20,7 @@ package org.apache.pinot.client.controller.response;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
@@ -78,16 +79,13 @@ public class TableResponse {
     @Override
     public TableResponse get(long timeout, TimeUnit unit)
         throws ExecutionException {
-      String response = getStringResponse(timeout, unit);
       try {
-        JsonNode jsonResponse = JsonUtils.stringToJsonNode(response);
-        TableResponse tableResponse = TableResponse.fromJson(jsonResponse);
-        return tableResponse;
+        InputStream response = getStreamResponse(timeout, unit);
+        JsonNode jsonResponse = JsonUtils.inputStreamToJsonNode(response);
+        return TableResponse.fromJson(jsonResponse);
       } catch (IOException e) {
-        new ExecutionException(e);
+        throw new ExecutionException(e);
       }
-
-      return null;
     }
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -196,6 +196,11 @@ public class JsonUtils {
     return DEFAULT_READER.forType(valueType).readValue(jsonInputStream);
   }
 
+  public static <T> T inputStreamToObject(InputStream jsonInputStream, TypeReference<T> valueTypeRef)
+      throws IOException {
+    return DEFAULT_READER.forType(valueTypeRef).readValue(jsonInputStream);
+  }
+
   public static JsonNode inputStreamToJsonNode(InputStream jsonInputStream)
       throws IOException {
     return DEFAULT_READER.readTree(jsonInputStream);


### PR DESCRIPTION
While running a large test, below log is seen often. 

2023/08/25 03:33:51.864 WARN [HttpMethodBase] [pool-12-thread-5] Going to buffer response body of large or unknown size. Using getResponseBodyAsStream instead is recommended.

This is coming from Apache library when the buffered response size is [larger than http.method.response.buffer.warnlimit](https://hc.apache.org/httpclient-legacy/preference-api.html).

This PR replaces few usages of getResponseBody with getResponseBodyAsStream