### PR TITLE
Force FileChannel to commit data to disk

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/geospatial/BaseH3IndexCreator.java
@@ -163,6 +163,7 @@ public abstract class BaseH3IndexCreator implements GeoSpatialIndexCreator {
           indexFileChannel);
       org.apache.pinot.common.utils.FileUtils.transferBytes(bitmapValueFileChannel, 0, _bitmapValueFile.length(),
           indexFileChannel);
+      indexFileChannel.force(true);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/BaseJsonIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/json/BaseJsonIndexCreator.java
@@ -168,6 +168,7 @@ public abstract class BaseJsonIndexCreator implements JsonIndexCreator {
         CleanerUtil.BufferCleaner cleaner = CleanerUtil.getCleaner();
         cleaner.freeBuffer(docIdMappingBuffer);
       }
+      indexFileChannel.force(true);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/StarTreeIndexSeparator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/StarTreeIndexSeparator.java
@@ -143,7 +143,7 @@ public class StarTreeIndexSeparator implements Closeable {
       throws IOException {
     try (FileChannel dest = new RandomAccessFile(destFile, "rw").getChannel()) {
       org.apache.pinot.common.utils.FileUtils.transferBytes(_indexFileChannel, value._offset, value._size, dest);
-      _indexFileChannel.force(true);
+      dest.force(true);
     }
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/StarTreeIndexSeparator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/builder/StarTreeIndexSeparator.java
@@ -143,6 +143,7 @@ public class StarTreeIndexSeparator implements Closeable {
       throws IOException {
     try (FileChannel dest = new RandomAccessFile(destFile, "rw").getChannel()) {
       org.apache.pinot.common.utils.FileUtils.transferBytes(_indexFileChannel, value._offset, value._size, dest);
+      _indexFileChannel.force(true);
     }
   }
 


### PR DESCRIPTION
 - We have FileChannel in certain places but don't force which can cause data not to be written to disk.
 - Added force to make sure we don't have data remaining in OS I/O buffers.
 - `bugfix` for #11368 