### PR TITLE
assign segments for upsert table with respect to ideal state

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerMeter.java
@@ -39,6 +39,7 @@ public enum ControllerMeter implements AbstractMetrics.Meter {
   CONTROLLER_TABLE_TENANT_CREATE_ERROR("TableTenantCreateError", true),
   CONTROLLER_TABLE_TENANT_DELETE_ERROR("TableTenantDeleteError", true),
   CONTROLLER_REALTIME_TABLE_SEGMENT_ASSIGNMENT_ERROR("errors", true),
+  CONTROLLER_REALTIME_TABLE_SEGMENT_ASSIGNMENT_MISMATCH("mismatch", true),
   CONTROLLER_LEADERSHIP_CHANGE_WITHOUT_CALLBACK("leadershipChangeWithoutCallback", true),
   LLC_STATE_MACHINE_ABORTS("aborts", false),
   LLC_ZOOKEEPER_FETCH_FAILURES("failures", false),

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -421,7 +421,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     _leadControllerManager.start();
 
     LOGGER.info("Starting Pinot Helix resource manager and connecting to Zookeeper");
-    _helixResourceManager.start(_helixParticipantManager);
+    _helixResourceManager.start(_helixParticipantManager, _controllerMetrics);
 
     // Initialize segment lifecycle event listeners
     PinotSegmentLifecycleEventListenerManager.getInstance().init(_helixParticipantManager);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -335,7 +335,7 @@ public class ZKOperator {
     }
 
     try {
-      _pinotHelixResourceManager.assignTableSegment(tableNameWithType, segmentMetadata.getName());
+      _pinotHelixResourceManager.assignTableSegment(tableNameWithType, segmentMetadata.getName(), _controllerMetrics);
     } catch (Exception e) {
       // assignTableSegment removes the zk entry.
       // Call deleteSegment to remove the segment from permanent location if needed.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/upload/ZKOperator.java
@@ -335,7 +335,7 @@ public class ZKOperator {
     }
 
     try {
-      _pinotHelixResourceManager.assignTableSegment(tableNameWithType, segmentMetadata.getName(), _controllerMetrics);
+      _pinotHelixResourceManager.assignTableSegment(tableNameWithType, segmentMetadata.getName());
     } catch (Exception e) {
       // assignTableSegment removes the zk entry.
       // Call deleteSegment to remove the segment from permanent location if needed.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/BaseSegmentAssignment.java
@@ -27,6 +27,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.tier.Tier;
 import org.apache.pinot.common.utils.config.TableConfigUtils;
 import org.apache.pinot.controller.helix.core.assignment.segment.strategy.SegmentAssignmentStrategy;
@@ -69,15 +70,16 @@ public abstract class BaseSegmentAssignment implements SegmentAssignment {
   protected int _replication;
   protected String _partitionColumn;
   protected TableConfig _tableConfig;
+  protected ControllerMetrics _controllerMetrics;
 
   @Override
-  public void init(HelixManager helixManager, TableConfig tableConfig) {
+  public void init(HelixManager helixManager, TableConfig tableConfig, @Nullable ControllerMetrics controllerMetrics) {
     _helixManager = helixManager;
     _tableNameWithType = tableConfig.getTableName();
     _tableConfig = tableConfig;
     _replication = tableConfig.getReplication();
     _partitionColumn = TableConfigUtils.getPartitionColumn(_tableConfig);
-
+    _controllerMetrics = controllerMetrics;
     if (_partitionColumn == null) {
       _logger.info("Initialized with replication: {} without partition column for table: {} ", _replication,
           _tableNameWithType);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeSegmentAssignment.java
@@ -106,8 +106,13 @@ public class RealtimeSegmentAssignment extends BaseSegmentAssignment {
    * Helper method to assign instances for CONSUMING segment based on the segment partition id and instance partitions.
    */
   private List<String> assignConsumingSegment(String segmentName, InstancePartitions instancePartitions) {
-    int segmentPartitionId = SegmentAssignmentUtils
-        .getRealtimeSegmentPartitionId(segmentName, _tableNameWithType, _helixManager, _partitionColumn);
+    int segmentPartitionId =
+        SegmentAssignmentUtils.getRealtimeSegmentPartitionId(segmentName, _tableNameWithType, _helixManager,
+            _partitionColumn);
+    return assignConsumingSegment(segmentPartitionId, instancePartitions);
+  }
+
+  protected List<String> assignConsumingSegment(int segmentPartitionId, InstancePartitions instancePartitions) {
     int numReplicaGroups = instancePartitions.getNumReplicaGroups();
     int numPartitions = instancePartitions.getNumPartitions();
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignment.java
@@ -53,6 +53,22 @@ public interface SegmentAssignment {
       Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap);
 
   /**
+   * Assign new segment but check if the assignment calculated with instancePartition is consistent with the one set
+   * in the current idealState. If not, use the one from idealState to stay consistent with the source of truth.
+   *
+   * @param segmentName Name of the segment to be assigned
+   * @param currentAssignment Current segment assignment of the table (map from segment name to instance state map)
+   * @param instancePartitionsMap Map from type (OFFLINE|CONSUMING|COMPLETED) to instance partitions
+   * @param instancesAssigned returns the list of instances to assign the segment
+   * @return true if consistent or found no existing assignment from idealState; false otherwise.
+   */
+  default boolean assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
+      Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap, List<String> instancesAssigned) {
+    instancesAssigned.addAll(assignSegment(segmentName, currentAssignment, instancePartitionsMap));
+    return true;
+  }
+
+  /**
    * Rebalances the segment assignment for a table.
    *
    * @param currentAssignment Current segment assignment of the table (map from segment name to instance state map)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignment.java
@@ -24,6 +24,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.configuration.Configuration;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.tier.Tier;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
@@ -39,7 +40,7 @@ public interface SegmentAssignment {
    * @param helixManager Helix manager
    * @param tableConfig Table config
    */
-  void init(HelixManager helixManager, TableConfig tableConfig);
+  void init(HelixManager helixManager, TableConfig tableConfig, @Nullable ControllerMetrics controllerMetrics);
 
   /**
    * Assigns segment to instances.
@@ -51,22 +52,6 @@ public interface SegmentAssignment {
    */
   List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
       Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap);
-
-  /**
-   * Assign new segment but check if the assignment calculated with instancePartition is consistent with the one set
-   * in the current idealState. If not, use the one from idealState to stay consistent with the source of truth.
-   *
-   * @param segmentName Name of the segment to be assigned
-   * @param currentAssignment Current segment assignment of the table (map from segment name to instance state map)
-   * @param instancePartitionsMap Map from type (OFFLINE|CONSUMING|COMPLETED) to instance partitions
-   * @param instancesAssigned returns the list of instances to assign the segment
-   * @return true if consistent or found no existing assignment from idealState; false otherwise.
-   */
-  default boolean assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
-      Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap, List<String> instancesAssigned) {
-    instancesAssigned.addAll(assignSegment(segmentName, currentAssignment, instancePartitionsMap));
-    return true;
-  }
 
   /**
    * Rebalances the segment assignment for a table.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentFactory.java
@@ -21,6 +21,7 @@ package org.apache.pinot.controller.helix.core.assignment.segment;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.UpsertConfig;
 
 
 /**
@@ -35,7 +36,12 @@ public class SegmentAssignmentFactory {
     if (tableConfig.getTableType() == TableType.OFFLINE) {
       segmentAssignment = new OfflineSegmentAssignment();
     } else {
-      segmentAssignment = new RealtimeSegmentAssignment();
+      UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
+      if (upsertConfig != null && upsertConfig.getMode() != UpsertConfig.Mode.NONE) {
+        segmentAssignment = new StrictRealtimeSegmentAssignment();
+      } else {
+        segmentAssignment = new RealtimeSegmentAssignment();
+      }
     }
     segmentAssignment.init(helixManager, tableConfig);
     return segmentAssignment;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/SegmentAssignmentFactory.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.controller.helix.core.assignment.segment;
 
+import javax.annotation.Nullable;
 import org.apache.helix.HelixManager;
+import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.UpsertConfig;
@@ -31,7 +33,8 @@ public class SegmentAssignmentFactory {
   private SegmentAssignmentFactory() {
   }
 
-  public static SegmentAssignment getSegmentAssignment(HelixManager helixManager, TableConfig tableConfig) {
+  public static SegmentAssignment getSegmentAssignment(HelixManager helixManager, TableConfig tableConfig,
+      @Nullable ControllerMetrics controllerMetrics) {
     SegmentAssignment segmentAssignment;
     if (tableConfig.getTableType() == TableType.OFFLINE) {
       segmentAssignment = new OfflineSegmentAssignment();
@@ -43,7 +46,7 @@ public class SegmentAssignmentFactory {
         segmentAssignment = new RealtimeSegmentAssignment();
       }
     }
-    segmentAssignment.init(helixManager, tableConfig);
+    segmentAssignment.init(helixManager, tableConfig, controllerMetrics);
     return segmentAssignment;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignment.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.assignment.segment;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
+
+
+/**
+ * Segment assignment for LLC real-time table using upsert. The assignSegment() of RealtimeSegmentAssignment is
+ * overridden to add new segment for a table partition in a way that's consistent with the assignment in idealState to
+ * make sure that at any time the segments from the same table partition is hosted by the same server.
+ * <ul>
+ *   <li>
+ *     For the CONSUMING segments, in addition to what's done in RealtimeSegmentAssignment, the assignment has to be
+ *     checked if it's consistent with the current idealState. If the assignment calculated according to the
+ *     InstancePartition and the one in idealState are different, the one in idealState must be used so that segments
+ *     from the same table partition are always hosted on the same server as set in current idealState. If the
+ *     idealState is not honored, segments from the same table partition may be assigned to different servers,
+ *     breaking the key assumption for queries to be correct for the table using upsert.
+ *   </li>
+ *   <li>
+ *     There is no need to handle COMPLETED segments for tables using upsert, because their completed segments should
+ *     not be relocated to servers tagged to host COMPLETED segments. Basically, upsert-enabled tables can only use
+ *     servers tagged for CONSUMING segments to host both consuming and completed segments from a table partition.
+ *   </li>
+ * </ul>
+ */
+public class StrictRealtimeSegmentAssignment extends RealtimeSegmentAssignment {
+
+  @Override
+  public List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
+      Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap) {
+    Preconditions.checkState(instancePartitionsMap.size() == 1, "One instance partition type should be provided");
+    Map.Entry<InstancePartitionsType, InstancePartitions> typeToInstancePartitions =
+        instancePartitionsMap.entrySet().iterator().next();
+    InstancePartitionsType instancePartitionsType = typeToInstancePartitions.getKey();
+    InstancePartitions instancePartitions = typeToInstancePartitions.getValue();
+    Preconditions.checkState(instancePartitionsType == InstancePartitionsType.CONSUMING,
+        "Only CONSUMING instance partition type is allowed for table using upsert but got: " + instancePartitionsType);
+    _logger.info("Assigning segment: {} with instance partitions: {} for table: {}", segmentName, instancePartitions,
+        _tableNameWithType);
+    int segmentPartitionId =
+        SegmentAssignmentUtils.getRealtimeSegmentPartitionId(segmentName, _tableNameWithType, _helixManager,
+            _partitionColumn);
+    List<String> instancesAssigned = assignConsumingSegment(segmentPartitionId, instancePartitions);
+    List<String> idealAssignment = new ArrayList<>(instancesAssigned.size());
+    // Iterate the idealState to find the first segment that's in the same table partition with the new segment, and
+    // check if their assignments are same. We try to derive the partition id from segment name to avoid ZK reads.
+    Set<String> nonStandardSegments = new HashSet<>();
+    for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
+      LLCSegmentName llcSegmentName = LLCSegmentName.of(entry.getKey());
+      if (llcSegmentName == null) {
+        nonStandardSegments.add(entry.getKey());
+        continue;
+      }
+      if (llcSegmentName.getPartitionGroupId() == segmentPartitionId) {
+        idealAssignment.addAll(entry.getValue().keySet());
+        break;
+      }
+    }
+    if (idealAssignment.isEmpty()) {
+      _logger.debug("Check ZK metadata of segments: {} for any one from partition: {}", nonStandardSegments.size(),
+          segmentPartitionId);
+      // Check ZK metadata for segments with non-standard LLC segment names.
+      for (String nonStandardSegment : nonStandardSegments) {
+        if (SegmentAssignmentUtils.getRealtimeSegmentPartitionId(nonStandardSegment, _tableNameWithType, _helixManager,
+            _partitionColumn) == segmentPartitionId) {
+          idealAssignment.addAll(currentAssignment.get(nonStandardSegment).keySet());
+          break;
+        }
+      }
+    }
+    if (idealAssignment.isEmpty()) {
+      _logger.info("Found no existing assignment from idealState, using the one decided by instancePartitions");
+    } else if (!idealAssignment.equals(instancesAssigned)) {
+      _logger.info("Assignment: {} is inconsistent with idealState: {}, using the one as from idealState",
+          instancesAssigned, idealAssignment);
+      instancesAssigned = idealAssignment;
+    }
+    _logger.info("Assigned segment: {} to instances: {} for table: {}", segmentName, instancesAssigned,
+        _tableNameWithType);
+    return instancesAssigned;
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -316,7 +316,8 @@ public class PinotLLCRealtimeSegmentManager {
     int numPartitionGroups = newPartitionGroupMetadataList.size();
     int numReplicas = getNumReplicas(tableConfig, instancePartitions);
 
-    SegmentAssignment segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(_helixManager, tableConfig);
+    SegmentAssignment segmentAssignment =
+        SegmentAssignmentFactory.getSegmentAssignment(_helixManager, tableConfig, _controllerMetrics);
     Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap =
         Collections.singletonMap(InstancePartitionsType.CONSUMING, instancePartitions);
 
@@ -555,7 +556,8 @@ public class PinotLLCRealtimeSegmentManager {
     }
 
     // Step-3
-    SegmentAssignment segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(_helixManager, tableConfig);
+    SegmentAssignment segmentAssignment =
+        SegmentAssignmentFactory.getSegmentAssignment(_helixManager, tableConfig, _controllerMetrics);
     Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap =
         Collections.singletonMap(InstancePartitionsType.CONSUMING, instancePartitions);
 
@@ -965,13 +967,8 @@ public class PinotLLCRealtimeSegmentManager {
         }
       }
       // Assign instances to the new segment and add instances as state CONSUMING
-      List<String> instancesAssigned = new ArrayList<>();
-      boolean consistent =
-          segmentAssignment.assignSegment(newSegmentName, instanceStatesMap, instancePartitionsMap, instancesAssigned);
-      if (!consistent) {
-        _controllerMetrics.addMeteredTableValue(newLLCSegmentName.getTableName(),
-            ControllerMeter.CONTROLLER_REALTIME_TABLE_SEGMENT_ASSIGNMENT_MISMATCH, 1L);
-      }
+      List<String> instancesAssigned =
+          segmentAssignment.assignSegment(newSegmentName, instanceStatesMap, instancePartitionsMap);
       instanceStatesMap.put(newSegmentName,
           SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.CONSUMING));
       LOGGER.info("Adding new CONSUMING segment: {} to instances: {}", newSegmentName, instancesAssigned);
@@ -1059,7 +1056,8 @@ public class PinotLLCRealtimeSegmentManager {
         newPartitionGroupMetadataList.stream().map(PartitionGroupMetadata::getPartitionGroupId)
             .collect(Collectors.toSet());
 
-    SegmentAssignment segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(_helixManager, tableConfig);
+    SegmentAssignment segmentAssignment =
+        SegmentAssignmentFactory.getSegmentAssignment(_helixManager, tableConfig, _controllerMetrics);
     Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap =
         Collections.singletonMap(InstancePartitionsType.CONSUMING, instancePartitions);
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -965,8 +965,13 @@ public class PinotLLCRealtimeSegmentManager {
         }
       }
       // Assign instances to the new segment and add instances as state CONSUMING
-      List<String> instancesAssigned =
-          segmentAssignment.assignSegment(newSegmentName, instanceStatesMap, instancePartitionsMap);
+      List<String> instancesAssigned = new ArrayList<>();
+      boolean consistent =
+          segmentAssignment.assignSegment(newSegmentName, instanceStatesMap, instancePartitionsMap, instancesAssigned);
+      if (!consistent) {
+        _controllerMetrics.addMeteredTableValue(newLLCSegmentName.getTableName(),
+            ControllerMeter.CONTROLLER_REALTIME_TABLE_SEGMENT_ASSIGNMENT_MISMATCH, 1L);
+      }
       instanceStatesMap.put(newSegmentName,
           SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.CONSUMING));
       LOGGER.info("Adding new CONSUMING segment: {} to instances: {}", newSegmentName, instancesAssigned);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineNonReplicaGroupTieredSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/OfflineNonReplicaGroupTieredSegmentAssignmentTest.java
@@ -112,7 +112,7 @@ public class OfflineNonReplicaGroupTieredSegmentAssignmentTest {
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS)
             .setTierConfigList(tierConfigList).build();
 
-    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(null, tableConfig);
+    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(null, tableConfig, null);
 
     // {
     //   0_0=[instance_0, instance_1, instance_2, instance_3, instance_4, instance_5, instance_6, instance_7,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupSegmentAssignmentTest.java
@@ -84,7 +84,7 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS)
             .setStreamConfigs(streamConfigs).build();
-    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig);
+    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig, null);
 
     _instancePartitionsMap = new TreeMap<>();
     // CONSUMING instances:
@@ -122,7 +122,7 @@ public class RealtimeNonReplicaGroupSegmentAssignmentTest {
     // Update the replication by changing the NUM_REPLICAS_PER_PARTITION
     tableConfig.getValidationConfig().setReplicasPerPartition(NUM_REPLICAS_PER_PARTITION);
     SegmentAssignment segmentAssignment =
-        SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig);
+        SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig, null);
 
     Map<InstancePartitionsType, InstancePartitions> onlyCompletedInstancePartitionMap =
         ImmutableMap.of(InstancePartitionsType.COMPLETED, _instancePartitionsMap.get(InstancePartitionsType.COMPLETED));

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupTieredSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeNonReplicaGroupTieredSegmentAssignmentTest.java
@@ -123,7 +123,7 @@ public class RealtimeNonReplicaGroupTieredSegmentAssignmentTest {
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS)
             .setTierConfigList(tierConfigList).setStreamConfigs(streamConfigs).build();
-    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(null, tableConfig);
+    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(null, tableConfig, null);
 
     _instancePartitionsMap = new TreeMap<>();
     // CONSUMING instances:

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/RealtimeReplicaGroupSegmentAssignmentTest.java
@@ -90,7 +90,7 @@ public class RealtimeReplicaGroupSegmentAssignmentTest {
             .setStreamConfigs(streamConfigs)
             .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
             .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(PARTITION_COLUMN, 1)).build();
-    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig);
+    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig, null);
 
     _instancePartitionsMap = new TreeMap<>();
     // CONSUMING instances:

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
@@ -47,7 +47,6 @@ import static org.mockito.ArgumentMatchers.isNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 
@@ -87,7 +86,7 @@ public class StrictRealtimeSegmentAssignmentTest {
             .setStreamConfigs(streamConfigs).setUpsertConfig(upsertConfig)
             .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
             .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(PARTITION_COLUMN, 1)).build();
-    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig);
+    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig, null);
 
     _instancePartitionsMap = new TreeMap<>();
     // CONSUMING instances:
@@ -144,10 +143,8 @@ public class StrictRealtimeSegmentAssignmentTest {
     boolean consistent;
     for (int segmentId = 0; segmentId < 3; segmentId++) {
       String segmentName = _segments.get(segmentId);
-      instancesAssigned = new ArrayList<>();
-      consistent = _segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap,
-          instancesAssigned);
-      assertTrue(consistent);
+      instancesAssigned =
+          _segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap);
       assertEquals(instancesAssigned.size(), NUM_REPLICAS);
       // Segment 0 (partition 0) should be assigned to instance 0, 3, 6
       // Segment 1 (partition 1) should be assigned to instance 1, 4, 7
@@ -173,10 +170,8 @@ public class StrictRealtimeSegmentAssignmentTest {
     // So segment 3 (partition 3) should be assigned to instance new_0, new_3, new_6
     int segmentId = 3;
     String segmentName = _segments.get(segmentId);
-    instancesAssigned = new ArrayList<>();
-    consistent = _segmentAssignment.assignSegment(segmentName, currentAssignment, newConsumingInstancePartitionMap,
-        instancesAssigned);
-    assertTrue(consistent);
+    instancesAssigned =
+        _segmentAssignment.assignSegment(segmentName, currentAssignment, newConsumingInstancePartitionMap);
     assertEquals(instancesAssigned,
         Arrays.asList("new_consumingInstance_0", "new_consumingInstance_3", "new_consumingInstance_6"));
     addToAssignment(currentAssignment, segmentId, instancesAssigned);
@@ -184,10 +179,8 @@ public class StrictRealtimeSegmentAssignmentTest {
     // Use existing assignment for partition 0/1/2, instead of the one decided by new instancePartition.
     for (segmentId = 4; segmentId < 7; segmentId++) {
       segmentName = _segments.get(segmentId);
-      instancesAssigned = new ArrayList<>();
-      consistent = _segmentAssignment.assignSegment(segmentName, currentAssignment, newConsumingInstancePartitionMap,
-          instancesAssigned);
-      assertFalse(consistent);
+      instancesAssigned =
+          _segmentAssignment.assignSegment(segmentName, currentAssignment, newConsumingInstancePartitionMap);
       assertEquals(instancesAssigned.size(), NUM_REPLICAS);
 
       // Those segments are assigned according to the assignment from idealState, instead of using new_xxx instances
@@ -216,10 +209,8 @@ public class StrictRealtimeSegmentAssignmentTest {
     boolean consistent;
     for (int segmentId = 0; segmentId < 3; segmentId++) {
       String segmentName = _segments.get(segmentId);
-      instancesAssigned = new ArrayList<>();
-      consistent = _segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap,
-          instancesAssigned);
-      assertTrue(consistent);
+      instancesAssigned =
+          _segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap);
       assertEquals(instancesAssigned.size(), NUM_REPLICAS);
       // Segment 0 (partition 0) should be assigned to instance 0, 3, 6
       // Segment 1 (partition 1) should be assigned to instance 1, 4, 7
@@ -246,10 +237,8 @@ public class StrictRealtimeSegmentAssignmentTest {
     // segments for partition 0/1/2 are offline, thus skipped, so use the assignment decided by new instancePartition.
     for (int segmentId = 3; segmentId < 7; segmentId++) {
       String segmentName = _segments.get(segmentId);
-      instancesAssigned = new ArrayList<>();
-      consistent = _segmentAssignment.assignSegment(segmentName, currentAssignment, newConsumingInstancePartitionMap,
-          instancesAssigned);
-      assertTrue(consistent);
+      instancesAssigned =
+          _segmentAssignment.assignSegment(segmentName, currentAssignment, newConsumingInstancePartitionMap);
       assertEquals(instancesAssigned.size(), NUM_REPLICAS);
 
       // Those segments are assigned according to the assignment from idealState, instead of using new_xxx instances

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignmentTest.java
@@ -1,0 +1,225 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.assignment.segment;
+
+import com.google.common.collect.ImmutableMap;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Map;
+import java.util.TreeMap;
+import org.apache.helix.HelixManager;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.assignment.InstancePartitions;
+import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.core.realtime.impl.fakestream.FakeStreamConfigUtils;
+import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.UpsertConfig;
+import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
+import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
+import org.apache.pinot.spi.utils.CommonConstants.Segment.AssignmentStrategy;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.isNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertTrue;
+
+
+@SuppressWarnings("unchecked")
+public class StrictRealtimeSegmentAssignmentTest {
+  private static final int NUM_REPLICAS = 3;
+  private static final String PARTITION_COLUMN = "partitionColumn";
+  private static final int NUM_PARTITIONS = 4;
+  private static final int NUM_SEGMENTS = 24;
+  private static final String CONSUMING_INSTANCE_NAME_PREFIX = "consumingInstance_";
+  private static final int NUM_CONSUMING_INSTANCES = 9;
+  private static final List<String> CONSUMING_INSTANCES =
+      SegmentAssignmentTestUtils.getNameList(CONSUMING_INSTANCE_NAME_PREFIX, NUM_CONSUMING_INSTANCES);
+  private static final List<String> NEW_CONSUMING_INSTANCES =
+      SegmentAssignmentTestUtils.getNameList("new_" + CONSUMING_INSTANCE_NAME_PREFIX, NUM_CONSUMING_INSTANCES);
+  private static final String RAW_TABLE_NAME = "testTable";
+  private static final String CONSUMING_INSTANCE_PARTITIONS_NAME =
+      InstancePartitionsType.CONSUMING.getInstancePartitionsName(RAW_TABLE_NAME);
+
+  private List<String> _segments;
+  private SegmentAssignment _segmentAssignment;
+  private Map<InstancePartitionsType, InstancePartitions> _instancePartitionsMap;
+  private InstancePartitions _newConsumingInstancePartitions;
+
+  @BeforeClass
+  public void setUp() {
+    _segments = new ArrayList<>(NUM_SEGMENTS);
+    for (int segmentId = 0; segmentId < NUM_SEGMENTS; segmentId++) {
+      _segments.add(new LLCSegmentName(RAW_TABLE_NAME, segmentId % NUM_PARTITIONS, segmentId / NUM_PARTITIONS,
+          System.currentTimeMillis()).getSegmentName());
+    }
+
+    Map<String, String> streamConfigs = FakeStreamConfigUtils.getDefaultLowLevelStreamConfigs().getStreamConfigsMap();
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
+    TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS)
+            .setStreamConfigs(streamConfigs).setUpsertConfig(upsertConfig)
+            .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
+            .setReplicaGroupStrategyConfig(new ReplicaGroupStrategyConfig(PARTITION_COLUMN, 1)).build();
+    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(createHelixManager(), tableConfig);
+
+    _instancePartitionsMap = new TreeMap<>();
+    // CONSUMING instances:
+    // {
+    //   0_0=[instance_0, instance_1, instance_2],
+    //   0_1=[instance_3, instance_4, instance_5],
+    //   0_2=[instance_6, instance_7, instance_8]
+    // }
+    //        p0          p1          p2
+    //        p3
+    InstancePartitions consumingInstancePartitions = new InstancePartitions(CONSUMING_INSTANCE_PARTITIONS_NAME);
+    int numConsumingInstancesPerReplicaGroup = NUM_CONSUMING_INSTANCES / NUM_REPLICAS;
+    int consumingInstanceIdToAdd = 0;
+    for (int replicaGroupId = 0; replicaGroupId < NUM_REPLICAS; replicaGroupId++) {
+      List<String> consumingInstancesForReplicaGroup = new ArrayList<>(numConsumingInstancesPerReplicaGroup);
+      for (int i = 0; i < numConsumingInstancesPerReplicaGroup; i++) {
+        consumingInstancesForReplicaGroup.add(CONSUMING_INSTANCES.get(consumingInstanceIdToAdd++));
+      }
+      consumingInstancePartitions.setInstances(0, replicaGroupId, consumingInstancesForReplicaGroup);
+    }
+    _instancePartitionsMap.put(InstancePartitionsType.CONSUMING, consumingInstancePartitions);
+
+    // new CONSUMING instances:
+    // {
+    //   0_0=[new_instance_0, new_instance_1, new_instance_2],
+    //   0_1=[new_instance_3, new_instance_4, new_instance_5],
+    //   0_2=[new_instance_6, new_instance_7, new_instance_8]
+    // }
+    consumingInstanceIdToAdd = 0;
+    _newConsumingInstancePartitions = new InstancePartitions(CONSUMING_INSTANCE_PARTITIONS_NAME);
+    for (int replicaGroupId = 0; replicaGroupId < NUM_REPLICAS; replicaGroupId++) {
+      List<String> consumingInstancesForReplicaGroup = new ArrayList<>(numConsumingInstancesPerReplicaGroup);
+      for (int i = 0; i < numConsumingInstancesPerReplicaGroup; i++) {
+        consumingInstancesForReplicaGroup.add(NEW_CONSUMING_INSTANCES.get(consumingInstanceIdToAdd++));
+      }
+      _newConsumingInstancePartitions.setInstances(0, replicaGroupId, consumingInstancesForReplicaGroup);
+    }
+  }
+
+  @Test
+  public void testFactory() {
+    assertTrue(_segmentAssignment instanceof StrictRealtimeSegmentAssignment);
+  }
+
+  @Test
+  public void testAssignSegment() {
+    assertTrue(_segmentAssignment instanceof StrictRealtimeSegmentAssignment);
+    Map<InstancePartitionsType, InstancePartitions> onlyConsumingInstancePartitionMap =
+        ImmutableMap.of(InstancePartitionsType.CONSUMING, _instancePartitionsMap.get(InstancePartitionsType.CONSUMING));
+    int numInstancesPerReplicaGroup = NUM_CONSUMING_INSTANCES / NUM_REPLICAS;
+    Map<String, Map<String, String>> currentAssignment = new TreeMap<>();
+    // Add segments for partition 0/1/2, but add no segment for partition 3.
+    for (int segmentId = 0; segmentId < 3; segmentId++) {
+      String segmentName = _segments.get(segmentId);
+      List<String> instancesAssigned =
+          _segmentAssignment.assignSegment(segmentName, currentAssignment, onlyConsumingInstancePartitionMap);
+      assertEquals(instancesAssigned.size(), NUM_REPLICAS);
+      // Segment 0 (partition 0) should be assigned to instance 0, 3, 6
+      // Segment 1 (partition 1) should be assigned to instance 1, 4, 7
+      // Segment 2 (partition 2) should be assigned to instance 2, 5, 8
+      // Following segments are assigned to those instances if continue to use the same instancePartition
+      // Segment 3 (partition 3) should be assigned to instance 0, 3, 6
+      // Segment 4 (partition 0) should be assigned to instance 0, 3, 6
+      // Segment 5 (partition 1) should be assigned to instance 1, 4, 7
+      // ...
+      for (int replicaGroupId = 0; replicaGroupId < NUM_REPLICAS; replicaGroupId++) {
+        int partitionId = segmentId % NUM_PARTITIONS;
+        int expectedAssignedInstanceId =
+            partitionId % numInstancesPerReplicaGroup + replicaGroupId * numInstancesPerReplicaGroup;
+        assertEquals(instancesAssigned.get(replicaGroupId), CONSUMING_INSTANCES.get(expectedAssignedInstanceId));
+      }
+      addToAssignment(currentAssignment, segmentId, instancesAssigned);
+    }
+    // Use new instancePartition to assign the new segments below.
+    ImmutableMap<InstancePartitionsType, InstancePartitions> newConsumingInstancePartitionMap =
+        ImmutableMap.of(InstancePartitionsType.CONSUMING, _newConsumingInstancePartitions);
+
+    // No existing segments for partition 3, so use the assignment decided by new instancePartition.
+    // So segment 3 (partition 3) should be assigned to instance new_0, new_3, new_6
+    int segmentId = 3;
+    String segmentName = _segments.get(segmentId);
+    List<String> instancesAssigned =
+        _segmentAssignment.assignSegment(segmentName, currentAssignment, newConsumingInstancePartitionMap);
+    assertEquals(instancesAssigned,
+        Arrays.asList("new_consumingInstance_0", "new_consumingInstance_3", "new_consumingInstance_6"));
+
+    // Use existing assignment for partition 0/1/2, instead of the one decided by new instancePartition.
+    for (segmentId = 4; segmentId < 7; segmentId++) {
+      segmentName = _segments.get(segmentId);
+      instancesAssigned =
+          _segmentAssignment.assignSegment(segmentName, currentAssignment, newConsumingInstancePartitionMap);
+      assertEquals(instancesAssigned.size(), NUM_REPLICAS);
+
+      // Those segments are assigned according to the assignment from idealState, instead of using new_xxx instances
+      // Segment 4 (partition 0) should be assigned to instance 0, 3, 6
+      // Segment 5 (partition 1) should be assigned to instance 1, 4, 7
+      // Segment 6 (partition 2) should be assigned to instance 2, 5, 8
+      for (int replicaGroupId = 0; replicaGroupId < NUM_REPLICAS; replicaGroupId++) {
+        int partitionId = segmentId % NUM_PARTITIONS;
+        int expectedAssignedInstanceId =
+            partitionId % numInstancesPerReplicaGroup + replicaGroupId * numInstancesPerReplicaGroup;
+        assertEquals(instancesAssigned.get(replicaGroupId), CONSUMING_INSTANCES.get(expectedAssignedInstanceId));
+      }
+      addToAssignment(currentAssignment, segmentId, instancesAssigned);
+    }
+  }
+
+  @Test(expectedExceptions = IllegalStateException.class)
+  public void testAssignSegmentToCompletedServers() {
+    _segmentAssignment.assignSegment("seg01", new TreeMap<>(), new TreeMap<>());
+  }
+
+  private void addToAssignment(Map<String, Map<String, String>> currentAssignment, int segmentId,
+      List<String> instancesAssigned) {
+    // Change the state of the last segment in the same partition from CONSUMING to ONLINE if exists
+    if (segmentId >= NUM_PARTITIONS) {
+      String lastSegmentInPartition = _segments.get(segmentId - NUM_PARTITIONS);
+      Map<String, String> instanceStateMap = currentAssignment.get(lastSegmentInPartition);
+      currentAssignment.put(lastSegmentInPartition,
+          SegmentAssignmentUtils.getInstanceStateMap(new ArrayList<>(instanceStateMap.keySet()),
+              SegmentStateModel.ONLINE));
+    }
+
+    // Add the new segment into the assignment as CONSUMING
+    currentAssignment.put(_segments.get(segmentId),
+        SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, SegmentStateModel.CONSUMING));
+  }
+
+  private HelixManager createHelixManager() {
+    HelixManager helixManager = mock(HelixManager.class);
+    ZkHelixPropertyStore<ZNRecord> propertyStore = mock(ZkHelixPropertyStore.class);
+    when(helixManager.getHelixPropertyStore()).thenReturn(propertyStore);
+    when(propertyStore.get(anyString(), isNull(), anyInt())).thenReturn(new ZNRecord("0"));
+    return helixManager;
+  }
+}

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/AllServersSegmentAssignmentStrategyTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/AllServersSegmentAssignmentStrategyTest.java
@@ -86,7 +86,7 @@ public class AllServersSegmentAssignmentStrategyTest {
 
     _instancePartitionsMap.put(InstancePartitionsType.OFFLINE, instancePartitions);
     _instancePartitionsMap.put(InstancePartitionsType.COMPLETED, completedInstancePartitions);
-    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(_helixManager, tableConfig);
+    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(_helixManager, tableConfig, null);
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/BalancedNumSegmentAssignmentStrategyTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/BalancedNumSegmentAssignmentStrategyTest.java
@@ -65,7 +65,7 @@ public class BalancedNumSegmentAssignmentStrategyTest {
   public void setUp() {
     TableConfig tableConfig =
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS).build();
-    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(null, tableConfig);
+    _segmentAssignment = SegmentAssignmentFactory.getSegmentAssignment(null, tableConfig, null);
 
     // {
     //   0_0=[instance_0, instance_1, instance_2, instance_3, instance_4, instance_5, instance_6, instance_7,

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategyTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/assignment/segment/strategy/ReplicaGroupSegmentAssignmentStrategyTest.java
@@ -95,7 +95,7 @@ public class ReplicaGroupSegmentAssignmentStrategyTest {
             .setNumReplicas(NUM_REPLICAS)
             .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY).build();
     _segmentAssignmentWithoutPartition =
-        SegmentAssignmentFactory.getSegmentAssignment(null, tableConfigWithoutPartitions);
+        SegmentAssignmentFactory.getSegmentAssignment(null, tableConfigWithoutPartitions, null);
 
     // {
     //   0_0=[instance_0, instance_1, instance_2, instance_3, instance_4, instance_5],
@@ -146,7 +146,7 @@ public class ReplicaGroupSegmentAssignmentStrategyTest {
             .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY)
             .setReplicaGroupStrategyConfig(replicaGroupStrategyConfig).build();
     _segmentAssignmentWithPartition =
-        SegmentAssignmentFactory.getSegmentAssignment(helixManagerWithPartitions, tableConfigWithPartitions);
+        SegmentAssignmentFactory.getSegmentAssignment(helixManagerWithPartitions, tableConfigWithPartitions, null);
 
     // {
     //   0_0=[instance_0, instance_1], 1_0=[instance_2, instance_3], 2_0=[instance_4, instance_5],
@@ -404,7 +404,7 @@ public class ReplicaGroupSegmentAssignmentStrategyTest {
             .setSegmentAssignmentStrategy(AssignmentStrategy.REPLICA_GROUP_SEGMENT_ASSIGNMENT_STRATEGY).build();
     tableConfigWithPartitions.getValidationConfig().setReplicaGroupStrategyConfig(replicaGroupStrategyConfig);
     SegmentAssignment segmentAssignment =
-        SegmentAssignmentFactory.getSegmentAssignment(helixManager, tableConfigWithPartitions);
+        SegmentAssignmentFactory.getSegmentAssignment(helixManager, tableConfigWithPartitions, null);
 
     // {
     //   0_0=[instance_0, instance_1, instance_2, instance_3, instance_4, instance_5],

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -290,7 +290,7 @@ public class PerfBenchmarkDriver {
       _helixResourceManager = new PinotHelixResourceManager(controllerConf);
       String instanceId = controllerConf.getControllerHost() + "_" + controllerConf.getControllerPort();
       HelixManager helixManager = registerAndConnectAsHelixSpectator(instanceId);
-      _helixResourceManager.start(helixManager);
+      _helixResourceManager.start(helixManager, null);
     }
 
     // Create server tenants if required


### PR DESCRIPTION
This PR adds more checks when assigning new segments for upsert table, in order to process queries correctly. The extra checks make sure that at any time the idealState has all segments from the same table partition hosted on same server. Basically, it honors the assignment in the current idealState over the one as calculated by InstancePartition.

The segment is assigned according to InstancePartition, which can be ahead of IdealState if table rebalance fails to update idealState completely according to the new InstancePartition or is in middle of updating the idealState. If the new segment assignment is simply set in IdealState as done today, it's possible new segments from the same partition start to go to new server, causing queries to return wrong results.The new checks added here avoid such issue by checking if the assignment in the current idealState for the table partition is same as the one calculated from InstancePartition and favor the idealState if mismatch. 