### PR TITLE
[Minor] Change an argument name in PlanMaker

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/PlanMaker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/PlanMaker.java
@@ -57,7 +57,7 @@ public interface PlanMaker {
    * segments.
    */
   Plan makeStreamingInstancePlan(List<IndexSegment> indexSegments, QueryContext queryContext,
-      ExecutorService executorService, ResultsBlockStreamer streamObserver, ServerMetrics serverMetrics);
+      ExecutorService executorService, ResultsBlockStreamer streamer, ServerMetrics serverMetrics);
 
   /**
    * Returns a segment level {@link PlanNode} for a streaming query which contains the logical execution plan for one


### PR DESCRIPTION
Missed it when modifying the interface in #11472 