### PR TITLE
[DRAFT] custom partial upsert row merger

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/LazyRow.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/LazyRow.java
@@ -1,0 +1,94 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.readers;
+
+import java.io.IOException;
+import java.util.HashMap;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.spi.data.readers.GenericRow;
+
+
+/**
+ * A wrapper class to read column values of a row. The wrapper can either be over a {@link IndexSegment} and docId or
+ * over a {@link GenericRow}<br>
+ * The advantage of having wrapper over segment and docId is column values are read only when
+ * {@link LazyRow#getValue(String)} is invoked.
+ * This is useful to reduce the disk reads incurred due to loading the previous row during merge step.
+ * There isn't any advantage to have a LazyRow wrap a GenericRow but has been kept for syntactic sugar.
+ */
+public class LazyRow {
+    private IndexSegment _segment;
+    private int _docId;
+    private GenericRow _row;
+
+    private HashMap<String, Object> _fieldToValueMap = new HashMap<>();
+
+    public LazyRow() {
+    }
+
+    public LazyRow(GenericRow row) {
+        _row = row;
+    }
+
+    public LazyRow(IndexSegment segment, int docId) {
+        _segment = segment;
+        _docId = docId;
+    }
+
+    public void setRow(GenericRow row) {
+        _row = row;
+    }
+
+    public void init(IndexSegment segment, int docId) {
+        this.clear();
+        _segment = segment;
+        _docId = docId;
+    }
+
+    public void init(GenericRow row) {
+        this.clear();
+        _row = row;
+    }
+
+    public Object getValue(String column) {
+
+        if (_row != null) {
+            if (_row.isNullValue(column)) {
+                return null;
+            }
+            return _row.getValue(column);
+        }
+        return _fieldToValueMap.computeIfAbsent(column, col -> {
+            Object value = null;
+            try (PinotSegmentColumnReader columnReader = new PinotSegmentColumnReader(_segment, col)) {
+                if (!columnReader.isNull(_docId)) {
+                    value = columnReader.getValue(_docId);
+                }
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return value;
+        });
+    }
+
+    public void clear() {
+        _row = null;
+        _fieldToValueMap.clear();
+    }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -36,7 +36,7 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   public ConcurrentMapPartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
     return _partitionMetadataManagerMap.computeIfAbsent(partitionId,
         k -> new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _primaryKeyColumns,
-            _comparisonColumns, _deleteRecordColumn, _hashFunction, _partialUpsertHandler,
+            _comparisonColumns, _deleteRecordColumn, _hashFunction, getPartialUpsertHandler(),
             _enableSnapshot, _metadataTTL, _tableIndexDir, _serverMetrics));
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertRowMergeEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertRowMergeEvaluator.java
@@ -1,0 +1,27 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.upsert.merger;
+
+import java.util.Map;
+import org.apache.pinot.segment.local.segment.readers.LazyRow;
+
+
+public interface PartialUpsertRowMergeEvaluator {
+    void evaluate(LazyRow previousRow, LazyRow newRow, Map<String, Object> result);
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertRowMergeEvaluatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/merger/PartialUpsertRowMergeEvaluatorFactory.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.upsert.merger;
+
+import org.apache.commons.lang3.StringUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class PartialUpsertRowMergeEvaluatorFactory {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(PartialUpsertRowMergeEvaluatorFactory.class);
+
+    private PartialUpsertRowMergeEvaluatorFactory() {
+    }
+
+    public static PartialUpsertRowMergeEvaluator getInstance(String implementationClassName) {
+        LOGGER.info("Creating PartialUpsertRowMergeEvaluator for class {}", implementationClassName);
+        if (StringUtils.isBlank(implementationClassName)) {
+            throw new IllegalArgumentException("Empty implementationClassName");
+        }
+        try {
+            Class<?> aClass = Class.forName(implementationClassName);
+            if (!PartialUpsertRowMergeEvaluator.class.isAssignableFrom(aClass)) {
+                throw new IllegalArgumentException(
+                        "The provided class is not an implementation of PartialUpsertRowMergeEvaluator");
+            }
+            return (PartialUpsertRowMergeEvaluator) aClass.getConstructor().newInstance();
+        } catch (Exception e) {
+            throw new RuntimeException(String.format("Failed to create a PartialUpsertRowMergeEvaluator with class %s",
+                implementationClassName), e);
+        }
+    }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -51,6 +51,9 @@ public class UpsertConfig extends BaseJsonConfig {
   @JsonPropertyDescription("default upsert strategy for partial mode")
   private Strategy _defaultPartialUpsertStrategy = Strategy.OVERWRITE;
 
+  @JsonPropertyDescription("Class name for custom row merger implementation")
+  private String _rowMergerCustomImplementation;
+
   @JsonPropertyDescription("Columns for upsert comparison, default to time column")
   private List<String> _comparisonColumns;
 
@@ -99,6 +102,10 @@ public class UpsertConfig extends BaseJsonConfig {
 
   public Strategy getDefaultPartialUpsertStrategy() {
     return _defaultPartialUpsertStrategy;
+  }
+
+  public String getRowMergerCustomImplementation() {
+    return _rowMergerCustomImplementation;
   }
 
   public List<String> getComparisonColumns() {
@@ -151,6 +158,10 @@ public class UpsertConfig extends BaseJsonConfig {
    */
   public void setDefaultPartialUpsertStrategy(Strategy defaultPartialUpsertStrategy) {
     _defaultPartialUpsertStrategy = defaultPartialUpsertStrategy;
+  }
+
+  public void setRowMergerCustomImplementation(String rowMergerCustomImplementation) {
+    _rowMergerCustomImplementation = rowMergerCustomImplementation;
   }
 
   /**


### PR DESCRIPTION
`feature`
`release-notes`

Problem: The PR addresses the feature gap of conditional column merger in partial upsert. With this, a table can be configured using a groovy script/custom class implementation to merge previous and new row column values based on a user-specified logic between previous and new row columns values.

Solution:
1. A new row abstraction class called LazyRow, enables reading of the previous row's column's value from disk only when getValue() on LazyRow is called and caches the reads.
2. Defines a new interface called PartialUpsertRowMergeEvaluator.merge() that takes previous and new Row and generates merged columns as Map<column_name, value>
3. Moves creation of PartialUpsertHandler per table to per partition to avoid concurrent modification of LazyRow defined in PartialUpsertHandler by multiple consuming partitions.

TODO:
1. Add implementation for PartialUpsertRowMergeEvaluator for groovy merger.
2. Add groovy row merger configs
3. Add test plan

Design doc: https://docs.google.com/document/d/1bBTCYZFP2stvzc6xZUOEh-XweVgC9WfD7uiSPbKtaZY/edit

