### PR TITLE
update lombok version and config

### DIFF
--- a/lombok.config
+++ b/lombok.config
@@ -1,2 +1,21 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
 # remove prefix _ from member variables when generating getters and setters
 lombok.accessors.prefix += _

--- a/lombok.config
+++ b/lombok.config
@@ -1,0 +1,2 @@
+# remove prefix _ from member variables when generating getters and setters
+lombok.accessors.prefix += _

--- a/pom.xml
+++ b/pom.xml
@@ -1259,7 +1259,7 @@
         <!-- Older versions fail with Java >= 16 -->
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
-        <version>1.18.28</version>
+        <version>1.18.30</version>
       </dependency>
 
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1256,7 +1256,7 @@
         </exclusions>
       </dependency>
       <dependency>
-        <!-- Older versions fail with Java >= 16 -->
+        <!-- starting from 1.18.30, JDK21 is supported -->
         <groupId>org.projectlombok</groupId>
         <artifactId>lombok</artifactId>
         <version>1.18.30</version>


### PR DESCRIPTION
This PR does two things:
1. configure lombok so generated getters and setter will remove prefix _ from member variables
2. update lombok to 1.18.30 to support JDK21: https://projectlombok.org/changelog

With this PR, we can refactor classes that explicitly write getters and setters