### PR TITLE
Allow INT/FLOAT cast to TIMESTAMP type

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -297,7 +297,7 @@ public enum PinotDataType {
 
     @Override
     public Timestamp toTimestamp(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value from INTEGER to TIMESTAMP");
+      return new Timestamp(((Integer) value).longValue());
     }
 
     @Override
@@ -404,7 +404,7 @@ public enum PinotDataType {
 
     @Override
     public Timestamp toTimestamp(Object value) {
-      throw new UnsupportedOperationException("Cannot convert value from FLOAT to TIMESTAMP");
+      return new Timestamp(((Float) value).longValue());
     }
 
     @Override
@@ -974,7 +974,7 @@ public enum PinotDataType {
         // String does not represent a well-formed JSON. Ignore this exception because we are going to try to convert
         // Java String object to JSON string.
       } catch (Exception e) {
-          throw new RuntimeException("Unable to convert String into JSON. Input value: " + value, e);
+        throw new RuntimeException("Unable to convert String into JSON. Input value: " + value, e);
       }
     }
 
@@ -1232,7 +1232,7 @@ public enum PinotDataType {
       return (boolean[]) value;
     }
     if (isSingleValue()) {
-      return new boolean[] {toBoolean(value)};
+      return new boolean[]{toBoolean(value)};
     } else {
       Object[] valueArray = toObjectArray(value);
       int length = valueArray.length;
@@ -1250,7 +1250,7 @@ public enum PinotDataType {
       return (Timestamp[]) value;
     }
     if (isSingleValue()) {
-      return new Timestamp[] {toTimestamp(value)};
+      return new Timestamp[]{toTimestamp(value)};
     } else {
       Object[] valueArray = toObjectArray(value);
       int length = valueArray.length;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/MultiStageEngineIntegrationTest.java
@@ -626,6 +626,26 @@ public class MultiStageEngineIntegrationTest extends BaseClusterIntegrationTestS
     Assert.assertEquals(jsonNode.get("resultTable").get("rows").size(), 154);
   }
 
+  @Test
+  public void testLastWithTimeWithSubQuery()
+      throws Exception {
+    String pinotQuery =
+        "SELECT Carrier, LASTWITHTIME(s1, CAST(time_bucket as TIMESTAMP), 'LONG'), "
+            + "          LASTWITHTIME(s2, CAST(time_bucket as TIMESTAMP), 'DOUBLE')\n"
+            + "FROM (\n"
+            + "  SELECT DaysSinceEpoch*86400 as time_bucket, Carrier, "
+            + "  SUM(LongestAddGTime) as s1, AVG(TotalAddGTime) as s2 \n"
+            + "  FROM \"mytable\"\n"
+            + "  WHERE DaysSinceEpoch <= 16101 AND DaysSinceEpoch >= 16071 \n"
+            + "  GROUP BY DaysSinceEpoch, Carrier\n"
+            + "  ORDER BY DaysSinceEpoch\n"
+            + ")\n"
+            + "GROUP BY Carrier\n"
+            + "LIMIT 1000\n";
+    JsonNode jsonNode = postQuery(pinotQuery);
+    Assert.assertEquals(jsonNode.get("resultTable").get("rows").size(), 14);
+  }
+
   @AfterClass
   public void tearDown()
       throws Exception {


### PR DESCRIPTION
Cast scalar function convert long to int in the intermediate stage.

The issue here is `CAST` ignored the inner type and directly cast in outer query, see below plan, `DaysSinceEpoch` is `INT`, the `CAST` transparently takes it and tries to cast `INT` to `TIMESTAMP`, which caused the exception.

Example query: 
```
explain plan for SELECT Carrier, LASTWITHTIME(s1, CAST(time_bucket as TIMESTAMP), 'LONG') 
FROM (
  SELECT  cast(DaysSinceEpoch*86400000 as BIGINT)  as time_bucket, Carrier, SUM(LongestAddGTime) as s1
  FROM "airlineStats"
  GROUP BY DaysSinceEpoch, Carrier
)
GROUP BY Carrier
LIMIT 1000
```
And sample plan:
```
Execution Plan
LogicalSort(offset=[0], fetch=[1000])
  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])
    LogicalSort(fetch=[1000])
      LogicalAggregate(group=[{0}], agg#0=[LASTWITHTIME($1)])
        PinotLogicalExchange(distribution=[hash[0]])
          LogicalAggregate(group=[{0}], agg#0=[LASTWITHTIME($1, $2, $3)])
            LogicalProject(Carrier=[$0], s1=[$2], $f2=[CAST(*($1, 86400000)):TIMESTAMP(0) NOT NULL], $f3=['LONG'])
              LogicalAggregate(group=[{0, 1}], agg#0=[$SUM0($2)])
                PinotLogicalExchange(distribution=[hash[0, 1]])
                  LogicalAggregate(group=[{17, 21}], agg#0=[$SUM0($58)])
                    LogicalTableScan(table=[[airlineStats]])
```