### PR TITLE
Fail reload if derived columns can't be created

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -104,6 +104,7 @@ public class IndexLoadingConfig {
   private boolean _isDirectRealtimeOffHeapAllocation;
   private boolean _enableSplitCommitEndWithMetadata;
   private String _segmentStoreURI;
+  private boolean _errorOnColumnBuildFailure;
 
   // constructed from FieldConfig
   private Map<String, Map<String, String>> _columnProperties = new HashMap<>();
@@ -878,6 +879,14 @@ public class IndexLoadingConfig {
   public void setTableDataDir(String tableDataDir) {
     _tableDataDir = tableDataDir;
     _dirty = true;
+  }
+
+  public boolean isErrorOnColumnBuildFailure() {
+    return _errorOnColumnBuildFailure;
+  }
+
+  public void setErrorOnColumnBuildFailure(boolean errorOnColumnBuildFailure) {
+    _errorOnColumnBuildFailure = errorOnColumnBuildFailure;
   }
 
   public String getTableDataDir() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManager.java
@@ -472,8 +472,9 @@ public class HelixInstanceDataManager implements InstanceDataManager {
       segmentLock.lock();
 
       // Reloads an existing segment, and the local segment metadata is existing as asserted above.
-      tableDataManager.reloadSegment(segmentName,
-          new IndexLoadingConfig(_instanceDataManagerConfig, tableConfig, schema), zkMetadata, segmentMetadata, schema,
+      IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig(_instanceDataManagerConfig, tableConfig, schema);
+      indexLoadingConfig.setErrorOnColumnBuildFailure(true);
+      tableDataManager.reloadSegment(segmentName, indexLoadingConfig, zkMetadata, segmentMetadata, schema,
           forceDownload);
       LOGGER.info("Reloaded segment: {} of table: {}", segmentName, tableNameWithType);
     } finally {


### PR DESCRIPTION
Currently, a reload operation silently fails without errors when a newly added derived column can't be created due to transform function failures. This change makes sure we always fail a reload op with an error if newly added derived columns can't be created. If for whatever reason this behaviour is desirable for certain reload ops, we may add a new option (like forceDownload) to the reload API to toggle.
