### PR TITLE
DO NOT MERGE: Change notSupportedInV2 to fail in order to have the actual pass rate

### DIFF
--- a/.github/workflows/scripts/.pinot_test.sh
+++ b/.github/workflows/scripts/.pinot_test.sh
@@ -32,13 +32,13 @@ if [ "$RUN_INTEGRATION_TESTS" != false ]; then
   cd pinot-integration-tests || exit 1
   if [ "$RUN_TEST_SET" == "1" ]; then
     mvn test \
-        -P github-actions,custom-cluster-integration-test-suite || exit 1
+        -P github-actions,custom-cluster-integration-test-suite -fn || exit 1
     mvn test \
-        -P github-actions,integration-tests-set-1 && exit 0 || exit 1
+        -P github-actions,integration-tests-set-1 -fn && exit 0 || exit 1
   fi
   if [ "$RUN_TEST_SET" == "2" ]; then
     mvn test \
-        -P github-actions,integration-tests-set-2 && exit 0 || exit 1
+        -P github-actions,integration-tests-set-2 -fn && exit 0 || exit 1
   fi
 else
   # Unit Tests
@@ -63,7 +63,7 @@ else
         -pl 'pinot-core' \
         -pl 'pinot-query-planner' \
         -pl 'pinot-query-runtime' \
-        -P github-actions,no-integration-tests && exit 0 || exit 1
+        -P github-actions,no-integration-tests  -fn  && exit 0 || exit 1
   fi
   if [ "$RUN_TEST_SET" == "2" ]; then
     mvn clean install -DskipTests -Dcheckstyle.skip -Dspotless.skip -Denforcer.skip -Dlicense.skip -T 16 || exit 1
@@ -76,7 +76,7 @@ else
         -pl '!pinot-query-planner' \
         -pl '!pinot-query-runtime' \
         -P github-actions,no-integration-tests \
-        -Dspotless.skip -Dcheckstyle.skip -Denforcer.skip -Dlicense.skip \
+        -Dspotless.skip -Dcheckstyle.skip -Denforcer.skip -Dlicense.skip -fn \
          && exit 0 || exit 1
   fi
 fi

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -78,7 +78,6 @@ import org.apache.pinot.spi.utils.NetUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.testng.Assert;
-import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
 
 import static org.apache.pinot.integration.tests.ClusterIntegrationTestUtils.getBrokerQueryApiUrl;
@@ -576,7 +575,8 @@ public abstract class ClusterTest extends ControllerTest {
 
   protected void notSupportedInV2() {
     if (useMultiStageQueryEngine()) {
-      throw new SkipException("Some queries fail when using multi-stage engine");
+      //throw new SkipException("Some queries fail when using multi-stage engine");
+      Assert.fail("Some queries fail when using multi-stage engine");
     }
   }
 }

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -574,9 +574,8 @@ public abstract class ClusterTest extends ControllerTest {
   }
 
   protected void notSupportedInV2() {
-    if (useMultiStageQueryEngine()) {
-      //throw new SkipException("Some queries fail when using multi-stage engine");
-      Assert.fail("Some queries fail when using multi-stage engine");
-    }
+    //if (useMultiStageQueryEngine()) {
+    //  throw new SkipException("Some queries fail when using multi-stage engine");
+    //}
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

PR makes V2\-unsupported tests run and adds \-fn to Maven to continue on failures for accurate pass rate\.

```mermaid
flowchart TD
  N0["notSupportedInV2#40;#41; no longer throws SkipException #40;F2#41;"]:::stModified
  N1["Test methods using notSupportedInV2#40;#41; are not skipped #40;F2#41;"]:::stModified
  N2["Maven test invoked with #45;fn flag #40;F1#41;"]:::stModified
  N3["Pass rate collected despite failures #40;F1#41;"]:::stModified
  N0 -->|"removal of SkipException allows test to proceed"| N1
  N2 -->|"#45;fn flag makes Maven continue after failures"| N3
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: \.github/workflows/scripts/\.pinot\_test\.sh — [before](https://github.com/apache/pinot/blob/e6655dd9d417b46db032e8079691d9201ca59edb/.github/workflows/scripts/.pinot_test.sh) · [after](https://github.com/apache/pinot/blob/fd49d0d9317286f8a82abe3ef41d0e8b33777cb0/.github/workflows/scripts/.pinot_test.sh)
- F2: pinot\-integration\-test\-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest\.java — [before](https://github.com/apache/pinot/blob/e6655dd9d417b46db032e8079691d9201ca59edb/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java) · [after](https://github.com/apache/pinot/blob/fd49d0d9317286f8a82abe3ef41d0e8b33777cb0/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImU2NjU1ZGQ5ZDQxN2I0NmRiMDMyZTgwNzk2OTFkOTIwMWNhNTllZGIiLCJjb250ZXh0X2hhc2giOiI0OGY4ZGFkM2ZkMzJkMzY1YmRkNzE4MTgyZTY2YmMwZjY1MTAxNWE5MTE4YmI4ZDEzZWU3NmYwMjc0YmQyNGI4IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NjMwMzEyLCJoZWFkX3NoYSI6ImZkNDlkMGQ5MzE3Mjg2ZjhhODJhYmUzZWY0MWQwZThiMzM3NzdjYjAiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlNjY1NWRkOWQ0MTdiNDZkYjAzMmU4MDc5NjkxZDkyMDFjYTU5ZWRiIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature cbf8e6636f3856eb9ce5e8e5c960b42b6ffe19bd1f7b29899e361be2043e5ac9 -->
<!-- pinot-pr-flow:end -->

This PR changes `ClusterTest.notSupportedInV2()` to do not ignore tests.

We don't want to merge this, but it is useful to get the pass rate.