### PR TITLE
Make all accessor methods on BrokerResponse public

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerResponse.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/BrokerResponse.java
@@ -46,27 +46,27 @@ public class BrokerResponse {
     _executionStats = ExecutionStats.fromJson(brokerResponse);
   }
 
-  boolean hasExceptions() {
+  public boolean hasExceptions() {
     return _exceptions != null && !_exceptions.isEmpty();
   }
 
-  JsonNode getExceptions() {
+  public JsonNode getExceptions() {
     return _exceptions;
   }
 
-  JsonNode getAggregationResults() {
+  public JsonNode getAggregationResults() {
     return _aggregationResults;
   }
 
-  JsonNode getSelectionResults() {
+  public JsonNode getSelectionResults() {
     return _selectionResults;
   }
 
-  JsonNode getResultTable() {
+  public JsonNode getResultTable() {
     return _resultTable;
   }
 
-  int getAggregationResultsSize() {
+  public int getAggregationResultsSize() {
     if (_aggregationResults == null) {
       return 0;
     } else {
@@ -74,15 +74,15 @@ public class BrokerResponse {
     }
   }
 
-  ExecutionStats getExecutionStats() {
+  public ExecutionStats getExecutionStats() {
     return _executionStats;
   }
 
-  static BrokerResponse fromJson(JsonNode json) {
+  public static BrokerResponse fromJson(JsonNode json) {
     return new BrokerResponse(json);
   }
 
-  static BrokerResponse empty() {
+  public static BrokerResponse empty() {
     return new BrokerResponse();
   }
 


### PR DESCRIPTION
bugfix, release-notes, pinot-java-client

In #10932, I requested for BrokerResponse class to be made public so that an external implementation of PinotClientTransport could be created. At that time, I failed to rectify that most of the methods to access data from BrokerResponse class are package-private which again hinders using them in a custom transport. Hence, opening this PR to make those public methods too.

CC: @tsegismont