### PR TITLE
handle reading empty parquet files

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordReaderFullTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetNativeRecordReaderFullTest.java
@@ -39,7 +39,7 @@ public class ParquetNativeRecordReaderFullTest {
     testParquetFile("test-data/test-null.parquet");
     testParquetFile("test-data/test-null-dictionary.parquet");
     testParquetFile("test-data/airlines_parquet/4345e5eef217aa1b-c8f16177f35fd983_1150363067_data.1.parq");
-    //testParquetFile("test-data/dir_metadata/empty.parquet");
+    testParquetFile("test-data/dir_metadata/empty.parquet");
     testParquetFile("test-data/multi_rgs_pyarrow/b=hi/a97cc141d16f4014a59e5b234dddf07c.parquet");
     testParquetFile("test-data/multi_rgs_pyarrow/b=lo/01bc139247874a0aa9e0e541f2eec497.parquet");
     for (int i = 1; i < 4; i++) {
@@ -54,7 +54,7 @@ public class ParquetNativeRecordReaderFullTest {
     testParquetFile("test-data/customer.impala.parquet");
     testParquetFile("test-data/datapage_v2.snappy.parquet");
     testParquetFile("test-data/decimals.parquet");
-    //testParquetFile("test-data/empty.parquet");
+    testParquetFile("test-data/empty.parquet");
     testParquetFile("test-data/foo.parquet");
     testParquetFile("test-data/gzip-nation.impala.parquet");
     testParquetFile("test-data/map-test.snappy.parquet");
@@ -129,6 +129,11 @@ public class ParquetNativeRecordReaderFullTest {
     while (recordReader.hasNext()) {
       recordReader.next();
     }
+    recordReader.rewind();
+    while (recordReader.hasNext()) {
+      recordReader.next();
+    }
+
     recordReader.close();
   }
 }

--- a/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/src/test/java/org/apache/pinot/plugin/inputformat/parquet/ParquetRecordReaderTest.java
@@ -148,6 +148,15 @@ public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
     Assert.assertTrue(avroRecordReader.useAvroParquetRecordReader());
     Assert.assertFalse(nativeRecordReader.useAvroParquetRecordReader());
 
+    testComparison(avroRecordReader, nativeRecordReader, totalRecords);
+    avroRecordReader.rewind();
+    nativeRecordReader.rewind();
+    testComparison(avroRecordReader, nativeRecordReader, totalRecords);
+  }
+
+  private void testComparison(ParquetRecordReader avroRecordReader, ParquetRecordReader nativeRecordReader,
+      int totalRecords)
+      throws IOException {
     GenericRow avroReuse = new GenericRow();
     GenericRow nativeReuse = new GenericRow();
     int recordsRead = 0;
@@ -159,6 +168,7 @@ public class ParquetRecordReaderTest extends AbstractRecordReaderTest {
       Assert.assertTrue(avroReaderRow.equals(nativeReaderRow));
       recordsRead++;
     }
+    Assert.assertFalse(nativeRecordReader.hasNext());
     Assert.assertEquals(recordsRead, totalRecords,
         "Message read from ParquetRecordReader doesn't match the expected number.");
   }


### PR DESCRIPTION
This is a small `bugfix` to allow the parquet reader to handle empty files. This came up with a user testing loading staging data into Pinot. It's unclear why there's a file with no records, and we'll likely mitigate this by looking at the spark job itself, but I figured this fix is useful either way. If the file comes from an empty partition, this might be unavoidable.

The issue arises from trying to construct a record reader with a null page. `hasNext` already guarded against this, but this fails directly in `init`. I also removed an unnecessary cast.

I haven't had a chance to test this against pinot, but I will try to reproduce this locally tomorrow. In the meantime, I've uncommented the "empty" parquet tests and added further testing to ensure rewind + read still works.