### PR TITLE
Remove the outer istrue and isfalse functions.

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterIntegrationTestUtils.java
@@ -293,7 +293,7 @@ public class ClusterIntegrationTestUtils {
       throws Exception {
     int numAvroFiles = avroFiles.size();
     if (numAvroFiles == 1) {
-      buildSegmentFromAvro(avroFiles.get(0), tableConfig, schema, baseSegmentIndex, segmentDir, tarDir);
+      buildSegmentFromAvro(avroFiles.get(0), tableConfig, schema, baseSegmentIndex, segmentDir, tarDir, false);
     } else {
       ExecutorService executorService = Executors.newFixedThreadPool(numAvroFiles);
       List<Future<Void>> futures = new ArrayList<>(numAvroFiles);
@@ -301,7 +301,7 @@ public class ClusterIntegrationTestUtils {
         File avroFile = avroFiles.get(i);
         int segmentIndex = i + baseSegmentIndex;
         futures.add(executorService.submit(() -> {
-          buildSegmentFromAvro(avroFile, tableConfig, schema, segmentIndex, segmentDir, tarDir);
+          buildSegmentFromAvro(avroFile, tableConfig, schema, segmentIndex, segmentDir, tarDir, false);
           return null;
         }));
       }
@@ -321,12 +321,14 @@ public class ClusterIntegrationTestUtils {
    * @param segmentIndex Segment index number
    * @param segmentDir Output directory for the un-tarred segments
    * @param tarDir Output directory for the tarred segments
+   * @param nullHandlingEnabled whether to enable null handling for the segment
    */
   public static void buildSegmentFromAvro(File avroFile, TableConfig tableConfig,
-      org.apache.pinot.spi.data.Schema schema, int segmentIndex, File segmentDir, File tarDir)
+      org.apache.pinot.spi.data.Schema schema, int segmentIndex, File segmentDir, File tarDir,
+      boolean nullHandlingEnabled)
       throws Exception {
     // Test segment with space and special character in the file name
-    buildSegmentFromAvro(avroFile, tableConfig, schema, segmentIndex + " %", segmentDir, tarDir);
+    buildSegmentFromAvro(avroFile, tableConfig, schema, segmentIndex + " %", segmentDir, tarDir, nullHandlingEnabled);
   }
 
   /**
@@ -338,15 +340,18 @@ public class ClusterIntegrationTestUtils {
    * @param segmentNamePostfix Segment name postfix
    * @param segmentDir Output directory for the un-tarred segments
    * @param tarDir Output directory for the tarred segments
+   * @param nullHandlingEnabled whether to enable null handling for the segment
    */
   public static void buildSegmentFromAvro(File avroFile, TableConfig tableConfig,
-      org.apache.pinot.spi.data.Schema schema, String segmentNamePostfix, File segmentDir, File tarDir)
+      org.apache.pinot.spi.data.Schema schema, String segmentNamePostfix, File segmentDir, File tarDir,
+      boolean nullHandlingEnabled)
       throws Exception {
     SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(tableConfig, schema);
     segmentGeneratorConfig.setInputFilePath(avroFile.getPath());
     segmentGeneratorConfig.setOutDir(segmentDir.getPath());
     segmentGeneratorConfig.setTableName(tableConfig.getTableName());
     segmentGeneratorConfig.setSegmentNamePostfix(segmentNamePostfix);
+    segmentGeneratorConfig.setNullHandlingEnabled(nullHandlingEnabled);
 
     // Build the segment
     SegmentIndexCreationDriver driver = new SegmentIndexCreationDriverImpl();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
@@ -122,7 +122,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
 
     // Create 1 segment, for METADATA push WITH move to final location
     ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(0), offlineTableConfig, schema, "_with_move",
-        _segmentDir, _tarDir);
+        _segmentDir, _tarDir, getNullHandlingEnabled());
 
     SegmentMetadataPushJobRunner runner = new SegmentMetadataPushJobRunner();
     SegmentGenerationJobSpec jobSpec = new SegmentGenerationJobSpec();
@@ -176,7 +176,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
 
     // Create 1 segment, for METADATA push WITHOUT move to final location
     ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(1), offlineTableConfig, schema, "_without_move",
-        _segmentDir, _tarDir);
+        _segmentDir, _tarDir, getNullHandlingEnabled());
     jobSpec.setPushJobSpec(new PushJobSpec());
     runner = new SegmentMetadataPushJobRunner();
 
@@ -223,7 +223,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     String firstTimeStamp = Long.toString(System.currentTimeMillis());
 
     ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(0), offlineTableConfig, schema, firstTimeStamp,
-        _segmentDir, _tarDir);
+        _segmentDir, _tarDir, getNullHandlingEnabled());
 
     // First test standalone metadata push job runner
     BaseSegmentPushJobRunner runner = new SegmentMetadataPushJobRunner();
@@ -287,7 +287,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     String secondTimeStamp = Long.toString(System.currentTimeMillis());
 
     ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFiles.get(1), offlineTableConfig, schema, secondTimeStamp,
-        _segmentDir, _tarDir);
+        _segmentDir, _tarDir, getNullHandlingEnabled());
     jobSpec.setPushJobSpec(new PushJobSpec());
 
     // Now test standalone tar push job runner

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/CustomDataQueryClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/CustomDataQueryClusterIntegrationTest.java
@@ -84,7 +84,8 @@ public abstract class CustomDataQueryClusterIntegrationTest extends BaseClusterI
 
     // create & upload segments
     File avroFile = createAvroFile();
-    ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFile, tableConfig, schema, 0, _segmentDir, _tarDir);
+    ClusterIntegrationTestUtils.buildSegmentFromAvro(avroFile, tableConfig, schema, 0, _segmentDir, _tarDir,
+        getNullHandlingEnabled());
     uploadSegments(getTableName(), _tarDir);
 
     waitForAllDocsLoaded(60_000);
@@ -117,7 +118,8 @@ public abstract class CustomDataQueryClusterIntegrationTest extends BaseClusterI
 
   @Override
   public TableConfig createOfflineTableConfig() {
-    return new TableConfigBuilder(TableType.OFFLINE).setTableName(getTableName()).build();
+    return new TableConfigBuilder(TableType.OFFLINE).setTableName(getTableName())
+        .setNullHandlingEnabled(getNullHandlingEnabled()).build();
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/MultiStageNullHandlingTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/MultiStageNullHandlingTest.java
@@ -1,0 +1,214 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.io.IOException;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+@Test(suiteName = "MultiStageNullHandlingTest")
+public class MultiStageNullHandlingTest extends CustomDataQueryClusterIntegrationTest {
+  private static final String DEFAULT_TABLE_NAME = "testTable";
+  private static final String INT_COLUMN = "int1";
+  private static final String BOOL_COLUMN = "bool1";
+
+  @Override
+  public String getTableName() {
+    return DEFAULT_TABLE_NAME;
+  }
+
+  @Override
+  public Schema createSchema() {
+    return new Schema.SchemaBuilder().setSchemaName(getTableName())
+        .addSingleValueDimension(INT_COLUMN, FieldSpec.DataType.INT)
+        .addSingleValueDimension(BOOL_COLUMN, FieldSpec.DataType.BOOLEAN).build();
+  }
+
+  @Override
+  protected boolean getNullHandlingEnabled() {
+    return true;
+  }
+
+  @Override
+  protected long getCountStarResult() {
+    /*
+    Uploaded table content:
+
+    row#  int1  bool1
+    ----  ====  =====
+    1     1     true
+    2     2     false
+    3     3     null
+    4     null  null
+     */
+    return 4;
+  }
+
+  @Override
+  public File createAvroFile()
+      throws IOException {
+
+    // create avro schema
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("myRecord", null, null, false);
+
+    avroSchema.setFields(ImmutableList.of(new org.apache.avro.Schema.Field(INT_COLUMN,
+            org.apache.avro.Schema.createUnion(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.INT),
+                org.apache.avro.Schema.create(org.apache.avro.Schema.Type.NULL)), null, null),
+        new org.apache.avro.Schema.Field(BOOL_COLUMN,
+            org.apache.avro.Schema.createUnion(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BOOLEAN),
+                org.apache.avro.Schema.create(org.apache.avro.Schema.Type.NULL)), null, null)));
+
+    // create avro file
+    File avroFile = new File(_tempDir, "data.avro");
+    try (DataFileWriter<GenericData.Record> fileWriter = new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
+      fileWriter.create(avroSchema, avroFile);
+      GenericData.Record record = new GenericData.Record(avroSchema);
+      record.put(INT_COLUMN, 1);
+      record.put(BOOL_COLUMN, true);
+      fileWriter.append(record);
+
+      record = new GenericData.Record(avroSchema);
+      record.put(INT_COLUMN, 2);
+      record.put(BOOL_COLUMN, false);
+      fileWriter.append(record);
+
+      record = new GenericData.Record(avroSchema);
+      record.put(INT_COLUMN, 3);
+      record.put(BOOL_COLUMN, null);
+      fileWriter.append(record);
+
+      record = new GenericData.Record(avroSchema);
+      record.put(INT_COLUMN, null);
+      record.put(BOOL_COLUMN, null);
+      fileWriter.append(record);
+    }
+
+    return avroFile;
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testFilterEqualsTrue(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SET enableNullHandling = true; SELECT int1 FROM testTable WHERE bool1 = true";
+
+    JsonNode jsonNode = postQuery(query);
+
+    assertEquals(getRowSize(jsonNode), 1);
+    assertEquals(getRowZeroColumnZero(jsonNode), 1);
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testFilterEqualsFalse(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SET enableNullHandling = true; SELECT int1 FROM testTable WHERE bool1 = false";
+
+    JsonNode jsonNode = postQuery(query);
+
+    assertEquals(getRowSize(jsonNode), 1);
+    assertEquals(getRowZeroColumnZero(jsonNode), 2);
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testFilterNotEqualsTrue(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SET enableNullHandling = true; SELECT int1 FROM testTable WHERE bool1 != true";
+
+    JsonNode jsonNode = postQuery(query);
+
+    assertEquals(getRowSize(jsonNode), 1);
+    assertEquals(getRowZeroColumnZero(jsonNode), 2);
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testFilterNotEqualsFalse(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SET enableNullHandling = true; SELECT int1 FROM testTable WHERE bool1 != false";
+
+    JsonNode jsonNode = postQuery(query);
+
+    assertEquals(getRowSize(jsonNode), 1);
+    assertEquals(getRowZeroColumnZero(jsonNode), 1);
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testFilterInAggregateFunctionEqualsTrue(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SET enableNullHandling = true; SELECT SUM(int1) FILTER(WHERE bool1 = true) FROM testTable";
+
+    JsonNode jsonNode = postQuery(query);
+
+    assertEquals(getRowZeroColumnZero(jsonNode), 1);
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testFilterInAggregateFunctionEqualsFalse(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SET enableNullHandling = true; SELECT SUM(int1) FILTER(WHERE bool1 = false) FROM testTable";
+
+    JsonNode jsonNode = postQuery(query);
+
+    assertEquals(getRowZeroColumnZero(jsonNode), 2);
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testFilterInAggregateFunctionNotEqualsTrue(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SET enableNullHandling = true; SELECT SUM(int1) FILTER(WHERE bool1 != true) FROM testTable";
+
+    JsonNode jsonNode = postQuery(query);
+
+    assertEquals(getRowZeroColumnZero(jsonNode), 2);
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testFilterInAggregateFunctionNotEqualsFalse(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SET enableNullHandling = true; SELECT SUM(int1) FILTER(WHERE bool1 != false) FROM testTable";
+
+    JsonNode jsonNode = postQuery(query);
+
+    assertEquals(getRowZeroColumnZero(jsonNode), 1);
+  }
+
+  private int getRowSize(JsonNode jsonNode) {
+    return jsonNode.get("resultTable").get("rows").size();
+  }
+
+  private int getRowZeroColumnZero(JsonNode jsonNode) {
+    return Integer.parseInt(jsonNode.get("resultTable").get("rows").get(0).get(0).asText());
+  }
+}


### PR DESCRIPTION
See the `removeOuterIsTrueFunction` method javadoc for more details.

Without this PR, V2 queries that depend on V1 engine may get an error `Unsupported function: istrue not found`.