### PR TITLE
do not emit lag once tabledatamanager shutdown

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -210,8 +210,9 @@ public class IngestionDelayTracker {
    */
   public void updateIngestionDelay(long ingestionTimeMs, long firstStreamIngestionTimeMs, int partitionGroupId) {
     // Store new measure and wipe old one for this partition
-    if (!_isServerReadyToServeQueries.get()) {
+    if (!_isServerReadyToServeQueries.get() || _realTimeTableDataManager.isShutDown()) {
       // Do not update the ingestion delay metrics during server startup period
+      // or once the table data manager has been shutdown.
       return;
     }
     if ((ingestionTimeMs < 0) && (firstStreamIngestionTimeMs < 0)) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -247,6 +247,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
 
   @Override
   protected void doShutdown() {
+    // Make sure we do metric cleanup when we shut down the table.
+    // Do this first, so we do not show ingestion lag during shutdown.
+    _ingestionDelayTracker.shutdown();
     if (_tableUpsertMetadataManager != null) {
       // Stop the upsert metadata manager first to prevent removing metadata when destroying segments
       _tableUpsertMetadataManager.stop();
@@ -262,8 +265,6 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     if (_leaseExtender != null) {
       _leaseExtender.shutDown();
     }
-    // Make sure we do metric cleanup when we shut down the table.
-    _ingestionDelayTracker.shutdown();
   }
 
   /*


### PR DESCRIPTION
This is a fix for #11533.

First, we shutdown the ingestion delay first when the `RealtimeTableDataManger` is shutdown. This way the gauges are removed and stop reporting lag instead of waiting for all segments to get shutdown. Second, we stop emitting ingestion lag in `updateIngestionDelay` once the `RealtimeTableDataManger` is shutdown. This way, segments that have stopped consuming cannot keep updating ingestion delay.

I've tested this on a QA cluster consuming thousands of events per second. Before this, shutting down a server would show ~10 minutes of ingestion lag. After this, the ingestion lag stays stable and eventually stops reporting once all segments are destroyed.