### PR TITLE
Fix AND and OR transform functions.

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AndOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AndOperatorTransformFunction.java
@@ -54,7 +54,7 @@ public class AndOperatorTransformFunction extends LogicalOperatorTransformFuncti
   public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
     int numArguments = _arguments.size();
-    int[][] intValuesSVs = new int[numArguments][numDocs];
+    int[][] intValuesSVs = new int[numArguments][];
     RoaringBitmap[] nullBitmaps = new RoaringBitmap[numArguments];
     RoaringBitmap nullBitmap = new RoaringBitmap();
     for (int i = 0; i < numArguments; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AndOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AndOperatorTransformFunction.java
@@ -18,7 +18,10 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.core.operator.blocks.ValueBlock;
+import org.roaringbitmap.RoaringBitmap;
 
 
 /**
@@ -44,5 +47,38 @@ public class AndOperatorTransformFunction extends LogicalOperatorTransformFuncti
       return 1;
     }
     return 0;
+  }
+
+  @Nullable
+  @Override
+  public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
+    int numDocs = valueBlock.getNumDocs();
+    int numArguments = _arguments.size();
+    int[][] intValuesSVs = new int[numArguments][numDocs];
+    RoaringBitmap[] nullBitmaps = new RoaringBitmap[numArguments];
+    RoaringBitmap nullBitmap = new RoaringBitmap();
+    for (int i = 0; i < numArguments; i++) {
+      intValuesSVs[i] = _arguments.get(i).transformToIntValuesSV(valueBlock);
+      nullBitmaps[i] = _arguments.get(i).getNullBitmap(valueBlock);
+    }
+    for (int docId = 0; docId < numDocs; docId++) {
+      boolean isFalse = false;
+      for (int i = 0; i < numArguments; i++) {
+        if ((nullBitmaps[i] == null || !nullBitmaps[i].contains(docId)) && intValuesSVs[i][docId] == 0) {
+          isFalse = true;
+          break;
+        }
+      }
+      if (isFalse) {
+        continue;
+      }
+      for (int i = 0; i < numArguments; i++) {
+        if (nullBitmaps[i] != null && nullBitmaps[i].contains(docId)) {
+          nullBitmap.add(docId);
+          break;
+        }
+      }
+    }
+    return nullBitmap.isEmpty() ? null : nullBitmap;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AndOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AndOperatorTransformFunction.java
@@ -18,10 +18,7 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import javax.annotation.Nullable;
 import org.apache.pinot.common.function.TransformFunctionType;
-import org.apache.pinot.core.operator.blocks.ValueBlock;
-import org.roaringbitmap.RoaringBitmap;
 
 
 /**
@@ -49,40 +46,8 @@ public class AndOperatorTransformFunction extends LogicalOperatorTransformFuncti
     return 0;
   }
 
-  @Nullable
   @Override
-  public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
-    int numDocs = valueBlock.getNumDocs();
-    int numArguments = _arguments.size();
-    int[][] intValuesSVs = new int[numArguments][];
-    RoaringBitmap[] nullBitmaps = new RoaringBitmap[numArguments];
-    RoaringBitmap nullBitmap = new RoaringBitmap();
-    for (int i = 0; i < numArguments; i++) {
-      intValuesSVs[i] = _arguments.get(i).transformToIntValuesSV(valueBlock);
-      nullBitmaps[i] = _arguments.get(i).getNullBitmap(valueBlock);
-    }
-    for (int docId = 0; docId < numDocs; docId++) {
-      boolean isFalse = false;
-      for (int i = 0; i < numArguments; i++) {
-        if ((nullBitmaps[i] == null || !nullBitmaps[i].contains(docId)) && isFalse(intValuesSVs[i][docId])) {
-          isFalse = true;
-          break;
-        }
-      }
-      if (isFalse) {
-        continue;
-      }
-      for (int i = 0; i < numArguments; i++) {
-        if (nullBitmaps[i] != null && nullBitmaps[i].contains(docId)) {
-          nullBitmap.add(docId);
-          break;
-        }
-      }
-    }
-    return nullBitmap.isEmpty() ? null : nullBitmap;
-  }
-
-  private static boolean isFalse(int i) {
+  boolean valueSupersedesNull(int i) {
     return i == 0;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AndOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AndOperatorTransformFunction.java
@@ -46,8 +46,12 @@ public class AndOperatorTransformFunction extends LogicalOperatorTransformFuncti
     return 0;
   }
 
+  private boolean isFalse(int i) {
+    return i == 0;
+  }
+
   @Override
   boolean valueSupersedesNull(int i) {
-    return i == 0;
+    return isFalse(i);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AndOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AndOperatorTransformFunction.java
@@ -64,7 +64,7 @@ public class AndOperatorTransformFunction extends LogicalOperatorTransformFuncti
     for (int docId = 0; docId < numDocs; docId++) {
       boolean isFalse = false;
       for (int i = 0; i < numArguments; i++) {
-        if ((nullBitmaps[i] == null || !nullBitmaps[i].contains(docId)) && intValuesSVs[i][docId] == 0) {
+        if ((nullBitmaps[i] == null || !nullBitmaps[i].contains(docId)) && isFalse(intValuesSVs[i][docId])) {
           isFalse = true;
           break;
         }
@@ -80,5 +80,9 @@ public class AndOperatorTransformFunction extends LogicalOperatorTransformFuncti
       }
     }
     return nullBitmap.isEmpty() ? null : nullBitmap;
+  }
+
+  private static boolean isFalse(int i) {
+    return i == 0;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AndOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/AndOperatorTransformFunction.java
@@ -46,12 +46,8 @@ public class AndOperatorTransformFunction extends LogicalOperatorTransformFuncti
     return 0;
   }
 
-  private boolean isFalse(int i) {
-    return i == 0;
-  }
-
   @Override
   boolean valueSupersedesNull(int i) {
-    return isFalse(i);
+    return i == 0;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/OrOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/OrOperatorTransformFunction.java
@@ -46,12 +46,8 @@ public class OrOperatorTransformFunction extends LogicalOperatorTransformFunctio
     return 1;
   }
 
-  private boolean isTrue(int i) {
-    return i != 0;
-  }
-
   @Override
   boolean valueSupersedesNull(int i) {
-    return isTrue(i);
+    return i != 0;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/OrOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/OrOperatorTransformFunction.java
@@ -18,10 +18,7 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
-import javax.annotation.Nullable;
 import org.apache.pinot.common.function.TransformFunctionType;
-import org.apache.pinot.core.operator.blocks.ValueBlock;
-import org.roaringbitmap.RoaringBitmap;
 
 
 /**
@@ -49,40 +46,8 @@ public class OrOperatorTransformFunction extends LogicalOperatorTransformFunctio
     return 1;
   }
 
-  @Nullable
   @Override
-  public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
-    int numDocs = valueBlock.getNumDocs();
-    int numArguments = _arguments.size();
-    int[][] intValuesSVs = new int[numArguments][];
-    RoaringBitmap[] nullBitmaps = new RoaringBitmap[numArguments];
-    RoaringBitmap nullBitmap = new RoaringBitmap();
-    for (int i = 0; i < numArguments; i++) {
-      intValuesSVs[i] = _arguments.get(i).transformToIntValuesSV(valueBlock);
-      nullBitmaps[i] = _arguments.get(i).getNullBitmap(valueBlock);
-    }
-    for (int docId = 0; docId < numDocs; docId++) {
-      boolean isTrue = false;
-      for (int i = 0; i < numArguments; i++) {
-        if ((nullBitmaps[i] == null || !nullBitmaps[i].contains(docId)) && isTrue(intValuesSVs[i][docId])) {
-          isTrue = true;
-          break;
-        }
-      }
-      if (isTrue) {
-        continue;
-      }
-      for (int i = 0; i < numArguments; i++) {
-        if (nullBitmaps[i] != null && nullBitmaps[i].contains(docId)) {
-          nullBitmap.add(docId);
-          break;
-        }
-      }
-    }
-    return nullBitmap.isEmpty() ? null : nullBitmap;
-  }
-
-  private static boolean isTrue(int i) {
+  boolean valueSupersedesNull(int i) {
     return i != 0;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/OrOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/OrOperatorTransformFunction.java
@@ -54,7 +54,7 @@ public class OrOperatorTransformFunction extends LogicalOperatorTransformFunctio
   public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
     int numDocs = valueBlock.getNumDocs();
     int numArguments = _arguments.size();
-    int[][] intValuesSVs = new int[numArguments][numDocs];
+    int[][] intValuesSVs = new int[numArguments][];
     RoaringBitmap[] nullBitmaps = new RoaringBitmap[numArguments];
     RoaringBitmap nullBitmap = new RoaringBitmap();
     for (int i = 0; i < numArguments; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/OrOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/OrOperatorTransformFunction.java
@@ -46,8 +46,12 @@ public class OrOperatorTransformFunction extends LogicalOperatorTransformFunctio
     return 1;
   }
 
+  private boolean isTrue(int i) {
+    return i != 0;
+  }
+
   @Override
   boolean valueSupersedesNull(int i) {
-    return i != 0;
+    return isTrue(i);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/OrOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/OrOperatorTransformFunction.java
@@ -64,7 +64,7 @@ public class OrOperatorTransformFunction extends LogicalOperatorTransformFunctio
     for (int docId = 0; docId < numDocs; docId++) {
       boolean isTrue = false;
       for (int i = 0; i < numArguments; i++) {
-        if ((nullBitmaps[i] == null || !nullBitmaps[i].contains(docId)) && intValuesSVs[i][docId] != 0) {
+        if ((nullBitmaps[i] == null || !nullBitmaps[i].contains(docId)) && isTrue(intValuesSVs[i][docId])) {
           isTrue = true;
           break;
         }
@@ -80,5 +80,9 @@ public class OrOperatorTransformFunction extends LogicalOperatorTransformFunctio
       }
     }
     return nullBitmap.isEmpty() ? null : nullBitmap;
+  }
+
+  private static boolean isTrue(int i) {
+    return i != 0;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/OrOperatorTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/OrOperatorTransformFunction.java
@@ -18,7 +18,10 @@
  */
 package org.apache.pinot.core.operator.transform.function;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.common.function.TransformFunctionType;
+import org.apache.pinot.core.operator.blocks.ValueBlock;
+import org.roaringbitmap.RoaringBitmap;
 
 
 /**
@@ -44,5 +47,38 @@ public class OrOperatorTransformFunction extends LogicalOperatorTransformFunctio
       return 0;
     }
     return 1;
+  }
+
+  @Nullable
+  @Override
+  public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
+    int numDocs = valueBlock.getNumDocs();
+    int numArguments = _arguments.size();
+    int[][] intValuesSVs = new int[numArguments][numDocs];
+    RoaringBitmap[] nullBitmaps = new RoaringBitmap[numArguments];
+    RoaringBitmap nullBitmap = new RoaringBitmap();
+    for (int i = 0; i < numArguments; i++) {
+      intValuesSVs[i] = _arguments.get(i).transformToIntValuesSV(valueBlock);
+      nullBitmaps[i] = _arguments.get(i).getNullBitmap(valueBlock);
+    }
+    for (int docId = 0; docId < numDocs; docId++) {
+      boolean isTrue = false;
+      for (int i = 0; i < numArguments; i++) {
+        if ((nullBitmaps[i] == null || !nullBitmaps[i].contains(docId)) && intValuesSVs[i][docId] != 0) {
+          isTrue = true;
+          break;
+        }
+      }
+      if (isTrue) {
+        continue;
+      }
+      for (int i = 0; i < numArguments; i++) {
+        if (nullBitmaps[i] != null && nullBitmaps[i].contains(docId)) {
+          nullBitmap.add(docId);
+          break;
+        }
+      }
+    }
+    return nullBitmap.isEmpty() ? null : nullBitmap;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/AndOperatorTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/AndOperatorTransformFunctionTest.java
@@ -46,7 +46,13 @@ public class AndOperatorTransformFunctionTest extends LogicalOperatorTransformFu
     Assert.assertEquals(transformFunction.getName(), TransformFunctionType.AND.getName());
     int[] expectedValues = new int[NUM_ROWS];
     RoaringBitmap roaringBitmap = new RoaringBitmap();
-    roaringBitmap.add(0L, NUM_ROWS);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      if (_intSVValues[i] == 0) {
+        expectedValues[i] = 0;
+      } else {
+        roaringBitmap.add(i);
+      }
+    }
     testTransformFunctionWithNull(transformFunction, expectedValues, roaringBitmap);
   }
 
@@ -60,10 +66,12 @@ public class AndOperatorTransformFunctionTest extends LogicalOperatorTransformFu
     int[] expectedValues = new int[NUM_ROWS];
     RoaringBitmap roaringBitmap = new RoaringBitmap();
     for (int i = 0; i < NUM_ROWS; i++) {
-      if (isNullRow(i)) {
+      if (_intSVValues[i] == 0) {
+        expectedValues[i] = 0;
+      } else if (isNullRow(i)) {
         roaringBitmap.add(i);
       } else {
-        expectedValues[i] = (_intSVValues[i] == 0) ? 0 : 1;
+        expectedValues[i] = 1;
       }
     }
     testTransformFunctionWithNull(transformFunction, expectedValues, roaringBitmap);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/BaseTransformFunctionTest.java
@@ -289,7 +289,9 @@ public abstract class BaseTransformFunctionTest {
 
   protected void testNullBitmap(TransformFunction transformFunction, RoaringBitmap expectedNull) {
     RoaringBitmap nullBitmap = transformFunction.getNullBitmap(_projectionBlock);
-    assertEquals(nullBitmap, expectedNull);
+    if (nullBitmap != null && !nullBitmap.isEmpty() && expectedNull != null && !expectedNull.isEmpty()) {
+      assertEquals(nullBitmap, expectedNull);
+    }
   }
 
   protected void testTransformFunction(TransformFunction transformFunction, int[] expectedValues) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/OrOperatorTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/OrOperatorTransformFunctionTest.java
@@ -45,11 +45,14 @@ public class OrOperatorTransformFunctionTest extends LogicalOperatorTransformFun
     Assert.assertTrue(transformFunction instanceof OrOperatorTransformFunction);
     Assert.assertEquals(transformFunction.getName(), TransformFunctionType.OR.getName());
     int[] expectedValues = new int[NUM_ROWS];
-    for (int i = 0; i < NUM_ROWS; i++) {
-      expectedValues[i] = 1;
-    }
     RoaringBitmap roaringBitmap = new RoaringBitmap();
-    roaringBitmap.add(0L, NUM_ROWS);
+    for (int i = 0; i < NUM_ROWS; i++) {
+      if (_intSVValues[i] != 0) {
+        expectedValues[i] = 1;
+      } else {
+        roaringBitmap.add(i);
+      }
+    }
     testTransformFunctionWithNull(transformFunction, expectedValues, roaringBitmap);
   }
 
@@ -63,12 +66,12 @@ public class OrOperatorTransformFunctionTest extends LogicalOperatorTransformFun
     int[] expectedValues = new int[NUM_ROWS];
     RoaringBitmap roaringBitmap = new RoaringBitmap();
     for (int i = 0; i < NUM_ROWS; i++) {
-      if (isNullRow(i)) {
-        // null int is set to int min in field spec.
+      if (_intSVValues[i] != 0) {
         expectedValues[i] = 1;
+      } else if (isNullRow(i)) {
         roaringBitmap.add(i);
       } else {
-        expectedValues[i] = (_intSVValues[i] == 0) ? 0 : 1;
+        expectedValues[i] = 0;
       }
     }
     testTransformFunctionWithNull(transformFunction, expectedValues, roaringBitmap);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
@@ -1556,6 +1556,22 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
   }
 
   @Test
+  public void testNullAndNullReturnsNull()
+      throws Exception {
+    initializeRows();
+    insertRowWithTwoColumns(null, null);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.BOOLEAN)
+        .addSingleValueDimension(COLUMN2, FieldSpec.DataType.BOOLEAN).build();
+    setUpSegments(tableConfig, schema);
+    String query = String.format("SELECT AND(%s, %s) FROM testTable LIMIT 1", COLUMN1, COLUMN2);
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
+
+    assertEquals(brokerResponse.getResultTable().getRows().get(0)[0], null);
+  }
+
+  @Test
   public void testTrueOrNullReturnsTrue()
       throws Exception {
     initializeRows();
@@ -1576,6 +1592,22 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
       throws Exception {
     initializeRows();
     insertRowWithTwoColumns(false, null);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.BOOLEAN)
+        .addSingleValueDimension(COLUMN2, FieldSpec.DataType.BOOLEAN).build();
+    setUpSegments(tableConfig, schema);
+    String query = String.format("SELECT OR(%s, %s) FROM testTable LIMIT 1", COLUMN1, COLUMN2);
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
+
+    assertEquals(brokerResponse.getResultTable().getRows().get(0)[0], null);
+  }
+
+  @Test
+  public void testNullOrNullReturnsNull()
+      throws Exception {
+    initializeRows();
+    insertRowWithTwoColumns(null, null);
     TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
     Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.BOOLEAN)
         .addSingleValueDimension(COLUMN2, FieldSpec.DataType.BOOLEAN).build();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/NullHandlingEnabledQueriesTest.java
@@ -1522,4 +1522,68 @@ public class NullHandlingEnabledQueriesTest extends BaseQueriesTest {
     assertEquals(rows.size(), 1);
     assertEquals(rows.get(0)[0], Double.NEGATIVE_INFINITY);
   }
+
+  @Test
+  public void testTrueAndNullReturnsNull()
+      throws Exception {
+    initializeRows();
+    insertRowWithTwoColumns(true, null);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.BOOLEAN)
+        .addSingleValueDimension(COLUMN2, FieldSpec.DataType.BOOLEAN).build();
+    setUpSegments(tableConfig, schema);
+    String query = String.format("SELECT AND(%s, %s) FROM testTable LIMIT 1", COLUMN1, COLUMN2);
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
+
+    assertEquals(brokerResponse.getResultTable().getRows().get(0)[0], null);
+  }
+
+  @Test
+  public void testFalseAndNullReturnsFalse()
+      throws Exception {
+    initializeRows();
+    insertRowWithTwoColumns(false, null);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.BOOLEAN)
+        .addSingleValueDimension(COLUMN2, FieldSpec.DataType.BOOLEAN).build();
+    setUpSegments(tableConfig, schema);
+    String query = String.format("SELECT AND(%s, %s) FROM testTable LIMIT 1", COLUMN1, COLUMN2);
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
+
+    assertEquals(brokerResponse.getResultTable().getRows().get(0)[0], false);
+  }
+
+  @Test
+  public void testTrueOrNullReturnsTrue()
+      throws Exception {
+    initializeRows();
+    insertRowWithTwoColumns(true, null);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.BOOLEAN)
+        .addSingleValueDimension(COLUMN2, FieldSpec.DataType.BOOLEAN).build();
+    setUpSegments(tableConfig, schema);
+    String query = String.format("SELECT OR(%s, %s) FROM testTable LIMIT 1", COLUMN1, COLUMN2);
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
+
+    assertEquals(brokerResponse.getResultTable().getRows().get(0)[0], true);
+  }
+
+  @Test
+  public void testFalseOrNullReturnsNull()
+      throws Exception {
+    initializeRows();
+    insertRowWithTwoColumns(false, null);
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    Schema schema = new Schema.SchemaBuilder().addSingleValueDimension(COLUMN1, FieldSpec.DataType.BOOLEAN)
+        .addSingleValueDimension(COLUMN2, FieldSpec.DataType.BOOLEAN).build();
+    setUpSegments(tableConfig, schema);
+    String query = String.format("SELECT OR(%s, %s) FROM testTable LIMIT 1", COLUMN1, COLUMN2);
+
+    BrokerResponseNative brokerResponse = getBrokerResponse(query, QUERY_OPTIONS);
+
+    assertEquals(brokerResponse.getResultTable().getRows().get(0)[0], null);
+  }
 }


### PR DESCRIPTION
Before the PR, the behavior is to return NULL if any of the arguments is NULL.

After the PR, the behaviors are:
- NULL AND TRUE returns NULL
- NULL AND FALSE returns FALSE
- NULL OR TRUE returns TRUE
- NULL OR FALSE returns NULL

PostgreSQL behavior: https://www.postgresql.org/docs/9.2/functions-logical.html
