### PR TITLE
Allow GcsPinotFS to work with granular permissions

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -315,7 +315,8 @@ public class GcsPinotFS extends BasePinotFS {
     try {
       // Return true if folder was not explicitly created but is a prefix of one or more files.
       // Use lazy iterable iterateAll() and verify that the iterator has elements.
-      return getBucket(gcsUri).list(Storage.BlobListOption.prefix(prefix)).iterateAll().iterator().hasNext();
+      return _storage.list(gcsUri.getBucketName(), Storage.BlobListOption.prefix(prefix)).iterateAll().iterator()
+          .hasNext();
     } catch (Exception t) {
       throw new IOException(t);
     }
@@ -332,7 +333,7 @@ public class GcsPinotFS extends BasePinotFS {
     if (prefix.equals(GcsUri.DELIMITER)) {
       page = getBucket(gcsUri).list();
     } else {
-      page = getBucket(gcsUri).list(Storage.BlobListOption.prefix(prefix));
+      page = _storage.list(gcsUri.getBucketName(), Storage.BlobListOption.prefix(prefix));
     }
     for (Blob blob : page.iterateAll()) {
       if (blob.getName().equals(prefix)) {
@@ -388,7 +389,7 @@ public class GcsPinotFS extends BasePinotFS {
         if (prefix.equals(GcsUri.DELIMITER)) {
           page = getBucket(segmentUri).list();
         } else {
-          page = getBucket(segmentUri).list(Storage.BlobListOption.prefix(prefix));
+          page = _storage.list(segmentUri.getBucketName(), Storage.BlobListOption.prefix(prefix));
         }
         return batchDelete(page);
       } else {
@@ -427,7 +428,8 @@ public class GcsPinotFS extends BasePinotFS {
   private boolean copyFile(GcsUri srcUri, GcsUri dstUri)
       throws IOException {
     Blob blob = getBlob(srcUri);
-    Blob newBlob = getBucket(dstUri).create(dstUri.getPath(), new byte[0]);
+    Blob newBlob =
+        _storage.create(BlobInfo.newBuilder(BlobId.of(dstUri.getBucketName(), dstUri.getPath())).build(), new byte[0]);
     CopyWriter copyWriter = blob.copyTo(newBlob.getBlobId());
     copyWriter.getResult();
     return copyWriter.isDone() && blob.exists();

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -307,7 +307,7 @@ public class GcsPinotFS extends BasePinotFS {
     if (prefix.isEmpty()) {
       return true;
     }
-    Blob blob = _storage.get(BlobId.of(gcsUri.getBucketName(), gcsUri.getPath()));
+    Blob blob = _storage.get(BlobId.of(gcsUri.getBucketName(), prefix));
     if (existsBlob(blob)) {
       return true;
     }

--- a/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/src/main/java/org/apache/pinot/plugin/filesystem/GcsPinotFS.java
@@ -102,7 +102,8 @@ public class GcsPinotFS extends BasePinotFS {
       if (existsDirectoryOrBucket(gcsUri)) {
         return true;
       }
-      Blob blob = getBucket(gcsUri).create(directoryPath, new byte[0]);
+      Blob blob =
+          _storage.create(BlobInfo.newBuilder(BlobId.of(gcsUri.getBucketName(), directoryPath)).build(), new byte[0]);
       return blob.exists();
     } catch (Exception e) {
       throw new IOException(e);
@@ -274,7 +275,7 @@ public class GcsPinotFS extends BasePinotFS {
   private Blob getBlob(GcsUri gcsUri)
       throws IOException {
     try {
-      return getBucket(gcsUri).get(gcsUri.getPath());
+      return _storage.get(BlobId.of(gcsUri.getBucketName(), gcsUri.getPath()));
     } catch (StorageException e) {
       throw new IOException(e);
     }
@@ -306,7 +307,7 @@ public class GcsPinotFS extends BasePinotFS {
     if (prefix.isEmpty()) {
       return true;
     }
-    Blob blob = getBucket(gcsUri).get(prefix);
+    Blob blob = _storage.get(BlobId.of(gcsUri.getBucketName(), gcsUri.getPath()));
     if (existsBlob(blob)) {
       return true;
     }


### PR DESCRIPTION
When GcsPinotFS is initialised with credentials that only have a folder level access, most operations (eg: copyToLocalFile) fail with

```
java.io.IOException: com.google.cloud.storage.StorageException: <account> does not have storage.buckets.get access to the Google Cloud Storage bucket. Permission 'storage.buckets.get' denied on resource (or it may not exist).
        at org.apache.pinot.plugin.filesystem.GcsPinotFS.getBlob(GcsPinotFS.java:279) 
        at org.apache.pinot.plugin.filesystem.GcsPinotFS.copyToLocalFile(GcsPinotFS.java:216) 
        ....
        
Caused by: com.google.cloud.storage.StorageException: startree-poc@production-267908.iam.gserviceaccount.com does not have storage.buckets.get access to the Google Cloud Storage bucket. Permission 'storage.buckets.get' denied on resource (or it may not exist).
        at com.google.cloud.storage.spi.v1.HttpStorageRpc.translate(HttpStorageRpc.java:231) 
        at com.google.cloud.storage.spi.v1.HttpStorageRpc.get(HttpStorageRpc.java:423) 
        at com.google.cloud.storage.StorageImpl$4.call(StorageImpl.java:297) 
        at com.google.cloud.storage.StorageImpl$4.call(StorageImpl.java:294) 
        at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:103) 
        at com.google.cloud.RetryHelper.run(RetryHelper.java:76) 
        at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50) 
        at com.google.cloud.storage.StorageImpl.get(StorageImpl.java:293) 
        at org.apache.pinot.plugin.filesystem.GcsPinotFS.getBucket(GcsPinotFS.java:271) 
        at org.apache.pinot.plugin.filesystem.GcsPinotFS.getBlob(GcsPinotFS.java:277) 
        ... 16 more
Caused by: com.google.api.client.googleapis.json.GoogleJsonResponseException: 403 Forbidden
GET https://storage.googleapis.com/storage/v1/b/platform-poc-data?projection=full
{
  "code" : 403,
  "errors" : [ {
    "domain" : "global",
    "message" : "<account> does not have storage.buckets.get access to the Google Cloud Storage bucket. Permission 'storage.buckets.get' denied on resource (or it may not exist).",
    "reason" : "forbidden"
  } ],
  "message" : "<account> does not have storage.buckets.get access to the Google Cloud Storage bucket. Permission 'storage.buckets.get' denied on resource (or it may not exist)."
}
        at com.google.api.client.googleapis.json.GoogleJsonResponseException.from(GoogleJsonResponseException.java:149) 
        at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:112) 
        at com.google.api.client.googleapis.services.json.AbstractGoogleJsonClientRequest.newExceptionOnError(AbstractGoogleJsonClientRequest.java:39) 
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest$1.interceptResponse(AbstractGoogleClientRequest.java:443) 
        at com.google.api.client.http.HttpRequest.execute(HttpRequest.java:1111) 
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:541) 
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.executeUnparsed(AbstractGoogleClientRequest.java:474) 
        at com.google.api.client.googleapis.services.AbstractGoogleClientRequest.execute(AbstractGoogleClientRequest.java:591) 
        at com.google.cloud.storage.spi.v1.HttpStorageRpc.get(HttpStorageRpc.java:420) 
        at com.google.cloud.storage.StorageImpl$4.call(StorageImpl.java:297) 
        at com.google.cloud.storage.StorageImpl$4.call(StorageImpl.java:294) 
        at com.google.api.gax.retrying.DirectRetryingExecutor.submit(DirectRetryingExecutor.java:103) 
        at com.google.cloud.RetryHelper.run(RetryHelper.java:76) 
        at com.google.cloud.RetryHelper.runWithRetries(RetryHelper.java:50) 
        at com.google.cloud.storage.StorageImpl.get(StorageImpl.java:293) 
        at org.apache.pinot.plugin.filesystem.GcsPinotFS.getBucket(GcsPinotFS.java:271) 
        at org.apache.pinot.plugin.filesystem.GcsPinotFS.getBlob(GcsPinotFS.java:277) 
        ... 16 more
  ```
  
This is due to each file access trying to first get `Bucket` object when downloading the file. We need to support cases where we may not have bucket level access but its still possible to download the file.