### PR TITLE
Add pre-aggregation support for distinct count hll++

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -109,7 +109,7 @@ public final class TableConfigUtils {
   // hardcode the value here to avoid pulling the entire pinot-kinesis module as dependency.
   private static final String KINESIS_STREAM_TYPE = "kinesis";
   private static final EnumSet<AggregationFunctionType> SUPPORTED_INGESTION_AGGREGATIONS =
-      EnumSet.of(SUM, MIN, MAX, COUNT, DISTINCTCOUNTHLL, SUMPRECISION);
+      EnumSet.of(SUM, MIN, MAX, COUNT, DISTINCTCOUNTHLL, SUMPRECISION, DISTINCTCOUNTHLLPLUS);
 
   private static final Set<String> UPSERT_DEDUP_ALLOWED_ROUTING_STRATEGIES =
       ImmutableSet.of(RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE,
@@ -416,6 +416,30 @@ public final class TableConfigUtils {
               Preconditions.checkState(dataType == DataType.BYTES,
                   "Result type for DISTINCT_COUNT_HLL must be BYTES: %s", aggregationConfig);
             }
+          } else if (functionType == DISTINCTCOUNTHLLPLUS) {
+            Preconditions.checkState(numArguments >= 1 && numArguments <= 3,
+                "DISTINCT_COUNT_HLL_PLUS can have at most three arguments: %s", aggregationConfig);
+            if (numArguments == 2) {
+              ExpressionContext secondArgument = arguments.get(1);
+              Preconditions.checkState(secondArgument.getType() == ExpressionContext.Type.LITERAL,
+                  "Second argument of DISTINCT_COUNT_HLL_PLUS must be literal: %s", aggregationConfig);
+              String literal = secondArgument.getLiteral().getStringValue();
+              Preconditions.checkState(StringUtils.isNumeric(literal),
+                  "Second argument of DISTINCT_COUNT_HLL_PLUS must be a number: %s", aggregationConfig);
+            }
+            if (numArguments == 3) {
+              ExpressionContext thirdArgument = arguments.get(2);
+              Preconditions.checkState(thirdArgument.getType() == ExpressionContext.Type.LITERAL,
+                  "Third argument of DISTINCT_COUNT_HLL_PLUS must be literal: %s", aggregationConfig);
+              String literal = thirdArgument.getLiteral().getStringValue();
+              Preconditions.checkState(StringUtils.isNumeric(literal),
+                  "Third argument of DISTINCT_COUNT_HLL_PLUS must be a number: %s", aggregationConfig);
+            }
+            if (fieldSpec != null) {
+              DataType dataType = fieldSpec.getDataType();
+              Preconditions.checkState(dataType == DataType.BYTES,
+                  "Result type for DISTINCT_COUNT_HLL_PLUS must be BYTES: %s", aggregationConfig);
+            }
           } else if (functionType == SUMPRECISION) {
             Preconditions.checkState(numArguments >= 2 && numArguments <= 3,
                 "SUM_PRECISION must specify precision (required), scale (optional): %s", aggregationConfig);
@@ -536,7 +560,7 @@ public final class TableConfigUtils {
   public final static EnumSet<AggregationFunctionType> AVAILABLE_CORE_VALUE_AGGREGATORS =
       EnumSet.of(MIN, MAX, SUM, DISTINCTCOUNTHLL, DISTINCTCOUNTRAWHLL, DISTINCTCOUNTTHETASKETCH,
           DISTINCTCOUNTRAWTHETASKETCH, DISTINCTCOUNTTUPLESKETCH, DISTINCTCOUNTRAWINTEGERSUMTUPLESKETCH,
-          SUMVALUESINTEGERSUMTUPLESKETCH, AVGVALUEINTEGERSUMTUPLESKETCH);
+          SUMVALUESINTEGERSUMTUPLESKETCH, AVGVALUEINTEGERSUMTUPLESKETCH, DISTINCTCOUNTHLLPLUS, DISTINCTCOUNTRAWHLLPLUS);
 
   @VisibleForTesting
   static void validateTaskConfigs(TableConfig tableConfig, Schema schema) {


### PR DESCRIPTION
`enhancement`: Add pre-aggregation support for distinct count hll++ function. 

rohityadav1993 (Rohit Yadav) has done a CPU usage benchmark for hll++ functions. 

Test plan and setup
- Two types of queries
- Each run: 5 minutes, 1 rps
- Record, max(minCPU_hosts), max(avgCPU_hosts), max(maxCPU_hosts)
- Using uber's load testing tool to do load testing
- Performance baseline query with distinctCount without approximation
- Performance approximation queries with different parameters

<meta charset="utf-8"><b style="font-weight:normal;" id="docs-internal-guid-1d745475-7fff-70c5-721e-738f40d2f8c6"><div dir="ltr" style="margin-left:0pt;" align="left">

  | Query1 (% of CPU) | Query2 (% of CPU)
-- | -- | --
Distinct Count distinctCount(uuid) | min: 1.54, max: 5.79, avg: 2.78 | min: 0.33, max: 4.51, avg: 1.15
HLL (default log2m=8) distinctCountHLL(uuid) | min: 0.07, max: 2.81, avg: 0.68 | min: 0.46, max: 1.38, avg: 0.76
HLL log2m=9 (e=0.035) distinctCountHLL(uuid, 9) | min: 0.07, max: 1.62, avg: 0.73 | min: 0.34, max: 1.42, avg: 0.76
HLL log2m=10 (e=0.03) distinctCountHLL(uuid, 10) | min: 0.07, max: 1.58, avg: 0.88 | min: 0.52, max: 1.27, avg: 0.73
HLL++ default p=14 distinctCountHLLPLUS(uuid) | min: 0.06, max: 1.99, avg: 0.63 | min: 0.34, max: 1.46, avg: 0.75
hLL++ p=12 distinctCountHLLPLUS(uuid, 12) | min: 0.09, max: 3.33, avg: 0.35 | min: 0.31, max: 1.57, avg: 0.85
HLL++ p=10 distinctCountHLLPLUS(uuid, 10) | min: 0.08, max: 4.41, avg: 1.37 | min: 0.48, max: 1.26, avg: 0.70

</div></b>


We want to enable hll++ in pre-aggregration to further perform some benchmarking with distinctCountHLL++ on pre-computed hll bytes fields.



