### PR TITLE
fix float to double type conversion

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
@@ -334,14 +334,12 @@ public class NumericalFilterOptimizer extends BaseAndOrBooleanFilterOptimizer {
               // Literal value is less than the bounds of LONG.
               return getExpressionFromBoolean(
                   kind == FilterKind.GREATER_THAN || kind == FilterKind.GREATER_THAN_OR_EQUAL);
-            } else {
-              int comparison = Double.compare(actual, converted);
-              // Rewrite range operator
-              rewriteRangeOperator(range, kind, comparison);
-
-              // Rewrite range literal
-              rhs.getLiteral().setDoubleValue(converted);
             }
+            // Do not rewrite range operator since double has higher precision than float
+            // If we do, we may introduce problems.
+            // For example, in the previous logic, "> 0.5" will be converted into ">= 0.05000000074505806". When the
+            // query reaches a server, the server will convert it to ">= 0.5" in
+            // ColumnValueSegmentPruner#pruneRangePredicate, which is incorrect.
             break;
           }
           default:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
@@ -337,8 +337,8 @@ public class NumericalFilterOptimizer extends BaseAndOrBooleanFilterOptimizer {
             }
             // Do not rewrite range operator since double has higher precision than float
             // If we do, we may introduce problems.
-            // For example, in the previous logic, "> 0.5" will be converted into ">= 0.05000000074505806". When the
-            // query reaches a server, the server will convert it to ">= 0.5" in
+            // For example, in the previous logic, "> 0.05" will be converted into ">= 0.05000000074505806". When the
+            // query reaches a server, the server will convert it to ">= 0.05" in
             // ColumnValueSegmentPruner#pruneRangePredicate, which is incorrect.
             break;
           }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunctionTest.java
@@ -41,7 +41,8 @@ public class AdditionTransformFunctionTest extends BaseTransformFunctionTest {
     double[] expectedValues = new double[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] =
-          (double) _intSVValues[i] + (double) _longSVValues[i] + (double) _floatSVValues[i] + _doubleSVValues[i]
+          (double) _intSVValues[i] + (double) _longSVValues[i]
+              + Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()) + _doubleSVValues[i]
               + Double.parseDouble(_stringSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
@@ -53,8 +54,8 @@ public class AdditionTransformFunctionTest extends BaseTransformFunctionTest {
     Assert.assertTrue(transformFunction instanceof AdditionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] = ((12d + Double.parseDouble(_stringSVValues[i])) + _doubleSVValues[i] + (
-          ((double) _floatSVValues[i] + (double) _longSVValues[i]) + 0.34 + (double) _intSVValues[i])
-          + _doubleSVValues[i]);
+          (Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()) + (double) _longSVValues[i]) + 0.34
+              + (double) _intSVValues[i]) + _doubleSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -78,7 +79,7 @@ public class AdditionTransformFunctionTest extends BaseTransformFunctionTest {
     for (int i = 0; i < NUM_ROWS; i++) {
       double val1 = 12d + Double.parseDouble(_stringSVValues[i]);
       double val2 = _doubleSVValues[i];
-      double val3 = (double) _floatSVValues[i] + (double) _longSVValues[i];
+      double val3 = Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()) + (double) _longSVValues[i];
       BigDecimal val6 = BigDecimal.valueOf(val3).add(val4).add(BigDecimal.valueOf(_intSVValues[i]));
       expectedBigDecimalValues[i] =
           BigDecimal.valueOf(val1).add(BigDecimal.valueOf(val2)).add(val6).add(_bigDecimalSVValues[i]);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -387,7 +387,7 @@ public abstract class BaseTransformFunctionTest {
       assertEquals(intValues[i], (int) expectedValues[i]);
       assertEquals(longValues[i], (long) expectedValues[i]);
       assertEquals(floatValues[i], expectedValues[i]);
-      assertEquals(doubleValues[i], (double) expectedValues[i]);
+      assertEquals(doubleValues[i], Double.parseDouble(Float.valueOf(expectedValues[i]).toString()));
       assertEquals(bigDecimalValues[i].floatValue(), expectedValues[i]);
       assertEquals(stringValues[i], Float.toString(expectedValues[i]));
     }
@@ -629,7 +629,7 @@ public abstract class BaseTransformFunctionTest {
         assertEquals(intValuesMV[i][j], (int) expectedValues[i][j]);
         assertEquals(longValuesMV[i][j], (long) expectedValues[i][j]);
         assertEquals(floatValuesMV[i][j], expectedValues[i][j]);
-        assertEquals(doubleValuesMV[i][j], (double) expectedValues[i][j]);
+        assertEquals(doubleValuesMV[i][j], Double.parseDouble(Float.valueOf(expectedValues[i][j]).toString()));
         assertEquals(stringValuesMV[i][j], Float.toString(expectedValues[i][j]));
       }
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CastTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CastTransformFunctionTest.java
@@ -132,9 +132,11 @@ public class CastTransformFunctionTest extends BaseTransformFunctionTest {
     long[] longScalarValues = new long[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedLongValues[i] =
-          (long) ((double) (int) _doubleSVValues[i] - (double) (float) _longSVValues[i] / (double) _intSVValues[i]);
+          (long) ((double) (int) _doubleSVValues[i]
+              - Double.parseDouble(Float.valueOf((float) _longSVValues[i]).toString()) / (double) _intSVValues[i]);
       longScalarValues[i] = (long) cast((double) (int) cast(_doubleSVValues[i], "int")
-          - (double) (float) cast(_longSVValues[i], "float") / (double) cast(_intSVValues[i], "double"), "long");
+          - Double.parseDouble(Float.valueOf((float) cast(_longSVValues[i], "float")).toString())
+          / (double) cast(_intSVValues[i], "double"), "long");
     }
     testTransformFunction(transformFunction, expectedLongValues);
     assertEquals(expectedLongValues, longScalarValues);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunctionTest.java
@@ -48,7 +48,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = (double) _longSVValues[i] / (double) _floatSVValues[i];
+      expectedValues[i] = (double) _longSVValues[i] / Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString());
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -56,7 +56,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = (double) _floatSVValues[i] / _doubleSVValues[i];
+      expectedValues[i] = Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()) / _doubleSVValues[i];
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -83,8 +83,8 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] = (((((12d / Double.parseDouble(_stringSVValues[i])) / _doubleSVValues[i]) / (
-          ((double) _floatSVValues[i] / (double) _longSVValues[i]) / 0.34)) / (double) _intSVValues[i])
-          / _doubleSVValues[i]);
+          (Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()) / (double) _longSVValues[i]) / 0.34))
+          / (double) _intSVValues[i]) / _doubleSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ModuloTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ModuloTransformFunctionTest.java
@@ -46,7 +46,7 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ModuloTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = (double) _longSVValues[i] % (double) _floatSVValues[i];
+      expectedValues[i] = (double) _longSVValues[i] % Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString());
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -55,7 +55,7 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof ModuloTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = (double) _floatSVValues[i] % _doubleSVValues[i];
+      expectedValues[i] = Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()) % _doubleSVValues[i];
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -83,8 +83,8 @@ public class ModuloTransformFunctionTest extends BaseTransformFunctionTest {
     Assert.assertTrue(transformFunction instanceof ModuloTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] = (((((12d % Double.parseDouble(_stringSVValues[i])) % _doubleSVValues[i]) % (
-          ((double) _floatSVValues[i] % (double) _longSVValues[i]) % 0.34)) % (double) _intSVValues[i])
-          % _doubleSVValues[i]);
+          (Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()) % (double) _longSVValues[i]) % 0.34))
+          % (double) _intSVValues[i]) % _doubleSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/MultiplicationTransformFunctionTest.java
@@ -40,7 +40,8 @@ public class MultiplicationTransformFunctionTest extends BaseTransformFunctionTe
     double[] expectedValues = new double[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] =
-          (double) _intSVValues[i] * (double) _longSVValues[i] * (double) _floatSVValues[i] * _doubleSVValues[i]
+          (double) _intSVValues[i] * (double) _longSVValues[i]
+              * Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()) * _doubleSVValues[i]
               * Double.parseDouble(_stringSVValues[i]);
     }
     testTransformFunction(transformFunction, expectedValues);
@@ -66,7 +67,8 @@ public class MultiplicationTransformFunctionTest extends BaseTransformFunctionTe
     expectedBigDecimalValues = new BigDecimal[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedBigDecimalValues[i] =
-          BigDecimal.valueOf((double) _intSVValues[i] * (double) _longSVValues[i] * (double) _floatSVValues[i])
+          BigDecimal.valueOf((double) _intSVValues[i] * (double) _longSVValues[i]
+                  * Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()))
               .multiply(BigDecimal.valueOf(_doubleSVValues[i])).multiply(new BigDecimal(_stringSVValues[i]))
               .multiply(_bigDecimalSVValues[i]);
     }
@@ -79,8 +81,8 @@ public class MultiplicationTransformFunctionTest extends BaseTransformFunctionTe
     Assert.assertTrue(transformFunction instanceof MultiplicationTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] = ((12d * Double.parseDouble(_stringSVValues[i])) * _doubleSVValues[i] * (
-          ((double) _floatSVValues[i] * (double) _longSVValues[i]) * 0.34 * (double) _intSVValues[i])
-          * _doubleSVValues[i]);
+          (Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()) * (double) _longSVValues[i]) * 0.34
+              * (double) _intSVValues[i]) * _doubleSVValues[i]);
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SingleParamMathTransformFunctionTest.java
@@ -61,7 +61,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof AbsTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.abs(_floatSVValues[i]);
+      expectedValues[i] = Double.parseDouble(Float.valueOf(Math.abs(_floatSVValues[i])).toString());
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -128,7 +128,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CeilTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.ceil(_floatSVValues[i]);
+      expectedValues[i] = Math.ceil(Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()));
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -261,7 +261,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof FloorTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.floor(_floatSVValues[i]);
+      expectedValues[i] = Math.floor(Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()));
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -329,7 +329,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof LnTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.log(_floatSVValues[i]);
+      expectedValues[i] = Math.log(Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()));
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -396,7 +396,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SqrtTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.sqrt(_floatSVValues[i]);
+      expectedValues[i] = Math.sqrt(Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()));
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -498,7 +498,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof Log10TransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.log10(_floatSVValues[i]);
+      expectedValues[i] = Math.log10(Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()));
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -555,7 +555,7 @@ public class SingleParamMathTransformFunctionTest extends BaseTransformFunctionT
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof Log2TransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.log(_floatSVValues[i]) / Math.log(2);
+      expectedValues[i] = Math.log(Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString())) / Math.log(2);
     }
     testTransformFunction(transformFunction, expectedValues);
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/SubtractionTransformFunctionTest.java
@@ -47,7 +47,7 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = (double) _longSVValues[i] - (double) _floatSVValues[i];
+      expectedValues[i] = (double) _longSVValues[i] - Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString());
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -55,7 +55,7 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = (double) _floatSVValues[i] - _doubleSVValues[i];
+      expectedValues[i] = Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()) - _doubleSVValues[i];
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -82,8 +82,8 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     Assert.assertTrue(transformFunction instanceof SubtractionTransformFunction);
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedValues[i] = (((((12d - Double.parseDouble(_stringSVValues[i])) - _doubleSVValues[i]) - (
-          ((double) _floatSVValues[i] - (double) _longSVValues[i]) - 0.34)) - (double) _intSVValues[i])
-          - _doubleSVValues[i]);
+          ((Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()) - (double) _longSVValues[i]) - 0.34))
+          - (double) _intSVValues[i]) - _doubleSVValues[i]));
     }
     testTransformFunction(transformFunction, expectedValues);
 
@@ -96,7 +96,8 @@ public class SubtractionTransformFunctionTest extends BaseTransformFunctionTest 
     for (int i = 0; i < NUM_ROWS; i++) {
       expectedBigDecimalValues[i] = (BigDecimal.valueOf(
               (((12d - Double.parseDouble(_stringSVValues[i])) - _doubleSVValues[i]) - (
-                  ((double) _floatSVValues[i] - (double) _longSVValues[i]) - 0.34)) - (double) _intSVValues[i])
+                  (Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()) - (double) _longSVValues[i]) - 0.34))
+                  - (double) _intSVValues[i])
           .subtract(_bigDecimalSVValues[i]));
     }
     testTransformFunction(transformFunction, expectedBigDecimalValues);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TrigonometricFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/TrigonometricFunctionsTest.java
@@ -104,7 +104,8 @@ public class TrigonometricFunctionsTest extends BaseTransformFunctionTest {
     Assert.assertEquals(transformFunction.getName(), Atan2TransformFunction.FUNCTION_NAME);
     double[] expectedValues = new double[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = Math.atan2(_doubleSVValues[i], _floatSVValues[i]);
+      expectedValues[i] = Math.atan2(_doubleSVValues[i],
+          Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()));
     }
     testTransformFunction(transformFunction, expectedValues);
   }
@@ -137,7 +138,7 @@ public class TrigonometricFunctionsTest extends BaseTransformFunctionTest {
     Assert.assertEquals(transformFunction.getName(), sqlFunction);
     expectedValues = new double[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = op.applyAsDouble(_floatSVValues[i]);
+      expectedValues[i] = op.applyAsDouble(Double.parseDouble(Float.valueOf(_floatSVValues[i]).toString()));
     }
     testTransformFunction(transformFunction, expectedValues);
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizerTest.java
@@ -216,29 +216,29 @@ public class NumericalFilterOptimizerTest {
             + " identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:-9"
             + ".223372036854776E18>)]))");
 
-    // Test FLOAT column with DOUBLE value that is within bounds of FLOAT.
+    // Test FLOAT column with DOUBLE value: no rewrite.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn > -2100000000.5"),
-        "Expression(type:FUNCTION, functionCall:Function(operator:GREATER_THAN_OR_EQUAL, operands:[Expression"
+        "Expression(type:FUNCTION, functionCall:Function(operator:GREATER_THAN, operands:[Expression"
             + "(type:IDENTIFIER, identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal "
-            + "doubleValue:-2.1E9>)]))");
+            + "doubleValue:-2.1000000005E9>)]))");
 
-    // Test FLOAT column with DOUBLE value that is within bounds of FLOAT.
+    // Test FLOAT column with DOUBLE value: no rewrite.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn < -2100000000.5"),
         "Expression(type:FUNCTION, functionCall:Function(operator:LESS_THAN, operands:[Expression(type:IDENTIFIER, "
-            + "identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:-2"
-            + ".1E9>)]))");
+            + "identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:"
+            + "-2.1000000005E9>)]))");
 
-    // Test FLOAT column with DOUBLE value that is within bounds of FLOAT.
+    // Test FLOAT column with DOUBLE value: no rewrite.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn <= 2100000000.5"),
         "Expression(type:FUNCTION, functionCall:Function(operator:LESS_THAN_OR_EQUAL, operands:[Expression"
             + "(type:IDENTIFIER, identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal "
-            + "doubleValue:2.1E9>)]))");
+            + "doubleValue:2.1000000005E9>)]))");
 
-    // Test FLOAT column with DOUBLE value that is within bounds of FLOAT.
+    // Test FLOAT column with DOUBLE value: no rewrite.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn >= 2100000000.5"),
-        "Expression(type:FUNCTION, functionCall:Function(operator:GREATER_THAN, operands:[Expression(type:IDENTIFIER,"
-            + " identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:2"
-            + ".1E9>)]))");
+        "Expression(type:FUNCTION, functionCall:Function(operator:GREATER_THAN_OR_EQUAL, operands:[Expression("
+            + "type:IDENTIFIER, identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal "
+            + "doubleValue:2.1000000005E9>)]))");
 
     // Test LONG column with DOUBLE value greater than Long.MAX_VALUE.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE longColumn > 999999999999999999999999999999.9999"),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/FloatingPointDataTypeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/FloatingPointDataTypeTest.java
@@ -83,7 +83,7 @@ public class FloatingPointDataTypeTest extends CustomDataQueryClusterIntegration
       fileWriter.create(avroSchema, avroFile);
       double sortedValue = 0.0;
       double unsortedValue = 0.05;
-      for (int i = 0; i < getCountStarResult(); i++) {
+      for (int i = 0; i < NUM_DOCS; i++) {
         // create avro record
         GenericData.Record record = new GenericData.Record(avroSchema);
         record.put(MET_DOUBLE_SORTED, sortedValue);
@@ -112,6 +112,7 @@ public class FloatingPointDataTypeTest extends CustomDataQueryClusterIntegration
   public void testQueries(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    // Choose 0.05 because if it's not converted correctly, float 0.05 will be converted to double 0.05000000074505806
     String[][] filterAndExpectedCount = {
         {MET_DOUBLE_SORTED + " > 0.05", "4"}, {MET_DOUBLE_SORTED + " = 0.05", "1"},
         {MET_DOUBLE_SORTED + " < 0.05", "5"},

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/FloatingPointDataTypeTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/FloatingPointDataTypeTest.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.io.IOException;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+/**
+ * Integration test for floating point data type (float & double) filter queries.
+ */
+@Test(suiteName = "CustomClusterIntegrationTest")
+public class FloatingPointDataTypeTest extends CustomDataQueryClusterIntegrationTest {
+  private static final String DEFAULT_TABLE_NAME = "FloatingPointDataTypeTest";
+  private static final int NUM_DOCS = 10;
+  private static final String MET_DOUBLE = "metDouble";
+  private static final String MET_FLOAT = "metFloat";
+
+  @Override
+  public String getTableName() {
+    return DEFAULT_TABLE_NAME;
+  }
+
+  @Override
+  public Schema createSchema() {
+    return new Schema.SchemaBuilder().setSchemaName(getTableName())
+        .addMetric(MET_DOUBLE, FieldSpec.DataType.DOUBLE)
+        .addMetric(MET_FLOAT, FieldSpec.DataType.FLOAT)
+        .build();
+  }
+
+  @Override
+  public File createAvroFile()
+      throws IOException {
+
+    // create avro schema
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("myRecord", null, null, false);
+    avroSchema.setFields(ImmutableList.of(
+        new org.apache.avro.Schema.Field(MET_DOUBLE, org.apache.avro.Schema.create(org.apache.avro.Schema.Type.DOUBLE),
+            null, null),
+        new org.apache.avro.Schema.Field(MET_FLOAT, org.apache.avro.Schema.create(org.apache.avro.Schema.Type.FLOAT),
+            null, null)));
+
+    // create avro file
+    File avroFile = new File(_tempDir, "data.avro");
+    try (DataFileWriter<GenericData.Record> fileWriter = new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
+      fileWriter.create(avroSchema, avroFile);
+      double doubleValue = 0.0;
+      float floatValue = 0.0f;
+      for (int i = 0; i < getCountStarResult(); i++) {
+        // create avro record
+        GenericData.Record record = new GenericData.Record(avroSchema);
+        record.put(MET_DOUBLE, doubleValue);
+        record.put(MET_FLOAT, floatValue);
+        doubleValue += 0.01;
+        floatValue += 0.01f;
+
+        // add avro record to file
+        fileWriter.append(record);
+      }
+    }
+    return avroFile;
+  }
+
+  @Override
+  protected long getCountStarResult() {
+    return NUM_DOCS;
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testQueries(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String[][] filterAndExpectedCount = {
+        {MET_DOUBLE + " > 0.05", "4"}, {MET_DOUBLE + " = 0.05", "1"}, {MET_DOUBLE + " < 0.05", "5"},
+        {MET_FLOAT + " > 0.05", "4"}
+        // FIXME: the result of the following queries is not correct
+        //  , {MET_FLOAT + " = 0.05", "1"}, {MET_FLOAT + " < 0.05", "5"}
+    };
+    for (String[] faec : filterAndExpectedCount) {
+      String filter = faec[0];
+      long expected = Long.parseLong(faec[1]);
+      String query = String.format("SELECT COUNT(*) FROM %s WHERE %s", getTableName(), filter);
+      JsonNode jsonNode = postQuery(query);
+      assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).asLong(), expected);
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/FloatOffHeapMutableDictionary.java
@@ -206,7 +206,7 @@ public class FloatOffHeapMutableDictionary extends BaseOffHeapMutableDictionary 
 
   @Override
   public double getDoubleValue(int dictId) {
-    return getFloatValue(dictId);
+    return Double.parseDouble(Float.valueOf(getFloatValue(dictId)).toString());
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/FloatOnHeapMutableDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/dictionary/FloatOnHeapMutableDictionary.java
@@ -189,7 +189,7 @@ public class FloatOnHeapMutableDictionary extends BaseOnHeapMutableDictionary {
 
   @Override
   public double getDoubleValue(int dictId) {
-    return getFloatValue(dictId);
+    return Double.parseDouble(Float.valueOf(getFloatValue(dictId)).toString());
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/FloatDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/FloatDictionary.java
@@ -66,7 +66,7 @@ public class FloatDictionary extends BaseImmutableDictionary {
 
   @Override
   public double getDoubleValue(int dictId) {
-    return getFloat(dictId);
+    return Double.parseDouble(Float.valueOf(getFloat(dictId)).toString());
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/OnHeapFloatDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/OnHeapFloatDictionary.java
@@ -104,7 +104,7 @@ public class OnHeapFloatDictionary extends BaseImmutableDictionary {
 
   @Override
   public double getDoubleValue(int dictId) {
-    return _dictIdToVal[dictId];
+    return Double.parseDouble(Float.valueOf(_dictIdToVal[dictId]).toString());
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/BaseChunkForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/BaseChunkForwardIndexReader.java
@@ -337,7 +337,7 @@ public abstract class BaseChunkForwardIndexReader implements ForwardIndexReader<
           int minOffset = docIds[0] * Float.BYTES;
           FloatBuffer buffer = _rawData.toDirectByteBuffer(minOffset, length * Float.BYTES).asFloatBuffer();
           for (int i = 0; i < buffer.limit(); i++) {
-            values[i] = buffer.get(i);
+            values[i] = Double.parseDouble(Float.valueOf(buffer.get(i)).toString());
           }
         }
         break;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readers/ImmutableDictionaryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/readers/ImmutableDictionaryTest.java
@@ -270,7 +270,7 @@ public class ImmutableDictionaryTest {
       assertEquals(floatDictionary.getIntValue(i), (int) _floatValues[i]);
       assertEquals(floatDictionary.getLongValue(i), (long) _floatValues[i]);
       assertEquals(floatDictionary.getFloatValue(i), _floatValues[i]);
-      assertEquals(floatDictionary.getDoubleValue(i), (double) _floatValues[i]);
+      assertEquals(floatDictionary.getDoubleValue(i), Double.parseDouble(Float.valueOf(_floatValues[i]).toString()));
       Assert.assertEquals(Float.parseFloat(floatDictionary.getStringValue(i)), _floatValues[i], 0.0f);
 
       assertEquals(floatDictionary.indexOf(String.valueOf(_floatValues[i])), i);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
@@ -287,7 +287,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         break;
       case FLOAT:
         for (int i = 0; i < length; i++) {
-          values[i] = getFloat(docIds[i], context);
+          values[i] = Double.parseDouble(Float.valueOf(getFloat(docIds[i], context)).toString());
         }
         break;
       case DOUBLE:

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ArrayCopyUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/ArrayCopyUtils.java
@@ -116,7 +116,7 @@ public class ArrayCopyUtils {
 
   public static void copy(float[] src, double[] dest, int length) {
     for (int i = 0; i < length; i++) {
-      dest[i] = src[i];
+      dest[i] = Double.parseDouble(Float.valueOf(src[i]).toString());
     }
   }
 

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/utils/ArrayCopyUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/utils/ArrayCopyUtilsTest.java
@@ -90,7 +90,7 @@ public class ArrayCopyUtilsTest {
     for (int i = 0; i < COPY_LENGTH; i++) {
       Assert.assertEquals(INT_BUFFER[i], (int) FLOAT_ARRAY[i]);
       Assert.assertEquals(LONG_BUFFER[i], (long) FLOAT_ARRAY[i]);
-      Assert.assertEquals(DOUBLE_BUFFER[i], (double) FLOAT_ARRAY[i]);
+      Assert.assertEquals(DOUBLE_BUFFER[i], Double.parseDouble(Float.valueOf(FLOAT_ARRAY[i]).toString()));
       Assert.assertEquals(STRING_BUFFER[i], Float.toString(FLOAT_ARRAY[i]));
     }
   }


### PR DESCRIPTION
This PR contains 3 parts:
1. Fix NumericalFilterOptimizer for float datatype.

Specifically, do not rewrite range operator since double has higher precision than float. If we do, we may introduce problems. For example, with the previous logic, "> 0.05" will be converted into ">= 0.05000000074505806". When the query reaches a server, the server will convert it to ">= 0.05" (lose some precision) in ColumnValueSegmentPruner#pruneRangePredicate, which is incorrect.

2. Fix float to double conversion on the query path.
3. Add an integration test to make sure float to double conversion works as expected.