### PR TITLE
Handle interrupt gracefully for Lucene mutable index

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneDocIdCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneDocIdCollector.java
@@ -62,7 +62,7 @@ public class RealtimeLuceneDocIdCollector implements Collector {
       public void collect(int doc)
           throws IOException {
         if (_shouldCancel) {
-          throw new RuntimeException("Lucene query was cancelled after timeout was reached");
+          throw new RuntimeException("Lucene query was cancelled");
         }
         // Compute the absolute lucene docID across sub-indexes as doc that is passed is relative to the current reader
         _docIds.add(context.docBase + doc);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneDocIdCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneDocIdCollector.java
@@ -62,7 +62,7 @@ public class RealtimeLuceneDocIdCollector implements Collector {
       public void collect(int doc)
           throws IOException {
         if (_shouldCancel) {
-          throw new RuntimeException("Lucene query was cancelled");
+          throw new RuntimeException("TEXT_MATCH query was cancelled");
         }
         // Compute the absolute lucene docID across sub-indexes as doc that is passed is relative to the current reader
         _docIds.add(context.docBase + doc);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
@@ -142,9 +142,9 @@ public class RealtimeLuceneTextIndex implements MutableTextIndex {
       return searchFuture.get();
     } catch (InterruptedException e) {
       docIDCollector.markShouldCancel();
-      LOGGER.warn("Lucene query timed out while searching the realtime text index for segment {}, column {},"
-              + " search query {}", _segmentName, _column, searchQuery);
-      throw new RuntimeException("Lucene query was cancelled after timeout was reached");
+      LOGGER.warn("TEXT_MATCH query timeout on realtime consuming segment {}, column {}, search query {}", _segmentName,
+          _column, searchQuery);
+      throw new RuntimeException("TEXT_MATCH query timeout on realtime consuming segment");
     } catch (Exception e) {
       LOGGER.error("Failed while searching the realtime text index for segment {}, column {}, search query {},"
               + " exception {}", _segmentName, _column, searchQuery, e.getMessage());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndexSearcherPool.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndexSearcherPool.java
@@ -45,7 +45,7 @@ public class RealtimeLuceneTextIndexSearcherPool {
     return _singletonInstance;
   }
 
-  public static synchronized RealtimeLuceneTextIndexSearcherPool init(int size) {
+  public static RealtimeLuceneTextIndexSearcherPool init(int size) {
     _singletonInstance = new RealtimeLuceneTextIndexSearcherPool(size);
     return _singletonInstance;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndexSearcherPool.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndexSearcherPool.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.realtime.impl.invertedindex;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+
+/**
+ * This class manages a thread pool used for searching over realtime Lucene segments by {@link RealtimeLuceneTextIndex}.
+ * The pool max size is equivalent to pinot.query.scheduler.query_worker_threads to ensure each worker thread can have
+ * an accompanying Lucene searcher thread if needed. init() is called in BaseServerStarter to avoid creating a
+ * dependency on pinot-core.
+ */
+public class RealtimeLuceneTextIndexSearcherPool {
+  private static RealtimeLuceneTextIndexSearcherPool _singletonInstance;
+  private static ExecutorService _executorService;
+
+  private RealtimeLuceneTextIndexSearcherPool(int size) {
+    _executorService = new ThreadPoolExecutor(0, size, 500, TimeUnit.MILLISECONDS, new LinkedBlockingQueue<>());
+  }
+
+  public static RealtimeLuceneTextIndexSearcherPool getInstance() {
+    if (_singletonInstance == null) {
+      throw new AssertionError("RealtimeLuceneTextIndexSearcherPool.init() must be called first");
+    }
+    return _singletonInstance;
+  }
+
+  public static synchronized RealtimeLuceneTextIndexSearcherPool init(int size) {
+    _singletonInstance = new RealtimeLuceneTextIndexSearcherPool(size);
+    return _singletonInstance;
+  }
+
+  public ExecutorService getExecutorService() {
+    return _executorService;
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -37,6 +37,7 @@ import static org.testng.Assert.assertEquals;
 public class LuceneMutableTextIndexTest {
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "LuceneMutableIndexTest");
   private static final String TEXT_COLUMN_NAME = "testColumnName";
+  private static RealtimeLuceneTextIndexSearcherPool _realtimeLuceneTextIndexSearcherPool;
 
   private RealtimeLuceneTextIndex _realtimeLuceneTextIndex;
 
@@ -55,6 +56,7 @@ public class LuceneMutableTextIndexTest {
   @BeforeClass
   public void setUp()
       throws Exception {
+    _realtimeLuceneTextIndexSearcherPool = RealtimeLuceneTextIndexSearcherPool.init(1);
     _realtimeLuceneTextIndex =
         new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500);
     String[][] documents = getTextData();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -93,7 +93,7 @@ public class LuceneMutableTextIndexTest {
   }
 
   @Test(expectedExceptions = ExecutionException.class,
-      expectedExceptionsMessageRegExp = ".*Lucene query was cancelled after timeout was reached.*")
+      expectedExceptionsMessageRegExp = ".*TEXT_MATCH query timeout on realtime consuming segment.*")
   public void testQueryCancellationIsSuccessful()
       throws InterruptedException, ExecutionException {
     ExecutorService executor = Executors.newSingleThreadExecutor();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -37,7 +37,8 @@ import static org.testng.Assert.assertEquals;
 public class LuceneMutableTextIndexTest {
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "LuceneMutableIndexTest");
   private static final String TEXT_COLUMN_NAME = "testColumnName";
-  private static RealtimeLuceneTextIndexSearcherPool _realtimeLuceneTextIndexSearcherPool;
+  private static final RealtimeLuceneTextIndexSearcherPool SEARCHER_POOL =
+      RealtimeLuceneTextIndexSearcherPool.init(1);
 
   private RealtimeLuceneTextIndex _realtimeLuceneTextIndex;
 
@@ -56,7 +57,6 @@ public class LuceneMutableTextIndexTest {
   @BeforeClass
   public void setUp()
       throws Exception {
-    _realtimeLuceneTextIndexSearcherPool = RealtimeLuceneTextIndexSearcherPool.init(1);
     _realtimeLuceneTextIndex =
         new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500);
     String[][] documents = getTextData();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -19,9 +19,14 @@
 package org.apache.pinot.segment.local.realtime.impl.invertedindex;
 
 import java.io.File;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.search.SearcherManager;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -41,14 +46,28 @@ public class LuceneMutableTextIndexTest {
     };
   }
 
+  private String[][] getRepeatedData() {
+    return new String[][]{
+        {"distributed storage", "multi-threading"}
+    };
+  }
+
   @BeforeClass
   public void setUp()
       throws Exception {
     _realtimeLuceneTextIndex =
         new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500);
     String[][] documents = getTextData();
+    String[][] repeatedDocuments = getRepeatedData();
+
     for (String[] row : documents) {
       _realtimeLuceneTextIndex.add(row);
+    }
+
+    for (int i = 0; i < 1000; i++) {
+      for (String[] row : repeatedDocuments) {
+        _realtimeLuceneTextIndex.add(row);
+      }
     }
 
     SearcherManager searcherManager = _realtimeLuceneTextIndex.getSearcherManager();
@@ -69,5 +88,15 @@ public class LuceneMutableTextIndexTest {
     assertEquals(_realtimeLuceneTextIndex.getDocIds("stream"), ImmutableRoaringBitmap.bitmapOf(0));
     assertEquals(_realtimeLuceneTextIndex.getDocIds("/.*house.*/"), ImmutableRoaringBitmap.bitmapOf(1));
     assertEquals(_realtimeLuceneTextIndex.getDocIds("invalid"), ImmutableRoaringBitmap.bitmapOf());
+  }
+
+  @Test(expectedExceptions = ExecutionException.class,
+      expectedExceptionsMessageRegExp = ".*Lucene query was cancelled after timeout was reached.*")
+  public void testQueryCancellationIsSuccessful()
+      throws InterruptedException, ExecutionException {
+    ExecutorService executor = Executors.newSingleThreadExecutor();
+    Future<MutableRoaringBitmap> res = executor.submit(() -> _realtimeLuceneTextIndex.getDocIds("/.*read.*/"));
+    executor.shutdownNow();
+    res.get();
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
@@ -34,6 +34,8 @@ public class NativeAndLuceneMutableTextIndexTest {
   private static final File INDEX_DIR = new File(FileUtils.getTempDirectory(), "RealTimeNativeVsLuceneTest");
   private static final String TEXT_COLUMN_NAME = "testColumnName";
   private static final String MV_TEXT_COLUMN_NAME = "testMVColumnName";
+  private static final RealtimeLuceneTextIndexSearcherPool SEARCHER_POOL =
+      RealtimeLuceneTextIndexSearcherPool.init(1);
 
   private RealtimeLuceneTextIndex _realtimeLuceneTextIndex;
   private NativeMutableTextIndex _nativeMutableTextIndex;

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -66,9 +66,11 @@ import org.apache.pinot.common.version.PinotVersion;
 import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeConsumptionRateManager;
+import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
 import org.apache.pinot.core.transport.ListenerConfig;
 import org.apache.pinot.core.util.ListenerConfigUtil;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeLuceneIndexRefreshState;
+import org.apache.pinot.segment.local.realtime.impl.invertedindex.RealtimeLuceneTextIndexSearcherPool;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.server.access.AccessControlFactory;
 import org.apache.pinot.server.api.AdminApiApplication;
@@ -137,6 +139,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
   protected AdminApiApplication _adminApiApplication;
   protected ServerQueriesDisabledTracker _serverQueriesDisabledTracker;
   protected RealtimeLuceneIndexRefreshState _realtimeLuceneIndexRefreshState;
+  protected RealtimeLuceneTextIndexSearcherPool _realtimeLuceneTextIndexSearcherPool;
   protected PinotEnvironmentProvider _pinotEnvironmentProvider;
   protected volatile boolean _isServerReadyToServeQueries = false;
 
@@ -619,6 +622,11 @@ public abstract class BaseServerStarter implements ServiceStartable {
         throw e;
       }
     }
+
+    // Create a thread pool used for mutable lucene index searches, with size based on query_worker_threads config
+    int queryWorkerThreads =
+        _serverConf.getProperty(ResourceManager.QUERY_WORKER_CONFIG_KEY, ResourceManager.DEFAULT_QUERY_WORKER_THREADS);
+    _realtimeLuceneTextIndexSearcherPool = RealtimeLuceneTextIndexSearcherPool.init(queryWorkerThreads);
 
     preServeQueries();
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -559,6 +559,12 @@ public abstract class BaseServerStarter implements ServiceStartable {
               + "'", e);
     }
 
+    // Create a thread pool used for mutable lucene index searches, with size based on query_worker_threads config
+    LOGGER.info("Initializing lucene searcher thread pool");
+    int queryWorkerThreads =
+        _serverConf.getProperty(ResourceManager.QUERY_WORKER_CONFIG_KEY, ResourceManager.DEFAULT_QUERY_WORKER_THREADS);
+    _realtimeLuceneTextIndexSearcherPool = RealtimeLuceneTextIndexSearcherPool.init(queryWorkerThreads);
+
     LOGGER.info("Initializing server instance and registering state model factory");
     Utils.logVersions();
     ControllerLeaderLocator.create(_helixManager);
@@ -622,11 +628,6 @@ public abstract class BaseServerStarter implements ServiceStartable {
         throw e;
       }
     }
-
-    // Create a thread pool used for mutable lucene index searches, with size based on query_worker_threads config
-    int queryWorkerThreads =
-        _serverConf.getProperty(ResourceManager.QUERY_WORKER_CONFIG_KEY, ResourceManager.DEFAULT_QUERY_WORKER_THREADS);
-    _realtimeLuceneTextIndexSearcherPool = RealtimeLuceneTextIndexSearcherPool.init(queryWorkerThreads);
 
     preServeQueries();
 


### PR DESCRIPTION
This addresses https://github.com/apache/pinot/issues/11402. 

When a thread is interrupted when searching the consuming segment, the underlying FSDirectory used by the IndexWriter which the SearcherManager was created with can be corrupted. To ensure the index is never corrupted this PR changes the the search to be executed in a child thread and the interrupt is handled in the current thread by canceling the search gracefully.

This was tested on an internal cluster, query timeouts no longer cause massive numbers of 'failed to index' logs and exceptions reported in the aforementioned issue are no longer present.

Some additional background on this behavior is here: https://github.com/apache/lucene/issues/9309 

tags: `bugfix`