### PR TITLE
Add API to query upsert metadata for a primary key from servers

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -715,4 +715,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     }
     return isValid;
   }
+
+  @Override
+  public TableUpsertMetadataManager getTableUpsertMetadataManager() {
+    return _tableUpsertMetadataManager;
+  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManager;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -237,4 +238,9 @@ public interface TableDataManager {
    */
   default void onConsumingToOnline(String segmentNameStr) {
   };
+
+
+  default TableUpsertMetadataManager getTableUpsertMetadataManager() {
+    return null;
+  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -304,6 +304,23 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
     return record;
   }
 
+  @Override
+  public GenericRow getRecordLocation(PrimaryKey primaryKey) {
+    RecordLocation recordLocation =
+        _primaryKeyToRecordLocationMap.get(HashUtils.hashPrimaryKey(primaryKey, _hashFunction));
+    if (recordLocation == null) {
+      return null;
+    } else {
+      GenericRow genericRow = new GenericRow();
+      IndexSegment segment = recordLocation.getSegment();
+      int docId = recordLocation.getDocId();
+      genericRow.putValue("segmentName", segment.getSegmentName());
+      genericRow.putValue("docId", docId);
+      genericRow.putValue("comparisonValue", recordLocation.getComparisonValue());
+      return genericRow;
+    }
+  }
+
   @VisibleForTesting
   static class RecordLocation {
     private final IndexSegment _segment;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -41,6 +41,11 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   }
 
   @Override
+  public ConcurrentMapPartitionUpsertMetadataManager get(int partitionId) {
+    return _partitionMetadataManagerMap.get(partitionId);
+  }
+
+  @Override
   public void stop() {
     for (ConcurrentMapPartitionUpsertMetadataManager metadataManager : _partitionMetadataManagerMap.values()) {
       metadataManager.stop();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/PartitionUpsertMetadataManager.java
@@ -25,6 +25,7 @@ import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
 
 
 /**
@@ -101,6 +102,11 @@ public interface PartitionUpsertMetadataManager extends Closeable {
    * Remove the expired primary keys from the metadata when TTL is enabled.
    */
   void removeExpiredPrimaryKeys();
+
+  /**
+   * Returns the record location for the given primary key.
+   */
+  GenericRow getRecordLocation(PrimaryKey primaryKey);
 
   /**
    * Stops the metadata manager. After invoking this method, no access to the metadata will be accepted.

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -40,6 +40,8 @@ public interface TableUpsertMetadataManager extends Closeable {
 
   PartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId);
 
+  PartitionUpsertMetadataManager get(int partitionId);
+
   UpsertConfig.Mode getUpsertMode();
 
   /**


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Adds API to query upsert metadata for a primary key, returning segment name, docId, and comparison value\.

```mermaid
flowchart TD
  N0["API endpoint getUpsertMetadata #40;F7#41;"]:::stAdded
  N1["Get TableDataManager #40;F7#41;"]:::stAdded
  N2["Get TableUpsertMetadataManager #40;F7#41;"]:::stAdded
  N3["Get PartitionUpsertMetadataManager #40;F7#41;"]:::stAdded
  N4["Build PrimaryKey from query params #40;F7#41;"]:::stAdded
  N5["Call getRecordLocation#40;primaryKey#41; #40;F7#41;"]:::stAdded
  N6["Build GenericRow with segmentName#44; docId#44; comparisonValue #40;F3#41;"]:::stAdded
  N7["Return JSON response #40;F7#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"calls"| N2
  N2 -->|"calls"| N3
  N3 -->|"calls"| N5
  N4 -->|"passes primaryKey"| N5
  N5 -->|"calls"| N6
  N6 -->|"returns GenericRow"| N7
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F3: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager\.java — [before](https://github.com/apache/pinot/blob/86a6b78935e98e6f6e9999d4a9b61b406f15a1c9/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java) · [after](https://github.com/apache/pinot/blob/3923f7cc9e796af18b59c4c22f9ca35486a4a8a0/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java)
- F7: pinot\-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource\.java — [before](https://github.com/apache/pinot/blob/86a6b78935e98e6f6e9999d4a9b61b406f15a1c9/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java) · [after](https://github.com/apache/pinot/blob/3923f7cc9e796af18b59c4c22f9ca35486a4a8a0/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6Ijg2YTZiNzg5MzVlOThlNmY2ZTk5OTlkNGE5YjYxYjQwNmYxNWExYzkiLCJjb250ZXh0X2hhc2giOiI1MGViN2IwNjczYzA3YWJmYTNlYTEwNzBhZTBjMjY5ZjExNTM3NmNhMjg2NjlmNjQ4ZGMwMjk0ZDUyODVjMjRjIiwiZ2VuZXJhdGVkX2F0IjoxNzg5Mjk1NTU1LCJoZWFkX3NoYSI6IjM5MjNmN2NjOWU3OTZhZjE4YjU5YzRjMjJmOWNhMzU0ODZhNGE4YTAiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJhNDg1Nzc4YThlYmY2ODRiYjM4YjhjNTk2YzYwYmQ2ZGY0NTk4YzczIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature fb3e3a3b55065719f5b34368dab98c2a46475b7da56078fd9ffcdbf63ecd95fc -->
<!-- pinot-pr-flow:end -->

This will help in debugging upsert related issues. Currently the metadata is blackbox once the code is deployed in prod. 

The API will help give visibility.

Example

```
curl -XGET "http://localhost:7500/tables/upsertMeetupRsvp_REALTIME/upsertMetadata?partitionId=0&primaryKey=21"                                                 
{
  "comparisonValue" : 1693667178312,
  "docId" : 2,
  "segmentName" : "upsertMeetupRsvp__0__8__20230902T1506Z"
}
```