### PR TITLE
Support several extensions on indexes

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/bloom/BloomIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/bloom/BloomIndexType.java
@@ -19,6 +19,8 @@
 
 package org.apache.pinot.segment.local.segment.index.bloom;
 
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.segment.creator.impl.bloom.OnHeapGuavaBloomFilterCreator;
@@ -51,6 +53,8 @@ public class BloomIndexType
     extends AbstractIndexType<BloomFilterConfig, BloomFilterReader, BloomFilterCreator>
     implements ConfigurableFromIndexLoadingConfig<BloomFilterConfig> {
   public static final String INDEX_DISPLAY_NAME = "bloom";
+  private static final List<String> EXTENSIONS =
+      Collections.singletonList(V1Constants.Indexes.BLOOM_FILTER_FILE_EXTENSION);
 
   protected BloomIndexType() {
     super(StandardIndexes.BLOOM_FILTER_ID);
@@ -116,8 +120,8 @@ public class BloomIndexType
   }
 
   @Override
-  public String getFileExtension(ColumnMetadata columnMetadata) {
-    return V1Constants.Indexes.BLOOM_FILTER_FILE_EXTENSION;
+  public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+    return EXTENSIONS;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
@@ -89,6 +89,7 @@ public class DictionaryIndexType
     extends AbstractIndexType<DictionaryIndexConfig, Dictionary, SegmentDictionaryCreator>
     implements ConfigurableFromIndexLoadingConfig<DictionaryIndexConfig> {
   private static final Logger LOGGER = LoggerFactory.getLogger(DictionaryIndexType.class);
+  private static final List<String> EXTENSIONS = Collections.singletonList(V1Constants.Dict.FILE_EXTENSION);
 
   protected DictionaryIndexType() {
     super(StandardIndexes.DICTIONARY_ID);
@@ -334,8 +335,8 @@ public class DictionaryIndexType
   }
 
   @Override
-  public String getFileExtension(ColumnMetadata columnMetadata) {
-    return getFileExtension();
+  public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+    return EXTENSIONS;
   }
 
   private static class ReaderFactory extends IndexReaderFactory.Default<DictionaryIndexConfig, Dictionary> {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexType.java
@@ -19,8 +19,10 @@
 
 package org.apache.pinot.segment.local.segment.index.forward;
 
+import com.google.common.collect.Lists;
 import com.google.common.collect.Sets;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -67,6 +69,13 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
   private static final int MAX_MULTI_VALUES_PER_ROW = 1000;
   private static final int NODICT_VARIABLE_WIDTH_ESTIMATED_AVERAGE_VALUE_LENGTH_DEFAULT = 100;
   private static final int NODICT_VARIABLE_WIDTH_ESTIMATED_NUMBER_OF_VALUES_DEFAULT = 100_000;
+  private static final List<String> EXTENSIONS = Lists.newArrayList(
+      V1Constants.Indexes.RAW_SV_FORWARD_INDEX_FILE_EXTENSION,
+      V1Constants.Indexes.SORTED_SV_FORWARD_INDEX_FILE_EXTENSION,
+      V1Constants.Indexes.UNSORTED_SV_FORWARD_INDEX_FILE_EXTENSION,
+      V1Constants.Indexes.RAW_MV_FORWARD_INDEX_FILE_EXTENSION,
+      V1Constants.Indexes.UNSORTED_MV_FORWARD_INDEX_FILE_EXTENSION
+  );
 
   protected ForwardIndexType() {
     super(StandardIndexes.FORWARD_ID);
@@ -209,7 +218,6 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
     return ForwardIndexReaderFactory.INSTANCE;
   }
 
-  @Override
   public String getFileExtension(ColumnMetadata columnMetadata) {
     if (columnMetadata.isSingleValue()) {
       if (!columnMetadata.hasDictionary()) {
@@ -224,6 +232,14 @@ public class ForwardIndexType extends AbstractIndexType<ForwardIndexConfig, Forw
     } else {
       return V1Constants.Indexes.UNSORTED_MV_FORWARD_INDEX_FILE_EXTENSION;
     }
+  }
+
+  @Override
+  public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+    if (columnMetadata == null) {
+      return EXTENSIONS;
+    }
+    return Collections.singletonList(getFileExtension(columnMetadata));
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/fst/FstIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/fst/FstIndexType.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.local.segment.index.fst;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -62,6 +63,8 @@ import org.apache.pinot.spi.data.Schema;
 public class FstIndexType extends AbstractIndexType<FstIndexConfig, TextIndexReader, FSTIndexCreator>
     implements ConfigurableFromIndexLoadingConfig<FstIndexConfig> {
   public static final String INDEX_DISPLAY_NAME = "fst";
+  private static final List<String> EXTENSIONS =
+      Collections.singletonList(V1Constants.Indexes.FST_INDEX_FILE_EXTENSION);
 
   protected FstIndexType() {
     super(StandardIndexes.FST_ID);
@@ -172,8 +175,8 @@ public class FstIndexType extends AbstractIndexType<FstIndexConfig, TextIndexRea
   }
 
   @Override
-  public String getFileExtension(ColumnMetadata columnMetadata) {
-    return V1Constants.Indexes.FST_INDEX_FILE_EXTENSION;
+  public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+    return EXTENSIONS;
   }
 
   private static class ReaderFactory extends IndexReaderFactory.Default<FstIndexConfig, TextIndexReader> {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/h3/H3IndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/h3/H3IndexType.java
@@ -22,6 +22,8 @@ package org.apache.pinot.segment.local.segment.index.h3;
 import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.io.UncheckedIOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
@@ -60,6 +62,7 @@ import org.apache.pinot.spi.data.Schema;
 public class H3IndexType extends AbstractIndexType<H3IndexConfig, H3IndexReader, GeoSpatialIndexCreator>
   implements ConfigurableFromIndexLoadingConfig<H3IndexConfig> {
   public static final String INDEX_DISPLAY_NAME = "h3";
+  private static final List<String> EXTENSIONS = Collections.singletonList(V1Constants.Indexes.H3_INDEX_FILE_EXTENSION);
 
   protected H3IndexType() {
     super(StandardIndexes.H3_ID);
@@ -118,8 +121,8 @@ public class H3IndexType extends AbstractIndexType<H3IndexConfig, H3IndexReader,
   }
 
   @Override
-  public String getFileExtension(ColumnMetadata columnMetadata) {
-    return V1Constants.Indexes.H3_INDEX_FILE_EXTENSION;
+  public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+    return EXTENSIONS;
   }
 
   private static class ReaderFactory extends IndexReaderFactory.Default<H3IndexConfig, H3IndexReader> {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/inverted/InvertedIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/inverted/InvertedIndexType.java
@@ -21,6 +21,8 @@ package org.apache.pinot.segment.local.segment.index.inverted;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
@@ -61,6 +63,8 @@ public class InvertedIndexType
     extends AbstractIndexType<IndexConfig, InvertedIndexReader, DictionaryBasedInvertedIndexCreator>
     implements ConfigurableFromIndexLoadingConfig<IndexConfig> {
   public static final String INDEX_DISPLAY_NAME = "inverted";
+  private static final List<String> EXTENSIONS =
+      Collections.singletonList(V1Constants.Indexes.BITMAP_INVERTED_INDEX_FILE_EXTENSION);
 
   protected InvertedIndexType() {
     super(StandardIndexes.INVERTED_ID);
@@ -131,8 +135,8 @@ public class InvertedIndexType
   }
 
   @Override
-  public String getFileExtension(ColumnMetadata columnMetadata) {
-    return V1Constants.Indexes.BITMAP_INVERTED_INDEX_FILE_EXTENSION;
+  public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+    return EXTENSIONS;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/json/JsonIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/json/JsonIndexType.java
@@ -21,6 +21,8 @@ package org.apache.pinot.segment.local.segment.index.json;
 
 import com.google.common.base.Preconditions;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.realtime.impl.json.MutableJsonIndexImpl;
@@ -57,6 +59,8 @@ import org.apache.pinot.spi.data.Schema;
 public class JsonIndexType extends AbstractIndexType<JsonIndexConfig, JsonIndexReader, JsonIndexCreator>
     implements ConfigurableFromIndexLoadingConfig<JsonIndexConfig> {
   public static final String INDEX_DISPLAY_NAME = "json";
+  private static final List<String> EXTENSIONS =
+      Collections.singletonList(V1Constants.Indexes.JSON_INDEX_FILE_EXTENSION);
 
   protected JsonIndexType() {
     super(StandardIndexes.JSON_ID);
@@ -120,8 +124,8 @@ public class JsonIndexType extends AbstractIndexType<JsonIndexConfig, JsonIndexR
   }
 
   @Override
-  public String getFileExtension(ColumnMetadata columnMetadata) {
-    return V1Constants.Indexes.JSON_INDEX_FILE_EXTENSION;
+  public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+    return EXTENSIONS;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
@@ -21,6 +21,8 @@ package org.apache.pinot.segment.local.segment.index.nullvalue;
 
 import java.io.File;
 import java.io.IOException;
+import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.local.segment.creator.impl.nullvalue.NullValueVectorCreator;
@@ -45,6 +47,8 @@ import org.apache.pinot.spi.data.Schema;
 
 public class NullValueIndexType extends AbstractIndexType<IndexConfig, NullValueVectorReader, NullValueVectorCreator> {
   public static final String INDEX_DISPLAY_NAME = "null";
+  private static final List<String> EXTENSIONS =
+      Collections.singletonList(V1Constants.Indexes.NULLVALUE_VECTOR_FILE_EXTENSION);
 
   protected NullValueIndexType() {
     super(StandardIndexes.NULL_VALUE_VECTOR_ID);
@@ -99,8 +103,8 @@ public class NullValueIndexType extends AbstractIndexType<IndexConfig, NullValue
   }
 
   @Override
-  public String getFileExtension(ColumnMetadata columnMetadata) {
-    return V1Constants.Indexes.NULLVALUE_VECTOR_FILE_EXTENSION;
+  public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+    return EXTENSIONS;
   }
 
   private static class ReaderFactory implements IndexReaderFactory<NullValueVectorReader> {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/range/RangeIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/range/RangeIndexType.java
@@ -59,6 +59,8 @@ import org.apache.pinot.spi.data.Schema;
 public class RangeIndexType extends AbstractIndexType<RangeIndexConfig, RangeIndexReader, CombinedInvertedIndexCreator>
   implements ConfigurableFromIndexLoadingConfig<RangeIndexConfig> {
   public static final String INDEX_DISPLAY_NAME = "range";
+  private static final List<String> EXTENSIONS =
+      Collections.singletonList(V1Constants.Indexes.BITMAP_RANGE_INDEX_FILE_EXTENSION);
 
   protected RangeIndexType() {
     super(StandardIndexes.RANGE_ID);
@@ -138,8 +140,8 @@ public class RangeIndexType extends AbstractIndexType<RangeIndexConfig, RangeInd
   }
 
   @Override
-  public String getFileExtension(ColumnMetadata columnMetadata) {
-    return V1Constants.Indexes.BITMAP_RANGE_INDEX_FILE_EXTENSION;
+  public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+    return EXTENSIONS;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
@@ -20,6 +20,7 @@
 package org.apache.pinot.segment.local.segment.index.text;
 
 import com.google.common.base.Preconditions;
+import com.google.common.collect.Lists;
 import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
@@ -70,6 +71,11 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
   protected static final Logger LOGGER = LoggerFactory.getLogger(TextIndexType.class);
 
   public static final String INDEX_DISPLAY_NAME = "text";
+  // TODO: Should V1Constants.Indexes.LUCENE_TEXT_INDEX_DOCID_MAPPING_FILE_EXTENSION be added here?
+  private static final List<String> EXTENSIONS = Lists.newArrayList(
+      V1Constants.Indexes.LUCENE_TEXT_INDEX_FILE_EXTENSION,
+      V1Constants.Indexes.NATIVE_TEXT_INDEX_FILE_EXTENSION
+  );
 
   protected TextIndexType() {
     super(StandardIndexes.TEXT_ID);
@@ -146,8 +152,8 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
   }
 
   @Override
-  public String getFileExtension(ColumnMetadata columnMetadata) {
-    return V1Constants.Indexes.LUCENE_TEXT_INDEX_FILE_EXTENSION;
+  public List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata) {
+    return EXTENSIONS;
   }
 
   private static class ReaderFactory implements IndexReaderFactory<TextIndexReader> {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.spi.index;
 
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.ColumnMetadata;
@@ -94,7 +95,13 @@ public interface IndexType<C extends IndexConfig, IR extends IndexReader, IC ext
     return indexContainer.getIndex(this);
   }
 
-  String getFileExtension(ColumnMetadata columnMetadata);
+  /**
+   * Returns the possible file extensions for this index type.
+   *
+   * @param columnMetadata an optional filter. In case it is provided, the index type will do its best to try to filter
+   *                      which extensions are valid. See ForwardIndexType.
+   */
+  List<String> getFileExtensions(@Nullable ColumnMetadata columnMetadata);
 
   IndexHandler createIndexHandler(SegmentDirectory segmentDirectory, Map<String, FieldIndexConfigs> configsByCol,
       @Nullable Schema schema, @Nullable TableConfig tableConfig);


### PR DESCRIPTION
Most index types use a single file extension. But some others do not. 

Thinking that ForwardIndexType was the only that supports multiple file extensions, which depends on whether the column is sorted, dictionary encoded, etc. We initially added a ColumnMetadata argument to `IndexType.getFileExtension`. But recent bug reports (see https://github.com/apache/pinot/issues/11529 and https://github.com/apache/pinot/issues/11520) prove that we were wrong and Text index does also use different file extensions depending on whether it uses the native or lucene type.

This PR changes the code a bit. It replaces `String IndexType.getFileExtension(ColumnMetadata)` with `List<String> IndexType.getFileExtensions(@Nullable ColumnMetadata)`. This means that each index may return several extensions. The code that called this method has been changed accordingly. This mainly affects `FilePerIndexDirectory.getFileFor`, which now depends on `FilePerIndexDirectory.getFilesFor`, which returns a list of them. The older method returns the first file that does exist or any on the list in case there is no file with a valid extension. That is compatible with the older implementation, which my return files that didn't exist.

A couple of new test were added. They reproduce the error detected in https://github.com/apache/pinot/issues/11529. These test fail on master and run successfully in this PR. Creating a test that replicates https://github.com/apache/pinot/issues/11520 is more difficult and I propose to merge this without having an automatic test for that case.