### PR TITLE
[multistage] bugfix: override leaf query limit to 0 if set explicitly from outside

### DIFF
--- a/pinot-query-planner/src/test/resources/queries/BasicQueryPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/BasicQueryPlans.json
@@ -11,6 +11,30 @@
         ]
       },
       {
+        "description": "Select * with limit 0",
+        "sql": "EXPLAIN PLAN FOR SELECT * FROM d LIMIT 0",
+        "output": [
+          "Execution Plan",
+          "\nLogicalSort(offset=[0], fetch=[0])",
+          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
+          "\n    LogicalSort(fetch=[0])",
+          "\n      LogicalTableScan(table=[[d]])",
+          "\n"
+        ]
+      },
+      {
+        "description": "Select * with limit 0 offset 0",
+        "sql": "EXPLAIN PLAN FOR SELECT * FROM d LIMIT 0 OFFSET 0",
+        "output": [
+          "Execution Plan",
+          "\nLogicalSort(offset=[0], fetch=[0])",
+          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
+          "\n    LogicalSort(fetch=[0])",
+          "\n      LogicalTableScan(table=[[d]])",
+          "\n"
+        ]
+      },
+      {
         "description": "Select with filters",
         "sql": "EXPLAIN PLAN FOR SELECT a.col1, a.col3 + a.ts FROM a WHERE a.col3 >= 0 AND a.col2 = 'a'",
         "output": [

--- a/pinot-query-planner/src/test/resources/queries/ValidationErrorPlan.json
+++ b/pinot-query-planner/src/test/resources/queries/ValidationErrorPlan.json
@@ -10,6 +10,16 @@
         "description": "arrayToMV validation error 2",
         "sql": "EXPLAIN PLAN FOR SELECT SUM(a.col3) as sumCol3, arrayToMv(e.mcol1), a.col2  FROM a JOIN e on a.col1=e.col1 GROUP BY arrayToMv(e.mcol1), a.col2",
         "expectedException": "Error composing query plan for.*"
+      },
+      {
+        "description": "Select * with negative limit -1",
+        "sql": "EXPLAIN PLAN FOR SELECT * FROM d LIMIT -1",
+        "expectedException": "Caught exception while parsing query.*"
+      },
+      {
+        "description": "Select * with negative offset",
+        "sql": "EXPLAIN PLAN FOR SELECT * FROM d LIMIT 10 OFFSET -1",
+        "expectedException": "Caught exception while parsing query.*"
       }
     ]
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestVisitor.java
@@ -122,7 +122,7 @@ public class ServerPlanRequestVisitor implements PlanNodeVisitor<Void, ServerPla
       }
     }
 
-    if (resultDataContainer.size() > 0) {
+    if (!resultDataContainer.isEmpty()) {
       // rewrite SEMI-JOIN as filter clause.
       ServerPlanRequestUtils.attachDynamicFilter(context.getPinotQuery(), node.getJoinKeys(), resultDataContainer,
           dataSchema);
@@ -157,13 +157,13 @@ public class ServerPlanRequestVisitor implements PlanNodeVisitor<Void, ServerPla
   public Void visitSort(SortNode node, ServerPlanRequestContext context) {
     visitChildren(node, context);
     PinotQuery pinotQuery = context.getPinotQuery();
-    if (node.getCollationKeys().size() > 0) {
+    if (!node.getCollationKeys().isEmpty()) {
       pinotQuery.setOrderByList(CalciteRexExpressionParser.convertOrderByList(node, pinotQuery));
     }
-    if (node.getFetch() > 0) {
+    if (node.getFetch() >= 0) {
       pinotQuery.setLimit(node.getFetch());
     }
-    if (node.getOffset() > 0) {
+    if (node.getOffset() >= 0) {
       pinotQuery.setOffset(node.getOffset());
     }
     return null;


### PR DESCRIPTION
Current behavior will return full table for query:  `Select * from LIMIT 0`