### PR TITLE
Using isOptional instead of the deprecated hasOptionalKeyword

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractor.java
@@ -53,7 +53,15 @@ public class ProtoBufRecordExtractor extends BaseRecordExtractor<Message> {
     }
   }
 
+  /**
+   * For fields that are not set, we want to populate a null, instead of proto default.
+   * @param fieldDescriptor
+   * @param message
+   */
   private Object getFieldValue(Descriptors.FieldDescriptor fieldDescriptor, Message message) {
+    // Note w.r.t proto3 - If a field is not declared with optional keyword, there's no way to distinguish
+    // if its explicitly set to a proto default or not been set at all i.e hasField() returns false
+    // and we would use null.
     if (fieldDescriptor.isRepeated() || !fieldDescriptor.isOptional() || message.hasField(fieldDescriptor)) {
       return message.getField(fieldDescriptor);
     } else {

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/main/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractor.java
@@ -54,7 +54,7 @@ public class ProtoBufRecordExtractor extends BaseRecordExtractor<Message> {
   }
 
   private Object getFieldValue(Descriptors.FieldDescriptor fieldDescriptor, Message message) {
-    if (fieldDescriptor.isRepeated() || !fieldDescriptor.hasOptionalKeyword() || message.hasField(fieldDescriptor)) {
+    if (fieldDescriptor.isRepeated() || !fieldDescriptor.isOptional() || message.hasField(fieldDescriptor)) {
       return message.getField(fieldDescriptor);
     } else {
       return null;

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractorTest.java
@@ -70,7 +70,7 @@ public class ProtoBufRecordExtractorTest extends AbstractRecordExtractorTest {
 
   @Override
   protected List<Map<String, Object>> getInputRecords() {
-    return Arrays.asList(createRecord1(), createRecord2());
+    return Arrays.asList(createExplicitOptionalDefaultRecord(), createOptionalDefaultRecordWithNulls());
   }
 
   @Override
@@ -159,7 +159,11 @@ public class ProtoBufRecordExtractorTest extends AbstractRecordExtractorTest {
         .setNestedStringField((String) nestedMessageFields.get(NESTED_STRING_FIELD)).build();
   }
 
-  private Map<String, Object> createRecord1() {
+  /**
+   * Test that verifies that optional fields with explicitly set default protobuf values
+   * are preserved/not treated as nulls.
+   */
+  private Map<String, Object> createExplicitOptionalDefaultRecord() {
     Map<String, Object> record = new HashMap<>();
     record.put(STRING_FIELD, "hello");
     record.put(INT_FIELD, 10);
@@ -168,6 +172,8 @@ public class ProtoBufRecordExtractorTest extends AbstractRecordExtractorTest {
     record.put(FLOAT_FIELD, 2.2f);
     record.put(BOOL_FIELD, "true");
     record.put(BYTES_FIELD, "hello world!".getBytes(UTF_8));
+    // These optional fields are explicitly set to proto defaults and expect
+    // to see these values preserved (not treated as null).
     record.put(NULLABLE_STRING_FIELD, "");
     record.put(NULLABLE_INT_FIELD, 0);
     record.put(NULLABLE_LONG_FIELD, 0L);
@@ -188,7 +194,10 @@ public class ProtoBufRecordExtractorTest extends AbstractRecordExtractorTest {
     return record;
   }
 
-  private Map<String, Object> createRecord2() {
+  /**
+   * Test that verifies that optional fields not explicitly set are treated as nulls.
+   */
+  private Map<String, Object> createOptionalDefaultRecordWithNulls() {
     Map<String, Object> record = new HashMap<>();
     record.put(STRING_FIELD, "world");
     record.put(INT_FIELD, 20);

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractorTest.java
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/java/org/apache/pinot/plugin/inputformat/protobuf/ProtoBufRecordExtractorTest.java
@@ -166,7 +166,7 @@ public class ProtoBufRecordExtractorTest extends AbstractRecordExtractorTest {
     record.put(LONG_FIELD, 100L);
     record.put(DOUBLE_FIELD, 1.1);
     record.put(FLOAT_FIELD, 2.2f);
-    record.put(BOOL_FIELD, "false");
+    record.put(BOOL_FIELD, "true");
     record.put(BYTES_FIELD, "hello world!".getBytes(UTF_8));
     record.put(NULLABLE_STRING_FIELD, "");
     record.put(NULLABLE_INT_FIELD, 0);


### PR DESCRIPTION
**Problem**:
hasOptionalKeyword has been deprecated due to which protobuf null handling was also not working correctly.  
PR that marked it deprecated
https://github.com/protocolbuffers/protobuf/commit/d6157f7c7ec78a6942cfd6d96d2e0b40e007ae0d
We use isOptional() instead that checks only the field LABEL

` /** Is this field declared optional? */
    public boolean isOptional() {
      return proto.getLabel() == FieldDescriptorProto.Label.LABEL_OPTIONAL;
    }`

Reference - https://github.com/protocolbuffers/protobuf/blob/d6157f7c7ec78a6942cfd6d96d2e0b40e007ae0d/java/core/src/main/java/com/google/protobuf/Descriptors.java

**Test:**
Ingested Kafka protobuf stream that has defaults and verified that they are treated as nulls through query (attached image)

<img width="1728" alt="Screenshot 2023-09-25 at 2 06 30 PM" src="https://github.com/apache/pinot/assets/126024920/d2bc4324-57cc-4c57-9b8b-6633bae5b6db">

**Note:** Proto3 treats the field as optional, when the value is set to its default ([issue](https://github.com/protocolbuffers/protobuf/issues/10560.))

How to use optional field - https://protobuf.dev/programming-guides/proto3/

