### PR TITLE
UI: fix sql exception display

### DIFF
--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -257,4 +257,9 @@ declare module 'Models' {
     REALTIME = "realtime",
     OFFLINE = "offline"
   }
+
+  export interface SqlException {
+    errorCode: number,
+    message: string
+  }
 }

--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -88,7 +88,7 @@ const useStyles = makeStyles((theme) => ({
     paddingBottom: '48px',
   },
   sqlError: {
-    whiteSpace: 'pre-wrap',
+    whiteSpace: 'pre',
     overflow: "auto"
   },
   timeoutControl: {

--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -20,10 +20,10 @@
 
 import React, { useEffect, useState } from 'react';
 import { makeStyles } from '@material-ui/core/styles';
-import { Grid, Checkbox, Button, FormControl, Input, InputLabel } from '@material-ui/core';
+import { Grid, Checkbox, Button, FormControl, Input, InputLabel, Box } from '@material-ui/core';
 import Alert from '@material-ui/lab/Alert';
 import FileCopyIcon from '@material-ui/icons/FileCopy';
-import { TableData } from 'Models';
+import { SqlException, TableData } from 'Models';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/material.css';
@@ -89,6 +89,7 @@ const useStyles = makeStyles((theme) => ({
   },
   sqlError: {
     whiteSpace: 'pre-wrap',
+    overflow: "auto"
   },
   timeoutControl: {
     bottom: 10
@@ -183,7 +184,7 @@ const QueryPage = () => {
 
   const [outputResult, setOutputResult] = useState('');
 
-  const [resultError, setResultError] = useState('');
+  const [resultError, setResultError] = useState<SqlException[] | string>([]);
 
   const [queryStats, setQueryStats] = useState<TableData>({
     columns: [],
@@ -299,7 +300,7 @@ const QueryPage = () => {
     }
 
     const results = await PinotMethodUtils.getQueryResults(params);
-    setResultError(results.error || '');
+    setResultError(results.exceptions || []);
     setResultData(results.result || { columns: [], records: [] });
     setQueryStats(results.queryStats || { columns: responseStatCols, records: [] });
     setOutputResult(JSON.stringify(results.data, null, 2) || '');
@@ -499,7 +500,7 @@ const QueryPage = () => {
                 Tracing
               </Grid>
 
-              <Grid item xs={2}>
+              <Grid item xs={3}>
                 <Checkbox
                     name="useMSE"
                     color="primary"
@@ -551,11 +552,24 @@ const QueryPage = () => {
                 }
         
                 {/* Sql result errors */}
-                {resultError && (
+                {resultError && typeof resultError === "string" && (
                   <Alert severity="error" className={classes.sqlError}>
                     {resultError}
                   </Alert>
                 )}
+
+                {resultError && typeof resultError === "object" && resultError.length && (
+                  <>
+                    {
+                      resultError.map((error) => (
+                        <Box style={{paddingBottom: "16px"}}>
+                          <Alert className={classes.sqlError} severity="error">{error.message}</Alert>
+                        </Box>
+                      ))
+                    }
+                  </>
+                  )
+                }
         
                 <Grid item xs style={{ backgroundColor: 'white' }}>
                   {resultData.columns.length ? (

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -19,7 +19,7 @@
 
 import jwtDecode from "jwt-decode";
 import { get, map, each, isEqual, isArray, keys, union } from 'lodash';
-import { DataTable, SQLResult } from 'Models';
+import { DataTable, SqlException, SQLResult } from 'Models';
 import moment from 'moment';
 import {
   getTenants,
@@ -267,19 +267,15 @@ const getQueryResults = (params) => {
   return getQueryResult(params).then(({ data }) => {
     let queryResponse = getAsObject(data);
 
-    let errorStr = '';
+    let exceptions: SqlException[] | string = [];
     let dataArray = [];
     let columnList = [];
     // if sql api throws error, handle here
     if(typeof queryResponse === 'string'){
-      errorStr = queryResponse;
+      exceptions = queryResponse;
     } 
     if (queryResponse && queryResponse.exceptions && queryResponse.exceptions.length) {
-      try{
-        errorStr = JSON.stringify(queryResponse.exceptions, null, 2);
-      } catch {
-        errorStr = "";
-      }
+      exceptions = queryResponse.exceptions as SqlException[];
     } 
     if (queryResponse.resultTable?.dataSchema?.columnNames?.length) {
       columnList = queryResponse.resultTable.dataSchema.columnNames;
@@ -311,7 +307,7 @@ const getQueryResults = (params) => {
     ];
 
     return {
-      error: errorStr,
+      exceptions: exceptions,
       result: {
         columns: columnList,
         records: dataArray,


### PR DESCRIPTION
## What does this PR do?
- Fixes SQL exception message formatting (earlier it used to ignore escape sequence which made the exception hard to read, but now the message is formatted properly)
- Fix message overflow from the box issue

## Screenshots 

Before 
<img width="1728" alt="image" src="https://github.com/apache/pinot/assets/41536903/a9527029-926b-4b71-898e-9b369ae31aa1">


After
<img width="1728" alt="image" src="https://github.com/apache/pinot/assets/41536903/28ccde41-5ed8-47a9-a338-a7f775dd8188">

