### PR TITLE
[logging] Reduce noise level due to slow topics

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/LLRealtimeSegmentDataManager.java
@@ -1602,7 +1602,7 @@ public class LLRealtimeSegmentDataManager extends RealtimeSegmentDataManager {
    * Assumes there is a valid instance of {@link PartitionGroupConsumer}
    */
   private void recreateStreamConsumer(String reason) {
-    _segmentLogger.warn("Recreating stream consumer for topic partition {}, reason: {}", _clientId, reason);
+    _segmentLogger.info("Recreating stream consumer for topic partition {}, reason: {}", _clientId, reason);
     _currentOffset = _partitionGroupConsumer.checkpoint(_currentOffset);
     closePartitionGroupConsumer();
     _partitionGroupConsumer =


### PR DESCRIPTION
Our deployment of Pinot has plenty of "slow" REALTIME tables for which no new data are produced for several minutes in a row. As the result, stream consumers are regularly recreated with the following WARN messages

```
Recreating stream consumer for topic partition <kafka-topic>-<partition>, reason: Total idle time: 183623 ms exceeded idle timeout: 180000 ms
```

I'd like to reduce the level of this message to drop plenty of noisy WARN+ messages that pollutes our logging system.

Speaking of the actual usage, this message inside `recreateStreamConsumer` being called from two places:
1. From `handleTransientStreamErrors`, when max consecutive error count exceeds the threshold. In this case there's another warning message `_segmentLogger
          .warn("Stream transient exception when fetching messages, retrying (count={})", _consecutiveErrorCount, e);`
2. From `consumeLoop`, upon hitting idle timeout. This is the primary source of noisy log messages.