### PR TITLE
Ensure dataStream is closed even when offsetStream fails to flush

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowFileWriter.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/genericrow/GenericRowFileWriter.java
@@ -66,7 +66,11 @@ public class GenericRowFileWriter implements Closeable {
   @Override
   public void close()
       throws IOException {
-    _offsetStream.close();
-    _dataStream.close();
+    try {
+      // Wrapping around try block to make sure dataStream is closed, despite failures while closing offsetStream.
+      _offsetStream.close();
+    } finally {
+      _dataStream.close();
+    }
   }
 }


### PR DESCRIPTION
**Problem**:
We had a situation where SegmentProcessingFramework ran out of disk and GenericRowFileWriter failed while closing _offsetStream. This prevented _dataStream from getting closed, which leads to file descriptor leak. 

**Solution**: Ensure that we close _dataStream, even when _offsetStream fails to flush. 

Stack -
Task failed in 726023ms with error: java.io.IOException: No space left on device
	at java.base/java.io.FileOutputStream.writeBytes(Native Method)
	at java.base/java.io.FileOutputStream.write(FileOutputStream.java:354)
	at java.base/java.io.BufferedOutputStream.flushBuffer(BufferedOutputStream.java:81)
	at java.base/java.io.BufferedOutputStream.flush(BufferedOutputStream.java:142)
	at java.base/java.io.FilterOutputStream.close(FilterOutputStream.java:182)
	at java.base/java.io.FilterOutputStream.close(FilterOutputStream.java:191)
	at org.apache.pinot.core.segment.processing.genericrow.GenericRowFileWriter.close(GenericRowFileWriter.java:69)
	at org.apache.pinot.core.segment.processing.genericrow.GenericRowFileManager.closeFileWriter(GenericRowFileManager.java:94)
