### PR TITLE
do not rewrite float double comparison in NumericalFilterOptimizer

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizer.java
@@ -334,14 +334,12 @@ public class NumericalFilterOptimizer extends BaseAndOrBooleanFilterOptimizer {
               // Literal value is less than the bounds of LONG.
               return getExpressionFromBoolean(
                   kind == FilterKind.GREATER_THAN || kind == FilterKind.GREATER_THAN_OR_EQUAL);
-            } else {
-              int comparison = Double.compare(actual, converted);
-              // Rewrite range operator
-              rewriteRangeOperator(range, kind, comparison);
-
-              // Rewrite range literal
-              rhs.getLiteral().setDoubleValue(converted);
             }
+            // Do not rewrite range operator since double has higher precision than float
+            // If we do, we may introduce problems.
+            // For example, in the previous logic, "> 0.05" will be converted into ">= 0.05000000074505806". When the
+            // query reaches a server, the server will convert it to ">= 0.05" in
+            // ColumnValueSegmentPruner#pruneRangePredicate, which is incorrect.
             break;
           }
           default:

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizerTest.java
@@ -216,29 +216,29 @@ public class NumericalFilterOptimizerTest {
             + " identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:-9"
             + ".223372036854776E18>)]))");
 
-    // Test FLOAT column with DOUBLE value that is within bounds of FLOAT.
+    // Test FLOAT column with DOUBLE value: no rewrite.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn > -2100000000.5"),
-        "Expression(type:FUNCTION, functionCall:Function(operator:GREATER_THAN_OR_EQUAL, operands:[Expression"
+        "Expression(type:FUNCTION, functionCall:Function(operator:GREATER_THAN, operands:[Expression"
             + "(type:IDENTIFIER, identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal "
-            + "doubleValue:-2.1E9>)]))");
+            + "doubleValue:-2.1000000005E9>)]))");
 
-    // Test FLOAT column with DOUBLE value that is within bounds of FLOAT.
+    // Test FLOAT column with DOUBLE value: no rewrite.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn < -2100000000.5"),
         "Expression(type:FUNCTION, functionCall:Function(operator:LESS_THAN, operands:[Expression(type:IDENTIFIER, "
-            + "identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:-2"
-            + ".1E9>)]))");
+            + "identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:"
+            + "-2.1000000005E9>)]))");
 
-    // Test FLOAT column with DOUBLE value that is within bounds of FLOAT.
+    // Test FLOAT column with DOUBLE value: no rewrite.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn <= 2100000000.5"),
         "Expression(type:FUNCTION, functionCall:Function(operator:LESS_THAN_OR_EQUAL, operands:[Expression"
             + "(type:IDENTIFIER, identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal "
-            + "doubleValue:2.1E9>)]))");
+            + "doubleValue:2.1000000005E9>)]))");
 
-    // Test FLOAT column with DOUBLE value that is within bounds of FLOAT.
+    // Test FLOAT column with DOUBLE value: no rewrite.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn >= 2100000000.5"),
-        "Expression(type:FUNCTION, functionCall:Function(operator:GREATER_THAN, operands:[Expression(type:IDENTIFIER,"
-            + " identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:2"
-            + ".1E9>)]))");
+        "Expression(type:FUNCTION, functionCall:Function(operator:GREATER_THAN_OR_EQUAL, operands:[Expression("
+            + "type:IDENTIFIER, identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal "
+            + "doubleValue:2.1000000005E9>)]))");
 
     // Test LONG column with DOUBLE value greater than Long.MAX_VALUE.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE longColumn > 999999999999999999999999999999.9999"),


### PR DESCRIPTION
Fix NumericalFilterOptimizer for float datatype.
Specifically, do not rewrite range operator since double has higher precision than float. If we do, we may introduce problems. For example, with the previous logic, "> 0.05" will be converted into ">= 0.05000000074505806". When the query reaches a server, the server will convert it to ">= 0.05" (lose some precision) in ColumnValueSegmentPruner#pruneRangePredicate, which is incorrect.

