### PR TITLE
Fix Segment Assignment and Routing for consuming segments

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentUtils.java
@@ -137,6 +137,7 @@ public class SegmentAssignmentUtils {
       instancesAssigned
           .add(instancePartitions.getInstances(partitionId, replicaGroupId).get(instanceIdWithLeastSegmentsAssigned));
     }
+
     return instancesAssigned;
   }
 
@@ -242,7 +243,9 @@ public class SegmentAssignmentUtils {
       newAssignment.put(segmentName, getReplicaGroupBasedInstanceStateMap(instancePartitions, partitionId, instanceId));
       intPair.setLeft(intPair.getLeft() + 1);
       heap.add(intPair);
+      numSegmentsAssignedPerInstance[instanceId]++;
     }
+
   }
 
   /**


### PR DESCRIPTION
This check will help in not sending queries to instances that don't have all the segments for a particular partition in case of upsert tables. 

Such scenarios can arise during a table rebalance operation which leads to incorrect results.

Verified with quickstart and modifying the IS explicitly to assign some segment to another server. 

Pending: 

Unit Tests