### PR TITLE
Java 21 pipeline

### DIFF
--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -77,9 +77,9 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 17 ]
+        java: [ 11, 21 ]
         distribution: [ "corretto" ]
-        skip_bytebuffer: [false, true]
+        skip_bytebuffer: [false]
         include:
           - java: 21
             testset: 1
@@ -156,9 +156,9 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 17 ]
+        java: [ 11, 21 ]
         distribution: [ "corretto" ]
-        skip_bytebuffer: [false, true]
+        skip_bytebuffer: [false]
         include:
           - java: 21
             testset: 1
@@ -314,13 +314,13 @@ jobs:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false
       matrix:
-        java: [ 11, 17 ]
+        java: [ 11, 21 ]
         distribution: [ "corretto" ]
-        skip_bytebuffer: [false, true]
+        skip_bytebuffer: [false]
         include:
           - java: 21
             distribution: "corretto"
-            skip_bytebuffer: false
+            skip_bytebuffer: true
     name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }} with skip bytebuffers:${{matrix.skip_bytebuffer}}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -77,15 +77,12 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 17 ]
-        distribution: [ "temurin" ]
+        java: [ 11, 17, 21 ]
+        distribution: [ "corretto" ]
         prioritize_bytebuffer: [false]
         include:
-          - distribution: corretto
-            java: 21
-          - distribution: corretto
-            java: 21
-            prioritize_bytebuffer: true
+          - java: 21
+          - prioritize_bytebuffer: true
     name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
       - uses: actions/checkout@v3
@@ -153,15 +150,12 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 17 ]
-        distribution: [ "temurin" ]
+        java: [ 11, 17, 21 ]
+        distribution: [ "corretto" ]
         prioritize_bytebuffer: [false]
         include:
-          - distribution: corretto
-            java: 21
-          - distribution: corretto
-            java: 21
-            prioritize_bytebuffer: true
+          - java: 21
+          - prioritize_bytebuffer: true
     name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
       - uses: actions/checkout@v3
@@ -308,15 +302,13 @@ jobs:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false
       matrix:
-        java: [ 11, 17 ]
-        distribution: [ "temurin" ]
+        testset: [ 1, 2 ]
+        java: [ 11, 17, 21 ]
+        distribution: [ "corretto" ]
         prioritize_bytebuffer: [false]
         include:
-          - distribution: corretto
-            java: 21
-          - distribution: corretto
-            java: 21
-            prioritize_bytebuffer: true
+          - java: 21
+          - prioritize_bytebuffer: true
     name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -77,12 +77,19 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 17, 20 ]
+        java: [ 11, 17 ]
         distribution: [ "temurin" ]
+        prioritize_bytebuffer: [false]
+        include:
+          - distribution: corretto
+            java: 21
+          - distribution: corretto
+            java: 21
+            prioritize_bytebuffer: true
     name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK ${{ matrix.java }}
+      - name: Set up JDK ${{ matrix.java }}-${{ matrix.distribution }}
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
@@ -116,6 +123,7 @@ jobs:
         env:
           RUN_INTEGRATION_TESTS: false
           RUN_TEST_SET: ${{ matrix.testset }}
+          PINOT_OFFHEAP_PRIORITIZE_BYTEBUFFER: ${{ matrix.prioritize_bytebuffer }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
           MAVEN_OPTS: >
             -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
@@ -145,12 +153,19 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 17, 20 ]
+        java: [ 11, 17 ]
         distribution: [ "temurin" ]
+        prioritize_bytebuffer: [false]
+        include:
+          - distribution: corretto
+            java: 21
+          - distribution: corretto
+            java: 21
+            prioritize_bytebuffer: true
     name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
       - uses: actions/checkout@v3
-      - name: Set up JDK ${{ matrix.java }}
+      - name: Set up JDK ${{ matrix.java }}-${{ matrix.distribution }}
         uses: actions/setup-java@v3
         with:
           java-version: ${{ matrix.java }}
@@ -183,6 +198,7 @@ jobs:
         env:
           RUN_INTEGRATION_TESTS: true
           RUN_TEST_SET: ${{ matrix.testset }}
+          PINOT_OFFHEAP_PRIORITIZE_BYTEBUFFER: ${{ matrix.prioritize_bytebuffer }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
           MAVEN_OPTS: >
             -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
@@ -292,9 +308,16 @@ jobs:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false
       matrix:
-        java: [ 11, 17, 20 ]
+        java: [ 11, 17 ]
         distribution: [ "temurin" ]
-    name: Pinot Quickstart on JDK ${{ matrix.java }}
+        prioritize_bytebuffer: [false]
+        include:
+          - distribution: corretto
+            java: 21
+          - distribution: corretto
+            java: 21
+            prioritize_bytebuffer: true
+    name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}
@@ -314,4 +337,6 @@ jobs:
           restore-keys: |
             ${{ runner.os }}-maven-
       - name: Quickstart on JDK ${{ matrix.java }}
+        env:
+          PINOT_OFFHEAP_PRIORITIZE_BYTEBUFFER: ${{ matrix.prioritize_bytebuffer }}
         run: .github/workflows/scripts/.pinot_quickstart.sh

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -143,7 +143,7 @@ jobs:
         continue-on-error: true
         timeout-minutes: 5
         with:
-          flags: unittests,unittests${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
+          flags: unittests,unittests${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}},skip-bytebuffers-${{matrix.skip_bytebuffer}}
           name: codecov-unit-tests
           fail_ci_if_error: false
           verbose: true
@@ -221,7 +221,7 @@ jobs:
         continue-on-error: true
         timeout-minutes: 5
         with:
-          flags: integration,integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}}
+          flags: integration,integration${{ matrix.testset }},${{matrix.distribution}},java-${{matrix.java}},skip-bytebuffers-${{matrix.skip_bytebuffer}}
           name: codecov-integration-tests
           fail_ci_if_error: false
           verbose: true

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -82,7 +82,13 @@ jobs:
         prioritize_bytebuffer: [false]
         include:
           - java: 21
-          - prioritize_bytebuffer: true
+            testset: 1
+            distribution: "corretto"
+            prioritize_bytebuffer: true
+          - java: 21
+            testset: 2
+            distribution: "corretto"
+            prioritize_bytebuffer: true
     name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
       - uses: actions/checkout@v3
@@ -155,7 +161,13 @@ jobs:
         prioritize_bytebuffer: [false]
         include:
           - java: 21
-          - prioritize_bytebuffer: true
+            testset: 1
+            distribution: "corretto"
+            prioritize_bytebuffer: true
+          - java: 21
+            testset: 2
+            distribution: "corretto"
+            prioritize_bytebuffer: true
     name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
       - uses: actions/checkout@v3
@@ -308,7 +320,13 @@ jobs:
         prioritize_bytebuffer: [false]
         include:
           - java: 21
-          - prioritize_bytebuffer: true
+            testset: 1
+            distribution: "corretto"
+            prioritize_bytebuffer: true
+          - java: 21
+            testset: 2
+            distribution: "corretto"
+            prioritize_bytebuffer: true
     name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -77,18 +77,10 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 17, 21 ]
+        java: [ 11, 17 ]
         distribution: [ "corretto" ]
-        prioritize_bytebuffer: [false]
+        prioritize_bytebuffer: [false, true]
         include:
-          - java: 11
-            testset: 1
-            distribution: "corretto"
-            prioritize_bytebuffer: true
-          - java: 11
-            testset: 2
-            distribution: "corretto"
-            prioritize_bytebuffer: true
           - java: 21
             testset: 1
             distribution: "corretto"
@@ -164,18 +156,10 @@ jobs:
       fail-fast: false
       matrix:
         testset: [ 1, 2 ]
-        java: [ 11, 17, 21 ]
+        java: [ 11, 17 ]
         distribution: [ "corretto" ]
-        prioritize_bytebuffer: [false]
+        prioritize_bytebuffer: [false, true]
         include:
-          - java: 11
-            testset: 1
-            distribution: "corretto"
-            prioritize_bytebuffer: true
-          - java: 11
-            testset: 2
-            distribution: "corretto"
-            prioritize_bytebuffer: true
           - java: 21
             testset: 1
             distribution: "corretto"
@@ -330,13 +314,10 @@ jobs:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false
       matrix:
-        java: [ 11, 17, 21 ]
+        java: [ 11, 17 ]
         distribution: [ "corretto" ]
-        prioritize_bytebuffer: [false]
+        prioritize_bytebuffer: [false, true]
         include:
-          - java: 11
-            distribution: "corretto"
-            prioritize_bytebuffer: true
           - java: 21
             distribution: "corretto"
             prioritize_bytebuffer: false

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -79,17 +79,17 @@ jobs:
         testset: [ 1, 2 ]
         java: [ 11, 17 ]
         distribution: [ "corretto" ]
-        prioritize_bytebuffer: [false, true]
+        skip_bytebuffer: [false, true]
         include:
           - java: 21
             testset: 1
             distribution: "corretto"
-            prioritize_bytebuffer: false
+            skip_bytebuffer: true
           - java: 21
             testset: 2
             distribution: "corretto"
-            prioritize_bytebuffer: false
-    name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}}) with bytebuffers:${{matrix.prioritize_bytebuffer}}
+            skip_bytebuffer: true
+    name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}}) with skip bytebuffers:${{matrix.skip_bytebuffer}}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}-${{ matrix.distribution }}
@@ -126,7 +126,7 @@ jobs:
         env:
           RUN_INTEGRATION_TESTS: false
           RUN_TEST_SET: ${{ matrix.testset }}
-          PINOT_OFFHEAP_PRIORITIZE_BYTEBUFFER: ${{ matrix.prioritize_bytebuffer }}
+          PINOT_OFFHEAP_SKIP_BYTEBUFFER: ${{ matrix.skip_bytebuffer }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
           MAVEN_OPTS: >
             -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
@@ -158,17 +158,17 @@ jobs:
         testset: [ 1, 2 ]
         java: [ 11, 17 ]
         distribution: [ "corretto" ]
-        prioritize_bytebuffer: [false, true]
+        skip_bytebuffer: [false, true]
         include:
           - java: 21
             testset: 1
             distribution: "corretto"
-            prioritize_bytebuffer: false
+            skip_bytebuffer: true
           - java: 21
             testset: 2
             distribution: "corretto"
-            prioritize_bytebuffer: false
-    name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}}) with bytebuffers:${{matrix.prioritize_bytebuffer}}
+            skip_bytebuffer: true
+    name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}}) with skip bytebuffers:${{matrix.skip_bytebuffer}}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}-${{ matrix.distribution }}
@@ -204,7 +204,7 @@ jobs:
         env:
           RUN_INTEGRATION_TESTS: true
           RUN_TEST_SET: ${{ matrix.testset }}
-          PINOT_OFFHEAP_PRIORITIZE_BYTEBUFFER: ${{ matrix.prioritize_bytebuffer }}
+          PINOT_OFFHEAP_SKIP_BYTEBUFFER: ${{ matrix.skip_bytebuffer }}
           GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
           MAVEN_OPTS: >
             -Xmx2G -DskipShade -DfailIfNoTests=false -Dmaven.wagon.httpconnectionManager.ttlSeconds=25
@@ -316,12 +316,12 @@ jobs:
       matrix:
         java: [ 11, 17 ]
         distribution: [ "corretto" ]
-        prioritize_bytebuffer: [false, true]
+        skip_bytebuffer: [false, true]
         include:
           - java: 21
             distribution: "corretto"
-            prioritize_bytebuffer: false
-    name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }} with bytebuffers:${{matrix.prioritize_bytebuffer}}
+            skip_bytebuffer: false
+    name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }} with skip bytebuffers:${{matrix.skip_bytebuffer}}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}
@@ -342,5 +342,5 @@ jobs:
             ${{ runner.os }}-maven-
       - name: Quickstart on JDK ${{ matrix.java }}
         env:
-          PINOT_OFFHEAP_PRIORITIZE_BYTEBUFFER: ${{ matrix.prioritize_bytebuffer }}
+          PINOT_OFFHEAP_SKIP_BYTEBUFFER: ${{ matrix.skip_bytebuffer }}
         run: .github/workflows/scripts/.pinot_quickstart.sh

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -78,16 +78,16 @@ jobs:
       matrix:
         testset: [ 1, 2 ]
         java: [ 11, 21 ]
-        distribution: [ "corretto" ]
+        distribution: [ "temurin" ]
         skip_bytebuffer: [false]
         include:
           - java: 21
             testset: 1
-            distribution: "corretto"
+            distribution: "temurin"
             skip_bytebuffer: true
           - java: 21
             testset: 2
-            distribution: "corretto"
+            distribution: "temurin"
             skip_bytebuffer: true
     name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}}) with skip bytebuffers:${{matrix.skip_bytebuffer}}
     steps:
@@ -157,16 +157,16 @@ jobs:
       matrix:
         testset: [ 1, 2 ]
         java: [ 11, 21 ]
-        distribution: [ "corretto" ]
+        distribution: [ "temurin" ]
         skip_bytebuffer: [false]
         include:
           - java: 21
             testset: 1
-            distribution: "corretto"
+            distribution: "temurin"
             skip_bytebuffer: true
           - java: 21
             testset: 2
-            distribution: "corretto"
+            distribution: "temurin"
             skip_bytebuffer: true
     name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}}) with skip bytebuffers:${{matrix.skip_bytebuffer}}
     steps:
@@ -315,11 +315,11 @@ jobs:
       fail-fast: false
       matrix:
         java: [ 11, 21 ]
-        distribution: [ "corretto" ]
+        distribution: [ "temurin" ]
         skip_bytebuffer: [false]
         include:
           - java: 21
-            distribution: "corretto"
+            distribution: "temurin"
             skip_bytebuffer: true
     name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }} with skip bytebuffers:${{matrix.skip_bytebuffer}}
     steps:

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -81,14 +81,22 @@ jobs:
         distribution: [ "corretto" ]
         prioritize_bytebuffer: [false]
         include:
-          - java: 21
+          - java: 11
             testset: 1
             distribution: "corretto"
             prioritize_bytebuffer: true
-          - java: 21
+          - java: 11
             testset: 2
             distribution: "corretto"
             prioritize_bytebuffer: true
+          - java: 21
+            testset: 1
+            distribution: "corretto"
+            prioritize_bytebuffer: false
+          - java: 21
+            testset: 2
+            distribution: "corretto"
+            prioritize_bytebuffer: false
     name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
       - uses: actions/checkout@v3
@@ -160,14 +168,22 @@ jobs:
         distribution: [ "corretto" ]
         prioritize_bytebuffer: [false]
         include:
-          - java: 21
+          - java: 11
             testset: 1
             distribution: "corretto"
             prioritize_bytebuffer: true
-          - java: 21
+          - java: 11
             testset: 2
             distribution: "corretto"
             prioritize_bytebuffer: true
+          - java: 21
+            testset: 1
+            distribution: "corretto"
+            prioritize_bytebuffer: false
+          - java: 21
+            testset: 2
+            distribution: "corretto"
+            prioritize_bytebuffer: false
     name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
     steps:
       - uses: actions/checkout@v3
@@ -314,19 +330,16 @@ jobs:
       # Changed to false in order to improve coverage using unsafe buffers
       fail-fast: false
       matrix:
-        testset: [ 1, 2 ]
         java: [ 11, 17, 21 ]
         distribution: [ "corretto" ]
         prioritize_bytebuffer: [false]
         include:
-          - java: 21
-            testset: 1
+          - java: 11
             distribution: "corretto"
             prioritize_bytebuffer: true
           - java: 21
-            testset: 2
             distribution: "corretto"
-            prioritize_bytebuffer: true
+            prioritize_bytebuffer: false
     name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/pinot_tests.yml
+++ b/.github/workflows/pinot_tests.yml
@@ -97,7 +97,7 @@ jobs:
             testset: 2
             distribution: "corretto"
             prioritize_bytebuffer: false
-    name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
+    name: Pinot Unit Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}}) with bytebuffers:${{matrix.prioritize_bytebuffer}}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}-${{ matrix.distribution }}
@@ -184,7 +184,7 @@ jobs:
             testset: 2
             distribution: "corretto"
             prioritize_bytebuffer: false
-    name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}})
+    name: Pinot Integration Test Set ${{ matrix.testset }} (${{matrix.distribution}}-${{matrix.java}}) with bytebuffers:${{matrix.prioritize_bytebuffer}}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}-${{ matrix.distribution }}
@@ -340,7 +340,7 @@ jobs:
           - java: 21
             distribution: "corretto"
             prioritize_bytebuffer: false
-    name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }}
+    name: Pinot Quickstart on JDK ${{ matrix.java }}-${{ matrix.distribution }} with bytebuffers:${{matrix.prioritize_bytebuffer}}
     steps:
       - uses: actions/checkout@v3
       - name: Set up JDK ${{ matrix.java }}

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
-    <spark.version>3.2.1</spark.version>
+    <spark.version>3.5.0</spark.version>
     <commons-lang3.version>3.11</commons-lang3.version>
   </properties>
 

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pom.xml
@@ -36,9 +36,7 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
-    <scala.major.version>2.12</scala.major.version>
     <spark.version>3.5.0</spark.version>
-    <scala.minor.version>2.12.15</scala.minor.version>
     <commons-lang3.version>3.11</commons-lang3.version>
   </properties>
 
@@ -50,7 +48,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.spark</groupId>
-      <artifactId>spark-core_${scala.major.version}</artifactId>
+      <artifactId>spark-core_${scala.compat.version}</artifactId>
       <version>${spark.version}</version>
       <scope>provided</scope>
       <exclusions>
@@ -99,7 +97,7 @@
     <dependency>
       <groupId>org.scala-lang</groupId>
       <artifactId>scala-library</artifactId>
-      <version>${scala.minor.version}</version>
+      <version>${scala.version}</version>
       <scope>provided</scope>
     </dependency>
     <dependency>

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pom.xml
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-spark-3/pom.xml
@@ -36,7 +36,7 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
-    <spark.version>3.5.0</spark.version>
+    <spark.version>3.2.1</spark.version>
     <commons-lang3.version>3.11</commons-lang3.version>
   </properties>
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PinotDataBuffer.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PinotDataBuffer.java
@@ -68,6 +68,12 @@ public abstract class PinotDataBuffer implements Closeable {
   // With number of bytes more than this threshold, we create a ByteBuffer from the buffer and use bulk get/put method
   public static final int BULK_BYTES_PROCESSING_THRESHOLD = 10;
   private static final String SKIP_BYTEBUFFER_ENV = "PINOT_OFFHEAP_SKIP_BYTEBUFFER";
+  private static final boolean DEFAULT_PRIORITIZE_BYTE_BUFFER;
+
+  static {
+     String skipBbEnvValue = System.getenv(SKIP_BYTEBUFFER_ENV);
+     DEFAULT_PRIORITIZE_BYTE_BUFFER = !Boolean.parseBoolean(skipBbEnvValue);
+  }
 
   private static class BufferContext {
     enum Type {
@@ -153,9 +159,7 @@ public abstract class PinotDataBuffer implements Closeable {
   }
 
   public static PinotBufferFactory createDefaultFactory() {
-    String skipBbEnvValue = System.getenv(SKIP_BYTEBUFFER_ENV);
-    boolean prioritizeByteBuffer = !Boolean.parseBoolean(skipBbEnvValue);
-    return createDefaultFactory(prioritizeByteBuffer);
+    return createDefaultFactory(DEFAULT_PRIORITIZE_BYTE_BUFFER);
   }
 
   public static PinotBufferFactory createDefaultFactory(boolean prioritizeByteBuffer) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PinotDataBuffer.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PinotDataBuffer.java
@@ -67,7 +67,7 @@ public abstract class PinotDataBuffer implements Closeable {
   // With number of bytes less than this threshold, we get/put bytes one by one
   // With number of bytes more than this threshold, we create a ByteBuffer from the buffer and use bulk get/put method
   public static final int BULK_BYTES_PROCESSING_THRESHOLD = 10;
-  private static final String PRIORITIZE_BYTEBUFFER_ENV = "PINOT_OFFHEAP_PRIORITIZE_BYTEBUFFER";
+  private static final String SKIP_BYTEBUFFER_ENV = "PINOT_OFFHEAP_SKIP_BYTEBUFFER";
 
   private static class BufferContext {
     enum Type {
@@ -153,8 +153,8 @@ public abstract class PinotDataBuffer implements Closeable {
   }
 
   public static PinotBufferFactory createDefaultFactory() {
-    String prioritizeBbEnvValue = System.getenv(PRIORITIZE_BYTEBUFFER_ENV);
-    boolean prioritizeByteBuffer = prioritizeBbEnvValue == null || Boolean.parseBoolean(prioritizeBbEnvValue);
+    String skipBbEnvValue = System.getenv(SKIP_BYTEBUFFER_ENV);
+    boolean prioritizeByteBuffer = !Boolean.parseBoolean(skipBbEnvValue);
     return createDefaultFactory(prioritizeByteBuffer);
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -229,6 +229,16 @@
         </plugins>
       </build>
     </profile>
+    <profile>
+      <id>scala-2.12</id>
+      <activation>
+        <activeByDefault>true</activeByDefault>
+      </activation>
+      <properties>
+        <scala.version>2.12.18</scala.version>
+        <scala.compat.version>2.12</scala.compat.version>
+      </properties>
+    </profile>
 
     <profile>
       <id>scala-2.13</id>

--- a/pom.xml
+++ b/pom.xml
@@ -1499,6 +1499,7 @@
               --add-opens=java.base/java.util=ALL-UNNAMED
               --add-exports=java.base/jdk.internal.util.random=ALL-UNNAMED
               --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+              -Dnet.bytebuddy.experimental=true
             </argLine>
           </configuration>
           <!-- Explicitly select the test provider, instead of relying on the classpath -->

--- a/pom.xml
+++ b/pom.xml
@@ -1142,13 +1142,13 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>5.3.1</version>
+        <version>5.5.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-inline</artifactId>
-        <version>4.7.0</version>
+        <version>5.2.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -184,6 +184,10 @@
     <scala.version>2.12.18</scala.version>
     <scala.compat.version>2.12</scala.compat.version>
 
+    <!-- Configuration for Scala -->
+    <scala.version>2.12.18</scala.version>
+    <scala.compat.version>2.12</scala.compat.version>
+
     <flink.version>1.12.0</flink.version>
     <commons-configuration2.version>2.9.0</commons-configuration2.version>
   </properties>
@@ -228,16 +232,6 @@
           </plugin>
         </plugins>
       </build>
-    </profile>
-    <profile>
-      <id>scala-2.12</id>
-      <activation>
-        <activeByDefault>true</activeByDefault>
-      </activation>
-      <properties>
-        <scala.version>2.12.18</scala.version>
-        <scala.compat.version>2.12</scala.compat.version>
-      </properties>
     </profile>
 
     <profile>


### PR DESCRIPTION
The reason to be of this PR is to be able to progress on https://github.com/apache/pinot/issues/11656.

Specifically it:
- Includes https://github.com/apache/pinot/pull/11670
- Includes https://github.com/apache/pinot/pull/11671
- Adds 2 new tests pipelines:
  - One with Java 21.
  - One with Java 21 that always use the new buffer api. Normally this API is only used when buffers are larger than 2GBs. The idea of this execution is to always use this API (even with small buffers) to increase the confidence on the library.