### PR TITLE
Support excluding time values in SimpleSegmentNameGenerator

### DIFF
--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
@@ -65,6 +65,7 @@ public class SegmentGenerationTaskRunner implements Serializable {
   public static final String DEPRECATED_USE_LOCAL_DIRECTORY_SEQUENCE_ID = "local.directory.sequence.id";
   public static final String USE_GLOBAL_DIRECTORY_SEQUENCE_ID = "use.global.directory.sequence.id";
   public static final String APPEND_UUID_TO_SEGMENT_NAME = "append.uuid.to.segment.name";
+  public static final String OMIT_TIMESTAMPS_IN_SEGMENT_NAME = "omit.timestamps.in.segment.name";
 
   private final SegmentGenerationTaskSpec _taskSpec;
 
@@ -134,13 +135,15 @@ public class SegmentGenerationTaskRunner implements Serializable {
 
     boolean appendUUIDToSegmentName =
         Boolean.parseBoolean(segmentNameGeneratorConfigs.get(APPEND_UUID_TO_SEGMENT_NAME));
+    boolean omitTimestampsInSegmentName =
+        Boolean.parseBoolean(segmentNameGeneratorConfigs.get(OMIT_TIMESTAMPS_IN_SEGMENT_NAME));
 
     switch (segmentNameGeneratorType) {
       case BatchConfigProperties.SegmentNameGeneratorType.FIXED:
         return new FixedSegmentNameGenerator(segmentNameGeneratorConfigs.get(SEGMENT_NAME));
       case BatchConfigProperties.SegmentNameGeneratorType.SIMPLE:
         return new SimpleSegmentNameGenerator(tableName, segmentNameGeneratorConfigs.get(SEGMENT_NAME_POSTFIX),
-            appendUUIDToSegmentName);
+            appendUUIDToSegmentName, omitTimestampsInSegmentName);
       case BatchConfigProperties.SegmentNameGeneratorType.NORMALIZED_DATE:
         SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
         DateTimeFormatSpec dateTimeFormatSpec = null;

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
@@ -65,7 +65,7 @@ public class SegmentGenerationTaskRunner implements Serializable {
   public static final String DEPRECATED_USE_LOCAL_DIRECTORY_SEQUENCE_ID = "local.directory.sequence.id";
   public static final String USE_GLOBAL_DIRECTORY_SEQUENCE_ID = "use.global.directory.sequence.id";
   public static final String APPEND_UUID_TO_SEGMENT_NAME = "append.uuid.to.segment.name";
-  public static final String EXCLUDE_TIMESTAMPS_IN_SEGMENT_NAME = "exclude.timestamps.in.segment.name";
+  public static final String EXCLUDE_TIME_IN_SEGMENT_NAME = BatchConfigProperties.EXCLUDE_TIME_IN_SEGMENT_NAME;
 
   private final SegmentGenerationTaskSpec _taskSpec;
 
@@ -135,15 +135,15 @@ public class SegmentGenerationTaskRunner implements Serializable {
 
     boolean appendUUIDToSegmentName =
         Boolean.parseBoolean(segmentNameGeneratorConfigs.get(APPEND_UUID_TO_SEGMENT_NAME));
-    boolean excludeTimestampsInSegmentName =
-        Boolean.parseBoolean(segmentNameGeneratorConfigs.get(EXCLUDE_TIMESTAMPS_IN_SEGMENT_NAME));
+    boolean excludeTimeInSegmentName =
+        Boolean.parseBoolean(segmentNameGeneratorConfigs.get(EXCLUDE_TIME_IN_SEGMENT_NAME));
 
     switch (segmentNameGeneratorType) {
       case BatchConfigProperties.SegmentNameGeneratorType.FIXED:
         return new FixedSegmentNameGenerator(segmentNameGeneratorConfigs.get(SEGMENT_NAME));
       case BatchConfigProperties.SegmentNameGeneratorType.SIMPLE:
         return new SimpleSegmentNameGenerator(tableName, segmentNameGeneratorConfigs.get(SEGMENT_NAME_POSTFIX),
-            appendUUIDToSegmentName, excludeTimestampsInSegmentName);
+            appendUUIDToSegmentName, excludeTimeInSegmentName);
       case BatchConfigProperties.SegmentNameGeneratorType.NORMALIZED_DATE:
         SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
         DateTimeFormatSpec dateTimeFormatSpec = null;

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-common/src/main/java/org/apache/pinot/plugin/ingestion/batch/common/SegmentGenerationTaskRunner.java
@@ -65,7 +65,7 @@ public class SegmentGenerationTaskRunner implements Serializable {
   public static final String DEPRECATED_USE_LOCAL_DIRECTORY_SEQUENCE_ID = "local.directory.sequence.id";
   public static final String USE_GLOBAL_DIRECTORY_SEQUENCE_ID = "use.global.directory.sequence.id";
   public static final String APPEND_UUID_TO_SEGMENT_NAME = "append.uuid.to.segment.name";
-  public static final String OMIT_TIMESTAMPS_IN_SEGMENT_NAME = "omit.timestamps.in.segment.name";
+  public static final String EXCLUDE_TIMESTAMPS_IN_SEGMENT_NAME = "exclude.timestamps.in.segment.name";
 
   private final SegmentGenerationTaskSpec _taskSpec;
 
@@ -135,15 +135,15 @@ public class SegmentGenerationTaskRunner implements Serializable {
 
     boolean appendUUIDToSegmentName =
         Boolean.parseBoolean(segmentNameGeneratorConfigs.get(APPEND_UUID_TO_SEGMENT_NAME));
-    boolean omitTimestampsInSegmentName =
-        Boolean.parseBoolean(segmentNameGeneratorConfigs.get(OMIT_TIMESTAMPS_IN_SEGMENT_NAME));
+    boolean excludeTimestampsInSegmentName =
+        Boolean.parseBoolean(segmentNameGeneratorConfigs.get(EXCLUDE_TIMESTAMPS_IN_SEGMENT_NAME));
 
     switch (segmentNameGeneratorType) {
       case BatchConfigProperties.SegmentNameGeneratorType.FIXED:
         return new FixedSegmentNameGenerator(segmentNameGeneratorConfigs.get(SEGMENT_NAME));
       case BatchConfigProperties.SegmentNameGeneratorType.SIMPLE:
         return new SimpleSegmentNameGenerator(tableName, segmentNameGeneratorConfigs.get(SEGMENT_NAME_POSTFIX),
-            appendUUIDToSegmentName, omitTimestampsInSegmentName);
+            appendUUIDToSegmentName, excludeTimestampsInSegmentName);
       case BatchConfigProperties.SegmentNameGeneratorType.NORMALIZED_DATE:
         SegmentsValidationAndRetentionConfig validationConfig = tableConfig.getValidationConfig();
         DateTimeFormatSpec dateTimeFormatSpec = null;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -167,7 +167,7 @@ public final class IngestionUtils {
 
       case BatchConfigProperties.SegmentNameGeneratorType.SIMPLE:
         return new SimpleSegmentNameGenerator(rawTableName, batchConfig.getSegmentNamePostfix(),
-            batchConfig.isAppendUUIDToSegmentName(), batchConfig.isExcludeTimestampsFromSegmentName());
+            batchConfig.isAppendUUIDToSegmentName(), batchConfig.isExcludeTimeFromSegmentName());
       default:
         throw new IllegalStateException(String
             .format("Unsupported segmentNameGeneratorType: %s for table: %s", segmentNameGeneratorType,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -167,7 +167,7 @@ public final class IngestionUtils {
 
       case BatchConfigProperties.SegmentNameGeneratorType.SIMPLE:
         return new SimpleSegmentNameGenerator(rawTableName, batchConfig.getSegmentNamePostfix(),
-            batchConfig.isAppendUUIDToSegmentName());
+            batchConfig.isAppendUUIDToSegmentName(), batchConfig.isOmitTimestampsFromSegmentName());
       default:
         throw new IllegalStateException(String
             .format("Unsupported segmentNameGeneratorType: %s for table: %s", segmentNameGeneratorType,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -167,7 +167,7 @@ public final class IngestionUtils {
 
       case BatchConfigProperties.SegmentNameGeneratorType.SIMPLE:
         return new SimpleSegmentNameGenerator(rawTableName, batchConfig.getSegmentNamePostfix(),
-            batchConfig.isAppendUUIDToSegmentName(), batchConfig.isOmitTimestampsFromSegmentName());
+            batchConfig.isAppendUUIDToSegmentName(), batchConfig.isExcludeTimestampsFromSegmentName());
       default:
         throw new IllegalStateException(String
             .format("Unsupported segmentNameGeneratorType: %s for table: %s", segmentNameGeneratorType,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/IngestionUtils.java
@@ -167,7 +167,7 @@ public final class IngestionUtils {
 
       case BatchConfigProperties.SegmentNameGeneratorType.SIMPLE:
         return new SimpleSegmentNameGenerator(rawTableName, batchConfig.getSegmentNamePostfix(),
-            batchConfig.isAppendUUIDToSegmentName(), batchConfig.isExcludeTimeFromSegmentName());
+            batchConfig.isAppendUUIDToSegmentName(), batchConfig.isExcludeTimeInSegmentName());
       default:
         throw new IllegalStateException(String
             .format("Unsupported segmentNameGeneratorType: %s for table: %s", segmentNameGeneratorType,

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
@@ -40,13 +40,14 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
   private final String _segmentNamePrefix;
   private final String _segmentNamePostfix;
   private final boolean _appendUUIDToSegmentName;
+  private final boolean _omitTimestampsInSegmentName;
 
   public SimpleSegmentNameGenerator(String segmentNamePrefix, @Nullable String segmentNamePostfix) {
-    this(segmentNamePrefix, segmentNamePostfix, false);
+    this(segmentNamePrefix, segmentNamePostfix, false, false);
   }
 
   public SimpleSegmentNameGenerator(String segmentNamePrefix, @Nullable String segmentNamePostfix,
-      boolean appendUUIDToSegmentName) {
+      boolean appendUUIDToSegmentName, boolean omitTimestampsInSegmentName) {
     Preconditions.checkArgument(segmentNamePrefix != null, "Missing segmentNamePrefix for SimpleSegmentNameGenerator");
     SegmentNameUtils.validatePartialOrFullSegmentName(segmentNamePrefix);
     if (segmentNamePostfix != null) {
@@ -55,6 +56,7 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
     _segmentNamePrefix = segmentNamePrefix;
     _segmentNamePostfix = segmentNamePostfix;
     _appendUUIDToSegmentName = appendUUIDToSegmentName;
+    _omitTimestampsInSegmentName = omitTimestampsInSegmentName;
   }
 
   @Override
@@ -66,8 +68,9 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
       SegmentNameUtils.validatePartialOrFullSegmentName(maxTimeValue.toString());
     }
 
-    return JOINER.join(_segmentNamePrefix, minTimeValue, maxTimeValue, _segmentNamePostfix,
-        sequenceId >= 0 ? sequenceId : null, _appendUUIDToSegmentName ? UUID.randomUUID() : null);
+    return JOINER.join(_segmentNamePrefix, _omitTimestampsInSegmentName ? null : minTimeValue,
+        _omitTimestampsInSegmentName ? null : maxTimeValue, _segmentNamePostfix, sequenceId >= 0 ? sequenceId : null,
+        _appendUUIDToSegmentName ? UUID.randomUUID() : null);
   }
 
   @Override
@@ -77,6 +80,8 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
     if (_segmentNamePostfix != null) {
       stringBuilder.append(", segmentNamePostfix=").append(_segmentNamePostfix);
     }
+    stringBuilder.append(", appendUUIDToSegmentName=").append(_appendUUIDToSegmentName);
+    stringBuilder.append(", omitTimestampsInSegmentName=").append(_omitTimestampsInSegmentName);
     return stringBuilder.toString();
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
@@ -40,14 +40,14 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
   private final String _segmentNamePrefix;
   private final String _segmentNamePostfix;
   private final boolean _appendUUIDToSegmentName;
-  private final boolean _omitTimestampsInSegmentName;
+  private final boolean _excludeTimestampsInSegmentName;
 
   public SimpleSegmentNameGenerator(String segmentNamePrefix, @Nullable String segmentNamePostfix) {
     this(segmentNamePrefix, segmentNamePostfix, false, false);
   }
 
   public SimpleSegmentNameGenerator(String segmentNamePrefix, @Nullable String segmentNamePostfix,
-      boolean appendUUIDToSegmentName, boolean omitTimestampsInSegmentName) {
+      boolean appendUUIDToSegmentName, boolean excludeTimestampsInSegmentName) {
     Preconditions.checkArgument(segmentNamePrefix != null, "Missing segmentNamePrefix for SimpleSegmentNameGenerator");
     SegmentNameUtils.validatePartialOrFullSegmentName(segmentNamePrefix);
     if (segmentNamePostfix != null) {
@@ -56,7 +56,7 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
     _segmentNamePrefix = segmentNamePrefix;
     _segmentNamePostfix = segmentNamePostfix;
     _appendUUIDToSegmentName = appendUUIDToSegmentName;
-    _omitTimestampsInSegmentName = omitTimestampsInSegmentName;
+    _excludeTimestampsInSegmentName = excludeTimestampsInSegmentName;
   }
 
   @Override
@@ -68,8 +68,8 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
       SegmentNameUtils.validatePartialOrFullSegmentName(maxTimeValue.toString());
     }
 
-    return JOINER.join(_segmentNamePrefix, _omitTimestampsInSegmentName ? null : minTimeValue,
-        _omitTimestampsInSegmentName ? null : maxTimeValue, _segmentNamePostfix, sequenceId >= 0 ? sequenceId : null,
+    return JOINER.join(_segmentNamePrefix, _excludeTimestampsInSegmentName ? null : minTimeValue,
+        _excludeTimestampsInSegmentName ? null : maxTimeValue, _segmentNamePostfix, sequenceId >= 0 ? sequenceId : null,
         _appendUUIDToSegmentName ? UUID.randomUUID() : null);
   }
 
@@ -81,7 +81,7 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
       stringBuilder.append(", segmentNamePostfix=").append(_segmentNamePostfix);
     }
     stringBuilder.append(", appendUUIDToSegmentName=").append(_appendUUIDToSegmentName);
-    stringBuilder.append(", omitTimestampsInSegmentName=").append(_omitTimestampsInSegmentName);
+    stringBuilder.append(", excludeTimestampsInSegmentName=").append(_excludeTimestampsInSegmentName);
     return stringBuilder.toString();
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGenerator.java
@@ -40,14 +40,14 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
   private final String _segmentNamePrefix;
   private final String _segmentNamePostfix;
   private final boolean _appendUUIDToSegmentName;
-  private final boolean _excludeTimestampsInSegmentName;
+  private final boolean _excludeTimeInSegmentName;
 
   public SimpleSegmentNameGenerator(String segmentNamePrefix, @Nullable String segmentNamePostfix) {
     this(segmentNamePrefix, segmentNamePostfix, false, false);
   }
 
   public SimpleSegmentNameGenerator(String segmentNamePrefix, @Nullable String segmentNamePostfix,
-      boolean appendUUIDToSegmentName, boolean excludeTimestampsInSegmentName) {
+      boolean appendUUIDToSegmentName, boolean excludeTimeInSegmentName) {
     Preconditions.checkArgument(segmentNamePrefix != null, "Missing segmentNamePrefix for SimpleSegmentNameGenerator");
     SegmentNameUtils.validatePartialOrFullSegmentName(segmentNamePrefix);
     if (segmentNamePostfix != null) {
@@ -56,21 +56,25 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
     _segmentNamePrefix = segmentNamePrefix;
     _segmentNamePostfix = segmentNamePostfix;
     _appendUUIDToSegmentName = appendUUIDToSegmentName;
-    _excludeTimestampsInSegmentName = excludeTimestampsInSegmentName;
+    _excludeTimeInSegmentName = excludeTimeInSegmentName;
   }
 
   @Override
   public String generateSegmentName(int sequenceId, @Nullable Object minTimeValue, @Nullable Object maxTimeValue) {
-    if (minTimeValue != null) {
-      SegmentNameUtils.validatePartialOrFullSegmentName(minTimeValue.toString());
-    }
-    if (maxTimeValue != null) {
-      SegmentNameUtils.validatePartialOrFullSegmentName(maxTimeValue.toString());
-    }
+    if (_excludeTimeInSegmentName) {
+      return JOINER.join(_segmentNamePrefix, _segmentNamePostfix, sequenceId >= 0 ? sequenceId : null,
+          _appendUUIDToSegmentName ? UUID.randomUUID().toString() : null);
+    } else {
+      if (minTimeValue != null) {
+        SegmentNameUtils.validatePartialOrFullSegmentName(minTimeValue.toString());
+      }
+      if (maxTimeValue != null) {
+        SegmentNameUtils.validatePartialOrFullSegmentName(maxTimeValue.toString());
+      }
 
-    return JOINER.join(_segmentNamePrefix, _excludeTimestampsInSegmentName ? null : minTimeValue,
-        _excludeTimestampsInSegmentName ? null : maxTimeValue, _segmentNamePostfix, sequenceId >= 0 ? sequenceId : null,
-        _appendUUIDToSegmentName ? UUID.randomUUID() : null);
+      return JOINER.join(_segmentNamePrefix, minTimeValue, maxTimeValue, _segmentNamePostfix,
+          sequenceId >= 0 ? sequenceId : null, _appendUUIDToSegmentName ? UUID.randomUUID().toString() : null);
+    }
   }
 
   @Override
@@ -81,7 +85,7 @@ public class SimpleSegmentNameGenerator implements SegmentNameGenerator {
       stringBuilder.append(", segmentNamePostfix=").append(_segmentNamePostfix);
     }
     stringBuilder.append(", appendUUIDToSegmentName=").append(_appendUUIDToSegmentName);
-    stringBuilder.append(", excludeTimestampsInSegmentName=").append(_excludeTimestampsInSegmentName);
+    stringBuilder.append(", excludeTimeInSegmentName=").append(_excludeTimeInSegmentName);
     return stringBuilder.toString();
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGeneratorTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGeneratorTest.java
@@ -40,7 +40,7 @@ public class SimpleSegmentNameGeneratorTest {
     SegmentNameGenerator segmentNameGenerator = new SimpleSegmentNameGenerator(TABLE_NAME, null);
     assertEquals(segmentNameGenerator.toString(),
         "SimpleSegmentNameGenerator: tableName=testTable, appendUUIDToSegmentName=false, "
-            + "omitTimestampsInSegmentName=false");
+            + "excludeTimestampsInSegmentName=false");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, null, null), "testTable");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE),
         "testTable_1234_5678");
@@ -54,7 +54,7 @@ public class SimpleSegmentNameGeneratorTest {
     SegmentNameGenerator segmentNameGenerator = new SimpleSegmentNameGenerator(TABLE_NAME, SEGMENT_NAME_POSTFIX);
     assertEquals(segmentNameGenerator.toString(),
         "SimpleSegmentNameGenerator: tableName=testTable, segmentNamePostfix=postfix, appendUUIDToSegmentName=false, "
-            + "omitTimestampsInSegmentName=false");
+            + "excludeTimestampsInSegmentName=false");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, null, null), "testTable_postfix");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE),
         "testTable_1234_5678_postfix");
@@ -88,12 +88,12 @@ public class SimpleSegmentNameGeneratorTest {
   }
 
   @Test
-  public void testWithOmitTimestampsInSegmentName() {
+  public void testWithExcludeTimestampsInSegmentName() {
     SegmentNameGenerator segmentNameGenerator = new SimpleSegmentNameGenerator(TABLE_NAME, null, false, true);
     segmentNameGenerator.generateSegmentName(VALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE);
     assertEquals(segmentNameGenerator.toString(),
         "SimpleSegmentNameGenerator: tableName=testTable, appendUUIDToSegmentName=false, "
-            + "omitTimestampsInSegmentName=true");
+            + "excludeTimestampsInSegmentName=true");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, null, null), "testTable");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE),
         "testTable");

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGeneratorTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGeneratorTest.java
@@ -38,7 +38,9 @@ public class SimpleSegmentNameGeneratorTest {
   @Test
   public void testWithoutSegmentNamePostfix() {
     SegmentNameGenerator segmentNameGenerator = new SimpleSegmentNameGenerator(TABLE_NAME, null);
-    assertEquals(segmentNameGenerator.toString(), "SimpleSegmentNameGenerator: tableName=testTable");
+    assertEquals(segmentNameGenerator.toString(),
+        "SimpleSegmentNameGenerator: tableName=testTable, appendUUIDToSegmentName=false, "
+            + "omitTimestampsInSegmentName=false");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, null, null), "testTable");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE),
         "testTable_1234_5678");
@@ -51,7 +53,8 @@ public class SimpleSegmentNameGeneratorTest {
   public void testWithSegmentNamePostfix() {
     SegmentNameGenerator segmentNameGenerator = new SimpleSegmentNameGenerator(TABLE_NAME, SEGMENT_NAME_POSTFIX);
     assertEquals(segmentNameGenerator.toString(),
-        "SimpleSegmentNameGenerator: tableName=testTable, segmentNamePostfix=postfix");
+        "SimpleSegmentNameGenerator: tableName=testTable, segmentNamePostfix=postfix, appendUUIDToSegmentName=false, "
+            + "omitTimestampsInSegmentName=false");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, null, null), "testTable_postfix");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE),
         "testTable_1234_5678_postfix");
@@ -82,5 +85,20 @@ public class SimpleSegmentNameGeneratorTest {
       // Expected
       assertEquals(e.getMessage(), "Invalid partial or full segment name: 12|34");
     }
+  }
+
+  @Test
+  public void testWithOmitTimestampsInSegmentName() {
+    SegmentNameGenerator segmentNameGenerator = new SimpleSegmentNameGenerator(TABLE_NAME, null, false, true);
+    segmentNameGenerator.generateSegmentName(VALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE);
+    assertEquals(segmentNameGenerator.toString(),
+        "SimpleSegmentNameGenerator: tableName=testTable, appendUUIDToSegmentName=false, "
+            + "omitTimestampsInSegmentName=true");
+    assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, null, null), "testTable");
+    assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE),
+        "testTable");
+    assertEquals(segmentNameGenerator.generateSegmentName(VALID_SEQUENCE_ID, null, null), "testTable_0");
+    assertEquals(segmentNameGenerator.generateSegmentName(VALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE),
+        "testTable_0");
   }
 }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGeneratorTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGeneratorTest.java
@@ -88,7 +88,7 @@ public class SimpleSegmentNameGeneratorTest {
   }
 
   @Test
-  public void testWithexcludeTimeInSegmentName() {
+  public void testWithExcludeTimeInSegmentName() {
     SegmentNameGenerator segmentNameGenerator = new SimpleSegmentNameGenerator(TABLE_NAME, null, false, true);
     segmentNameGenerator.generateSegmentName(VALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE);
     assertEquals(segmentNameGenerator.toString(),

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGeneratorTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/creator/name/SimpleSegmentNameGeneratorTest.java
@@ -40,7 +40,7 @@ public class SimpleSegmentNameGeneratorTest {
     SegmentNameGenerator segmentNameGenerator = new SimpleSegmentNameGenerator(TABLE_NAME, null);
     assertEquals(segmentNameGenerator.toString(),
         "SimpleSegmentNameGenerator: tableName=testTable, appendUUIDToSegmentName=false, "
-            + "excludeTimestampsInSegmentName=false");
+            + "excludeTimeInSegmentName=false");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, null, null), "testTable");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE),
         "testTable_1234_5678");
@@ -54,7 +54,7 @@ public class SimpleSegmentNameGeneratorTest {
     SegmentNameGenerator segmentNameGenerator = new SimpleSegmentNameGenerator(TABLE_NAME, SEGMENT_NAME_POSTFIX);
     assertEquals(segmentNameGenerator.toString(),
         "SimpleSegmentNameGenerator: tableName=testTable, segmentNamePostfix=postfix, appendUUIDToSegmentName=false, "
-            + "excludeTimestampsInSegmentName=false");
+            + "excludeTimeInSegmentName=false");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, null, null), "testTable_postfix");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE),
         "testTable_1234_5678_postfix");
@@ -88,12 +88,12 @@ public class SimpleSegmentNameGeneratorTest {
   }
 
   @Test
-  public void testWithExcludeTimestampsInSegmentName() {
+  public void testWithexcludeTimeInSegmentName() {
     SegmentNameGenerator segmentNameGenerator = new SimpleSegmentNameGenerator(TABLE_NAME, null, false, true);
     segmentNameGenerator.generateSegmentName(VALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE);
     assertEquals(segmentNameGenerator.toString(),
         "SimpleSegmentNameGenerator: tableName=testTable, appendUUIDToSegmentName=false, "
-            + "excludeTimestampsInSegmentName=true");
+            + "excludeTimeInSegmentName=true");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, null, null), "testTable");
     assertEquals(segmentNameGenerator.generateSegmentName(INVALID_SEQUENCE_ID, MIN_TIME_VALUE, MAX_TIME_VALUE),
         "testTable");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfig.java
@@ -51,7 +51,7 @@ public class BatchConfig {
   private final String _segmentNamePostfix;
   private final boolean _excludeSequenceId;
   private final boolean _appendUUIDToSegmentName;
-  private final boolean _excludeTimeFromSegmentName;
+  private final boolean _excludeTimeInSegmentName;
   private final String _sequenceId;
 
   private final String _pushMode;
@@ -100,7 +100,7 @@ public class BatchConfig {
     _sequenceId = batchConfigsMap.get(BatchConfigProperties.SEQUENCE_ID);
     _appendUUIDToSegmentName =
         Boolean.parseBoolean(segmentNameGeneratorProps.get(BatchConfigProperties.APPEND_UUID_TO_SEGMENT_NAME));
-    _excludeTimeFromSegmentName =
+    _excludeTimeInSegmentName =
         Boolean.parseBoolean(segmentNameGeneratorProps.get(BatchConfigProperties.EXCLUDE_TIME_IN_SEGMENT_NAME));
 
     _pushMode = IngestionConfigUtils.getPushMode(batchConfigsMap);
@@ -193,8 +193,8 @@ public class BatchConfig {
     return _appendUUIDToSegmentName;
   }
 
-  public boolean isExcludeTimeFromSegmentName() {
-    return _excludeTimeFromSegmentName;
+  public boolean isExcludeTimeInSegmentName() {
+    return _excludeTimeInSegmentName;
   }
 
   public String getPushMode() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfig.java
@@ -51,6 +51,7 @@ public class BatchConfig {
   private final String _segmentNamePostfix;
   private final boolean _excludeSequenceId;
   private final boolean _appendUUIDToSegmentName;
+  private final boolean _omitTimestampsFromSegmentName;
   private final String _sequenceId;
 
   private final String _pushMode;
@@ -85,12 +86,12 @@ public class BatchConfig {
 
     _recordReaderClassName = batchConfigsMap.get(BatchConfigProperties.RECORD_READER_CLASS);
     _recordReaderConfigClassName = batchConfigsMap.get(BatchConfigProperties.RECORD_READER_CONFIG_CLASS);
-    _recordReaderProps = IngestionConfigUtils
-        .extractPropsMatchingPrefix(batchConfigsMap, BatchConfigProperties.RECORD_READER_PROP_PREFIX);
+    _recordReaderProps = IngestionConfigUtils.extractPropsMatchingPrefix(batchConfigsMap,
+        BatchConfigProperties.RECORD_READER_PROP_PREFIX);
 
     _segmentNameGeneratorType = IngestionConfigUtils.getSegmentNameGeneratorType(batchConfigsMap);
-    _segmentNameGeneratorConfigs = IngestionConfigUtils
-        .extractPropsMatchingPrefix(batchConfigsMap, BatchConfigProperties.SEGMENT_NAME_GENERATOR_PROP_PREFIX);
+    _segmentNameGeneratorConfigs = IngestionConfigUtils.extractPropsMatchingPrefix(batchConfigsMap,
+        BatchConfigProperties.SEGMENT_NAME_GENERATOR_PROP_PREFIX);
     Map<String, String> segmentNameGeneratorProps = IngestionConfigUtils.getSegmentNameGeneratorProps(batchConfigsMap);
     _segmentName = segmentNameGeneratorProps.get(BatchConfigProperties.SEGMENT_NAME);
     _segmentNamePrefix = segmentNameGeneratorProps.get(BatchConfigProperties.SEGMENT_NAME_PREFIX);
@@ -99,6 +100,8 @@ public class BatchConfig {
     _sequenceId = batchConfigsMap.get(BatchConfigProperties.SEQUENCE_ID);
     _appendUUIDToSegmentName =
         Boolean.parseBoolean(segmentNameGeneratorProps.get(BatchConfigProperties.APPEND_UUID_TO_SEGMENT_NAME));
+    _omitTimestampsFromSegmentName =
+        Boolean.parseBoolean(segmentNameGeneratorProps.get(BatchConfigProperties.OMIT_TIMESTAMPS_IN_SEGMENT_NAME));
 
     _pushMode = IngestionConfigUtils.getPushMode(batchConfigsMap);
     _pushAttempts = IngestionConfigUtils.getPushAttempts(batchConfigsMap);
@@ -188,6 +191,10 @@ public class BatchConfig {
 
   public boolean isAppendUUIDToSegmentName() {
     return _appendUUIDToSegmentName;
+  }
+
+  public boolean isOmitTimestampsFromSegmentName() {
+    return _omitTimestampsFromSegmentName;
   }
 
   public String getPushMode() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfig.java
@@ -51,7 +51,7 @@ public class BatchConfig {
   private final String _segmentNamePostfix;
   private final boolean _excludeSequenceId;
   private final boolean _appendUUIDToSegmentName;
-  private final boolean _excludeTimestampsFromSegmentName;
+  private final boolean _excludeTimeFromSegmentName;
   private final String _sequenceId;
 
   private final String _pushMode;
@@ -100,8 +100,8 @@ public class BatchConfig {
     _sequenceId = batchConfigsMap.get(BatchConfigProperties.SEQUENCE_ID);
     _appendUUIDToSegmentName =
         Boolean.parseBoolean(segmentNameGeneratorProps.get(BatchConfigProperties.APPEND_UUID_TO_SEGMENT_NAME));
-    _excludeTimestampsFromSegmentName =
-        Boolean.parseBoolean(segmentNameGeneratorProps.get(BatchConfigProperties.EXCLUDE_TIMESTAMPS_IN_SEGMENT_NAME));
+    _excludeTimeFromSegmentName =
+        Boolean.parseBoolean(segmentNameGeneratorProps.get(BatchConfigProperties.EXCLUDE_TIME_IN_SEGMENT_NAME));
 
     _pushMode = IngestionConfigUtils.getPushMode(batchConfigsMap);
     _pushAttempts = IngestionConfigUtils.getPushAttempts(batchConfigsMap);
@@ -193,8 +193,8 @@ public class BatchConfig {
     return _appendUUIDToSegmentName;
   }
 
-  public boolean isExcludeTimestampsFromSegmentName() {
-    return _excludeTimestampsFromSegmentName;
+  public boolean isExcludeTimeFromSegmentName() {
+    return _excludeTimeFromSegmentName;
   }
 
   public String getPushMode() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfig.java
@@ -51,7 +51,7 @@ public class BatchConfig {
   private final String _segmentNamePostfix;
   private final boolean _excludeSequenceId;
   private final boolean _appendUUIDToSegmentName;
-  private final boolean _omitTimestampsFromSegmentName;
+  private final boolean _excludeTimestampsFromSegmentName;
   private final String _sequenceId;
 
   private final String _pushMode;
@@ -100,8 +100,8 @@ public class BatchConfig {
     _sequenceId = batchConfigsMap.get(BatchConfigProperties.SEQUENCE_ID);
     _appendUUIDToSegmentName =
         Boolean.parseBoolean(segmentNameGeneratorProps.get(BatchConfigProperties.APPEND_UUID_TO_SEGMENT_NAME));
-    _omitTimestampsFromSegmentName =
-        Boolean.parseBoolean(segmentNameGeneratorProps.get(BatchConfigProperties.OMIT_TIMESTAMPS_IN_SEGMENT_NAME));
+    _excludeTimestampsFromSegmentName =
+        Boolean.parseBoolean(segmentNameGeneratorProps.get(BatchConfigProperties.EXCLUDE_TIMESTAMPS_IN_SEGMENT_NAME));
 
     _pushMode = IngestionConfigUtils.getPushMode(batchConfigsMap);
     _pushAttempts = IngestionConfigUtils.getPushAttempts(batchConfigsMap);
@@ -193,8 +193,8 @@ public class BatchConfig {
     return _appendUUIDToSegmentName;
   }
 
-  public boolean isOmitTimestampsFromSegmentName() {
-    return _omitTimestampsFromSegmentName;
+  public boolean isExcludeTimestampsFromSegmentName() {
+    return _excludeTimestampsFromSegmentName;
   }
 
   public String getPushMode() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
@@ -62,6 +62,7 @@ public class BatchConfigProperties {
   public static final String FAIL_ON_EMPTY_SEGMENT = "fail.on.empty.segment";
   public static final String AUTH_TOKEN = "authToken";
   public static final String APPEND_UUID_TO_SEGMENT_NAME = "append.uuid.to.segment.name";
+  public static final String OMIT_TIMESTAMPS_IN_SEGMENT_NAME = "omit.timestamps.in.segment.name";
 
   public static final String OUTPUT_SEGMENT_DIR_URI = "output.segment.dir.uri";
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
@@ -62,7 +62,7 @@ public class BatchConfigProperties {
   public static final String FAIL_ON_EMPTY_SEGMENT = "fail.on.empty.segment";
   public static final String AUTH_TOKEN = "authToken";
   public static final String APPEND_UUID_TO_SEGMENT_NAME = "append.uuid.to.segment.name";
-  public static final String EXCLUDE_TIMESTAMPS_IN_SEGMENT_NAME = "exclude.timestamps.in.segment.name";
+  public static final String EXCLUDE_TIME_IN_SEGMENT_NAME = "exclude.time.in.segment.name";
 
   public static final String OUTPUT_SEGMENT_DIR_URI = "output.segment.dir.uri";
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/ingestion/batch/BatchConfigProperties.java
@@ -62,7 +62,7 @@ public class BatchConfigProperties {
   public static final String FAIL_ON_EMPTY_SEGMENT = "fail.on.empty.segment";
   public static final String AUTH_TOKEN = "authToken";
   public static final String APPEND_UUID_TO_SEGMENT_NAME = "append.uuid.to.segment.name";
-  public static final String OMIT_TIMESTAMPS_IN_SEGMENT_NAME = "omit.timestamps.in.segment.name";
+  public static final String EXCLUDE_TIMESTAMPS_IN_SEGMENT_NAME = "exclude.timestamps.in.segment.name";
 
   public static final String OUTPUT_SEGMENT_DIR_URI = "output.segment.dir.uri";
 


### PR DESCRIPTION
Related to https://github.com/apache/pinot/issues/11649

We use the `normalizedDate` segment name generator for an append table w/ a time column. The generators add a min/max time value to the segment name (ex. `example_table_2023-09-22_2023-10-02_46`). We had a user backfill their batch jobs overwriting existing data. Some of the upstream data had changed as part of this backfill which caused the min/max time value in the segment name to also change. This caused inconsistent data since some new segments didn't replace thier old ones.

This PR adds param `omit.timestamps.in.segment.name` to the SimpleSegmentNameGenerator to omit time values from the segment name. I've only added this to the simple generator since it doesn't seem intuitive to have the `normalizedDate` generator omit timestamps. We plan to create segments w/ this generator by including the execution date for the batch run (ex. `example_table_20230928_46`) since it will give us a consistent set of segment file names as long as the # of input files is the same.

I've updated the unit tests. It seems like the best place to write an end to end test might be in https://github.com/apache/pinot/blob/master/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-standalone/src/test/java/org/apache/pinot/plugin/ingestion/batch/standalone/SegmentGenerationJobRunnerTest.java Let me know if that's desired.

Long-term, it seems ideal that we'd use https://docs.pinot.apache.org/operators/operating-pinot/consistent-push-and-rollback for re-running segment creation on a given day so users aren't contrained on how the input data is structured.

cc @Jackie-Jiang 