### PR TITLE
Gapfill: Add support for lowercase datatypes

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
@@ -23,6 +23,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
@@ -134,6 +137,8 @@ abstract class BaseGapfillProcessor {
     for (int i = 0; i < dataSchema.getColumnNames().length; i++) {
       if (columnNameToAliasMap.containsKey(dataSchema.getColumnNames()[i])) {
         dataSchema.getColumnNames()[i] = columnNameToAliasMap.get(dataSchema.getColumnNames()[i]);
+      } else if (columnNameToAliasMap.containsKey(caseInsensitiveTypeString(dataSchema.getColumnNames()[i]))) {
+        dataSchema.getColumnNames()[i] = columnNameToAliasMap.get(caseInsensitiveTypeString(dataSchema.getColumnNames()[i]));
       }
     }
   }
@@ -225,5 +230,17 @@ abstract class BaseGapfillProcessor {
   protected List<Object[]> gapFillAndAggregate(List<Object[]> rows, DataSchema dataSchema,
       DataSchema resultTableSchema) {
     throw new UnsupportedOperationException("Not supported");
+  }
+
+  protected String caseInsensitiveTypeString(String columnName) {
+    String dataTypePattern = "(BOOLEAN|INT|LONG|FLOAT|DOUBLE|STRING)";
+    Matcher matcher = Pattern.compile(dataTypePattern, Pattern.CASE_INSENSITIVE).matcher(columnName);
+    StringBuffer result = new StringBuffer();
+    while (matcher.find()) {
+      String dataType = matcher.group().toLowerCase();
+      matcher.appendReplacement(result, dataType);
+    }
+    matcher.appendTail(result);
+    return result.toString();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
@@ -138,7 +138,8 @@ abstract class BaseGapfillProcessor {
       if (columnNameToAliasMap.containsKey(dataSchema.getColumnNames()[i])) {
         dataSchema.getColumnNames()[i] = columnNameToAliasMap.get(dataSchema.getColumnNames()[i]);
       } else if (columnNameToAliasMap.containsKey(caseInsensitiveTypeString(dataSchema.getColumnNames()[i]))) {
-        dataSchema.getColumnNames()[i] = columnNameToAliasMap.get(caseInsensitiveTypeString(dataSchema.getColumnNames()[i]));
+        dataSchema.getColumnNames()[i] =
+                columnNameToAliasMap.get(caseInsensitiveTypeString(dataSchema.getColumnNames()[i]));
       }
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/GapfillQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/GapfillQueriesTest.java
@@ -4072,7 +4072,7 @@ public class GapfillQueriesTest extends BaseQueriesTest {
   }
 
   @Test
-  public void GapfillTestAggregateUpperCaseDataType() {
+  public void gapfillTestAggregateUpperCaseDataType() {
     DateTimeFormatSpec dateTimeFormatter =
             new DateTimeFormatSpec("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS");
     DateTimeGranularitySpec dateTimeGranularity = new DateTimeGranularitySpec("1:HOURS");

--- a/pinot-core/src/test/java/org/apache/pinot/queries/GapfillQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/GapfillQueriesTest.java
@@ -4071,6 +4071,89 @@ public class GapfillQueriesTest extends BaseQueriesTest {
     }
   }
 
+  @Test
+  public void GapfillTestAggregateUpperCaseDataType() {
+    DateTimeFormatSpec dateTimeFormatter =
+            new DateTimeFormatSpec("1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS");
+    DateTimeGranularitySpec dateTimeGranularity = new DateTimeGranularitySpec("1:HOURS");
+    long start;
+
+    String gapfillQuery1 = "SELECT "
+            + "time_col, SUM(occupied) as occupied_slots_count, time_col "
+            + "FROM ("
+            + "  SELECT GapFill(time_col, "
+            + "    '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS', "
+            + "    '2021-11-07 8:00:00.000',  '2021-11-07 10:00:00.000', '1:HOURS',"
+            + "     FILL(occupied, 'FILL_PREVIOUS_VALUE'), TIMESERIESON(levelId, lotId)) AS time_col,"
+            + "     occupied, lotId, levelId"
+            + "  FROM ("
+            + "    SELECT DATETIMECONVERT(eventTime, '1:MILLISECONDS:EPOCH', "
+            + "      '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS', '1:HOURS') AS time_col,"
+            + "       lastWithTime(isOccupied, eventTime, 'int') as occupied, lotId, levelId"
+            + "    FROM parkingData "
+            + "    WHERE eventTime >= 1636257600000 AND eventTime <= 1636286400000 "
+            + "    GROUP BY time_col, levelId, lotId "
+            + "    LIMIT 200 "
+            + "  ) "
+            + "  LIMIT 200 "
+            + ") "
+            + " GROUP BY time_col "
+            + " LIMIT 200 ";
+
+    BrokerResponseNative gapfillBrokerResponse1 = getBrokerResponse(gapfillQuery1);
+
+    double[] expectedOccupiedSlotsCounts1 = new double[]{6, 4};
+    ResultTable gapFillResultTable1 = gapfillBrokerResponse1.getResultTable();
+    List<Object[]> gapFillRows1 = gapFillResultTable1.getRows();
+    Assert.assertEquals(gapFillRows1.size(), expectedOccupiedSlotsCounts1.length);
+    start = dateTimeFormatter.fromFormatToMillis("2021-11-07 08:00:00.000");
+    for (int i = 0; i < expectedOccupiedSlotsCounts1.length; i++) {
+      String firstTimeCol = (String) gapFillRows1.get(i)[0];
+      long timeStamp = dateTimeFormatter.fromFormatToMillis(firstTimeCol);
+      Assert.assertEquals(timeStamp, start);
+      Assert.assertEquals(expectedOccupiedSlotsCounts1[i], gapFillRows1.get(i)[1]);
+      start += dateTimeGranularity.granularityToMillis();
+    }
+
+    String gapfillQuery2 = "SELECT "
+            + "time_col, SUM(occupied) as occupied_slots_count, time_col "
+            + "FROM ("
+            + "  SELECT GapFill(time_col, "
+            + "    '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS', "
+            + "    '2021-11-07 8:00:00.000',  '2021-11-07 10:00:00.000', '1:HOURS',"
+            + "     FILL(occupied, 'FILL_PREVIOUS_VALUE'), TIMESERIESON(levelId, lotId)) AS time_col,"
+            + "     occupied, lotId, levelId"
+            + "  FROM ("
+            + "    SELECT DATETIMECONVERT(eventTime, '1:MILLISECONDS:EPOCH', "
+            + "      '1:MILLISECONDS:SIMPLE_DATE_FORMAT:yyyy-MM-dd HH:mm:ss.SSS', '1:HOURS') AS time_col,"
+            + "       lastWithTime(isOccupied, eventTime, 'int') as occupied, lotId, levelId"
+            + "    FROM parkingData "
+            + "    WHERE eventTime >= 1636257600000 AND eventTime <= 1636286400000 "
+            + "    GROUP BY time_col, levelId, lotId "
+            + "    LIMIT 200 "
+            + "  ) "
+            + "  LIMIT 200 "
+            + ") "
+            + " WHERE occupied = 1 "
+            + " GROUP BY time_col "
+            + " LIMIT 200 ";
+
+    BrokerResponseNative gapfillBrokerResponse2 = getBrokerResponse(gapfillQuery2);
+
+    double[] expectedOccupiedSlotsCounts2 = new double[]{6, 4};
+    ResultTable gapFillResultTable2 = gapfillBrokerResponse2.getResultTable();
+    List<Object[]> gapFillRows2 = gapFillResultTable2.getRows();
+    Assert.assertEquals(gapFillRows2.size(), expectedOccupiedSlotsCounts2.length);
+    start = dateTimeFormatter.fromFormatToMillis("2021-11-07 08:00:00.000");
+    for (int i = 0; i < expectedOccupiedSlotsCounts2.length; i++) {
+      String firstTimeCol = (String) gapFillRows2.get(i)[0];
+      long timeStamp = dateTimeFormatter.fromFormatToMillis(firstTimeCol);
+      Assert.assertEquals(timeStamp, start);
+      Assert.assertEquals(expectedOccupiedSlotsCounts2[i], gapFillRows2.get(i)[1]);
+      start += dateTimeGranularity.granularityToMillis();
+    }
+  }
+
   @AfterClass
   public void tearDown()
       throws IOException {


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Handles lowercase datatype column names in gapfill by checking alias map case‑insensitively and replacing with proper alias\.

```mermaid
flowchart TD
  N0["replaceColumnNameWithAlias #40;F1#41;"]:::stModified
  N1["exact match check #40;F1#41;"]:::stModified
  N2["set alias #40;exact#41; #40;F1#41;"]:::stModified
  N3["caseInsensitiveTypeString call #40;F1#41;"]:::stModified
  N4["lowercase matched datatype #40;F1#41;"]:::stModified
  N5["case#8209;insensitive map check #40;F1#41;"]:::stModified
  N6["set alias #40;ci#41; #40;F1#41;"]:::stModified
  N0 -->|"enter loop"| N1
  N1 -->|"true"| N2
  N1 -->|"false"| N3
  N3 -->|"process match"| N4
  N4 -->|"return ciString"| N5
  N5 -->|"true"| N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor\.java — [before](https://github.com/apache/pinot/blob/ae1681273c4929587729d71c6dc9526c62ca1fcc/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java) · [after](https://github.com/apache/pinot/blob/31ef6b78c3d890623cb14993820728da8f30de71/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImFlMTY4MTI3M2M0OTI5NTg3NzI5ZDcxYzZkYzk1MjZjNjJjYTFmY2MiLCJjb250ZXh0X2hhc2giOiJmMmM2NDYxMGMwN2UwY2Q5ZjUzYTczMjMyNDg0NjE1YjAzNDdjYTVkMzRhZmE2MDA0ZmNkOWI5YjMwNzIzMWE1IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NzA5MjAzLCJoZWFkX3NoYSI6IjMxZWY2Yjc4YzNkODkwNjIzY2IxNDk5MzgyMDcyOGRhOGYzMGRlNzEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJhZTE2ODEyNzNjNDkyOTU4NzcyOWQ3MWM2ZGM5NTI2YzYyY2ExZmNjIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature e80ccb6bd3d7d3c04182362f0acaa2795aa03304e64dd16c4d4f938a12e5f5e6 -->
<!-- pinot-pr-flow:end -->

bugfix for Gapfill functions where lowercase datatypes with certain aggregate functions do not work (causing null ptr exceptions). 

- Pinot natively [supports](https://docs.pinot.apache.org/users/user-guide-query/query-syntax/supported-aggregations) lower case for aggregate functions. However this functionality breaks when used with Gapfill.

- This is because the dataschema returned by the server is always uppercase. There is a mismatch between the column names causing NPE (when attempting to map the column alias with the fetched data). 

- Added a check to handle lowercase data schemas when creating response of gapfill queries.
- Fixes #11322