### PR TITLE
Log warning when multi-stage engine planning throws exception

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -138,7 +138,7 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       throw e;
     } catch (RuntimeException e) {
       String consolidatedMessage = ExceptionUtils.consolidateExceptionMessages(e);
-      LOGGER.info("Caught exception compiling request {}: {}, {}", requestId, query, consolidatedMessage);
+      LOGGER.warn("Caught exception planning request {}: {}, {}", requestId, query, consolidatedMessage);
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.REQUEST_COMPILATION_EXCEPTIONS, 1);
       requestContext.setErrorCode(QueryException.QUERY_PLANNING_ERROR_CODE);
       return new BrokerResponseNative(


### PR DESCRIPTION
We usually log `info` on query parsing because that indicates user error. For multi-stage planning, exception could indicate some state mismatch, so log `warn` is more appropriate