### PR TITLE
[multistage] fix usage of metadata overrides

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -203,9 +203,9 @@ public class QueryRunner {
   private Map<String, String> consolidateMetadata(Map<String, String> customProperties,
       Map<String, String> requestMetadata) {
     Map<String, String> opChainMetadata = new HashMap<>();
-    // 1. put all custom Properties
+    // 1. put all request level metadata
     opChainMetadata.putAll(requestMetadata);
-    // 2. put all request level metadata
+    // 2. put all stageMetadata.customProperties.
     opChainMetadata.putAll(customProperties);
     // 3. add all overrides from config if anything is still empty.
     Integer numGroupsLimit = QueryOptionsUtils.getNumGroupsLimit(opChainMetadata);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -133,7 +133,7 @@ public class AggregateOperator extends MultiStageOperator {
     // Initialize the appropriate executor.
     if (!groupSet.isEmpty()) {
       _isGroupByAggregation = true;
-      Map<String, String> metadata = context.getRequestMetadata();
+      Map<String, String> metadata = context.getContextMetadata();
       _groupByExecutor =
           new MultistageGroupByExecutor(groupByExpr, aggFunctions, filterArgIndexArray, aggType, _colNameToIndexMap,
               _resultSchema, metadata, nodeHint);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -48,7 +48,6 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.block.DataBlockValSet;
 import org.apache.pinot.query.runtime.operator.block.FilteredDataBlockValSet;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
-import org.apache.pinot.query.runtime.plan.StageMetadata;
 import org.apache.pinot.spi.data.FieldSpec;
 
 
@@ -134,12 +133,10 @@ public class AggregateOperator extends MultiStageOperator {
     // Initialize the appropriate executor.
     if (!groupSet.isEmpty()) {
       _isGroupByAggregation = true;
-      StageMetadata stageMetadata = context.getStageMetadata();
-      Map<String, String> customProperties =
-          stageMetadata != null ? stageMetadata.getCustomProperties() : Collections.emptyMap();
+      Map<String, String> metadata = context.getRequestMetadata();
       _groupByExecutor =
           new MultistageGroupByExecutor(groupByExpr, aggFunctions, filterArgIndexArray, aggType, _colNameToIndexMap,
-              _resultSchema, customProperties, nodeHint);
+              _resultSchema, metadata, nodeHint);
     } else {
       _isGroupByAggregation = false;
       _aggregationExecutor =

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -133,10 +133,10 @@ public class AggregateOperator extends MultiStageOperator {
     // Initialize the appropriate executor.
     if (!groupSet.isEmpty()) {
       _isGroupByAggregation = true;
-      Map<String, String> metadata = context.getContextMetadata();
+      Map<String, String> opChainMetadata = context.getOpChainMetadata();
       _groupByExecutor =
           new MultistageGroupByExecutor(groupByExpr, aggFunctions, filterArgIndexArray, aggType, _colNameToIndexMap,
-              _resultSchema, metadata, nodeHint);
+              _resultSchema, opChainMetadata, nodeHint);
     } else {
       _isGroupByAggregation = false;
       _aggregationExecutor =

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -143,12 +143,12 @@ public class HashJoinOperator extends MultiStageOperator {
     } else {
       _matchedRightRows = null;
     }
-    Map<String, String> metadata = context.getRequestMetadata();
+    Map<String, String> metadata = context.getContextMetadata();
     _maxRowsInHashTable = getMaxRowInJoin(metadata, node.getJoinHints());
     _joinOverflowMode = getJoinOverflowMode(metadata, node.getJoinHints());
   }
 
-  private int getMaxRowInJoin(Map<String, String> customProperties, @Nullable AbstractPlanNode.NodeHint nodeHint) {
+  private int getMaxRowInJoin(Map<String, String> contextMetadata, @Nullable AbstractPlanNode.NodeHint nodeHint) {
     if (nodeHint != null) {
       Map<String, String> joinOptions = nodeHint._hintOptions.get(PinotHintOptions.JOIN_HINT_OPTIONS);
       if (joinOptions != null) {
@@ -158,11 +158,11 @@ public class HashJoinOperator extends MultiStageOperator {
         }
       }
     }
-    Integer maxRowsInJoin = QueryOptionsUtils.getMaxRowsInJoin(customProperties);
+    Integer maxRowsInJoin = QueryOptionsUtils.getMaxRowsInJoin(contextMetadata);
     return maxRowsInJoin != null ? maxRowsInJoin : DEFAULT_MAX_ROWS_IN_JOIN;
   }
 
-  private JoinOverFlowMode getJoinOverflowMode(Map<String, String> customProperties,
+  private JoinOverFlowMode getJoinOverflowMode(Map<String, String> contextMetadata,
       @Nullable AbstractPlanNode.NodeHint nodeHint) {
     if (nodeHint != null) {
       Map<String, String> joinOptions = nodeHint._hintOptions.get(PinotHintOptions.JOIN_HINT_OPTIONS);
@@ -173,7 +173,7 @@ public class HashJoinOperator extends MultiStageOperator {
         }
       }
     }
-    JoinOverFlowMode joinOverflowMode = QueryOptionsUtils.getJoinOverflowMode(customProperties);
+    JoinOverFlowMode joinOverflowMode = QueryOptionsUtils.getJoinOverflowMode(contextMetadata);
     return joinOverflowMode != null ? joinOverflowMode : DEFAULT_JOIN_OVERFLOW_MODE;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -22,7 +22,6 @@ import com.google.common.base.Preconditions;
 import com.google.common.collect.ImmutableList;
 import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -46,7 +45,6 @@ import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
-import org.apache.pinot.query.runtime.plan.StageMetadata;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.CommonConstants.MultiStageQueryRunner.JoinOverFlowMode;
 
@@ -145,11 +143,9 @@ public class HashJoinOperator extends MultiStageOperator {
     } else {
       _matchedRightRows = null;
     }
-    StageMetadata stageMetadata = context.getStageMetadata();
-    Map<String, String> customProperties =
-        stageMetadata != null ? stageMetadata.getCustomProperties() : Collections.emptyMap();
-    _maxRowsInHashTable = getMaxRowInJoin(customProperties, node.getJoinHints());
-    _joinOverflowMode = getJoinOverflowMode(customProperties, node.getJoinHints());
+    Map<String, String> metadata = context.getRequestMetadata();
+    _maxRowsInHashTable = getMaxRowInJoin(metadata, node.getJoinHints());
+    _joinOverflowMode = getJoinOverflowMode(metadata, node.getJoinHints());
   }
 
   private int getMaxRowInJoin(Map<String, String> customProperties, @Nullable AbstractPlanNode.NodeHint nodeHint) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -143,12 +143,12 @@ public class HashJoinOperator extends MultiStageOperator {
     } else {
       _matchedRightRows = null;
     }
-    Map<String, String> metadata = context.getContextMetadata();
+    Map<String, String> metadata = context.getOpChainMetadata();
     _maxRowsInHashTable = getMaxRowInJoin(metadata, node.getJoinHints());
     _joinOverflowMode = getJoinOverflowMode(metadata, node.getJoinHints());
   }
 
-  private int getMaxRowInJoin(Map<String, String> contextMetadata, @Nullable AbstractPlanNode.NodeHint nodeHint) {
+  private int getMaxRowInJoin(Map<String, String> opChainMetadata, @Nullable AbstractPlanNode.NodeHint nodeHint) {
     if (nodeHint != null) {
       Map<String, String> joinOptions = nodeHint._hintOptions.get(PinotHintOptions.JOIN_HINT_OPTIONS);
       if (joinOptions != null) {
@@ -158,7 +158,7 @@ public class HashJoinOperator extends MultiStageOperator {
         }
       }
     }
-    Integer maxRowsInJoin = QueryOptionsUtils.getMaxRowsInJoin(contextMetadata);
+    Integer maxRowsInJoin = QueryOptionsUtils.getMaxRowsInJoin(opChainMetadata);
     return maxRowsInJoin != null ? maxRowsInJoin : DEFAULT_MAX_ROWS_IN_JOIN;
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -93,7 +93,7 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     _dataSchema = dataSchema;
     _queryExecutor = queryExecutor;
     _executorService = executorService;
-    Integer maxStreamingPendingBlocks = QueryOptionsUtils.getMaxStreamingPendingBlocks(context.getRequestMetadata());
+    Integer maxStreamingPendingBlocks = QueryOptionsUtils.getMaxStreamingPendingBlocks(context.getContextMetadata());
     _blockingQueue = new ArrayBlockingQueue<>(maxStreamingPendingBlocks != null ? maxStreamingPendingBlocks
         : QueryOptionValue.DEFAULT_MAX_STREAMING_PENDING_BLOCKS);
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -93,7 +93,7 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
     _dataSchema = dataSchema;
     _queryExecutor = queryExecutor;
     _executorService = executorService;
-    Integer maxStreamingPendingBlocks = QueryOptionsUtils.getMaxStreamingPendingBlocks(context.getContextMetadata());
+    Integer maxStreamingPendingBlocks = QueryOptionsUtils.getMaxStreamingPendingBlocks(context.getOpChainMetadata());
     _blockingQueue = new ArrayBlockingQueue<>(maxStreamingPendingBlocks != null ? maxStreamingPendingBlocks
         : QueryOptionValue.DEFAULT_MAX_STREAMING_PENDING_BLOCKS);
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
@@ -72,7 +72,7 @@ public class MultistageGroupByExecutor {
 
   public MultistageGroupByExecutor(List<ExpressionContext> groupByExpr, AggregationFunction[] aggFunctions,
       @Nullable int[] filterArgIndices, AggType aggType, Map<String, Integer> colNameToIndexMap,
-      DataSchema resultSchema, Map<String, String> contextMetadata, @Nullable AbstractPlanNode.NodeHint nodeHint) {
+      DataSchema resultSchema, Map<String, String> opChainMetadata, @Nullable AbstractPlanNode.NodeHint nodeHint) {
     _aggType = aggType;
     _colNameToIndexMap = colNameToIndexMap;
     _groupSet = groupByExpr;
@@ -85,8 +85,8 @@ public class MultistageGroupByExecutor {
 
     _groupKeyToIdMap = new HashMap<>();
 
-    _numGroupsLimit = getNumGroupsLimit(contextMetadata, nodeHint);
-    _maxInitialResultHolderCapacity = getMaxInitialResultHolderCapacity(contextMetadata, nodeHint);
+    _numGroupsLimit = getNumGroupsLimit(opChainMetadata, nodeHint);
+    _maxInitialResultHolderCapacity = getMaxInitialResultHolderCapacity(opChainMetadata, nodeHint);
 
     for (int i = 0; i < _aggFunctions.length; i++) {
       _aggregateResultHolders[i] =

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
@@ -72,7 +72,7 @@ public class MultistageGroupByExecutor {
 
   public MultistageGroupByExecutor(List<ExpressionContext> groupByExpr, AggregationFunction[] aggFunctions,
       @Nullable int[] filterArgIndices, AggType aggType, Map<String, Integer> colNameToIndexMap,
-      DataSchema resultSchema, Map<String, String> customProperties, @Nullable AbstractPlanNode.NodeHint nodeHint) {
+      DataSchema resultSchema, Map<String, String> contextMetadata, @Nullable AbstractPlanNode.NodeHint nodeHint) {
     _aggType = aggType;
     _colNameToIndexMap = colNameToIndexMap;
     _groupSet = groupByExpr;
@@ -85,8 +85,8 @@ public class MultistageGroupByExecutor {
 
     _groupKeyToIdMap = new HashMap<>();
 
-    _numGroupsLimit = getNumGroupsLimit(customProperties, nodeHint);
-    _maxInitialResultHolderCapacity = getMaxInitialResultHolderCapacity(customProperties, nodeHint);
+    _numGroupsLimit = getNumGroupsLimit(contextMetadata, nodeHint);
+    _maxInitialResultHolderCapacity = getMaxInitialResultHolderCapacity(contextMetadata, nodeHint);
 
     for (int i = 0; i < _aggFunctions.length; i++) {
       _aggregateResultHolders[i] =

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
@@ -39,7 +39,7 @@ public class OpChainExecutionContext {
   private final int _stageId;
   private final VirtualServerAddress _server;
   private final long _deadlineMs;
-  private final Map<String, String> _contextMetadata;
+  private final Map<String, String> _opChainMetadata;
   private final StageMetadata _stageMetadata;
   private final OpChainId _id;
   private final OpChainStats _stats;
@@ -47,14 +47,14 @@ public class OpChainExecutionContext {
   private final boolean _traceEnabled;
 
   public OpChainExecutionContext(MailboxService mailboxService, long requestId, int stageId,
-      VirtualServerAddress server, long deadlineMs, Map<String, String> contextMetadata, StageMetadata stageMetadata,
+      VirtualServerAddress server, long deadlineMs, Map<String, String> opChainMetadata, StageMetadata stageMetadata,
       PipelineBreakerResult pipelineBreakerResult) {
     _mailboxService = mailboxService;
     _requestId = requestId;
     _stageId = stageId;
     _server = server;
     _deadlineMs = deadlineMs;
-    _contextMetadata = Collections.unmodifiableMap(contextMetadata);
+    _opChainMetadata = Collections.unmodifiableMap(opChainMetadata);
     _stageMetadata = stageMetadata;
     _id = new OpChainId(requestId, server.workerId(), stageId);
     _stats = new OpChainStats(_id.toString());
@@ -62,7 +62,7 @@ public class OpChainExecutionContext {
     if (pipelineBreakerResult != null && pipelineBreakerResult.getOpChainStats() != null) {
       _stats.getOperatorStatsMap().putAll(pipelineBreakerResult.getOpChainStats().getOperatorStatsMap());
     }
-    _traceEnabled = Boolean.parseBoolean(contextMetadata.get(CommonConstants.Broker.Request.TRACE));
+    _traceEnabled = Boolean.parseBoolean(opChainMetadata.get(CommonConstants.Broker.Request.TRACE));
   }
 
   public MailboxService getMailboxService() {
@@ -85,8 +85,8 @@ public class OpChainExecutionContext {
     return _deadlineMs;
   }
 
-  public Map<String, String> getContextMetadata() {
-    return _contextMetadata;
+  public Map<String, String> getOpChainMetadata() {
+    return _opChainMetadata;
   }
 
   public StageMetadata getStageMetadata() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
@@ -39,7 +39,7 @@ public class OpChainExecutionContext {
   private final int _stageId;
   private final VirtualServerAddress _server;
   private final long _deadlineMs;
-  private final Map<String, String> _requestMetadata;
+  private final Map<String, String> _contextMetadata;
   private final StageMetadata _stageMetadata;
   private final OpChainId _id;
   private final OpChainStats _stats;
@@ -47,14 +47,14 @@ public class OpChainExecutionContext {
   private final boolean _traceEnabled;
 
   public OpChainExecutionContext(MailboxService mailboxService, long requestId, int stageId,
-      VirtualServerAddress server, long deadlineMs, Map<String, String> requestMetadata, StageMetadata stageMetadata,
+      VirtualServerAddress server, long deadlineMs, Map<String, String> contextMetadata, StageMetadata stageMetadata,
       PipelineBreakerResult pipelineBreakerResult) {
     _mailboxService = mailboxService;
     _requestId = requestId;
     _stageId = stageId;
     _server = server;
     _deadlineMs = deadlineMs;
-    _requestMetadata = requestMetadata;
+    _contextMetadata = Collections.unmodifiableMap(contextMetadata);
     _stageMetadata = stageMetadata;
     _id = new OpChainId(requestId, server.workerId(), stageId);
     _stats = new OpChainStats(_id.toString());
@@ -62,7 +62,7 @@ public class OpChainExecutionContext {
     if (pipelineBreakerResult != null && pipelineBreakerResult.getOpChainStats() != null) {
       _stats.getOperatorStatsMap().putAll(pipelineBreakerResult.getOpChainStats().getOperatorStatsMap());
     }
-    _traceEnabled = Boolean.parseBoolean(requestMetadata.get(CommonConstants.Broker.Request.TRACE));
+    _traceEnabled = Boolean.parseBoolean(contextMetadata.get(CommonConstants.Broker.Request.TRACE));
   }
 
   public MailboxService getMailboxService() {
@@ -85,8 +85,8 @@ public class OpChainExecutionContext {
     return _deadlineMs;
   }
 
-  public Map<String, String> getRequestMetadata() {
-    return Collections.unmodifiableMap(_requestMetadata);
+  public Map<String, String> getContextMetadata() {
+    return _contextMetadata;
   }
 
   public StageMetadata getStageMetadata() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/OpChainExecutionContext.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.runtime.plan;
 
+import java.util.Collections;
 import java.util.Map;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.routing.VirtualServerAddress;
@@ -85,7 +86,7 @@ public class OpChainExecutionContext {
   }
 
   public Map<String, String> getRequestMetadata() {
-    return _requestMetadata;
+    return Collections.unmodifiableMap(_requestMetadata);
   }
 
   public StageMetadata getStageMetadata() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/StageMetadata.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/StageMetadata.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.runtime.plan;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -42,7 +43,7 @@ public class StageMetadata {
   }
 
   public Map<String, String> getCustomProperties() {
-    return _customProperties;
+    return Collections.unmodifiableMap(_customProperties);
   }
 
   public static class Builder {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/StageMetadata.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/StageMetadata.java
@@ -35,7 +35,7 @@ public class StageMetadata {
 
   StageMetadata(List<WorkerMetadata> workerMetadataList, Map<String, String> customProperties) {
     _workerMetadataList = workerMetadataList;
-    _customProperties = customProperties;
+    _customProperties = Collections.unmodifiableMap(customProperties);
   }
 
   public List<WorkerMetadata> getWorkerMetadataList() {
@@ -43,7 +43,7 @@ public class StageMetadata {
   }
 
   public Map<String, String> getCustomProperties() {
-    return Collections.unmodifiableMap(_customProperties);
+    return _customProperties;
   }
 
   public static class Builder {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerExecutor.java
@@ -56,7 +56,7 @@ public class PipelineBreakerExecutor {
    * @param scheduler scheduler service to run the pipeline breaker main thread.
    * @param mailboxService mailbox service to attach the {@link MailboxReceiveNode} against.
    * @param distributedStagePlan the distributed stage plan to run pipeline breaker on.
-   * @param requestMetadata request metadata, including query options
+   * @param contextMetadata request metadata, including query options
    * @param requestId request ID
    * @param deadlineMs execution deadline
    * @return pipeline breaker result;
@@ -65,7 +65,7 @@ public class PipelineBreakerExecutor {
    */
   @Nullable
   public static PipelineBreakerResult executePipelineBreakers(OpChainSchedulerService scheduler,
-      MailboxService mailboxService, DistributedStagePlan distributedStagePlan, Map<String, String> requestMetadata,
+      MailboxService mailboxService, DistributedStagePlan distributedStagePlan, Map<String, String> contextMetadata,
       long requestId, long deadlineMs) {
     PipelineBreakerContext pipelineBreakerContext = new PipelineBreakerContext();
     PipelineBreakerVisitor.visitPlanRoot(distributedStagePlan.getStageRoot(), pipelineBreakerContext);
@@ -76,7 +76,7 @@ public class PipelineBreakerExecutor {
         // see also: MailboxIdUtils TODOs, de-couple mailbox id from query information
         OpChainExecutionContext opChainExecutionContext =
             new OpChainExecutionContext(mailboxService, requestId, distributedStagePlan.getStageId(),
-                distributedStagePlan.getServer(), deadlineMs, requestMetadata, distributedStagePlan.getStageMetadata(),
+                distributedStagePlan.getServer(), deadlineMs, contextMetadata, distributedStagePlan.getStageMetadata(),
                 null);
         return execute(scheduler, pipelineBreakerContext, opChainExecutionContext);
       } catch (Exception e) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/pipeline/PipelineBreakerExecutor.java
@@ -56,7 +56,7 @@ public class PipelineBreakerExecutor {
    * @param scheduler scheduler service to run the pipeline breaker main thread.
    * @param mailboxService mailbox service to attach the {@link MailboxReceiveNode} against.
    * @param distributedStagePlan the distributed stage plan to run pipeline breaker on.
-   * @param contextMetadata request metadata, including query options
+   * @param opChainMetadata request metadata, including query options
    * @param requestId request ID
    * @param deadlineMs execution deadline
    * @return pipeline breaker result;
@@ -65,7 +65,7 @@ public class PipelineBreakerExecutor {
    */
   @Nullable
   public static PipelineBreakerResult executePipelineBreakers(OpChainSchedulerService scheduler,
-      MailboxService mailboxService, DistributedStagePlan distributedStagePlan, Map<String, String> contextMetadata,
+      MailboxService mailboxService, DistributedStagePlan distributedStagePlan, Map<String, String> opChainMetadata,
       long requestId, long deadlineMs) {
     PipelineBreakerContext pipelineBreakerContext = new PipelineBreakerContext();
     PipelineBreakerVisitor.visitPlanRoot(distributedStagePlan.getStageRoot(), pipelineBreakerContext);
@@ -76,7 +76,7 @@ public class PipelineBreakerExecutor {
         // see also: MailboxIdUtils TODOs, de-couple mailbox id from query information
         OpChainExecutionContext opChainExecutionContext =
             new OpChainExecutionContext(mailboxService, requestId, distributedStagePlan.getStageId(),
-                distributedStagePlan.getServer(), deadlineMs, contextMetadata, distributedStagePlan.getStageMetadata(),
+                distributedStagePlan.getServer(), deadlineMs, opChainMetadata, distributedStagePlan.getStageMetadata(),
                 null);
         return execute(scheduler, pipelineBreakerContext, opChainExecutionContext);
       } catch (Exception e) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -122,7 +122,7 @@ public class ServerPlanRequestUtils {
     long requestId = (executionContext.getRequestId() << 16) + ((long) stagePlan.getStageId() << 8) + (
         tableType == TableType.REALTIME ? 1 : 0);
     PinotQuery pinotQuery = new PinotQuery();
-    Integer leafNodeLimit = QueryOptionsUtils.getMultiStageLeafLimit(executionContext.getRequestMetadata());
+    Integer leafNodeLimit = QueryOptionsUtils.getMultiStageLeafLimit(executionContext.getContextMetadata());
     if (leafNodeLimit != null) {
       pinotQuery.setLimit(leafNodeLimit);
     } else {
@@ -174,7 +174,7 @@ public class ServerPlanRequestUtils {
    * Helper method to update query options.
    */
   private static void updateQueryOptions(PinotQuery pinotQuery, OpChainExecutionContext executionContext) {
-    Map<String, String> queryOptions = new HashMap<>(executionContext.getRequestMetadata());
+    Map<String, String> queryOptions = new HashMap<>(executionContext.getContextMetadata());
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.TIMEOUT_MS,
         Long.toString(executionContext.getDeadlineMs() - System.currentTimeMillis()));
     pinotQuery.setQueryOptions(queryOptions);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -122,7 +122,7 @@ public class ServerPlanRequestUtils {
     long requestId = (executionContext.getRequestId() << 16) + ((long) stagePlan.getStageId() << 8) + (
         tableType == TableType.REALTIME ? 1 : 0);
     PinotQuery pinotQuery = new PinotQuery();
-    Integer leafNodeLimit = QueryOptionsUtils.getMultiStageLeafLimit(executionContext.getContextMetadata());
+    Integer leafNodeLimit = QueryOptionsUtils.getMultiStageLeafLimit(executionContext.getOpChainMetadata());
     if (leafNodeLimit != null) {
       pinotQuery.setLimit(leafNodeLimit);
     } else {
@@ -174,7 +174,7 @@ public class ServerPlanRequestUtils {
    * Helper method to update query options.
    */
   private static void updateQueryOptions(PinotQuery pinotQuery, OpChainExecutionContext executionContext) {
-    Map<String, String> queryOptions = new HashMap<>(executionContext.getContextMetadata());
+    Map<String, String> queryOptions = new HashMap<>(executionContext.getOpChainMetadata());
     queryOptions.put(CommonConstants.Broker.Request.QueryOptionKey.TIMEOUT_MS,
         Long.toString(executionContext.getDeadlineMs() - System.currentTimeMillis()));
     pinotQuery.setQueryOptions(queryOptions);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -22,6 +22,7 @@ import io.grpc.Server;
 import io.grpc.ServerBuilder;
 import io.grpc.Status;
 import io.grpc.stub.StreamObserver;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -99,7 +100,7 @@ public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
     // Deserialize the request
     List<DistributedStagePlan> distributedStagePlans;
     Map<String, String> requestMetadata;
-    requestMetadata = request.getMetadataMap();
+    requestMetadata = Collections.unmodifiableMap(request.getMetadataMap());
     long requestId = Long.parseLong(requestMetadata.get(CommonConstants.Query.Request.MetadataKeys.REQUEST_ID));
     long timeoutMs = Long.parseLong(requestMetadata.get(CommonConstants.Broker.Request.QueryOptionKey.TIMEOUT_MS));
     long deadlineMs = System.currentTimeMillis() + timeoutMs;


### PR DESCRIPTION
custom properties in StageMetadata and 
requestMetadata from WorkerRequest are immutable

mutating it during execution causes race-condition in set b/c multiple worker shares the same metadata

thus 
1. create an immutable wrapper around
2. move the consolidation logic to create a new local map of requestMetadata for each queryRunner call and set it context, never use the customProperties field from StageMetadata again.
