### PR TITLE
[multistage] framework to back-propagate metadata across opChains

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/GrpcSendingMailbox.java
@@ -60,7 +60,7 @@ public class GrpcSendingMailbox implements SendingMailbox {
   @Override
   public void send(TransferableBlock block)
       throws IOException {
-    if (isTerminated()) {
+    if (isTerminated() || (isEarlyTerminated() && !block.isEndOfStreamBlock())) {
       return;
     }
     if (LOGGER.isDebugEnabled()) {
@@ -102,8 +102,12 @@ public class GrpcSendingMailbox implements SendingMailbox {
   }
 
   @Override
+  public boolean isEarlyTerminated() {
+    return _statusObserver.isEarlyTerminated();
+  }
+
+  @Override
   public boolean isTerminated() {
-    // TODO: We cannot differentiate early termination vs stream error
     return _statusObserver.isFinished();
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
@@ -21,6 +21,7 @@ package org.apache.pinot.query.mailbox;
 import java.util.concurrent.TimeoutException;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
+import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -33,7 +34,7 @@ public class InMemorySendingMailbox implements SendingMailbox {
   private final long _deadlineMs;
 
   private ReceivingMailbox _receivingMailbox;
-  private volatile boolean _isTerminated;
+  private volatile boolean _isEarlyTerminated;
 
   public InMemorySendingMailbox(String id, MailboxService mailboxService, long deadlineMs) {
     _id = id;
@@ -44,7 +45,7 @@ public class InMemorySendingMailbox implements SendingMailbox {
   @Override
   public void send(TransferableBlock block)
       throws TimeoutException {
-    if (_isTerminated) {
+    if (_isEarlyTerminated && !block.isEndOfStreamBlock()) {
       return;
     }
     if (_receivingMailbox == null) {
@@ -55,13 +56,15 @@ public class InMemorySendingMailbox implements SendingMailbox {
     switch (status) {
       case SUCCESS:
         break;
+      case CANCELLED:
+        throw new EarlyTerminationException(String.format("Mailbox: %s already cancelled from upstream", _id));
       case ERROR:
         throw new RuntimeException(String.format("Mailbox: %s already errored out (received error block before)", _id));
       case TIMEOUT:
         throw new TimeoutException(
             String.format("Timed out adding block into mailbox: %s with timeout: %dms", _id, timeoutMs));
       case EARLY_TERMINATED:
-        _isTerminated = true;
+        _isEarlyTerminated = true;
         break;
       default:
         throw new IllegalStateException("Unsupported mailbox status: " + status);
@@ -74,7 +77,7 @@ public class InMemorySendingMailbox implements SendingMailbox {
 
   @Override
   public void cancel(Throwable t) {
-    if (_isTerminated) {
+    if (_isEarlyTerminated) {
       return;
     }
     LOGGER.debug("Cancelling mailbox: {}", _id);
@@ -86,7 +89,13 @@ public class InMemorySendingMailbox implements SendingMailbox {
   }
 
   @Override
+  public boolean isEarlyTerminated() {
+    return _isEarlyTerminated;
+  }
+
+  @Override
   public boolean isTerminated() {
-    return _isTerminated;
+    // in-mem sending mailbox will never have a broken channel.
+    return false;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
@@ -79,7 +79,7 @@ public class InMemorySendingMailbox implements SendingMailbox {
 
   @Override
   public void cancel(Throwable t) {
-    if (_isEarlyTerminated || _isTerminated) {
+    if (_isTerminated) {
       return;
     }
     LOGGER.debug("Cancelling mailbox: {}", _id);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/SendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/SendingMailbox.java
@@ -62,4 +62,10 @@ public interface SendingMailbox {
    * mailbox is terminated.
    */
   boolean isTerminated();
+
+  /**
+   * Returns whether the {@link ReceivingMailbox} is considered itself finished, and is expected a EOS block with
+   * statistics to be sent next.
+   */
+  boolean isEarlyTerminated();
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/ChannelUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/ChannelUtils.java
@@ -23,5 +23,5 @@ public class ChannelUtils {
   }
 
   public static final String MAILBOX_METADATA_BUFFER_SIZE_KEY = "buffer.size";
-  public static final String MAILBOX_METADATA_BEGIN_OF_STREAM_KEY = "begin.of.stream";
+  public static final String MAILBOX_METADATA_REQUEST_EARLY_TERMINATE = "request.early.terminate";
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentObserver.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentObserver.java
@@ -99,7 +99,7 @@ public class MailboxContentObserver implements StreamObserver<MailboxContent> {
         case EARLY_TERMINATED:
           LOGGER.debug("Mailbox: {} has been early terminated", mailboxId);
           _responseObserver.onNext(MailboxStatus.newBuilder().setMailboxId(mailboxId)
-              .putMetadata(ChannelUtils.MAILBOX_METADATA_REQUEST_EARLY_TERMINATE, "TRUE").build());
+              .putMetadata(ChannelUtils.MAILBOX_METADATA_REQUEST_EARLY_TERMINATE, "true").build());
           break;
         default:
           throw new IllegalStateException("Unsupported mailbox status: " + status);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentObserver.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxContentObserver.java
@@ -84,6 +84,10 @@ public class MailboxContentObserver implements StreamObserver<MailboxContent> {
               .putMetadata(ChannelUtils.MAILBOX_METADATA_BUFFER_SIZE_KEY,
                   Integer.toString(_mailbox.getNumPendingBlocks())).build());
           break;
+        case CANCELLED:
+          LOGGER.warn("Mailbox: {} already cancelled from upstream", mailboxId);
+          cancelStream();
+          break;
         case ERROR:
           LOGGER.warn("Mailbox: {} already errored out (received error block before)", mailboxId);
           cancelStream();
@@ -94,7 +98,8 @@ public class MailboxContentObserver implements StreamObserver<MailboxContent> {
           break;
         case EARLY_TERMINATED:
           LOGGER.debug("Mailbox: {} has been early terminated", mailboxId);
-          onCompleted();
+          _responseObserver.onNext(MailboxStatus.newBuilder().setMailboxId(mailboxId)
+              .putMetadata(ChannelUtils.MAILBOX_METADATA_REQUEST_EARLY_TERMINATE, "TRUE").build());
           break;
         default:
           throw new IllegalStateException("Unsupported mailbox status: " + status);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxStatusObserver.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxStatusObserver.java
@@ -34,8 +34,8 @@ public class MailboxStatusObserver implements StreamObserver<MailboxStatus> {
   private static final int DEFAULT_MAILBOX_QUEUE_CAPACITY = 5;
 
   private final AtomicInteger _bufferSize = new AtomicInteger(DEFAULT_MAILBOX_QUEUE_CAPACITY);
-  private final AtomicBoolean _isEarlyTerminated = new AtomicBoolean();
   private final AtomicBoolean _finished = new AtomicBoolean();
+  private volatile boolean _isEarlyTerminated;
 
   @Override
   public void onNext(MailboxStatus mailboxStatus) {
@@ -45,7 +45,7 @@ public class MailboxStatusObserver implements StreamObserver<MailboxStatus> {
     // -- handle early-terminate EOS request.
     if (Boolean.parseBoolean(
         mailboxStatus.getMetadataMap().get(ChannelUtils.MAILBOX_METADATA_REQUEST_EARLY_TERMINATE))) {
-      _isEarlyTerminated.set(true);
+      _isEarlyTerminated = true;
     }
     // -- handling buffer size back-pressure
     // TODO: this feedback info is not used to throttle the send speed. it is currently being discarded.
@@ -58,7 +58,7 @@ public class MailboxStatusObserver implements StreamObserver<MailboxStatus> {
   }
 
   public boolean isEarlyTerminated() {
-    return _isEarlyTerminated.get();
+    return _isEarlyTerminated;
   }
 
   public int getBufferSize() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxStatusObserver.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/channel/MailboxStatusObserver.java
@@ -43,7 +43,8 @@ public class MailboxStatusObserver implements StreamObserver<MailboxStatus> {
     //   1. the buffer size available, for back-pressure handling
     //   2. status whether there's no need to send any additional data block b/c it considered itself finished.
     // -- handle early-terminate EOS request.
-    if (mailboxStatus.getMetadataMap().containsKey(ChannelUtils.MAILBOX_METADATA_REQUEST_EARLY_TERMINATE)) {
+    if (Boolean.parseBoolean(
+        mailboxStatus.getMetadataMap().get(ChannelUtils.MAILBOX_METADATA_REQUEST_EARLY_TERMINATE))) {
       _isEarlyTerminated.set(true);
     }
     // -- handling buffer size back-pressure

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -64,7 +64,7 @@ public class AggregateOperator extends MultiStageOperator {
       new CountAggregationFunction(Collections.singletonList(ExpressionContext.forIdentifier("*")), false);
   private static final ExpressionContext PLACEHOLDER_IDENTIFIER = ExpressionContext.forIdentifier("__PLACEHOLDER__");
 
-  private final MultiStageOperator _inputOperator;
+  private final MultiStageOperator _upstreamOperator;
   private final DataSchema _resultSchema;
   private final AggType _aggType;
   private final MultistageAggregationExecutor _aggregationExecutor;
@@ -72,11 +72,11 @@ public class AggregateOperator extends MultiStageOperator {
 
   private boolean _hasReturnedAggregateBlock;
 
-  public AggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator, DataSchema resultSchema,
-      List<RexExpression> aggCalls, List<RexExpression> groupSet, AggType aggType, List<Integer> filterArgIndices,
-      @Nullable AbstractPlanNode.NodeHint nodeHint) {
+  public AggregateOperator(OpChainExecutionContext context, MultiStageOperator upstreamOperator,
+      DataSchema resultSchema, List<RexExpression> aggCalls, List<RexExpression> groupSet, AggType aggType,
+      List<Integer> filterArgIndices, @Nullable AbstractPlanNode.NodeHint nodeHint) {
     super(context);
-    _inputOperator = inputOperator;
+    _upstreamOperator = upstreamOperator;
     _resultSchema = resultSchema;
     _aggType = aggType;
 
@@ -120,7 +120,7 @@ public class AggregateOperator extends MultiStageOperator {
 
   @Override
   public List<MultiStageOperator> getChildOperators() {
-    return ImmutableList.of(_inputOperator);
+    return ImmutableList.of(_upstreamOperator);
   }
 
   @Nullable
@@ -142,7 +142,6 @@ public class AggregateOperator extends MultiStageOperator {
       if (!_hasReturnedAggregateBlock) {
         return produceAggregatedBlock();
       } else {
-        // TODO: Move to close call.
         return TransferableBlockUtils.getEndOfStreamTransferableBlock();
       }
     } catch (Exception e) {
@@ -175,10 +174,10 @@ public class AggregateOperator extends MultiStageOperator {
    * @return the last block, which must always be either an error or the end of the stream
    */
   private TransferableBlock consumeGroupBy() {
-    TransferableBlock block = _inputOperator.nextBlock();
+    TransferableBlock block = _upstreamOperator.nextBlock();
     while (block.isDataBlock()) {
       _groupByExecutor.processBlock(block);
-      block = _inputOperator.nextBlock();
+      block = _upstreamOperator.nextBlock();
     }
     return block;
   }
@@ -188,10 +187,10 @@ public class AggregateOperator extends MultiStageOperator {
    * @return the last block, which must always be either an error or the end of the stream
    */
   private TransferableBlock consumeAggregation() {
-    TransferableBlock block = _inputOperator.nextBlock();
+    TransferableBlock block = _upstreamOperator.nextBlock();
     while (block.isDataBlock()) {
       _aggregationExecutor.processBlock(block);
-      block = _inputOperator.nextBlock();
+      block = _upstreamOperator.nextBlock();
     }
     return block;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
@@ -82,6 +82,12 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
   }
 
   @Override
+  protected void setEarlyTerminate() {
+    _isEarlyTerminated = true;
+    _multiConsumer.earlyTerminate();
+  }
+
+  @Override
   public List<MultiStageOperator> getChildOperators() {
     return Collections.emptyList();
   }
@@ -126,6 +132,11 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
     @Override
     public void addOnNewDataListener(OnNewData onNewData) {
       _mailbox.registeredReader(onNewData::newDataAvailable);
+    }
+
+    @Override
+    public void earlyTerminate() {
+      _mailbox.earlyTerminate();
     }
 
     @Override

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/BaseMailboxReceiveOperator.java
@@ -82,7 +82,7 @@ public abstract class BaseMailboxReceiveOperator extends MultiStageOperator {
   }
 
   @Override
-  protected void setEarlyTerminate() {
+  protected void earlyTerminate() {
     _isEarlyTerminated = true;
     _multiConsumer.earlyTerminate();
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -218,7 +218,8 @@ public class HashJoinOperator extends MultiStageOperator {
         _resourceLimitExceededException =
             new ProcessingException(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE);
         _resourceLimitExceededException.setMessage(
-            "Cannot build in memory hash table for join operator, reach number of rows limit: " + _maxRowsInHashTable);
+            "Exception occurred when building in-memory hash table for join operator, reach number of rows limit: "
+                + _maxRowsInHashTable);
         if (_joinOverflowMode == JoinOverFlowMode.THROW) {
           throw _resourceLimitExceededException;
         } else {
@@ -239,8 +240,10 @@ public class HashJoinOperator extends MultiStageOperator {
       }
       _currentRowsInHashTable += container.size();
       if (_currentRowsInHashTable == _maxRowsInHashTable) {
-        // Early terminate right table operator.
-        _rightTableOperator.close();
+        // setting only the rightTableOperator to be early terminated.
+        _rightTableOperator.setEarlyTerminate();
+        // pulling one extra early termination message from rightTable.
+        rightBlock = _rightTableOperator.nextBlock();
         break;
       }
       rightBlock = _rightTableOperator.nextBlock();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -218,8 +218,7 @@ public class HashJoinOperator extends MultiStageOperator {
         _resourceLimitExceededException =
             new ProcessingException(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE);
         _resourceLimitExceededException.setMessage(
-            "Exception occurred when building in-memory hash table for join operator, reach number of rows limit: "
-                + _maxRowsInHashTable);
+            "Cannot build in memory hash table for join operator, reach number of rows limit: " + _maxRowsInHashTable);
         if (_joinOverflowMode == JoinOverFlowMode.THROW) {
           throw _resourceLimitExceededException;
         } else {
@@ -240,11 +239,8 @@ public class HashJoinOperator extends MultiStageOperator {
       }
       _currentRowsInHashTable += container.size();
       if (_currentRowsInHashTable == _maxRowsInHashTable) {
-        // setting only the rightTableOperator to be early terminated.
-        _rightTableOperator.setEarlyTerminate();
-        // pulling one extra early termination message from rightTable.
-        rightBlock = _rightTableOperator.nextBlock();
-        break;
+        // setting only the rightTableOperator to be early terminated and awaits EOS block next.
+        _rightTableOperator.earlyTerminate();
       }
       rightBlock = _rightTableOperator.nextBlock();
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LiteralValueOperator.java
@@ -61,7 +61,7 @@ public class LiteralValueOperator extends MultiStageOperator {
 
   @Override
   protected TransferableBlock getNextBlock() {
-    if (!_isLiteralBlockReturned) {
+    if (!_isLiteralBlockReturned && !_isEarlyTerminated) {
       _isLiteralBlockReturned = true;
       return _rexLiteralBlock;
     } else {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -43,6 +43,10 @@ public class MailboxReceiveOperator extends BaseMailboxReceiveOperator {
   @Override
   protected TransferableBlock getNextBlock() {
     TransferableBlock block = getMultiConsumer().readBlockBlocking();
+    // When early termination flag is set, caller is expecting an EOS block to be returned, however since the 2 stages
+    // between sending/receiving mailbox are setting early termination flag asynchronously, there's chances that the
+    // next block pulled out of the ReceivingMailbox to be an already buffered normal data block. This requires the
+    // MailboxReceiveOperator to continue pulling and dropping data block until an EOS block is observed.
     while (_isEarlyTerminated && !block.isEndOfStreamBlock()) {
       block = getMultiConsumer().readBlockBlocking();
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperator.java
@@ -42,6 +42,10 @@ public class MailboxReceiveOperator extends BaseMailboxReceiveOperator {
 
   @Override
   protected TransferableBlock getNextBlock() {
-    return getMultiConsumer().readBlockBlocking();
+    TransferableBlock block = getMultiConsumer().readBlockBlocking();
+    while (_isEarlyTerminated && !block.isEndOfStreamBlock()) {
+      block = getMultiConsumer().readBlockBlocking();
+    }
+    return block;
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -36,11 +36,13 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
   protected final OpChainExecutionContext _context;
   protected final String _operatorId;
   protected final OpChainStats _opChainStats;
+  protected boolean _isEarlyTerminated;
 
   public MultiStageOperator(OpChainExecutionContext context) {
     _context = context;
     _operatorId = Joiner.on("_").join(getClass().getSimpleName(), _context.getStageId(), _context.getServer());
     _opChainStats = _context.getStats();
+    _isEarlyTerminated = false;
   }
 
   @Override
@@ -69,6 +71,13 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
 
   // Make it protected because we should always call nextBlock()
   protected abstract TransferableBlock getNextBlock();
+
+  protected void setEarlyTerminate() {
+    _isEarlyTerminated = true;
+    for (MultiStageOperator upstreamOperator : getChildOperators()) {
+      upstreamOperator.setEarlyTerminate();
+    }
+  }
 
   protected boolean shouldCollectStats() {
     return _context.isTraceEnabled();

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -72,10 +72,10 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
   // Make it protected because we should always call nextBlock()
   protected abstract TransferableBlock getNextBlock();
 
-  protected void setEarlyTerminate() {
+  protected void earlyTerminate() {
     _isEarlyTerminated = true;
-    for (MultiStageOperator upstreamOperator : getChildOperators()) {
-      upstreamOperator.setEarlyTerminate();
+    for (MultiStageOperator child : getChildOperators()) {
+      child.earlyTerminate();
     }
   }
 

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -51,7 +51,7 @@ public class SortOperator extends MultiStageOperator {
   private final ArrayList<Object[]> _rows;
   private final int _numRowsToKeep;
 
-  private boolean _isSortedBlockConstructed;
+  private boolean _hasReturnedSortedBlock;
   private TransferableBlock _upstreamErrorBlock;
 
   public SortOperator(OpChainExecutionContext context, MultiStageOperator upstreamOperator,
@@ -74,7 +74,7 @@ public class SortOperator extends MultiStageOperator {
     _offset = Math.max(offset, 0);
     _dataSchema = dataSchema;
     _upstreamErrorBlock = null;
-    _isSortedBlockConstructed = false;
+    _hasReturnedSortedBlock = false;
     // Setting numRowsToKeep as default maximum on Broker if limit not set.
     // TODO: make this default behavior configurable.
     _numRowsToKeep = _fetch > 0 ? _fetch + _offset : defaultResponseLimit;
@@ -123,8 +123,8 @@ public class SortOperator extends MultiStageOperator {
       return _upstreamErrorBlock;
     }
 
-    if (!_isSortedBlockConstructed) {
-      _isSortedBlockConstructed = true;
+    if (!_hasReturnedSortedBlock) {
+      _hasReturnedSortedBlock = true;
       if (_priorityQueue == null) {
         if (_rows.size() > _offset) {
           List<Object[]> row = _rows.subList(_offset, _rows.size());
@@ -150,7 +150,7 @@ public class SortOperator extends MultiStageOperator {
   }
 
   private void consumeInputBlocks() {
-    if (!_isSortedBlockConstructed) {
+    if (!_hasReturnedSortedBlock) {
       TransferableBlock block = _upstreamOperator.nextBlock();
       while (block.isDataBlock()) {
         List<Object[]> container = block.getContainer();
@@ -164,6 +164,9 @@ public class SortOperator extends MultiStageOperator {
               _rows.addAll(container.subList(0, _numRowsToKeep - numRows));
               LOGGER.debug("Early terminate at SortOperator - operatorId={}, opChainId={}", _operatorId,
                   _context.getId());
+              setEarlyTerminate();
+              // acquire extra metadata block
+              block = _upstreamOperator.nextBlock();
               break;
             }
           }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -164,10 +164,8 @@ public class SortOperator extends MultiStageOperator {
               _rows.addAll(container.subList(0, _numRowsToKeep - numRows));
               LOGGER.debug("Early terminate at SortOperator - operatorId={}, opChainId={}", _operatorId,
                   _context.getId());
-              setEarlyTerminate();
-              // acquire extra metadata block
-              block = _upstreamOperator.nextBlock();
-              break;
+              // setting operator to be early terminated and awaits EOS block next.
+              earlyTerminate();
             }
           }
         } else {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
@@ -87,7 +87,7 @@ public class WindowAggregateOperator extends MultiStageOperator {
   // List of ranking window functions whose output depends on the ordering of input rows and not on the actual values
   private static final Set<String> RANKING_FUNCTION_NAMES = ImmutableSet.of("RANK", "DENSE_RANK");
 
-  private final MultiStageOperator _upstreamOperator;
+  private final MultiStageOperator _inputOperator;
   private final List<RexExpression> _groupSet;
   private final OrderSetInfo _orderSetInfo;
   private final WindowFrame _windowFrame;
@@ -101,17 +101,17 @@ public class WindowAggregateOperator extends MultiStageOperator {
   private int _numRows;
   private boolean _hasReturnedWindowAggregateBlock;
 
-  public WindowAggregateOperator(OpChainExecutionContext context, MultiStageOperator upstreamOperator,
+  public WindowAggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator,
       List<RexExpression> groupSet, List<RexExpression> orderSet, List<RelFieldCollation.Direction> orderSetDirection,
       List<RelFieldCollation.NullDirection> orderSetNullDirection, List<RexExpression> aggCalls, int lowerBound,
       int upperBound, WindowNode.WindowFrameType windowFrameType, List<RexExpression> constants,
       DataSchema resultSchema, DataSchema inputSchema) {
-    this(context, upstreamOperator, groupSet, orderSet, orderSetDirection, orderSetNullDirection, aggCalls, lowerBound,
+    this(context, inputOperator, groupSet, orderSet, orderSetDirection, orderSetNullDirection, aggCalls, lowerBound,
         upperBound, windowFrameType, constants, resultSchema, inputSchema, WindowAggregateAccumulator.WIN_AGG_MERGERS);
   }
 
   @VisibleForTesting
-  public WindowAggregateOperator(OpChainExecutionContext context, MultiStageOperator upstreamOperator,
+  public WindowAggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator,
       List<RexExpression> groupSet, List<RexExpression> orderSet, List<RelFieldCollation.Direction> orderSetDirection,
       List<RelFieldCollation.NullDirection> orderSetNullDirection, List<RexExpression> aggCalls, int lowerBound,
       int upperBound, WindowNode.WindowFrameType windowFrameType, List<RexExpression> constants,
@@ -119,7 +119,7 @@ public class WindowAggregateOperator extends MultiStageOperator {
       Map<String, Function<ColumnDataType, AggregationUtils.Merger>> mergers) {
     super(context);
 
-    _upstreamOperator = upstreamOperator;
+    _inputOperator = inputOperator;
     _groupSet = groupSet;
     _isPartitionByOnly = isPartitionByOnlyQuery(groupSet, orderSet);
     _orderSetInfo = new OrderSetInfo(orderSet, orderSetDirection, orderSetNullDirection, _isPartitionByOnly);
@@ -152,7 +152,7 @@ public class WindowAggregateOperator extends MultiStageOperator {
 
   @Override
   public List<MultiStageOperator> getChildOperators() {
-    return ImmutableList.of(_upstreamOperator);
+    return ImmutableList.of(_inputOperator);
   }
 
   @Nullable
@@ -278,7 +278,7 @@ public class WindowAggregateOperator extends MultiStageOperator {
    */
   private TransferableBlock consumeInputBlocks() {
     Key emptyOrderKey = AggregationUtils.extractEmptyKey();
-    TransferableBlock block = _upstreamOperator.nextBlock();
+    TransferableBlock block = _inputOperator.nextBlock();
     while (!TransferableBlockUtils.isEndOfStream(block)) {
       List<Object[]> container = block.getContainer();
       if (_windowFrame.getWindowFrameType() == WindowNode.WindowFrameType.RANGE) {
@@ -306,7 +306,7 @@ public class WindowAggregateOperator extends MultiStageOperator {
           _partitionRows.computeIfAbsent(key, k -> new ArrayList<>()).add(row);
         }
       }
-      block = _upstreamOperator.nextBlock();
+      block = _inputOperator.nextBlock();
     }
     return block;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchange.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/exchange/BlockExchange.java
@@ -28,7 +28,6 @@ import org.apache.pinot.query.mailbox.SendingMailbox;
 import org.apache.pinot.query.planner.partitioning.KeySelectorFactory;
 import org.apache.pinot.query.runtime.blocks.BlockSplitter;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
-import org.apache.pinot.spi.exception.EarlyTerminationException;
 
 
 /**
@@ -68,25 +67,29 @@ public abstract class BlockExchange {
     _splitter = splitter;
   }
 
-  public void send(TransferableBlock block)
+  /**
+   * API to send a block to the destination mailboxes.
+   * @param block the block to be transferred
+   * @return true if any of the upstream mailboxes requested EOS (e.g. early termination)
+   * @throws Exception when sending stream unexpectedly closed.
+   */
+  public boolean send(TransferableBlock block)
       throws Exception {
     boolean isEarlyTerminated = true;
     for (SendingMailbox sendingMailbox : _sendingMailboxes) {
-      if (!sendingMailbox.isTerminated()) {
+      if (!sendingMailbox.isEarlyTerminated()) {
         isEarlyTerminated = false;
         break;
       }
-    }
-    if (isEarlyTerminated) {
-      throw new EarlyTerminationException();
     }
     if (block.isEndOfStreamBlock()) {
       for (SendingMailbox sendingMailbox : _sendingMailboxes) {
         sendBlock(sendingMailbox, block);
       }
-    } else {
+    } else if (!isEarlyTerminated) {
       route(_sendingMailboxes, block);
     }
+    return isEarlyTerminated;
   }
 
   protected void sendBlock(SendingMailbox sendingMailbox, TransferableBlock block)

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/AsyncStream.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/AsyncStream.java
@@ -67,6 +67,11 @@ public interface AsyncStream<E> {
    */
   void cancel();
 
+  /**
+   * Set this stream to early terminate state, asking for metadata block.
+   */
+  void earlyTerminate();
+
   interface OnNewData {
     void newDataAvailable();
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java
@@ -72,10 +72,6 @@ public abstract class BlockingMultiStreamConsumer<E> implements AutoCloseable {
   }
 
   public void earlyTerminate() {
-    earlyTerminateMailboxes();
-  }
-
-  protected void earlyTerminateMailboxes() {
     for (AsyncStream<E> mailbox : _mailboxes) {
       mailbox.earlyTerminate();
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java
@@ -71,6 +71,16 @@ public abstract class BlockingMultiStreamConsumer<E> implements AutoCloseable {
     cancelRemainingMailboxes();
   }
 
+  public void earlyTerminate() {
+    earlyTerminateMailboxes();
+  }
+
+  protected void earlyTerminateMailboxes() {
+    for (AsyncStream<E> mailbox : _mailboxes) {
+      mailbox.earlyTerminate();
+    }
+  }
+
   protected void cancelRemainingMailboxes() {
     for (AsyncStream<E> mailbox : _mailboxes) {
       mailbox.cancel();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -646,6 +646,7 @@ public class HashJoinOperatorTest {
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
     TransferableBlock result = join.nextBlock();
+    Mockito.verify(_rightOperator).setEarlyTerminate();
     Assert.assertFalse(result.isErrorBlock());
     Assert.assertEquals(result.getNumRows(), 1);
     Assert.assertTrue(result.getExceptions().get(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE)

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -646,7 +646,7 @@ public class HashJoinOperatorTest {
         new HashJoinOperator(OperatorTestUtil.getDefaultContext(), _leftOperator, _rightOperator, leftSchema, node);
 
     TransferableBlock result = join.nextBlock();
-    Mockito.verify(_rightOperator).setEarlyTerminate();
+    Mockito.verify(_rightOperator).earlyTerminate();
     Assert.assertFalse(result.isErrorBlock());
     Assert.assertEquals(result.getNumRows(), 1);
     Assert.assertTrue(result.getExceptions().get(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE)

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -257,7 +257,7 @@ public class MailboxReceiveOperatorTest {
       // Receive first block from server1
       assertEquals(receiveOp.nextBlock().getContainer().get(0), row1);
       // at this point operator received a signal to early terminate
-      receiveOp.setEarlyTerminate();
+      receiveOp.earlyTerminate();
       // Receive next block should be EOS even if upstream keep sending normal block.
       assertTrue(receiveOp.nextBlock().isEndOfStreamBlock());
       // Assure that early terminate signal goes into each mailbox

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxReceiveOperatorTest.java
@@ -44,6 +44,7 @@ import org.testng.annotations.Test;
 
 import static org.apache.pinot.common.utils.DataSchema.ColumnDataType.INT;
 import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -234,6 +235,34 @@ public class MailboxReceiveOperatorTest {
       TransferableBlock block = receiveOp.nextBlock();
       assertTrue(block.isErrorBlock());
       assertTrue(block.getExceptions().get(QueryException.UNKNOWN_ERROR_CODE).contains(errorMessage));
+    }
+  }
+
+  @Test
+  public void shouldEarlyTerminateMailboxesWhenIndicated() {
+    Object[] row1 = new Object[]{1, 1};
+    Object[] row2 = new Object[]{2, 2};
+    Object[] row3 = new Object[]{3, 3};
+    when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_1))).thenReturn(_mailbox1);
+    when(_mailbox1.poll()).thenReturn(OperatorTestUtil.block(DATA_SCHEMA, row1),
+        OperatorTestUtil.block(DATA_SCHEMA, row3), TransferableBlockUtils.getEndOfStreamTransferableBlock());
+    when(_mailboxService.getReceivingMailbox(eq(MAILBOX_ID_2))).thenReturn(_mailbox2);
+    when(_mailbox2.poll()).thenReturn(OperatorTestUtil.block(DATA_SCHEMA, row2),
+        TransferableBlockUtils.getEndOfStreamTransferableBlock());
+
+    OpChainExecutionContext context =
+        OperatorTestUtil.getOpChainContext(_mailboxService, RECEIVER_ADDRESS, Long.MAX_VALUE, _stageMetadataBoth);
+    try (MailboxReceiveOperator receiveOp = new MailboxReceiveOperator(context, RelDistribution.Type.HASH_DISTRIBUTED,
+        1)) {
+      // Receive first block from server1
+      assertEquals(receiveOp.nextBlock().getContainer().get(0), row1);
+      // at this point operator received a signal to early terminate
+      receiveOp.setEarlyTerminate();
+      // Receive next block should be EOS even if upstream keep sending normal block.
+      assertTrue(receiveOp.nextBlock().isEndOfStreamBlock());
+      // Assure that early terminate signal goes into each mailbox
+      verify(_mailbox1).earlyTerminate();
+      verify(_mailbox2).earlyTerminate();
     }
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -195,7 +195,7 @@ public class MailboxSendOperatorTest {
     TransferableBlock block = getMailboxSendOperator().nextBlock();
 
     // Then:
-    verify(_sourceOperator).setEarlyTerminate();
+    verify(_sourceOperator).earlyTerminate();
   }
 
   private MailboxSendOperator getMailboxSendOperator() {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -39,10 +39,7 @@ import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
-import static org.mockito.Mockito.doThrow;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.mockito.MockitoAnnotations.openMocks;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertSame;
@@ -183,6 +180,22 @@ public class MailboxSendOperatorTest {
     Map<String, OperatorStats> resultMetadata = blocks.get(2).getResultMetadata();
     assertEquals(resultMetadata.size(), 1);
     assertTrue(resultMetadata.containsKey(mailboxSendOperator.getOperatorId()));
+  }
+
+  @Test
+  public void shouldEarlyTerminateWhenUpstreamIndicates()
+      throws Exception {
+    // Given:
+    TransferableBlock dataBlock =
+        OperatorTestUtil.block(new DataSchema(new String[]{}, new DataSchema.ColumnDataType[]{}));
+    when(_sourceOperator.nextBlock()).thenReturn(dataBlock);
+    doReturn(true).when(_exchange).send(any());
+
+    // When:
+    TransferableBlock block = getMailboxSendOperator().nextBlock();
+
+    // Then:
+    verify(_sourceOperator).setEarlyTerminate();
   }
 
   private MailboxSendOperator getMailboxSendOperator() {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/MailboxSendOperatorTest.java
@@ -183,7 +183,7 @@ public class MailboxSendOperatorTest {
   }
 
   @Test
-  public void shouldEarlyTerminateWhenUpstreamIndicates()
+  public void shouldEarlyTerminateWhenUpstreamWhenIndicated()
       throws Exception {
     // Given:
     TransferableBlock dataBlock =

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/OpChainTest.java
@@ -376,6 +376,11 @@ public class OpChainTest {
     }
 
     @Override
+    public List<MultiStageOperator> getChildOperators() {
+      return Collections.singletonList(_upstream);
+    }
+
+    @Override
     protected TransferableBlock getNextBlock() {
       try {
         Thread.sleep(_sleepTimeInMillis);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
@@ -640,7 +640,7 @@ public class SortOperatorTest {
     TransferableBlock block2 = op.nextBlock(); // eos
 
     // Then:
-    Mockito.verify(_input).setEarlyTerminate();
+    Mockito.verify(_input).earlyTerminate();
     Assert.assertEquals(block.getNumRows(), 10);
     Assert.assertTrue(block2.isEndOfStreamBlock(), "expected EOS block to propagate");
   }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/SortOperatorTest.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.collect.ImmutableList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.calcite.rel.RelFieldCollation.Direction;
@@ -615,6 +616,32 @@ public class SortOperatorTest {
     Assert.assertEquals(block.getContainer().get(0), new Object[]{null, 1});
     Assert.assertEquals(block.getContainer().get(1), new Object[]{1, 1});
     Assert.assertEquals(block.getContainer().get(2), new Object[]{1, null});
+    Assert.assertTrue(block2.isEndOfStreamBlock(), "expected EOS block to propagate");
+  }
+
+  @Test
+  public void shouldEarlyTerminateCorrectlyWithSignalingPropagateUpstream() {
+    // Given:
+    List<RexExpression> collation = Collections.emptyList();
+    List<Direction> directions = ImmutableList.of(Direction.ASCENDING);
+    List<NullDirection> nullDirections = ImmutableList.of(NullDirection.LAST);
+    DataSchema schema = new DataSchema(new String[]{"sort"}, new DataSchema.ColumnDataType[]{INT});
+    SortOperator op =
+        new SortOperator(OperatorTestUtil.getDefaultContext(), _input, collation, directions, nullDirections, 10, 0,
+            schema, false);
+
+    Mockito.when(_input.nextBlock()).thenReturn(block(schema, new Object[]{1}, new Object[]{2}, new Object[]{3},
+        new Object[]{4}, new Object[]{5}, new Object[]{6}, new Object[]{7}, new Object[]{8}, new Object[]{9},
+        new Object[]{10}, new Object[]{11}, new Object[]{12}))
+        .thenReturn(TransferableBlockUtils.getEndOfStreamTransferableBlock());
+
+    // When:
+    TransferableBlock block = op.nextBlock(); // construct
+    TransferableBlock block2 = op.nextBlock(); // eos
+
+    // Then:
+    Mockito.verify(_input).setEarlyTerminate();
+    Assert.assertEquals(block.getNumRows(), 10);
     Assert.assertTrue(block2.isEndOfStreamBlock(), "expected EOS block to propagate");
   }
 


### PR DESCRIPTION
Changes
===

`MultiStageOperator`
---
- [x] add `setEarlyTerminate()` API which sets the early termination flag to true. This API is meant to populate upstream
    - contract of this is when `_isEarlyTerminate` is set to true, the next call to `nextBlock()` should return EOS if it has not already done so.
    - all future status propagation should follow the same status flag-setting contract.

`Mailbox`es
---
- [x] `SendingMailbox` and `ReceivingMailbox` now bear a contract to indicate whether early termination has occurred from upstream (receiving --> sending)
- [x] `ReceivingMailbox`es are set earlyTerminaton flag by `ReceiveOperator` 
- [x] `ReceivingMailbox` populate this info back to `SendingMailbox` 
- [x] `SendingMailbox` returns the boolean flag to `SendingOperator`, and `SendingOperator` checks this boolean flag and subsequently call its opChain's `setEarlyTermination()` method.


TODO
===
- add checks to ensure that EOS block are only called and return once: we are not even logging warning for now but as a contract: any operator should guarantee that no call to `operator.nextBlock()` should occur if the `operator` in question has already returned EOS.