### PR TITLE
Adding a metric to measure total thread cpu time for a table

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -103,7 +103,8 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   NUM_SEGMENTS_PRUNED_INVALID("numSegmentsPrunedInvalid", false),
   NUM_SEGMENTS_PRUNED_BY_LIMIT("numSegmentsPrunedByLimit", false),
   NUM_SEGMENTS_PRUNED_BY_VALUE("numSegmentsPrunedByValue", false),
-  LARGE_QUERY_RESPONSES_SENT("largeResponses", false);
+  LARGE_QUERY_RESPONSES_SENT("largeResponses", false),
+  TOTAL_THREAD_CPU_TIME_MILLIS("millis", false);
 
   private final String _meterName;
   private final String _unit;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/scheduler/QueryScheduler.java
@@ -227,6 +227,8 @@ public abstract class QueryScheduler {
       if (threadCpuTimeNs > 0) {
         _serverMetrics.addTimedTableValue(tableNameWithType, ServerTimer.EXECUTION_THREAD_CPU_TIME_NS, threadCpuTimeNs,
             TimeUnit.NANOSECONDS);
+        _serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.TOTAL_THREAD_CPU_TIME_MILLIS,
+            TimeUnit.MILLISECONDS.convert(threadCpuTimeNs, TimeUnit.NANOSECONDS));
       }
       if (systemActivitiesCpuTimeNs > 0) {
         _serverMetrics.addTimedTableValue(tableNameWithType, ServerTimer.SYSTEM_ACTIVITIES_CPU_TIME_NS,


### PR DESCRIPTION
Allows us to compute the total thread cpu time each table uses for queries.