### PR TITLE
fix jackson vulnerability

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -125,7 +125,7 @@
     <parquet.version>1.12.3</parquet.version>
     <helix.version>1.0.4</helix.version>
     <zkclient.version>0.7</zkclient.version>
-    <jackson.version>2.12.7</jackson.version>
+    <jackson.version>2.12.7.20221012</jackson.version>
     <zookeeper.version>3.6.3</zookeeper.version>
     <async-http-client.version>2.12.3</async-http-client.version>
     <jersey.version>2.39</jersey.version>


### PR DESCRIPTION
Bump jackson version from `2.12.7` to `2.12.7.20221012`.

CVE-2022-42003 7.5 Deserialization of Untrusted Data vulnerability pending CVSS allocation
