### PR TITLE
Fix the wrong reference comparison in PinotEvaluateLiteralRule

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotEvaluateLiteralRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotEvaluateLiteralRule.java
@@ -85,7 +85,7 @@ public class PinotEvaluateLiteralRule {
       RexNode newNode = newProjects.get(i);
       // Need to cast the result to the original type if the literal type is changed, e.g. VARCHAR literal is typed as
       // CHAR(STRING_LENGTH) in Calcite, but we need to cast it back to VARCHAR.
-      if (oldNode.getType() != newNode.getType()) {
+      if (!oldNode.getType().equals(newNode.getType())) {
         needCast = true;
         newNode = rexBuilder.makeCast(oldNode.getType(), newNode, true);
       }


### PR DESCRIPTION
Avoid unnecessary casting caused by different reference but same type. Note that the casting won't really be applied because Calcite also checks whether the case is required, but this fix can reduce overhead and avoid creating a new project.