### PR TITLE
Disallow tenant tag override with upsert tables

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -649,6 +649,8 @@ public final class TableConfigUtils {
     Preconditions.checkState(
         tableConfig.getRoutingConfig() != null && isRoutingStrategyAllowedForUpsert(tableConfig.getRoutingConfig()),
         "Upsert/Dedup table must use strict replica-group (i.e. strictReplicaGroup) based routing");
+    Preconditions.checkState(tableConfig.getTenantConfig().getTagOverrideConfig() == null,
+        "Upsert/Dedup table cannot use tenant tag override");
 
     // specifically for upsert
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();


### PR DESCRIPTION
Disallows using tenant tag override with upsert enabled tables that can cause wrong results if segments belonging to a given partition are moved to a different server.