### PR TITLE
[multistage] Fixing the bytes literal usage in leaf stage

### DIFF
--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
@@ -122,8 +122,9 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
     _mailboxService.start();
 
     QueryServerEnclosure server1 = new QueryServerEnclosure(factory1);
-    QueryServerEnclosure server2 = new QueryServerEnclosure(factory2);
     server1.start();
+    // Start server1 to ensure the next server will have a different port.
+    QueryServerEnclosure server2 = new QueryServerEnclosure(factory2);
     server2.start();
     // this doesn't test the QueryServer functionality so the server port can be the same as the mailbox port.
     // this is only use for test identifier purpose.


### PR DESCRIPTION
The literal bytes passed from planner is a wrapped proto ByteString. This should be converted to Pinot internal ByteArray at inside `LiteralOperand` to ensure the bytes RexExpression returns same internal type.
1. Deserialize proto ByteString to Pinot internal ByteArray
2. cleanup the usage of proto ByteString