### PR TITLE
Fix the broken Pinot JDBC client.

### DIFF
--- a/pinot-clients/pinot-java-client/pom.xml
+++ b/pinot-clients/pinot-java-client/pom.xml
@@ -66,48 +66,6 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-common</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.logging.log4j</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.webjars</groupId>
-          <artifactId>swagger-ui</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.lz4</groupId>
-          <artifactId>lz4-java</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.mindrot</groupId>
-          <artifactId>jbcrypt</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.github.seancfoley</groupId>
-          <artifactId>ipaddress</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.yetus</groupId>
-          <artifactId>audience-annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.github.luben</groupId>
-          <artifactId>zstd-jni</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>it.unimi.dsi</groupId>
-          <artifactId>fastutil</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.mindrot</groupId>
-          <artifactId>jbcrypt</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.fasterxml.jackson.core</groupId>

--- a/pinot-clients/pinot-jdbc-client/pom.xml
+++ b/pinot-clients/pinot-jdbc-client/pom.xml
@@ -73,32 +73,6 @@
       <groupId>org.apache.pinot</groupId>
       <artifactId>pinot-core</artifactId>
       <version>${project.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.lucene</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.datasketches</groupId>
-          <artifactId>datasketches-java</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.slf4j</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.uber</groupId>
-          <artifactId>h3</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.roaringbitmap</groupId>
-          <artifactId>RoaringBitmap</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>io.netty</groupId>
-          <artifactId>*</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.testng</groupId>


### PR DESCRIPTION
This is to roll back https://github.com/apache/pinot/pull/11510.

Currently the Pinot JDBC client is broken:
```
2023-09-14 14:24:45.641 -0700 (test-site,,,,6,59) pool-3-thread-1 : ERROR org.apache.pinot.spi.utils.PinotReflectionUtils - Error scanning methods within package: 'org.apache.pinot' with regex pattern: '.*\.function\..*', annotation: ScalarFunction
java.lang.NoClassDefFoundError: org/apache/datasketches/theta/Sketch
        at java.lang.Class.getDeclaredMethods0(Native Method) ~[?:?]
        at java.lang.Class.privateGetDeclaredMethods(Unknown Source) ~[?:?]
        at java.lang.Class.getDeclaredMethod(Unknown Source) ~[?:?]
        at org.reflections.util.Utils.getMemberFromDescriptor(Utils.java:88) ~[?:?]
        at org.reflections.util.Utils.getMethodsFromDescriptors(Utils.java:101) ~[?:?]
        at org.reflections.Reflections.getMethodsAnnotatedWith(Reflections.java:482) ~[?:?]
        at org.apache.pinot.spi.utils.PinotReflectionUtils.getMethodsThroughReflection(PinotReflectionUtils.java:97) ~[?:?]
        at org.apache.pinot.spi.utils.PinotReflectionUtils.getMethodsThroughReflection(PinotReflectionUtils.java:88) ~[?:?]
        at org.apache.pinot.common.function.FunctionRegistry.<clinit>(FunctionRegistry.java:62) ~[?:?]
        at org.apache.pinot.sql.parsers.rewriter.CompileTimeFunctionsInvoker.invokeCompileTimeFunctionExpression(CompileTimeFunctionsInvoker.java:74) ~[?:?]
        at org.apache.pinot.sql.parsers.rewriter.CompileTimeFunctionsInvoker.invokeCompileTimeFunctionExpression(CompileTimeFunctionsInvoker.java:66) ~[?:?]
        at org.apache.pinot.sql.parsers.rewriter.CompileTimeFunctionsInvoker.rewrite(CompileTimeFunctionsInvoker.java:47) ~[?:?]
        at org.apache.pinot.sql.parsers.CalciteSqlParser.queryRewrite(CalciteSqlParser.java:549) ~[?:?]
        at org.apache.pinot.sql.parsers.CalciteSqlParser.compileSqlNodeToPinotQuery(CalciteSqlParser.java:486) ~[?:?]
        at org.apache.pinot.client.Connection.resolveTableName(Connection.java:195) ~[?:?]
        at org.apache.pinot.client.Connection.execute(Connection.java:119) ~[?:?]
        at org.apache.pinot.client.Connection.execute(Connection.java:94) ~[?:?]
        at org.apache.pinot.client.PinotStatement.executeQuery(PinotStatement.java:67) ~[?:?]
        at org.apache.pinot.client.PinotStatement.execute(PinotStatement.java:82) ~[?:?]
        at com.tableausoftware.jdbc.JDBCProtocolImpl.runQuery(JDBCProtocolImpl.java:628) ~[jdbcserver.jar:20231.0.6]
        at com.tableausoftware.jdbc.JDBCProtocolImpl.runQuery(JDBCProtocolImpl.java:688) ~[jdbcserver.jar:20231.0.6]
        at com.tableau.connect.service.QueryTask.readData(QueryTask.java:124) ~[jdbcserver.jar:20231.0.6]
        at com.tableau.connect.service.QueryTask.call(QueryTask.java:91) ~[jdbcserver.jar:20231.0.6]
        at com.tableau.connect.service.QueryTask.call(QueryTask.java:41) ~[jdbcserver.jar:20231.0.6]
        at java.util.concurrent.FutureTask.run(Unknown Source) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor.runWorker(Unknown Source) ~[?:?]
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(Unknown Source) ~[?:?]
        at java.lang.Thread.run(Unknown Source) [?:?]
Caused by: java.lang.ClassNotFoundException: org.apache.datasketches.theta.Sketch
        at java.net.URLClassLoader.findClass(Unknown Source) ~[?:?]
        at java.lang.ClassLoader.loadClass(Unknown Source) ~[?:?]
        at java.net.FactoryURLClassLoader.loadClass(Unknown Source) ~[?:?]
        at java.lang.ClassLoader.loadClass(Unknown Source) ~[?:?]
        ... 28 more
```

Prefer rollback to rolling forward with fix as per [release best practices](https://cloud.google.com/blog/products/gcp/reliable-releases-and-rollbacks-cre-life-lessons). We can try the [comprehensive solution](https://github.com/apache/pinot/issues/11507#issuecomment-1708392274) afterwards.

Tested the Pinot JDBC client built from this PR and got no error.

CC @abhioncbr @xiangfu0 

https://github.com/apache/pinot/issues/11507