### PR TITLE
[multistage] fix the logic of parsing float literal

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -191,8 +191,15 @@ public class RequestUtils {
     if (object instanceof Integer || object instanceof Long) {
       return RequestUtils.getLiteralExpression(((Number) object).longValue());
     }
-    if (object instanceof Float || object instanceof Double) {
+    if (object instanceof Float) {
+      // We need to use Double.parseDouble(object.toString()) instead of ((Number) object).doubleValue()
+      // or ((Float) object).doubleValue() because the latter two will return slightly different values
+      // For example, if object is 0.06f, Double.parseDouble(object.toString()) will return 0.06, while
+      // ((Number) object).doubleValue() or ((Float) object).doubleValue() will return 0.05999999865889549
       return RequestUtils.getLiteralExpression(Double.parseDouble(object.toString()));
+    }
+    if (object instanceof Double) {
+      return RequestUtils.getLiteralExpression(((Double) object).doubleValue());
     }
     if (object instanceof byte[]) {
       return RequestUtils.getLiteralExpression((byte[]) object);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -192,7 +192,7 @@ public class RequestUtils {
       return RequestUtils.getLiteralExpression(((Number) object).longValue());
     }
     if (object instanceof Float || object instanceof Double) {
-      return RequestUtils.getLiteralExpression(((Number) object).doubleValue());
+      return RequestUtils.getLiteralExpression(Double.parseDouble(object.toString()));
     }
     if (object instanceof byte[]) {
       return RequestUtils.getLiteralExpression((byte[]) object);

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.utils.request;
+
+import org.apache.pinot.common.request.Expression;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class RequestUtilsTest {
+  @Test
+  public void testGetLiteralExpressionForObject() {
+    Expression literalExpression = RequestUtils.getLiteralExpression(Float.valueOf(0.06f));
+    Assert.assertEquals((literalExpression.getLiteral().getDoubleValue()), 0.06);
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/request/RequestUtilsTest.java
@@ -24,6 +24,7 @@ import org.testng.annotations.Test;
 
 
 public class RequestUtilsTest {
+  // please check comments inside RequestUtils.getLiteralExpression() for why we need this test
   @Test
   public void testGetLiteralExpressionForObject() {
     Expression literalExpression = RequestUtils.getLiteralExpression(Float.valueOf(0.06f));


### PR DESCRIPTION
This PR fixes float literal parsing logic.

for example, without this fix, 
`select * from table where foo > 0.06` 
will be parsed as 
`select * from table where foo > 0.05999999865889549`

