### PR TITLE
Find next available port when start test servers in ClusterTest

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -213,9 +213,12 @@ public abstract class ClusterTest extends ControllerTest {
     serverConf.setProperty(Server.CONFIG_OF_INSTANCE_DATA_DIR, Server.DEFAULT_INSTANCE_DATA_DIR + "-" + serverId);
     serverConf.setProperty(Server.CONFIG_OF_INSTANCE_SEGMENT_TAR_DIR,
         Server.DEFAULT_INSTANCE_SEGMENT_TAR_DIR + "-" + serverId);
-    serverConf.setProperty(Server.CONFIG_OF_ADMIN_API_PORT, Server.DEFAULT_ADMIN_API_PORT - serverId);
-    serverConf.setProperty(Helix.KEY_OF_SERVER_NETTY_PORT, Helix.DEFAULT_SERVER_NETTY_PORT + serverId);
-    serverConf.setProperty(Server.CONFIG_OF_GRPC_PORT, Server.DEFAULT_GRPC_PORT + serverId);
+    serverConf.setProperty(Server.CONFIG_OF_ADMIN_API_PORT,
+        NetUtils.findOpenPort(Server.DEFAULT_ADMIN_API_PORT - serverId));
+    serverConf.setProperty(Helix.KEY_OF_SERVER_NETTY_PORT,
+        NetUtils.findOpenPort(Helix.DEFAULT_SERVER_NETTY_PORT + serverId));
+    serverConf.setProperty(Server.CONFIG_OF_GRPC_PORT, NetUtils.findOpenPort(Server.DEFAULT_GRPC_PORT + serverId));
+
     // Thread time measurement is disabled by default, enable it in integration tests.
     // TODO: this can be removed when we eventually enable thread time measurement by default.
     serverConf.setProperty(Server.CONFIG_OF_ENABLE_THREAD_CPU_TIME_MEASUREMENT, true);
@@ -545,7 +548,7 @@ public abstract class ClusterTest extends ControllerTest {
 
   @DataProvider(name = "systemColumns")
   public Object[][] systemColumns() {
-    return new Object[][] {
+    return new Object[][]{
         {"$docId"},
         {"$hostName"},
         {"$segmentName"}


### PR DESCRIPTION
Fix the issue that port could already be used in test.

https://github.com/apache/pinot/actions/runs/6254563237/job/16982357903?pr=11638
```
2023-09-20T22:50:59.3896854Z [ERROR] Tests run: 15, Failures: 1, Errors: 0, Skipped: 14, Time elapsed: 16.955 s <<< FAILURE! - in org.apache.pinot.integration.tests.OfflineGRPCServerIntegrationTest
2023-09-20T22:50:59.3899106Z [ERROR] org.apache.pinot.integration.tests.OfflineGRPCServerIntegrationTest.setUp  Time elapsed: 16.735 s  <<< FAILURE!
2023-09-20T22:50:59.3899724Z java.lang.RuntimeException: java.lang.RuntimeException: java.io.IOException: Failed to bind to address 0.0.0.0/0.0.0.0:43533
2023-09-20T22:50:59.3900250Z 	at org.apache.pinot.server.worker.WorkerQueryServer.start(WorkerQueryServer.java:92)
2023-09-20T22:50:59.3900816Z 	at org.apache.pinot.server.starter.ServerInstance.startQueryServer(ServerInstance.java:219)
2023-09-20T22:50:59.3901386Z 	at org.apache.pinot.server.starter.helix.BaseServerStarter.start(BaseServerStarter.java:637)
2023-09-20T22:50:59.3901924Z 	at org.apache.pinot.integration.tests.ClusterTest.startOneServer(ClusterTest.java:244)
2023-09-20T22:50:59.3902455Z 	at org.apache.pinot.integration.tests.ClusterTest.startServers(ClusterTest.java:236)
2023-09-20T22:50:59.3903681Z 	at org.apache.pinot.integration.tests.ClusterTest.startServer(ClusterTest.java:228)
2023-09-20T22:50:59.3904366Z 	at org.apache.pinot.integration.tests.OfflineGRPCServerIntegrationTest.setUp(OfflineGRPCServerIntegrationTest.java:74)
2023-09-20T22:50:59.3905030Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
2023-09-20T22:50:59.3905673Z 	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
2023-09-20T22:50:59.3906479Z 	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
2023-09-20T22:50:59.3907302Z 	at java.base/java.lang.reflect.Method.invoke(Method.java:568)
2023-09-20T22:50:59.3907763Z 	at org.testng.internal.MethodInvocationHelper.invokeMethod(MethodInvocationHelper.java:108)
2023-09-20T22:50:59.3908268Z 	at org.testng.internal.Invoker.invokeConfigurationMethod(Invoker.java:523)
2023-09-20T22:50:59.3908724Z 	at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:224)
2023-09-20T22:50:59.3909154Z 	at org.testng.internal.Invoker.invokeConfigurations(Invoker.java:146)
2023-09-20T22:50:59.3909680Z 	at org.testng.internal.TestMethodWorker.invokeBeforeClassMethods(TestMethodWorker.java:166)
2023-09-20T22:50:59.3910485Z 	at org.testng.internal.TestMethodWorker.run(TestMethodWorker.java:105)
2023-09-20T22:50:59.3910905Z 	at org.testng.TestRunner.privateRun(TestRunner.java:744)
2023-09-20T22:50:59.3911235Z 	at org.testng.TestRunner.run(TestRunner.java:602)
2023-09-20T22:50:59.3911580Z 	at org.testng.SuiteRunner.runTest(SuiteRunner.java:380)
2023-09-20T22:50:59.3911955Z 	at org.testng.SuiteRunner.runSequentially(SuiteRunner.java:375)
2023-09-20T22:50:59.3912338Z 	at org.testng.SuiteRunner.privateRun(SuiteRunner.java:340)
2023-09-20T22:50:59.3912688Z 	at org.testng.SuiteRunner.run(SuiteRunner.java:289)
2023-09-20T22:50:59.3913046Z 	at org.testng.SuiteRunnerWorker.runSuite(SuiteRunnerWorker.java:52)
2023-09-20T22:50:59.3913452Z 	at org.testng.SuiteRunnerWorker.run(SuiteRunnerWorker.java:86)
2023-09-20T22:50:59.3913836Z 	at org.testng.TestNG.runSuitesSequentially(TestNG.java:1301)
2023-09-20T22:50:59.3914785Z 	at org.testng.TestNG.runSuitesLocally(TestNG.java:1226)
2023-09-20T22:50:59.3915317Z 	at org.testng.TestNG.runSuites(TestNG.java:1144)
2023-09-20T22:50:59.3915680Z 	at org.testng.TestNG.run(TestNG.java:1115)
2023-09-20T22:50:59.3916093Z 	at org.apache.maven.surefire.testng.TestNGExecutor.run(TestNGExecutor.java:136)
2023-09-20T22:50:59.3916752Z 	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.executeSingleClass(TestNGDirectoryTestSuite.java:112)
2023-09-20T22:50:59.3917470Z 	at org.apache.maven.surefire.testng.TestNGDirectoryTestSuite.execute(TestNGDirectoryTestSuite.java:99)
2023-09-20T22:50:59.3918400Z 	at org.apache.maven.surefire.testng.TestNGProvider.invoke(TestNGProvider.java:145)
2023-09-20T22:50:59.3918928Z 	at org.apache.maven.surefire.booter.ForkedBooter.runSuitesInProcess(ForkedBooter.java:428)
2023-09-20T22:50:59.3919453Z 	at org.apache.maven.surefire.booter.ForkedBooter.execute(ForkedBooter.java:162)
2023-09-20T22:50:59.3919921Z 	at org.apache.maven.surefire.booter.ForkedBooter.run(ForkedBooter.java:562)
2023-09-20T22:50:59.3920378Z 	at org.apache.maven.surefire.booter.ForkedBooter.main(ForkedBooter.java:548)
2023-09-20T22:50:59.3920847Z Caused by: java.lang.RuntimeException: java.io.IOException: Failed to bind to address 0.0.0.0/0.0.0.0:43533
2023-09-20T22:50:59.3921323Z 	at org.apache.pinot.query.service.server.QueryServer.start(QueryServer.java:80)
2023-09-20T22:50:59.3921822Z 	at org.apache.pinot.server.worker.WorkerQueryServer.start(WorkerQueryServer.java:90)
2023-09-20T22:50:59.3922172Z 	... 36 more
2023-09-20T22:50:59.3922456Z Caused by: java.io.IOException: Failed to bind to address 0.0.0.0/0.0.0.0:43533
2023-09-20T22:50:59.3922857Z 	at io.grpc.netty.shaded.io.grpc.netty.NettyServer.start(NettyServer.java:328)
2023-09-20T22:50:59.3923269Z 	at io.grpc.internal.ServerImpl.start(ServerImpl.java:184)
2023-09-20T22:50:59.3928649Z 	at io.grpc.internal.ServerImpl.start(ServerImpl.java:93)
2023-09-20T22:50:59.3929350Z 	at org.apache.pinot.query.service.server.QueryServer.start(QueryServer.java:78)
2023-09-20T22:50:59.3929916Z 	... 37 more
2023-09-20T22:50:59.3930318Z Caused by: io.grpc.netty.shaded.io.netty.channel.unix.Errors$NativeIoException: bind(..) failed: Address already in use
```