### PR TITLE
Expose Additional Realtime Ingestion Metrics

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -77,7 +77,7 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeConsumptionExceptions\"><>(\\w+)"
   name: "pinot_server_realtime_consumptionExceptions_$1"
   cache: true
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).(\\w+)\"><>(\\w+)"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\.]*?)_(OFFLINE|REALTIME)\-(.+)\-(\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed)\"><>(\\w+)"
   name: "pinot_server_$4_$2"
   cache: true
   labels:

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -78,13 +78,13 @@ rules:
   name: "pinot_server_realtime_consumptionExceptions_$1"
   cache: true
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed)\"><>(\\w+)"
-  name: "pinot_server_$4_$2"
+  name: "pinot_server_$5_$6"
   cache: true
   labels:
     table: "$1"
     tableType: "$2"
     topic: "$3"
-    partition: "$5"
+    partition: "$4"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeOffheapMemoryUsed.([^\\.]*?)\"><>(\\w+)"
   name: "pinot_server_realtime_offheapMemoryUsed_$2"
   cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -85,6 +85,9 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeConsumptionExceptions\"><>(\\w+)"
   name: "pinot_server_realtime_consumptionExceptions_$1"
   cache: true
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.invalidRealtimeRowsDropped\"><>(\\w+)"
+  name: "pinot_server_realtime_invalidRealtimeRowsDropped_$1"
+  cache: true
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeOffheapMemoryUsed.([^\\.]*?)\"><>(\\w+)"
   name: "pinot_server_realtime_offheapMemoryUsed_$2"
   cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -93,6 +93,9 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeOffsetCommits\"><>(\\w+)"
   name: "pinot_server_realtime_offsetCommits_$1"
   cache: true
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeRowsConsumed\"><>(\\w+)"
+  name: "pinot_server_realtime_rowsConsumed_$1"
+  cache: true
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)Exceptions\"><>(\\w+)"
   name: "pinot_server_realtime_exceptions_$1_$2"
   cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -166,3 +166,4 @@ rules:
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_$2_$3"
   cache: true
+

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -85,21 +85,30 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeConsumptionExceptions\"><>(\\w+)"
   name: "pinot_server_realtime_consumptionExceptions_$1"
   cache: true
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?).invalidRealtimeRowsDropped\"><>(\\w+)"
-  name: "pinot_server_realtime_invalidRealtimeRowsDropped_$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).invalidRealtimeRowsDropped\"><>(\\w+)"
+  name: "pinot_server_invalidRealtimeRowsDropped_$2"
   cache: true
   labels:
     table: "$1"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?).incompleteRealtimeRowsConsumed\"><>(\\w+)"
-  name: "pinot_server_realtime_incompleteRealtimeRowsConsumed_$2"
+    tableType: "$2"
+    topic: "$3"
+    partition: "$4"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).incompleteRealtimeRowsConsumed\"><>(\\w+)"
+  name: "pinot_server_incompleteRealtimeRowsConsumed_$5"
   cache: true
   labels:
     table: "$1"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?).rowsWithErrors\"><>(\\w+)"
-  name: "pinot_server_realtime_rowsWithErrors_$2"
+    tableType: "$2"
+    topic: "$3"
+    partition: "$4"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).rowsWithErrors\"><>(\\w+)"
+  name: "pinot_server_rowsWithErrors_$2"
   cache: true
   labels:
     table: "$1"
+    tableType: "$2"
+    topic: "$3"
+    partition: "$4"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeOffheapMemoryUsed.([^\\.]*?)\"><>(\\w+)"
   name: "pinot_server_realtime_offheapMemoryUsed_$2"
   cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -85,9 +85,16 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeConsumptionExceptions\"><>(\\w+)"
   name: "pinot_server_realtime_consumptionExceptions_$1"
   cache: true
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.invalidRealtimeRowsDropped\"><>(\\w+)"
-  name: "pinot_server_realtime_invalidRealtimeRowsDropped_$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?).invalidRealtimeRowsDropped\"><>(\\w+)"
+  name: "pinot_server_realtime_invalidRealtimeRowsDropped_$2"
   cache: true
+  labels:
+    table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?).incompleteRealtimeRowsConsumed\"><>(\\w+)"
+  name: "pinot_server_realtime_incompleteRealtimeRowsConsumed_$2"
+  cache: true
+  labels:
+    table: "$1"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeOffheapMemoryUsed.([^\\.]*?)\"><>(\\w+)"
   name: "pinot_server_realtime_offheapMemoryUsed_$2"
   cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -95,6 +95,11 @@ rules:
   cache: true
   labels:
     table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?).rowsWithErrors\"><>(\\w+)"
+  name: "pinot_server_realtime_rowsWithErrors_$2"
+  cache: true
+  labels:
+    table: "$1"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeOffheapMemoryUsed.([^\\.]*?)\"><>(\\w+)"
   name: "pinot_server_realtime_offheapMemoryUsed_$2"
   cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -77,7 +77,7 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeConsumptionExceptions\"><>(\\w+)"
   name: "pinot_server_realtime_consumptionExceptions_$1"
   cache: true
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\.]*?)_(OFFLINE|REALTIME)\-(.+)\-(\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed)\"><>(\\w+)"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed)\"><>(\\w+)"
   name: "pinot_server_$4_$2"
   cache: true
   labels:

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -17,14 +17,6 @@ rules:
   labels:
     table: "$1"
     tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).realtimeRowsConsumed\"><>(\\w+)"
-  name: "pinot_server_realtimeRowsConsumed_$5"
-  cache: true
-  labels:
-    table: "$1"
-    tableType: "$2"
-    topic: "$3"
-    partition: "$4"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.helix.connected\"><>(\\w+)"
   name: "pinot_server_helix_connected_$1"
   cache: true
@@ -85,30 +77,14 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeConsumptionExceptions\"><>(\\w+)"
   name: "pinot_server_realtime_consumptionExceptions_$1"
   cache: true
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).invalidRealtimeRowsDropped\"><>(\\w+)"
-  name: "pinot_server_invalidRealtimeRowsDropped_$2"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).(\\w+)\"><>(\\w+)"
+  name: "pinot_server_$4_$2"
   cache: true
   labels:
     table: "$1"
     tableType: "$2"
     topic: "$3"
-    partition: "$4"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).incompleteRealtimeRowsConsumed\"><>(\\w+)"
-  name: "pinot_server_incompleteRealtimeRowsConsumed_$5"
-  cache: true
-  labels:
-    table: "$1"
-    tableType: "$2"
-    topic: "$3"
-    partition: "$4"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).rowsWithErrors\"><>(\\w+)"
-  name: "pinot_server_rowsWithErrors_$2"
-  cache: true
-  labels:
-    table: "$1"
-    tableType: "$2"
-    topic: "$3"
-    partition: "$4"
+    partition: "$5"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeOffheapMemoryUsed.([^\\.]*?)\"><>(\\w+)"
   name: "pinot_server_realtime_offheapMemoryUsed_$2"
   cache: true
@@ -116,9 +92,6 @@ rules:
     table: "$1"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeOffsetCommits\"><>(\\w+)"
   name: "pinot_server_realtime_offsetCommits_$1"
-  cache: true
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeRowsConsumed\"><>(\\w+)"
-  name: "pinot_server_realtime_rowsConsumed_$1"
   cache: true
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)Exceptions\"><>(\\w+)"
   name: "pinot_server_realtime_exceptions_$1_$2"


### PR DESCRIPTION
- Expose `invalidRealtimeRowsDropped` to measure decoding errors in stream.
- Expose `incompleteRealtimeRowsConsumed` to measure transformation errors when `continueOnError` has been set to true.
- Expose `rowsWithErrors` to cover any error while processing a row (catch-all, covers both the cases above).

JConsole output:

<img width="595" alt="Screenshot 2023-09-26 at 11 38 38 AM" src="https://github.com/apache/pinot/assets/84911643/9928f5aa-7a38-4efb-a160-cde6ddf1c584">


<img width="592" alt="Screenshot 2023-09-26 at 11 40 31 AM" src="https://github.com/apache/pinot/assets/84911643/779862c2-fdef-4cf6-986a-a8f17de6798d">


<img width="577" alt="Screenshot 2023-09-26 at 12 06 04 PM" src="https://github.com/apache/pinot/assets/84911643/612f3c2d-01f4-4111-91f9-e2b0313a7860">



Regex test:

```
public class RegexMatcher {
  public static void main(String[] args) {
    // Define the regex patterns
    String[] regexPatterns = {
        "pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed)"
    };

    // Input strings to test against the regex patterns
    String[] inputStrings = {
        "pinot.server.airlineStats_REALTIME-flights-realtime-8.invalidRealtimeRowsDropped",
        "pinot.server.airlineStats_OFFLINE-flights-realtime-8.invalidRealtimeRowsDropped",
        "pinot.server.githubEvents_REALTIME-githubEvents-0.incompleteRealtimeRowsConsumed",
        "pinot.server.githubEvents_OFFLINE-githubEvents-0.incompleteRealtimeRowsConsumed",
        "pinot.server.meetupRsvp_REALTIME-meetupRSVPEvents-1.rowsWithErrors",
        "pinot.server.meetupRsvp_OFFLINE-meetupRSVPEvents-1.rowsWithErrors",
        "pinot.server.meetupRsvp_REALTIME-meetupRSVPEvents-1.realtimeRowsConsumed",
        "pinot.server.meetupRsvp_OFFLINE-meetupRSVPEvents-1.realtimeRowsConsumed"
    };

    // Iterate over each regex pattern
    for (String regexPattern : regexPatterns) {
      // Compile the regex pattern into a Pattern object
      Pattern pattern = Pattern.compile(regexPattern);

      // Iterate over each input string
      for (String inputString : inputStrings) {
        // Create a Matcher object to match the pattern against the input string
        Matcher matcher = pattern.matcher(inputString);

        // Perform the matching and check if it matches
        if (matcher.matches()) {
          System.out.println("Input string '" + inputString + "' matches the regex pattern: " + regexPattern);
        } else {
          System.out.println("Input string '" + inputString + "' does not match the regex pattern: " + regexPattern);
        }
      }
    }
  }
}
```

Output:
```
Input string 'pinot.server.airlineStats_REALTIME-flights-realtime-8.invalidRealtimeRowsDropped' matches the regex pattern: pinot.server.([^\.]*?)_(OFFLINE|REALTIME)\-(.+)\-(\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed)
Input string 'pinot.server.airlineStats_OFFLINE-flights-realtime-8.invalidRealtimeRowsDropped' matches the regex pattern: pinot.server.([^\.]*?)_(OFFLINE|REALTIME)\-(.+)\-(\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed)
Input string 'pinot.server.githubEvents_REALTIME-githubEvents-0.incompleteRealtimeRowsConsumed' matches the regex pattern: pinot.server.([^\.]*?)_(OFFLINE|REALTIME)\-(.+)\-(\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed)
Input string 'pinot.server.githubEvents_OFFLINE-githubEvents-0.incompleteRealtimeRowsConsumed' matches the regex pattern: pinot.server.([^\.]*?)_(OFFLINE|REALTIME)\-(.+)\-(\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed)
Input string 'pinot.server.meetupRsvp_REALTIME-meetupRSVPEvents-1.rowsWithErrors' matches the regex pattern: pinot.server.([^\.]*?)_(OFFLINE|REALTIME)\-(.+)\-(\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed)
Input string 'pinot.server.meetupRsvp_OFFLINE-meetupRSVPEvents-1.rowsWithErrors' matches the regex pattern: pinot.server.([^\.]*?)_(OFFLINE|REALTIME)\-(.+)\-(\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed)
Input string 'pinot.server.meetupRsvp_REALTIME-meetupRSVPEvents-1.realtimeRowsConsumed' matches the regex pattern: pinot.server.([^\.]*?)_(OFFLINE|REALTIME)\-(.+)\-(\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed)
Input string 'pinot.server.meetupRsvp_OFFLINE-meetupRSVPEvents-1.realtimeRowsConsumed' matches the regex pattern: pinot.server.([^\.]*?)_(OFFLINE|REALTIME)\-(.+)\-(\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed)

Process finished with exit code 0

```
<img width="1502" alt="Screenshot 2023-09-27 at 6 48 14 PM" src="https://github.com/apache/pinot/assets/84911643/a4c1d721-6eab-466b-80c2-248a84bee2bc">



<img width="1717" alt="Screenshot 2023-09-27 at 6 48 24 PM" src="https://github.com/apache/pinot/assets/84911643/020dca70-c6d8-4a5d-98d7-d9c74abe22fc">


