### PR TITLE
Do not execute spotless in Java 21

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -62,35 +62,6 @@
         <artifactId>protobuf-maven-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.28.0</version>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <java>
-            <includes>
-              <include>src/main/java/**/*.java</include>
-              <include>src/test/java/**/*.java</include>
-            </includes>
-            <excludes>
-              <exclude>src/main/java/org/apache/pinot/common/request/*.java</exclude>
-              <exclude>src/main/java/org/apache/pinot/common/response/ProcessingException.java</exclude>
-            </excludes>
-            <importOrder>
-              <order>,\#</order>
-            </importOrder>
-            <removeUnusedImports/>
-          </java>
-        </configuration>
-      </plugin>
-      <plugin>
         <!-- Extract parser grammar template from calcite-core.jar and put
              it under ${project.build.directory} where all freemarker templates are. -->
         <groupId>org.apache.maven.plugins</groupId>
@@ -178,6 +149,30 @@
         </executions>
       </plugin>
     </plugins>
+    <pluginManagement>
+      <plugins>
+        <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <configuration>
+            <java>
+              <includes>
+                <include>src/main/java/**/*.java</include>
+                <include>src/test/java/**/*.java</include>
+              </includes>
+              <excludes>
+                <exclude>src/main/java/org/apache/pinot/common/request/*.java</exclude>
+                <exclude>src/main/java/org/apache/pinot/common/response/ProcessingException.java</exclude>
+              </excludes>
+              <importOrder>
+                <order>,\#</order>
+              </importOrder>
+              <removeUnusedImports/>
+            </java>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
   </build>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -181,6 +181,20 @@
 
   <profiles>
     <profile>
+      <id>not-java-21</id>
+      <activation>
+        <jdk>!21</jdk>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>com.diffplug.spotless</groupId>
+            <artifactId>spotless-maven-plugin</artifactId>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>github-actions</id>
       <activation>
         <activeByDefault>false</activeByDefault>
@@ -1307,6 +1321,31 @@
     <pluginManagement>
       <plugins>
         <plugin>
+          <groupId>com.diffplug.spotless</groupId>
+          <artifactId>spotless-maven-plugin</artifactId>
+          <version>2.28.0</version>
+          <executions>
+            <execution>
+              <phase>verify</phase>
+              <goals>
+                <goal>check</goal>
+              </goals>
+            </execution>
+          </executions>
+          <configuration>
+            <java>
+              <includes>
+                <include>src/main/java/**/*.java</include>
+                <include>src/test/java/**/*.java</include>
+              </includes>
+              <importOrder>
+                <order>,\#</order>
+              </importOrder>
+              <removeUnusedImports/>
+            </java>
+          </configuration>
+        </plugin>
+        <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>appassembler-maven-plugin</artifactId>
           <version>1.10</version>
@@ -1640,31 +1679,6 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>sonar-maven-plugin</artifactId>
         <version>2.7.1</version>
-      </plugin>
-      <plugin>
-        <groupId>com.diffplug.spotless</groupId>
-        <artifactId>spotless-maven-plugin</artifactId>
-        <version>2.28.0</version>
-        <executions>
-          <execution>
-            <phase>verify</phase>
-            <goals>
-              <goal>check</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <java>
-            <includes>
-              <include>src/main/java/**/*.java</include>
-              <include>src/test/java/**/*.java</include>
-            </includes>
-            <importOrder>
-              <order>,\#</order>
-            </importOrder>
-            <removeUnusedImports/>
-          </java>
-        </configuration>
       </plugin>
       <plugin>
         <groupId>com.mycila</groupId>


### PR DESCRIPTION
The reason to be of this PR is to be able to progress on https://github.com/apache/pinot/issues/11656.

Spotless does not support Java 21 yet (see https://github.com/diffplug/spotless/pull/1822) so this PR moves the spotless usage to its own profile, which is active automatically if and only if the JVM being used is not 21. Once Spotless support Java 21 (probably when https://github.com/diffplug/spotless/pull/1822 is merged) we could just remove this profile and move the spotless config to the build->pluginManagement section.

### Why don't just disable spotless with `-Dspotless.skip`?

IT would be a great, but spotless doesn't work in that way. Even with that property set, spotless actually executes. What the flag controls is whether the pipeline should fail or not if spotless detects an issue in the code (like importing something that is not being used). When using Java 21, spotless throws an exception that is not caught, so it always aborts the maven execution, even if `-Dspotless.skip` is set.

This changes are included in https://github.com/apache/pinot/pull/11672, so we can decide to merge this alone or merge everything together.