### PR TITLE
Revert Helix back to 1.0.4 because of a critical bug

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -404,11 +404,11 @@ org.apache.flink:flink-shaded-netty:4.1.49.Final-12.0
 org.apache.flink:flink-shaded-zookeeper-3:3.4.14-12.0
 org.apache.flink:flink-streaming-java_2.12:1.12.0
 org.apache.flink:force-shading:1.12.0
-org.apache.helix:helix-common:1.3.0
-org.apache.helix:helix-core:1.3.0
-org.apache.helix:metadata-store-directory-common:1.3.0
-org.apache.helix:metrics-common:1.3.0
-org.apache.helix:zookeeper-api:1.3.0
+org.apache.helix:helix-common:1.0.4
+org.apache.helix:helix-core:1.0.4
+org.apache.helix:metadata-store-directory-common:1.0.4
+org.apache.helix:metrics-common:1.0.4
+org.apache.helix:zookeeper-api:1.0.4
 org.apache.hive:hive-storage-api:2.7.1
 org.apache.httpcomponents:httpclient:4.5.13
 org.apache.httpcomponents:httpcore:4.4.13

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
     <avro.version>1.9.2</avro.version>
     <parquet.version>1.12.3</parquet.version>
-    <helix.version>1.3.0</helix.version>
+    <helix.version>1.0.4</helix.version>
     <zkclient.version>0.7</zkclient.version>
     <jackson.version>2.12.7</jackson.version>
     <zookeeper.version>3.6.3</zookeeper.version>


### PR DESCRIPTION
Need to revert Helix back to 1.0.4 because of this [bug](https://github.com/apache/helix/issues/2613) introduced in 1.1.0