### PR TITLE
Update Segment Download URL Even When CRC Matches

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -211,6 +211,11 @@ public class ZKOperator {
           // If no modifier is provided, use the custom map from the segment metadata
           segmentZKMetadata.setCustomMap(segmentMetadata.getCustomMap());
         }
+        if (!segmentZKMetadata.getDownloadUrl().equals(segmentDownloadURIStr)) {
+          LOGGER.info("Updating segment download url from: {} to: {} even though crc is the same",
+                  segmentZKMetadata.getDownloadUrl(), segmentDownloadURIStr);
+          segmentZKMetadata.setDownloadUrl(segmentDownloadURIStr);
+        }
         if (!_pinotHelixResourceManager.updateZkMetadata(tableNameWithType, segmentZKMetadata, expectedVersion)) {
           throw new RuntimeException(
               String.format("Failed to update ZK metadata for segment: %s, table: %s, expected version: %d",

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/upload/ZKOperatorTest.java
@@ -292,8 +292,9 @@ public class ZKOperatorTest {
     assertEquals(segmentZKMetadata.getCreationTime(), 456L);
     long refreshTime = segmentZKMetadata.getRefreshTime();
     assertTrue(refreshTime > 0);
-    // DownloadURL and crypter should not unchanged
-    assertEquals(segmentZKMetadata.getDownloadUrl(), "downloadUrl");
+    // Download URL should change. Refer: https://github.com/apache/pinot/issues/11535
+    assertEquals(segmentZKMetadata.getDownloadUrl(), "otherDownloadUrl");
+    // crypter should not be changed
     assertEquals(segmentZKMetadata.getCrypterName(), "crypter");
     assertEquals(segmentZKMetadata.getSegmentUploadStartTime(), -1);
     assertEquals(segmentZKMetadata.getSizeInBytes(), 10);


### PR DESCRIPTION
fixes #11535

During segment upload at present we don't update Segment Download URL if the CRC of the new segment is same as the old segment. This part of the code is used only in `PinotSegmentUploadDownloadRestletResource` which handles the `POST /segments` and `POST /v2/segments` APIs.

This PR fixes that. This is not expected behavior in my opinion since the POST request states that the segment's Download URI is the passed URI, and Pinot should honor that and update its metadata regardless of the CRC. In offline ingestion scenarios this case can be quite common. This case can also represent a scenario where a user wishes to move their segment from 1 Deepstore location to another.

**Test Plan**

We will test this in our internal cluster once tomorrow. (I will update with details)