### PR TITLE
Post build index creation

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -195,7 +195,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       Map<IndexType<?, ?, ?>, IndexCreator> creatorsByIndex =
           Maps.newHashMapWithExpectedSize(IndexService.getInstance().getAllIndexes().size());
       for (IndexType<?, ?, ?> index : IndexService.getInstance().getAllIndexes()) {
-        if (index.getIndexBuildLifecycle() != IndexType.IndexBuildLifecycle.DURING_SEGMENT_CREATION) {
+        if (index.getIndexBuildLifecycle() != IndexType.BuildLifecycle.DURING_SEGMENT_CREATION) {
           continue;
         }
         tryCreateIndexCreator(creatorsByIndex, index, context, config);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -94,7 +94,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
   /**
    * Contains, indexed by column name, the creator associated with each index type.
    *
-   * Indexes that {@link #hasSpecialLifecycle(IndexType) have a special lyfecycle} are not included here.
+   * Indexes whose build lifecycle is not DURING_SEGMENT_CREATION are not included here.
    */
   private Map<String, Map<IndexType<?, ?, ?>, IndexCreator>> _creatorsByColAndIndex = new HashMap<>();
   private final Map<String, NullValueVectorCreator> _nullValueVectorCreatorMap = new HashMap<>();
@@ -195,7 +195,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       Map<IndexType<?, ?, ?>, IndexCreator> creatorsByIndex =
           Maps.newHashMapWithExpectedSize(IndexService.getInstance().getAllIndexes().size());
       for (IndexType<?, ?, ?> index : IndexService.getInstance().getAllIndexes()) {
-        if (hasSpecialLifecycle(index)) {
+        if (index.getIndexBuildLifecycle() != IndexType.IndexBuildLifecycle.DURING_SEGMENT_CREATION) {
           continue;
         }
         tryCreateIndexCreator(creatorsByIndex, index, context, config);
@@ -241,14 +241,6 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
       builder.undeclare(StandardIndexes.inverted());
     }
     return builder.build();
-  }
-
-  /**
-   * Returns true if the given index type has their own construction lifecycle and therefore should not be instantiated
-   * in the general index loop and shouldn't be notified of each new column.
-   */
-  private boolean hasSpecialLifecycle(IndexType<?, ?, ?> indexType) {
-    return indexType == StandardIndexes.nullValueVector() || indexType == StandardIndexes.dictionary();
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -324,36 +324,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     if (_totalDocs > 0) {
       buildStarTreeV2IfNecessary(segmentOutputDir);
     }
-
-    Set<IndexType> postSegCreationIndexes = IndexService.getInstance().getAllIndexes().stream()
-        .filter(indexType -> indexType.getIndexBuildLifecycle() == IndexType.IndexBuildLifecycle.POST_SEGMENT_CREATION)
-        .collect(Collectors.toSet());
-
-    if (postSegCreationIndexes.size() > 0) {
-      // Build other indexes
-      Map<String, Object> props = new HashMap<>();
-      props.put(IndexLoadingConfig.READ_MODE_KEY, ReadMode.mmap);
-      PinotConfiguration segmentDirectoryConfigs = new PinotConfiguration(props);
-
-      SegmentDirectoryLoaderContext segmentLoaderContext =
-          new SegmentDirectoryLoaderContext.Builder().setTableConfig(_config.getTableConfig())
-              .setSchema(_config.getSchema()).setSegmentName(_segmentName)
-              .setSegmentDirectoryConfigs(segmentDirectoryConfigs).build();
-
-      IndexLoadingConfig indexLoadingConfig =
-          new IndexLoadingConfig(null, _config.getTableConfig(), _config.getSchema());
-
-      try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
-          .load(segmentOutputDir.toURI(), segmentLoaderContext);
-          SegmentDirectory.Writer segmentWriter = segmentDirectory.createWriter()) {
-        for (IndexType indexType : postSegCreationIndexes) {
-          IndexHandler handler =
-              indexType.createIndexHandler(segmentDirectory, indexLoadingConfig.getFieldIndexConfigByColName(),
-                  _config.getSchema(), _config.getTableConfig());
-          handler.updateIndices(segmentWriter);
-        }
-      }
-    }
+    updatePostSegmentCreationIndexes(segmentOutputDir);
 
     // Compute CRC and creation time
     long crc = CrcUtils.forAllFilesInFolder(segmentOutputDir).computeCrc();
@@ -377,6 +348,39 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     LOGGER.info("Driver, stats collector time : {}", _totalStatsCollectorTime);
     LOGGER.info("Driver, indexing time : {}", _totalIndexTime);
   }
+
+  private void updatePostSegmentCreationIndexes(File indexDir) throws Exception {
+    Set<IndexType> postSegCreationIndexes = IndexService.getInstance().getAllIndexes().stream()
+        .filter(indexType -> indexType.getIndexBuildLifecycle() == IndexType.BuildLifecycle.POST_SEGMENT_CREATION)
+        .collect(Collectors.toSet());
+
+    if (postSegCreationIndexes.size() > 0) {
+      // Build other indexes
+      Map<String, Object> props = new HashMap<>();
+      props.put(IndexLoadingConfig.READ_MODE_KEY, ReadMode.mmap);
+      PinotConfiguration segmentDirectoryConfigs = new PinotConfiguration(props);
+
+      SegmentDirectoryLoaderContext segmentLoaderContext =
+          new SegmentDirectoryLoaderContext.Builder().setTableConfig(_config.getTableConfig())
+              .setSchema(_config.getSchema()).setSegmentName(_segmentName)
+              .setSegmentDirectoryConfigs(segmentDirectoryConfigs).build();
+
+      IndexLoadingConfig indexLoadingConfig =
+          new IndexLoadingConfig(null, _config.getTableConfig(), _config.getSchema());
+
+      try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
+          .load(indexDir.toURI(), segmentLoaderContext);
+          SegmentDirectory.Writer segmentWriter = segmentDirectory.createWriter()) {
+        for (IndexType indexType : postSegCreationIndexes) {
+          IndexHandler handler =
+              indexType.createIndexHandler(segmentDirectory, indexLoadingConfig.getFieldIndexConfigByColName(),
+                  _config.getSchema(), _config.getTableConfig());
+          handler.updateIndices(segmentWriter);
+        }
+      }
+    }
+  }
+
 
   private void buildStarTreeV2IfNecessary(File indexDir)
       throws Exception {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -23,11 +23,14 @@ import java.io.DataOutputStream;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.io.FileUtils;
@@ -37,6 +40,7 @@ import org.apache.pinot.segment.local.segment.creator.RecordReaderSegmentCreatio
 import org.apache.pinot.segment.local.segment.creator.TransformPipeline;
 import org.apache.pinot.segment.local.segment.index.converter.SegmentFormatConverterFactory;
 import org.apache.pinot.segment.local.segment.index.dictionary.DictionaryIndexType;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
 import org.apache.pinot.segment.local.startree.v2.builder.MultipleTreesBuilder;
 import org.apache.pinot.segment.local.utils.CrcUtils;
@@ -52,7 +56,13 @@ import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.segment.spi.creator.SegmentPreIndexStatsContainer;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.creator.StatsCollectorConfig;
+import org.apache.pinot.segment.spi.index.IndexHandler;
+import org.apache.pinot.segment.spi.index.IndexService;
+import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.creator.SegmentIndexCreationInfo;
+import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
+import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
+import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -65,7 +75,9 @@ import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderFactory;
+import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.ReadMode;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -311,6 +323,37 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     // Build star-tree V2 if necessary
     if (_totalDocs > 0) {
       buildStarTreeV2IfNecessary(segmentOutputDir);
+    }
+
+    Set<IndexType> postSegCreationIndexes = IndexService.getInstance().getAllIndexes().stream()
+        .filter(indexType -> indexType.getIndexBuildLifecycle() == IndexType.IndexBuildLifecycle.POST_SEGMENT_CREATION)
+        .collect(Collectors.toSet());
+
+    if (postSegCreationIndexes.size() > 0) {
+      // Build other indexes
+      Map<String, Object> props = new HashMap<>();
+      props.put(IndexLoadingConfig.READ_MODE_KEY, ReadMode.mmap);
+      PinotConfiguration segmentDirectoryConfigs = new PinotConfiguration(props);
+
+      SegmentDirectoryLoaderContext segmentLoaderContext =
+          new SegmentDirectoryLoaderContext.Builder().setTableConfig(_config.getTableConfig())
+              .setSchema(_config.getSchema()).setSegmentName(_segmentName)
+              .setSegmentDirectoryConfigs(segmentDirectoryConfigs).build();
+
+      IndexLoadingConfig indexLoadingConfig =
+          new IndexLoadingConfig(null, _config.getTableConfig(), _config.getSchema());
+
+      try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
+          .load(segmentOutputDir.toURI(), segmentLoaderContext)) {
+        for (IndexType indexType : postSegCreationIndexes) {
+          IndexHandler handler =
+              indexType.createIndexHandler(segmentDirectory, indexLoadingConfig.getFieldIndexConfigByColName(),
+                  _config.getSchema(), _config.getTableConfig());
+          if (handler.needUpdateIndices(segmentDirectory.createReader())) {
+            handler.updateIndices(segmentDirectory.createWriter());
+          }
+        }
+      }
     }
 
     // Compute CRC and creation time

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -344,14 +344,13 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
           new IndexLoadingConfig(null, _config.getTableConfig(), _config.getSchema());
 
       try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
-          .load(segmentOutputDir.toURI(), segmentLoaderContext)) {
+          .load(segmentOutputDir.toURI(), segmentLoaderContext);
+          SegmentDirectory.Writer segmentWriter = segmentDirectory.createWriter()){
         for (IndexType indexType : postSegCreationIndexes) {
           IndexHandler handler =
               indexType.createIndexHandler(segmentDirectory, indexLoadingConfig.getFieldIndexConfigByColName(),
                   _config.getSchema(), _config.getTableConfig());
-          if (handler.needUpdateIndices(segmentDirectory.createReader())) {
-            handler.updateIndices(segmentDirectory.createWriter());
-          }
+          handler.updateIndices(segmentWriter);
         }
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -345,7 +345,7 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
 
       try (SegmentDirectory segmentDirectory = SegmentDirectoryLoaderRegistry.getDefaultSegmentDirectoryLoader()
           .load(segmentOutputDir.toURI(), segmentLoaderContext);
-          SegmentDirectory.Writer segmentWriter = segmentDirectory.createWriter()){
+          SegmentDirectory.Writer segmentWriter = segmentDirectory.createWriter()) {
         for (IndexType indexType : postSegCreationIndexes) {
           IndexHandler handler =
               indexType.createIndexHandler(segmentDirectory, indexLoadingConfig.getFieldIndexConfigByColName(),

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentIndexCreationDriverImpl.java
@@ -381,7 +381,6 @@ public class SegmentIndexCreationDriverImpl implements SegmentIndexCreationDrive
     }
   }
 
-
   private void buildStarTreeV2IfNecessary(File indexDir)
       throws Exception {
     List<StarTreeIndexConfig> starTreeIndexConfigs = _config.getStarTreeIndexConfigs();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
@@ -449,4 +449,8 @@ public class DictionaryIndexType
     return MutableDictionaryFactory.getMutableDictionary(storedType, context.isOffHeap(), context.getMemoryManager(),
         dictionaryColumnSize, Math.min(estimatedCardinality, context.getCapacity()), dictionaryAllocationContext);
   }
+
+  public IndexBuildLifecycle getIndexBuildLifecycle() {
+    return IndexBuildLifecycle.CUSTOM;
+  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/dictionary/DictionaryIndexType.java
@@ -450,7 +450,7 @@ public class DictionaryIndexType
         dictionaryColumnSize, Math.min(estimatedCardinality, context.getCapacity()), dictionaryAllocationContext);
   }
 
-  public IndexBuildLifecycle getIndexBuildLifecycle() {
-    return IndexBuildLifecycle.CUSTOM;
+  public BuildLifecycle getIndexBuildLifecycle() {
+    return BuildLifecycle.CUSTOM;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
@@ -130,4 +130,8 @@ public class NullValueIndexType extends AbstractIndexType<IndexConfig, NullValue
   @Override
   public void convertToNewFormat(TableConfig tableConfig, Schema schema) {
   }
+
+  public IndexBuildLifecycle getIndexBuildLifecycle() {
+    return IndexBuildLifecycle.CUSTOM;
+  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
@@ -131,7 +131,7 @@ public class NullValueIndexType extends AbstractIndexType<IndexConfig, NullValue
   public void convertToNewFormat(TableConfig tableConfig, Schema schema) {
   }
 
-  public IndexBuildLifecycle getIndexBuildLifecycle() {
-    return IndexBuildLifecycle.CUSTOM;
+  public BuildLifecycle getIndexBuildLifecycle() {
+    return BuildLifecycle.CUSTOM;
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
@@ -38,6 +38,11 @@ import org.apache.pinot.spi.data.Schema;
  * @param <IC> the {@link IndexCreator} subclass that should be used to create indexes of this type.
  */
 public interface IndexType<C extends IndexConfig, IR extends IndexReader, IC extends IndexCreator> {
+  enum IndexBuildLifecycle {
+    DURING_SEGMENT_CREATION,
+    POST_SEGMENT_CREATION,
+    CUSTOM
+  }
 
   /**
    * The unique id that identifies this index type.
@@ -126,5 +131,9 @@ public interface IndexType<C extends IndexConfig, IR extends IndexReader, IC ext
   @Nullable
   default MutableIndex createMutableIndex(MutableIndexContext context, C config) {
     return null;
+  }
+
+  default IndexBuildLifecycle getIndexBuildLifecycle() {
+    return IndexBuildLifecycle.DURING_SEGMENT_CREATION;
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/IndexType.java
@@ -38,10 +38,11 @@ import org.apache.pinot.spi.data.Schema;
  * @param <IC> the {@link IndexCreator} subclass that should be used to create indexes of this type.
  */
 public interface IndexType<C extends IndexConfig, IR extends IndexReader, IC extends IndexCreator> {
-  enum IndexBuildLifecycle {
-    DURING_SEGMENT_CREATION,
-    POST_SEGMENT_CREATION,
-    CUSTOM
+  /**
+   * Returns the {@link BuildLifecycle} for this index type. This is used to determine when the index should be built.
+   */
+  default BuildLifecycle getIndexBuildLifecycle() {
+    return BuildLifecycle.DURING_SEGMENT_CREATION;
   }
 
   /**
@@ -133,7 +134,22 @@ public interface IndexType<C extends IndexConfig, IR extends IndexReader, IC ext
     return null;
   }
 
-  default IndexBuildLifecycle getIndexBuildLifecycle() {
-    return IndexBuildLifecycle.DURING_SEGMENT_CREATION;
+  enum BuildLifecycle {
+    /**
+     * The index will be built during segment creation, using the {@link IndexCreator#add} call for each of the column
+     * values being added.
+     */
+    DURING_SEGMENT_CREATION,
+
+    /**
+     * The index will be build post the segment file has been created, using the {@link IndexHandler#updateIndices} call
+     * This is useful for indexes that may need the entire prebuilt segment to be available before they can be built.
+     */
+    POST_SEGMENT_CREATION,
+
+    /**
+     * The index's built lifecycle is managed in a custom manner.
+     */
+    CUSTOM
   }
 }


### PR DESCRIPTION
It may be desirable for some index types to be build post segment file has been created. This PR allows for that.
The behaviour can be achieved for a custom index being added (using index-spi) by overriding the `getIndexBuildLifecycle` method to return `BuildLifecycle.POST_SEGMENT_CREATION`

## Release notes

Adds support for building indexes post segment file creation, allowing indexes that may depend on a completed segment to be built as part of the segment creation process. 