### PR TITLE
Use operator name instead of explain string in operatorId

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -39,8 +39,7 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
 
   public MultiStageOperator(OpChainExecutionContext context) {
     _context = context;
-    _operatorId =
-        Joiner.on("_").join(toExplainString(), _context.getRequestId(), _context.getStageId(), _context.getServer());
+    _operatorId = Joiner.on("_").join(getClass().getName(), _context.getStageId(), _context.getServer());
     _opChainStats = _context.getStats();
   }
 


### PR DESCRIPTION
Explain string can be very long, which is not appropriate as operator id.
Also, request id is not required for inner query stats tracking