### PR TITLE
[multistage] support legacy query function "lookup" in multi-stage

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -181,7 +181,8 @@ public enum TransformFunctionType {
 
   // special functions
   INIDSET("inIdSet"),
-  LOOKUP("lookUp"),
+  LOOKUP("lookUp", ReturnTypes.explicit(SqlTypeName.ANY), OperandTypes.family(
+      ImmutableList.of(SqlTypeFamily.ANY, SqlTypeFamily.ANY, SqlTypeFamily.ANY, SqlTypeFamily.ANY))),
   GROOVY("groovy"),
 
   // CLP functions


### PR DESCRIPTION
support lookup in multi-stage, see #11651 

Limitation and Example
===
```
-- compatible syntax
    -- direct selection
SELECT LOOKUP('dimTbl', 'dimCol', 'dimKey', priKey) FROM tbl
    -- direct selection with up to 3 primary key columns when combo primary key is configured on the dim table.
SELECT LOOKUP('dimTbl', 'dimCol', 'dimKey1', priKey1, 'dimKey2', priKey2) FROM tbl
    -- used as group-key
SELECT LOOKUP('dimTbl', 'dimCol', 'dimKey', priKey), COUNT(*) FROM tbl GROUP BY 1

-- incompatible syntax
    -- used in aggregate function
SELECT SUM(LOOKUP('dimTbl', 'dimCol', 'dimKey', priKey)) FROM tbl 
    -- used in transform after lookup
SELECT LOOKUP('dimTbl', 'dimCol', 'dimKey', priKey) + priCol FROM tbl 
```

Details
===
- No further processing applies on top of the lookup function is supported due to insufficient type info during planning
- the column selected out will have `OBJECT` result type b/c it cannot be determined during plan time.