### PR TITLE
Add some catch-all prometheus rules

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/README.md
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/README.md
@@ -6,17 +6,27 @@ Prometheus is not a full-fledged dashboarding solution and needs to be hooked up
 
 #### How do Pinot metrics end up in Prometheus?
 
-Currently, Pinot metrics are exposed as JMX mbeans through the PinotJmxReporter. These JMX mbeans are consumed by Prometheus using the [Prometheus JMX Exporter](https://github.com/prometheus/jmx_exporter). A fairly comprehensive Prometheus JMX Exporter config can be found under `docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml`.
+Currently, Pinot metrics are exposed as JMX mbeans through the PinotJmxReporter. 
+These JMX mbeans are consumed by Prometheus using the [Prometheus JMX Exporter](https://github.com/prometheus/jmx_exporter).
+Fairly comprehensive Prometheus JMX Exporter config files can be found under
+[docker/images/pinot/etc/jmx_prometheus_javaagent/configs/](docker/images/pinot/etc/jmx_prometheus_javaagent/configs/).
 
 See the [Pinot docs](https://docs.pinot.apache.org/operators/operating-pinot/monitoring) for more info.
 
 #### How can I view and test metrics?
 
-First, you need to make sure the metrics are exposed though JMX. Note, that if no metric has been published (e.g. no values recorded), the metric will not show up in JMX or Prometheus server.
-With a local Pinot deployment, you can launch `jconsole`, select your local deployment and view all the metrics exposed as jmx mbeans. To see if the metrics are being consumed with the Prometheus JMX Exporter and your config file, you can set the JAVA_OPTS env variable before running Pinot locally.
+First, you need to make sure the metrics are exposed though JMX. 
+Note, that if no metric has been published (e.g. no values recorded), the metric will not show up in JMX or Prometheus server.
+With a local Pinot deployment, you can launch `jconsole`, select your local deployment and view all the metrics exposed as jmx mbeans.
+Alternative, you can use [jmxterm](https://docs.cyclopsgroup.org/jmxterm) in order to read them using a CLI.
+To see if the metrics are being consumed with the Prometheus JMX Exporter and your config file, 
+you can set the JAVA_OPTS env variable before running Pinot locally.
 
 `export JAVA_OPTS="-javaagent:jmx_prometheus_javaagent.jar=8080:pinot.yml -Xms4G -Xmx4G -XX:MaxDirectMemorySize=30g -Dlog4j2.configurationFile=conf/pinot-admin-log4j2.xml -Dplugins.dir=$BASEDIR/plugins"
 bin/pinot-admin.sh ....
 `
+
+Remember that it is recommended to use service specific prometheus configurations (like `broker.yml`, `server.yml`, etc)
+in production instead of `pinot.xml`.
 
 This will expose a port at 8080 to dump metrics as Prometheus format for Prometheus scraper to fetch.

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
@@ -144,8 +144,30 @@ rules:
   cache: true
   labels:
     table: "$1"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"BrokerMetrics\", name=\"pinot.broker.version.(\\w+)\"><>(\\w+)"
-  name: "pinot_broker_version"
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.version\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_version"
   cache: true
   labels:
-    version: "$1"
+    version: "$2"
+
+  ## Metrics that fit the catch-all patterns above should not be added to this file.
+  ## In case a metric does not fit the catch-all patterns, add them before this comment
+
+  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix.
+  # Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$4_$5"
+  cache: true
+  labels:
+    table: "$2"
+    tableType: "$3"
+  # This is a catch-all pattern for pinot table metrics. Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$3_$4"
+  cache: true
+  labels:
+    table: "$2"
+  # This is a catch-all pattern for pinot controller metrics not related to tables. Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$2_$3"
+  cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -193,8 +193,30 @@ rules:
   labels:
     table: "$1"
     tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.version.(\\w+)\"><>(\\w+)"
-  name: "pinot_controller_version"
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.version\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_version"
   cache: true
   labels:
-    version: "$1"
+    version: "$2"
+
+  ## Metrics that fit the catch-all patterns above should not be added to this file.
+  ## In case a metric does not fit the catch-all patterns, add them before this comment
+
+  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix.
+  # Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$4_$5"
+  cache: true
+  labels:
+    table: "$2"
+    tableType: "$3"
+  # This is a catch-all pattern for pinot table metrics. Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$3_$4"
+  cache: true
+  labels:
+    table: "$2"
+  # This is a catch-all pattern for pinot controller metrics not related to tables. Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$2_$3"
+  cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/minion.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/minion.yml
@@ -25,3 +25,30 @@ rules:
   cache: true
   labels:
     id: "$1"
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.version\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_version"
+  cache: true
+  labels:
+    version: "$2"
+
+  ## Metrics that fit the catch-all patterns above should not be added to this file.
+  ## In case a metric does not fit the catch-all patterns, add them before this comment
+
+  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix.
+  # Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$4_$5"
+  cache: true
+  labels:
+    table: "$2"
+    tableType: "$3"
+  # This is a catch-all pattern for pinot table metrics. Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$3_$4"
+  cache: true
+  labels:
+    table: "$2"
+  # This is a catch-all pattern for pinot controller metrics not related to tables. Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$2_$3"
+  cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -1,3 +1,8 @@
+# It is recommended to use the specific service yml file (like broker.yml, controller.yml, etc)
+# instead of this file.
+# Prometheus executes rules in a linear time, so the more rules your configuration has, the more CPU will be spent by
+# Prometheus Java agent.
+
 rules:
 # Pinot Controller
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ControllerMetrics\", name=\"pinot.controller.controller(\\w+)\"><>(\\w+)"
@@ -482,3 +487,31 @@ rules:
   cache: true
   labels:
     id: "$1"
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.version\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_version"
+  cache: true
+  labels:
+    version: "$2"
+
+
+  ## Metrics that fit the catch-all patterns above should not be added to this file.
+  ## In case a metric does not fit the catch-all patterns, add them before this comment
+
+  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix.
+  # Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$4_$5"
+  cache: true
+  labels:
+    table: "$2"
+    tableType: "$3"
+  # This is a catch-all pattern for pinot table metrics. Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$3_$4"
+  cache: true
+  labels:
+    table: "$2"
+  # This is a catch-all pattern for pinot controller metrics not related to tables. Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$2_$3"
+  cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -125,8 +125,30 @@ rules:
     table: "$1"
     tableType: "$2"
     partition: "$3"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.version.(\\w+)\"><>(\\w+)"
-  name: "pinot_server_version"
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.version\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_version"
   cache: true
   labels:
-    version: "$1"
+    version: "$2"
+
+  ## Metrics that fit the catch-all patterns above should not be added to this file.
+  ## In case a metric does not fit the catch-all patterns, add them before this comment
+
+  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix.
+  # Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$4_$5"
+  cache: true
+  labels:
+    table: "$2"
+    tableType: "$3"
+  # This is a catch-all pattern for pinot table metrics. Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$3_$4"
+  cache: true
+  labels:
+    table: "$2"
+  # This is a catch-all pattern for pinot controller metrics not related to tables. Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$2_$3"
+  cache: true


### PR DESCRIPTION
Before this PR, every time we added a new Pinot metric we needed to add it to the relative Prometheus file (`controller.yml`, `server.yml`, etc) and/or `pinot.yml` in order to be able to consume these metrics from Prometheus. Obviously, sometimes we forgot about that and the metric was not stored in Prometheus.

This PR includes a bunch of catch-all rules that will match most common Pinot patterns. It also generalizes the newly added version pattern and add it to `pinot.yml`

By using the new `pinot.yml` file in a very simple server, I've found all these new metrics in Prometheus:

```
pinot_server_grpcBytesReceived_<...>
pinot_server_grpcBytesSent_<...>
pinot_server_grpcQueries_<...>
pinot_server_heapCriticalLevelExceeded_<...>
pinot_server_heapPanicLevelExceeded_<...>
pinot_server_indexingFailures_<...>
pinot_server_jvmHeapUsedBytes_Value
pinot_server_noTableAccess_<...>
pinot_server_queriesDisabled_<...>
pinot_server_queriesKilled_<...>
pinot_server_readinessCheckBadCalls_<...>
pinot_server_readinessCheckOkCalls_<...>
pinot_server_version_Value
pinot_server_version
```