### PR TITLE
Add metric to track the number of primary keys in valid doc id snapshot

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -50,7 +50,8 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   REALTIME_INGESTION_DELAY_MS("milliseconds", false),
   END_TO_END_REALTIME_INGESTION_DELAY_MS("milliseconds", false),
   // Needed to track if valid doc id snapshots are present for faster restarts
-  UPSERT_VALID_DOC_ID_SNAPSHOT_COUNT("upsertValidDocIdSnapshotCount", false);
+  UPSERT_VALID_DOC_ID_SNAPSHOT_COUNT("upsertValidDocIdSnapshotCount", false),
+  UPSERT_PRIMARY_KEYS_IN_SNAPSHOT_COUNT("upsertPrimaryKeysInSnapshotCount", false);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -588,6 +588,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   // TODO: Consider optimizing it by tracking and persisting only the changed snapshot
   protected void doTakeSnapshot() {
     int numTrackedSegments = _trackedSegments.size();
+    int numPrimaryKeysInSnapshot = 0;
     _logger.info("Taking snapshot for {} segments", numTrackedSegments);
     long startTimeMs = System.currentTimeMillis();
 
@@ -596,11 +597,15 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       if (segment instanceof ImmutableSegmentImpl) {
         ((ImmutableSegmentImpl) segment).persistValidDocIdsSnapshot();
         numImmutableSegments++;
+        numPrimaryKeysInSnapshot +=
+            ((ImmutableSegmentImpl) segment).getValidDocIds().getMutableRoaringBitmap().getCardinality();
       }
     }
 
     _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId,
         ServerGauge.UPSERT_VALID_DOC_ID_SNAPSHOT_COUNT, numImmutableSegments);
+    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId,
+        ServerGauge.UPSERT_PRIMARY_KEYS_IN_SNAPSHOT_COUNT, numPrimaryKeysInSnapshot);
     _logger.info("Finished taking snapshot for {} immutable segments (out of {} total segments) in {}ms",
         numImmutableSegments, numTrackedSegments, System.currentTimeMillis() - startTimeMs);
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -588,7 +588,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   // TODO: Consider optimizing it by tracking and persisting only the changed snapshot
   protected void doTakeSnapshot() {
     int numTrackedSegments = _trackedSegments.size();
-    int numPrimaryKeysInSnapshot = 0;
+    long numPrimaryKeysInSnapshot = 0L;
     _logger.info("Taking snapshot for {} segments", numTrackedSegments);
     long startTimeMs = System.currentTimeMillis();
 


### PR DESCRIPTION
This will help to detect any large inconsistencies b/w the number of primary keys in server vs the keys in snapshot.

The [old PR ](https://github.com/apache/pinot/pull/11482) got messy after rebase so raising a new one  