### PR TITLE
Fix the alias handling in single-stage engine

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -140,6 +140,11 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       String consolidatedMessage = ExceptionUtils.consolidateExceptionMessages(e);
       LOGGER.warn("Caught exception planning request {}: {}, {}", requestId, query, consolidatedMessage);
       _brokerMetrics.addMeteredGlobalValue(BrokerMeter.REQUEST_COMPILATION_EXCEPTIONS, 1);
+      if (e.getMessage().matches(".* Column .* not found in any table'")) {
+        requestContext.setErrorCode(QueryException.UNKNOWN_COLUMN_ERROR_CODE);
+        return new BrokerResponseNative(
+            QueryException.getException(QueryException.UNKNOWN_COLUMN_ERROR, consolidatedMessage));
+      }
       requestContext.setErrorCode(QueryException.QUERY_PLANNING_ERROR_CODE);
       return new BrokerResponseNative(
           QueryException.getException(QueryException.QUERY_PLANNING_ERROR, consolidatedMessage));

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandlerTest.java
@@ -88,11 +88,11 @@ public class BaseBrokerRequestHandlerTest {
     Map<String, String> columnNameMap = new HashMap<>();
     columnNameMap.put("student_name", "student_name");
     String actualColumnName =
-        BaseBrokerRequestHandler.getActualColumnName("mytable", "mytable.student_name", columnNameMap, null, false);
+        BaseBrokerRequestHandler.getActualColumnName("mytable", "mytable.student_name", columnNameMap, false);
     Assert.assertEquals(actualColumnName, "student_name");
     boolean exceptionThrown = false;
     try {
-      BaseBrokerRequestHandler.getActualColumnName("mytable", "mytable2.student_name", columnNameMap, null, false);
+      BaseBrokerRequestHandler.getActualColumnName("mytable", "mytable2.student_name", columnNameMap, false);
       Assert.fail("should throw exception if column is not known");
     } catch (BadQueryRequestException ex) {
       exceptionThrown = true;
@@ -100,7 +100,7 @@ public class BaseBrokerRequestHandlerTest {
     Assert.assertTrue(exceptionThrown, "should throw exception if column is not known");
     exceptionThrown = false;
     try {
-      BaseBrokerRequestHandler.getActualColumnName("mytable", "MYTABLE.student_name", columnNameMap, null, false);
+      BaseBrokerRequestHandler.getActualColumnName("mytable", "MYTABLE.student_name", columnNameMap, false);
       Assert.fail("should throw exception if case sensitive and table name different");
     } catch (BadQueryRequestException ex) {
       exceptionThrown = true;
@@ -108,12 +108,12 @@ public class BaseBrokerRequestHandlerTest {
     Assert.assertTrue(exceptionThrown, "should throw exception if column is not known");
     columnNameMap.put("mytable_student_name", "mytable_student_name");
     String wrongColumnName2 =
-        BaseBrokerRequestHandler.getActualColumnName("mytable", "mytable_student_name", columnNameMap, null, false);
+        BaseBrokerRequestHandler.getActualColumnName("mytable", "mytable_student_name", columnNameMap, false);
     Assert.assertEquals(wrongColumnName2, "mytable_student_name");
 
     columnNameMap.put("mytable", "mytable");
     String wrongColumnName3 =
-        BaseBrokerRequestHandler.getActualColumnName("mytable", "mytable", columnNameMap, null, false);
+        BaseBrokerRequestHandler.getActualColumnName("mytable", "mytable", columnNameMap, false);
     Assert.assertEquals(wrongColumnName3, "mytable");
   }
 
@@ -122,11 +122,11 @@ public class BaseBrokerRequestHandlerTest {
     Map<String, String> columnNameMap = new HashMap<>();
     columnNameMap.put("student_name", "student_name");
     String actualColumnName =
-        BaseBrokerRequestHandler.getActualColumnName("mytable", "MYTABLE.student_name", columnNameMap, null, true);
+        BaseBrokerRequestHandler.getActualColumnName("mytable", "MYTABLE.student_name", columnNameMap, true);
     Assert.assertEquals(actualColumnName, "student_name");
     boolean exceptionThrown = false;
     try {
-      BaseBrokerRequestHandler.getActualColumnName("student", "MYTABLE2.student_name", columnNameMap, null, true);
+      BaseBrokerRequestHandler.getActualColumnName("student", "MYTABLE2.student_name", columnNameMap, true);
       Assert.fail("should throw exception if column is not known");
     } catch (BadQueryRequestException ex) {
       exceptionThrown = true;
@@ -134,12 +134,12 @@ public class BaseBrokerRequestHandlerTest {
     Assert.assertTrue(exceptionThrown, "should throw exception if column is not known");
     columnNameMap.put("mytable_student_name", "mytable_student_name");
     String wrongColumnName2 =
-        BaseBrokerRequestHandler.getActualColumnName("mytable", "MYTABLE_student_name", columnNameMap, null, true);
+        BaseBrokerRequestHandler.getActualColumnName("mytable", "MYTABLE_student_name", columnNameMap, true);
     Assert.assertEquals(wrongColumnName2, "mytable_student_name");
 
     columnNameMap.put("mytable", "mytable");
     String wrongColumnName3 =
-        BaseBrokerRequestHandler.getActualColumnName("MYTABLE", "mytable", columnNameMap, null, true);
+        BaseBrokerRequestHandler.getActualColumnName("MYTABLE", "mytable", columnNameMap, true);
     Assert.assertEquals(wrongColumnName3, "mytable");
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/QueryRewriterFactory.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/QueryRewriterFactory.java
@@ -33,10 +33,14 @@ public class QueryRewriterFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(QueryRewriterFactory.class);
 
+  // NOTE:
+  //   OrdinalsUpdater must be applied after AliasApplier because OrdinalsUpdater can put the select expression
+  //   (reference) into the group-by list, but the alias should not be applied to the reference.
+  //   E.g. SELECT a + 1 AS a FROM table GROUP BY 1
   public static final List<String> DEFAULT_QUERY_REWRITERS_CLASS_NAMES =
       ImmutableList.of(CompileTimeFunctionsInvoker.class.getName(), SelectionsRewriter.class.getName(),
-          PredicateComparisonRewriter.class.getName(), OrdinalsUpdater.class.getName(),
-          AliasApplier.class.getName(), NonAggregationGroupByToDistinctQueryRewriter.class.getName());
+          PredicateComparisonRewriter.class.getName(), AliasApplier.class.getName(), OrdinalsUpdater.class.getName(),
+          NonAggregationGroupByToDistinctQueryRewriter.class.getName());
 
   public static void init(String queryRewritersClassNamesStr) {
     List<String> queryRewritersClassNames =

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/QueryRewriterFactoryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/QueryRewriterFactoryTest.java
@@ -27,16 +27,15 @@ import static org.apache.pinot.sql.parsers.CalciteSqlParser.QUERY_REWRITERS;
 public class QueryRewriterFactoryTest {
 
   @Test
-  public void testQueryRewriters()
-      throws ReflectiveOperationException {
+  public void testQueryRewriters() {
     // Default behavior
     QueryRewriterFactory.init(null);
     Assert.assertEquals(QUERY_REWRITERS.size(), 6);
     Assert.assertTrue(QUERY_REWRITERS.get(0) instanceof CompileTimeFunctionsInvoker);
     Assert.assertTrue(QUERY_REWRITERS.get(1) instanceof SelectionsRewriter);
     Assert.assertTrue(QUERY_REWRITERS.get(2) instanceof PredicateComparisonRewriter);
-    Assert.assertTrue(QUERY_REWRITERS.get(3) instanceof OrdinalsUpdater);
-    Assert.assertTrue(QUERY_REWRITERS.get(4) instanceof AliasApplier);
+    Assert.assertTrue(QUERY_REWRITERS.get(3) instanceof AliasApplier);
+    Assert.assertTrue(QUERY_REWRITERS.get(4) instanceof OrdinalsUpdater);
     Assert.assertTrue(QUERY_REWRITERS.get(5) instanceof NonAggregationGroupByToDistinctQueryRewriter);
 
     // Check init with other configs
@@ -54,8 +53,8 @@ public class QueryRewriterFactoryTest {
     Assert.assertTrue(QUERY_REWRITERS.get(0) instanceof CompileTimeFunctionsInvoker);
     Assert.assertTrue(QUERY_REWRITERS.get(1) instanceof SelectionsRewriter);
     Assert.assertTrue(QUERY_REWRITERS.get(2) instanceof PredicateComparisonRewriter);
-    Assert.assertTrue(QUERY_REWRITERS.get(3) instanceof OrdinalsUpdater);
-    Assert.assertTrue(QUERY_REWRITERS.get(4) instanceof AliasApplier);
+    Assert.assertTrue(QUERY_REWRITERS.get(3) instanceof AliasApplier);
+    Assert.assertTrue(QUERY_REWRITERS.get(4) instanceof OrdinalsUpdater);
     Assert.assertTrue(QUERY_REWRITERS.get(5) instanceof NonAggregationGroupByToDistinctQueryRewriter);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1468,9 +1468,7 @@ public class PinotLLCRealtimeSegmentManager {
       return 0L;
     }
 
-    if (!isLowLevelConsumer(tableNameWithType, tableConfig)
-        || !getIsSplitCommitEnabled()
-        || !isTmpSegmentAsyncDeletionEnabled()) {
+    if (!getIsSplitCommitEnabled() || !isTmpSegmentAsyncDeletionEnabled()) {
       return 0L;
     }
 
@@ -1503,7 +1501,8 @@ public class PinotLLCRealtimeSegmentManager {
     return deletedTmpSegments;
   }
 
-  private boolean isTmpAndCanDelete(URI uri, Set<String> deepURIs, PinotFS pinotFS) throws Exception {
+  private boolean isTmpAndCanDelete(URI uri, Set<String> deepURIs, PinotFS pinotFS)
+      throws Exception {
     long lastModified = pinotFS.lastModified(uri);
     if (lastModified <= 0) {
       LOGGER.warn("file {} modification time {} is not positive, ineligible for delete", uri.toString(), lastModified);
@@ -1512,12 +1511,6 @@ public class PinotLLCRealtimeSegmentManager {
     String uriString = uri.toString();
     return SegmentCompletionUtils.isTmpFile(uriString) && !deepURIs.contains(uriString)
         && getCurrentTimeMs() - lastModified > _controllerConf.getTmpSegmentRetentionInSeconds() * 1000L;
-  }
-
-  private boolean isLowLevelConsumer(String tableNameWithType, TableConfig tableConfig) {
-    PartitionLevelStreamConfig streamConfig = new PartitionLevelStreamConfig(tableNameWithType,
-        IngestionConfigUtils.getStreamConfigMap(tableConfig));
-    return streamConfig.hasLowLevelConsumerType();
   }
 
   /**

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/request/context/utils/BrokerRequestToQueryContextConverterTest.java
@@ -321,7 +321,8 @@ public class BrokerRequestToQueryContextConverterTest {
     // Alias
     // NOTE: All the references to the alias should already be converted to the original expressions.
     {
-      String query = "SELECT SUM(foo) AS a, bar AS b FROM testTable WHERE b IN (5, 10, 15) GROUP BY b ORDER BY a DESC";
+      String query =
+          "SELECT SUM(foo) AS a, bar AS b FROM testTable WHERE bar IN (5, 10, 15) GROUP BY b ORDER BY a DESC";
       QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
       assertEquals(queryContext.getTableName(), "testTable");
       List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();

--- a/pinot-core/src/test/java/org/apache/pinot/queries/MultiValueRawQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/MultiValueRawQueriesTest.java
@@ -2154,15 +2154,16 @@ public class MultiValueRawQueriesTest extends BaseQueriesTest {
 
   private String getConcatUseInWhereQueryString(String concatFunction, String col1, String col2, String concatCol,
       String table, String compareOperator, int mvPerArray, int limit) {
-    return String.format("SELECT %s(%s, %s) AS %s FROM %s WHERE arraylength(%s) %s %d LIMIT %d", concatFunction, col1,
-        col2, concatCol, table, concatCol, compareOperator, mvPerArray, limit);
+    String function = String.format("%s(%s, %s)", concatFunction, col1, col2);
+    return String.format("SELECT %s AS %s FROM %s WHERE arraylength(%s) %s %d LIMIT %d", function, concatCol, table,
+        function, compareOperator, mvPerArray, limit);
   }
 
   private String getConcatGroupByQueryString(String concatFunction, String col1, String col2, String concatCol,
       String table, String compareOperator, int mvPerArray, int limit) {
-    return String.format(
-        "SELECT %s(%s, %s) AS %s, sum(svIntCol) FROM %s WHERE arraylength(%s) %s %d GROUP BY %s LIMIT %d",
-        concatFunction, col1, col2, concatCol, table, concatCol, compareOperator, mvPerArray, concatCol, limit);
+    String function = String.format("%s(%s, %s)", concatFunction, col1, col2);
+    return String.format("SELECT %s AS %s, sum(svIntCol) FROM %s WHERE arraylength(%s) %s %d GROUP BY %s LIMIT %d",
+        function, concatCol, table, function, compareOperator, mvPerArray, concatCol, limit);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -2254,6 +2254,16 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
 
       query = "SELECT count(*) AS cnt, Carrier AS CarrierName FROM mytable GROUP BY CarrierName ORDER BY cnt";
       testQuery(query);
+
+      // Test: 1. Alias should not be applied to filter; 2. Ordinal can be properly applied
+      query =
+          "SELECT DaysSinceEpoch + 100 AS DaysSinceEpoch, COUNT(*) AS cnt FROM mytable WHERE DaysSinceEpoch <= 16312 "
+              + "GROUP BY 1 ORDER BY 1 DESC";
+      // NOTE: H2 does not support ordinal in GROUP BY
+      String h2Query =
+          "SELECT DaysSinceEpoch + 100 AS DaysSinceEpoch, COUNT(*) AS cnt FROM mytable WHERE DaysSinceEpoch <= 16312 "
+              + "GROUP BY DaysSinceEpoch ORDER BY 1 DESC";
+      testQuery(query, h2Query);
     }
     {
       //test multiple alias

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -2231,6 +2231,13 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
     {
+      String pinotQuery = "SELECT count(*), DaysSinceEpoch as d FROM mytable WHERE d = 16138 GROUP BY d";
+      JsonNode jsonNode = postQuery(pinotQuery);
+      JsonNode exceptions = jsonNode.get("exceptions");
+      assertFalse(exceptions.isEmpty());
+      assertEquals(exceptions.get(0).get("errorCode").asInt(), 710);
+    }
+    {
       //test same alias name with column name
       String query = "SELECT ArrTime AS ArrTime, Carrier AS Carrier, DaysSinceEpoch AS DaysSinceEpoch FROM mytable "
           + "ORDER BY DaysSinceEpoch DESC";
@@ -2598,7 +2605,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     pinotQuery = "SELECT DISTINCT Carrier FROM db.mytable LIMIT 1000000";
     testQuery(pinotQuery, h2Query);
   }
-
 
   @Test
   public void testQuerySourceWithDatabaseNameV2()

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/JsonPathTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/JsonPathTest.java
@@ -339,7 +339,7 @@ public class JsonPathTest extends CustomDataQueryClusterIntegrationTest {
     JsonNode pinotResponse = postQuery(query);
     int expectedStatusCode;
     if (useMultiStageQueryEngine) {
-      expectedStatusCode = QueryException.QUERY_PLANNING_ERROR_CODE;
+      expectedStatusCode = QueryException.UNKNOWN_COLUMN_ERROR_CODE;
     } else {
       expectedStatusCode = QueryException.SQL_PARSING_ERROR_CODE;
     }


### PR DESCRIPTION
Fix 3 issues:
- Fix #11597 
- Alias should not be applied to filter (SQL standard)
- Fix the regression introduced by https://github.com/apache/pinot/pull/10815
## Incompatible

Alias can no longer be applied to filter to comply with standard SQL