### PR TITLE
UI: add toggle to hide/show query exceptions

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -577,20 +577,12 @@ const QueryPage = () => {
 
                       {
                         showException && resultError.map((error) => (
-                          <>
                           <Box style={{paddingBottom: "10px"}}>
                             <Alert className={classes.sqlError} severity="error">
                               {error.errorCode && <Typography variant="body2">Error Code: {error.errorCode}</Typography>}
                               {error.message}
                             </Alert>
                           </Box>
-                           <Box style={{paddingBottom: "10px"}}>
-                           <Alert className={classes.sqlError} severity="error">
-                             {error.errorCode && <Typography variant="body2">Error Code: {error.errorCode}</Typography>}
-                             {error.message}
-                           </Alert>
-                         </Box>
-                         </>
                         ))
                       }
                     </>

--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -166,6 +166,7 @@ const QueryPage = () => {
     columns: [],
     records: [],
   });
+  const [showException, setShowException] = useState<boolean>(false);
 
   const [tableSchema, setTableSchema] = useState<TableData>({
     columns: [],
@@ -184,7 +185,7 @@ const QueryPage = () => {
 
   const [outputResult, setOutputResult] = useState('');
 
-  const [resultError, setResultError] = useState<SqlException[] | string>([]);
+  const [resultError, setResultError] = useState<SqlException[]>([]);
 
   const [queryStats, setQueryStats] = useState<TableData>({
     columns: [],
@@ -552,25 +553,47 @@ const QueryPage = () => {
                 }
         
                 {/* Sql result errors */}
-                {resultError && typeof resultError === "string" && (
-                  <Alert severity="error" className={classes.sqlError}>
-                    {resultError}
-                  </Alert>
-                )}
+                {resultError && resultError.length > 0 && (
+                    <>
+                      <Alert 
+                        className={classes.sqlError} 
+                        severity="error" 
+                        action={
+                          <FormControlLabel
+                            control={<Switch color="primary" checked={showException} onChange={(e) => setShowException(e.target.checked)} name="checkedA" />}
+                            label={<Typography variant='body2'>Show Exceptions</Typography>}
+                          />
+                        }
+                      >
+                        {
+                          resultData.columns.length > 0 ? (
+                            <Typography variant='body2'>Partial results due to exceptions. Please toggle the switch to view details.</Typography>
+                          ) : (
+                            <Typography variant='body2'>Query failed with exceptions. Please toggle the switch to view details.</Typography>
+                          )
+                        }
+                      </Alert>
+                      <Box m={"16px"}></Box>
 
-                {resultError && typeof resultError === "object" && resultError.length > 0 && (
-                  <>
-                    {
-                      resultError.map((error) => (
-                        <Box style={{paddingBottom: "16px"}}>
-                          <Alert className={classes.sqlError} severity="error">
-                            <Typography variant="body2">Error Code: {error.errorCode}</Typography>
-                            {error.message}
-                          </Alert>
-                        </Box>
-                      ))
-                    }
-                  </>
+                      {
+                        showException && resultError.map((error) => (
+                          <>
+                          <Box style={{paddingBottom: "10px"}}>
+                            <Alert className={classes.sqlError} severity="error">
+                              {error.errorCode && <Typography variant="body2">Error Code: {error.errorCode}</Typography>}
+                              {error.message}
+                            </Alert>
+                          </Box>
+                           <Box style={{paddingBottom: "10px"}}>
+                           <Alert className={classes.sqlError} severity="error">
+                             {error.errorCode && <Typography variant="body2">Error Code: {error.errorCode}</Typography>}
+                             {error.message}
+                           </Alert>
+                         </Box>
+                         </>
+                        ))
+                      }
+                    </>
                   )
                 }
         

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -267,19 +267,19 @@ const getQueryResults = (params) => {
   return getQueryResult(params).then(({ data }) => {
     let queryResponse = getAsObject(data);
 
-    let exceptions: SqlException[] | string = [];
+    let exceptions: SqlException[] = [];
     let dataArray = [];
     let columnList = [];
     // if sql api throws error, handle here
     if(typeof queryResponse === 'string'){
-      exceptions = queryResponse;
+      exceptions.push({errorCode: null, message: queryResponse});
     }
     // if sql api returns a structured error with a `code`, handle here
     if (queryResponse && queryResponse.code) {
       if (queryResponse.error) {
-        exceptions = "Query failed with error code: " + queryResponse.code + " and error: " + queryResponse.error;
+        exceptions.push({errorCode: null, message: "Query failed with error code: " + queryResponse.code + " and error: " + queryResponse.error});
       } else {
-        exceptions = "Query failed with error code: " + queryResponse.code + " but no logs. Please see controller logs for error.";
+        exceptions.push({errorCode: null, message: "Query failed with error code: " + queryResponse.code + " but no logs. Please see controller logs for error."});
       }
     }
     if (queryResponse && queryResponse.exceptions && queryResponse.exceptions.length) {


### PR DESCRIPTION
This is UI, enhancement

### What does this PR do?
- Add a toggle to show/hide query exceptions in the UI
- By Default, the exceptions will be collapsed and can be viewed by toggling show exception switch.

## Screenshots 

- When there is only result or only exceptions

https://github.com/apache/pinot/assets/41536903/a283df84-cf68-4b91-9a5d-2d8c06344b3c



- when there are both exceptions and result 

https://github.com/apache/pinot/assets/41536903/00d97847-2392-4faa-8758-042e1962f42a



