### PR TITLE
Improve PinotEvaluateLiteralRule

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
@@ -66,7 +66,9 @@ public class PinotQueryRuleSets {
           // push project through WINDOW
           CoreRules.PROJECT_WINDOW_TRANSPOSE,
 
-          PinotEvaluateLiteralRule.INSTANCE,
+          // TODO: Revisit and see if they can be replaced with CoreRules.PROJECT_REDUCE_EXPRESSIONS and
+          //       CoreRules.FILTER_REDUCE_EXPRESSIONS
+          PinotEvaluateLiteralRule.Project.INSTANCE, PinotEvaluateLiteralRule.Filter.INSTANCE,
 
           // TODO: evaluate the SORT_JOIN_TRANSPOSE and SORT_JOIN_COPY rules
 

--- a/pinot-query-planner/src/test/resources/queries/LiteralEvaluationPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/LiteralEvaluationPlans.json
@@ -136,7 +136,7 @@
         "sql": "EXPLAIN PLAN FOR Select ST_Distance(X'8040340000000000004024000000000000', ST_Point(-122, 37.5, 1)) FROM a",
         "output": [
           "Execution Plan",
-          "\nLogicalProject(EXPR$0=[13416951.966757335:DOUBLE])",
+          "\nLogicalProject(EXPR$0=[1.3416951966757335E7:DOUBLE])",
           "\n  LogicalTableScan(table=[[a]])",
           "\n"
         ]


### PR DESCRIPTION
- Break `PinotEvaluateLiteralRule` into `Project` and `Filter` so that it doesn't match all the `RelNode`
- Remove `matches` since we already limit the node type
- Enhance the `RexShuttle` to achieve bottom up evaluation so that we can finish the evaluation in one shot