### PR TITLE
In multi-stage aggregate, directly store column index as identifier

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -41,6 +41,7 @@ import org.apache.pinot.core.operator.docvalsets.FilteredRowBasedBlockValSet;
 import org.apache.pinot.core.operator.docvalsets.RowBasedBlockValSet;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionFactory;
+import org.apache.pinot.core.query.aggregation.function.CountAggregationFunction;
 import org.apache.pinot.core.util.DataBlockExtractUtils;
 import org.apache.pinot.query.planner.logical.LiteralHintUtils;
 import org.apache.pinot.query.planner.logical.RexExpression;
@@ -49,7 +50,6 @@ import org.apache.pinot.query.planner.plannode.AggregateNode.AggType;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
-import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -60,52 +60,44 @@ import org.roaringbitmap.RoaringBitmap;
  */
 public class AggregateOperator extends MultiStageOperator {
   private static final String EXPLAIN_NAME = "AGGREGATE_OPERATOR";
+  private static final CountAggregationFunction COUNT_STAR_AGG_FUNCTION =
+      new CountAggregationFunction(Collections.singletonList(ExpressionContext.forIdentifier("*")), false);
+  private static final ExpressionContext PLACEHOLDER_IDENTIFIER = ExpressionContext.forIdentifier("__PLACEHOLDER__");
 
   private final MultiStageOperator _inputOperator;
   private final DataSchema _resultSchema;
-  private final DataSchema _inputSchema;
   private final AggType _aggType;
+  private final MultistageAggregationExecutor _aggregationExecutor;
+  private final MultistageGroupByExecutor _groupByExecutor;
 
-  // Map that maintains the mapping between columnName and the column ordinal index. It is used to fetch the required
-  // column value from row-based container and fetch the input datatype for the column.
-  // TODO: Pass the column index instead of converting back and forth
-  private final Map<String, Integer> _colNameToIndexMap;
-
-  private final Map<Integer, Map<Integer, Literal>> _aggCallSignatureMap;
-
-  private MultistageAggregationExecutor _aggregationExecutor;
-  private MultistageGroupByExecutor _groupByExecutor;
   private boolean _hasReturnedAggregateBlock;
 
   public AggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator, DataSchema resultSchema,
-      DataSchema inputSchema, List<RexExpression> aggCalls, List<RexExpression> groupSet, AggType aggType,
-      List<Integer> filterArgIndices, @Nullable AbstractPlanNode.NodeHint nodeHint) {
+      List<RexExpression> aggCalls, List<RexExpression> groupSet, AggType aggType, List<Integer> filterArgIndices,
+      @Nullable AbstractPlanNode.NodeHint nodeHint) {
     super(context);
     _inputOperator = inputOperator;
     _resultSchema = resultSchema;
-    _inputSchema = inputSchema;
     _aggType = aggType;
 
     // Process literal hints
-    if (nodeHint != null && nodeHint._hintOptions != null
-        && nodeHint._hintOptions.get(PinotHintOptions.INTERNAL_AGG_OPTIONS) != null) {
-      _aggCallSignatureMap = LiteralHintUtils.hintStringToLiteralMap(
-          nodeHint._hintOptions.get(PinotHintOptions.INTERNAL_AGG_OPTIONS)
-              .get(PinotHintOptions.InternalAggregateOptions.AGG_CALL_SIGNATURE));
-    } else {
-      _aggCallSignatureMap = Collections.emptyMap();
+    Map<Integer, Map<Integer, Literal>> literalArgumentsMap = null;
+    if (nodeHint != null) {
+      Map<String, String> aggOptions = nodeHint._hintOptions.get(PinotHintOptions.INTERNAL_AGG_OPTIONS);
+      if (aggOptions != null) {
+        literalArgumentsMap = LiteralHintUtils.hintStringToLiteralMap(
+            aggOptions.get(PinotHintOptions.InternalAggregateOptions.AGG_CALL_SIGNATURE));
+      }
+    }
+    if (literalArgumentsMap == null) {
+      literalArgumentsMap = Collections.emptyMap();
     }
 
     // Initialize the aggregation functions
-    _colNameToIndexMap = new HashMap<>();
-    List<FunctionContext> functionContexts = getFunctionContexts(aggCalls);
-    int numFunctions = functionContexts.size();
-    AggregationFunction<?, ?>[] aggFunctions = new AggregationFunction[numFunctions];
-    for (int i = 0; i < numFunctions; i++) {
-      aggFunctions[i] = AggregationFunctionFactory.getAggregationFunction(functionContexts.get(i), true);
-    }
+    AggregationFunction<?, ?>[] aggFunctions = getAggFunctions(aggCalls, literalArgumentsMap);
 
     // Process the filter argument indices
+    int numFunctions = aggFunctions.length;
     int[] filterArgIds = new int[numFunctions];
     int maxFilterArgId = -1;
     for (int i = 0; i < numFunctions; i++) {
@@ -116,13 +108,12 @@ public class AggregateOperator extends MultiStageOperator {
     // Initialize the appropriate executor.
     if (groupSet.isEmpty()) {
       _aggregationExecutor =
-          new MultistageAggregationExecutor(aggFunctions, filterArgIds, maxFilterArgId, aggType, _colNameToIndexMap,
-              _resultSchema);
+          new MultistageAggregationExecutor(aggFunctions, filterArgIds, maxFilterArgId, aggType, _resultSchema);
       _groupByExecutor = null;
     } else {
       _groupByExecutor =
           new MultistageGroupByExecutor(getGroupKeyIds(groupSet), aggFunctions, filterArgIds, maxFilterArgId, aggType,
-              _colNameToIndexMap, _resultSchema, context.getOpChainMetadata(), nodeHint);
+              _resultSchema, context.getOpChainMetadata(), nodeHint);
       _aggregationExecutor = null;
     }
   }
@@ -205,90 +196,78 @@ public class AggregateOperator extends MultiStageOperator {
     return block;
   }
 
-  private List<FunctionContext> getFunctionContexts(List<RexExpression> aggCalls) {
+  private AggregationFunction<?, ?>[] getAggFunctions(List<RexExpression> aggCalls,
+      Map<Integer, Map<Integer, Literal>> literalArgumentsMap) {
     int numFunctions = aggCalls.size();
-    List<FunctionContext> functionContexts = new ArrayList<>(numFunctions);
+    AggregationFunction<?, ?>[] aggFunctions = new AggregationFunction[numFunctions];
     for (int i = 0; i < numFunctions; i++) {
       RexExpression.FunctionCall functionCall = (RexExpression.FunctionCall) aggCalls.get(i);
-      FunctionContext funcContext = convertRexExpressionsToFunctionContext(i, functionCall);
-      functionContexts.add(funcContext);
+      Map<Integer, Literal> literalArguments = literalArgumentsMap.getOrDefault(i, Collections.emptyMap());
+      aggFunctions[i] = getAggFunction(functionCall, literalArguments);
     }
-    return functionContexts;
+    return aggFunctions;
   }
 
-  private FunctionContext convertRexExpressionsToFunctionContext(int aggIdx,
-      RexExpression.FunctionCall aggFunctionCall) {
-    // Extract details from RexExpression aggFunctionCall.
-    String functionName = aggFunctionCall.getFunctionName();
-    List<RexExpression> functionOperands = aggFunctionCall.getFunctionOperands();
-
-    List<ExpressionContext> aggArguments = new ArrayList<>();
-    for (int argIdx = 0; argIdx < functionOperands.size(); argIdx++) {
-      RexExpression operand = functionOperands.get(argIdx);
-      ExpressionContext exprContext = convertRexExpressionToExpressionContext(aggIdx, argIdx, operand);
-      aggArguments.add(exprContext);
+  private AggregationFunction<?, ?> getAggFunction(RexExpression.FunctionCall functionCall,
+      Map<Integer, Literal> literalArguments) {
+    String functionName = functionCall.getFunctionName();
+    List<RexExpression> operands = functionCall.getFunctionOperands();
+    int numArguments = operands.size();
+    if (numArguments == 0) {
+      Preconditions.checkState(functionName.equals("COUNT"),
+          "Aggregate function without argument must be COUNT, got: %s", functionName);
+      return COUNT_STAR_AGG_FUNCTION;
     }
 
-    // add additional arguments for aggFunctionCall
+    // For intermediate aggregation, we might need to append the arguments to match the signature of the aggregation
+    int numExpectedArguments = numArguments;
     if (_aggType.isInputIntermediateFormat()) {
-      rewriteAggArgumentForIntermediateInput(aggArguments, aggIdx);
-    }
-    // This can only be true for COUNT aggregation functions on intermediate stage.
-    // The literal value here does not matter. We create a dummy literal here just so that the count aggregation
-    // has some column to process.
-    if (aggArguments.isEmpty()) {
-      aggArguments.add(ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, "__PLACEHOLDER__"));
+      Literal literal = literalArguments.get(-1);
+      if (literal != null) {
+        numExpectedArguments = literal.getIntValue();
+      }
     }
 
-    return new FunctionContext(FunctionContext.Type.AGGREGATION, functionName, aggArguments);
+    List<ExpressionContext> arguments = new ArrayList<>(numExpectedArguments);
+    for (int i = 0; i < numExpectedArguments; i++) {
+      Literal literal = literalArguments.get(i);
+      if (literal != null) {
+        arguments.add(ExpressionContext.forLiteralContext(literal));
+        continue;
+      }
+      if (i >= numArguments) {
+        // Append placeholder argument for intermediate aggregation
+        arguments.add(PLACEHOLDER_IDENTIFIER);
+        continue;
+      }
+      RexExpression operand = operands.get(i);
+      switch (operand.getKind()) {
+        case INPUT_REF:
+          RexExpression.InputRef inputRef = (RexExpression.InputRef) operand;
+          arguments.add(ExpressionContext.forIdentifier(fromColIdToIdentifier(inputRef.getIndex())));
+          break;
+        case LITERAL:
+          RexExpression.Literal literalRexExp = (RexExpression.Literal) operand;
+          arguments.add(
+              ExpressionContext.forLiteralContext(literalRexExp.getDataType().toDataType(), literalRexExp.getValue()));
+          break;
+        default:
+          throw new IllegalStateException("Illegal aggregation function operand type: " + operand.getKind());
+      }
+    }
+
+    return AggregationFunctionFactory.getAggregationFunction(
+        new FunctionContext(FunctionContext.Type.AGGREGATION, functionName, arguments), true);
   }
 
-  private void rewriteAggArgumentForIntermediateInput(List<ExpressionContext> aggArguments, int aggIdx) {
-    Map<Integer, Literal> aggCallSignature = _aggCallSignatureMap.get(aggIdx);
-    if (aggCallSignature != null && !aggCallSignature.isEmpty()) {
-      int argListSize = aggCallSignature.get(-1).getIntValue();
-      for (int argIdx = 1; argIdx < argListSize; argIdx++) {
-        Literal aggIdxLiteral = aggCallSignature.get(argIdx);
-        if (aggIdxLiteral != null) {
-          aggArguments.add(ExpressionContext.forLiteralContext(aggIdxLiteral));
-        } else {
-          aggArguments.add(ExpressionContext.forIdentifier("__PLACEHOLDER__"));
-        }
-      }
-    }
+  private static String fromColIdToIdentifier(int colId) {
+    return "$" + colId;
   }
 
-  private ExpressionContext convertRexExpressionToExpressionContext(int aggIdx, int argIdx, RexExpression rexExpr) {
-    ExpressionContext exprContext;
-    if (_aggCallSignatureMap.get(aggIdx) != null && _aggCallSignatureMap.get(aggIdx).get(argIdx) != null) {
-      return ExpressionContext.forLiteralContext(_aggCallSignatureMap.get(aggIdx).get(argIdx));
-    }
-
-    // This is used only for aggregation arguments and groupby columns. The rexExpression can never be a function type.
-    switch (rexExpr.getKind()) {
-      case INPUT_REF: {
-        RexExpression.InputRef inputRef = (RexExpression.InputRef) rexExpr;
-        int identifierIndex = inputRef.getIndex();
-        String columnName = _inputSchema.getColumnName(identifierIndex);
-        // Calcite generates unique column names for aggregation functions. For example, select avg(col1), sum(col1)
-        // will generate names $f0 and $f1 for avg and sum respectively. We use a map to store the name -> index
-        // mapping to extract the required column value from row-based container and fetch the input datatype for the
-        // column.
-        _colNameToIndexMap.put(columnName, identifierIndex);
-        exprContext = ExpressionContext.forIdentifier(columnName);
-        break;
-      }
-      case LITERAL: {
-        RexExpression.Literal literalRexExp = (RexExpression.Literal) rexExpr;
-        Object value = literalRexExp.getValue();
-        exprContext = ExpressionContext.forLiteralContext(literalRexExp.getDataType().toDataType(), value);
-        break;
-      }
-      default:
-        throw new IllegalStateException("Aggregation Function operands or GroupBy columns cannot be a function.");
-    }
-
-    return exprContext;
+  private static int fromIdentifierToColId(String identifier) {
+    Preconditions.checkArgument(identifier.charAt(0) == '$', "Got identifier not representing column index: %s",
+        identifier);
+    return Integer.parseInt(identifier.substring(1));
   }
 
   private int[] getGroupKeyIds(List<RexExpression> groupSet) {
@@ -327,31 +306,31 @@ public class AggregateOperator extends MultiStageOperator {
   }
 
   static Map<ExpressionContext, BlockValSet> getBlockValSetMap(AggregationFunction<?, ?> aggFunction,
-      TransferableBlock block, Map<String, Integer> colNameToIndexMap) {
+      TransferableBlock block) {
     List<ExpressionContext> expressions = aggFunction.getInputExpressions();
     int numExpressions = expressions.size();
     if (numExpressions == 0) {
       return Collections.emptyMap();
     }
+    DataSchema dataSchema = block.getDataSchema();
     Map<ExpressionContext, BlockValSet> blockValSetMap = new HashMap<>();
     if (block.isContainerConstructed()) {
       List<Object[]> rows = block.getContainer();
       for (ExpressionContext expression : expressions) {
-        if (expression.getType() == ExpressionContext.Type.IDENTIFIER && !"__PLACEHOLDER__".equals(
-            expression.getIdentifier())) {
-          int colId = colNameToIndexMap.get(expression.getIdentifier());
+        String identifier = expression.getIdentifier();
+        if (identifier != null) {
+          int colId = fromIdentifierToColId(identifier);
           blockValSetMap.put(expression,
-              new RowBasedBlockValSet(block.getDataSchema().getColumnDataType(colId), rows, colId, true));
+              new RowBasedBlockValSet(dataSchema.getColumnDataType(colId), rows, colId, true));
         }
       }
     } else {
       DataBlock dataBlock = block.getDataBlock();
       for (ExpressionContext expression : expressions) {
-        if (expression.getType() == ExpressionContext.Type.IDENTIFIER && !"__PLACEHOLDER__".equals(
-            expression.getIdentifier())) {
-          int colId = colNameToIndexMap.get(expression.getIdentifier());
-          blockValSetMap.put(expression,
-              new DataBlockValSet(block.getDataSchema().getColumnDataType(colId), dataBlock, colId));
+        String identifier = expression.getIdentifier();
+        if (identifier != null) {
+          int colId = fromIdentifierToColId(identifier);
+          blockValSetMap.put(expression, new DataBlockValSet(dataSchema.getColumnDataType(colId), dataBlock, colId));
         }
       }
     }
@@ -359,31 +338,31 @@ public class AggregateOperator extends MultiStageOperator {
   }
 
   static Map<ExpressionContext, BlockValSet> getFilteredBlockValSetMap(AggregationFunction<?, ?> aggFunction,
-      TransferableBlock block, Map<String, Integer> colNameToIndexMap, int numMatchedRows,
-      RoaringBitmap matchedBitmap) {
+      TransferableBlock block, int numMatchedRows, RoaringBitmap matchedBitmap) {
     List<ExpressionContext> expressions = aggFunction.getInputExpressions();
     int numExpressions = expressions.size();
     if (numExpressions == 0) {
       return Collections.emptyMap();
     }
+    DataSchema dataSchema = block.getDataSchema();
     Map<ExpressionContext, BlockValSet> blockValSetMap = new HashMap<>();
     if (block.isContainerConstructed()) {
       List<Object[]> rows = block.getContainer();
       for (ExpressionContext expression : expressions) {
-        if (expression.getType() == ExpressionContext.Type.IDENTIFIER && !"__PLACEHOLDER__".equals(
-            expression.getIdentifier())) {
-          int colId = colNameToIndexMap.get(expression.getIdentifier());
+        String identifier = expression.getIdentifier();
+        if (identifier != null) {
+          int colId = fromIdentifierToColId(identifier);
           blockValSetMap.put(expression,
-              new FilteredRowBasedBlockValSet(block.getDataSchema().getColumnDataType(colId), rows, colId,
-                  numMatchedRows, matchedBitmap, true));
+              new FilteredRowBasedBlockValSet(dataSchema.getColumnDataType(colId), rows, colId, numMatchedRows,
+                  matchedBitmap, true));
         }
       }
     } else {
       DataBlock dataBlock = block.getDataBlock();
       for (ExpressionContext expression : expressions) {
-        if (expression.getType() == ExpressionContext.Type.IDENTIFIER && !"__PLACEHOLDER__".equals(
-            expression.getIdentifier())) {
-          int colId = colNameToIndexMap.get(expression.getIdentifier());
+        String identifier = expression.getIdentifier();
+        if (identifier != null) {
+          int colId = fromIdentifierToColId(identifier);
           blockValSetMap.put(expression,
               new FilteredDataBlockValSet(block.getDataSchema().getColumnDataType(colId), dataBlock, colId,
                   numMatchedRows, matchedBitmap));
@@ -393,20 +372,17 @@ public class AggregateOperator extends MultiStageOperator {
     return blockValSetMap;
   }
 
-  static Object[] getIntermediateResults(AggregationFunction<?, ?> aggregationFunction, TransferableBlock block,
-      Map<String, Integer> colNameToIndexMap) {
-    ExpressionContext exp = aggregationFunction.getInputExpressions().get(0);
-    Preconditions.checkState(exp.getType() == ExpressionContext.Type.IDENTIFIER, "Expected identifier, got: %s",
-        exp.getType());
-    Integer index = colNameToIndexMap.get(exp.getIdentifier());
-    Preconditions.checkState(index != null, "Failed to find index for column: %s", exp.getIdentifier());
-    int colId = index;
-    int numValues = block.getNumRows();
+  static Object[] getIntermediateResults(AggregationFunction<?, ?> aggFunctions, TransferableBlock block) {
+    ExpressionContext firstArgument = aggFunctions.getInputExpressions().get(0);
+    Preconditions.checkState(firstArgument.getType() == ExpressionContext.Type.IDENTIFIER,
+        "Expected the first argument to be IDENTIFIER, got: %s", firstArgument.getType());
+    int colId = fromIdentifierToColId(firstArgument.getIdentifier());
+    int numRows = block.getNumRows();
     if (block.isContainerConstructed()) {
-      Object[] values = new Object[numValues];
+      Object[] values = new Object[numRows];
       List<Object[]> rows = block.getContainer();
-      for (int i = 0; i < numValues; i++) {
-        values[i] = rows.get(i)[colId];
+      for (int rowId = 0; rowId < numRows; rowId++) {
+        values[rowId] = rows.get(rowId)[colId];
       }
       return values;
     } else {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -20,7 +20,6 @@ package org.apache.pinot.query.runtime.plan;
 
 import java.util.ArrayList;
 import java.util.List;
-import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.plannode.AggregateNode;
 import org.apache.pinot.query.planner.plannode.ExchangeNode;
 import org.apache.pinot.query.planner.plannode.FilterNode;
@@ -89,10 +88,7 @@ public class PhysicalPlanVisitor implements PlanNodeVisitor<MultiStageOperator, 
   @Override
   public MultiStageOperator visitAggregate(AggregateNode node, OpChainExecutionContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
-    DataSchema inputSchema = node.getInputs().get(0).getDataSchema();
-    DataSchema resultSchema = node.getDataSchema();
-
-    return new AggregateOperator(context, nextOperator, resultSchema, inputSchema, node.getAggCalls(),
+    return new AggregateOperator(context, nextOperator, node.getDataSchema(), node.getAggCalls(),
         node.getGroupSet(), node.getAggType(), node.getFilterArgIndices(), node.getNodeHint());
   }
 


### PR DESCRIPTION
Avoid constructing the column name to index map and converting back and forth