### PR TITLE
log errors without exceptions in query console

### DIFF
--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -273,7 +273,15 @@ const getQueryResults = (params) => {
     // if sql api throws error, handle here
     if(typeof queryResponse === 'string'){
       exceptions = queryResponse;
-    } 
+    }
+    // if sql api returns a structured error with a `code`, handle here
+    if (queryResponse && queryResponse.code) {
+      if (queryResponse.error) {
+        exceptions = "Query failed with error code: " + queryResponse.code + " and error: " + queryResponse.error;
+      } else {
+        exceptions = "Query failed with error code: " + queryResponse.code + " but no logs. Please see controller logs for error.";
+      }
+    }
     if (queryResponse && queryResponse.exceptions && queryResponse.exceptions.length) {
       exceptions = queryResponse.exceptions as SqlException[];
     } 


### PR DESCRIPTION
this is a `bugfix` for #11596.

similar to #11513, this will log errors when the controller returns a structured error response like `{code: 500, error: ...}`. In my case, it's returning error=null, so I'm including a separate log for that.

This is what it looks like replicating the error from #11597

<img width="893" alt="image" src="https://github.com/apache/pinot/assets/4760722/12748461-dfbb-4183-9763-96b916bc21d3">
