### PR TITLE
fixing dateTimeConvert with double scientific notation values

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
@@ -531,6 +531,9 @@ public class DateTimeFunctionsTest {
     testDateTimeConvert("20180418T01:00:00", "1:HOURS:SIMPLE_DATE_FORMAT:yyyyMMdd''T''HH:mm:ss",
         "1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS tz(America/Los_Angeles)", "1:DAYS",
         "2018-04-17 00:00:00.000");
+    // Test time value with scientific number
+    testDateTimeConvert(1.50598536E12/* 20170921T02:16:00 */, "1:MILLISECONDS:EPOCH",
+        "1:DAYS:SIMPLE_DATE_FORMAT:yyyyMMdd", "1:DAYS", "20170921");
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatSpec.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.data;
 
 import com.google.common.base.Preconditions;
+import java.math.BigDecimal;
 import java.sql.Timestamp;
 import java.util.Objects;
 import java.util.concurrent.TimeUnit;
@@ -301,7 +302,8 @@ public class DateTimeFormatSpec {
   public long fromFormatToMillis(String dateTimeValue) {
     switch (_patternSpec.getTimeFormat()) {
       case EPOCH:
-        return TimeUnit.MILLISECONDS.convert(Long.parseLong(dateTimeValue) * _size, _unitSpec.getTimeUnit());
+        return TimeUnit.MILLISECONDS.convert((new BigDecimal(dateTimeValue).longValue() * _size),
+            _unitSpec.getTimeUnit());
       case TIMESTAMP:
         return TimestampUtils.toMillisSinceEpoch(dateTimeValue);
       case SIMPLE_DATE_FORMAT:


### PR DESCRIPTION
This happens in v1 query:
Sample query:
```
select  
DATETIMECONVERT(
   		max(rawTs), 
		'1:SECONDS:EPOCH', 
		'1:SECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss a', 
		'1:SECONDS') 
  from mytable limit 10
```
```
ProcessingException(errorCode:450, message:InternalError:
java.io.IOException: Failed : HTTP error code : 500. 
Root Cause: Caught exception while invoking method: public java.lang.String org.apache.pinot.common.function.scalar.DateTimeConvert.dateTimeConvert(java.lang.String,java.lang.String,java.lang.String,java.lang.String) with arguments: [1.6932672E12, 1:SECONDS:EPOCH, 1:SECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss a, 1:SECONDS]
```