### PR TITLE
Add table indexes API

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/response/server/TableIndexMetadataResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/server/TableIndexMetadataResponse.java
@@ -25,11 +25,11 @@ import java.util.Map;
 
 public class TableIndexMetadataResponse {
   private final long _totalOnlineSegments;
-  private final Map<String, Map<String, Long>> _columnToIndexesCount;
+  private final Map<String, Map<String, Integer>> _columnToIndexesCount;
 
   @JsonCreator
   public TableIndexMetadataResponse(@JsonProperty("totalOnlineSegments") long totalOnlineSegments,
-      @JsonProperty("columnToIndexesCount") Map<String, Map<String, Long>> columnToIndexesCount) {
+      @JsonProperty("columnToIndexesCount") Map<String, Map<String, Integer>> columnToIndexesCount) {
     _totalOnlineSegments = totalOnlineSegments;
     _columnToIndexesCount = columnToIndexesCount;
   }
@@ -38,7 +38,7 @@ public class TableIndexMetadataResponse {
     return _totalOnlineSegments;
   }
 
-  public Map<String, Map<String, Long>> getColumnToIndexesCount() {
+  public Map<String, Map<String, Integer>> getColumnToIndexesCount() {
     return _columnToIndexesCount;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/server/TableIndexMetadataResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/server/TableIndexMetadataResponse.java
@@ -24,18 +24,18 @@ import java.util.Map;
 
 
 public class TableIndexMetadataResponse {
-  private final long _totalSegments;
+  private final long _totalOnlineSegments;
   private final Map<String, Map<String, Long>> _columnToIndexesCount;
 
   @JsonCreator
-  public TableIndexMetadataResponse(@JsonProperty("totalSegments") long totalSegments,
+  public TableIndexMetadataResponse(@JsonProperty("totalOnlineSegments") long totalOnlineSegments,
       @JsonProperty("columnToIndexesCount") Map<String, Map<String, Long>> columnToIndexesCount) {
-    _totalSegments = totalSegments;
+    _totalOnlineSegments = totalOnlineSegments;
     _columnToIndexesCount = columnToIndexesCount;
   }
 
-  public long getTotalSegments() {
-    return _totalSegments;
+  public long getTotalOnlineSegments() {
+    return _totalOnlineSegments;
   }
 
   public Map<String, Map<String, Long>> getColumnToIndexesCount() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/server/TableIndexMetadataResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/server/TableIndexMetadataResponse.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.response.server;
+
+import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import java.util.Map;
+
+
+public class TableIndexMetadataResponse {
+  private final long _totalSegments;
+  private final Map<String, Map<String, Long>> _columnToIndexesCount;
+
+  @JsonCreator
+  public TableIndexMetadataResponse(@JsonProperty("totalSegments") long totalSegments,
+      @JsonProperty("columnToIndexesCount") Map<String, Map<String, Long>> columnToIndexesCount) {
+    _totalSegments = totalSegments;
+    _columnToIndexesCount = columnToIndexesCount;
+  }
+
+  public long getTotalSegments() {
+    return _totalSegments;
+  }
+
+  public Map<String, Map<String, Long>> getColumnToIndexesCount() {
+    return _columnToIndexesCount;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -1019,7 +1019,7 @@ public class PinotTableRestletResource {
     for (Map.Entry<String, String> streamResponse : serviceResponse._httpResponses.entrySet()) {
       String responseString = streamResponse.getValue();
       TableIndexMetadataResponse response = JsonUtils.stringToObject(responseString, TableIndexMetadataResponse.class);
-      totalSegments += response.getTotalSegments();
+      totalSegments += response.getTotalOnlineSegments();
       response.getColumnToIndexesCount().forEach((col, indexToCount) -> {
         columnToIndexCountMap.putIfAbsent(col, new HashMap<>());
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -1019,7 +1019,7 @@ public class PinotTableRestletResource {
       TableIndexMetadataResponse response = JsonUtils.stringToObject(responseString, TableIndexMetadataResponse.class);
       totalSegments += response.getTotalOnlineSegments();
       response.getColumnToIndexesCount().forEach((col, indexToCount) -> {
-        Map<String, Integer> indexCountMap = columnToIndexCountMap.putIfAbsent(col, new HashMap<>());
+        Map<String, Integer> indexCountMap = columnToIndexCountMap.computeIfAbsent(col, c -> new HashMap<>());
         indexToCount.forEach((indexName, count) -> {
           indexCountMap.merge(indexName, count, Integer::sum);
         });

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -81,6 +81,7 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.controllerjob.ControllerJobType;
 import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.response.server.TableIndexMetadataResponse;
 import org.apache.pinot.common.restlet.resources.TableSegmentValidationInfo;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.ControllerConf;
@@ -962,6 +963,77 @@ public class PinotTableRestletResource {
           Response.Status.INTERNAL_SERVER_ERROR, ioe);
     }
     return segmentsMetadata;
+  }
+
+  @GET
+  @Path("tables/{tableName}/indexes")
+  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get the aggregate index details of all segments for a table", notes = "Get the aggregate "
+      + "index details of all segments for a table")
+  public String getTableIndexes(
+      @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr) {
+    LOGGER.info("Received a request to fetch aggregate metadata for a table {}", tableName);
+    TableType tableType = Constants.validateTableType(tableTypeStr);
+    String tableNameWithType =
+        ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableType, LOGGER).get(0);
+
+    String tableIndexMetadata;
+    try {
+      JsonNode segmentsMetadataJson = getAggregateIndexMetadataFromServer(tableNameWithType);
+      tableIndexMetadata = JsonUtils.objectToPrettyString(segmentsMetadataJson);
+    } catch (InvalidConfigException e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST);
+    } catch (IOException ioe) {
+      throw new ControllerApplicationException(LOGGER, "Error parsing Pinot server response: " + ioe.getMessage(),
+          Response.Status.INTERNAL_SERVER_ERROR, ioe);
+    }
+    return tableIndexMetadata;
+  }
+
+  private JsonNode getAggregateIndexMetadataFromServer(String tableNameWithType)
+      throws InvalidConfigException, JsonProcessingException {
+    final Map<String, List<String>> serverToSegments =
+        _pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType);
+    BiMap<String, String> endpoints =
+        _pinotHelixResourceManager.getDataInstanceAdminEndpoints(serverToSegments.keySet());
+
+    BiMap<String, String> serverEndPoints =
+        _pinotHelixResourceManager.getDataInstanceAdminEndpoints(serverToSegments.keySet());
+    CompletionServiceHelper completionServiceHelper =
+        new CompletionServiceHelper(_executor, _connectionManager, serverEndPoints);
+
+    List<String> serverUrls = new ArrayList<>();
+    BiMap<String, String> endpointsToServers = serverEndPoints.inverse();
+    for (String endpoint : endpointsToServers.keySet()) {
+      String reloadTaskStatusEndpoint = endpoint + String.format("/tables/%s/indexes", tableNameWithType);
+      serverUrls.add(reloadTaskStatusEndpoint);
+    }
+
+    CompletionServiceHelper.CompletionServiceResponse serviceResponse =
+        completionServiceHelper.doMultiGetRequest(serverUrls, null, true, 10000);
+
+    long totalSegments = 0;
+    Map<String, Map<String, Long>> columnToIndexCountMap = new HashMap<>();
+    for (Map.Entry<String, String> streamResponse : serviceResponse._httpResponses.entrySet()) {
+      String responseString = streamResponse.getValue();
+      TableIndexMetadataResponse response = JsonUtils.stringToObject(responseString, TableIndexMetadataResponse.class);
+      totalSegments += response.getTotalSegments();
+      response.getColumnToIndexesCount().forEach((col, indexToCount) -> {
+        columnToIndexCountMap.putIfAbsent(col, new HashMap<>());
+
+        indexToCount.forEach((indexName, count) -> {
+          columnToIndexCountMap.get(col)
+              .put(indexName, columnToIndexCountMap.get(col).getOrDefault(indexName, 0L) + count);
+        });
+      });
+    }
+
+    TableIndexMetadataResponse tableIndexMetadataResponse =
+        new TableIndexMetadataResponse(totalSegments, columnToIndexCountMap);
+
+    return JsonUtils.objectToJsonNode(tableIndexMetadataResponse);
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -2920,8 +2920,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
         JsonUtils.stringToObject(sendGetRequest(getControllerBaseApiUrl() + "/tables/mytable/indexes?type=OFFLINE"),
             TableIndexMetadataResponse.class);
 
-    assertEquals(tableIndexMetadataResponse.getTotalOnlineSegments(), 12L);
-
     getInvertedIndexColumns().forEach(column -> {
       Assert.assertEquals(
           (long) tableIndexMetadataResponse.getColumnToIndexesCount().get(column).get(StandardIndexes.INVERTED_ID),

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -54,12 +54,14 @@ import org.apache.pinot.common.datatable.DataTableFactory;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
 import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.response.server.TableIndexMetadataResponse;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.ServiceStatus;
 import org.apache.pinot.common.utils.SimpleHttpResponse;
 import org.apache.pinot.common.utils.http.HttpClient;
 import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
 import org.apache.pinot.core.operator.query.NonScanBasedAggregationOperator;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
 import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.config.table.IndexingConfig;
@@ -2909,6 +2911,40 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   public void testHardcodedServerPartitionedSqlQueries()
       throws Exception {
     super.testHardcodedServerPartitionedSqlQueries();
+  }
+
+  @Test
+  public void testIndexMetadataAPI()
+      throws Exception {
+    TableIndexMetadataResponse tableIndexMetadataResponse =
+        JsonUtils.stringToObject(sendGetRequest(getControllerBaseApiUrl() + "/tables/mytable/indexes?type=OFFLINE"),
+            TableIndexMetadataResponse.class);
+
+    assertEquals(tableIndexMetadataResponse.getTotalOnlineSegments(), 12L);
+
+    getInvertedIndexColumns().forEach(column -> {
+      Assert.assertEquals(
+          (long) tableIndexMetadataResponse.getColumnToIndexesCount().get(column).get(StandardIndexes.INVERTED_ID),
+          tableIndexMetadataResponse.getTotalOnlineSegments());
+    });
+
+    getNoDictionaryColumns().forEach(column -> {
+      Assert.assertEquals(
+          (long) tableIndexMetadataResponse.getColumnToIndexesCount().get(column).get(StandardIndexes.DICTIONARY_ID),
+          0);
+    });
+
+    getRangeIndexColumns().forEach(column -> {
+      Assert.assertEquals(
+          (long) tableIndexMetadataResponse.getColumnToIndexesCount().get(column).get(StandardIndexes.RANGE_ID),
+          tableIndexMetadataResponse.getTotalOnlineSegments());
+    });
+
+    getBloomFilterColumns().forEach(column -> {
+      Assert.assertEquals(
+          (long) tableIndexMetadataResponse.getColumnToIndexesCount().get(column).get(StandardIndexes.BLOOM_FILTER_ID),
+          tableIndexMetadataResponse.getTotalOnlineSegments());
+    });
   }
 
   @Test

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -340,9 +340,9 @@ public class TablesResource {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Provide segment metadata", notes = "Provide segments metadata for the segment on server")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error",
-      response = ErrorInfo.class), @ApiResponse(code = 404, message = "Table or segment not found", response =
-      ErrorInfo.class)
+      @ApiResponse(code = 200, message = "Success"),
+      @ApiResponse(code = 500, message = "Internal server error", response = ErrorInfo.class),
+      @ApiResponse(code = 404, message = "Table or segment not found", response = ErrorInfo.class)
   })
   public String getSegmentMetadata(
       @ApiParam(value = "Table name including type", required = true, example = "myTable_OFFLINE")

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -306,8 +306,8 @@ public class TablesResource {
     TableDataManager tableDataManager = ServerResourceUtils.checkGetTableDataManager(_serverInstance, tableName);
     List<SegmentDataManager> allSegments = tableDataManager.acquireAllSegments();
     try {
-      long totalSegmentCount = 0;
-      Map<String, Map<String, Long>> columnToIndexesCount = new HashMap<>();
+      int totalSegmentCount = 0;
+      Map<String, Map<String, Integer>> columnToIndexesCount = new HashMap<>();
       for (SegmentDataManager segmentDataManager : allSegments) {
         if (segmentDataManager instanceof RealtimeSegmentDataManager) {
           // REALTIME segments may not have indexes since not all indexes have mutable implementations
@@ -319,8 +319,8 @@ public class TablesResource {
           columnToIndexesCount.putIfAbsent(col, new HashMap<>());
           DataSource colDataSource = segment.getDataSource(col);
           IndexService.getInstance().getAllIndexes().forEach(idxType -> {
-            long count = colDataSource.getIndex(idxType) != null ? 1L : 0L;
-            columnToIndexesCount.get(col).merge(idxType.getId(), count, Long::sum);
+            int count = colDataSource.getIndex(idxType) != null ? 1 : 0;
+            columnToIndexesCount.get(col).merge(idxType.getId(), count, Integer::sum);
           });
         });
       }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -62,6 +62,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.response.server.TableIndexMetadataResponse;
 import org.apache.pinot.common.restlet.resources.ResourceUtils;
 import org.apache.pinot.common.restlet.resources.SegmentConsumerInfo;
 import org.apache.pinot.common.restlet.resources.TableMetadataInfo;
@@ -83,6 +84,8 @@ import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImp
 import org.apache.pinot.segment.spi.ColumnMetadata;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.index.IndexService;
 import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.server.access.AccessControlFactory;
@@ -93,6 +96,7 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.stream.ConsumerPartitionState;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
+import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.slf4j.Logger;
@@ -287,13 +291,58 @@ public class TablesResource {
 
   @GET
   @Encoded
+  @Path("/tables/{tableName}/indexes")
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Provide index metadata", notes = "Provide index details for the table")
+  @ApiResponses(value = {
+      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error",
+      response = ErrorInfo.class), @ApiResponse(code = 404, message = "Table or segment not found", response =
+      ErrorInfo.class)
+  })
+  public String getTableIndexes(
+      @ApiParam(value = "Table name including type", required = true, example = "myTable_OFFLINE")
+      @PathParam("tableName") String tableName)
+      throws Exception {
+    TableDataManager tableDataManager = ServerResourceUtils.checkGetTableDataManager(_serverInstance, tableName);
+    List<SegmentDataManager> allSegments = tableDataManager.acquireAllSegments();
+    try {
+      long totalSegmentCount = 0;
+      Map<String, Map<String, Long>> columnToIndexesCount = new HashMap<>();
+      for (SegmentDataManager segmentDataManager : allSegments) {
+        if (segmentDataManager instanceof RealtimeSegmentDataManager) {
+          // REALTIME segments may not have indexes since not all indexes have mutable implementations
+          continue;
+        }
+        totalSegmentCount++;
+        IndexSegment segment = segmentDataManager.getSegment();
+        segment.getColumnNames().forEach(col -> {
+          columnToIndexesCount.putIfAbsent(col, new HashMap<>());
+          DataSource colDataSource = segment.getDataSource(col);
+          IndexService.getInstance().getAllIndexes().forEach(idxType -> {
+            long count = colDataSource.getIndex(idxType) != null ? 1L : 0L;
+            columnToIndexesCount.get(col).merge(idxType.getPrettyName(), count, Long::sum);
+          });
+        });
+      }
+      TableIndexMetadataResponse tableIndexMetadataResponse =
+          new TableIndexMetadataResponse(totalSegmentCount, columnToIndexesCount);
+      return JsonUtils.objectToString(tableIndexMetadataResponse);
+    } finally {
+      for (SegmentDataManager segmentDataManager : allSegments) {
+        tableDataManager.releaseSegment(segmentDataManager);
+      }
+    }
+  }
+
+  @GET
+  @Encoded
   @Path("/tables/{tableName}/segments/{segmentName}/metadata")
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Provide segment metadata", notes = "Provide segments metadata for the segment on server")
   @ApiResponses(value = {
-      @ApiResponse(code = 200, message = "Success"),
-      @ApiResponse(code = 500, message = "Internal server error", response = ErrorInfo.class),
-      @ApiResponse(code = 404, message = "Table or segment not found", response = ErrorInfo.class)
+      @ApiResponse(code = 200, message = "Success"), @ApiResponse(code = 500, message = "Internal server error",
+      response = ErrorInfo.class), @ApiResponse(code = 404, message = "Table or segment not found", response =
+      ErrorInfo.class)
   })
   public String getSegmentMetadata(
       @ApiParam(value = "Table name including type", required = true, example = "myTable_OFFLINE")

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -320,7 +320,7 @@ public class TablesResource {
           DataSource colDataSource = segment.getDataSource(col);
           IndexService.getInstance().getAllIndexes().forEach(idxType -> {
             long count = colDataSource.getIndex(idxType) != null ? 1L : 0L;
-            columnToIndexesCount.get(col).merge(idxType.getPrettyName(), count, Long::sum);
+            columnToIndexesCount.get(col).merge(idxType.getId(), count, Long::sum);
           });
         });
       }

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -126,14 +126,14 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertNotNull(tableIndexMetadataResponse);
     Assert.assertEquals(tableIndexMetadataResponse.getTotalOnlineSegments(), _offlineIndexSegments.size());
 
-    Map<String, Map<String, Long>> columnToIndexCountMap = new HashMap<>();
+    Map<String, Map<String, Integer>> columnToIndexCountMap = new HashMap<>();
     for (ImmutableSegment segment : _offlineIndexSegments) {
       segment.getColumnNames().forEach(colName -> {
         DataSource dataSource = segment.getDataSource(colName);
         columnToIndexCountMap.putIfAbsent(colName, new HashMap<>());
         IndexService.getInstance().getAllIndexes().forEach(indexType -> {
-          long count = dataSource.getIndex(indexType) != null ? 1L : 0L;
-          columnToIndexCountMap.get(colName).merge(indexType.getId(), count, Long::sum);
+          int count = dataSource.getIndex(indexType) != null ? 1 : 0;
+          columnToIndexCountMap.get(colName).merge(indexType.getId(), count, Integer::sum);
         });
       });
     }


### PR DESCRIPTION
This API is primarily for the controller UI -> tables -> <table name> -> reload status -> STATUS ui element. Right now it uses the `/segments/{tableName}/metadata?type={type}&columns=*` API to display the column level index details. This has a few problems

1) This is an expensive API call especially for large tables. This leads to bad ux when using the reload status UI feature
2) The UI logic to build tableLevel column -> index mapping using this segmentName level metadata is simply wrong (uss the first segment's metadata to build the view).
3) Since Index-spi changes are merged, this API does not return metadata of dynamically added index types, but only some hardcoded ones.

This new API's reponse looks like this

The `totalSegments` is the total count of `ONLINE` segments (replication included). Since mutable version of all indexes don't exist, `CONSUMING` segments will not be used when building the response.

```
{
    "totalSegments": 31,
    "columnToIndexesCount":
    {
        "FlightNum":
        {
            "dictionary": 31,
            "bloom": 0,
            "null": 0,
            "forward": 31,
            "fst": 0,
            "json": 0,
            "range": 0,
            "h3": 0,
            "text": 0,
            "inverted": 0,
            "some-dynamically-injected-index-type": 31,
        },
        "Origin":
        {
            "dictionary": 31,
            "bloom": 0,
            "null": 0,
            "forward": 31,
            "fst": 0,
            "json": 0,
            "range": 0,
            "h3": 0,
            "text": 0,
            "inverted": 0,
            "some-dynamically-injected-index-type": 0,
        }
        ...
}
```

I'll followup with @jayeshchoudhary to move the UI API call to this new one, and how best to display the UI element once this PR is merged.