### PR TITLE
Optimize group-by and join for single key scenario

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -48,7 +48,6 @@ import org.apache.calcite.rel.type.RelRecordType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
-import org.apache.pinot.query.planner.partitioning.FieldSelectionKeySelector;
 import org.apache.pinot.query.planner.plannode.AggregateNode;
 import org.apache.pinot.query.planner.plannode.ExchangeNode;
 import org.apache.pinot.query.planner.plannode.FilterNode;
@@ -180,8 +179,7 @@ public final class RelToPlanNodeConverter {
 
     // Parse out all equality JOIN conditions
     JoinInfo joinInfo = node.analyzeCondition();
-    JoinNode.JoinKeys joinKeys = new JoinNode.JoinKeys(new FieldSelectionKeySelector(joinInfo.leftKeys),
-        new FieldSelectionKeySelector(joinInfo.rightKeys));
+    JoinNode.JoinKeys joinKeys = new JoinNode.JoinKeys(joinInfo.leftKeys, joinInfo.rightKeys);
     List<RexExpression> joinClause =
         joinInfo.nonEquiConditions.stream().map(RexExpressionUtils::fromRexNode).collect(Collectors.toList());
     return new JoinNode(currentStageId, toDataSchema(node.getRowType()), toDataSchema(node.getLeft().getRowType()),

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/partitioning/EmptyKeySelector.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/partitioning/EmptyKeySelector.java
@@ -18,30 +18,20 @@
  */
 package org.apache.pinot.query.planner.partitioning;
 
-/**
- * The {@code KeySelector} provides a partitioning function to encode a specific input data type into a key.
- *
- * <p>This key selector is used for computation such as GROUP BY or equality JOINs.
- *
- * <p>Key selector should always produce the same selection hash key when the same input is provided.
- */
-public interface KeySelector<T> {
-  String DEFAULT_HASH_ALGORITHM = "absHashCode";
+public class EmptyKeySelector implements KeySelector<Integer> {
+  private EmptyKeySelector() {
+  }
 
-  /**
-   * Extracts the key out of the given row.
-   */
-  T getKey(Object[] row);
+  public static final EmptyKeySelector INSTANCE = new EmptyKeySelector();
+  private static final Integer PLACE_HOLDER = 0;
 
-  /**
-   * Computes the hash of the given row.
-   */
-  int computeHash(Object[] input);
+  @Override
+  public Integer getKey(Object[] row) {
+    return PLACE_HOLDER;
+  }
 
-  /**
-   * Returns the hash algorithm used to compute the hash.
-   */
-  default String hashAlgorithm() {
-    return DEFAULT_HASH_ALGORITHM;
+  @Override
+  public int computeHash(Object[] input) {
+    return 0;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/partitioning/KeySelectorFactory.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/partitioning/KeySelectorFactory.java
@@ -18,30 +18,25 @@
  */
 package org.apache.pinot.query.planner.partitioning;
 
-/**
- * The {@code KeySelector} provides a partitioning function to encode a specific input data type into a key.
- *
- * <p>This key selector is used for computation such as GROUP BY or equality JOINs.
- *
- * <p>Key selector should always produce the same selection hash key when the same input is provided.
- */
-public interface KeySelector<T> {
-  String DEFAULT_HASH_ALGORITHM = "absHashCode";
+import java.util.List;
 
-  /**
-   * Extracts the key out of the given row.
-   */
-  T getKey(Object[] row);
 
-  /**
-   * Computes the hash of the given row.
-   */
-  int computeHash(Object[] input);
+public class KeySelectorFactory {
+  private KeySelectorFactory() {
+  }
 
-  /**
-   * Returns the hash algorithm used to compute the hash.
-   */
-  default String hashAlgorithm() {
-    return DEFAULT_HASH_ALGORITHM;
+  public static KeySelector<?> getKeySelector(List<Integer> keyIds) {
+    int numKeys = keyIds.size();
+    if (numKeys == 0) {
+      return EmptyKeySelector.INSTANCE;
+    } else if (numKeys == 1) {
+      return new SingleColumnKeySelector(keyIds.get(0));
+    } else {
+      int[] ids = new int[numKeys];
+      for (int i = 0; i < numKeys; i++) {
+        ids[i] = keyIds.get(i);
+      }
+      return new MultiColumnKeySelector(ids);
+    }
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/partitioning/SingleColumnKeySelector.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/partitioning/SingleColumnKeySelector.java
@@ -18,30 +18,20 @@
  */
 package org.apache.pinot.query.planner.partitioning;
 
-/**
- * The {@code KeySelector} provides a partitioning function to encode a specific input data type into a key.
- *
- * <p>This key selector is used for computation such as GROUP BY or equality JOINs.
- *
- * <p>Key selector should always produce the same selection hash key when the same input is provided.
- */
-public interface KeySelector<T> {
-  String DEFAULT_HASH_ALGORITHM = "absHashCode";
+public class SingleColumnKeySelector implements KeySelector<Object> {
+  private final int _keyId;
 
-  /**
-   * Extracts the key out of the given row.
-   */
-  T getKey(Object[] row);
+  public SingleColumnKeySelector(int keyId) {
+    _keyId = keyId;
+  }
 
-  /**
-   * Computes the hash of the given row.
-   */
-  int computeHash(Object[] input);
+  @Override
+  public Object getKey(Object[] row) {
+    return row[_keyId];
+  }
 
-  /**
-   * Returns the hash algorithm used to compute the hash.
-   */
-  default String hashAlgorithm() {
-    return DEFAULT_HASH_ALGORITHM;
+  @Override
+  public int computeHash(Object[] input) {
+    return input[_keyId].hashCode() & Integer.MAX_VALUE;
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/JoinNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/JoinNode.java
@@ -24,8 +24,6 @@ import org.apache.calcite.rel.core.JoinRelType;
 import org.apache.calcite.rel.hint.RelHint;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
-import org.apache.pinot.query.planner.partitioning.FieldSelectionKeySelector;
-import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
 
 
@@ -94,24 +92,24 @@ public class JoinNode extends AbstractPlanNode {
 
   public static class JoinKeys {
     @ProtoProperties
-    private KeySelector<Object[], Object[]> _leftJoinKeySelector;
+    private List<Integer> _leftKeys;
     @ProtoProperties
-    private KeySelector<Object[], Object[]> _rightJoinKeySelector;
+    private List<Integer> _rightKeys;
 
     public JoinKeys() {
     }
 
-    public JoinKeys(FieldSelectionKeySelector leftKeySelector, FieldSelectionKeySelector rightKeySelector) {
-      _leftJoinKeySelector = leftKeySelector;
-      _rightJoinKeySelector = rightKeySelector;
+    public JoinKeys(List<Integer> leftKeys, List<Integer> rightKeys) {
+      _leftKeys = leftKeys;
+      _rightKeys = rightKeys;
     }
 
-    public KeySelector<Object[], Object[]> getLeftJoinKeySelector() {
-      return _leftJoinKeySelector;
+    public List<Integer> getLeftKeys() {
+      return _leftKeys;
     }
 
-    public KeySelector<Object[], Object[]> getRightJoinKeySelector() {
-      return _rightJoinKeySelector;
+    public List<Integer> getRightKeys() {
+      return _rightKeys;
     }
   }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/MailboxReceiveNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/MailboxReceiveNode.java
@@ -31,7 +31,6 @@ import org.apache.calcite.rel.logical.PinotRelExchangeType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
-import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
 
 
@@ -43,7 +42,7 @@ public class MailboxReceiveNode extends AbstractPlanNode {
   @ProtoProperties
   private PinotRelExchangeType _exchangeType;
   @ProtoProperties
-  private KeySelector<Object[], Object[]> _partitionKeySelector;
+  private List<Integer> _distributionKeys;
   @ProtoProperties
   private List<RexExpression> _collationKeys;
   @ProtoProperties
@@ -65,14 +64,13 @@ public class MailboxReceiveNode extends AbstractPlanNode {
 
   public MailboxReceiveNode(int planFragmentId, DataSchema dataSchema, int senderStageId,
       RelDistribution.Type distributionType, PinotRelExchangeType exchangeType,
-      @Nullable KeySelector<Object[], Object[]> partitionKeySelector,
-      @Nullable List<RelFieldCollation> fieldCollations, boolean isSortOnSender, boolean isSortOnReceiver,
-      PlanNode sender) {
+      @Nullable List<Integer> distributionKeys, @Nullable List<RelFieldCollation> fieldCollations,
+      boolean isSortOnSender, boolean isSortOnReceiver, PlanNode sender) {
     super(planFragmentId, dataSchema);
     _senderStageId = senderStageId;
     _distributionType = distributionType;
     _exchangeType = exchangeType;
-    _partitionKeySelector = partitionKeySelector;
+    _distributionKeys = distributionKeys;
     if (!CollectionUtils.isEmpty(fieldCollations)) {
       int numCollations = fieldCollations.size();
       _collationKeys = new ArrayList<>(numCollations);
@@ -125,8 +123,8 @@ public class MailboxReceiveNode extends AbstractPlanNode {
     return _exchangeType;
   }
 
-  public KeySelector<Object[], Object[]> getPartitionKeySelector() {
-    return _partitionKeySelector;
+  public List<Integer> getDistributionKeys() {
+    return _distributionKeys;
   }
 
   public List<RexExpression> getCollationKeys() {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/MailboxSendNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/MailboxSendNode.java
@@ -29,7 +29,6 @@ import org.apache.calcite.rel.logical.PinotRelExchangeType;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
-import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.planner.serde.ProtoProperties;
 
 
@@ -41,7 +40,7 @@ public class MailboxSendNode extends AbstractPlanNode {
   @ProtoProperties
   private PinotRelExchangeType _exchangeType;
   @ProtoProperties
-  private KeySelector<Object[], Object[]> _partitionKeySelector;
+  private List<Integer> _distributionKeys;
   @ProtoProperties
   private List<RexExpression> _collationKeys;
   @ProtoProperties
@@ -55,13 +54,13 @@ public class MailboxSendNode extends AbstractPlanNode {
 
   public MailboxSendNode(int planFragmentId, DataSchema dataSchema, int receiverStageId,
       RelDistribution.Type distributionType, PinotRelExchangeType exchangeType,
-      @Nullable KeySelector<Object[], Object[]> partitionKeySelector,
-      @Nullable List<RelFieldCollation> fieldCollations, boolean isSortOnSender) {
+      @Nullable List<Integer> distributionKeys, @Nullable List<RelFieldCollation> fieldCollations,
+      boolean isSortOnSender) {
     super(planFragmentId, dataSchema);
     _receiverStageId = receiverStageId;
     _distributionType = distributionType;
     _exchangeType = exchangeType;
-    _partitionKeySelector = partitionKeySelector;
+    _distributionKeys = distributionKeys;
     // TODO: Support ordering here if the 'fieldCollations' aren't empty and 'sortOnSender' is true
     Preconditions.checkState(!isSortOnSender, "Ordering is not yet supported on Mailbox Send");
     if (!CollectionUtils.isEmpty(fieldCollations) && isSortOnSender) {
@@ -102,8 +101,8 @@ public class MailboxSendNode extends AbstractPlanNode {
     return _exchangeType;
   }
 
-  public KeySelector<Object[], Object[]> getPartitionKeySelector() {
-    return _partitionKeySelector;
+  public List<Integer> getDistributionKeys() {
+    return _distributionKeys;
   }
 
   public List<RexExpression> getCollationKeys() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/QueryRunner.java
@@ -264,7 +264,7 @@ public class QueryRunner {
             _leafQueryExecutor, _executorService);
     MailboxSendOperator mailboxSendOperator =
         new MailboxSendOperator(executionContext, leafStageOperator, sendNode.getDistributionType(),
-            sendNode.getPartitionKeySelector(), sendNode.getCollationKeys(), sendNode.getCollationDirections(),
+            sendNode.getDistributionKeys(), sendNode.getCollationKeys(), sendNode.getCollationDirections(),
             sendNode.isSortOnSender(), sendNode.getReceiverStageId());
     return new OpChain(executionContext, mailboxSendOperator);
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxSendOperator.java
@@ -20,11 +20,10 @@ package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
-import com.google.common.collect.ImmutableSet;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.EnumSet;
 import java.util.List;
-import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import javax.annotation.Nullable;
 import org.apache.calcite.rel.RelDistribution;
@@ -33,7 +32,6 @@ import org.apache.pinot.query.mailbox.MailboxIdUtils;
 import org.apache.pinot.query.mailbox.MailboxService;
 import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.planner.logical.RexExpression;
-import org.apache.pinot.query.planner.partitioning.KeySelector;
 import org.apache.pinot.query.routing.MailboxMetadata;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
@@ -51,8 +49,8 @@ import org.slf4j.LoggerFactory;
  * TODO: Add support to sort the data prior to sending if sorting is enabled
  */
 public class MailboxSendOperator extends MultiStageOperator {
-  public static final Set<RelDistribution.Type> SUPPORTED_EXCHANGE_TYPES =
-      ImmutableSet.of(RelDistribution.Type.SINGLETON, RelDistribution.Type.RANDOM_DISTRIBUTED,
+  public static final EnumSet<RelDistribution.Type> SUPPORTED_EXCHANGE_TYPES =
+      EnumSet.of(RelDistribution.Type.SINGLETON, RelDistribution.Type.RANDOM_DISTRIBUTED,
           RelDistribution.Type.BROADCAST_DISTRIBUTED, RelDistribution.Type.HASH_DISTRIBUTED);
 
   private static final Logger LOGGER = LoggerFactory.getLogger(MailboxSendOperator.class);
@@ -65,11 +63,11 @@ public class MailboxSendOperator extends MultiStageOperator {
   private final boolean _isSortOnSender;
 
   public MailboxSendOperator(OpChainExecutionContext context, MultiStageOperator sourceOperator,
-      RelDistribution.Type exchangeType, KeySelector<Object[], Object[]> keySelector,
+      RelDistribution.Type distributionType, @Nullable List<Integer> distributionKeys,
       @Nullable List<RexExpression> collationKeys, @Nullable List<RelFieldCollation.Direction> collationDirections,
       boolean isSortOnSender, int receiverStageId) {
-    this(context, sourceOperator, getBlockExchange(context, exchangeType, keySelector, receiverStageId), collationKeys,
-        collationDirections, isSortOnSender);
+    this(context, sourceOperator, getBlockExchange(context, distributionType, distributionKeys, receiverStageId),
+        collationKeys, collationDirections, isSortOnSender);
   }
 
   @VisibleForTesting
@@ -84,10 +82,10 @@ public class MailboxSendOperator extends MultiStageOperator {
     _isSortOnSender = isSortOnSender;
   }
 
-  private static BlockExchange getBlockExchange(OpChainExecutionContext context, RelDistribution.Type exchangeType,
-      KeySelector<Object[], Object[]> keySelector, int receiverStageId) {
-    Preconditions.checkState(SUPPORTED_EXCHANGE_TYPES.contains(exchangeType), "Unsupported exchange type: %s",
-        exchangeType);
+  private static BlockExchange getBlockExchange(OpChainExecutionContext context, RelDistribution.Type distributionType,
+      @Nullable List<Integer> distributionKeys, int receiverStageId) {
+    Preconditions.checkState(SUPPORTED_EXCHANGE_TYPES.contains(distributionType), "Unsupported distribution type: %s",
+        distributionType);
     MailboxService mailboxService = context.getMailboxService();
     long requestId = context.getRequestId();
     long deadlineMs = context.getDeadlineMs();
@@ -101,7 +99,8 @@ public class MailboxSendOperator extends MultiStageOperator {
       sendingMailboxes.add(mailboxService.getSendingMailbox(mailboxMetadata.getVirtualAddress(i).hostname(),
           mailboxMetadata.getVirtualAddress(i).port(), sendingMailboxIds.get(i), deadlineMs));
     }
-    return BlockExchange.getExchange(sendingMailboxes, exchangeType, keySelector, TransferableBlockUtils::splitBlock);
+    return BlockExchange.getExchange(sendingMailboxes, distributionType, distributionKeys,
+        TransferableBlockUtils::splitBlock);
   }
 
   @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultistageGroupByExecutor.java
@@ -18,9 +18,10 @@
  */
 package org.apache.pinot.query.runtime.operator;
 
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
@@ -60,13 +61,11 @@ public class MultistageGroupByExecutor {
 
   // Group By Result holders for each mode
   private final GroupByResultHolder[] _aggregateResultHolders;
-  private final Map<Integer, Object[]> _mergeResultHolder;
+  private final List<Object[]> _mergeResultHolder;
 
   // Mapping from the row-key to a zero based integer index. This is used when we invoke the v1 aggregation functions
   // because they use the zero based integer indexes to store results.
-  private final Map<Key, Integer> _groupKeyToIdMap = new HashMap<>();
-
-  private boolean _numGroupsLimitReached;
+  private final Object2IntOpenHashMap<Object> _groupKeyToIdMap;
 
   public MultistageGroupByExecutor(int[] groupKeyIds, AggregationFunction[] aggFunctions, int[] filterArgIds,
       int maxFilterArgId, AggType aggType, DataSchema resultSchema, Map<String, String> opChainMetadata,
@@ -82,16 +81,19 @@ public class MultistageGroupByExecutor {
 
     int numFunctions = aggFunctions.length;
     if (!aggType.isInputIntermediateFormat()) {
-      _aggregateResultHolders = new GroupByResultHolder[_aggFunctions.length];
-      for (int i = 0; i < _aggFunctions.length; i++) {
+      _aggregateResultHolders = new GroupByResultHolder[numFunctions];
+      for (int i = 0; i < numFunctions; i++) {
         _aggregateResultHolders[i] =
             _aggFunctions[i].createGroupByResultHolder(maxInitialResultHolderCapacity, _numGroupsLimit);
       }
       _mergeResultHolder = null;
     } else {
-      _mergeResultHolder = new HashMap<>();
+      _mergeResultHolder = new ArrayList<>(maxInitialResultHolderCapacity);
       _aggregateResultHolders = null;
     }
+
+    _groupKeyToIdMap = new Object2IntOpenHashMap<>();
+    _groupKeyToIdMap.defaultReturnValue(GroupKeyGenerator.INVALID_ID);
   }
 
   private int getNumGroupsLimit(Map<String, String> customProperties, @Nullable AbstractPlanNode.NodeHint nodeHint) {
@@ -152,43 +154,54 @@ public class MultistageGroupByExecutor {
     int numFunctions = _aggFunctions.length;
     int numColumns = numKeys + numFunctions;
     ColumnDataType[] resultStoredTypes = _resultSchema.getStoredColumnDataTypes();
-    for (Map.Entry<Key, Integer> entry : _groupKeyToIdMap.entrySet()) {
-      Object[] row = new Object[numColumns];
-      Object[] keyValues = entry.getKey().getValues();
-      System.arraycopy(keyValues, 0, row, 0, numKeys);
-      int groupId = entry.getValue();
-      for (int i = 0; i < numFunctions; i++) {
-        AggregationFunction func = _aggFunctions[i];
-        int index = numKeys + i;
-        Object value;
-        switch (_aggType) {
-          case LEAF:
-            value = func.extractGroupByResult(_aggregateResultHolders[i], groupId);
-            break;
-          case INTERMEDIATE:
-            value = _mergeResultHolder.get(groupId)[i];
-            break;
-          case FINAL:
-            value = func.extractFinalResult(_mergeResultHolder.get(groupId)[i]);
-            break;
-          case DIRECT:
-            Object intermediate = _aggFunctions[i].extractGroupByResult(_aggregateResultHolders[i], groupId);
-            value = func.extractFinalResult(intermediate);
-            break;
-          default:
-            throw new UnsupportedOperationException("Unsupported aggTyp: " + _aggType);
+    if (numKeys == 1) {
+      for (Object2IntMap.Entry<Object> entry : _groupKeyToIdMap.object2IntEntrySet()) {
+        Object[] row = new Object[numColumns];
+        row[0] = entry.getKey();
+        int groupId = entry.getIntValue();
+        for (int i = 0; i < numFunctions; i++) {
+          row[i + 1] = getResultValue(i, groupId);
         }
-        row[index] = value;
+        // Convert the results from AggregationFunction to the desired type
+        TypeUtils.convertRow(row, resultStoredTypes);
+        rows.add(row);
       }
-      // Convert the results from AggregationFunction to the desired type
-      TypeUtils.convertRow(row, resultStoredTypes);
-      rows.add(row);
+    } else {
+      for (Object2IntMap.Entry<Object> entry : _groupKeyToIdMap.object2IntEntrySet()) {
+        Object[] row = new Object[numColumns];
+        Object[] keyValues = ((Key) entry.getKey()).getValues();
+        System.arraycopy(keyValues, 0, row, 0, numKeys);
+        int groupId = entry.getIntValue();
+        for (int i = 0; i < numFunctions; i++) {
+          row[numKeys + i] = getResultValue(i, groupId);
+        }
+        // Convert the results from AggregationFunction to the desired type
+        TypeUtils.convertRow(row, resultStoredTypes);
+        rows.add(row);
+      }
     }
     return rows;
   }
 
+  private Object getResultValue(int functionId, int groupId) {
+    AggregationFunction aggFunction = _aggFunctions[functionId];
+    switch (_aggType) {
+      case LEAF:
+        return aggFunction.extractGroupByResult(_aggregateResultHolders[functionId], groupId);
+      case INTERMEDIATE:
+        return _mergeResultHolder.get(groupId)[functionId];
+      case FINAL:
+        return aggFunction.extractFinalResult(_mergeResultHolder.get(groupId)[functionId]);
+      case DIRECT:
+        Object intermediate = aggFunction.extractGroupByResult(_aggregateResultHolders[functionId], groupId);
+        return aggFunction.extractFinalResult(intermediate);
+      default:
+        throw new IllegalStateException("Unsupported aggType: " + _aggType);
+    }
+  }
+
   public boolean isNumGroupsLimitReached() {
-    return _numGroupsLimitReached;
+    return _groupKeyToIdMap.size() == _numGroupsLimit;
   }
 
   private void processAggregate(TransferableBlock block) {
@@ -243,15 +256,25 @@ public class MultistageGroupByExecutor {
   }
 
   private void processMerge(TransferableBlock block) {
-    int[] intKeys = generateGroupByKeys(block);
-    int numRows = intKeys.length;
+    int[] groupByKeys = generateGroupByKeys(block);
+    int numRows = groupByKeys.length;
     int numFunctions = _aggFunctions.length;
     Object[][] intermediateResults = new Object[numFunctions][numRows];
     for (int i = 0; i < numFunctions; i++) {
       intermediateResults[i] = AggregateOperator.getIntermediateResults(_aggFunctions[i], block);
     }
     for (int i = 0; i < numRows; i++) {
-      Object[] mergedResults = _mergeResultHolder.computeIfAbsent(intKeys[i], k -> new Object[numFunctions]);
+      int groupByKey = groupByKeys[i];
+      if (groupByKey == GroupKeyGenerator.INVALID_ID) {
+        continue;
+      }
+      Object[] mergedResults;
+      if (_mergeResultHolder.size() == groupByKey) {
+        mergedResults = new Object[numFunctions];
+        _mergeResultHolder.add(mergedResults);
+      } else {
+        mergedResults = _mergeResultHolder.get(groupByKey);
+      }
       for (int j = 0; j < numFunctions; j++) {
         AggregationFunction aggFunction = _aggFunctions[j];
         Object intermediateResult = intermediateResults[j][i];
@@ -282,23 +305,35 @@ public class MultistageGroupByExecutor {
     int numRows = rows.size();
     int[] intKeys = new int[numRows];
     int numKeys = _groupKeyIds.length;
-    for (int i = 0; i < numRows; i++) {
-      Object[] row = rows.get(i);
-      Object[] keyValues = new Object[numKeys];
-      for (int j = 0; j < numKeys; j++) {
-        keyValues[j] = row[_groupKeyIds[j]];
+    if (numKeys == 1) {
+      int groupKeyId = _groupKeyIds[0];
+      for (int i = 0; i < numRows; i++) {
+        intKeys[i] = getGroupId(rows.get(i)[groupKeyId]);
       }
-      intKeys[i] = getGroupId(new Key(keyValues));
+    } else {
+      for (int i = 0; i < numRows; i++) {
+        Object[] row = rows.get(i);
+        Object[] keyValues = new Object[numKeys];
+        for (int j = 0; j < numKeys; j++) {
+          keyValues[j] = row[_groupKeyIds[j]];
+        }
+        intKeys[i] = getGroupId(new Key(keyValues));
+      }
     }
     return intKeys;
   }
 
   private int[] generateGroupByKeys(DataBlock dataBlock) {
-    List<Key> keys = DataBlockExtractUtils.extractKeys(dataBlock, _groupKeyIds);
-    int numRows = keys.size();
+    Object[] keys;
+    if (_groupKeyIds.length == 1) {
+      keys = DataBlockExtractUtils.extractColumn(dataBlock, _groupKeyIds[0]);
+    } else {
+      keys = DataBlockExtractUtils.extractKeys(dataBlock, _groupKeyIds);
+    }
+    int numRows = keys.length;
     int[] intKeys = new int[numRows];
     for (int i = 0; i < numRows; i++) {
-      intKeys[i] = getGroupId(keys.get(i));
+      intKeys[i] = getGroupId(keys[i]);
     }
     return intKeys;
   }
@@ -316,37 +351,45 @@ public class MultistageGroupByExecutor {
     int[] intKeys = new int[numMatchedRows];
     int numKeys = _groupKeyIds.length;
     PeekableIntIterator iterator = matchedBitmap.getIntIterator();
-    for (int i = 0; i < numMatchedRows; i++) {
-      int rowId = iterator.next();
-      Object[] row = rows.get(rowId);
-      Object[] keyValues = new Object[numKeys];
-      for (int j = 0; j < numKeys; j++) {
-        keyValues[j] = row[_groupKeyIds[j]];
+    if (numKeys == 1) {
+      int groupKeyId = _groupKeyIds[0];
+      for (int i = 0; i < numMatchedRows; i++) {
+        intKeys[i] = getGroupId(rows.get(iterator.next())[groupKeyId]);
       }
-      intKeys[i] = getGroupId(new Key(keyValues));
+    } else {
+      for (int i = 0; i < numMatchedRows; i++) {
+        int rowId = iterator.next();
+        Object[] row = rows.get(rowId);
+        Object[] keyValues = new Object[numKeys];
+        for (int j = 0; j < numKeys; j++) {
+          keyValues[j] = row[_groupKeyIds[j]];
+        }
+        intKeys[i] = getGroupId(new Key(keyValues));
+      }
     }
     return intKeys;
   }
 
   private int[] generateGroupByKeys(DataBlock dataBlock, int numMatchedRows, RoaringBitmap matchedBitmap) {
-    List<Key> keys = DataBlockExtractUtils.extractKeys(dataBlock, _groupKeyIds, numMatchedRows, matchedBitmap);
+    Object[] keys;
+    if (_groupKeyIds.length == 1) {
+      keys = DataBlockExtractUtils.extractColumn(dataBlock, _groupKeyIds[0], numMatchedRows, matchedBitmap);
+    } else {
+      keys = DataBlockExtractUtils.extractKeys(dataBlock, _groupKeyIds, numMatchedRows, matchedBitmap);
+    }
     int[] intKeys = new int[numMatchedRows];
     for (int i = 0; i < numMatchedRows; i++) {
-      intKeys[i] = getGroupId(keys.get(i));
+      intKeys[i] = getGroupId(keys[i]);
     }
     return intKeys;
   }
 
-  private int getGroupId(Key key) {
-    Integer groupKey = _groupKeyToIdMap.computeIfAbsent(key, k -> {
-      int numGroupKeys = _groupKeyToIdMap.size();
-      if (numGroupKeys == _numGroupsLimit) {
-        _numGroupsLimitReached = true;
-        return null;
-      } else {
-        return numGroupKeys;
-      }
-    });
-    return groupKey != null ? groupKey : GroupKeyGenerator.INVALID_ID;
+  private int getGroupId(Object key) {
+    int numGroups = _groupKeyToIdMap.size();
+    if (numGroups < _numGroupsLimit) {
+      return _groupKeyToIdMap.computeIntIfAbsent(key, k -> numGroups);
+    } else {
+      return _groupKeyToIdMap.getInt(key);
+    }
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/PhysicalPlanVisitor.java
@@ -81,7 +81,7 @@ public class PhysicalPlanVisitor implements PlanNodeVisitor<MultiStageOperator, 
   @Override
   public MultiStageOperator visitMailboxSend(MailboxSendNode node, OpChainExecutionContext context) {
     MultiStageOperator nextOperator = node.getInputs().get(0).visit(this, context);
-    return new MailboxSendOperator(context, nextOperator, node.getDistributionType(), node.getPartitionKeySelector(),
+    return new MailboxSendOperator(context, nextOperator, node.getDistributionType(), node.getDistributionKeys(),
         node.getCollationKeys(), node.getCollationDirections(), node.isSortOnSender(), node.getReceiverStageId());
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -39,7 +39,6 @@ import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.common.utils.request.RequestUtils;
 import org.apache.pinot.core.query.optimizer.QueryOptimizer;
 import org.apache.pinot.core.routing.TimeBoundaryInfo;
-import org.apache.pinot.query.planner.partitioning.FieldSelectionKeySelector;
 import org.apache.pinot.query.planner.plannode.JoinNode;
 import org.apache.pinot.query.routing.WorkerMetadata;
 import org.apache.pinot.query.runtime.plan.DistributedStagePlan;
@@ -207,12 +206,12 @@ public class ServerPlanRequestUtils {
    */
   static void attachDynamicFilter(PinotQuery pinotQuery, JoinNode.JoinKeys joinKeys, List<Object[]> dataContainer,
       DataSchema dataSchema) {
-    FieldSelectionKeySelector leftSelector = (FieldSelectionKeySelector) joinKeys.getLeftJoinKeySelector();
-    FieldSelectionKeySelector rightSelector = (FieldSelectionKeySelector) joinKeys.getRightJoinKeySelector();
+    List<Integer> leftJoinKeys = joinKeys.getLeftKeys();
+    List<Integer> rightJoinKeys = joinKeys.getRightKeys();
     List<Expression> expressions = new ArrayList<>();
-    for (int i = 0; i < leftSelector.getColumnIndices().size(); i++) {
-      Expression leftExpr = pinotQuery.getSelectList().get(leftSelector.getColumnIndices().get(i));
-      int rightIdx = rightSelector.getColumnIndices().get(i);
+    for (int i = 0; i < leftJoinKeys.size(); i++) {
+      Expression leftExpr = pinotQuery.getSelectList().get(leftJoinKeys.get(i));
+      int rightIdx = rightJoinKeys.get(i);
       Expression inFilterExpr = RequestUtils.getFunctionExpression(FilterKind.IN.name());
       List<Expression> operands = new ArrayList<>(dataContainer.size() + 1);
       operands.add(leftExpr);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -33,7 +33,6 @@ import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
-import org.apache.pinot.query.planner.partitioning.FieldSelectionKeySelector;
 import org.apache.pinot.query.planner.plannode.JoinNode;
 import org.apache.pinot.query.routing.VirtualServerAddress;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
@@ -71,10 +70,8 @@ public class HashJoinOperatorTest {
     _mocks.close();
   }
 
-  private static JoinNode.JoinKeys getJoinKeys(List<Integer> leftIdx, List<Integer> rightIdx) {
-    FieldSelectionKeySelector leftSelect = new FieldSelectionKeySelector(leftIdx);
-    FieldSelectionKeySelector rightSelect = new FieldSelectionKeySelector(rightIdx);
-    return new JoinNode.JoinKeys(leftSelect, rightSelect);
+  private static JoinNode.JoinKeys getJoinKeys(List<Integer> leftKeys, List<Integer> rightKeys) {
+    return new JoinNode.JoinKeys(leftKeys, rightKeys);
   }
 
   private static List<RelHint> getJoinHints(Map<String, String> hintsMap) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/HashExchangeTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/exchange/HashExchangeTest.java
@@ -83,9 +83,7 @@ public class HashExchangeTest {
     Assert.assertEquals(captor.getValue().getContainer().get(0), new Object[]{2});
   }
 
-  private static class TestSelector implements KeySelector<Object[], Object[]> {
-    private static final String HASH_ALGORITHM = "dummyHash";
-
+  private static class TestSelector implements KeySelector<Object> {
     private final Iterator<Integer> _hashes;
 
     public TestSelector(Iterator<Integer> hashes) {
@@ -93,18 +91,13 @@ public class HashExchangeTest {
     }
 
     @Override
-    public Object[] getKey(Object[] input) {
+    public Object getKey(Object[] input) {
       throw new UnsupportedOperationException("Should not be called");
     }
 
     @Override
     public int computeHash(Object[] input) {
       return _hashes.next();
-    }
-
-    @Override
-    public String hashAlgorithm() {
-      return HASH_ALGORITHM;
     }
   }
 }


### PR DESCRIPTION
- For single join key and group key scenario, no need to wrap the values into the `Key` object. Directly use the value as the key in the map.
- Optimize the case of no join key
- In group-by executor, store merged results in `ArrayList`, group key map in `Object2IntOpenHashMap`
- In join operator, store matched right rows in `BitSet`