### PR TITLE
Enhance SegmentPartitionMetadataManager to handle new segment

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
@@ -29,10 +29,12 @@ import javax.annotation.Nullable;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.broker.routing.instanceselector.InstanceSelector;
 import org.apache.pinot.broker.routing.segmentmetadata.SegmentZkMetadataFetchListener;
 import org.apache.pinot.core.routing.TablePartitionInfo;
 import org.apache.pinot.core.routing.TablePartitionInfo.PartitionInfo;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -49,6 +51,7 @@ import org.slf4j.LoggerFactory;
 public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchListener {
   private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPartitionMetadataManager.class);
   private static final int INVALID_PARTITION_ID = -1;
+  private static final long INVALID_PUSH_TIME_MS = -1L;
 
   private final String _tableNameWithType;
 
@@ -77,15 +80,17 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
     int numSegments = onlineSegments.size();
     for (int i = 0; i < numSegments; i++) {
       String segment = onlineSegments.get(i);
-      SegmentPartitionInfo partitionInfo =
-          SegmentPartitionUtils.extractPartitionInfo(_tableNameWithType, _partitionColumn, segment, znRecords.get(i));
-      SegmentInfo segmentInfo = new SegmentInfo(getPartitionId(partitionInfo), getOnlineServers(externalView, segment));
+      ZNRecord znRecord = znRecords.get(i);
+      SegmentInfo segmentInfo = new SegmentInfo(getPartitionId(segment, znRecord), getPushTimeMs(znRecord),
+          getOnlineServers(externalView, segment));
       _segmentInfoMap.put(segment, segmentInfo);
     }
     computeTablePartitionInfo();
   }
 
-  private int getPartitionId(@Nullable SegmentPartitionInfo segmentPartitionInfo) {
+  private int getPartitionId(String segment, @Nullable ZNRecord znRecord) {
+    SegmentPartitionInfo segmentPartitionInfo =
+        SegmentPartitionUtils.extractPartitionInfo(_tableNameWithType, _partitionColumn, segment, znRecord);
     if (segmentPartitionInfo == null || segmentPartitionInfo == SegmentPartitionUtils.INVALID_PARTITION_INFO) {
       return INVALID_PARTITION_ID;
     }
@@ -106,7 +111,20 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
     return partitions.iterator().next();
   }
 
-  private List<String> getOnlineServers(ExternalView externalView, String segment) {
+  private static long getPushTimeMs(@Nullable ZNRecord znRecord) {
+    if (znRecord == null) {
+      return INVALID_PUSH_TIME_MS;
+    }
+    String pushTimeString = znRecord.getSimpleField(CommonConstants.Segment.PUSH_TIME);
+    // Handle legacy push time key
+    if (pushTimeString == null) {
+      pushTimeString = znRecord.getSimpleField(CommonConstants.Segment.Offline.PUSH_TIME);
+    }
+    // Return INVALID_PUSH_TIME_MS if unavailable for backward compatibility
+    return pushTimeString != null ? Long.parseLong(pushTimeString) : INVALID_PUSH_TIME_MS;
+  }
+
+  private static List<String> getOnlineServers(ExternalView externalView, String segment) {
     Map<String, String> instanceStateMap = externalView.getStateMap(segment);
     if (instanceStateMap == null) {
       return Collections.emptyList();
@@ -123,16 +141,23 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
 
   private void computeTablePartitionInfo() {
     PartitionInfo[] partitionInfoMap = new PartitionInfo[_numPartitions];
-    Set<String> segmentsWithInvalidPartition = new HashSet<>();
+    List<String> segmentsWithInvalidPartition = new ArrayList<>();
+    List<Map.Entry<String, SegmentInfo>> newSegmentInfoEntries = new ArrayList<>();
+    long currentTimeMs = System.currentTimeMillis();
     for (Map.Entry<String, SegmentInfo> entry : _segmentInfoMap.entrySet()) {
       String segment = entry.getKey();
       SegmentInfo segmentInfo = entry.getValue();
       int partitionId = segmentInfo._partitionId;
-      List<String> onlineServers = segmentInfo._onlineServers;
       if (partitionId == INVALID_PARTITION_ID) {
         segmentsWithInvalidPartition.add(segment);
         continue;
       }
+      // Process new segments in the end
+      if (InstanceSelector.isNewSegment(segmentInfo._pushTimeMs, currentTimeMs)) {
+        newSegmentInfoEntries.add(entry);
+        continue;
+      }
+      List<String> onlineServers = segmentInfo._onlineServers;
       PartitionInfo partitionInfo = partitionInfoMap[partitionId];
       if (partitionInfo == null) {
         Set<String> fullyReplicatedServers = new HashSet<>(onlineServers);
@@ -151,8 +176,48 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
         LOGGER.warn("Found {} segments: {} with invalid partition from table: {}", numSegmentsWithInvalidPartition,
             segmentsWithInvalidPartition, _tableNameWithType);
       } else {
-        LOGGER.warn("Found {} segments: {} with invalid partition from table: {}", numSegmentsWithInvalidPartition,
-            segmentsWithInvalidPartition, _tableNameWithType);
+        LOGGER.warn("Found {} segments: {}... with invalid partition from table: {}", numSegmentsWithInvalidPartition,
+            segmentsWithInvalidPartition.subList(0, 10), _tableNameWithType);
+      }
+    }
+    // Process new segments
+    if (!newSegmentInfoEntries.isEmpty()) {
+      List<String> excludedNewSegments = new ArrayList<>();
+      for (Map.Entry<String, SegmentInfo> entry : newSegmentInfoEntries) {
+        String segment = entry.getKey();
+        SegmentInfo segmentInfo = entry.getValue();
+        int partitionId = segmentInfo._partitionId;
+        List<String> onlineServers = segmentInfo._onlineServers;
+        PartitionInfo partitionInfo = partitionInfoMap[partitionId];
+        if (partitionInfo == null) {
+          // If the new segment is the first segment of a partition, treat it as regular segment
+          Set<String> fullyReplicatedServers = new HashSet<>(onlineServers);
+          List<String> segments = new ArrayList<>();
+          segments.add(segment);
+          partitionInfo = new PartitionInfo(fullyReplicatedServers, segments);
+          partitionInfoMap[partitionId] = partitionInfo;
+        } else {
+          // If the new segment is not the first segment of a partition, add it only if it won't reduce the fully
+          // replicated servers. It is common that a new segment (newly pushed, or a new consuming segment) doesn't have
+          // all the replicas available yet, and we want to exclude it from the partition info until all the replicas
+          // are available.
+          //noinspection SlowListContainsAll
+          if (onlineServers.containsAll(partitionInfo._fullyReplicatedServers)) {
+            partitionInfo._segments.add(segment);
+          } else {
+            excludedNewSegments.add(segment);
+          }
+        }
+      }
+      if (!excludedNewSegments.isEmpty()) {
+        int numExcludedNewSegments = excludedNewSegments.size();
+        if (numExcludedNewSegments <= 10) {
+          LOGGER.info("Excluded {} new segments: {} without all replicas available from table: {}",
+              numExcludedNewSegments, excludedNewSegments, _tableNameWithType);
+        } else {
+          LOGGER.info("Excluded {} new segments: {}... without all replicas available from table: {}",
+              numExcludedNewSegments, excludedNewSegments.subList(0, 10), _tableNameWithType);
+        }
       }
     }
     _tablePartitionInfo =
@@ -167,16 +232,20 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
     int numSegments = pulledSegments.size();
     for (int i = 0; i < numSegments; i++) {
       String segment = pulledSegments.get(i);
-      SegmentPartitionInfo partitionInfo =
-          SegmentPartitionUtils.extractPartitionInfo(_tableNameWithType, _partitionColumn, segment, znRecords.get(i));
-      SegmentInfo segmentInfo = new SegmentInfo(getPartitionId(partitionInfo), getOnlineServers(externalView, segment));
+      ZNRecord znRecord = znRecords.get(i);
+      SegmentInfo segmentInfo = new SegmentInfo(getPartitionId(segment, znRecord), getPushTimeMs(znRecord),
+          getOnlineServers(externalView, segment));
       _segmentInfoMap.put(segment, segmentInfo);
     }
     // Update online servers for all online segments
     for (String segment : onlineSegments) {
       SegmentInfo segmentInfo = _segmentInfoMap.get(segment);
       if (segmentInfo == null) {
-        segmentInfo = new SegmentInfo(INVALID_PARTITION_ID, getOnlineServers(externalView, segment));
+        // NOTE: This should not happen, but we still handle it gracefully by adding an invalid SegmentInfo
+        LOGGER.error("Failed to find segment info for segment: {} in table: {} while handling assignment change",
+            segment, _tableNameWithType);
+        segmentInfo =
+            new SegmentInfo(INVALID_PARTITION_ID, INVALID_PUSH_TIME_MS, getOnlineServers(externalView, segment));
         _segmentInfoMap.put(segment, segmentInfo);
       } else {
         segmentInfo._onlineServers = getOnlineServers(externalView, segment);
@@ -188,15 +257,18 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
 
   @Override
   public synchronized void refreshSegment(String segment, @Nullable ZNRecord znRecord) {
-    SegmentPartitionInfo partitionInfo =
-        SegmentPartitionUtils.extractPartitionInfo(_tableNameWithType, _partitionColumn, segment, znRecord);
-    int partitionId = getPartitionId(partitionInfo);
+    int partitionId = getPartitionId(segment, znRecord);
+    long pushTimeMs = getPushTimeMs(znRecord);
     SegmentInfo segmentInfo = _segmentInfoMap.get(segment);
     if (segmentInfo == null) {
-      segmentInfo = new SegmentInfo(partitionId, Collections.emptyList());
+      // NOTE: This should not happen, but we still handle it gracefully by adding an invalid SegmentInfo
+      LOGGER.error("Failed to find segment info for segment: {} in table: {} while handling segment refresh", segment,
+          _tableNameWithType);
+      segmentInfo = new SegmentInfo(partitionId, pushTimeMs, Collections.emptyList());
       _segmentInfoMap.put(segment, segmentInfo);
     } else {
       segmentInfo._partitionId = partitionId;
+      segmentInfo._pushTimeMs = pushTimeMs;
     }
     computeTablePartitionInfo();
   }
@@ -207,10 +279,12 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
 
   private static class SegmentInfo {
     int _partitionId;
+    long _pushTimeMs;
     List<String> _onlineServers;
 
-    SegmentInfo(int partitionId, List<String> onlineServers) {
+    SegmentInfo(int partitionId, long pushTimeMs, List<String> onlineServers) {
       _partitionId = partitionId;
+      _pushTimeMs = pushTimeMs;
       _onlineServers = onlineServers;
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/routing/TablePartitionInfo.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/routing/TablePartitionInfo.java
@@ -28,10 +28,10 @@ public class TablePartitionInfo {
   private final String _partitionFunctionName;
   private final int _numPartitions;
   private final PartitionInfo[] _partitionInfoMap;
-  private final Set<String> _segmentsWithInvalidPartition;
+  private final List<String> _segmentsWithInvalidPartition;
 
   public TablePartitionInfo(String tableNameWithType, String partitionColumn, String partitionFunctionName,
-      int numPartitions, PartitionInfo[] partitionInfoMap, Set<String> segmentsWithInvalidPartition) {
+      int numPartitions, PartitionInfo[] partitionInfoMap, List<String> segmentsWithInvalidPartition) {
     _tableNameWithType = tableNameWithType;
     _partitionColumn = partitionColumn;
     _partitionFunctionName = partitionFunctionName;
@@ -60,7 +60,7 @@ public class TablePartitionInfo {
     return _partitionInfoMap;
   }
 
-  public Set<String> getSegmentsWithInvalidPartition() {
+  public List<String> getSegmentsWithInvalidPartition() {
     return _segmentsWithInvalidPartition;
   }
 

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -246,7 +246,7 @@ public class QueryEnvironmentTestBase {
         }
         TablePartitionInfo tablePartitionInfo =
             new TablePartitionInfo(tableNameWithType, partitionColumn, "hashCode", numPartitions, partitionIdToInfoMap,
-                Collections.emptySet());
+                Collections.emptyList());
         partitionInfoMap.put(tableNameWithType, tablePartitionInfo);
       }
     }


### PR DESCRIPTION
Similar to #10466, we need to be more graceful for new segment (newly pushed or new consuming segment) because it is common that they don't have all replicas available in external view.
This PR adds the new segment into the partition info only when all the replicas are available