### PR TITLE
Upgrade Avro dependency to 1.10.2

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
@@ -74,7 +74,7 @@ public class AvroRecordExtractor extends BaseRecordExtractor<GenericRecord> {
       }
     } else {
       for (String fieldName : _fields) {
-        Object value = from.get(fieldName);
+        Object value = from.hasField(fieldName) ? from.get(fieldName) : null;
         if (_applyLogicalTypes) {
           Schema.Field field = from.getSchema().getField(fieldName);
           value = AvroSchemaUtil.applyLogicalType(field, value);

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
@@ -73,10 +73,12 @@ public class AvroRecordExtractor extends BaseRecordExtractor<GenericRecord> {
         to.putValue(fieldName, value);
       }
     } else {
+      Schema.Field field;
+      Object value;
       for (String fieldName : _fields) {
-        Object value = from.hasField(fieldName) ? from.get(fieldName) : null;
+        field = from.getSchema().getField(fieldName);
+        value = field == null ? null : from.get(field.pos());
         if (_applyLogicalTypes) {
-          Schema.Field field = from.getSchema().getField(fieldName);
           value = AvroSchemaUtil.applyLogicalType(field, value);
         }
         if (value != null) {

--- a/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
+++ b/pinot-plugins/pinot-input-format/pinot-avro-base/src/main/java/org/apache/pinot/plugin/inputformat/avro/AvroRecordExtractor.java
@@ -73,11 +73,9 @@ public class AvroRecordExtractor extends BaseRecordExtractor<GenericRecord> {
         to.putValue(fieldName, value);
       }
     } else {
-      Schema.Field field;
-      Object value;
       for (String fieldName : _fields) {
-        field = from.getSchema().getField(fieldName);
-        value = field == null ? null : from.get(field.pos());
+        Schema.Field field = from.getSchema().getField(fieldName);
+        Object value = field == null ? null : from.get(field.pos());
         if (_applyLogicalTypes) {
           value = AvroSchemaUtil.applyLogicalType(field, value);
         }

--- a/pom.xml
+++ b/pom.xml
@@ -121,7 +121,7 @@
       See also: the surefire plugin section and the profiles section.-->
     <SKIP_INTEGRATION_TESTS>true</SKIP_INTEGRATION_TESTS>
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
-    <avro.version>1.9.2</avro.version>
+    <avro.version>1.10.2</avro.version>
     <parquet.version>1.12.3</parquet.version>
     <helix.version>1.0.4</helix.version>
     <zkclient.version>0.7</zkclient.version>


### PR DESCRIPTION
Upgraded `Avro` version from `1.9.2` to `1.10.2`. In our installation, the newer version gets pulled transitively. Although major version is the same, and there's no interface changes, but the way OSS Pinot handles Avro fields of type map doesn't work with 1.10.2. In Pinot, for map fields, `fieldName__KEYS` and `fieldName__VALUES` are dynamically added to the avro record. Since they are not defined in the schema, in avro 1.10.2, a runtime exception gets thrown when record.get(fieldName) is called. To fix the issue, I simply added a check to see if the schema has that field, and if not, we set value as null.