### PR TITLE
Update License-binary for stax2-api.

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -551,7 +551,7 @@ BSD 2-Clause
 ------------
 com.github.luben:zstd-jni:1.5.2-3
 org.clapper:grizzled-slf4j_2.12:1.3.2
-org.codehaus.woodstox:stax2-api:3.1.4
+org.codehaus.woodstox:stax2-api:4.1
 
 
 BSD 3-Clause


### PR DESCRIPTION
We recently upgraded the hadoop dependency in [PR](https://github.com/apache/pinot/pull/11369) and introduced the newer version of `stax2-api`, however, missed the License-binary update.

This minor PR is just for updating it. 