### PR TITLE
Keep header parsing logic the same in default CSVRecordReader and the line iterator

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/resources/dataFileWithNoRecords.csv
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/resources/dataFileWithNoRecords.csv
@@ -1,0 +1,1 @@
+id,firstName,lastName

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/resources/dataFileWithPartialLastRow.csv
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/resources/dataFileWithPartialLastRow.csv
@@ -1,0 +1,4 @@
+id,firstName,lastName,appVersion,active
+100,jane,doe,"1.0.0",yes
+101,john,doe,"1.0.1",yes
+102,jen,doe,"2.

--- a/pinot-plugins/pinot-input-format/pinot-csv/src/test/resources/dataFileWithSpaceAroundHeaders.csv
+++ b/pinot-plugins/pinot-input-format/pinot-csv/src/test/resources/dataFileWithSpaceAroundHeaders.csv
@@ -1,0 +1,4 @@
+ firstName , lastName , id
+John,Doe,100
+Jane,Doe,101
+Jen,Doe,102

--- a/pom.xml
+++ b/pom.xml
@@ -1133,7 +1133,7 @@
       <dependency>
         <groupId>org.apache.commons</groupId>
         <artifactId>commons-csv</artifactId>
-        <version>1.0</version>
+        <version>1.10.0</version>
       </dependency>
       <dependency>
         <groupId>com.h2database</groupId>


### PR DESCRIPTION
## Description
This is a follow-up to the PR – [11487](https://github.com/apache/pinot/pull/11487/files)

The following is addressed in the change.

* Update commons-csv library version from 1.0 to 1.10
* Header parsing logic is kept the same in the default CSVRecordReader and the line iterator
* Validate header logic is removed as it was found not to work in all scenarios
* Added unit tests for additional scenarios
