### PR TITLE
Reduce direct memory OOM chances on broker with a per server query response size budget

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -682,13 +682,13 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         return new BrokerResponseNative(exceptions);
       }
 
-    // Set the maximum serialized response size per server
+      // Set the maximum serialized response size per server
       int numServers = 0;
       if (offlineRoutingTable != null) {
-        numServers += offlineRoutingTable.keySet().size();
+        numServers += offlineRoutingTable.size();
       }
       if (realtimeRoutingTable != null) {
-        numServers += realtimeRoutingTable.keySet().size();
+        numServers += realtimeRoutingTable.size();
       }
 
       if (offlineBrokerRequest != null) {
@@ -1694,9 +1694,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     if (QueryOptionsUtils.getMaxServerResponseSizeBytes(queryOptions) != null) {
       return;
     }
-    if (QueryOptionsUtils.getMaxQueryResponseSizeBytes(queryOptions) != null) {
-      Long maxQueryResponseSize = QueryOptionsUtils.getMaxQueryResponseSizeBytes(queryOptions);
-      Long maxServerResponseSize = maxQueryResponseSize / numServers;
+    Long maxQueryResponseSizeQOption = QueryOptionsUtils.getMaxQueryResponseSizeBytes(queryOptions);
+    if (maxQueryResponseSizeQOption != null) {
+      Long maxServerResponseSize = maxQueryResponseSizeQOption / numServers;
       queryOptions.put(Broker.Request.QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
           Long.toString(maxServerResponseSize));
       return;
@@ -1716,8 +1716,6 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       Long maxServerResponseSize = maxQueryResponseSize / numServers;
       queryOptions.put(Broker.Request.QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
           Long.toString(maxServerResponseSize));
-      _brokerMetrics.addMeteredTableValue(tableConfig.getTableName(), BrokerMeter.MAX_QUERY_RESPONSE_SIZE,
-          maxQueryResponseSize);
       return;
     }
 
@@ -1733,7 +1731,6 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       return;
     }
     if (maxQueryResponseSizeCfg > 0) {
-      _brokerMetrics.addMeteredGlobalValue(BrokerMeter.MAX_QUERY_RESPONSE_SIZE, maxQueryResponseSizeCfg);
       Long maxServerResponseSize = maxQueryResponseSizeCfg / numServers;
       queryOptions.put(Broker.Request.QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
           Long.toString(maxServerResponseSize));

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -99,8 +99,7 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   NETTY_CONNECTION_BYTES_RECEIVED("nettyConnection", true),
 
   PROACTIVE_CLUSTER_CHANGE_CHECK("proactiveClusterChangeCheck", true),
-  DIRECT_MEMORY_OOM("directMemoryOOMCount", true),
-  MAX_QUERY_RESPONSE_SIZE("maxQueryResponseSize", true);
+  DIRECT_MEMORY_OOM("directMemoryOOMCount", true);
 
   private final String _brokerMeterName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -99,7 +99,8 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   NETTY_CONNECTION_BYTES_RECEIVED("nettyConnection", true),
 
   PROACTIVE_CLUSTER_CHANGE_CHECK("proactiveClusterChangeCheck", true),
-  DIRECT_MEMORY_OOM("directMemoryOOMCount", true);
+  DIRECT_MEMORY_OOM("directMemoryOOMCount", true),
+  MAX_QUERY_RESPONSE_SIZE("maxQueryResponseSize", true);
 
   private final String _brokerMeterName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -104,7 +104,8 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   NUM_SEGMENTS_PRUNED_BY_LIMIT("numSegmentsPrunedByLimit", false),
   NUM_SEGMENTS_PRUNED_BY_VALUE("numSegmentsPrunedByValue", false),
   LARGE_QUERY_RESPONSES_SENT("largeResponses", false),
-  TOTAL_THREAD_CPU_TIME_MILLIS("millis", false);
+  TOTAL_THREAD_CPU_TIME_MILLIS("millis", false),
+  LARGE_QUERY_RESPONSE_SIZE_EXCEPTIONS("exceptions", false);
 
   private final String _meterName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -113,6 +113,18 @@ public class QueryOptionsUtils {
     return null;
   }
 
+  @Nullable
+  public static Long getMaxQueryResponseSizeBytes(Map<String, String> queryOptions) {
+    String responseSize = queryOptions.get(QueryOptionKey.MAX_QUERY_RESPONSE_SIZE_BYTES);
+    if (responseSize != null) {
+      long maxSize = Long.parseLong(responseSize);
+      Preconditions.checkState(maxSize > 0, "maxQueryResponseSize must be positive. got %s", maxSize);
+      return maxSize;
+    }
+
+    return null;
+  }
+
   public static boolean isAndScanReorderingEnabled(Map<String, String> queryOptions) {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.AND_SCAN_REORDERING));
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -101,6 +101,18 @@ public class QueryOptionsUtils {
     }
   }
 
+  @Nullable
+  public static Long getMaxSerializedResponseLengthPerServer(Map<String, String> queryOptions) {
+    String responseLength = queryOptions.get(QueryOptionKey.MAX_SERIALIZED_RESPONSE_LENGTH_PER_SERVER);
+    if (responseLength != null) {
+      long maxLength = Long.parseLong(responseLength);
+      Preconditions.checkState(maxLength > 0, "maxSerializedResponseLength must be positive. got %s", maxLength);
+      return maxLength;
+    }
+
+    return null;
+  }
+
   public static boolean isAndScanReorderingEnabled(Map<String, String> queryOptions) {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.AND_SCAN_REORDERING));
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -102,12 +102,12 @@ public class QueryOptionsUtils {
   }
 
   @Nullable
-  public static Long getMaxSerializedResponseLengthPerServer(Map<String, String> queryOptions) {
-    String responseLength = queryOptions.get(QueryOptionKey.MAX_SERIALIZED_RESPONSE_LENGTH_PER_SERVER);
-    if (responseLength != null) {
-      long maxLength = Long.parseLong(responseLength);
-      Preconditions.checkState(maxLength > 0, "maxSerializedResponseLength must be positive. got %s", maxLength);
-      return maxLength;
+  public static Long getMaxServerResponseSizeBytes(Map<String, String> queryOptions) {
+    String responseSize = queryOptions.get(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES);
+    if (responseSize != null) {
+      long maxSize = Long.parseLong(responseSize);
+      Preconditions.checkState(maxSize > 0, "maxServerResponseSize must be positive. got %s", maxSize);
+      return maxSize;
     }
 
     return null;

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -192,7 +192,8 @@ public class TableConfigSerDeTest {
     }
     {
       // With query config
-      QueryConfig queryConfig = new QueryConfig(1000L, true, true, Collections.singletonMap("func(a)", "b"), null);
+      QueryConfig queryConfig = new QueryConfig(1000L, true, true, Collections.singletonMap("func(a)", "b"), null,
+          null);
       TableConfig tableConfig = tableConfigBuilder.setQueryConfig(queryConfig).build();
 
       checkQueryConfig(tableConfig);

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -192,7 +192,7 @@ public class TableConfigSerDeTest {
     }
     {
       // With query config
-      QueryConfig queryConfig = new QueryConfig(1000L, true, true, Collections.singletonMap("func(a)", "b"));
+      QueryConfig queryConfig = new QueryConfig(1000L, true, true, Collections.singletonMap("func(a)", "b"), null);
       TableConfig tableConfig = tableConfigBuilder.setQueryConfig(queryConfig).build();
 
       checkQueryConfig(tableConfig);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -174,8 +174,9 @@ public abstract class QueryScheduler {
 
       // TODO: Perform this check sooner during the serialization of DataTable.
       if (maxResponseSizeBytes != null && responseBytes.length > maxResponseSizeBytes) {
-        String errMsg = String.format("Serialized query response size %d exceeds threshold for requestId %d from "
-            + "broker %s", responseBytes.length, queryRequest.getRequestId(), queryRequest.getBrokerId());
+        String errMsg =
+            String.format("Serialized query response size %d exceeds threshold %d for requestId %d from broker %s",
+                responseBytes.length, maxResponseSizeBytes, queryRequest.getRequestId(), queryRequest.getBrokerId());
         LOGGER.error(errMsg);
         _serverMetrics.addMeteredTableValue(queryRequest.getTableNameWithType(),
             ServerMeter.LARGE_QUERY_RESPONSE_SIZE_EXCEPTIONS, 1);

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -250,7 +250,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
 
   protected QueryConfig getQueryConfig() {
     // Enable groovy for tables used in the tests
-    return new QueryConfig(null, false, null, null, null);
+    return new QueryConfig(null, false, null, null, null, null);
   }
 
   protected boolean getNullHandlingEnabled() {

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -250,7 +250,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
 
   protected QueryConfig getQueryConfig() {
     // Enable groovy for tables used in the tests
-    return new QueryConfig(null, false, null, null);
+    return new QueryConfig(null, false, null, null, null);
   }
 
   protected boolean getNullHandlingEnabled() {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -357,7 +357,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
       throws Exception {
     // Set timeout as 5ms so that query will timeout
     TableConfig tableConfig = getOfflineTableConfig();
-    tableConfig.setQueryConfig(new QueryConfig(5L, null, null, null));
+    tableConfig.setQueryConfig(new QueryConfig(5L, null, null, null, null));
     updateTableConfig(tableConfig);
 
     // Wait for at most 1 minute for broker to receive and process the table config refresh message
@@ -626,6 +626,44 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assert response.get("exceptions").size() > 0;
     int errorCode = response.get("exceptions").get(0).get("errorCode").asInt();
     assertEquals(errorCode, 503);
+  }
+
+  @Test
+  public void testMaxQueryResponseSizeBytesTableConfig() throws Exception {
+    TableConfig tableConfig = getOfflineTableConfig();
+    tableConfig.setQueryConfig(new QueryConfig(null, false, null, null, 1000L));
+    updateTableConfig(tableConfig);
+
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        // Server should return an exception
+        JsonNode response = postQuery(SELECT_STAR_QUERY);
+        assert response.get("exceptions").size() > 0;
+        int errorCode = response.get("exceptions").get(0).get("errorCode").asInt();
+        if (errorCode == 503) {
+          return true;
+        }
+        return false;
+      } catch (Exception e) {
+        return false;
+      }
+    }, 60_000L, "Failed to execute query");
+
+    tableConfig.setQueryConfig(null);
+    updateTableConfig(tableConfig);
+
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        // Server should not return an exception
+        JsonNode response = postQuery(SELECT_STAR_QUERY);
+        if (response.get("exceptions").size() == 0) {
+          return true;
+        }
+        return false;
+      } catch (Exception e) {
+        return false;
+      }
+    }, 60_000L, "Failed to execute query");
   }
 
   @Test(dataProvider = "useBothQueryEngines")
@@ -1360,7 +1398,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     String groovyQuery = "SELECT GROOVY('{\"returnType\":\"STRING\",\"isSingleValue\":true}', "
         + "'arg0 + arg1', FlightNum, Origin) FROM mytable";
     TableConfig tableConfig = getOfflineTableConfig();
-    tableConfig.setQueryConfig(new QueryConfig(null, false, null, null));
+    tableConfig.setQueryConfig(new QueryConfig(null, false, null, null, null));
     updateTableConfig(tableConfig);
 
     TestUtils.waitForCondition(aVoid -> {
@@ -1604,7 +1642,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     // Add expression override
     TableConfig tableConfig = getOfflineTableConfig();
     tableConfig.setQueryConfig(new QueryConfig(null, null, null,
-        Collections.singletonMap("DaysSinceEpoch * 24", "NewAddedDerivedHoursSinceEpoch")));
+        Collections.singletonMap("DaysSinceEpoch * 24", "NewAddedDerivedHoursSinceEpoch"), null));
     updateTableConfig(tableConfig);
 
     TestUtils.waitForCondition(aVoid -> {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -621,11 +621,11 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   @Test
   public void testMaxSerializedResponseLengthPerServer()
       throws Exception {
-    String queryWithOption = "SET maxSerializedResponseLengthPerServer=1000; " + SELECT_STAR_QUERY;
+    String queryWithOption = "SET maxServerResponseSizeBytes=1000; " + SELECT_STAR_QUERY;
     JsonNode response = postQuery(queryWithOption);
     assert response.get("exceptions").size() > 0;
-    String exceptionStr = response.get("exceptions").get(0).get("message").toString();
-    assert exceptionStr.contains("Serialized response exceeds threshold");
+    int errorCode = response.get("exceptions").get(0).get("errorCode").asInt();
+    assertEquals(errorCode, 503);
   }
 
   @Test(dataProvider = "useBothQueryEngines")

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -618,6 +618,16 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(oneHourAgoTodayStr, expectedOneHourAgoTodayStr);
   }
 
+  @Test
+  public void testMaxSerializedResponseLengthPerServer()
+      throws Exception {
+    String queryWithOption = "SET maxSerializedResponseLengthPerServer=1000; " + SELECT_STAR_QUERY;
+    JsonNode response = postQuery(queryWithOption);
+    assert response.get("exceptions").size() > 0;
+    String exceptionStr = response.get("exceptions").get(0).get("message").toString();
+    assert exceptionStr.contains("Serialized response exceeds threshold");
+  }
+
   @Test(dataProvider = "useBothQueryEngines")
   public void testRegexpReplace(boolean useMultiStageQueryEngine)
       throws Exception {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QueryConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QueryConfig.java
@@ -49,16 +49,26 @@ public class QueryConfig extends BaseJsonConfig {
   // the expressions within the query to the desired ones (e.g. override transform function to derived column).
   private final Map<String, String> _expressionOverrideMap;
 
+  // Indicates the maximum response size that can be returned for a query. On the broker side, this value is used to
+  // compute the per-server response size budget. If the server serialized response exceeds the assigned budget, the
+  // query is failed with an error.
+  private final Long _maxQueryResponseSizeBytes;
+
   @JsonCreator
   public QueryConfig(@JsonProperty("timeoutMs") @Nullable Long timeoutMs,
       @JsonProperty("disableGroovy") @Nullable Boolean disableGroovy,
       @JsonProperty("useApproximateFunction") @Nullable Boolean useApproximateFunction,
-      @JsonProperty("expressionOverrideMap") @Nullable Map<String, String> expressionOverrideMap) {
+      @JsonProperty("expressionOverrideMap") @Nullable Map<String, String> expressionOverrideMap,
+      @JsonProperty("maxQueryResponseSizeBytes") @Nullable Long maxQueryResponseSizeBytes) {
     Preconditions.checkArgument(timeoutMs == null || timeoutMs > 0, "Invalid 'timeoutMs': %s", timeoutMs);
+    Preconditions.checkArgument(maxQueryResponseSizeBytes == null || maxQueryResponseSizeBytes > 0,
+        "Invalid 'maxQueryResponseSizeBytes': %s", maxQueryResponseSizeBytes);
+
     _timeoutMs = timeoutMs;
     _disableGroovy = disableGroovy;
     _useApproximateFunction = useApproximateFunction;
     _expressionOverrideMap = expressionOverrideMap;
+    _maxQueryResponseSizeBytes = maxQueryResponseSizeBytes;
   }
 
   @Nullable
@@ -83,5 +93,11 @@ public class QueryConfig extends BaseJsonConfig {
   @JsonProperty("expressionOverrideMap")
   public Map<String, String> getExpressionOverrideMap() {
     return _expressionOverrideMap;
+  }
+
+  @Nullable
+  @JsonProperty("maxQueryResponseSizeBytes")
+  public Long getMaxQueryResponseSizeBytes() {
+    return _maxQueryResponseSizeBytes;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QueryConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/QueryConfig.java
@@ -49,26 +49,32 @@ public class QueryConfig extends BaseJsonConfig {
   // the expressions within the query to the desired ones (e.g. override transform function to derived column).
   private final Map<String, String> _expressionOverrideMap;
 
-  // Indicates the maximum response size that can be returned for a query. On the broker side, this value is used to
-  // compute the per-server response size budget. If the server serialized response exceeds the assigned budget, the
-  // query is failed with an error.
+  // Indicates the maximum length of serialized response across all servers for a query. This value is equally
+  // divided across all servers processing the query.
   private final Long _maxQueryResponseSizeBytes;
+
+  // Indicates the maximum length of the serialized response per server for a query.
+  private final Long _maxServerResponseSizeBytes;
 
   @JsonCreator
   public QueryConfig(@JsonProperty("timeoutMs") @Nullable Long timeoutMs,
       @JsonProperty("disableGroovy") @Nullable Boolean disableGroovy,
       @JsonProperty("useApproximateFunction") @Nullable Boolean useApproximateFunction,
       @JsonProperty("expressionOverrideMap") @Nullable Map<String, String> expressionOverrideMap,
-      @JsonProperty("maxQueryResponseSizeBytes") @Nullable Long maxQueryResponseSizeBytes) {
+      @JsonProperty("maxQueryResponseSizeBytes") @Nullable Long maxQueryResponseSizeBytes,
+      @JsonProperty("maxServerResponseSizeBytes") @Nullable Long maxServerResponseSizeBytes) {
     Preconditions.checkArgument(timeoutMs == null || timeoutMs > 0, "Invalid 'timeoutMs': %s", timeoutMs);
     Preconditions.checkArgument(maxQueryResponseSizeBytes == null || maxQueryResponseSizeBytes > 0,
         "Invalid 'maxQueryResponseSizeBytes': %s", maxQueryResponseSizeBytes);
+    Preconditions.checkArgument(maxServerResponseSizeBytes == null || maxServerResponseSizeBytes > 0,
+        "Invalid 'maxServerResponseSizeBytes': %s", maxServerResponseSizeBytes);
 
     _timeoutMs = timeoutMs;
     _disableGroovy = disableGroovy;
     _useApproximateFunction = useApproximateFunction;
     _expressionOverrideMap = expressionOverrideMap;
     _maxQueryResponseSizeBytes = maxQueryResponseSizeBytes;
+    _maxServerResponseSizeBytes = maxServerResponseSizeBytes;
   }
 
   @Nullable
@@ -99,5 +105,11 @@ public class QueryConfig extends BaseJsonConfig {
   @JsonProperty("maxQueryResponseSizeBytes")
   public Long getMaxQueryResponseSizeBytes() {
     return _maxQueryResponseSizeBytes;
+  }
+
+  @Nullable
+  @JsonProperty("maxServerResponseSizeBytes")
+  public Long getMaxServerResponseSizeBytes() {
+    return _maxServerResponseSizeBytes;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -318,6 +318,9 @@ public class CommonConstants {
         "pinot.broker.enable.partition.metadata.manager";
     public static final boolean DEFAULT_ENABLE_PARTITION_METADATA_MANAGER = false;
 
+    public static final String CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES = "pinot.broker.max.query.response.size.bytes";
+    public static final long DEFAULT_MAX_QUERY_RESPONSE_SIZE_BYTES = -1;
+
     public static class Request {
       public static final String SQL = "sql";
       public static final String TRACE = "trace";
@@ -361,6 +364,11 @@ public class CommonConstants {
         // Handle JOIN Overflow
         public static final String MAX_ROWS_IN_JOIN = "maxRowsInJoin";
         public static final String JOIN_OVERFLOW_MODE = "joinOverflowMode";
+
+        // Indicates the maximum length of the serialized response per server for a query. The response size that a
+        // server can return is allocated by dividing the total budget CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES across
+        // all servers processing the query.
+        public static final String MAX_SERIALIZED_RESPONSE_LENGTH_PER_SERVER = "maxSerializedResponseLengthPerServer";
 
         // TODO: Remove these keys (only apply to PQL) after releasing 0.11.0
         @Deprecated

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -319,7 +319,7 @@ public class CommonConstants {
     public static final boolean DEFAULT_ENABLE_PARTITION_METADATA_MANAGER = false;
 
     public static final String CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES = "pinot.broker.max.query.response.size.bytes";
-    public static final long DEFAULT_MAX_QUERY_RESPONSE_SIZE_BYTES = -1;
+    public static final long DEFAULT_MAX_QUERY_RESPONSE_SIZE_BYTES = Long.MAX_VALUE;
 
     public static class Request {
       public static final String SQL = "sql";
@@ -366,9 +366,9 @@ public class CommonConstants {
         public static final String JOIN_OVERFLOW_MODE = "joinOverflowMode";
 
         // Indicates the maximum length of the serialized response per server for a query. The response size that a
-        // server can return is allocated by dividing the total budget CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES across
+        // server can return is allocated by dividing the total budget CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES across
         // all servers processing the query.
-        public static final String MAX_SERIALIZED_RESPONSE_LENGTH_PER_SERVER = "maxSerializedResponseLengthPerServer";
+        public static final String MAX_SERVER_RESPONSE_SIZE_BYTES = "maxServerResponseSizeBytes";
 
         // TODO: Remove these keys (only apply to PQL) after releasing 0.11.0
         @Deprecated

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -318,8 +318,15 @@ public class CommonConstants {
         "pinot.broker.enable.partition.metadata.manager";
     public static final boolean DEFAULT_ENABLE_PARTITION_METADATA_MANAGER = false;
 
+    // Broker config indicating the maximum serialized response size across all servers for a query. This value is
+    // equally divided across all servers processing the query.
     public static final String CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES = "pinot.broker.max.query.response.size.bytes";
     public static final long DEFAULT_MAX_QUERY_RESPONSE_SIZE_BYTES = Long.MAX_VALUE;
+
+    // Broker config indicating the maximum length of the serialized response per server for a query.
+    public static final String CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES = "pinot.broker.max.server.response.size.bytes";
+    public static final long DEFAULT_MAX_SERVER_RESPONSE_SIZE_BYTES = Long.MAX_VALUE;
+
 
     public static class Request {
       public static final String SQL = "sql";
@@ -365,10 +372,12 @@ public class CommonConstants {
         public static final String MAX_ROWS_IN_JOIN = "maxRowsInJoin";
         public static final String JOIN_OVERFLOW_MODE = "joinOverflowMode";
 
-        // Indicates the maximum length of the serialized response per server for a query. The response size that a
-        // server can return is allocated by dividing the total budget CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES across
-        // all servers processing the query.
+        // Indicates the maximum length of the serialized response per server for a query.
         public static final String MAX_SERVER_RESPONSE_SIZE_BYTES = "maxServerResponseSizeBytes";
+
+        // Indicates the maximum length of serialized response across all servers for a query. This value is equally
+        // divided across all servers processing the query.
+        public static final String MAX_QUERY_RESPONSE_SIZE_BYTES = "maxQueryResponseSizeBytes";
 
         // TODO: Remove these keys (only apply to PQL) after releasing 0.11.0
         @Deprecated


### PR DESCRIPTION
When server responds for a query with a large response, the broker can potentially crash with direct memory OOM. 

In PR https://github.com/apache/pinot/pull/11496 - a fix was added to restart the Netty Channel in such scenarios. This will result in all active queries failing with an error. This is a good fix to have to protect Brokers in this extreme case. 

However, to reduce the probability of such events happening and contain the impact for other queries, this PR introduces a threshold at the Server. If the serialized query response at a Server exceeds the threshold, the query is failed.  The overall threshold for a query is set using a config. This budget is divided across all Servers processing the query. 

cc: @siddharthteotia @jasperjiaguo  @gortiz @ege-st @dinoocch 