### PR TITLE
Modify StPoint scalar function signature for v2 compatibility

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -213,7 +213,7 @@ public enum TransformFunctionType {
   ST_GEOG_FROM_WKB("ST_GeogFromWKB", ReturnTypes.explicit(SqlTypeName.VARBINARY), OperandTypes.BINARY),
   ST_GEOM_FROM_WKB("ST_GeomFromWKB", ReturnTypes.explicit(SqlTypeName.VARBINARY), OperandTypes.BINARY),
   ST_POINT("ST_Point", ReturnTypes.explicit(SqlTypeName.VARBINARY),
-      OperandTypes.family(ImmutableList.of(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC),
+      OperandTypes.family(ImmutableList.of(SqlTypeFamily.NUMERIC, SqlTypeFamily.NUMERIC, SqlTypeFamily.ANY),
           ordinal -> ordinal > 1 && ordinal < 4), "stPoint"),
   ST_POLYGON("ST_Polygon", ReturnTypes.explicit(SqlTypeName.VARBINARY), OperandTypes.STRING, "stPolygon"),
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/ScalarFunctions.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/ScalarFunctions.java
@@ -22,6 +22,7 @@ import org.apache.pinot.segment.local.utils.GeometrySerializer;
 import org.apache.pinot.segment.local.utils.GeometryUtils;
 import org.apache.pinot.segment.local.utils.H3Utils;
 import org.apache.pinot.spi.annotations.ScalarFunction;
+import org.apache.pinot.spi.utils.BooleanUtils;
 import org.locationtech.jts.geom.Coordinate;
 import org.locationtech.jts.geom.Geometry;
 import org.locationtech.jts.geom.Point;
@@ -56,9 +57,9 @@ public class ScalarFunctions {
    * @return the created point
    */
   @ScalarFunction(names = {"stPoint", "ST_point"})
-  public static byte[] stPoint(double x, double y, boolean isGeography) {
+  public static byte[] stPoint(double x, double y, Object isGeography) {
     Point point = GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(x, y));
-    if (isGeography) {
+    if (BooleanUtils.toBoolean(isGeography)) {
       GeometryUtils.setGeography(point);
     }
     return GeometrySerializer.serialize(point);

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StPointFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StPointFunction.java
@@ -28,6 +28,10 @@ import org.apache.pinot.core.operator.transform.function.BaseTransformFunction;
 import org.apache.pinot.core.operator.transform.function.LiteralTransformFunction;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
+import org.apache.pinot.segment.local.utils.GeometrySerializer;
+import org.apache.pinot.segment.local.utils.GeometryUtils;
+import org.locationtech.jts.geom.Coordinate;
+import org.locationtech.jts.geom.Point;
 
 
 /**
@@ -79,7 +83,11 @@ public class StPointFunction extends BaseTransformFunction {
     double[] firstValues = _firstArgument.transformToDoubleValuesSV(valueBlock);
     double[] secondValues = _secondArgument.transformToDoubleValuesSV(valueBlock);
     for (int i = 0; i < valueBlock.getNumDocs(); i++) {
-      _results[i] = ScalarFunctions.stPoint(firstValues[i], secondValues[i], _isGeography);
+      Point point = GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(firstValues[i], secondValues[i]));
+      if (_isGeography) {
+        GeometryUtils.setGeography(point);
+      }
+      _results[i] = GeometrySerializer.serialize(point);
     }
     return _results;
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/GeoSpatialTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/GeoSpatialTest.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericData;
 import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.pinot.core.geospatial.transform.function.ScalarFunctions;
 import org.apache.pinot.segment.local.utils.GeometrySerializer;
 import org.apache.pinot.segment.local.utils.GeometryUtils;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -45,6 +46,7 @@ public class GeoSpatialTest extends CustomDataQueryClusterIntegrationTest {
   private static final int NUM_TOTAL_DOCS = 1000;
   private static final String DIM_NAME = "dimName";
   private static final String ST_POINT = "st_point";
+  private static final String ST_POINT_1 = "st_point_1";
 
   private static final String ST_X_NAME = "st_x";
   private static final String ST_Y_NAME = "st_y";
@@ -109,6 +111,7 @@ public class GeoSpatialTest extends CustomDataQueryClusterIntegrationTest {
     return new Schema.SchemaBuilder().setSchemaName(getTableName())
         .addSingleValueDimension(DIM_NAME, FieldSpec.DataType.STRING)
         .addSingleValueDimension(ST_POINT, FieldSpec.DataType.BYTES)
+        .addSingleValueDimension(ST_POINT_1, FieldSpec.DataType.BYTES)
         .addSingleValueDimension(ST_X_NAME, FieldSpec.DataType.DOUBLE)
         .addSingleValueDimension(ST_Y_NAME, FieldSpec.DataType.DOUBLE)
         .addSingleValueDimension(WKT_1_NAME, FieldSpec.DataType.STRING)
@@ -140,6 +143,8 @@ public class GeoSpatialTest extends CustomDataQueryClusterIntegrationTest {
             null, null),
         new org.apache.avro.Schema.Field(ST_POINT,
             org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BYTES), null, null),
+        new org.apache.avro.Schema.Field(ST_POINT_1,
+            org.apache.avro.Schema.create(org.apache.avro.Schema.Type.BYTES), null, null),
         new org.apache.avro.Schema.Field(WKT_1_NAME, org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING),
             null, null),
         new org.apache.avro.Schema.Field(WKT_2_NAME, org.apache.avro.Schema.create(org.apache.avro.Schema.Type.STRING),
@@ -167,6 +172,8 @@ public class GeoSpatialTest extends CustomDataQueryClusterIntegrationTest {
         record.put(ST_X_NAME, point.getX());
         record.put(ST_Y_NAME, point.getY());
         record.put(ST_POINT, ByteBuffer.wrap(GeometrySerializer.serialize(point)));
+        GeometryUtils.setGeography(point);
+        record.put(ST_POINT_1, ByteBuffer.wrap(GeometrySerializer.serialize(point)));
         record.put(WKT_1_NAME, WKT_1_DATA[i % WKT_1_DATA.length]);
         record.put(WKT_2_NAME, WKT_2_DATA[i % WKT_2_DATA.length]);
         record.put(ST_WITHIN_RESULT_NAME, ST_WITHIN_RESULT[i % ST_WITHIN_RESULT.length]);
@@ -257,6 +264,99 @@ public class GeoSpatialTest extends CustomDataQueryClusterIntegrationTest {
         byte[] expectedValue = GeometrySerializer.serialize(point);
         byte[] actualValue = BytesUtils.toBytes(result);
         assertEquals(actualValue, expectedValue);
+      }
+    }
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testStDistanceFunction(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+
+    for (int isGeography = 0; isGeography < 2; isGeography++) {
+      String query =
+          String.format(
+              "Select ST_DISTANCE(ST_Point(st_x, st_y, %d), ST_Point(40, -40, %d)), st_x, st_y from %s",
+              isGeography, isGeography, getTableName());
+      JsonNode pinotResponse = postQuery(query);
+      JsonNode rows = pinotResponse.get("resultTable").get("rows");
+      for (int i = 0; i < rows.size(); i++) {
+        JsonNode record = rows.get(i);
+        Point point1 = GeometryUtils.GEOMETRY_FACTORY.createPoint(
+            new Coordinate(record.get(1).asDouble(), record.get(2).asDouble()));
+        Point point2 = GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(40, -40));
+        if (isGeography > 0) {
+          GeometryUtils.setGeography(point1);
+          GeometryUtils.setGeography(point2);
+        }
+        double expectedValue =
+            ScalarFunctions.stDistance(GeometrySerializer.serialize(point1), GeometrySerializer.serialize(point2));
+        double actualValue = record.get(0).asDouble();
+        assertEquals(actualValue, expectedValue);
+      }
+    }
+  }
+
+  @Test(dataProvider = "useV2QueryEngine")
+  public void testStPointFunctionWithV2(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    {
+      String query =
+          String.format("Select "
+                  + "ST_Point(a.st_x, a.st_y, -1), "
+                  + "ST_Point(a.st_x, a.st_y, 1), "
+                  + "b.st_point, "
+                  + "b.st_point_1, "
+                  + "ST_DISTANCE(ST_Point(a.st_x, a.st_y, -1), b.st_point), "
+                  + "ST_DISTANCE(ST_Point(a.st_x, a.st_y, 1), b.st_point_1) "
+                  + "FROM %s a "
+                  + "JOIN %s b "
+                  + "ON a.wkt1=b.wkt1 "
+                  + "LIMIT 10",
+              getTableName(),
+              getTableName());
+      JsonNode pinotResponse = postQuery(query);
+      JsonNode rows = pinotResponse.get("resultTable").get("rows");
+      for (int i = 0; i < rows.size(); i++) {
+        JsonNode record = rows.get(i);
+        double dist1 = record.get(4).doubleValue();
+        double dist2 = record.get(5).doubleValue();
+        double expectedDist1 = ScalarFunctions.stDistance(BytesUtils.toBytes(record.get(0).asText()),
+            BytesUtils.toBytes(record.get(2).asText()));
+        double expectedDist2 = ScalarFunctions.stDistance(BytesUtils.toBytes(record.get(1).asText()),
+            BytesUtils.toBytes(record.get(3).asText()));
+        assertEquals(dist1, expectedDist1);
+        assertEquals(dist2, expectedDist2);
+      }
+    }
+    {
+      String query =
+          String.format("Select "
+                  + "ST_Point(a.st_x, a.st_y, false), "
+                  + "ST_Point(a.st_x, a.st_y, true), "
+                  + "b.st_point, "
+                  + "b.st_point_1, "
+                  + "ST_DISTANCE(ST_Point(a.st_x, a.st_y, false), b.st_point), "
+                  + "ST_DISTANCE(ST_Point(a.st_x, a.st_y, true), b.st_point_1) "
+                  + "FROM %s a "
+                  + "JOIN %s b "
+                  + "ON a.wkt1=b.wkt1 "
+                  + "LIMIT 10",
+              getTableName(),
+              getTableName());
+      JsonNode pinotResponse = postQuery(query);
+      JsonNode rows = pinotResponse.get("resultTable").get("rows");
+      for (int i = 0; i < rows.size(); i++) {
+        JsonNode record = rows.get(i);
+        double dist1 = record.get(4).doubleValue();
+        double dist2 = record.get(5).doubleValue();
+        double expectedDist1 = ScalarFunctions.stDistance(BytesUtils.toBytes(record.get(0).asText()),
+            BytesUtils.toBytes(record.get(2).asText()));
+        double expectedDist2 = ScalarFunctions.stDistance(BytesUtils.toBytes(record.get(1).asText()),
+            BytesUtils.toBytes(record.get(3).asText()));
+        assertEquals(dist1, expectedDist1);
+        assertEquals(dist2, expectedDist2);
       }
     }
   }


### PR DESCRIPTION
Transform function allows different types, but scalar can only be registered using one type signature.
E.g. `byte[] stPoint(double x, double y, int isGeography)` and `byte[] stPoint(double x, double y, boolean isGeography)` cannot be registered together.

Since most of our examples/code is using 0/1 as the indicator for `isGeography`, the proposal is to modify scalar function signature to use int as the third argument.

1. Match scalar function signature for `stPoint`
2. Add test for v2 intermediate stage in `org.apache.pinot.integration.tests.custom.GeoSpatialTest`