### PR TITLE
add json_extract_index transform function to leverage json index for json value extraction

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/TransformFunctionType.java
@@ -113,6 +113,11 @@ public enum TransformFunctionType {
           SqlTypeName.VARCHAR), SqlTypeTransforms.FORCE_NULLABLE),
       OperandTypes.family(ImmutableList.of(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER,
           SqlTypeFamily.CHARACTER), ordinal -> ordinal > 2), "json_extract_scalar"),
+  JSON_EXTRACT_INDEX("jsonExtractIndex",
+      ReturnTypes.cascade(opBinding -> positionalReturnTypeInferenceFromStringLiteral(opBinding, 2,
+          SqlTypeName.VARCHAR), SqlTypeTransforms.FORCE_NULLABLE),
+      OperandTypes.family(ImmutableList.of(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER, SqlTypeFamily.CHARACTER,
+          SqlTypeFamily.CHARACTER), ordinal -> ordinal > 2), "json_extract_index"),
   JSON_EXTRACT_KEY("jsonExtractKey", ReturnTypes.TO_ARRAY,
       OperandTypes.family(ImmutableList.of(SqlTypeFamily.ANY, SqlTypeFamily.CHARACTER)), "json_extract_key"),
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/FunctionDefinitionRegistryTest.java
@@ -47,8 +47,8 @@ public class FunctionDefinitionRegistryTest {
       // Scalar function
       "scalar",
       // Functions without scalar function counterpart as of now
-      "arraylength", "arrayaverage", "arraymin", "arraymax", "arraysum", "clpdecode", "groovy",
-      "inidset", "jsonextractscalar", "jsonextractkey", "lookup", "mapvalue", "timeconvert", "valuein",
+      "arraylength", "arrayaverage", "arraymin", "arraymax", "arraysum", "clpdecode", "groovy", "inidset",
+      "jsonextractscalar", "jsonextractindex", "jsonextractkey", "lookup", "mapvalue", "timeconvert", "valuein",
       // functions not needed for register b/c they are in std sql table or they will not be composed directly.
       "in", "not_in", "and", "or", "range", "extract", "is_true", "is_not_true", "is_false", "is_not_false"
   );

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunction.java
@@ -1,0 +1,257 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import java.math.BigDecimal;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.pinot.core.operator.ColumnContext;
+import org.apache.pinot.core.operator.blocks.ValueBlock;
+import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.roaringbitmap.RoaringBitmap;
+
+
+/**
+ * The <code>JsonExtractIndexTransformFunction</code> provides the same behavior as JsonExtractScalar, with the
+ * implementation changed to read values from the JSON index. For large JSON blobs this can be faster than parsing
+ * GBs of JSON at query time. For small JSON blobs/highly filtered input this is generally slower than the *scalar
+ * implementation.
+ */
+public class JsonExtractIndexTransformFunction extends BaseTransformFunction {
+  public static final String FUNCTION_NAME = "jsonExtractIndex";
+
+  private TransformFunction _jsonFieldTransformFunction;
+  private String _jsonPathString;
+  private TransformResultMetadata _resultMetadata;
+  private JsonIndexReader _jsonIndexReader;
+  private Object _defaultValue;
+  private Map<Object, RoaringBitmap> _postingListCache;
+
+  @Override
+  public String getName() {
+    return FUNCTION_NAME;
+  }
+
+  @Override
+  public void init(List<TransformFunction> arguments, Map<String, ColumnContext> columnContextMap) {
+    // Check that there are exactly 3 or 4 arguments
+    if (arguments.size() < 3 || arguments.size() > 4) {
+      throw new IllegalArgumentException(
+          "Expected 3/4 arguments for transform function: jsonExtractIndex(jsonFieldName, 'jsonPath', 'resultsType',"
+              + " ['defaultValue'])");
+    }
+
+    TransformFunction firstArgument = arguments.get(0);
+    if (firstArgument instanceof LiteralTransformFunction || !firstArgument.getResultMetadata().isSingleValue()) {
+      throw new IllegalArgumentException(
+          "The first argument of jsonExtractIndex transform function must be a single-valued column or a transform "
+              + "function");
+    }
+    if (firstArgument instanceof IdentifierTransformFunction) {
+      String columnName = ((IdentifierTransformFunction) firstArgument).getColumnName();
+      if (columnContextMap.containsKey(columnName)) {
+        _jsonIndexReader = columnContextMap.get(columnName).getDataSource().getJsonIndex();
+        if (_jsonIndexReader == null) {
+          throw new UnsupportedOperationException("jsonExtractIndex can only be applied on a column with JSON index");
+        }
+      }
+    } else {
+      throw new IllegalArgumentException("jsonExtractIndex can only be applied to a raw column");
+    }
+    _jsonFieldTransformFunction = firstArgument;
+    _jsonPathString = ((LiteralTransformFunction) arguments.get(1)).getStringLiteral().substring(1); // remove $ prefix
+    String resultsType = ((LiteralTransformFunction) arguments.get(2)).getStringLiteral().toUpperCase();
+    boolean isSingleValue = !resultsType.endsWith("_ARRAY");
+    if (!isSingleValue) {
+      throw new IllegalArgumentException("jsonExtractIndex only supports single value type");
+    }
+    DataType dataType = DataType.valueOf(resultsType);
+    if (arguments.size() == 4) {
+      _defaultValue = dataType.convert(((LiteralTransformFunction) arguments.get(3)).getStringLiteral());
+    }
+
+    _resultMetadata = new TransformResultMetadata(dataType, true, false);
+    _postingListCache = new HashMap<>();
+  }
+
+  @Override
+  public TransformResultMetadata getResultMetadata() {
+    return _resultMetadata;
+  }
+
+  @Override
+  public int[] transformToIntValuesSV(ValueBlock valueBlock) {
+    int numDocs = valueBlock.getNumDocs();
+    int[] inputDocIds = valueBlock.getDocIds();
+    initIntValuesSV(numDocs);
+    String[] valuesFromIndex =
+        _jsonIndexReader.getValuesForKeyAndDocs(_jsonPathString, valueBlock.getDocIds(), _postingListCache);
+    for (int i = 0; i < numDocs; i++) {
+      String value = valuesFromIndex[inputDocIds[i]];
+      if (value == null) {
+        if (_defaultValue != null) {
+          _intValuesSV[i] = (int) _defaultValue;
+          continue;
+        }
+        throw new RuntimeException(
+            String.format("Illegal Json Path: [%s], for docId [%s]", _jsonPathString, inputDocIds[i]));
+      }
+      _intValuesSV[i] = Integer.parseInt(value);
+    }
+    return _intValuesSV;
+  }
+
+  @Override
+  public long[] transformToLongValuesSV(ValueBlock valueBlock) {
+    int numDocs = valueBlock.getNumDocs();
+    int[] inputDocIds = valueBlock.getDocIds();
+    initLongValuesSV(numDocs);
+    String[] valuesFromIndex =
+        _jsonIndexReader.getValuesForKeyAndDocs(_jsonPathString, valueBlock.getDocIds(), _postingListCache);
+    for (int i = 0; i < numDocs; i++) {
+      String value = valuesFromIndex[i];
+      if (value == null) {
+        if (_defaultValue != null) {
+          _longValuesSV[i] = (long) _defaultValue;
+          continue;
+        }
+        throw new RuntimeException(
+            String.format("Illegal Json Path: [%s], for docId [%s]", _jsonPathString, inputDocIds[i]));
+      }
+      _longValuesSV[i] = Long.parseLong(value);
+    }
+    return _longValuesSV;
+  }
+
+  @Override
+  public float[] transformToFloatValuesSV(ValueBlock valueBlock) {
+    int numDocs = valueBlock.getNumDocs();
+    int[] inputDocIds = valueBlock.getDocIds();
+    initFloatValuesSV(numDocs);
+    String[] valuesFromIndex =
+        _jsonIndexReader.getValuesForKeyAndDocs(_jsonPathString, valueBlock.getDocIds(), _postingListCache);
+    for (int i = 0; i < numDocs; i++) {
+      String value = valuesFromIndex[i];
+      if (value == null) {
+        if (_defaultValue != null) {
+          _floatValuesSV[i] = (float) _defaultValue;
+          continue;
+        }
+        throw new RuntimeException(
+            String.format("Illegal Json Path: [%s], for docId [%s]", _jsonPathString, inputDocIds[i]));
+      }
+      _floatValuesSV[i] = Float.parseFloat(value);
+    }
+    return _floatValuesSV;
+  }
+
+  @Override
+  public double[] transformToDoubleValuesSV(ValueBlock valueBlock) {
+    int numDocs = valueBlock.getNumDocs();
+    int[] inputDocIds = valueBlock.getDocIds();
+    initDoubleValuesSV(numDocs);
+    String[] valuesFromIndex =
+        _jsonIndexReader.getValuesForKeyAndDocs(_jsonPathString, valueBlock.getDocIds(), _postingListCache);
+    for (int i = 0; i < numDocs; i++) {
+      String value = valuesFromIndex[i];
+      if (value == null) {
+        if (_defaultValue != null) {
+          _doubleValuesSV[i] = (double) _defaultValue;
+          continue;
+        }
+        throw new RuntimeException(
+            String.format("Illegal Json Path: [%s], for docId [%s]", _jsonPathString, inputDocIds[i]));
+      }
+      _doubleValuesSV[i] = Double.parseDouble(value);
+    }
+    return _doubleValuesSV;
+  }
+
+  @Override
+  public BigDecimal[] transformToBigDecimalValuesSV(ValueBlock valueBlock) {
+    int numDocs = valueBlock.getNumDocs();
+    int[] inputDocIds = valueBlock.getDocIds();
+    initBigDecimalValuesSV(numDocs);
+    String[] valuesFromIndex =
+        _jsonIndexReader.getValuesForKeyAndDocs(_jsonPathString, valueBlock.getDocIds(), _postingListCache);
+    for (int i = 0; i < numDocs; i++) {
+      String value = valuesFromIndex[i];
+      if (value == null) {
+        if (_defaultValue != null) {
+          _bigDecimalValuesSV[i] = (BigDecimal) _defaultValue;
+          continue;
+        }
+        throw new RuntimeException(
+            String.format("Illegal Json Path: [%s], for docId [%s]", _jsonPathString, inputDocIds[i]));
+      }
+      _bigDecimalValuesSV[i] = new BigDecimal(value);
+    }
+    return _bigDecimalValuesSV;
+  }
+
+  @Override
+  public String[] transformToStringValuesSV(ValueBlock valueBlock) {
+    int numDocs = valueBlock.getNumDocs();
+    int[] inputDocIds = valueBlock.getDocIds();
+    initStringValuesSV(numDocs);
+    String[] valuesFromIndex =
+        _jsonIndexReader.getValuesForKeyAndDocs(_jsonPathString, valueBlock.getDocIds(), _postingListCache);
+    for (int i = 0; i < numDocs; i++) {
+      String value = valuesFromIndex[i];
+      if (value == null) {
+        if (_defaultValue != null) {
+          _stringValuesSV[i] = (String) _defaultValue;
+          continue;
+        }
+        throw new RuntimeException(
+            String.format("Illegal Json Path: [%s], for docId [%s]", _jsonPathString, inputDocIds[i]));
+      }
+      _stringValuesSV[i] = value;
+    }
+    return _stringValuesSV;
+  }
+
+  @Override
+  public int[][] transformToIntValuesMV(ValueBlock valueBlock) {
+    throw new UnsupportedOperationException("jsonExtractIndex does not support transforming to multi-value columns");
+  }
+
+  @Override
+  public long[][] transformToLongValuesMV(ValueBlock valueBlock) {
+    throw new UnsupportedOperationException("jsonExtractIndex does not support transforming to multi-value columns");
+  }
+
+  @Override
+  public float[][] transformToFloatValuesMV(ValueBlock valueBlock) {
+    throw new UnsupportedOperationException("jsonExtractIndex does not support transforming to multi-value columns");
+  }
+
+  @Override
+  public double[][] transformToDoubleValuesMV(ValueBlock valueBlock) {
+    throw new UnsupportedOperationException("jsonExtractIndex does not support transforming to multi-value columns");
+  }
+
+  @Override
+  public String[][] transformToStringValuesMV(ValueBlock valueBlock) {
+    throw new UnsupportedOperationException("jsonExtractIndex does not support transforming to multi-value columns");
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -124,6 +124,7 @@ public class TransformFunctionFactory {
     typeToImplementation.put(TransformFunctionType.TIME_CONVERT, TimeConversionTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.DATE_TIME_CONVERT, DateTimeConversionTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.DATE_TRUNC, DateTruncTransformFunction.class);
+    typeToImplementation.put(TransformFunctionType.JSON_EXTRACT_INDEX, JsonExtractIndexTransformFunction.class);
     typeToImplementation.put(TransformFunctionType.YEAR, DateTimeTransformFunction.Year.class);
     typeToImplementation.put(TransformFunctionType.YEAR_OF_WEEK, DateTimeTransformFunction.YearOfWeek.class);
     typeToImplementation.put(TransformFunctionType.QUARTER, DateTimeTransformFunction.Quarter.class);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/JsonExtractIndexTransformFunctionTest.java
@@ -1,0 +1,224 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.operator.transform.function;
+
+import com.jayway.jsonpath.Configuration;
+import com.jayway.jsonpath.JsonPath;
+import com.jayway.jsonpath.Option;
+import com.jayway.jsonpath.ParseContext;
+import com.jayway.jsonpath.spi.json.JacksonJsonProvider;
+import com.jayway.jsonpath.spi.mapper.JacksonMappingProvider;
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import org.apache.pinot.common.function.JsonPathCache;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class JsonExtractIndexTransformFunctionTest extends BaseTransformFunctionTest {
+  // Used to verify index value extraction
+  private static final ParseContext JSON_PARSER_CONTEXT = JsonPath.using(
+      new Configuration.ConfigurationBuilder().jsonProvider(new JacksonJsonProvider())
+          .mappingProvider(new JacksonMappingProvider()).options(Option.SUPPRESS_EXCEPTIONS).build());
+
+  @Test(dataProvider = "testJsonExtractIndexTransformFunction")
+  public void testJsonExtractIndexTransformFunction(String expressionStr, String jsonPathString,
+      DataType resultsDataType, boolean isSingleValue) {
+    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof JsonExtractIndexTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), JsonExtractIndexTransformFunction.FUNCTION_NAME);
+    Assert.assertEquals(transformFunction.getResultMetadata().getDataType(), resultsDataType);
+    Assert.assertEquals(transformFunction.getResultMetadata().isSingleValue(), isSingleValue);
+    JsonPath jsonPath = JsonPathCache.INSTANCE.getOrCompute(jsonPathString);
+    if (isSingleValue) {
+      switch (resultsDataType) {
+        case INT:
+          int[] intValues = transformFunction.transformToIntValuesSV(_projectionBlock);
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(intValues[i], Integer.parseInt(getValueForKey(_jsonSVValues[i], jsonPath)));
+          }
+          break;
+        case LONG:
+          long[] longValues = transformFunction.transformToLongValuesSV(_projectionBlock);
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(longValues[i], Long.parseLong(getValueForKey(_jsonSVValues[i], jsonPath)));
+          }
+          break;
+        case FLOAT:
+          float[] floatValues = transformFunction.transformToFloatValuesSV(_projectionBlock);
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(floatValues[i], Float.parseFloat(getValueForKey(_jsonSVValues[i], jsonPath)));
+          }
+          break;
+        case DOUBLE:
+          double[] doubleValues = transformFunction.transformToDoubleValuesSV(_projectionBlock);
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(doubleValues[i], Double.parseDouble(getValueForKey(_jsonSVValues[i], jsonPath)));
+          }
+          break;
+        case BIG_DECIMAL:
+          BigDecimal[] bigDecimalValues = transformFunction.transformToBigDecimalValuesSV(_projectionBlock);
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(bigDecimalValues[i], new BigDecimal(getValueForKey(_jsonSVValues[i], jsonPath)));
+          }
+          break;
+        case STRING:
+          String[] stringValues = transformFunction.transformToStringValuesSV(_projectionBlock);
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(stringValues[i], getValueForKey(_jsonSVValues[i], jsonPath));
+          }
+          break;
+        default:
+          throw new UnsupportedOperationException("Not support data type - " + resultsDataType);
+      }
+    }
+  }
+
+  @DataProvider(name = "testJsonExtractIndexTransformFunction")
+  public Object[][] testJsonExtractIndexTransformFunctionDataProvider() {
+    List<Object[]> testArguments = new ArrayList<>();
+    // Without default value
+    testArguments.add(new Object[]{
+        String.format("jsonExtractIndex(%s,'%s','INT')", JSON_STRING_SV_COLUMN,
+            "$.intVal"), "$.intVal", DataType.INT, true
+    });
+    testArguments.add(new Object[]{
+        String.format("jsonExtractIndex(%s,'%s','LONG')", JSON_STRING_SV_COLUMN,
+            "$.longVal"), "$.longVal", DataType.LONG, true
+    });
+    testArguments.add(new Object[]{
+        String.format("jsonExtractIndex(%s,'%s','FLOAT')", JSON_STRING_SV_COLUMN,
+            "$.floatVal"), "$.floatVal", DataType.FLOAT, true
+    });
+    testArguments.add(new Object[]{
+        String.format("jsonExtractIndex(%s,'%s','DOUBLE')", JSON_STRING_SV_COLUMN,
+            "$.doubleVal"), "$.doubleVal", DataType.DOUBLE, true
+    });
+    testArguments.add(new Object[]{
+        String.format("jsonExtractIndex(%s,'%s','BIG_DECIMAL')", JSON_STRING_SV_COLUMN,
+            "$.bigDecimalVal"), "$.bigDecimalVal", DataType.BIG_DECIMAL, true
+    });
+    testArguments.add(new Object[]{
+        String.format("jsonExtractIndex(%s,'%s','STRING')", JSON_STRING_SV_COLUMN,
+            "$.stringVal"), "$.stringVal", DataType.STRING, true
+    });
+    return testArguments.toArray(new Object[0][]);
+  }
+
+  @Test(dataProvider = "testJsonExtractIndexDefaultValue")
+  public void testJsonExtractIndexDefaultValue(String expressionStr, String jsonPathString, DataType resultsDataType,
+      boolean isSingleValue) {
+    ExpressionContext expression = RequestContextUtils.getExpression(expressionStr);
+    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
+    Assert.assertTrue(transformFunction instanceof JsonExtractIndexTransformFunction);
+    Assert.assertEquals(transformFunction.getName(), JsonExtractIndexTransformFunction.FUNCTION_NAME);
+    Assert.assertEquals(transformFunction.getResultMetadata().getDataType(), resultsDataType);
+    Assert.assertEquals(transformFunction.getResultMetadata().isSingleValue(), isSingleValue);
+    JsonPath jsonPath = JsonPathCache.INSTANCE.getOrCompute(jsonPathString);
+    if (isSingleValue) {
+      switch (resultsDataType) {
+        case INT:
+          int[] intValues = transformFunction.transformToIntValuesSV(_projectionBlock);
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(intValues[i], 0);
+          }
+          break;
+        case LONG:
+          long[] longValues = transformFunction.transformToLongValuesSV(_projectionBlock);
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(longValues[i], 0L);
+          }
+          break;
+        case FLOAT:
+          float[] floatValues = transformFunction.transformToFloatValuesSV(_projectionBlock);
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(floatValues[i], 0f);
+          }
+          break;
+        case DOUBLE:
+          double[] doubleValues = transformFunction.transformToDoubleValuesSV(_projectionBlock);
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(doubleValues[i], 0d);
+          }
+          break;
+        case BIG_DECIMAL:
+          BigDecimal[] bigDecimalValues = transformFunction.transformToBigDecimalValuesSV(_projectionBlock);
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(bigDecimalValues[i], BigDecimal.ZERO);
+          }
+          break;
+        case STRING:
+          String[] stringValues = transformFunction.transformToStringValuesSV(_projectionBlock);
+          for (int i = 0; i < NUM_ROWS; i++) {
+            Assert.assertEquals(stringValues[i], "null");
+          }
+          break;
+        default:
+          throw new UnsupportedOperationException("Not support data type - " + resultsDataType);
+      }
+    }
+  }
+
+  @DataProvider(name = "testJsonExtractIndexDefaultValue")
+  public Object[][] testJsonExtractIndexDefaultValueDataProvider() {
+    List<Object[]> testArguments = new ArrayList<>();
+    // With default value
+    testArguments.add(new Object[]{
+        String.format("jsonExtractIndex(%s,'%s','INT',0)", JSON_STRING_SV_COLUMN,
+            "$.noField"), "$.noField", DataType.INT, true
+    });
+    testArguments.add(new Object[]{
+        String.format("jsonExtractIndex(%s,'%s','LONG',0)", JSON_STRING_SV_COLUMN,
+            "$.noField"), "$.noField", DataType.LONG, true
+    });
+    testArguments.add(new Object[]{
+        String.format("jsonExtractIndex(%s,'%s','FLOAT',0)", JSON_STRING_SV_COLUMN,
+            "$.noField"), "$.noField", DataType.FLOAT, true
+    });
+    testArguments.add(new Object[]{
+        String.format("jsonExtractIndex(%s,'%s','DOUBLE',0)", JSON_STRING_SV_COLUMN,
+            "$.noField"), "$.noField", DataType.DOUBLE, true
+    });
+    testArguments.add(new Object[]{
+        String.format("jsonExtractIndex(%s,'%s','BIG_DECIMAL',0)", JSON_STRING_SV_COLUMN,
+            "$.noField"), "$.noField", DataType.BIG_DECIMAL, true
+    });
+    testArguments.add(new Object[]{
+        String.format("jsonExtractIndex(%s,'%s','STRING','null')", JSON_STRING_SV_COLUMN,
+            "$.noField"), "$.noField", DataType.STRING, true
+    });
+    return testArguments.toArray(new Object[0][]);
+  }
+
+  // get value for key, excluding nested
+  private String getValueForKey(String blob, JsonPath path) {
+    Object out = JSON_PARSER_CONTEXT.parse(blob).read(path);
+    if (out == null || out instanceof HashMap || out instanceof Object[]) {
+      return null;
+    }
+    return out.toString();
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl.java
@@ -321,11 +321,11 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
   }
 
   @Override
-  public String[] getValuesForKeyAndDocs(int[] docIds, Map<String, RoaringBitmap> context) {
+  public String[] getValuesForKeyAndDocs(int[] docIds, Map<String, RoaringBitmap> matchingDocsMap) {
     Int2ObjectOpenHashMap<String> docIdToValues = new Int2ObjectOpenHashMap<>(docIds.length);
     RoaringBitmap docIdMask = RoaringBitmap.bitmapOf(docIds);
 
-    for (Map.Entry<String, RoaringBitmap> entry : context.entrySet()) {
+    for (Map.Entry<String, RoaringBitmap> entry : matchingDocsMap.entrySet()) {
       RoaringBitmap intersection = RoaringBitmap.and(entry.getValue(), docIdMask);
       if (intersection.isEmpty()) {
         continue;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/json/MutableJsonIndexImpl.java
@@ -298,7 +298,7 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
 
   @Override
   public Map<String, RoaringBitmap> getMatchingDocsMap(String key) {
-    Map<String, RoaringBitmap> cache = new HashMap<>();
+    Map<String, RoaringBitmap> matchingDocsMap = new HashMap<>();
     _readLock.lock();
     try {
       for (Map.Entry<String, RoaringBitmap> entry : _postingListMap.entrySet()) {
@@ -312,12 +312,12 @@ public class MutableJsonIndexImpl implements MutableJsonIndex {
           postingList.add(_docIdMapping.getInt(it.next()));
         }
         String val = entry.getKey().substring(key.length() + 1);
-        cache.put(val, postingList.toRoaringBitmap());
+        matchingDocsMap.put(val, postingList.toRoaringBitmap());
       }
     } finally {
       _readLock.unlock();
     }
-    return cache;
+    return matchingDocsMap;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/json/ImmutableJsonIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/json/ImmutableJsonIndexReader.java
@@ -307,7 +307,7 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
 
   @Override
   public Map<String, RoaringBitmap> getMatchingDocsMap(String key) {
-    Map<String, RoaringBitmap> cache = new HashMap<>();
+    Map<String, RoaringBitmap> matchingDocsMap = new HashMap<>();
     int[] dictIds = getDictIdRangeForKey(key);
 
     for (int dictId = dictIds[0]; dictId < dictIds[1]; dictId++) {
@@ -318,10 +318,10 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
       while (it.hasNext()) {
         realDocIds.add(getDocId(it.next()));
       }
-      cache.put(_dictionary.getStringValue(dictId).substring(key.length() + 1), realDocIds);
+      matchingDocsMap.put(_dictionary.getStringValue(dictId).substring(key.length() + 1), realDocIds);
     }
 
-    return cache;
+    return matchingDocsMap;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/json/ImmutableJsonIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/json/ImmutableJsonIndexReader.java
@@ -325,11 +325,11 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
   }
 
   @Override
-  public String[] getValuesForKeyAndDocs(int[] docIds, Map<String, RoaringBitmap> context) {
+  public String[] getValuesForKeyAndDocs(int[] docIds, Map<String, RoaringBitmap> matchingDocsMap) {
     Int2ObjectOpenHashMap<String> docIdToValues = new Int2ObjectOpenHashMap<>(docIds.length);
     RoaringBitmap docIdMask = RoaringBitmap.bitmapOf(docIds);
 
-    for (Map.Entry<String, RoaringBitmap> entry : context.entrySet()) {
+    for (Map.Entry<String, RoaringBitmap> entry : matchingDocsMap.entrySet()) {
       RoaringBitmap intersection = RoaringBitmap.and(entry.getValue(), docIdMask);
       if (intersection.isEmpty()) {
         continue;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/json/ImmutableJsonIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/json/ImmutableJsonIndexReader.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.segment.index.readers.json;
 
 import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.List;
@@ -78,67 +79,6 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
         dataBuffer.view(dictionaryEndOffset, invertedIndexEndOffset, ByteOrder.BIG_ENDIAN), _dictionary.length());
     long docIdMappingEndOffset = invertedIndexEndOffset + docIdMappingLength;
     _docIdMapping = dataBuffer.view(invertedIndexEndOffset, docIdMappingEndOffset, ByteOrder.LITTLE_ENDIAN);
-  }
-
-  @Override
-  public String[] getValuesForKeyAndDocs(String key, int[] docIds, Map<Object, RoaringBitmap> cache) {
-    RoaringBitmap docIdMask = RoaringBitmap.bitmapOf(docIds);
-    int[] dictIds = getDictIdsForKey(key);
-    Map<Integer, String> docIdToValues = new HashMap<>(docIds.length);
-
-    if (cache.isEmpty()) {
-      for (int dictId = dictIds[0]; dictId < dictIds[1]; dictId++) {
-        // get docIds from posting list, convert these to the actual docIds
-        ImmutableRoaringBitmap flattenedDocIds = _invertedIndex.getDocIds(dictId);
-        PeekableIntIterator it = flattenedDocIds.getIntIterator();
-        MutableRoaringBitmap realDocIds = new MutableRoaringBitmap();
-        while (it.hasNext()) {
-          realDocIds.add(getDocId(it.next()));
-        }
-        cache.put(dictId, realDocIds.toRoaringBitmap());
-      }
-    }
-
-    for (int dictId = dictIds[0]; dictId < dictIds[1]; dictId++) {
-      RoaringBitmap intersection = RoaringBitmap.and(cache.get(dictId), docIdMask);
-      if (intersection.isEmpty()) {
-        continue;
-      }
-      // dictionary value lookup, stripping the path prefix
-      String val = _dictionary.getStringValue(dictId).substring(key.length() + 1);
-      for (int docId : intersection) {
-        docIdToValues.put(docId, val);
-      }
-    }
-
-    String[] values = new String[docIds.length];
-    for (int i = 0; i < docIds.length; i++) {
-      values[i] = docIdToValues.get(docIds[i]);
-    }
-    return values;
-  }
-
-  /**
-   * For a JSON key path, returns an int array of [min, max] of all values of the JSON key path
-   */
-  private int[] getDictIdsForKey(String key) {
-    // json_index uses \0 as the separator (or \u0000 in unicode)
-    // therefore, use the unicode char \u0001 to get the range of dict entries that have this prefix
-
-    // get min for key
-    int indexOfMin = _dictionary.indexOf(key);
-    if (indexOfMin == -1) {
-      return new int[]{-1, -1}; // if key does not exist, immediately return
-    }
-    int indexOfMax = _dictionary.insertionIndexOf(key + "\u0001");
-
-    int minDictId = indexOfMin + 1; // skip the index of the key only
-    int maxDictId = -1 * indexOfMax - 1; // undo the binary search
-    if (indexOfMax > 0) {
-      maxDictId = indexOfMax;
-    }
-
-    return new int[]{minDictId, maxDictId};
   }
 
   @Override
@@ -363,6 +303,70 @@ public class ImmutableJsonIndexReader implements JsonIndexReader {
 
   private int getDocId(int flattenedDocId) {
     return _docIdMapping.getInt((long) flattenedDocId << 2);
+  }
+
+  @Override
+  public Map<String, RoaringBitmap> getMatchingDocsMap(String key) {
+    Map<String, RoaringBitmap> cache = new HashMap<>();
+    int[] dictIds = getDictIdRangeForKey(key);
+
+    for (int dictId = dictIds[0]; dictId < dictIds[1]; dictId++) {
+      // get docIds from posting list, convert these to the actual docIds
+      ImmutableRoaringBitmap flattenedDocIds = _invertedIndex.getDocIds(dictId);
+      PeekableIntIterator it = flattenedDocIds.getIntIterator();
+      RoaringBitmap realDocIds = new RoaringBitmap();
+      while (it.hasNext()) {
+        realDocIds.add(getDocId(it.next()));
+      }
+      cache.put(_dictionary.getStringValue(dictId).substring(key.length() + 1), realDocIds);
+    }
+
+    return cache;
+  }
+
+  @Override
+  public String[] getValuesForKeyAndDocs(int[] docIds, Map<String, RoaringBitmap> context) {
+    Int2ObjectOpenHashMap<String> docIdToValues = new Int2ObjectOpenHashMap<>(docIds.length);
+    RoaringBitmap docIdMask = RoaringBitmap.bitmapOf(docIds);
+
+    for (Map.Entry<String, RoaringBitmap> entry : context.entrySet()) {
+      RoaringBitmap intersection = RoaringBitmap.and(entry.getValue(), docIdMask);
+      if (intersection.isEmpty()) {
+        continue;
+      }
+      for (int docId : intersection) {
+        docIdToValues.put(docId, entry.getKey());
+      }
+    }
+
+    String[] values = new String[docIds.length];
+    for (int i = 0; i < docIds.length; i++) {
+      values[i] = docIdToValues.get(docIds[i]);
+    }
+    return values;
+  }
+
+  /**
+   * For a JSON key path, returns an int array of the range [min, max] spanning all values for the JSON key path
+   */
+  private int[] getDictIdRangeForKey(String key) {
+    // json_index uses \0 as the separator (or \u0000 in unicode)
+    // therefore, use the unicode char \u0001 to get the range of dict entries that have this prefix
+
+    // get min for key
+    int indexOfMin = _dictionary.indexOf(key);
+    if (indexOfMin == -1) {
+      return new int[]{-1, -1}; // if key does not exist, immediately return
+    }
+    int indexOfMax = _dictionary.insertionIndexOf(key + "\u0001");
+
+    int minDictId = indexOfMin + 1; // skip the index of the key only
+    int maxDictId = -1 * indexOfMax - 1; // undo the binary search
+    if (indexOfMax > 0) {
+      maxDictId = indexOfMax;
+    }
+
+    return new int[]{minDictId, maxDictId};
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/JsonIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/JsonIndexReader.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.segment.spi.index.reader;
 
+import java.util.Map;
 import org.apache.pinot.segment.spi.index.IndexReader;
+import org.roaringbitmap.RoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
@@ -31,4 +33,13 @@ public interface JsonIndexReader extends IndexReader {
    * Returns the matching document ids for the given filter.
    */
   MutableRoaringBitmap getMatchingDocIds(String filterString);
+
+  /**
+   * For a JSON key and array of docIds, returns the corresponding values for each docId.
+   * This method takes a map as input which is used to cache the posting list for each dictId/value. It will be
+   * populated if empty, otherwise it will be used to avoid reading and converting the posting list of flattened docs
+   *
+   * @return String[] where String[i] is the value for docIds[i]
+   */
+  String[] getValuesForKeyAndDocs(String key, int[] docIds, Map<Object, RoaringBitmap> cache);
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/JsonIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/JsonIndexReader.java
@@ -35,11 +35,16 @@ public interface JsonIndexReader extends IndexReader {
   MutableRoaringBitmap getMatchingDocIds(String filterString);
 
   /**
-   * For a JSON key and array of docIds, returns the corresponding values for each docId.
-   * This method takes a map as input which is used to cache the posting list for each dictId/value. It will be
-   * populated if empty, otherwise it will be used to avoid reading and converting the posting list of flattened docs
+   * For an array of docIds and context specific to a JSON key, returns the corresponding values for each docId. The
+   * context should be created from the getMatchingDocsMap method.
    *
    * @return String[] where String[i] is the value for docIds[i]
    */
-  String[] getValuesForKeyAndDocs(String key, int[] docIds, Map<Object, RoaringBitmap> cache);
+  String[] getValuesForKeyAndDocs(int[] docIds, Map<String, RoaringBitmap> context);
+
+  /**
+   * For a JSON key, returns a Map from each value to the docId posting list. This map should be  used to avoid reading
+   * and converting the posting list of flattened docIds to real docIds
+   */
+  Map<String, RoaringBitmap> getMatchingDocsMap(String key);
 }


### PR DESCRIPTION
This is a follow up PR to https://github.com/apache/pinot/issues/11494

I worked on a poc for this, and took the approach of reading the JSON index through a new transform function `JSON_EXTRACT_INDEX`. This enables group by/regexp filtering/the majority of the functionality of `JSON_EXTRACT_SCALAR` and attempts to maintain the same syntax. This does not solve the generic problem of adding a code path to use inverted index to speed up group by. 

We've seen large improvements for large time ranges and large tables. This can reduce query latency for equivalent queries and massively improve memory pressure, preventing the OOM caused cluster crashes we encountered. 

As expected, for small time ranges and highly filtered results the existing `JSON_EXTRACT_SCALAR` function is faster. 

Benchmark results:
<img width="1248" alt="image" src="https://github.com/apache/pinot/assets/27231838/dc4773f1-7b3c-4bb9-ae71-b9519072acfe">
The gray bars signal a cluster crash and no data was able to be recorded. 
```
A: 10TB table, group by json_extract_scalar(col, ‘$.keyA’, ‘STRING’, ‘null)    
B: 10TB table, group by json_extract_scalar(col, ‘$.keyB’, ‘STRING’, ‘null)     
C: 10TB table, regexp_like(json_extract_scalar(json_data, '$.keyA, 'STRING', 'null'), 'val') group by json_extract_scalar(json_data, '$.keyA, 'STRING', 'null') 
D: 10TB table, regexp_like(json_extract_scalar(json_data, '$.keyA, 'STRING', 'null'), 'val')
E: 20GB table, group by json_extract_scalar(col, ‘$.keyA’, ‘STRING’, ‘null)
F: 20GB table, regexp_like(json_extract_scalar(json_data, '$.keyA, 'STRING', 'null'), 'val') group by json_extract_scalar(json_data, '$.keyA, 'STRING', 'null')
G: 20GB table, select json_extract_scalar(json_data, '$.keyA, 'STRING', 'null') ... where json_match(json_data, '"$.keyA" = ''val''')

- queries are repeated w/ filters `ts > now() -1m/10m/1h/3h/6h/12h/24h`
- keyA is high cardinality
- keyB is low cardinality
- 10TB table avg json_data row len: 3.4KB
- 20GB table avg json_data row len: 5.4KB
```

Thought not low latency, I think this would be a solid functionality to have available as it allows for queries that were otherwise unanswerable. 

Testing: benchmarks for a few of our common query shapes (see screenshot) + validation in prod clusters 