### PR TITLE
Stream leaf stage blocks

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandlerTest.java
@@ -39,6 +39,7 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
+
 public class MultiStageBrokerRequestHandlerTest {
 
   private PinotConfiguration _config;
@@ -60,11 +61,11 @@ public class MultiStageBrokerRequestHandlerTest {
   public void setUp() {
     MockitoAnnotations.openMocks(this);
     _config = new PinotConfiguration();
-    _config.setProperty(CommonConstants.Broker.CONFIG_OF_BROKER_TIMEOUT_MS, "10000");
+    _config.setProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME, "localhost");
     _config.setProperty(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT, "12345");
     _accessControlFactory = new AllowAllAccessControlFactory();
     _requestHandler =
-        new MultiStageBrokerRequestHandler(_config, "testBrokerId", _routingManager, _accessControlFactory,
+        new MultiStageBrokerRequestHandler(_config, "Broker_localhost", _routingManager, _accessControlFactory,
             _queryQuotaManager, _tableCache, _brokerMetrics);
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/exception/QueryException.java
@@ -152,7 +152,7 @@ public class QueryException {
     QUERY_SCHEDULING_TIMEOUT_ERROR.setMessage("QuerySchedulingTimeoutError");
     SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR.setMessage("ServerResourceLimitExceededError");
     EXECUTION_TIMEOUT_ERROR.setMessage("ExecutionTimeoutError");
-    DATA_TABLE_DESERIALIZATION_ERROR.setMessage("DataTableSerializationError");
+    DATA_TABLE_SERIALIZATION_ERROR.setMessage("DataTableSerializationError");
     BROKER_GATHER_ERROR.setMessage("BrokerGatherError");
     DATA_TABLE_DESERIALIZATION_ERROR.setMessage("DataTableDeserializationError");
     FUTURE_CALL_ERROR.setMessage("FutureCallError");

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -191,6 +191,12 @@ public class QueryOptionsUtils {
   }
 
   @Nullable
+  public static Integer getMaxStreamingPendingBlocks(Map<String, String> queryOptions) {
+    String maxStreamingPendingBlocks = queryOptions.get(QueryOptionKey.MAX_STREAMING_PENDING_BLOCKS);
+    return maxStreamingPendingBlocks != null ? Integer.parseInt(maxStreamingPendingBlocks) : null;
+  }
+
+  @Nullable
   public static Integer getMaxRowsInJoin(Map<String, String> queryOptions) {
     String maxRowsInJoin = queryOptions.get(QueryOptionKey.MAX_ROWS_IN_JOIN);
     return maxRowsInJoin != null ? Integer.parseInt(maxRowsInJoin) : null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
@@ -86,7 +86,7 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
 
       ThreadResourceUsageProvider mainThreadResourceUsageProvider = new ThreadResourceUsageProvider();
       BaseResultsBlock resultsBlock = getCombinedResults();
-      InstanceResponseBlock instanceResponseBlock = new InstanceResponseBlock(resultsBlock, _queryContext);
+      InstanceResponseBlock instanceResponseBlock = new InstanceResponseBlock(resultsBlock);
       long mainThreadCpuTimeNs = mainThreadResourceUsageProvider.getThreadTimeNs();
 
       long totalWallClockTimeNs = System.nanoTime() - startWallClockTimeNs;
@@ -108,7 +108,7 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
 
       return instanceResponseBlock;
     } else {
-      return new InstanceResponseBlock(getCombinedResults(), _queryContext);
+      return new InstanceResponseBlock(getCombinedResults());
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/InstanceResponseBlock.java
@@ -29,7 +29,6 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.Block;
 import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
 import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
-import org.apache.pinot.core.query.request.context.QueryContext;
 
 
 /**
@@ -37,13 +36,11 @@ import org.apache.pinot.core.query.request.context.QueryContext;
  */
 public class InstanceResponseBlock implements Block {
   private final BaseResultsBlock _resultsBlock;
-  private final QueryContext _queryContext;
   private final Map<Integer, String> _exceptions;
   private final Map<String, String> _metadata;
 
-  public InstanceResponseBlock(BaseResultsBlock resultsBlock, QueryContext queryContext) {
+  public InstanceResponseBlock(BaseResultsBlock resultsBlock) {
     _resultsBlock = resultsBlock;
-    _queryContext = queryContext;
     _exceptions = new HashMap<>();
     List<ProcessingException> processingExceptions = resultsBlock.getProcessingExceptions();
     if (processingExceptions != null) {
@@ -59,14 +56,12 @@ public class InstanceResponseBlock implements Block {
    */
   public InstanceResponseBlock() {
     _resultsBlock = null;
-    _queryContext = null;
     _exceptions = new HashMap<>();
     _metadata = new HashMap<>();
   }
 
   private InstanceResponseBlock(Map<Integer, String> exceptions, Map<String, String> metadata) {
     _resultsBlock = null;
-    _queryContext = null;
     _exceptions = exceptions;
     _metadata = metadata;
   }
@@ -92,11 +87,6 @@ public class InstanceResponseBlock implements Block {
     return _resultsBlock;
   }
 
-  @Nullable
-  public QueryContext getQueryContext() {
-    return _queryContext;
-  }
-
   public Map<Integer, String> getExceptions() {
     return _exceptions;
   }
@@ -107,12 +97,12 @@ public class InstanceResponseBlock implements Block {
 
   @Nullable
   public DataSchema getDataSchema() {
-    return _resultsBlock != null ? _resultsBlock.getDataSchema(_queryContext) : null;
+    return _resultsBlock != null ? _resultsBlock.getDataSchema() : null;
   }
 
   @Nullable
   public List<Object[]> getRows() {
-    return _resultsBlock != null ? _resultsBlock.getRows(_queryContext) : null;
+    return _resultsBlock != null ? _resultsBlock.getRows() : null;
   }
 
   public DataTable toDataTable()
@@ -124,8 +114,7 @@ public class InstanceResponseBlock implements Block {
 
   public DataTable toDataOnlyDataTable()
       throws IOException {
-    return _resultsBlock != null ? _resultsBlock.getDataTable(_queryContext)
-        : DataTableBuilderFactory.getEmptyDataTable();
+    return _resultsBlock != null ? _resultsBlock.getDataTable() : DataTableBuilderFactory.getEmptyDataTable();
   }
 
   public DataTable toMetadataOnlyDataTable() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/BaseResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/BaseResultsBlock.java
@@ -156,26 +156,32 @@ public abstract class BaseResultsBlock implements Block {
   /**
    * Returns the total size (number of rows) in this result block, without having to materialize the rows.
    *
-   * @see BaseResultsBlock#getRows(QueryContext)
+   * @see BaseResultsBlock#getRows()
    */
   public abstract int getNumRows();
+
+  /**
+   * Returns the query for the results. Return {@code null} when the block only contains metadata.
+   */
+  @Nullable
+  public abstract QueryContext getQueryContext();
 
   /**
    * Returns the data schema for the results. Return {@code null} when the block only contains metadata.
    */
   @Nullable
-  public abstract DataSchema getDataSchema(QueryContext queryContext);
+  public abstract DataSchema getDataSchema();
 
   /**
    * Returns the rows for the results. Return {@code null} when the block only contains metadata.
    */
   @Nullable
-  public abstract List<Object[]> getRows(QueryContext queryContext);
+  public abstract List<Object[]> getRows();
 
   /**
    * Returns a data table without metadata or exception attached.
    */
-  public abstract DataTable getDataTable(QueryContext queryContext)
+  public abstract DataTable getDataTable()
       throws IOException;
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/DistinctResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/DistinctResultsBlock.java
@@ -34,10 +34,13 @@ import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
  * Results block for distinct queries.
  */
 public class DistinctResultsBlock extends BaseResultsBlock {
+  private final QueryContext _queryContext;
+
   private DistinctTable _distinctTable;
 
-  public DistinctResultsBlock(DistinctTable distinctTable) {
+  public DistinctResultsBlock(DistinctTable distinctTable, QueryContext queryContext) {
     _distinctTable = distinctTable;
+    _queryContext = queryContext;
   }
 
   public DistinctTable getDistinctTable() {
@@ -54,12 +57,17 @@ public class DistinctResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  public DataSchema getDataSchema(QueryContext queryContext) {
+  public QueryContext getQueryContext() {
+    return _queryContext;
+  }
+
+  @Override
+  public DataSchema getDataSchema() {
     return _distinctTable.getDataSchema();
   }
 
   @Override
-  public List<Object[]> getRows(QueryContext queryContext) {
+  public List<Object[]> getRows() {
     List<Object[]> rows = new ArrayList<>(_distinctTable.size());
     for (Record record : _distinctTable.getRecords()) {
       rows.add(record.getValues());
@@ -68,10 +76,10 @@ public class DistinctResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  public DataTable getDataTable(QueryContext queryContext)
+  public DataTable getDataTable()
       throws IOException {
-    Collection<Object[]> rows = getRows(queryContext);
+    Collection<Object[]> rows = getRows();
     return SelectionOperatorUtils.getDataTableFromRows(rows, _distinctTable.getDataSchema(),
-        queryContext.isNullHandlingEnabled());
+        _queryContext.isNullHandlingEnabled());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ExceptionResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ExceptionResultsBlock.java
@@ -50,18 +50,24 @@ public class ExceptionResultsBlock extends BaseResultsBlock {
 
   @Nullable
   @Override
-  public DataSchema getDataSchema(QueryContext queryContext) {
+  public QueryContext getQueryContext() {
     return null;
   }
 
   @Nullable
   @Override
-  public List<Object[]> getRows(QueryContext queryContext) {
+  public DataSchema getDataSchema() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public List<Object[]> getRows() {
     return null;
   }
 
   @Override
-  public DataTable getDataTable(QueryContext queryContext) {
+  public DataTable getDataTable() {
     return DataTableBuilderFactory.getEmptyDataTable();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ExplainResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ExplainResultsBlock.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
@@ -34,15 +35,15 @@ import org.apache.pinot.core.query.request.context.QueryContext;
  * Results block for EXPLAIN queries.
  */
 public class ExplainResultsBlock extends BaseResultsBlock {
+  private final QueryContext _queryContext;
   private final List<ExplainEntry> _entries = new ArrayList<>();
+
+  public ExplainResultsBlock(QueryContext queryContext) {
+    _queryContext = queryContext;
+  }
 
   public void addOperator(String operatorName, int operatorId, int parentId) {
     _entries.add(new ExplainEntry(operatorName, operatorId, parentId));
-  }
-
-  @Override
-  public DataSchema getDataSchema(QueryContext queryContext) {
-    return DataSchema.EXPLAIN_RESULT_SCHEMA;
   }
 
   @Override
@@ -51,7 +52,18 @@ public class ExplainResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  public List<Object[]> getRows(QueryContext queryContext) {
+  public QueryContext getQueryContext() {
+    return _queryContext;
+  }
+
+  @Nullable
+  @Override
+  public DataSchema getDataSchema() {
+    return DataSchema.EXPLAIN_RESULT_SCHEMA;
+  }
+
+  @Override
+  public List<Object[]> getRows() {
     List<Object[]> rows = new ArrayList<>(_entries.size());
     for (ExplainEntry entry : _entries) {
       rows.add(entry.toRow());
@@ -60,7 +72,7 @@ public class ExplainResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  public DataTable getDataTable(QueryContext queryContext)
+  public DataTable getDataTable()
       throws IOException {
     DataTableBuilder dataTableBuilder = DataTableBuilderFactory.getDataTableBuilder(DataSchema.EXPLAIN_RESULT_SCHEMA);
     for (ExplainEntry entry : _entries) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/MetadataResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/MetadataResultsBlock.java
@@ -35,18 +35,24 @@ public class MetadataResultsBlock extends BaseResultsBlock {
 
   @Nullable
   @Override
-  public DataSchema getDataSchema(QueryContext queryContext) {
+  public QueryContext getQueryContext() {
     return null;
   }
 
   @Nullable
   @Override
-  public List<Object[]> getRows(QueryContext queryContext) {
+  public DataSchema getDataSchema() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public List<Object[]> getRows() {
     return null;
   }
 
   @Override
-  public DataTable getDataTable(QueryContext queryContext) {
+  public DataTable getDataTable() {
     return DataTableBuilderFactory.getEmptyDataTable();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtils.java
@@ -65,7 +65,7 @@ public class ResultsBlockUtils {
     // NOTE: Use STRING column data type as default for selection query
     Arrays.fill(columnDataTypes, ColumnDataType.STRING);
     DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);
-    return new SelectionResultsBlock(dataSchema, Collections.emptyList());
+    return new SelectionResultsBlock(dataSchema, Collections.emptyList(), queryContext);
   }
 
   private static AggregationResultsBlock buildEmptyAggregationQueryResults(QueryContext queryContext) {
@@ -76,7 +76,7 @@ public class ResultsBlockUtils {
     for (AggregationFunction aggregationFunction : aggregationFunctions) {
       results.add(aggregationFunction.extractAggregationResult(aggregationFunction.createAggregationResultHolder()));
     }
-    return new AggregationResultsBlock(aggregationFunctions, results);
+    return new AggregationResultsBlock(aggregationFunctions, results, queryContext);
   }
 
   private static GroupByResultsBlock buildEmptyGroupByQueryResults(QueryContext queryContext) {
@@ -100,7 +100,7 @@ public class ResultsBlockUtils {
       columnDataTypes[index] = aggregationFunction.getIntermediateResultColumnType();
       index++;
     }
-    return new GroupByResultsBlock(new DataSchema(columnNames, columnDataTypes));
+    return new GroupByResultsBlock(new DataSchema(columnNames, columnDataTypes), queryContext);
   }
 
   private static DistinctResultsBlock buildEmptyDistinctQueryResults(QueryContext queryContext) {
@@ -115,6 +115,6 @@ public class ResultsBlockUtils {
     Arrays.fill(columnDataTypes, ColumnDataType.STRING);
     DistinctTable distinctTable = new DistinctTable(new DataSchema(columns, columnDataTypes), Collections.emptySet(),
         queryContext.isNullHandlingEnabled());
-    return new DistinctResultsBlock(distinctTable);
+    return new DistinctResultsBlock(distinctTable, queryContext);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/SelectionResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/SelectionResultsBlock.java
@@ -34,25 +34,19 @@ import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 public class SelectionResultsBlock extends BaseResultsBlock {
   private final DataSchema _dataSchema;
   private final Comparator<? super Object[]> _comparator;
+  private final QueryContext _queryContext;
   private List<Object[]> _rows;
 
   public SelectionResultsBlock(DataSchema dataSchema, List<Object[]> rows,
-      @Nullable Comparator<? super Object[]> comparator) {
+      @Nullable Comparator<? super Object[]> comparator, QueryContext queryContext) {
     _dataSchema = dataSchema;
     _rows = rows;
     _comparator = comparator;
+    _queryContext = queryContext;
   }
 
-  public SelectionResultsBlock(DataSchema dataSchema, List<Object[]> rows) {
-    this(dataSchema, rows, null);
-  }
-
-  public DataSchema getDataSchema() {
-    return _dataSchema;
-  }
-
-  public List<Object[]> getRows() {
-    return _rows;
+  public SelectionResultsBlock(DataSchema dataSchema, List<Object[]> rows, QueryContext queryContext) {
+    this(dataSchema, rows, null, queryContext);
   }
 
   public void setRows(List<Object[]> rows) {
@@ -70,18 +64,23 @@ public class SelectionResultsBlock extends BaseResultsBlock {
   }
 
   @Override
-  public DataSchema getDataSchema(QueryContext queryContext) {
+  public QueryContext getQueryContext() {
+    return _queryContext;
+  }
+
+  @Override
+  public DataSchema getDataSchema() {
     return _dataSchema;
   }
 
   @Override
-  public List<Object[]> getRows(QueryContext queryContext) {
+  public List<Object[]> getRows() {
     return _rows;
   }
 
   @Override
-  public DataTable getDataTable(QueryContext queryContext)
+  public DataTable getDataTable()
       throws IOException {
-    return SelectionOperatorUtils.getDataTableFromRows(_rows, _dataSchema, queryContext.isNullHandlingEnabled());
+    return SelectionOperatorUtils.getDataTableFromRows(_rows, _dataSchema, _queryContext.isNullHandlingEnabled());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseCombineOperator.java
@@ -19,10 +19,8 @@
 package org.apache.pinot.core.operator.combine;
 
 import java.util.List;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.Phaser;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -66,8 +64,6 @@ public abstract class BaseCombineOperator<T extends BaseResultsBlock> extends Ba
 
   // Use an AtomicInteger to track the next operator to execute
   protected final AtomicInteger _nextOperatorId = new AtomicInteger();
-  // Use a BlockingQueue to store the intermediate results blocks
-  protected final BlockingQueue<BaseResultsBlock> _blockingQueue = new LinkedBlockingQueue<>();
   // Use an AtomicReference to track the exception/error during segment processing
   protected final AtomicReference<Throwable> _processingException = new AtomicReference<>();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/BaseSingleBlockCombineOperator.java
@@ -19,7 +19,9 @@
 package org.apache.pinot.core.operator.combine;
 
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.core.common.Operator;
@@ -41,9 +43,11 @@ import org.slf4j.LoggerFactory;
  * detects that the merged results can already satisfy the query, or the query is already errored out or timed out.
  */
 @SuppressWarnings({"rawtypes", "unchecked"})
-public abstract class BaseSingleBlockCombineOperator<T extends BaseResultsBlock>
-    extends BaseCombineOperator<T> {
+public abstract class BaseSingleBlockCombineOperator<T extends BaseResultsBlock> extends BaseCombineOperator<T> {
   private static final Logger LOGGER = LoggerFactory.getLogger(BaseSingleBlockCombineOperator.class);
+
+  // Use an unlimited BlockingQueue to store the intermediate results blocks
+  protected final BlockingQueue<BaseResultsBlock> _blockingQueue = new LinkedBlockingQueue<>();
 
   protected BaseSingleBlockCombineOperator(ResultsBlockMerger<T> resultsBlockMerger, List<Operator> operators,
       QueryContext queryContext, ExecutorService executorService) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/GroupByCombineOperator.java
@@ -244,7 +244,7 @@ public class GroupByCombineOperator extends BaseSingleBlockCombineOperator<Group
     } else {
       indexedTable.finish(true, true);
     }
-    GroupByResultsBlock mergedBlock = new GroupByResultsBlock(indexedTable);
+    GroupByResultsBlock mergedBlock = new GroupByResultsBlock(indexedTable, _queryContext);
     mergedBlock.setNumGroupsLimitReached(_numGroupsLimitReached);
     mergedBlock.setNumResizes(indexedTable.getNumResizes());
     mergedBlock.setResizeTimeMs(indexedTable.getResizeTimeMs());

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/MinMaxValueBasedSelectionOrderByCombineOperator.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.operator.combine;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.List;
 import java.util.PriorityQueue;
 import java.util.concurrent.ExecutorService;
@@ -36,6 +35,7 @@ import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.AcquireReleaseColumnsSegmentOperator;
 import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.ExceptionResultsBlock;
+import org.apache.pinot.core.operator.blocks.results.MetadataResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
@@ -63,9 +63,7 @@ public class MinMaxValueBasedSelectionOrderByCombineOperator
 
   // For min/max value based combine, when a thread detects that no more segment needs to be processed, it inserts this
   // special results block, which can be skipped during the merge phase
-  private static final BaseResultsBlock EMPTY_RESULTS_BLOCK =
-      new SelectionResultsBlock(new DataSchema(new String[0], new DataSchema.ColumnDataType[0]),
-          Collections.emptyList());
+  private static final BaseResultsBlock EMPTY_RESULTS_BLOCK = new MetadataResultsBlock();
 
   // Use an AtomicInteger to track the end operator id, beyond which no operator needs to be processed
   private final AtomicInteger _endOperatorId;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/AggregationOperator.java
@@ -28,6 +28,7 @@ import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.query.aggregation.AggregationExecutor;
 import org.apache.pinot.core.query.aggregation.DefaultAggregationExecutor;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.executor.StarTreeAggregationExecutor;
 
 
@@ -38,6 +39,7 @@ import org.apache.pinot.core.startree.executor.StarTreeAggregationExecutor;
 public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
   private static final String EXPLAIN_NAME = "AGGREGATE";
 
+  private final QueryContext _queryContext;
   private final AggregationFunction[] _aggregationFunctions;
   private final BaseProjectOperator<?> _projectOperator;
   private final long _numTotalDocs;
@@ -45,9 +47,10 @@ public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
 
   private int _numDocsScanned = 0;
 
-  public AggregationOperator(AggregationFunction[] aggregationFunctions, BaseProjectOperator<?> projectOperator,
-      long numTotalDocs, boolean useStarTree) {
-    _aggregationFunctions = aggregationFunctions;
+  public AggregationOperator(QueryContext queryContext, BaseProjectOperator<?> projectOperator, long numTotalDocs,
+      boolean useStarTree) {
+    _queryContext = queryContext;
+    _aggregationFunctions = queryContext.getAggregationFunctions();
     _projectOperator = projectOperator;
     _numTotalDocs = numTotalDocs;
     _useStarTree = useStarTree;
@@ -69,7 +72,7 @@ public class AggregationOperator extends BaseOperator<AggregationResultsBlock> {
     }
 
     // Build intermediate result block based on aggregation result from the executor
-    return new AggregationResultsBlock(_aggregationFunctions, aggregationExecutor.getResult());
+    return new AggregationResultsBlock(_aggregationFunctions, aggregationExecutor.getResult(), _queryContext);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedDistinctOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DictionaryBasedDistinctOperator.java
@@ -93,7 +93,7 @@ public class DictionaryBasedDistinctOperator extends BaseOperator<DistinctResult
       }
     }
 
-    return new DistinctResultsBlock(distinctTable);
+    return new DistinctResultsBlock(distinctTable, _queryContext);
   }
 
   private static List<Record> iterateOnDictionary(Dictionary dictionary, int length) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DistinctOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/DistinctOperator.java
@@ -39,16 +39,16 @@ public class DistinctOperator extends BaseOperator<DistinctResultsBlock> {
   private static final String EXPLAIN_NAME = "DISTINCT";
 
   private final IndexSegment _indexSegment;
-  private final BaseProjectOperator<?> _projectOperator;
   private final QueryContext _queryContext;
+  private final BaseProjectOperator<?> _projectOperator;
 
   private int _numDocsScanned = 0;
 
-  public DistinctOperator(IndexSegment indexSegment, BaseProjectOperator<?> projectOperator,
-      QueryContext queryContext) {
+  public DistinctOperator(IndexSegment indexSegment, QueryContext queryContext,
+      BaseProjectOperator<?> projectOperator) {
     _indexSegment = indexSegment;
-    _projectOperator = projectOperator;
     _queryContext = queryContext;
+    _projectOperator = projectOperator;
   }
 
   @Override
@@ -61,7 +61,7 @@ public class DistinctOperator extends BaseOperator<DistinctResultsBlock> {
         break;
       }
     }
-    return new DistinctResultsBlock(executor.getResult());
+    return new DistinctResultsBlock(executor.getResult(), _queryContext);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/EmptySelectionOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/EmptySelectionOperator.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.operator.BaseProjectOperator;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
 
 
@@ -39,12 +40,14 @@ public class EmptySelectionOperator extends BaseOperator<SelectionResultsBlock> 
   private static final String EXPLAIN_NAME = "SELECT_EMPTY";
 
   private final BaseProjectOperator<?> _projectOperator;
+  private final QueryContext _queryContext;
   private final DataSchema _dataSchema;
   private final ExecutionStatistics _executionStatistics;
 
-  public EmptySelectionOperator(IndexSegment indexSegment, List<ExpressionContext> expressions,
-      BaseProjectOperator<?> projectOperator) {
+  public EmptySelectionOperator(IndexSegment indexSegment, QueryContext queryContext,
+      List<ExpressionContext> expressions, BaseProjectOperator<?> projectOperator) {
     _projectOperator = projectOperator;
+    _queryContext = queryContext;
 
     int numExpressions = expressions.size();
     String[] columnNames = new String[numExpressions];
@@ -63,7 +66,7 @@ public class EmptySelectionOperator extends BaseOperator<SelectionResultsBlock> 
 
   @Override
   protected SelectionResultsBlock getNextBlock() {
-    return new SelectionResultsBlock(_dataSchema, Collections.emptyList());
+    return new SelectionResultsBlock(_dataSchema, Collections.emptyList(), _queryContext);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FastFilteredCountOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FastFilteredCountOperator.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.operator.ExecutionStatistics;
 import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 
 
@@ -35,17 +36,19 @@ public class FastFilteredCountOperator extends BaseOperator<AggregationResultsBl
 
   private static final String EXPLAIN_NAME = "FAST_FILTERED_COUNT";
 
-  private final BaseFilterOperator _filterOperator;
+  private final QueryContext _queryContext;
   private final AggregationFunction[] _aggregationFunctions;
+  private final BaseFilterOperator _filterOperator;
   private final SegmentMetadata _segmentMetadata;
 
   private long _docsCounted;
 
-  public FastFilteredCountOperator(AggregationFunction[] aggregationFunctions, BaseFilterOperator filterOperator,
+  public FastFilteredCountOperator(QueryContext queryContext, BaseFilterOperator filterOperator,
       SegmentMetadata segmentMetadata) {
+    _queryContext = queryContext;
+    _aggregationFunctions = queryContext.getAggregationFunctions();
     _filterOperator = filterOperator;
     _segmentMetadata = segmentMetadata;
-    _aggregationFunctions = aggregationFunctions;
   }
 
   @Override
@@ -65,7 +68,7 @@ public class FastFilteredCountOperator extends BaseOperator<AggregationResultsBl
     List<Object> aggregates = new ArrayList<>(1);
     aggregates.add(count);
     _docsCounted += count;
-    return new AggregationResultsBlock(_aggregationFunctions, aggregates);
+    return new AggregationResultsBlock(_aggregationFunctions, aggregates, _queryContext);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredAggregationOperator.java
@@ -32,6 +32,7 @@ import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.query.aggregation.AggregationExecutor;
 import org.apache.pinot.core.query.aggregation.DefaultAggregationExecutor;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.request.context.QueryContext;
 
 
 /**
@@ -44,6 +45,7 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 public class FilteredAggregationOperator extends BaseOperator<AggregationResultsBlock> {
   private static final String EXPLAIN_NAME = "AGGREGATE_FILTERED";
 
+  private final QueryContext _queryContext;
   private final AggregationFunction[] _aggregationFunctions;
   private final List<Pair<AggregationFunction[], BaseProjectOperator<?>>> _projectOperators;
   private final long _numTotalDocs;
@@ -52,9 +54,10 @@ public class FilteredAggregationOperator extends BaseOperator<AggregationResults
   private long _numEntriesScannedInFilter;
   private long _numEntriesScannedPostFilter;
 
-  public FilteredAggregationOperator(AggregationFunction[] aggregationFunctions,
+  public FilteredAggregationOperator(QueryContext queryContext,
       List<Pair<AggregationFunction[], BaseProjectOperator<?>>> projectOperators, long numTotalDocs) {
-    _aggregationFunctions = aggregationFunctions;
+    _queryContext = queryContext;
+    _aggregationFunctions = queryContext.getAggregationFunctions();
     _projectOperators = projectOperators;
     _numTotalDocs = numTotalDocs;
   }
@@ -87,7 +90,7 @@ public class FilteredAggregationOperator extends BaseOperator<AggregationResults
       _numEntriesScannedInFilter += projectOperator.getExecutionStatistics().getNumEntriesScannedInFilter();
       _numEntriesScannedPostFilter += (long) numDocsScanned * projectOperator.getNumColumnsProjected();
     }
-    return new AggregationResultsBlock(_aggregationFunctions, Arrays.asList(result));
+    return new AggregationResultsBlock(_aggregationFunctions, Arrays.asList(result), _queryContext);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
@@ -176,7 +176,7 @@ public class FilteredGroupByOperator extends BaseOperator<GroupByResultsBlock> {
         TableResizer tableResizer = new TableResizer(_dataSchema, _queryContext);
         Collection<IntermediateRecord> intermediateRecords =
             tableResizer.trimInSegmentResults(groupKeyGenerator, groupByResultHolders, trimSize);
-        GroupByResultsBlock resultsBlock = new GroupByResultsBlock(_dataSchema, intermediateRecords);
+        GroupByResultsBlock resultsBlock = new GroupByResultsBlock(_dataSchema, intermediateRecords, _queryContext);
         resultsBlock.setNumGroupsLimitReached(numGroupsLimitReached);
         return resultsBlock;
       }
@@ -184,7 +184,7 @@ public class FilteredGroupByOperator extends BaseOperator<GroupByResultsBlock> {
 
     AggregationGroupByResult aggGroupByResult =
         new AggregationGroupByResult(groupKeyGenerator, _aggregationFunctions, groupByResultHolders);
-    GroupByResultsBlock resultsBlock = new GroupByResultsBlock(_dataSchema, aggGroupByResult);
+    GroupByResultsBlock resultsBlock = new GroupByResultsBlock(_dataSchema, aggGroupByResult, _queryContext);
     resultsBlock.setNumGroupsLimitReached(numGroupsLimitReached);
     return resultsBlock;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/LinearSelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/LinearSelectionOrderByOperator.java
@@ -62,7 +62,7 @@ import org.roaringbitmap.RoaringBitmap;
  */
 public abstract class LinearSelectionOrderByOperator extends BaseOperator<SelectionResultsBlock> {
   protected final IndexSegment _indexSegment;
-
+  protected final QueryContext _queryContext;
   protected final boolean _nullHandlingEnabled;
   // Deduped order-by expressions followed by output expressions from SelectionOperatorUtils.extractExpressions()
   protected final List<ExpressionContext> _expressions;
@@ -83,6 +83,7 @@ public abstract class LinearSelectionOrderByOperator extends BaseOperator<Select
   public LinearSelectionOrderByOperator(IndexSegment indexSegment, QueryContext queryContext,
       List<ExpressionContext> expressions, BaseProjectOperator<?> projectOperator, int numSortedExpressions) {
     _indexSegment = indexSegment;
+    _queryContext = queryContext;
     _nullHandlingEnabled = queryContext.isNullHandlingEnabled();
     _expressions = expressions;
     _projectOperator = projectOperator;
@@ -213,7 +214,7 @@ public abstract class LinearSelectionOrderByOperator extends BaseOperator<Select
 
   @Override
   protected SelectionResultsBlock getNextBlock() {
-    return new SelectionResultsBlock(createDataSchema(), fetch(_listBuilderSupplier), _comparator);
+    return new SelectionResultsBlock(createDataSchema(), fetch(_listBuilderSupplier), _comparator, _queryContext);
   }
 
   protected DataSchema createDataSchema() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/NonScanBasedAggregationOperator.java
@@ -38,6 +38,7 @@ import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.DistinctCountHLLAggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.DistinctCountRawHLLAggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.DistinctCountSmartHLLAggregationFunction;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.local.customobject.MinMaxRangePair;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
@@ -61,16 +62,16 @@ import org.apache.pinot.spi.utils.ByteArray;
  */
 @SuppressWarnings("rawtypes")
 public class NonScanBasedAggregationOperator extends BaseOperator<AggregationResultsBlock> {
-
   private static final String EXPLAIN_NAME = "AGGREGATE_NO_SCAN";
 
+  private final QueryContext _queryContext;
   private final AggregationFunction[] _aggregationFunctions;
   private final DataSource[] _dataSources;
   private final int _numTotalDocs;
 
-  public NonScanBasedAggregationOperator(AggregationFunction[] aggregationFunctions, DataSource[] dataSources,
-      int numTotalDocs) {
-    _aggregationFunctions = aggregationFunctions;
+  public NonScanBasedAggregationOperator(QueryContext queryContext, DataSource[] dataSources, int numTotalDocs) {
+    _queryContext = queryContext;
+    _aggregationFunctions = queryContext.getAggregationFunctions();
     _dataSources = dataSources;
     _numTotalDocs = numTotalDocs;
   }
@@ -132,7 +133,7 @@ public class NonScanBasedAggregationOperator extends BaseOperator<AggregationRes
     }
 
     // Build intermediate result block based on aggregation result from the executor.
-    return new AggregationResultsBlock(_aggregationFunctions, aggregationResults);
+    return new AggregationResultsBlock(_aggregationFunctions, aggregationResults, _queryContext);
   }
 
   private static Double getMinValue(DataSource dataSource) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOnlyOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOnlyOperator.java
@@ -39,10 +39,10 @@ import org.roaringbitmap.RoaringBitmap;
 
 
 public class SelectionOnlyOperator extends BaseOperator<SelectionResultsBlock> {
-
   private static final String EXPLAIN_NAME = "SELECT";
 
   private final IndexSegment _indexSegment;
+  private final QueryContext _queryContext;
   private final boolean _nullHandlingEnabled;
   private final BaseProjectOperator<?> _projectOperator;
   private final List<ExpressionContext> _expressions;
@@ -57,6 +57,7 @@ public class SelectionOnlyOperator extends BaseOperator<SelectionResultsBlock> {
   public SelectionOnlyOperator(IndexSegment indexSegment, QueryContext queryContext,
       List<ExpressionContext> expressions, BaseProjectOperator<?> projectOperator) {
     _indexSegment = indexSegment;
+    _queryContext = queryContext;
     _nullHandlingEnabled = queryContext.isNullHandlingEnabled();
     _projectOperator = projectOperator;
     _expressions = expressions;
@@ -127,7 +128,7 @@ public class SelectionOnlyOperator extends BaseOperator<SelectionResultsBlock> {
       }
     }
 
-    return new SelectionResultsBlock(_dataSchema, _rows);
+    return new SelectionResultsBlock(_dataSchema, _rows, _queryContext);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/SelectionOrderByOperator.java
@@ -184,7 +184,7 @@ public class SelectionOrderByOperator extends BaseOperator<SelectionResultsBlock
     }
     DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);
 
-    return new SelectionResultsBlock(dataSchema, getSortedRows(), _comparator);
+    return new SelectionResultsBlock(dataSchema, getSortedRows(), _comparator, _queryContext);
   }
 
   /**
@@ -303,7 +303,7 @@ public class SelectionOrderByOperator extends BaseOperator<SelectionResultsBlock
     }
     DataSchema dataSchema = new DataSchema(columnNames, columnDataTypes);
 
-    return new SelectionResultsBlock(dataSchema, getSortedRows(), _comparator);
+    return new SelectionResultsBlock(dataSchema, getSortedRows(), _comparator, _queryContext);
   }
 
   private List<Object[]> getSortedRows() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingGroupByCombineOperator.java
@@ -249,7 +249,7 @@ public class StreamingGroupByCombineOperator extends BaseStreamingCombineOperato
     } else {
       indexedTable.finish(true, true);
     }
-    GroupByResultsBlock mergedBlock = new GroupByResultsBlock(indexedTable);
+    GroupByResultsBlock mergedBlock = new GroupByResultsBlock(indexedTable, _queryContext);
     mergedBlock.setNumGroupsLimitReached(_numGroupsLimitReached);
     mergedBlock.setNumResizes(indexedTable.getNumResizes());
     mergedBlock.setResizeTimeMs(indexedTable.getResizeTimeMs());

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingInstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingInstanceResponseOperator.java
@@ -18,22 +18,16 @@
  */
 package org.apache.pinot.core.operator.streaming;
 
-import com.google.common.base.Preconditions;
-import io.grpc.stub.StreamObserver;
-import java.io.IOException;
-import java.util.Collection;
 import java.util.List;
 import org.apache.commons.lang.StringUtils;
-import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.exception.QueryException;
-import org.apache.pinot.common.proto.Server;
-import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.InstanceResponseOperator;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
 import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.ExceptionResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.MetadataResultsBlock;
 import org.apache.pinot.core.operator.combine.BaseCombineOperator;
+import org.apache.pinot.core.query.executor.ResultsBlockStreamer;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.FetchContext;
 import org.apache.pinot.segment.spi.IndexSegment;
@@ -45,53 +39,60 @@ import org.apache.pinot.spi.trace.Tracing;
 public class StreamingInstanceResponseOperator extends InstanceResponseOperator {
   private static final String EXPLAIN_NAME = "STREAMING_INSTANCE_RESPONSE";
 
-  private final StreamObserver<Server.ServerResponse> _streamObserver;
+  private final BaseStreamingCombineOperator<?> _streamingCombineOperator;
+  private final ResultsBlockStreamer _streamer;
 
   public StreamingInstanceResponseOperator(BaseCombineOperator<?> combinedOperator, List<IndexSegment> indexSegments,
-      List<FetchContext> fetchContexts, StreamObserver<Server.ServerResponse> streamObserver,
-      QueryContext queryContext) {
+      List<FetchContext> fetchContexts, ResultsBlockStreamer streamer, QueryContext queryContext) {
     super(combinedOperator, indexSegments, fetchContexts, queryContext);
-    _streamObserver = streamObserver;
+    _streamingCombineOperator =
+        combinedOperator instanceof BaseStreamingCombineOperator ? (BaseStreamingCombineOperator<?>) combinedOperator
+            : null;
+    _streamer = streamer;
   }
 
-  @SuppressWarnings("rawtypes")
   @Override
   protected InstanceResponseBlock getNextBlock() {
-    BaseStreamingCombineOperator<?> streamingCombineOperator = (BaseStreamingCombineOperator) _combineOperator;
     try {
       prefetchAll();
-      streamingCombineOperator.start();
-      BaseResultsBlock resultsBlock = streamingCombineOperator.nextBlock();
-      while (!(resultsBlock instanceof MetadataResultsBlock)) {
-        if (resultsBlock instanceof ExceptionResultsBlock) {
-          return new InstanceResponseBlock(resultsBlock, _queryContext);
+      if (_streamingCombineOperator != null) {
+        _streamingCombineOperator.start();
+        BaseResultsBlock resultsBlock = _streamingCombineOperator.nextBlock();
+        while (!(resultsBlock instanceof MetadataResultsBlock)) {
+          if (resultsBlock instanceof ExceptionResultsBlock) {
+            return new InstanceResponseBlock(resultsBlock);
+          }
+          if (resultsBlock.getNumRows() > 0) {
+            _streamer.send(resultsBlock);
+          }
+          resultsBlock = _streamingCombineOperator.nextBlock();
         }
-        sendBlock(resultsBlock);
-        resultsBlock = streamingCombineOperator.nextBlock();
+        // Return a metadata-only block in the end
+        return new InstanceResponseBlock(resultsBlock);
+      } else {
+        // Handle single block combine operator in streaming fashion
+        BaseResultsBlock resultsBlock = _combineOperator.nextBlock();
+        if (resultsBlock instanceof ExceptionResultsBlock) {
+          return new InstanceResponseBlock(resultsBlock);
+        }
+        if (resultsBlock.getNumRows() > 0) {
+          _streamer.send(resultsBlock);
+        }
+        return new InstanceResponseBlock(resultsBlock).toMetadataOnlyResponseBlock();
       }
-      // Return a metadata-only block
-      return new InstanceResponseBlock(resultsBlock, _queryContext);
     } catch (EarlyTerminationException e) {
       Exception killedErrorMsg = Tracing.getThreadAccountant().getErrorStatus();
       return new InstanceResponseBlock(new ExceptionResultsBlock(new QueryCancelledException(
           "Cancelled while streaming results" + (killedErrorMsg == null ? StringUtils.EMPTY : " " + killedErrorMsg),
-          e)), _queryContext);
+          e)));
     } catch (Exception e) {
-      return new InstanceResponseBlock(new ExceptionResultsBlock(QueryException.DATA_TABLE_SERIALIZATION_ERROR, e),
-          _queryContext);
+      return new InstanceResponseBlock(new ExceptionResultsBlock(QueryException.INTERNAL_ERROR, e));
     } finally {
-      streamingCombineOperator.stop();
+      if (_streamingCombineOperator != null) {
+        _streamingCombineOperator.stop();
+      }
       releaseAll();
     }
-  }
-
-  private void sendBlock(BaseResultsBlock baseResultBlock)
-      throws IOException {
-    DataSchema dataSchema = baseResultBlock.getDataSchema(_queryContext);
-    Collection<Object[]> rows = baseResultBlock.getRows(_queryContext);
-    Preconditions.checkState(dataSchema != null && rows != null, "Malformed data block");
-    DataTable dataTable = baseResultBlock.getDataTable(_queryContext);
-    _streamObserver.onNext(StreamingResponseUtils.getDataResponse(dataTable));
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyOperator.java
@@ -47,6 +47,7 @@ public class StreamingSelectionOnlyOperator extends BaseOperator<SelectionResult
   private static final String EXPLAIN_NAME = "SELECT_STREAMING";
 
   private final IndexSegment _indexSegment;
+  private final QueryContext _queryContext;
   private final List<ExpressionContext> _expressions;
   private final BaseProjectOperator<?> _projectOperator;
   private final BlockValSet[] _blockValSets;
@@ -60,6 +61,7 @@ public class StreamingSelectionOnlyOperator extends BaseOperator<SelectionResult
   public StreamingSelectionOnlyOperator(IndexSegment indexSegment, QueryContext queryContext,
       List<ExpressionContext> expressions, BaseProjectOperator<?> projectOperator) {
     _indexSegment = indexSegment;
+    _queryContext = queryContext;
     _expressions = expressions;
     _projectOperator = projectOperator;
     _nullHandlingEnabled = queryContext.isNullHandlingEnabled();
@@ -118,7 +120,7 @@ public class StreamingSelectionOnlyOperator extends BaseOperator<SelectionResult
       }
     }
     _numDocsScanned += numDocs;
-    return new SelectionResultsBlock(_dataSchema, rows);
+    return new SelectionResultsBlock(_dataSchema, rows, _queryContext);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DistinctPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DistinctPlanNode.java
@@ -71,6 +71,6 @@ public class DistinctPlanNode implements PlanNode {
 
     BaseProjectOperator<?> projectOperator =
         new ProjectPlanNode(_indexSegment, _queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
-    return new DistinctOperator(_indexSegment, projectOperator, _queryContext);
+    return new DistinctOperator(_indexSegment, _queryContext, projectOperator);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
@@ -92,8 +92,7 @@ public class GroupByPlanNode implements PlanNode {
               BaseProjectOperator<?> projectOperator =
                   new StarTreeProjectPlanNode(_queryContext, starTreeV2, aggregationFunctionColumnPairs,
                       groupByExpressions, predicateEvaluatorsMap).run();
-              return new GroupByOperator(aggregationFunctions, groupByExpressions, projectOperator, numTotalDocs,
-                  _queryContext, true);
+              return new GroupByOperator(_queryContext, groupByExpressions, projectOperator, numTotalDocs, true);
             }
           }
         }
@@ -105,7 +104,6 @@ public class GroupByPlanNode implements PlanNode {
     BaseProjectOperator<?> projectOperator =
         new ProjectPlanNode(_indexSegment, _queryContext, expressionsToTransform, DocIdSetPlanNode.MAX_DOC_PER_CALL,
             filterOperator).run();
-    return new GroupByOperator(aggregationFunctions, groupByExpressions, projectOperator, numTotalDocs, _queryContext,
-        false);
+    return new GroupByOperator(_queryContext, groupByExpressions, projectOperator, numTotalDocs, false);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/SelectionPlanNode.java
@@ -59,7 +59,7 @@ public class SelectionPlanNode implements PlanNode {
     if (limit == 0) {
       // Empty selection (LIMIT 0)
       BaseProjectOperator<?> projectOperator = new ProjectPlanNode(_indexSegment, _queryContext, expressions, 0).run();
-      return new EmptySelectionOperator(_indexSegment, expressions, projectOperator);
+      return new EmptySelectionOperator(_indexSegment, _queryContext, expressions, projectOperator);
     }
 
     List<OrderByExpressionContext> orderByExpressions = _queryContext.getOrderByExpressions();

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/StreamingInstanceResponsePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/StreamingInstanceResponsePlanNode.java
@@ -18,29 +18,27 @@
  */
 package org.apache.pinot.core.plan;
 
-import io.grpc.stub.StreamObserver;
 import java.util.List;
-import org.apache.pinot.common.proto.Server;
 import org.apache.pinot.core.operator.InstanceResponseOperator;
 import org.apache.pinot.core.operator.streaming.StreamingInstanceResponseOperator;
+import org.apache.pinot.core.query.executor.ResultsBlockStreamer;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.FetchContext;
 import org.apache.pinot.segment.spi.IndexSegment;
 
 
 public class StreamingInstanceResponsePlanNode extends InstanceResponsePlanNode {
-  private final StreamObserver<Server.ServerResponse> _streamObserver;
+  private final ResultsBlockStreamer _streamer;
 
   public StreamingInstanceResponsePlanNode(CombinePlanNode combinePlanNode, List<IndexSegment> indexSegments,
-      List<FetchContext> fetchContexts, QueryContext queryContext,
-      StreamObserver<Server.ServerResponse> streamObserver) {
+      List<FetchContext> fetchContexts, QueryContext queryContext, ResultsBlockStreamer streamer) {
     super(combinePlanNode, indexSegments, fetchContexts, queryContext);
-    _streamObserver = streamObserver;
+    _streamer = streamer;
   }
 
   @Override
   public InstanceResponseOperator run() {
-    return new StreamingInstanceResponseOperator(_combinePlanNode.run(), _indexSegments, _fetchContexts,
-        _streamObserver, _queryContext);
+    return new StreamingInstanceResponseOperator(_combinePlanNode.run(), _indexSegments, _fetchContexts, _streamer,
+        _queryContext);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/PlanMaker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/PlanMaker.java
@@ -18,13 +18,12 @@
  */
 package org.apache.pinot.core.plan.maker;
 
-import io.grpc.stub.StreamObserver;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import org.apache.pinot.common.metrics.ServerMetrics;
-import org.apache.pinot.common.proto.Server;
 import org.apache.pinot.core.plan.Plan;
 import org.apache.pinot.core.plan.PlanNode;
+import org.apache.pinot.core.query.executor.ResultsBlockStreamer;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
@@ -58,8 +57,7 @@ public interface PlanMaker {
    * segments.
    */
   Plan makeStreamingInstancePlan(List<IndexSegment> indexSegments, QueryContext queryContext,
-      ExecutorService executorService, StreamObserver<Server.ServerResponse> streamObserver,
-      ServerMetrics serverMetrics);
+      ExecutorService executorService, ResultsBlockStreamer streamObserver, ServerMetrics serverMetrics);
 
   /**
    * Returns a segment level {@link PlanNode} for a streaming query which contains the logical execution plan for one

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/QueryExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/QueryExecutor.java
@@ -18,15 +18,11 @@
  */
 package org.apache.pinot.core.query.executor;
 
-import io.grpc.stub.StreamObserver;
 import java.util.concurrent.ExecutorService;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.configuration.ConfigurationException;
-import org.apache.pinot.common.datatable.DataTable;
-import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.ServerMetrics;
-import org.apache.pinot.common.proto.Server;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
@@ -57,43 +53,6 @@ public interface QueryExecutor {
   void shutDown();
 
   /**
-   * Processes the non-streaming query with the given executor service.
-   *
-   * Deprecated: use execute() instead.
-   */
-  @Deprecated
-  default DataTable processQuery(ServerQueryRequest queryRequest, ExecutorService executorService) {
-    return processQuery(queryRequest, executorService, null);
-  }
-
-  /**
-   * Processes the query (streaming or non-streaming) with the given executor service.
-   * <ul>
-   *   <li>
-   *     For streaming request, the returned {@link DataTable} contains only the metadata. The response is streamed back
-   *     via the observer.
-   *   </li>
-   *   <li>
-   *     For non-streaming request, the returned {@link DataTable} contains both data and metadata.
-   *   </li>
-   * </ul>
-   *
-   * Deprecated: use execute() instead.
-   */
-  @Deprecated
-  default DataTable processQuery(ServerQueryRequest queryRequest, ExecutorService executorService,
-      @Nullable StreamObserver<Server.ServerResponse> responseObserver) {
-    InstanceResponseBlock instanceResponse = execute(queryRequest, executorService, responseObserver);
-    try {
-      return instanceResponse.toDataTable();
-    } catch (Exception e) {
-      DataTable metadataOnlyDataTable = instanceResponse.toMetadataOnlyDataTable();
-      metadataOnlyDataTable.addException(QueryException.getException(QueryException.DATA_TABLE_SERIALIZATION_ERROR, e));
-      return metadataOnlyDataTable;
-    }
-  }
-
-  /**
    * Executes the non-streaming query with the given executor service.
    */
   default InstanceResponseBlock execute(ServerQueryRequest queryRequest, ExecutorService executorService) {
@@ -113,5 +72,5 @@ public interface QueryExecutor {
    * </ul>
    */
   InstanceResponseBlock execute(ServerQueryRequest queryRequest, ExecutorService executorService,
-      @Nullable StreamObserver<Server.ServerResponse> responseObserver);
+      @Nullable ResultsBlockStreamer streamer);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ResultsBlockStreamer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ResultsBlockStreamer.java
@@ -1,0 +1,34 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.executor;
+
+import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
+
+
+/**
+ * Streamer for results blocks.
+ */
+public interface ResultsBlockStreamer {
+
+  /**
+   * Sends the results block.
+   */
+  void send(BaseResultsBlock block)
+      throws Exception;
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
@@ -61,10 +61,15 @@ public class ServerQueryRequest {
   private final TimerContext _timerContext;
 
   public ServerQueryRequest(InstanceRequest instanceRequest, ServerMetrics serverMetrics, long queryArrivalTimeMs) {
+    this(instanceRequest, serverMetrics, queryArrivalTimeMs, false);
+  }
+
+  public ServerQueryRequest(InstanceRequest instanceRequest, ServerMetrics serverMetrics, long queryArrivalTimeMs,
+      boolean enableStreaming) {
     _requestId = instanceRequest.getRequestId();
     _brokerId = instanceRequest.getBrokerId() != null ? instanceRequest.getBrokerId() : "unknown";
     _enableTrace = instanceRequest.isEnableTrace();
-    _enableStreaming = false;
+    _enableStreaming = enableStreaming;
     _segmentsToQuery = instanceRequest.getSearchSegments();
     _queryContext = getQueryContext(instanceRequest.getQuery().getPinotQuery());
     _queryId = QueryIdUtils.getQueryId(_brokerId, _requestId,

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
@@ -149,7 +149,8 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
     // Process the query
     InstanceResponseBlock instanceResponse;
     try {
-      instanceResponse = _queryExecutor.execute(queryRequest, _executorService, responseObserver);
+      instanceResponse =
+          _queryExecutor.execute(queryRequest, _executorService, new GrpcResultsBlockStreamer(responseObserver));
     } catch (Exception e) {
       LOGGER.error("Caught exception while processing request {}: {} from broker: {}", queryRequest.getRequestId(),
           queryRequest.getQueryContext(), queryRequest.getBrokerId(), e);

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcResultsBlockStreamer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcResultsBlockStreamer.java
@@ -1,0 +1,49 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.transport.grpc;
+
+import com.google.common.base.Preconditions;
+import io.grpc.stub.StreamObserver;
+import java.io.IOException;
+import java.util.Collection;
+import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.proto.Server;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
+import org.apache.pinot.core.operator.streaming.StreamingResponseUtils;
+import org.apache.pinot.core.query.executor.ResultsBlockStreamer;
+
+
+public class GrpcResultsBlockStreamer implements ResultsBlockStreamer {
+  private final StreamObserver<Server.ServerResponse> _streamObserver;
+
+  public GrpcResultsBlockStreamer(StreamObserver<Server.ServerResponse> streamObserver) {
+    _streamObserver = streamObserver;
+  }
+
+  @Override
+  public void send(BaseResultsBlock block)
+      throws IOException {
+    DataSchema dataSchema = block.getDataSchema();
+    Collection<Object[]> rows = block.getRows();
+    Preconditions.checkState(dataSchema != null && rows != null, "Malformed data block");
+    DataTable dataTable = block.getDataTable();
+    _streamObserver.onNext(StreamingResponseUtils.getDataResponse(dataTable));
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtilsTest.java
@@ -36,7 +36,7 @@ public class ResultsBlockUtilsTest {
       throws IOException {
     // Selection
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable WHERE foo = 'bar'");
-    DataTable dataTable = ResultsBlockUtils.buildEmptyQueryResults(queryContext).getDataTable(queryContext);
+    DataTable dataTable = ResultsBlockUtils.buildEmptyQueryResults(queryContext).getDataTable();
     DataSchema dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"*"});
     assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{ColumnDataType.STRING});
@@ -45,7 +45,7 @@ public class ResultsBlockUtilsTest {
     // Aggregation
     queryContext =
         QueryContextConverterUtils.getQueryContext("SELECT COUNT(*), SUM(a), MAX(b) FROM testTable WHERE foo = 'bar'");
-    dataTable = ResultsBlockUtils.buildEmptyQueryResults(queryContext).getDataTable(queryContext);
+    dataTable = ResultsBlockUtils.buildEmptyQueryResults(queryContext).getDataTable();
     dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"count(*)", "sum(a)", "max(b)"});
     assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
@@ -59,7 +59,7 @@ public class ResultsBlockUtilsTest {
     // Group-by
     queryContext = QueryContextConverterUtils.getQueryContext(
         "SELECT c, d, COUNT(*), SUM(a), MAX(b) FROM testTable WHERE foo = 'bar' GROUP BY c, d");
-    dataTable = ResultsBlockUtils.buildEmptyQueryResults(queryContext).getDataTable(queryContext);
+    dataTable = ResultsBlockUtils.buildEmptyQueryResults(queryContext).getDataTable();
     dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"c", "d", "count(*)", "sum(a)", "max(b)"});
     assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{
@@ -69,7 +69,7 @@ public class ResultsBlockUtilsTest {
 
     // Distinct
     queryContext = QueryContextConverterUtils.getQueryContext("SELECT DISTINCT a, b FROM testTable WHERE foo = 'bar'");
-    dataTable = ResultsBlockUtils.buildEmptyQueryResults(queryContext).getDataTable(queryContext);
+    dataTable = ResultsBlockUtils.buildEmptyQueryResults(queryContext).getDataTable();
     dataSchema = dataTable.getDataSchema();
     assertEquals(dataSchema.getColumnNames(), new String[]{"a", "b"});
     assertEquals(dataSchema.getColumnDataTypes(), new ColumnDataType[]{

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineErrorOperatorsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/CombineErrorOperatorsTest.java
@@ -47,7 +47,12 @@ import static org.testng.Assert.assertTrue;
 public class CombineErrorOperatorsTest {
   private static final int NUM_OPERATORS = 10;
   private static final int NUM_THREADS = 2;
-  private static final long TIMEOUT_MS = 1000L;
+  private static final QueryContext QUERY_CONTEXT =
+      QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable");
+
+  static {
+    QUERY_CONTEXT.setEndTimeMs(Long.MAX_VALUE);
+  }
 
   private ExecutorService _executorService;
 
@@ -63,10 +68,8 @@ public class CombineErrorOperatorsTest {
       operators.add(new RegularOperator());
     }
     operators.add(new ExceptionOperator());
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable");
-    queryContext.setEndTimeMs(System.currentTimeMillis() + TIMEOUT_MS);
     SelectionOnlyCombineOperator combineOperator =
-        new SelectionOnlyCombineOperator(operators, queryContext, _executorService);
+        new SelectionOnlyCombineOperator(operators, QUERY_CONTEXT, _executorService);
     BaseResultsBlock resultsBlock = combineOperator.nextBlock();
     assertTrue(resultsBlock instanceof ExceptionResultsBlock);
     List<ProcessingException> processingExceptions = resultsBlock.getProcessingExceptions();
@@ -84,10 +87,8 @@ public class CombineErrorOperatorsTest {
       operators.add(new RegularOperator());
     }
     operators.add(new ErrorOperator());
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable");
-    queryContext.setEndTimeMs(System.currentTimeMillis() + TIMEOUT_MS);
     SelectionOnlyCombineOperator combineOperator =
-        new SelectionOnlyCombineOperator(operators, queryContext, _executorService);
+        new SelectionOnlyCombineOperator(operators, QUERY_CONTEXT, _executorService);
     BaseResultsBlock resultsBlock = combineOperator.nextBlock();
     assertTrue(resultsBlock instanceof ExceptionResultsBlock);
     List<ProcessingException> processingExceptions = resultsBlock.getProcessingExceptions();
@@ -106,10 +107,8 @@ public class CombineErrorOperatorsTest {
     }
     operators.add(new ExceptionOperator());
     operators.add(new ErrorOperator());
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable");
-    queryContext.setEndTimeMs(System.currentTimeMillis() + TIMEOUT_MS);
     SelectionOnlyCombineOperator combineOperator =
-        new SelectionOnlyCombineOperator(operators, queryContext, _executorService);
+        new SelectionOnlyCombineOperator(operators, QUERY_CONTEXT, _executorService);
     BaseResultsBlock resultsBlock = combineOperator.nextBlock();
     assertTrue(resultsBlock instanceof ExceptionResultsBlock);
     List<ProcessingException> processingExceptions = resultsBlock.getProcessingExceptions();
@@ -176,7 +175,7 @@ public class CombineErrorOperatorsTest {
     protected Block getNextBlock() {
       return new SelectionResultsBlock(
           new DataSchema(new String[]{"myColumn"}, new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT}),
-          new ArrayList<>());
+          new ArrayList<>(), QUERY_CONTEXT);
     }
 
     @Override

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/PrioritySchedulerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/PrioritySchedulerTest.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.query.scheduler;
 
 import com.google.common.util.concurrent.ListenableFuture;
 import com.google.common.util.concurrent.Uninterruptibles;
-import io.grpc.stub.StreamObserver;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -43,10 +42,10 @@ import org.apache.pinot.common.datatable.DataTable.MetadataKey;
 import org.apache.pinot.common.datatable.DataTableFactory;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metrics.ServerMetrics;
-import org.apache.pinot.common.proto.Server;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
 import org.apache.pinot.core.query.executor.QueryExecutor;
+import org.apache.pinot.core.query.executor.ResultsBlockStreamer;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.resources.PolicyBasedResourceManager;
 import org.apache.pinot.core.query.scheduler.resources.ResourceLimitPolicy;
@@ -298,7 +297,7 @@ public class PrioritySchedulerTest {
 
     @Override
     public InstanceResponseBlock execute(ServerQueryRequest queryRequest, ExecutorService executorService,
-        @Nullable StreamObserver<Server.ServerResponse> responseObserver) {
+        @Nullable ResultsBlockStreamer streamer) {
       if (_useBarrier) {
         try {
           _startupBarrier.await();

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOperatorServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOperatorServiceTest.java
@@ -161,11 +161,11 @@ public class SelectionOperatorServiceTest {
     List<Object[]> mergedRows = new ArrayList<>(2);
     mergedRows.add(_row1);
     mergedRows.add(_row2);
-    SelectionResultsBlock mergedBlock = new SelectionResultsBlock(_dataSchema, mergedRows);
+    SelectionResultsBlock mergedBlock = new SelectionResultsBlock(_dataSchema, mergedRows, _queryContext);
     List<Object[]> rowsToMerge = new ArrayList<>(2);
     rowsToMerge.add(_row3);
     rowsToMerge.add(_row4);
-    SelectionResultsBlock blockToMerge = new SelectionResultsBlock(_dataSchema, rowsToMerge);
+    SelectionResultsBlock blockToMerge = new SelectionResultsBlock(_dataSchema, rowsToMerge, _queryContext);
     SelectionOperatorUtils.mergeWithoutOrdering(mergedBlock, blockToMerge, 3);
     assertEquals(mergedRows.size(), 3);
     assertSame(mergedRows.get(0), _row1);
@@ -179,12 +179,15 @@ public class SelectionOperatorServiceTest {
     Comparator<Object[]> comparator =
         OrderByComparatorFactory.getComparator(_queryContext.getOrderByExpressions(), false);
     int maxNumRows = _queryContext.getOffset() + _queryContext.getLimit();
-    SelectionResultsBlock mergedBlock = new SelectionResultsBlock(_dataSchema, Collections.emptyList(), comparator);
+    SelectionResultsBlock mergedBlock =
+        new SelectionResultsBlock(_dataSchema, Collections.emptyList(), comparator, _queryContext);
     List<Object[]> rowsToMerge1 = Arrays.asList(_row2, _row1);
-    SelectionResultsBlock blockToMerge1 = new SelectionResultsBlock(_dataSchema, rowsToMerge1, comparator);
+    SelectionResultsBlock blockToMerge1 =
+        new SelectionResultsBlock(_dataSchema, rowsToMerge1, comparator, _queryContext);
     SelectionOperatorUtils.mergeWithOrdering(mergedBlock, blockToMerge1, maxNumRows);
     List<Object[]> rowsToMerge2 = Arrays.asList(_row4, _row3);
-    SelectionResultsBlock blockToMerge2 = new SelectionResultsBlock(_dataSchema, rowsToMerge2, comparator);
+    SelectionResultsBlock blockToMerge2 =
+        new SelectionResultsBlock(_dataSchema, rowsToMerge2, comparator, _queryContext);
     SelectionOperatorUtils.mergeWithOrdering(mergedBlock, blockToMerge2, maxNumRows);
     List<Object[]> mergedRows = mergedBlock.getRows();
     assertEquals(mergedRows.size(), 3);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -18,31 +18,39 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
-import com.google.common.collect.ImmutableList;
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
-import java.util.LinkedList;
 import java.util.List;
-import java.util.function.Function;
-import javax.annotation.Nullable;
+import java.util.Map;
+import java.util.concurrent.ArrayBlockingQueue;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.pinot.common.datablock.DataBlock;
-import org.apache.pinot.common.datablock.DataBlockUtils;
 import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
-import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
-import org.apache.pinot.core.operator.blocks.results.DistinctResultsBlock;
-import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
+import org.apache.pinot.core.operator.blocks.results.MetadataResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
+import org.apache.pinot.core.query.executor.QueryExecutor;
+import org.apache.pinot.core.query.executor.ResultsBlockStreamer;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.utils.TypeUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionValue;
 
 
 /**
@@ -61,27 +69,40 @@ import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
 public class LeafStageTransferableBlockOperator extends MultiStageOperator {
   private static final String EXPLAIN_NAME = "LEAF_STAGE_TRANSFER_OPERATOR";
 
-  private final LinkedList<ServerQueryRequest> _serverQueryRequestQueue;
-  private final DataSchema _desiredDataSchema;
-  private final Function<ServerQueryRequest, InstanceResponseBlock> _processCall;
+  // Use a special results block to indicate that this is the last results block
+  private static final MetadataResultsBlock LAST_RESULTS_BLOCK = new MetadataResultsBlock();
 
-  private InstanceResponseBlock _errorBlock;
+  private final List<ServerQueryRequest> _requests;
+  private final DataSchema _dataSchema;
+  private final QueryExecutor _queryExecutor;
+  private final ExecutorService _executorService;
 
-  public LeafStageTransferableBlockOperator(OpChainExecutionContext context,
-      Function<ServerQueryRequest, InstanceResponseBlock> processCall, List<ServerQueryRequest> serverQueryRequestList,
-      DataSchema dataSchema) {
+  // Use a limit-sized BlockingQueue to store the results blocks and apply back pressure to the single-stage threads
+  private final BlockingQueue<BaseResultsBlock> _blockingQueue;
+
+  private Future<Void> _executionFuture;
+  private volatile Map<Integer, String> _exceptions;
+  private volatile Map<String, String> _executionStats;
+
+  public LeafStageTransferableBlockOperator(OpChainExecutionContext context, List<ServerQueryRequest> requests,
+      DataSchema dataSchema, QueryExecutor queryExecutor, ExecutorService executorService) {
     super(context);
-    _processCall = processCall;
-    _serverQueryRequestQueue = new LinkedList<>(serverQueryRequestList);
-    _desiredDataSchema = dataSchema;
+    int numRequests = requests.size();
+    Preconditions.checkArgument(numRequests == 1 || numRequests == 2, "Expected 1 or 2 requests, got: %s", numRequests);
+    _requests = requests;
+    _dataSchema = dataSchema;
+    _queryExecutor = queryExecutor;
+    _executorService = executorService;
+    Integer maxStreamingPendingBlocks = QueryOptionsUtils.getMaxStreamingPendingBlocks(context.getRequestMetadata());
+    _blockingQueue = new ArrayBlockingQueue<>(maxStreamingPendingBlocks != null ? maxStreamingPendingBlocks
+        : QueryOptionValue.DEFAULT_MAX_STREAMING_PENDING_BLOCKS);
   }
 
   @Override
   public List<MultiStageOperator> getChildOperators() {
-    return ImmutableList.of();
+    return Collections.emptyList();
   }
 
-  @Nullable
   @Override
   public String toExplainString() {
     return EXPLAIN_NAME;
@@ -89,37 +110,142 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
 
   @Override
   protected TransferableBlock getNextBlock() {
-    if (_errorBlock != null) {
-      throw new RuntimeException("Leaf transfer terminated. next block should no longer be called.");
+    if (_executionFuture == null) {
+      _executionFuture = startExecution();
     }
-    // runLeafStage
-    InstanceResponseBlock responseBlock = getNextBlockFromLeafStage();
-    if (responseBlock == null) {
-      // finished getting next block from leaf stage. returning EOS
-      return new TransferableBlock(DataBlockUtils.getEndOfStreamDataBlock());
-    } else if (!responseBlock.getExceptions().isEmpty()) {
-      // get error from leaf stage, return ERROR
-      _errorBlock = responseBlock;
-      return new TransferableBlock(DataBlockUtils.getErrorDataBlock(_errorBlock.getExceptions()));
-    } else {
-      // return normal block.
-      OperatorStats operatorStats = _opChainStats.getOperatorStats(_context, getOperatorId());
-      operatorStats.recordExecutionStats(responseBlock.getResponseMetadata());
-      if (responseBlock.getResultsBlock() != null && responseBlock.getResultsBlock().getNumRows() > 0) {
-        return composeTransferableBlock(responseBlock, _desiredDataSchema);
-      } else {
-        return new TransferableBlock(Collections.emptyList(), _desiredDataSchema, DataBlock.Type.ROW);
+    try {
+      BaseResultsBlock resultsBlock =
+          _blockingQueue.poll(_context.getDeadlineMs() - System.currentTimeMillis(), TimeUnit.MILLISECONDS);
+      if (resultsBlock == null) {
+        throw new TimeoutException("Timed out waiting for results block");
       }
+      // Terminate when receiving exception block
+      Map<Integer, String> exceptions = _exceptions;
+      if (exceptions != null) {
+        return TransferableBlockUtils.getErrorTransferableBlock(exceptions);
+      }
+      if (resultsBlock != LAST_RESULTS_BLOCK) {
+        // Regular data block
+        return composeTransferableBlock(resultsBlock, _dataSchema);
+      } else {
+        // All data blocks have been returned. Record the stats and return EOS.
+        Map<String, String> executionStats = _executionStats;
+        OperatorStats operatorStats = _opChainStats.getOperatorStats(_context, getOperatorId());
+        operatorStats.recordExecutionStats(executionStats);
+        return TransferableBlockUtils.getEndOfStreamTransferableBlock();
+      }
+    } catch (Exception e) {
+      return TransferableBlockUtils.getErrorTransferableBlock(e);
     }
   }
 
-  @Nullable
-  private InstanceResponseBlock getNextBlockFromLeafStage() {
-    if (!_serverQueryRequestQueue.isEmpty()) {
-      ServerQueryRequest request = _serverQueryRequestQueue.pop();
-      return _processCall.apply(request);
-    } else {
-      return null;
+  private Future<Void> startExecution() {
+    ResultsBlockConsumer resultsBlockConsumer = new ResultsBlockConsumer();
+    return _executorService.submit(() -> {
+      try {
+        if (_requests.size() == 1) {
+          ServerQueryRequest request = _requests.get(0);
+          InstanceResponseBlock instanceResponseBlock =
+              _queryExecutor.execute(request, _executorService, resultsBlockConsumer);
+          // TODO: Revisit if we should treat all exceptions as query failure. Currently MERGE_RESPONSE_ERROR and
+          //       SERVER_SEGMENT_MISSING_ERROR are counted as query failure.
+          Map<Integer, String> exceptions = instanceResponseBlock.getExceptions();
+          if (!exceptions.isEmpty()) {
+            _exceptions = exceptions;
+          } else {
+            // NOTE: Instance response block might contain data (not metadata only) when all the segments are pruned.
+            //       Add the results block if it contains data.
+            BaseResultsBlock resultsBlock = instanceResponseBlock.getResultsBlock();
+            if (resultsBlock != null && resultsBlock.getNumRows() > 0) {
+              addResultsBlock(resultsBlock);
+            }
+            // Collect the execution stats
+            _executionStats = instanceResponseBlock.getResponseMetadata();
+          }
+        } else {
+          assert _requests.size() == 2;
+          Future<?>[] futures = new Future[2];
+          CountDownLatch latch = new CountDownLatch(2);
+          for (int i = 0; i < 2; i++) {
+            ServerQueryRequest request = _requests.get(i);
+            futures[i] = _executorService.submit(() -> {
+              try {
+                InstanceResponseBlock instanceResponseBlock =
+                    _queryExecutor.execute(request, _executorService, resultsBlockConsumer);
+                Map<Integer, String> exceptions = instanceResponseBlock.getExceptions();
+                if (!exceptions.isEmpty()) {
+                  // Drain the latch when receiving exception block and not wait for the other thread to finish
+                  _exceptions = exceptions;
+                  latch.countDown();
+                } else {
+                  // NOTE: Instance response block might contain data (not metadata only) when all the segments are
+                  //       pruned. Add the results block if it contains data.
+                  BaseResultsBlock resultsBlock = instanceResponseBlock.getResultsBlock();
+                  if (resultsBlock != null && resultsBlock.getNumRows() > 0) {
+                    addResultsBlock(resultsBlock);
+                  }
+                  // Collect the execution stats
+                  Map<String, String> executionStats = instanceResponseBlock.getResponseMetadata();
+                  synchronized (LeafStageTransferableBlockOperator.this) {
+                    if (_executionStats == null) {
+                      _executionStats = executionStats;
+                    } else {
+                      aggregateExecutionStats(_executionStats, executionStats);
+                    }
+                  }
+                }
+                return null;
+              } finally {
+                latch.countDown();
+              }
+            });
+          }
+          try {
+            if (!latch.await(_context.getDeadlineMs() - System.currentTimeMillis(), TimeUnit.MILLISECONDS)) {
+              throw new TimeoutException("Timed out waiting for leaf stage to finish");
+            }
+            // Propagate the exception thrown by the leaf stage
+            for (Future<?> future : futures) {
+              future.get();
+            }
+          } finally {
+            for (Future<?> future : futures) {
+              future.cancel(true);
+            }
+          }
+        }
+        return null;
+      } finally {
+        // Always add the last results block to mark the end of the execution
+        addResultsBlock(LAST_RESULTS_BLOCK);
+      }
+    });
+  }
+
+  @VisibleForTesting
+  void addResultsBlock(BaseResultsBlock resultsBlock)
+      throws InterruptedException, TimeoutException {
+    if (!_blockingQueue.offer(resultsBlock, _context.getDeadlineMs() - System.currentTimeMillis(),
+        TimeUnit.MILLISECONDS)) {
+      throw new TimeoutException("Timed out waiting to add results block");
+    }
+  }
+
+  // TODO: Revisit the stats aggregation logic
+  private void aggregateExecutionStats(Map<String, String> stats1, Map<String, String> stats2) {
+    for (Map.Entry<String, String> entry : stats2.entrySet()) {
+      String k2 = entry.getKey();
+      String v2 = entry.getValue();
+      stats1.compute(k2, (k1, v1) -> {
+        if (v1 == null) {
+          return v2;
+        }
+        try {
+          return Long.toString(Long.parseLong(v1) + Long.parseLong(v2));
+        } catch (Exception e) {
+          return v1 + "\n" + v2;
+        }
+      });
     }
   }
 
@@ -132,93 +258,40 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     return true;
   }
 
-  /**
-   * this is data transfer block compose method is here to ensure that V1 results match what the expected projection
-   * schema in the calcite logical operator.
-   * <p> it applies different clean up mechanism based on different type of {@link BaseResultsBlock} and the
-   *     {@link org.apache.pinot.core.query.request.context.QueryContext}.</p>
-   * <p> this also applies to the canonicalization of the data types during post post-process step.</p>
-   *
-   * @param responseBlock result block from leaf stage
-   * @param desiredDataSchema the desired schema for send operator
-   * @return the converted {@link TransferableBlock} that conform with the desiredDataSchema
-   */
-  private static TransferableBlock composeTransferableBlock(InstanceResponseBlock responseBlock,
-      DataSchema desiredDataSchema) {
-    BaseResultsBlock resultsBlock = responseBlock.getResultsBlock();
-    if (resultsBlock instanceof SelectionResultsBlock) {
-      return composeSelectTransferableBlock(responseBlock, desiredDataSchema);
-    } else if (resultsBlock instanceof AggregationResultsBlock) {
-      return composeAggregationTransferableBlock(responseBlock, desiredDataSchema);
-    } else if (resultsBlock instanceof GroupByResultsBlock) {
-      return composeGroupByTransferableBlock(responseBlock, desiredDataSchema);
-    } else if (resultsBlock instanceof DistinctResultsBlock) {
-      return composeDistinctTransferableBlock(responseBlock, desiredDataSchema);
-    } else {
-      throw new IllegalArgumentException("Unsupported result block type: " + resultsBlock);
+  @Override
+  public void close() {
+    if (_executionFuture != null) {
+      _executionFuture.cancel(true);
     }
   }
 
   /**
-   * we only need to rearrange columns when distinct is not conforming with selection columns, specifically:
-   * <ul>
-   *   <li> when distinct is not returning final result:
-   *       it should never happen as non-final result contains Object opaque columns v2 engine can't process.</li>
-   *   <li> when distinct columns are not all being selected:
-   *       it should never happen as leaf stage MUST return the entire list.</li>
-   * </ul>
-   *
-   * @see LeafStageTransferableBlockOperator#composeTransferableBlock(InstanceResponseBlock, DataSchema).
+   * Composes the {@link TransferableBlock} from the {@link BaseResultsBlock} returned from single-stage engine. It
+   * converts the data types of the results to conform with the desired data schema asked by the multi-stage engine.
    */
-  @SuppressWarnings("ConstantConditions")
-  private static TransferableBlock composeDistinctTransferableBlock(InstanceResponseBlock responseBlock,
+  private static TransferableBlock composeTransferableBlock(BaseResultsBlock resultsBlock,
       DataSchema desiredDataSchema) {
-    return composeDirectTransferableBlock(responseBlock, desiredDataSchema);
+    if (resultsBlock instanceof SelectionResultsBlock) {
+      return composeSelectTransferableBlock((SelectionResultsBlock) resultsBlock, desiredDataSchema);
+    } else {
+      return composeDirectTransferableBlock(resultsBlock, desiredDataSchema);
+    }
   }
 
   /**
-   * Calcite generated {@link DataSchema} should conform with Pinot's group by result schema thus we only need to check
-   * for correctness similar to distinct case.
-   *
-   * @see LeafStageTransferableBlockOperator#composeDirectTransferableBlock(InstanceResponseBlock, DataSchema).
-   * @see LeafStageTransferableBlockOperator#composeTransferableBlock(InstanceResponseBlock, DataSchema).
+   * For selection, we need to check if the columns are in order. If not, we need to re-arrange the columns.
    */
   @SuppressWarnings("ConstantConditions")
-  private static TransferableBlock composeGroupByTransferableBlock(InstanceResponseBlock responseBlock,
+  private static TransferableBlock composeSelectTransferableBlock(SelectionResultsBlock resultsBlock,
       DataSchema desiredDataSchema) {
-    return composeDirectTransferableBlock(responseBlock, desiredDataSchema);
-  }
-
-  /**
-   * Calcite generated {@link DataSchema} should conform with Pinot's agg result schema thus we only need to check
-   * for correctness similar to distinct case.
-   *
-   * @see LeafStageTransferableBlockOperator#composeDirectTransferableBlock(InstanceResponseBlock, DataSchema).
-   * @see LeafStageTransferableBlockOperator#composeTransferableBlock(InstanceResponseBlock, DataSchema).
-   */
-  @SuppressWarnings("ConstantConditions")
-  private static TransferableBlock composeAggregationTransferableBlock(InstanceResponseBlock responseBlock,
-      DataSchema desiredDataSchema) {
-    return composeDirectTransferableBlock(responseBlock, desiredDataSchema);
-  }
-
-  /**
-   * Only re-arrange columns to match the projection in the case of select / order-by, when the desiredDataSchema
-   * doesn't conform with the result block schema exactly.
-   *
-   * @see LeafStageTransferableBlockOperator#composeTransferableBlock(InstanceResponseBlock, DataSchema).
-   */
-  @SuppressWarnings("ConstantConditions")
-  private static TransferableBlock composeSelectTransferableBlock(InstanceResponseBlock responseBlock,
-      DataSchema desiredDataSchema) {
-    DataSchema resultSchema = responseBlock.getDataSchema();
+    DataSchema resultSchema = resultsBlock.getDataSchema();
     List<String> selectionColumns =
-        SelectionOperatorUtils.getSelectionColumns(responseBlock.getQueryContext(), resultSchema);
+        SelectionOperatorUtils.getSelectionColumns(resultsBlock.getQueryContext(), resultSchema);
     int[] columnIndices = SelectionOperatorUtils.getColumnIndices(selectionColumns, resultSchema);
     if (!inOrder(columnIndices)) {
-      return composeColumnIndexedTransferableBlock(responseBlock, desiredDataSchema, columnIndices);
+      return composeColumnIndexedTransferableBlock(resultsBlock, desiredDataSchema, columnIndices);
     } else {
-      return composeDirectTransferableBlock(responseBlock, desiredDataSchema);
+      return composeDirectTransferableBlock(resultsBlock, desiredDataSchema);
     }
   }
 
@@ -231,15 +304,10 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     return true;
   }
 
-  /**
-   * Created {@link TransferableBlock} using column indices.
-   *
-   * @see LeafStageTransferableBlockOperator#composeTransferableBlock(InstanceResponseBlock, DataSchema).
-   */
-  private static TransferableBlock composeColumnIndexedTransferableBlock(InstanceResponseBlock responseBlock,
+  private static TransferableBlock composeColumnIndexedTransferableBlock(BaseResultsBlock block,
       DataSchema outputDataSchema, int[] columnIndices) {
-    List<Object[]> resultRows = responseBlock.getRows();
-    DataSchema inputDataSchema = responseBlock.getDataSchema();
+    List<Object[]> resultRows = block.getRows();
+    DataSchema inputDataSchema = block.getDataSchema();
     assert resultRows != null && inputDataSchema != null;
     ColumnDataType[] inputStoredTypes = inputDataSchema.getStoredColumnDataTypes();
     ColumnDataType[] outputStoredTypes = outputDataSchema.getStoredColumnDataTypes();
@@ -291,16 +359,9 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     return resultRow;
   }
 
-  /**
-   * Fallback mechanism for {@link TransferableBlock}, used when no special handling is necessary. This method only
-   * performs {@link ColumnDataType} canonicalization.
-   *
-   * @see LeafStageTransferableBlockOperator#composeTransferableBlock(InstanceResponseBlock, DataSchema).
-   */
-  private static TransferableBlock composeDirectTransferableBlock(InstanceResponseBlock responseBlock,
-      DataSchema outputDataSchema) {
-    List<Object[]> resultRows = responseBlock.getRows();
-    DataSchema inputDataSchema = responseBlock.getDataSchema();
+  private static TransferableBlock composeDirectTransferableBlock(BaseResultsBlock block, DataSchema outputDataSchema) {
+    List<Object[]> resultRows = block.getRows();
+    DataSchema inputDataSchema = block.getDataSchema();
     assert resultRows != null && inputDataSchema != null;
     ColumnDataType[] inputStoredTypes = inputDataSchema.getStoredColumnDataTypes();
     ColumnDataType[] outputStoredTypes = outputDataSchema.getStoredColumnDataTypes();
@@ -319,6 +380,15 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
       if (value != null && inputStoredTypes[colId] != outputStoredTypes[colId]) {
         row[colId] = TypeUtils.convert(value, outputStoredTypes[colId]);
       }
+    }
+  }
+
+  private class ResultsBlockConsumer implements ResultsBlockStreamer {
+
+    @Override
+    public void send(BaseResultsBlock block)
+        throws InterruptedException, TimeoutException {
+      addResultsBlock(block);
     }
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryServerEnclosure.java
@@ -20,13 +20,10 @@ package org.apache.pinot.query;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.common.metrics.ServerMetrics;
-import org.apache.pinot.common.utils.NamedThreadFactory;
 import org.apache.pinot.common.utils.SchemaUtils;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.query.runtime.QueryRunner;
@@ -63,25 +60,17 @@ public class QueryServerEnclosure {
   private static final String SCHEMAS_PREFIX = "/SCHEMAS/";
 
   private final int _queryRunnerPort;
-  private final Map<String, Object> _runnerConfig = new HashMap<>();
-  private final InstanceDataManager _instanceDataManager;
-  private final HelixManager _helixManager;
-
   private final QueryRunner _queryRunner;
-  private final ExecutorService _executor =
-      Executors.newCachedThreadPool(new NamedThreadFactory("QueryServerTest_Server"));
 
   public QueryServerEnclosure(MockInstanceDataManagerFactory factory) {
-    try {
-      _instanceDataManager = factory.buildInstanceDataManager();
-      _helixManager = mockHelixManager(factory.buildSchemaMap());
-      _queryRunnerPort = QueryTestUtils.getAvailablePort();
-      _runnerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT, _queryRunnerPort);
-      _runnerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME, "Server_localhost");
-      _queryRunner = new QueryRunner();
-    } catch (Exception e) {
-      throw new RuntimeException("Test Failed!", e);
-    }
+    _queryRunnerPort = QueryTestUtils.getAvailablePort();
+    Map<String, Object> runnerConfig = new HashMap<>();
+    runnerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME, "Server_localhost");
+    runnerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT, _queryRunnerPort);
+    InstanceDataManager instanceDataManager = factory.buildInstanceDataManager();
+    HelixManager helixManager = mockHelixManager(factory.buildSchemaMap());
+    _queryRunner = new QueryRunner();
+    _queryRunner.init(new PinotConfiguration(runnerConfig), instanceDataManager, helixManager, mockServiceMetrics());
   }
 
   private HelixManager mockHelixManager(Map<String, Schema> schemaMap) {
@@ -111,23 +100,16 @@ public class QueryServerEnclosure {
     return _queryRunnerPort;
   }
 
-  public void start()
-      throws Exception {
-    PinotConfiguration configuration = new PinotConfiguration(_runnerConfig);
-    _queryRunner.init(configuration, _instanceDataManager, _helixManager, mockServiceMetrics());
+  public void start() {
     _queryRunner.start();
   }
 
   public void shutDown() {
-    try {
-      _queryRunner.shutDown();
-    } catch (Exception e) {
-      throw new RuntimeException(e);
-    }
+    _queryRunner.shutDown();
   }
 
   public void processQuery(DistributedStagePlan distributedStagePlan, Map<String, String> requestMetadataMap) {
-    _executor.submit(() -> {
+    _queryRunner.getExecutorService().submit(() -> {
       try {
         _queryRunner.processQuery(distributedStagePlan, requestMetadataMap);
       } catch (Exception e) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperatorTest.java
@@ -18,21 +18,20 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.function.Function;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicReference;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
-import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
-import org.apache.pinot.core.operator.blocks.results.AggregationResultsBlock;
-import org.apache.pinot.core.operator.blocks.results.DistinctResultsBlock;
-import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
+import org.apache.pinot.core.operator.blocks.results.BaseResultsBlock;
+import org.apache.pinot.core.operator.blocks.results.MetadataResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
-import org.apache.pinot.core.query.distinct.DistinctTable;
+import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
@@ -42,30 +41,61 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.testng.Assert;
+import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 
 // TODO: add tests for Agg / GroupBy / Distinct result blocks
 public class LeafStageTransferableBlockOperatorTest {
+  private final ExecutorService _executorService = Executors.newCachedThreadPool();
+  private final AtomicReference<LeafStageTransferableBlockOperator> _operatorRef = new AtomicReference<>();
+
   private AutoCloseable _mocks;
 
   @Mock
   private VirtualServerAddress _serverAddress;
 
   @BeforeMethod
-  public void setUp() {
+  public void setUpMethod() {
     _mocks = MockitoAnnotations.openMocks(this);
     Mockito.when(_serverAddress.toString()).thenReturn(new VirtualServerAddress("mock", 80, 0).toString());
   }
 
   @AfterMethod
-  public void tearDown()
+  public void tearDownMethod()
       throws Exception {
     _mocks.close();
+  }
+
+  @AfterClass
+  public void tearDown() {
+    _executorService.shutdown();
+  }
+
+  private QueryExecutor mockQueryExecutor(List<BaseResultsBlock> dataBlocks, InstanceResponseBlock metadataBlock) {
+    QueryExecutor queryExecutor = mock(QueryExecutor.class);
+    when(queryExecutor.execute(any(), any(), any())).thenAnswer(invocation -> {
+      LeafStageTransferableBlockOperator operator = _operatorRef.get();
+      for (BaseResultsBlock dataBlock : dataBlocks) {
+        operator.addResultsBlock(dataBlock);
+      }
+      return metadataBlock;
+    });
+    return queryExecutor;
+  }
+
+  private List<ServerQueryRequest> mockQueryRequests(int numRequests) {
+    List<ServerQueryRequest> queryRequests = new ArrayList<>(numRequests);
+    for (int i = 0; i < numRequests; i++) {
+      queryRequests.add(mock(ServerQueryRequest.class));
+    }
+    return queryRequests;
   }
 
   @Test
@@ -74,11 +104,14 @@ public class LeafStageTransferableBlockOperatorTest {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT strCol, intCol FROM tbl");
     DataSchema schema = new DataSchema(new String[]{"strCol", "intCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
-    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
-        new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2})), queryContext));
+    List<BaseResultsBlock> dataBlocks = Collections.singletonList(
+        new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2}), queryContext));
+    InstanceResponseBlock metadataBlock = new InstanceResponseBlock(new MetadataResultsBlock());
+    QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, metadataBlock);
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(),
-            getStaticBlockProcessor(resultsBlockList), getStaticServerQueryRequests(resultsBlockList.size()), schema);
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), mockQueryRequests(1), schema,
+            queryExecutor, _executorService);
+    _operatorRef.set(operator);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -86,7 +119,9 @@ public class LeafStageTransferableBlockOperatorTest {
     // Then:
     Assert.assertEquals(resultBlock.getContainer().get(0), new Object[]{"foo", 1});
     Assert.assertEquals(resultBlock.getContainer().get(1), new Object[]{"", 2});
-    Assert.assertTrue(operator.nextBlock().isEndOfStreamBlock(), "Expected EOS after reading two rows");
+    Assert.assertTrue(operator.nextBlock().isEndOfStreamBlock(), "Expected EOS after reading 2 blocks");
+
+    operator.close();
   }
 
   @Test
@@ -100,13 +135,14 @@ public class LeafStageTransferableBlockOperatorTest {
         new DataSchema(new String[]{"boolCol", "tsCol", "newNamedBoolCol"}, new DataSchema.ColumnDataType[]{
             DataSchema.ColumnDataType.BOOLEAN, DataSchema.ColumnDataType.TIMESTAMP, DataSchema.ColumnDataType.BOOLEAN
         });
-    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
-        new SelectionResultsBlock(resultSchema,
-            Arrays.asList(new Object[]{1, 1660000000000L}, new Object[]{0, 1600000000000L})), queryContext));
+    List<BaseResultsBlock> dataBlocks = Collections.singletonList(new SelectionResultsBlock(resultSchema,
+        Arrays.asList(new Object[]{1, 1660000000000L}, new Object[]{0, 1600000000000L}), queryContext));
+    InstanceResponseBlock metadataBlock = new InstanceResponseBlock(new MetadataResultsBlock());
+    QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, metadataBlock);
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(),
-            getStaticBlockProcessor(resultsBlockList), getStaticServerQueryRequests(resultsBlockList.size()),
-            desiredSchema);
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), mockQueryRequests(1),
+            desiredSchema, queryExecutor, _executorService);
+    _operatorRef.set(operator);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
@@ -114,7 +150,9 @@ public class LeafStageTransferableBlockOperatorTest {
     // Then:
     Assert.assertEquals(resultBlock.getContainer().get(0), new Object[]{1, 1660000000000L, 1});
     Assert.assertEquals(resultBlock.getContainer().get(1), new Object[]{0, 1600000000000L, 0});
-    Assert.assertTrue(operator.nextBlock().isEndOfStreamBlock(), "Expected EOS after reading two rows");
+    Assert.assertTrue(operator.nextBlock().isEndOfStreamBlock(), "Expected EOS after reading 2 blocks");
+
+    operator.close();
   }
 
   @Test
@@ -123,16 +161,15 @@ public class LeafStageTransferableBlockOperatorTest {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT strCol, intCol FROM tbl");
     DataSchema schema = new DataSchema(new String[]{"strCol", "intCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
-    List<InstanceResponseBlock> resultsBlockList = Arrays.asList(new InstanceResponseBlock(
-            new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2})),
-            queryContext),
-        new InstanceResponseBlock(
-            new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"bar", 3}, new Object[]{"foo", 4})),
-            queryContext),
-        new InstanceResponseBlock(new SelectionResultsBlock(schema, Collections.emptyList()), queryContext));
+    List<BaseResultsBlock> dataBlocks = Arrays.asList(
+        new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2}), queryContext),
+        new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"bar", 3}, new Object[]{"foo", 4}), queryContext));
+    InstanceResponseBlock metadataBlock = new InstanceResponseBlock(new MetadataResultsBlock());
+    QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, metadataBlock);
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(),
-            getStaticBlockProcessor(resultsBlockList), getStaticServerQueryRequests(resultsBlockList.size()), schema);
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), mockQueryRequests(1), schema,
+            queryExecutor, _executorService);
+    _operatorRef.set(operator);
 
     // When:
     TransferableBlock resultBlock1 = operator.nextBlock();
@@ -144,8 +181,35 @@ public class LeafStageTransferableBlockOperatorTest {
     Assert.assertEquals(resultBlock1.getContainer().get(1), new Object[]{"", 2});
     Assert.assertEquals(resultBlock2.getContainer().get(0), new Object[]{"bar", 3});
     Assert.assertEquals(resultBlock2.getContainer().get(1), new Object[]{"foo", 4});
-    Assert.assertEquals(resultBlock3.getContainer().size(), 0);
-    Assert.assertTrue(operator.nextBlock().isEndOfStreamBlock(), "Expected EOS after reading two rows");
+    Assert.assertTrue(resultBlock3.isEndOfStreamBlock(), "Expected EOS after reading 2 blocks");
+
+    operator.close();
+  }
+
+  @Test
+  public void shouldHandleMultipleRequests() {
+    // Given:
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT strCol, intCol FROM tbl");
+    DataSchema schema = new DataSchema(new String[]{"strCol", "intCol"},
+        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
+    List<BaseResultsBlock> dataBlocks = Arrays.asList(
+        new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2}), queryContext),
+        new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"bar", 3}, new Object[]{"foo", 4}), queryContext));
+    InstanceResponseBlock metadataBlock = new InstanceResponseBlock(new MetadataResultsBlock());
+    QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, metadataBlock);
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), mockQueryRequests(2), schema,
+            queryExecutor, _executorService);
+    _operatorRef.set(operator);
+
+    // Then: the 5th block should be EOS
+    Assert.assertTrue(operator.nextBlock().isDataBlock());
+    Assert.assertTrue(operator.nextBlock().isDataBlock());
+    Assert.assertTrue(operator.nextBlock().isDataBlock());
+    Assert.assertTrue(operator.nextBlock().isDataBlock());
+    Assert.assertTrue(operator.nextBlock().isEndOfStreamBlock(), "Expected EOS after reading 5 blocks");
+
+    operator.close();
   }
 
   @Test
@@ -154,139 +218,25 @@ public class LeafStageTransferableBlockOperatorTest {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT strCol, intCol FROM tbl");
     DataSchema schema = new DataSchema(new String[]{"strCol", "intCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
+    List<BaseResultsBlock> dataBlocks = Collections.singletonList(
+        new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2}), queryContext));
     InstanceResponseBlock errorBlock = new InstanceResponseBlock();
     errorBlock.addException(QueryException.QUERY_EXECUTION_ERROR.getErrorCode(), "foobar");
-    List<InstanceResponseBlock> resultsBlockList = Arrays.asList(new InstanceResponseBlock(
-            new SelectionResultsBlock(schema, Arrays.asList(new Object[]{"foo", 1}, new Object[]{"", 2})),
-            queryContext),
-        errorBlock,
-        new InstanceResponseBlock(new SelectionResultsBlock(schema, Collections.emptyList()), queryContext));
+    QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, errorBlock);
     LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(),
-            getStaticBlockProcessor(resultsBlockList), getStaticServerQueryRequests(resultsBlockList.size()), schema);
-
-    // When:
-    TransferableBlock resultBlock = operator.nextBlock();
-    // Then:
-    Assert.assertEquals(resultBlock.getContainer().get(0), new Object[]{"foo", 1});
-    Assert.assertEquals(resultBlock.getContainer().get(1), new Object[]{"", 2});
-
-    // When:
-    resultBlock = operator.nextBlock();
-    Assert.assertTrue(resultBlock.isErrorBlock());
-  }
-
-  @Test
-  public void shouldReorderWhenQueryContextAskForNotInOrderGroupByAsDistinct() {
-    // Given:
-    QueryContext queryContext =
-        QueryContextConverterUtils.getQueryContext("SELECT intCol, strCol FROM tbl GROUP BY strCol, intCol");
-    // result schema doesn't match with DISTINCT columns using GROUP BY.
-    DataSchema schema = new DataSchema(new String[]{"intCol", "strCol"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.STRING});
-    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
-        new DistinctResultsBlock(new DistinctTable(schema,
-            Arrays.asList(new Record(new Object[]{1, "foo"}), new Record(new Object[]{2, "bar"})))), queryContext));
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(),
-            getStaticBlockProcessor(resultsBlockList), getStaticServerQueryRequests(resultsBlockList.size()), schema);
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), mockQueryRequests(1), schema,
+            queryExecutor, _executorService);
+    _operatorRef.set(operator);
 
     // When:
     TransferableBlock resultBlock = operator.nextBlock();
 
-    // Then:
-    Assert.assertEquals(resultBlock.getContainer().get(0), new Object[]{1, "foo"});
-    Assert.assertEquals(resultBlock.getContainer().get(1), new Object[]{2, "bar"});
-  }
+    // Then: error block can be returned as first or second block depending on the sequence of the execution
+    if (!resultBlock.isErrorBlock()) {
+      Assert.assertTrue(operator.nextBlock().isErrorBlock());
+    }
 
-  @Test
-  public void shouldParsedBlocksSuccessfullyWithDistinctQuery() {
-    // Given:
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT DISTINCT strCol, intCol FROM tbl");
-    // result schema doesn't match with DISTINCT columns using GROUP BY.
-    DataSchema schema = new DataSchema(new String[]{"strCol", "intCol"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
-    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
-        new DistinctResultsBlock(new DistinctTable(schema,
-            Arrays.asList(new Record(new Object[]{"foo", 1}), new Record(new Object[]{"bar", 2})))), queryContext));
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(),
-            getStaticBlockProcessor(resultsBlockList), getStaticServerQueryRequests(resultsBlockList.size()), schema);
-
-    // When:
-    TransferableBlock resultBlock = operator.nextBlock();
-
-    // Then:
-    Assert.assertEquals(resultBlock.getContainer().get(0), new Object[]{"foo", 1});
-    Assert.assertEquals(resultBlock.getContainer().get(1), new Object[]{"bar", 2});
-  }
-
-  @Test
-  public void shouldReorderWhenQueryContextAskForGroupByOutOfOrder() {
-    // Given:
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
-        "SELECT intCol, count(*), sum(doubleCol), strCol FROM tbl GROUP BY strCol, intCol");
-    // result schema doesn't match with columns ordering using GROUP BY, this should not occur.
-    DataSchema schema =
-        new DataSchema(new String[]{"intCol", "count(*)", "sum(doubleCol)", "strCol"}, new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG,
-            DataSchema.ColumnDataType.STRING
-        });
-    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(
-        new InstanceResponseBlock(new GroupByResultsBlock(schema, Collections.emptyList()), queryContext));
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(),
-            getStaticBlockProcessor(resultsBlockList), getStaticServerQueryRequests(resultsBlockList.size()), schema);
-
-    // When:
-    TransferableBlock resultBlock = operator.nextBlock();
-
-    // Then:
-    Assert.assertFalse(resultBlock.isErrorBlock());
-  }
-
-  @Test
-  public void shouldNotErrorOutWhenQueryContextAskForGroupByOutOfOrderWithHaving() {
-    // Given:
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT strCol, intCol, count(*), "
-        + "sum(doubleCol) FROM tbl GROUP BY strCol, intCol HAVING sum(doubleCol) < 10 AND count(*) > 0");
-    // result schema contains duplicate reference from agg and having. it will repeat itself.
-    DataSchema schema = new DataSchema(new String[]{"strCol", "intCol", "count(*)", "sum(doubleCol)", "sum(doubleCol)"},
-        new DataSchema.ColumnDataType[]{
-            DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.INT,
-            DataSchema.ColumnDataType.LONG, DataSchema.ColumnDataType.LONG
-        });
-    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(
-        new InstanceResponseBlock(new GroupByResultsBlock(schema, Collections.emptyList()), queryContext));
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(),
-            getStaticBlockProcessor(resultsBlockList), getStaticServerQueryRequests(resultsBlockList.size()), schema);
-
-    // When:
-    TransferableBlock resultBlock = operator.nextBlock();
-
-    // Then:
-    Assert.assertFalse(resultBlock.isErrorBlock());
-  }
-
-  @Test
-  public void shouldNotErrorOutWhenDealingWithAggregationResults() {
-    // Given:
-    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT count(*), sum(doubleCol) FROM tbl");
-    // result schema doesn't match with DISTINCT columns using GROUP BY.
-    DataSchema schema = new DataSchema(new String[]{"count_star", "sum(doubleCol)"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.INT, DataSchema.ColumnDataType.LONG});
-    List<InstanceResponseBlock> resultsBlockList = Collections.singletonList(new InstanceResponseBlock(
-        new AggregationResultsBlock(queryContext.getAggregationFunctions(), Collections.emptyList()), queryContext));
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(),
-            getStaticBlockProcessor(resultsBlockList), getStaticServerQueryRequests(resultsBlockList.size()), schema);
-
-    // When:
-    TransferableBlock resultBlock = operator.nextBlock();
-
-    // Then:
-    Assert.assertFalse(resultBlock.isErrorBlock());
+    operator.close();
   }
 
   @Test
@@ -297,96 +247,21 @@ public class LeafStageTransferableBlockOperatorTest {
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
     DataSchema desiredSchema = new DataSchema(new String[]{"strCol", "intCol"},
         new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
+    List<BaseResultsBlock> dataBlocks = Collections.emptyList();
+    InstanceResponseBlock emptySelectionResponseBlock =
+        new InstanceResponseBlock(new SelectionResultsBlock(resultSchema, Collections.emptyList(), queryContext));
+    QueryExecutor queryExecutor = mockQueryExecutor(dataBlocks, emptySelectionResponseBlock);
+    LeafStageTransferableBlockOperator operator =
+        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(), mockQueryRequests(1),
+            desiredSchema, queryExecutor, _executorService);
+    _operatorRef.set(operator);
 
     // When:
-    List<InstanceResponseBlock> responseBlockList = Collections.singletonList(
-        new InstanceResponseBlock(new SelectionResultsBlock(resultSchema, Collections.emptyList()), queryContext));
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(),
-            getStaticBlockProcessor(responseBlockList), getStaticServerQueryRequests(responseBlockList.size()),
-            desiredSchema);
     TransferableBlock resultBlock = operator.nextBlock();
 
     // Then:
-    Assert.assertEquals(resultBlock.getContainer().size(), 0);
-    Assert.assertEquals(resultBlock.getDataSchema(), desiredSchema);
-  }
+    Assert.assertTrue(resultBlock.isEndOfStreamBlock());
 
-  @Test
-  public void shouldNotErrorOutWhenIncorrectDataSchemaProvidedWithEmptyRowsDistinct() {
-    // Given:
-    QueryContext queryContext =
-        QueryContextConverterUtils.getQueryContext("SELECT strCol, intCol FROM tbl GROUP BY strCol, intCol");
-    DataSchema resultSchema = new DataSchema(new String[]{"strCol", "intCol"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
-    DataSchema desiredSchema = new DataSchema(new String[]{"strCol", "intCol"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
-
-    // When:
-    List<InstanceResponseBlock> responseBlockList = Collections.singletonList(
-        new InstanceResponseBlock(new DistinctResultsBlock(new DistinctTable(resultSchema, Collections.emptyList())),
-            queryContext));
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(),
-            getStaticBlockProcessor(responseBlockList), getStaticServerQueryRequests(responseBlockList.size()),
-            desiredSchema);
-    TransferableBlock resultBlock = operator.nextBlock();
-
-    // Then:
-    Assert.assertEquals(resultBlock.getContainer().size(), 0);
-    Assert.assertEquals(resultBlock.getDataSchema(), desiredSchema);
-  }
-
-  @Test
-  public void shouldNotErrorOutWhenIncorrectDataSchemaProvidedWithEmptyRowsGroupBy() {
-    // Given:
-    QueryContext queryContext =
-        QueryContextConverterUtils.getQueryContext("SELECT strCol, SUM(intCol) FROM tbl GROUP BY strCol");
-    DataSchema resultSchema = new DataSchema(new String[]{"strCol", "SUM(intCol)"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.STRING});
-    DataSchema desiredSchema = new DataSchema(new String[]{"strCol", "SUM(intCol)"},
-        new DataSchema.ColumnDataType[]{DataSchema.ColumnDataType.STRING, DataSchema.ColumnDataType.INT});
-
-    // When:
-    List<InstanceResponseBlock> responseBlockList = Collections.singletonList(
-        new InstanceResponseBlock(new GroupByResultsBlock(resultSchema, Collections.emptyList()), queryContext));
-    LeafStageTransferableBlockOperator operator =
-        new LeafStageTransferableBlockOperator(OperatorTestUtil.getDefaultContext(),
-            getStaticBlockProcessor(responseBlockList), getStaticServerQueryRequests(responseBlockList.size()),
-            desiredSchema);
-    TransferableBlock resultBlock = operator.nextBlock();
-
-    // Then:
-    Assert.assertEquals(resultBlock.getContainer().size(), 0);
-    Assert.assertEquals(resultBlock.getDataSchema(), desiredSchema);
-  }
-
-  @VisibleForTesting
-  static Function<ServerQueryRequest, InstanceResponseBlock> getStaticBlockProcessor(
-      List<InstanceResponseBlock> resultBlockList) {
-    return new StaticBlockProcessor(resultBlockList)::process;
-  }
-
-  static List<ServerQueryRequest> getStaticServerQueryRequests(int count) {
-    List<ServerQueryRequest> staticMockRequests = new ArrayList<>();
-    while (count > 0) {
-      staticMockRequests.add(mock(ServerQueryRequest.class));
-      count--;
-    }
-    return staticMockRequests;
-  }
-
-  private static class StaticBlockProcessor {
-    private final List<InstanceResponseBlock> _resultBlockList;
-    private int _currentIdx;
-
-    StaticBlockProcessor(List<InstanceResponseBlock> resultBlockList) {
-      _resultBlockList = resultBlockList;
-      _currentIdx = 0;
-    }
-
-    public InstanceResponseBlock process(ServerQueryRequest request) {
-      return _resultBlockList.get(_currentIdx++);
-    }
+    operator.close();
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
@@ -16,7 +16,7 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.query.runtime;
+package org.apache.pinot.query.runtime.queries;
 
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -34,7 +34,6 @@ import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.planner.DispatchablePlanFragment;
 import org.apache.pinot.query.planner.DispatchableSubPlan;
 import org.apache.pinot.query.routing.QueryServerInstance;
-import org.apache.pinot.query.runtime.executor.OpChainSchedulerService;
 import org.apache.pinot.query.service.dispatch.QueryDispatcher;
 import org.apache.pinot.query.testutils.MockInstanceDataManagerFactory;
 import org.apache.pinot.query.testutils.QueryTestUtils;
@@ -60,21 +59,16 @@ import org.testng.annotations.Test;
  */
 public class QueryRunnerTest extends QueryRunnerTestBase {
   public static final Object[][] ROWS = new Object[][]{
-      new Object[]{"foo", "foo", 1},
-      new Object[]{"bar", "bar", 42},
-      new Object[]{"alice", "alice", 1},
-      new Object[]{"bob", "foo", 42},
-      new Object[]{"charlie", "bar", 1},
+      new Object[]{"foo", "foo", 1}, new Object[]{"bar", "bar", 42}, new Object[]{"alice", "alice", 1}, new Object[]{
+          "bob", "foo", 42}, new Object[]{"charlie", "bar", 1},
   };
   public static final Schema.SchemaBuilder SCHEMA_BUILDER;
 
   static {
-    SCHEMA_BUILDER = new Schema.SchemaBuilder()
-        .addSingleValueDimension("col1", FieldSpec.DataType.STRING, "")
+    SCHEMA_BUILDER = new Schema.SchemaBuilder().addSingleValueDimension("col1", FieldSpec.DataType.STRING, "")
         .addSingleValueDimension("col2", FieldSpec.DataType.STRING, "")
         .addDateTime("ts", FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:HOURS")
-        .addMetric("col3", FieldSpec.DataType.INT, 0)
-        .setSchemaName("defaultSchemaName");
+        .addMetric("col3", FieldSpec.DataType.INT, 0).setSchemaName("defaultSchemaName");
   }
 
   public static List<GenericRow> buildRows(String tableName) {
@@ -84,8 +78,9 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
       row.putValue("col1", ROWS[i][0]);
       row.putValue("col2", ROWS[i][1]);
       row.putValue("col3", ROWS[i][2]);
-      row.putValue("ts", TableType.OFFLINE.equals(TableNameBuilder.getTableTypeFromTableName(tableName))
-          ? System.currentTimeMillis() - TimeUnit.DAYS.toMillis(2) : System.currentTimeMillis());
+      row.putValue("ts",
+          TableType.OFFLINE.equals(TableNameBuilder.getTableTypeFromTableName(tableName)) ? System.currentTimeMillis()
+              - TimeUnit.DAYS.toMillis(2) : System.currentTimeMillis());
       rows.add(row);
     }
     return rows;
@@ -115,9 +110,6 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
     factory2.addSegment("d_OFFLINE", buildRows("d_OFFLINE"));
     factory2.addSegment("d_REALTIME", buildRows("d_REALTIME"));
 
-    QueryServerEnclosure server1 = new QueryServerEnclosure(factory1);
-    QueryServerEnclosure server2 = new QueryServerEnclosure(factory2);
-
     // Setting up H2 for validation
     setH2Connection();
     Schema schema = SCHEMA_BUILDER.build();
@@ -127,19 +119,16 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
       addDataToH2(tableName, schema, factory2.buildTableRowsMap().get(tableName));
     }
 
-    _reducerGrpcPort = QueryTestUtils.getAvailablePort();
-    _reducerHostname = "Broker_localhost";
+    _reducerHostname = "localhost";
+    _reducerPort = QueryTestUtils.getAvailablePort();
     Map<String, Object> reducerConfig = new HashMap<>();
-    reducerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT, _reducerGrpcPort);
     reducerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME, _reducerHostname);
-    _reducerScheduler = new OpChainSchedulerService(EXECUTOR);
-    _mailboxService = new MailboxService("localhost", _reducerGrpcPort, new PinotConfiguration(reducerConfig));
+    reducerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT, _reducerPort);
+    _mailboxService = new MailboxService(_reducerHostname, _reducerPort, new PinotConfiguration(reducerConfig));
     _mailboxService.start();
 
-    _queryEnvironment =
-        QueryEnvironmentTestBase.getQueryEnvironment(_reducerGrpcPort, server1.getPort(), server2.getPort(),
-            factory1.getRegisteredSchemaMap(), factory1.buildTableSegmentNameMap(), factory2.buildTableSegmentNameMap(),
-            null);
+    QueryServerEnclosure server1 = new QueryServerEnclosure(factory1);
+    QueryServerEnclosure server2 = new QueryServerEnclosure(factory2);
     server1.start();
     server2.start();
     // this doesn't test the QueryServer functionality so the server port can be the same as the mailbox port.
@@ -148,6 +137,10 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
     int port2 = server2.getPort();
     _servers.put(new QueryServerInstance("localhost", port1, port1), server1);
     _servers.put(new QueryServerInstance("localhost", port2, port2), server2);
+
+    _queryEnvironment = QueryEnvironmentTestBase.getQueryEnvironment(_reducerPort, server1.getPort(), server2.getPort(),
+        factory1.getRegisteredSchemaMap(), factory1.buildTableSegmentNameMap(), factory2.buildTableSegmentNameMap(),
+        null);
   }
 
   @AfterClass
@@ -163,8 +156,7 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
    * Test compares with expected row count only.
    */
   @Test(dataProvider = "testDataWithSqlToFinalRowCount")
-  public void testSqlWithFinalRowCountChecker(String sql, int expectedRows)
-      throws Exception {
+  public void testSqlWithFinalRowCountChecker(String sql, int expectedRows) {
     List<Object[]> resultRows = queryRunner(sql, null);
     Assert.assertEquals(resultRows.size(), expectedRows);
   }
@@ -246,52 +238,46 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
 
         // test dateTrunc
         //   - on leaf stage
-        new Object[]{"SELECT dateTrunc('DAY', ts) FROM a LIMIT 10", 10},
-        new Object[]{"SELECT dateTrunc('DAY', CAST(col3 AS BIGINT)) FROM a LIMIT 10", 10},
+        new Object[]{"SELECT dateTrunc('DAY', ts) FROM a LIMIT 10", 10}, new Object[]{"SELECT dateTrunc('DAY', CAST"
+        + "(col3 AS BIGINT)) FROM a LIMIT 10", 10},
         //   - on intermediate stage
         new Object[]{
-            "SELECT dateTrunc('DAY', round(a.ts, b.ts)) FROM a JOIN b "
-                + "ON a.col1 = b.col1 AND a.col2 = b.col2", 15
-        },
-        new Object[]{"SELECT dateTrunc('DAY', CAST(MAX(a.col3) AS BIGINT)) FROM a", 1},
+            "SELECT dateTrunc('DAY', round(a.ts, b.ts)) FROM a JOIN b " + "ON a.col1 = b.col1 AND a.col2 = b.col2", 15
+        }, new Object[]{"SELECT dateTrunc('DAY', CAST(MAX(a.col3) AS BIGINT)) FROM a", 1},
 
         // ScalarFunction
         // test function can be used in predicate/leaf/intermediate stage (using regexpLike)
         new Object[]{"SELECT a.col1, b.col1 FROM a JOIN b ON a.col3 = b.col3 WHERE regexpLike(a.col2, b.col1)", 9},
         new Object[]{"SELECT a.col1, b.col1 FROM a JOIN b ON a.col3 = b.col3 WHERE regexp_like(a.col2, b.col1)", 9},
-        new Object[]{"SELECT regexpLike(a.col1, b.col1) FROM a JOIN b ON a.col3 = b.col3", 39},
-        new Object[]{"SELECT regexp_like(a.col1, b.col1) FROM a JOIN b ON a.col3 = b.col3", 39},
+        new Object[]{"SELECT regexpLike(a.col1, b.col1) FROM a JOIN b ON a.col3 = b.col3", 39}, new Object[]{"SELECT "
+        + "regexp_like(a.col1, b.col1) FROM a JOIN b ON a.col3 = b.col3", 39},
 
         // test function with @ScalarFunction annotation and alias works (using round_decimal)
-        new Object[]{"SELECT roundDecimal(col3) FROM a", 15},
-        new Object[]{"SELECT round_decimal(col3) FROM a", 15},
-        new Object[]{"SELECT col1, roundDecimal(COUNT(*)) FROM a GROUP BY col1", 5},
-        new Object[]{"SELECT col1, round_decimal(COUNT(*)) FROM a GROUP BY col1", 5},
+        new Object[]{"SELECT roundDecimal(col3) FROM a", 15}, new Object[]{"SELECT round_decimal(col3) FROM a", 15},
+        new Object[]{"SELECT col1, roundDecimal(COUNT(*)) FROM a GROUP BY col1", 5}, new Object[]{"SELECT col1, "
+        + "round_decimal(COUNT(*)) FROM a GROUP BY col1", 5},
 
         // test queries with special query options attached
         //   - when leaf limit is set, each server returns multiStageLeafLimit number of rows only.
         new Object[]{"SET multiStageLeafLimit = 1; SELECT * FROM a", 2},
 
         // test groups limit in both leaf and intermediate stage
-        new Object[]{"SET numGroupsLimit = 1; SELECT col1, COUNT(*) FROM a GROUP BY col1", 1},
-        new Object[]{"SET numGroupsLimit = 2; SELECT col1, COUNT(*) FROM a GROUP BY col1", 2},
-        new Object[]{
-            "SET numGroupsLimit = 1; "
-                + "SELECT a.col2, b.col2, COUNT(*) FROM a JOIN b USING (col1) GROUP BY a.col2, b.col2", 1
-        },
-        new Object[]{
-            "SET numGroupsLimit = 2; "
-                + "SELECT a.col2, b.col2, COUNT(*) FROM a JOIN b USING (col1) GROUP BY a.col2, b.col2", 2
-        },
+        new Object[]{"SET numGroupsLimit = 1; SELECT col1, COUNT(*) FROM a GROUP BY col1", 1}, new Object[]{"SET "
+        + "numGroupsLimit = 2; SELECT col1, COUNT(*) FROM a GROUP BY col1", 2}, new Object[]{
+        "SET numGroupsLimit = 1; "
+            + "SELECT a.col2, b.col2, COUNT(*) FROM a JOIN b USING (col1) GROUP BY a.col2, b.col2", 1
+    }, new Object[]{
+        "SET numGroupsLimit = 2; "
+            + "SELECT a.col2, b.col2, COUNT(*) FROM a JOIN b USING (col1) GROUP BY a.col2, b.col2", 2
+    },
         // TODO: Consider pushing down hint to the leaf stage
         new Object[]{
             "SET numGroupsLimit = 2; SELECT /*+ aggOptions(num_groups_limit='1') */ "
                 + "col1, COUNT(*) FROM a GROUP BY col1", 2
-        },
-        new Object[]{
-            "SET numGroupsLimit = 2; SELECT /*+ aggOptions(num_groups_limit='1') */ "
-                + "a.col2, b.col2, COUNT(*) FROM a JOIN b USING (col1) GROUP BY a.col2, b.col2", 1
-        }
+        }, new Object[]{
+        "SET numGroupsLimit = 2; SELECT /*+ aggOptions(num_groups_limit='1') */ "
+            + "a.col2, b.col2, COUNT(*) FROM a JOIN b USING (col1) GROUP BY a.col2, b.col2", 1
+    }
     };
   }
 
@@ -300,39 +286,36 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
     return new Object[][]{
         // Missing index
         new Object[]{
-            "SELECT col1 FROM a WHERE textMatch(col1, 'f') LIMIT 10",
-            "without text index"
+            "SELECT col1 FROM a WHERE textMatch(col1, 'f') LIMIT 10", "without text index"
         },
 
         // Query hint with dynamic broadcast pipeline breaker should return error upstream
         new Object[]{
             "SELECT /*+ joinOptions(join_strategy='dynamic_broadcast') */ col1 FROM a "
-                + " WHERE a.col1 IN (SELECT b.col2 FROM b WHERE textMatch(col1, 'f')) AND a.col3 > 0",
-            "without text index"
+                + " WHERE a.col1 IN (SELECT b.col2 FROM b WHERE textMatch(col1, 'f')) AND a.col3 > 0", "without text "
+            + "index"
         },
 
         // Timeout exception should occur with this option:
         new Object[]{
-            "SET timeoutMs = 1; SELECT * FROM a JOIN b ON a.col1 = b.col1 JOIN c ON a.col1 = c.col1",
-            "Timeout"
+            "SET timeoutMs = 1; SELECT * FROM a JOIN b ON a.col1 = b.col1 JOIN c ON a.col1 = c.col1", "Timeout"
         },
 
         // Function with incorrect argument signature should throw runtime exception when casting string to numeric
         new Object[]{
-            "SELECT least(a.col2, b.col3) FROM a JOIN b ON a.col1 = b.col1",
-            "For input string:"
+            "SELECT least(a.col2, b.col3) FROM a JOIN b ON a.col1 = b.col1", "For input string:"
         },
 
         // Scalar function that doesn't have a valid use should throw an exception on the leaf stage
         //   - predicate only functions:
-        new Object[]{"SELECT * FROM a WHERE textMatch(col1, 'f')", "without text index"},
-        new Object[]{"SELECT * FROM a WHERE text_match(col1, 'f')", "without text index"},
-        new Object[]{"SELECT * FROM a WHERE textContains(col1, 'f')", "supported only on native text index"},
-        new Object[]{"SELECT * FROM a WHERE text_contains(col1, 'f')", "supported only on native text index"},
+        new Object[]{"SELECT * FROM a WHERE textMatch(col1, 'f')", "without text index"}, new Object[]{"SELECT * FROM"
+        + " a WHERE text_match(col1, 'f')", "without text index"}, new Object[]{"SELECT * FROM a WHERE textContains"
+        + "(col1, 'f')", "supported only on native text index"}, new Object[]{"SELECT * FROM a WHERE text_contains"
+        + "(col1, 'f')", "supported only on native text index"},
 
         //  - transform only functions
-        new Object[]{"SELECT jsonExtractKey(col1, 'path') FROM a", "was expecting (JSON String"},
-        new Object[]{"SELECT json_extract_key(col1, 'path') FROM a", "was expecting (JSON String"},
+        new Object[]{"SELECT jsonExtractKey(col1, 'path') FROM a", "was expecting (JSON String"}, new Object[]{
+            "SELECT json_extract_key(col1, 'path') FROM a", "was expecting (JSON String"},
 
         //  - PlaceholderScalarFunction registered will throw on intermediate stage, but works on leaf stage.
         //    - checked "Illegal Json Path" as col1 is not actually a json string, but the call is correctly triggered.

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -49,8 +49,6 @@ import org.apache.pinot.query.QueryEnvironmentTestBase;
 import org.apache.pinot.query.QueryServerEnclosure;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.routing.QueryServerInstance;
-import org.apache.pinot.query.runtime.QueryRunnerTestBase;
-import org.apache.pinot.query.runtime.executor.OpChainSchedulerService;
 import org.apache.pinot.query.testutils.MockInstanceDataManagerFactory;
 import org.apache.pinot.query.testutils.QueryTestUtils;
 import org.apache.pinot.spi.config.table.TableType;
@@ -180,25 +178,12 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
         }
       }
     }
-    QueryServerEnclosure server1 = new QueryServerEnclosure(factory1);
-    QueryServerEnclosure server2 = new QueryServerEnclosure(factory2);
-
-    _reducerGrpcPort = QueryTestUtils.getAvailablePort();
-    _reducerHostname = "Broker_localhost";
-    Map<String, Object> reducerConfig = new HashMap<>();
-    reducerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT, _reducerGrpcPort);
-    reducerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME, _reducerHostname);
-    _reducerScheduler = new OpChainSchedulerService(EXECUTOR);
-    _mailboxService = new MailboxService("localhost", _reducerGrpcPort, new PinotConfiguration(reducerConfig));
-    _mailboxService.start();
 
     Map<String, List<String>> tableToSegmentMap1 = factory1.buildTableSegmentNameMap();
     Map<String, List<String>> tableToSegmentMap2 = factory2.buildTableSegmentNameMap();
-
     for (Map.Entry<String, List<String>> entry : tableToSegmentMap1.entrySet()) {
       _tableToSegmentMap.put(entry.getKey(), new HashSet<>(entry.getValue()));
     }
-
     for (Map.Entry<String, List<String>> entry : tableToSegmentMap2.entrySet()) {
       if (_tableToSegmentMap.containsKey(entry.getKey())) {
         _tableToSegmentMap.get(entry.getKey()).addAll(entry.getValue());
@@ -207,10 +192,16 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
       }
     }
 
-    _queryEnvironment =
-        QueryEnvironmentTestBase.getQueryEnvironment(_reducerGrpcPort, server1.getPort(), server2.getPort(),
-            factory1.getRegisteredSchemaMap(), factory1.buildTableSegmentNameMap(), factory2.buildTableSegmentNameMap(),
-            partitionedSegmentsMap);
+    _reducerHostname = "localhost";
+    _reducerPort = QueryTestUtils.getAvailablePort();
+    Map<String, Object> reducerConfig = new HashMap<>();
+    reducerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME, _reducerHostname);
+    reducerConfig.put(CommonConstants.MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT, _reducerPort);
+    _mailboxService = new MailboxService(_reducerHostname, _reducerPort, new PinotConfiguration(reducerConfig));
+    _mailboxService.start();
+
+    QueryServerEnclosure server1 = new QueryServerEnclosure(factory1);
+    QueryServerEnclosure server2 = new QueryServerEnclosure(factory2);
     server1.start();
     server2.start();
     // this doesn't test the QueryServer functionality so the server port can be the same as the mailbox port.
@@ -219,6 +210,10 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
     int port2 = server2.getPort();
     _servers.put(new QueryServerInstance("localhost", port1, port1), server1);
     _servers.put(new QueryServerInstance("localhost", port2, port2), server2);
+
+    _queryEnvironment = QueryEnvironmentTestBase.getQueryEnvironment(_reducerPort, server1.getPort(), server2.getPort(),
+        factory1.getRegisteredSchemaMap(), factory1.buildTableSegmentNameMap(), factory2.buildTableSegmentNameMap(),
+        partitionedSegmentsMap);
   }
 
   private void addSegments(MockInstanceDataManagerFactory factory1, MockInstanceDataManagerFactory factory2,

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/service/dispatch/QueryDispatcherTest.java
@@ -25,18 +25,14 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.atomic.AtomicLong;
 import org.apache.pinot.common.proto.Worker;
-import org.apache.pinot.common.utils.NamedThreadFactory;
 import org.apache.pinot.query.QueryEnvironment;
 import org.apache.pinot.query.QueryEnvironmentTestBase;
 import org.apache.pinot.query.QueryTestSet;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.planner.DispatchableSubPlan;
 import org.apache.pinot.query.runtime.QueryRunner;
-import org.apache.pinot.query.runtime.executor.ExecutorServiceUtils;
 import org.apache.pinot.query.service.server.QueryServer;
 import org.apache.pinot.query.testutils.QueryTestUtils;
 import org.apache.pinot.spi.trace.DefaultRequestContext;
@@ -51,8 +47,6 @@ import org.testng.annotations.Test;
 public class QueryDispatcherTest extends QueryTestSet {
   private static final AtomicLong REQUEST_ID_GEN = new AtomicLong();
   private static final int QUERY_SERVER_COUNT = 2;
-  private static final ExecutorService EXECUTOR =
-      Executors.newCachedThreadPool(new NamedThreadFactory("worker_on_" + QueryDispatcherTest.class.getSimpleName()));
 
   private final Map<Integer, QueryServer> _queryServerMap = new HashMap<>();
 
@@ -65,7 +59,6 @@ public class QueryDispatcherTest extends QueryTestSet {
     for (int i = 0; i < QUERY_SERVER_COUNT; i++) {
       int availablePort = QueryTestUtils.getAvailablePort();
       QueryRunner queryRunner = Mockito.mock(QueryRunner.class);
-      Mockito.when(queryRunner.getOpChainExecutorService()).thenReturn(EXECUTOR);
       QueryServer queryServer = Mockito.spy(new QueryServer(availablePort, queryRunner));
       queryServer.start();
       _queryServerMap.put(availablePort, queryServer);
@@ -85,7 +78,6 @@ public class QueryDispatcherTest extends QueryTestSet {
     for (QueryServer worker : _queryServerMap.values()) {
       worker.shutdown();
     }
-    ExecutorServiceUtils.close(EXECUTOR);
   }
 
   @Test(dataProvider = "testSql")

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -349,6 +349,9 @@ public class CommonConstants {
 
         public static final String DROP_RESULTS = "dropResults";
 
+        // Maximum number of pending results blocks allowed in the streaming operator
+        public static final String MAX_STREAMING_PENDING_BLOCKS = "maxStreamingPendingBlocks";
+
         // Handle JOIN Overflow
         public static final String MAX_ROWS_IN_JOIN = "maxRowsInJoin";
         public static final String JOIN_OVERFLOW_MODE = "joinOverflowMode";
@@ -364,6 +367,7 @@ public class CommonConstants {
 
       public static class QueryOptionValue {
         public static final String DEFAULT_IN_PREDICATE_SORT_THRESHOLD = "1000";
+        public static final int DEFAULT_MAX_STREAMING_PENDING_BLOCKS = 100;
       }
     }
 


### PR DESCRIPTION
- Make multi-stage leaf operator use the streaming operator from single-stage engine to avoid memory issue and also improve efficiency.
- Applied back pressure to the streaming operator
- Allow streaming only for selection without order-by
- Fix the execution stats override issue

# Documentation

Added new query option `maxStreamingPendingBlocks` to control the pending blocks for streaming (back pressure, 100 by default)

# Incompatible

The following interface changed:
- BaseResultsBlock
- PlanMaker
- QueryExecutor