### PR TITLE
Reduce cpu usage by avoiding throwing an exception during query execution

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/Operator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/Operator.java
@@ -72,7 +72,7 @@ public interface Operator<T extends Block> {
    * Returns the index segment associated with the operator.
    */
   default IndexSegment getIndexSegment() {
-    throw new UnsupportedOperationException();
+    return null;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/CombineOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/CombineOperatorUtils.java
@@ -48,15 +48,13 @@ public class CombineOperatorUtils {
       if (executionStatistics.getNumDocsScanned() > 0) {
         numSegmentsMatched++;
       }
-      // TODO: Check all operators and properly implement the getIndexSegment and remove this exception handling
-      try {
-        if (operator.getIndexSegment() instanceof MutableSegment) {
-          numConsumingSegmentsProcessed += 1;
-          if (executionStatistics.getNumDocsScanned() > 0) {
-            numConsumingSegmentsMatched++;
-          }
+
+      // TODO: Check all operators and properly implement the getIndexSegment.
+      if (operator.getIndexSegment() != null && operator.getIndexSegment() instanceof MutableSegment) {
+        numConsumingSegmentsProcessed += 1;
+        if (executionStatistics.getNumDocsScanned() > 0) {
+          numConsumingSegmentsMatched++;
         }
-      } catch (UnsupportedOperationException ignored) {
       }
 
       numDocsScanned += executionStatistics.getNumDocsScanned();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/CombineOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/CombineOperatorUtils.java
@@ -50,7 +50,7 @@ public class CombineOperatorUtils {
       }
 
       // TODO: Check all operators and properly implement the getIndexSegment.
-      if (operator.getIndexSegment() != null && operator.getIndexSegment() instanceof MutableSegment) {
+      if (operator.getIndexSegment() instanceof MutableSegment) {
         numConsumingSegmentsProcessed += 1;
         if (executionStatistics.getNumDocsScanned() > 0) {
           numConsumingSegmentsMatched++;


### PR DESCRIPTION
In #9092, we added query execution stats to fetch setNumConsumingSegmentsProcessed and setNumConsumingSegmentsMatched

In one of our production clusters, we observed that `Operator.getIndexSegment -> UnsupportedOperationException()` was consuming > 8% of CPU. Analyzing it, the RCA is as follows:
- Stats collection calls getIndexSegment() which is not implemented by all operators.
- The default implementation throws an exception.
- We simply catch the exception and do nothing
The process of throwing an exception (needlessly in this case) is expensive CPU-wise because it collects a stack-trace (which is expensive and slow) amongst other things. Some benchmarking [here](https://www.baeldung.com/java-exceptions-performance).


Attaching flamegraph that shows CPU usage 

![image](https://github.com/apache/pinot/assets/21298365/a47cae03-dc12-4c46-97f6-1ef793a734b3)

cc: @dinoocch @siddharthteotia 

