### PR TITLE
Fix logging issue on RealtimeTableDataManager

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -406,7 +406,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
         return;
       } else {
         // For LLC and uploaded segments, delete the local copy and download a new copy
-        _logger.error("Failed to load LLC segment: {}, downloading a new copy", segmentName);
+        _logger.info("Unable to load local LLC segment: {}, downloading a new copy", segmentName);
         FileUtils.deleteQuietly(segmentDir);
       }
       // Local segment doesn't exist or cannot load, download a new copy


### PR DESCRIPTION
`tryLoadExistingSegment` can return false in regular cases where the segments are not on the server. Having the log as error is confusing. If there's an error in that method, we've already logged it. So the log message here is just informational. 
Converting it to an info.