### PR TITLE
Add metrics to export netty direct memory used and max

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.metrics;
 
+import com.google.common.base.Preconditions;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -659,14 +660,30 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
 
   /**
    * Like {@link #setOrUpdateGauge(String, Supplier)}
-   * @param metricName
-   * @param valueSupplier
    */
   public void setOrUpdateGauge(final String metricName, final LongSupplier valueSupplier) {
     PinotGauge<Long> pinotGauge = PinotMetricUtils.makeGauge(_metricsRegistry,
         PinotMetricUtils.makePinotMetricName(_clazz, _metricPrefix + metricName),
         PinotMetricUtils.makePinotGauge(avoid -> valueSupplier.getAsLong()));
     pinotGauge.setValueSupplier((Supplier<Long>) () -> (Long) valueSupplier.getAsLong());
+  }
+
+  /**
+   * Like {@link #setOrUpdateGauge(String, Supplier)} but using a global gauge
+   * @throws IllegalArgumentException if the gauge is not global
+   */
+  public void setOrUpdateGlobalGauge(final G gauge, final Supplier<Long> valueSupplier) {
+    Preconditions.checkArgument(gauge.isGlobal(), "Only global gauges should be sent to this method");
+    setOrUpdateGauge(gauge.getGaugeName(), valueSupplier);
+  }
+
+  /**
+   * Like {@link #setOrUpdateGauge(String, LongSupplier)} but using a global gauge
+   * @throws IllegalArgumentException if the gauge is not global
+   */
+  public void setOrUpdateGlobalGauge(final G gauge, final LongSupplier valueSupplier) {
+    Preconditions.checkArgument(gauge.isGlobal(), "Only global gauges should be sent to this method");
+    setOrUpdateGauge(gauge.getGaugeName(), valueSupplier);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -27,6 +27,7 @@ import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.LongSupplier;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.pinot.common.Utils;
@@ -654,6 +655,18 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
         PinotMetricUtils.makePinotMetricName(_clazz, _metricPrefix + metricName),
         PinotMetricUtils.makePinotGauge(avoid -> valueSupplier.get()));
     pinotGauge.setValueSupplier(valueSupplier);
+  }
+
+  /**
+   * Like {@link #setOrUpdateGauge(String, Supplier)}
+   * @param metricName
+   * @param valueSupplier
+   */
+  public void setOrUpdateGauge(final String metricName, final LongSupplier valueSupplier) {
+    PinotGauge<Long> pinotGauge = PinotMetricUtils.makeGauge(_metricsRegistry,
+        PinotMetricUtils.makePinotMetricName(_clazz, _metricPrefix + metricName),
+        PinotMetricUtils.makePinotGauge(avoid -> valueSupplier.getAsLong()));
+    pinotGauge.setValueSupplier((Supplier<Long>) () -> (Long) valueSupplier.getAsLong());
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerGauge.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.metrics;
 
+import io.netty.buffer.PooledByteBufAllocatorMetric;
 import org.apache.pinot.common.Utils;
 
 
@@ -35,7 +36,27 @@ public enum BrokerGauge implements AbstractMetrics.Gauge {
   RESIZE_TIME_MS("milliseconds", false),
   UNHEALTHY_SERVERS("servers", true),
   TIME_BOUNDARY_DIFFERENCE("milliseconds", false),
-  JVM_HEAP_USED_BYTES("bytes", true);
+  JVM_HEAP_USED_BYTES("bytes", true),
+  NETTY_POOLED_USED_DIRECT_MEMORY("bytes", true),
+  NETTY_POOLED_USED_HEAP_MEMORY("bytes", true),
+  NETTY_POOLED_ARENAS_DIRECT("arenas", true),
+  NETTY_POOLED_ARENAS_HEAP("arenas", true),
+
+  /**
+   * The size of the small cache.
+   * See {@link PooledByteBufAllocatorMetric#smallCacheSize()}
+   */
+  NETTY_POOLED_CACHE_SIZE_SMALL("bytes", true),
+  /**
+   * The size of the normal cache.
+   * See {@link PooledByteBufAllocatorMetric#normalCacheSize()}
+   */
+  NETTY_POOLED_CACHE_SIZE_NORMAL("bytes", true),
+  /**
+   * The cache size used by the allocator for normal arenas
+   */
+  NETTY_POOLED_THREADLOCALCACHE("bytes", true),
+  NETTY_POOLED_CHUNK_SIZE("bytes", true);
 
   private final String _brokerGaugeName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.metrics;
 
+import io.netty.buffer.PooledByteBufAllocatorMetric;
 import org.apache.pinot.common.Utils;
 
 
@@ -46,6 +47,26 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   DEDUP_PRIMARY_KEYS_COUNT("dedupPrimaryKeysCount", false),
   CONSUMPTION_QUOTA_UTILIZATION("ratio", false),
   JVM_HEAP_USED_BYTES("bytes", true),
+  NETTY_POOLED_USED_DIRECT_MEMORY("bytes", true),
+  NETTY_POOLED_USED_HEAP_MEMORY("bytes", true),
+  NETTY_POOLED_ARENAS_DIRECT("arenas", true),
+  NETTY_POOLED_ARENAS_HEAP("arenas", true),
+
+  /**
+   * The size of the small cache.
+   * See {@link PooledByteBufAllocatorMetric#smallCacheSize()}
+   */
+  NETTY_POOLED_CACHE_SIZE_SMALL("bytes", true),
+  /**
+   * The size of the normal cache.
+   * See {@link PooledByteBufAllocatorMetric#normalCacheSize()}
+   */
+  NETTY_POOLED_CACHE_SIZE_NORMAL("bytes", true),
+  /**
+   * The cache size used by the allocator for normal arenas
+   */
+  NETTY_POOLED_THREADLOCALCACHE("bytes", true),
+  NETTY_POOLED_CHUNK_SIZE("bytes", true),
   // Ingestion delay metrics
   REALTIME_INGESTION_DELAY_MS("milliseconds", false),
   END_TO_END_REALTIME_INGESTION_DELAY_MS("milliseconds", false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMetrics.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.metrics;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.concurrent.atomic.AtomicReference;
@@ -40,6 +41,11 @@ public class ServerMetrics extends AbstractMetrics<ServerQueryPhase, ServerMeter
    */
   public static boolean register(ServerMetrics serverMetrics) {
     return SERVER_METRICS_INSTANCE.compareAndSet(null, serverMetrics);
+  }
+
+  @VisibleForTesting
+  public static void deregister() {
+    SERVER_METRICS_INSTANCE.set(null);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/QueryServer.java
@@ -125,15 +125,14 @@ public class QueryServer {
 
       PooledByteBufAllocator bufAllocator = PooledByteBufAllocator.DEFAULT;
       PooledByteBufAllocatorMetric metric = bufAllocator.metric();
-      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_USED_DIRECT_MEMORY.getGaugeName(), metric.usedDirectMemory());
-      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_USED_HEAP_MEMORY.getGaugeName(), metric.usedHeapMemory());
-      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_ARENAS_DIRECT.getGaugeName(), metric.numDirectArenas());
-      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_ARENAS_HEAP.getGaugeName(), metric.numHeapArenas());
-      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_CACHE_SIZE_SMALL.getGaugeName(), metric.smallCacheSize());
-      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_CACHE_SIZE_NORMAL.getGaugeName(), metric.normalCacheSize());
-      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_THREADLOCALCACHE.getGaugeName(),
-          metric.numThreadLocalCaches());
-      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_CHUNK_SIZE.getGaugeName(), metric.chunkSize());
+      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_USED_DIRECT_MEMORY.getGaugeName(), metric::usedDirectMemory);
+      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_USED_HEAP_MEMORY.getGaugeName(), metric::usedHeapMemory);
+      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_ARENAS_DIRECT.getGaugeName(), metric::numDirectArenas);
+      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_ARENAS_HEAP.getGaugeName(), metric::numHeapArenas);
+      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_CACHE_SIZE_SMALL.getGaugeName(), metric::smallCacheSize);
+      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_CACHE_SIZE_NORMAL.getGaugeName(), metric::normalCacheSize);
+      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_THREADLOCALCACHE.getGaugeName(), metric::numThreadLocalCaches);
+      _metrics.setOrUpdateGauge(ServerGauge.NETTY_POOLED_CHUNK_SIZE.getGaugeName(), metric::chunkSize);
       _channel = serverBootstrap.group(_bossGroup, _workerGroup).channel(_channelClass)
           .option(ChannelOption.SO_BACKLOG, 128).childOption(ChannelOption.SO_KEEPALIVE, true)
           .option(ChannelOption.ALLOCATOR, bufAllocator)

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
@@ -155,18 +155,14 @@ public class ServerChannels {
       _serverRoutingInstance = serverRoutingInstance;
       PooledByteBufAllocator bufAllocator = PooledByteBufAllocator.DEFAULT;
       PooledByteBufAllocatorMetric metric = bufAllocator.metric();
-      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_USED_DIRECT_MEMORY.getGaugeName(),
-          metric::usedDirectMemory);
-      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_USED_HEAP_MEMORY.getGaugeName(),
-          metric::usedHeapMemory);
-      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_ARENAS_DIRECT.getGaugeName(), metric::numDirectArenas);
-      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_ARENAS_HEAP.getGaugeName(), metric::numHeapArenas);
-      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_CACHE_SIZE_SMALL.getGaugeName(), metric::smallCacheSize);
-      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_CACHE_SIZE_NORMAL.getGaugeName(),
-          metric::normalCacheSize);
-      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_THREADLOCALCACHE.getGaugeName(),
-          metric::numThreadLocalCaches);
-      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_CHUNK_SIZE.getGaugeName(), metric::chunkSize);
+      _brokerMetrics.setOrUpdateGlobalGauge(BrokerGauge.NETTY_POOLED_USED_DIRECT_MEMORY, metric::usedDirectMemory);
+      _brokerMetrics.setOrUpdateGlobalGauge(BrokerGauge.NETTY_POOLED_USED_HEAP_MEMORY, metric::usedHeapMemory);
+      _brokerMetrics.setOrUpdateGlobalGauge(BrokerGauge.NETTY_POOLED_ARENAS_DIRECT, metric::numDirectArenas);
+      _brokerMetrics.setOrUpdateGlobalGauge(BrokerGauge.NETTY_POOLED_ARENAS_HEAP, metric::numHeapArenas);
+      _brokerMetrics.setOrUpdateGlobalGauge(BrokerGauge.NETTY_POOLED_CACHE_SIZE_SMALL, metric::smallCacheSize);
+      _brokerMetrics.setOrUpdateGlobalGauge(BrokerGauge.NETTY_POOLED_CACHE_SIZE_NORMAL, metric::normalCacheSize);
+      _brokerMetrics.setOrUpdateGlobalGauge(BrokerGauge.NETTY_POOLED_THREADLOCALCACHE, metric::numThreadLocalCaches);
+      _brokerMetrics.setOrUpdateGlobalGauge(BrokerGauge.NETTY_POOLED_CHUNK_SIZE, metric::chunkSize);
 
       _bootstrap = new Bootstrap().remoteAddress(serverRoutingInstance.getHostname(), serverRoutingInstance.getPort())
           .option(ChannelOption.ALLOCATOR, bufAllocator)

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ServerChannels.java
@@ -156,18 +156,17 @@ public class ServerChannels {
       PooledByteBufAllocator bufAllocator = PooledByteBufAllocator.DEFAULT;
       PooledByteBufAllocatorMetric metric = bufAllocator.metric();
       _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_USED_DIRECT_MEMORY.getGaugeName(),
-          metric.usedDirectMemory());
+          metric::usedDirectMemory);
       _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_USED_HEAP_MEMORY.getGaugeName(),
-          metric.usedHeapMemory());
-      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_ARENAS_DIRECT.getGaugeName(), metric.numDirectArenas());
-      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_ARENAS_HEAP.getGaugeName(), metric.numHeapArenas());
-      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_CACHE_SIZE_SMALL.getGaugeName(),
-          metric.smallCacheSize());
+          metric::usedHeapMemory);
+      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_ARENAS_DIRECT.getGaugeName(), metric::numDirectArenas);
+      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_ARENAS_HEAP.getGaugeName(), metric::numHeapArenas);
+      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_CACHE_SIZE_SMALL.getGaugeName(), metric::smallCacheSize);
       _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_CACHE_SIZE_NORMAL.getGaugeName(),
-          metric.normalCacheSize());
+          metric::normalCacheSize);
       _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_THREADLOCALCACHE.getGaugeName(),
-          metric.numThreadLocalCaches());
-      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_CHUNK_SIZE.getGaugeName(), metric.chunkSize());
+          metric::numThreadLocalCaches);
+      _brokerMetrics.setOrUpdateGauge(BrokerGauge.NETTY_POOLED_CHUNK_SIZE.getGaugeName(), metric::chunkSize);
 
       _bootstrap = new Bootstrap().remoteAddress(serverRoutingInstance.getHostname(), serverRoutingInstance.getPort())
           .option(ChannelOption.ALLOCATOR, bufAllocator)

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
@@ -78,9 +78,10 @@ public class QueryRoutingTest {
   }
 
   private QueryServer getQueryServer(int responseDelayMs, byte[] responseBytes) {
+    ServerMetrics serverMetrics = mock(ServerMetrics.class);
     InstanceRequestHandler handler = new InstanceRequestHandler("server01", new PinotConfiguration(),
-        mockQueryScheduler(responseDelayMs, responseBytes), mock(ServerMetrics.class), mock(AccessControl.class));
-    return new QueryServer(TEST_PORT, null, handler);
+        mockQueryScheduler(responseDelayMs, responseBytes), serverMetrics, mock(AccessControl.class));
+    return new QueryServer(TEST_PORT, null, handler, serverMetrics);
   }
 
   private QueryScheduler mockQueryScheduler(int responseDelayMs, byte[] responseBytes) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
@@ -78,10 +78,9 @@ public class QueryRoutingTest {
   }
 
   private QueryServer getQueryServer(int responseDelayMs, byte[] responseBytes) {
-    ServerMetrics serverMetrics = mock(ServerMetrics.class);
     InstanceRequestHandler handler = new InstanceRequestHandler("server01", new PinotConfiguration(),
-        mockQueryScheduler(responseDelayMs, responseBytes), serverMetrics, mock(AccessControl.class));
-    return new QueryServer(TEST_PORT, null, handler, serverMetrics);
+        mockQueryScheduler(responseDelayMs, responseBytes), mock(ServerMetrics.class), mock(AccessControl.class));
+    return new QueryServer(TEST_PORT, null, handler);
   }
 
   private QueryScheduler mockQueryScheduler(int responseDelayMs, byte[] responseBytes) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/transport/QueryRoutingTest.java
@@ -38,6 +38,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.apache.pinot.util.TestUtils;
 import org.testng.annotations.AfterClass;
+import org.testng.annotations.AfterMethod;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
@@ -77,9 +78,16 @@ public class QueryRoutingTest {
     _requestCount = 0;
   }
 
+  @AfterMethod
+  void deregisterServerMetrics() {
+    ServerMetrics.deregister();
+  }
+
   private QueryServer getQueryServer(int responseDelayMs, byte[] responseBytes) {
+    ServerMetrics serverMetrics = mock(ServerMetrics.class);
     InstanceRequestHandler handler = new InstanceRequestHandler("server01", new PinotConfiguration(),
-        mockQueryScheduler(responseDelayMs, responseBytes), mock(ServerMetrics.class), mock(AccessControl.class));
+        mockQueryScheduler(responseDelayMs, responseBytes), serverMetrics, mock(AccessControl.class));
+    ServerMetrics.register(serverMetrics);
     return new QueryServer(TEST_PORT, null, handler);
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -135,7 +135,7 @@ public class ServerInstance {
       _instanceRequestHandler = ChannelHandlerFactory
           .getInstanceRequestHandler(helixManager.getInstanceName(), serverConf.getPinotConfig(), _queryScheduler,
               _serverMetrics, new AllowAllAccessFactory().create());
-      _nettyQueryServer = new QueryServer(nettyPort, nettyConfig, _instanceRequestHandler);
+      _nettyQueryServer = new QueryServer(nettyPort, nettyConfig, _instanceRequestHandler, _serverMetrics);
     } else {
       _nettyQueryServer = null;
     }
@@ -146,7 +146,8 @@ public class ServerInstance {
       _instanceRequestHandler = ChannelHandlerFactory
           .getInstanceRequestHandler(helixManager.getInstanceName(), serverConf.getPinotConfig(), _queryScheduler,
               _serverMetrics, _accessControl);
-      _nettyTlsQueryServer = new QueryServer(nettySecPort, nettyConfig, tlsConfig, _instanceRequestHandler);
+      _nettyTlsQueryServer = new QueryServer(nettySecPort, nettyConfig, tlsConfig, _instanceRequestHandler,
+          _serverMetrics);
     } else {
       _nettyTlsQueryServer = null;
     }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -135,7 +135,7 @@ public class ServerInstance {
       _instanceRequestHandler = ChannelHandlerFactory
           .getInstanceRequestHandler(helixManager.getInstanceName(), serverConf.getPinotConfig(), _queryScheduler,
               _serverMetrics, new AllowAllAccessFactory().create());
-      _nettyQueryServer = new QueryServer(nettyPort, nettyConfig, _instanceRequestHandler, _serverMetrics);
+      _nettyQueryServer = new QueryServer(nettyPort, nettyConfig, _instanceRequestHandler);
     } else {
       _nettyQueryServer = null;
     }
@@ -146,8 +146,7 @@ public class ServerInstance {
       _instanceRequestHandler = ChannelHandlerFactory
           .getInstanceRequestHandler(helixManager.getInstanceName(), serverConf.getPinotConfig(), _queryScheduler,
               _serverMetrics, _accessControl);
-      _nettyTlsQueryServer = new QueryServer(nettySecPort, nettyConfig, tlsConfig, _instanceRequestHandler,
-          _serverMetrics);
+      _nettyTlsQueryServer = new QueryServer(nettySecPort, nettyConfig, tlsConfig, _instanceRequestHandler);
     } else {
       _nettyTlsQueryServer = null;
     }


### PR DESCRIPTION
Lately we have been seeing some OOM exceptions related to direct memory in Netty channels. Right now we are mostly focused on dealing with the error (see https://github.com/apache/pinot/pull/11496), but we doesn't have too much insight.

This PR exports several buffer metrics Netty collects by default but does not register in JMX.

I've also tried to add `io.netty.util.internal.PlatformDependent.usedDirectMemory()`, but that seems to always be -1 in modern JVMs.

Note: We use the default PooledByteBufAllocator instance in both server and broker. Therefore in case we run both services in the same process (like we do in our quickstarts) the pool is shared between both services. That means that values are exported twice but should not be added. Given that it is not expected to run both services in the same process in production, I think it shouldn't be an actual issue.