### PR TITLE
[bugfix] Fix stream config validator for protobuf decoders

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -517,11 +517,14 @@ public final class TableConfigUtils {
   @VisibleForTesting
   static void validateDecoder(StreamConfig streamConfig) {
     if (streamConfig.getDecoderClass().equals("org.apache.pinot.plugin.inputformat.protobuf.ProtoBufMessageDecoder")) {
+      String streamType = streamConfig.getType();
+      String descriptorFilePath = String.format("stream.%s.decoder.prop.descriptorFile", streamType);
+      String protoClassName = String.format("stream.%s.decoder.prop.protoClassName", streamType);
       // check the existence of the needed decoder props
-      if (!streamConfig.getDecoderProperties().containsKey("stream.kafka.decoder.prop.descriptorFile")) {
+      if (!streamConfig.getDecoderProperties().containsKey(descriptorFilePath)) {
         throw new IllegalStateException("Missing property of descriptorFile for ProtoBufMessageDecoder");
       }
-      if (!streamConfig.getDecoderProperties().containsKey("stream.kafka.decoder.prop.protoClassName")) {
+      if (!streamConfig.getDecoderProperties().containsKey(protoClassName)) {
         throw new IllegalStateException("Missing property of protoClassName for ProtoBufMessageDecoder");
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -517,9 +517,8 @@ public final class TableConfigUtils {
   @VisibleForTesting
   static void validateDecoder(StreamConfig streamConfig) {
     if (streamConfig.getDecoderClass().equals("org.apache.pinot.plugin.inputformat.protobuf.ProtoBufMessageDecoder")) {
-      String streamType = streamConfig.getType();
-      String descriptorFilePath = String.format("stream.%s.decoder.prop.descriptorFile", streamType);
-      String protoClassName = String.format("stream.%s.decoder.prop.protoClassName", streamType);
+      String descriptorFilePath = "descriptorFile";
+      String protoClassName = "protoClassName";
       // check the existence of the needed decoder props
       if (!streamConfig.getDecoderProperties().containsKey(descriptorFilePath)) {
         throw new IllegalStateException("Missing property of descriptorFile for ProtoBufMessageDecoder");

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -64,6 +64,8 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
+import static org.testng.AssertJUnit.assertTrue;
+
 
 /**
  * Tests for the validations in {@link TableConfigUtils}
@@ -617,17 +619,36 @@ public class TableConfigUtilsTest {
     TableConfigUtils.validateIngestionConfig(tableConfig, null);
 
     // validate the proto decoder
-    streamConfigs = getStreamConfigs();
-    streamConfigs.put("stream.kafka.decoder.class.name",
-        "org.apache.pinot.plugin.inputformat.protobuf.ProtoBufMessageDecoder");
-    streamConfigs.put("stream.kafka.decoder.prop.descriptorFile", "file://test");
+    streamConfigs = getKafkaStreamConfigs();
+    //test config should be valid
+    TableConfigUtils.validateDecoder(new StreamConfig("test", streamConfigs));
+    streamConfigs.remove("stream.kafka.decoder.prop.descriptorFile");
     try {
       TableConfigUtils.validateDecoder(new StreamConfig("test", streamConfigs));
     } catch (IllegalStateException e) {
       // expected
     }
-    streamConfigs.remove("stream.kafka.decoder.prop.descriptorFile");
-    streamConfigs.put("stream.kafka.decoder.prop.protoClassName", "test");
+    streamConfigs = getKafkaStreamConfigs();
+    streamConfigs.remove("stream.kafka.decoder.prop.protoClassName");
+    try {
+      TableConfigUtils.validateDecoder(new StreamConfig("test", streamConfigs));
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    //validate the protobuf pulsar config
+    streamConfigs = getPulsarStreamConfigs();
+    //test config should be valid
+    TableConfigUtils.validateDecoder(new StreamConfig("test", streamConfigs));
+    //remove the descriptor file, should fail
+    streamConfigs.remove("stream.pulsar.decoder.prop.descriptorFile");
+    try {
+      TableConfigUtils.validateDecoder(new StreamConfig("test", streamConfigs));
+    } catch (IllegalStateException e) {
+      // expected
+    }
+    streamConfigs = getPulsarStreamConfigs();
+    //remove the proto class name, should fail
+    streamConfigs.remove("stream.pulsar.decoder.prop.protoClassName");
     try {
       TableConfigUtils.validateDecoder(new StreamConfig("test", streamConfigs));
     } catch (IllegalStateException e) {
@@ -2090,6 +2111,30 @@ public class TableConfigUtilsTest {
     streamConfigs.put("stream.kafka.topic.name", "test");
     streamConfigs.put("stream.kafka.decoder.class.name",
         "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder");
+    return streamConfigs;
+  }
+
+  private Map<String, String> getKafkaStreamConfigs() {
+    Map<String, String> streamConfigs = new HashMap<>();
+    streamConfigs.put("streamType", "kafka");
+    streamConfigs.put("stream.kafka.consumer.type", "lowlevel");
+    streamConfigs.put("stream.kafka.topic.name", "test");
+    streamConfigs.put("stream.kafka.decoder.class.name",
+        "org.apache.pinot.plugin.inputformat.protobuf.ProtoBufMessageDecoder");
+    streamConfigs.put("stream.kafka.decoder.prop.descriptorFile", "file://test");
+    streamConfigs.put("stream.kafka.decoder.prop.protoClassName", "test");
+    return streamConfigs;
+  }
+
+  private Map<String, String> getPulsarStreamConfigs() {
+    Map<String, String> streamConfigs = new HashMap<>();
+    streamConfigs.put("streamType", "pulsar");
+    streamConfigs.put("stream.pulsar.consumer.type", "lowlevel");
+    streamConfigs.put("stream.pulsar.topic.name", "test");
+    streamConfigs.put("stream.pulsar.decoder.prop.descriptorFile", "file://test");
+    streamConfigs.put("stream.pulsar.decoder.prop.protoClassName", "test");
+    streamConfigs.put("stream.pulsar.decoder.class.name",
+        "org.apache.pinot.plugin.inputformat.protobuf.ProtoBufMessageDecoder");
     return streamConfigs;
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -64,8 +64,6 @@ import org.mockito.Mockito;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
-import static org.testng.AssertJUnit.assertTrue;
-
 
 /**
  * Tests for the validations in {@link TableConfigUtils}


### PR DESCRIPTION
Fixes https://github.com/apache/pinot/issues/11530

Appears to duplicate https://github.com/apache/pinot/pull/11544 however in testing @navina 's PR, I noticed that my code was still failing validation when testing it with an actual docker build. I looked at it again and saw that the `streamConfig.getDecoderProperties()` call was returning a simple map of just the decoder properties, not what the original author had assumed.  
For the test data, the returned map is:
```
{protoClassName=test, descriptorFile=file://test/}
```
When examining the tests, I saw that they only validated the failure cases and not a full passing case. 

Label: `bugfix`

@navina 

@xiangfu0 / @Jackie-Jiang 