### PR TITLE
Use int literal for int values

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -116,15 +116,19 @@ public class RequestUtils {
     Expression expression = new Expression(ExpressionType.LITERAL);
     Literal literal = new Literal();
     if (node instanceof SqlNumericLiteral) {
-      // TODO: support different integer and floating point type.
-      // Mitigate calcite NPE bug, we need to check if SqlNumericLiteral.getScale() is null before calling
-      // SqlNumericLiteral.isInteger(). TODO: Undo this fix once a Calcite release that contains CALCITE-4199 is
-      // available and Pinot has been upgraded to use such a release.
+      BigDecimal bigDecimalValue = node.bigDecimalValue();
+      assert bigDecimalValue != null;
       SqlNumericLiteral sqlNumericLiteral = (SqlNumericLiteral) node;
-      if (sqlNumericLiteral.getScale() != null && sqlNumericLiteral.isInteger()) {
-        literal.setLongValue(node.bigDecimalValue().longValue());
+      if (sqlNumericLiteral.isExact() && sqlNumericLiteral.isInteger()) {
+        long longValue = bigDecimalValue.longValue();
+        if (longValue <= Integer.MAX_VALUE && longValue >= Integer.MIN_VALUE) {
+          literal.setIntValue((int) longValue);
+        } else {
+          literal.setLongValue(longValue);
+        }
       } else {
-        literal.setDoubleValue(node.bigDecimalValue().doubleValue());
+        // TODO: Support exact decimal value
+        literal.setDoubleValue(bigDecimalValue.doubleValue());
       }
     } else {
       switch (node.getTypeName()) {
@@ -156,11 +160,25 @@ public class RequestUtils {
     return expression;
   }
 
+  public static Expression getLiteralExpression(int value) {
+    Expression expression = createNewLiteralExpression();
+    expression.getLiteral().setIntValue(value);
+    return expression;
+  }
+
   public static Expression getLiteralExpression(long value) {
     Expression expression = createNewLiteralExpression();
     expression.getLiteral().setLongValue(value);
     return expression;
   }
+
+  /* TODO: Uncomment this after releasing 1.1 because float is added after releasing 1.0
+  public static Expression getLiteralExpression(float value) {
+    Expression expression = createNewLiteralExpression();
+    expression.getLiteral().setFloatValue(Float.floatToRawIntBits(value));
+    return expression;
+  }
+   */
 
   public static Expression getLiteralExpression(double value) {
     Expression expression = createNewLiteralExpression();
@@ -198,24 +216,28 @@ public class RequestUtils {
     if (object == null) {
       return getNullLiteralExpression();
     }
-    if (object instanceof Integer || object instanceof Long) {
-      return RequestUtils.getLiteralExpression(((Number) object).longValue());
+    if (object instanceof Integer) {
+      return RequestUtils.getLiteralExpression((int) object);
+    }
+    if (object instanceof Long) {
+      return RequestUtils.getLiteralExpression((long) object);
     }
     if (object instanceof Float) {
       // We need to use Double.parseDouble(object.toString()) instead of ((Number) object).doubleValue()
       // or ((Float) object).doubleValue() because the latter two will return slightly different values
       // For example, if object is 0.06f, Double.parseDouble(object.toString()) will return 0.06, while
       // ((Number) object).doubleValue() or ((Float) object).doubleValue() will return 0.05999999865889549
+      // TODO: Switch to RequestUtils.getLiteralExpression(float value) after releasing 1.1
       return RequestUtils.getLiteralExpression(Double.parseDouble(object.toString()));
     }
     if (object instanceof Double) {
-      return RequestUtils.getLiteralExpression(((Double) object).doubleValue());
+      return RequestUtils.getLiteralExpression((double) object);
     }
     if (object instanceof byte[]) {
       return RequestUtils.getLiteralExpression((byte[]) object);
     }
     if (object instanceof Boolean) {
-      return RequestUtils.getLiteralExpression(((Boolean) object).booleanValue());
+      return RequestUtils.getLiteralExpression((boolean) object);
     }
     return RequestUtils.getLiteralExpression(object.toString());
   }
@@ -264,8 +286,8 @@ public class RequestUtils {
       return expression.getIdentifier().getName();
     }
     if (expression.getLiteral() != null) {
-      if (expression.getLiteral().isSetLongValue()) {
-        return Long.toString(expression.getLiteral().getLongValue());
+      if (expression.getLiteral().isSetIntValue()) {
+        return Long.toString(expression.getLiteral().getIntValue());
       }
     }
     if (expression.getFunctionCall() != null) {

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/OrdinalsUpdater.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/OrdinalsUpdater.java
@@ -32,9 +32,9 @@ public class OrdinalsUpdater implements QueryRewriter {
   public PinotQuery rewrite(PinotQuery pinotQuery) {
     // handle GROUP BY clause
     for (int i = 0; i < pinotQuery.getGroupByListSize(); i++) {
-      final Expression groupByExpr = pinotQuery.getGroupByList().get(i);
-      if (groupByExpr.isSetLiteral() && groupByExpr.getLiteral().isSetLongValue()) {
-        final int ordinal = (int) groupByExpr.getLiteral().getLongValue();
+      Expression groupByExpr = pinotQuery.getGroupByList().get(i);
+      if (groupByExpr.isSetLiteral() && groupByExpr.getLiteral().isSetIntValue()) {
+        int ordinal = groupByExpr.getLiteral().getIntValue();
         pinotQuery.getGroupByList().set(i, getExpressionFromOrdinal(pinotQuery.getSelectList(), ordinal));
       }
     }
@@ -43,8 +43,8 @@ public class OrdinalsUpdater implements QueryRewriter {
     for (int i = 0; i < pinotQuery.getOrderByListSize(); i++) {
       Expression orderByExpr = CalciteSqlParser.removeOrderByFunctions(pinotQuery.getOrderByList().get(i));
       Boolean isNullsLast = CalciteSqlParser.isNullsLast(pinotQuery.getOrderByList().get(i));
-      if (orderByExpr.isSetLiteral() && orderByExpr.getLiteral().isSetLongValue()) {
-        final int ordinal = (int) orderByExpr.getLiteral().getLongValue();
+      if (orderByExpr.isSetLiteral() && orderByExpr.getLiteral().isSetIntValue()) {
+        int ordinal = orderByExpr.getLiteral().getIntValue();
         Function functionToSet = pinotQuery.getOrderByList().get(i).getFunctionCall();
         if (isNullsLast != null) {
           functionToSet = functionToSet.getOperands().get(0).getFunctionCall();

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -95,12 +95,12 @@ public class CalciteSqlCompilerTest {
     Function greatThanFunc = caseFunc.getOperands().get(0).getFunctionCall();
     Assert.assertEquals(greatThanFunc.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(greatThanFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
-    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 30L);
+    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 30);
     Assert.assertEquals(caseFunc.getOperands().get(1).getLiteral().getFieldValue(), "The quantity is greater than 30");
     Function equalsFunc = caseFunc.getOperands().get(2).getFunctionCall();
     Assert.assertEquals(equalsFunc.getOperator(), FilterKind.EQUALS.name());
     Assert.assertEquals(equalsFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
-    Assert.assertEquals(equalsFunc.getOperands().get(1).getLiteral().getFieldValue(), 30L);
+    Assert.assertEquals(equalsFunc.getOperands().get(1).getLiteral().getFieldValue(), 30);
     Assert.assertEquals(caseFunc.getOperands().get(3).getLiteral().getFieldValue(), "The quantity is 30");
     Assert.assertEquals(caseFunc.getOperands().get(4).getLiteral().getFieldValue(), "The quantity is under 30");
 
@@ -126,19 +126,19 @@ public class CalciteSqlCompilerTest {
     greatThanFunc = caseFunc.getOperands().get(0).getFunctionCall();
     Assert.assertEquals(greatThanFunc.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(greatThanFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
-    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 30L);
-    Assert.assertEquals(caseFunc.getOperands().get(1).getLiteral().getFieldValue(), 3L);
+    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 30);
+    Assert.assertEquals(caseFunc.getOperands().get(1).getLiteral().getFieldValue(), 3);
     greatThanFunc = caseFunc.getOperands().get(2).getFunctionCall();
     Assert.assertEquals(greatThanFunc.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(greatThanFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
-    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 20L);
-    Assert.assertEquals(caseFunc.getOperands().get(3).getLiteral().getFieldValue(), 2L);
+    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 20);
+    Assert.assertEquals(caseFunc.getOperands().get(3).getLiteral().getFieldValue(), 2);
     greatThanFunc = caseFunc.getOperands().get(4).getFunctionCall();
     Assert.assertEquals(greatThanFunc.getOperator(), FilterKind.GREATER_THAN.name());
     Assert.assertEquals(greatThanFunc.getOperands().get(0).getIdentifier().getName(), "Quantity");
-    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 10L);
-    Assert.assertEquals(caseFunc.getOperands().get(5).getLiteral().getFieldValue(), 1L);
-    Assert.assertEquals(caseFunc.getOperands().get(6).getLiteral().getFieldValue(), 0L);
+    Assert.assertEquals(greatThanFunc.getOperands().get(1).getLiteral().getFieldValue(), 10);
+    Assert.assertEquals(caseFunc.getOperands().get(5).getLiteral().getFieldValue(), 1);
+    Assert.assertEquals(caseFunc.getOperands().get(6).getLiteral().getFieldValue(), 0);
   }
 
   @Test(expectedExceptions = SqlCompilationException.class)
@@ -234,7 +234,7 @@ public class CalciteSqlCompilerTest {
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "b");
-      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 100L);
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 100);
     }
 
     {
@@ -242,7 +242,7 @@ public class CalciteSqlCompilerTest {
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "c");
-      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 10L);
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 10);
     }
 
     {
@@ -250,7 +250,7 @@ public class CalciteSqlCompilerTest {
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN_OR_EQUAL.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "d");
-      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 50L);
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 50);
     }
 
     {
@@ -259,8 +259,8 @@ public class CalciteSqlCompilerTest {
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.BETWEEN.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "e");
-      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 70L);
-      Assert.assertEquals(func.getOperands().get(2).getLiteral().getLongValue(), 80L);
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 70);
+      Assert.assertEquals(func.getOperands().get(2).getLiteral().getIntValue(), 80);
     }
 
     {
@@ -278,10 +278,10 @@ public class CalciteSqlCompilerTest {
       Function func = pinotQuery.getFilterExpression().getFunctionCall();
       Assert.assertEquals(func.getOperator(), FilterKind.IN.name());
       Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "g");
-      Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 12L);
-      Assert.assertEquals(func.getOperands().get(2).getLiteral().getLongValue(), 13L);
+      Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 12);
+      Assert.assertEquals(func.getOperands().get(2).getLiteral().getIntValue(), 13);
       Assert.assertEquals(func.getOperands().get(3).getLiteral().getDoubleValue(), 15.2);
-      Assert.assertEquals(func.getOperands().get(4).getLiteral().getLongValue(), 17L);
+      Assert.assertEquals(func.getOperands().get(4).getLiteral().getIntValue(), 17);
     }
 
     {
@@ -408,7 +408,7 @@ public class CalciteSqlCompilerTest {
         "a");
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
         "b");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 0);
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where 0 < a-b");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN.name());
@@ -417,7 +417,7 @@ public class CalciteSqlCompilerTest {
         "a");
     Assert.assertEquals(func.getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
         "b");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 0);
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where b < 100 + c");
     func = pinotQuery.getFilterExpression().getFunctionCall();
@@ -429,11 +429,11 @@ public class CalciteSqlCompilerTest {
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
-            .getLiteral().getLongValue(), 100L);
+            .getLiteral().getIntValue(), 100L);
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1)
             .getIdentifier().getName(), "c");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 0);
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where b -(100+c)< 0");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.LESS_THAN.name());
@@ -444,11 +444,11 @@ public class CalciteSqlCompilerTest {
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(), "plus");
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
-            .getLiteral().getLongValue(), 100L);
+            .getLiteral().getIntValue(), 100);
     Assert.assertEquals(
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1)
             .getIdentifier().getName(), "c");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 0);
 
     pinotQuery =
         CalciteSqlParser.compileToPinotQuery("select * from vegetables where foo1(bar1(a-b)) <= foo2(bar2(c+d))");
@@ -487,7 +487,7 @@ public class CalciteSqlCompilerTest {
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
             .getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
         "d");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 0);
     pinotQuery =
         CalciteSqlParser.compileToPinotQuery("select * from vegetables where foo1(bar1(a-b)) - foo2(bar2(c+d)) <= 0");
     func = pinotQuery.getFilterExpression().getFunctionCall();
@@ -525,18 +525,18 @@ public class CalciteSqlCompilerTest {
         func.getOperands().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(0)
             .getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1).getIdentifier().getName(),
         "d");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 0L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 0);
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where c >= 10");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "c");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 10L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 10);
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select * from vegetables where 10 <= c");
     func = pinotQuery.getFilterExpression().getFunctionCall();
     Assert.assertEquals(func.getOperator(), FilterKind.GREATER_THAN_OR_EQUAL.name());
     Assert.assertEquals(func.getOperands().get(0).getIdentifier().getName(), "c");
-    Assert.assertEquals(func.getOperands().get(1).getLiteral().getLongValue(), 10L);
+    Assert.assertEquals(func.getOperands().get(1).getLiteral().getIntValue(), 10);
   }
 
   @Test
@@ -984,9 +984,9 @@ public class CalciteSqlCompilerTest {
             .getIdentifier().getName(), "numberOfGames");
     Assert.assertEquals(
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
-            .getLiteral().getLongValue(), 10);
+            .getLiteral().getIntValue(), 10);
     Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 100);
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 100);
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery(
         "SELECT count(*) FROM mytable WHERE timeConvert(DaysSinceEpoch,'DAYS','SECONDS') = 1394323200");
@@ -1007,7 +1007,7 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(2)
             .getLiteral().getStringValue(), "SECONDS");
     Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getLongValue(),
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getIntValue(),
         1394323200);
   }
 
@@ -1097,7 +1097,7 @@ public class CalciteSqlCompilerTest {
     final Expression filter = pinotQuery.getFilterExpression();
     Assert.assertEquals(filter.getFunctionCall().getOperator(), "GREATER_THAN");
     Assert.assertEquals(filter.getFunctionCall().getOperands().get(0).getIdentifier().getName(), "c3");
-    Assert.assertEquals(filter.getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 100);
+    Assert.assertEquals(filter.getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 100);
 
     c1 = distinctFunction.getOperands().get(0).getIdentifier();
     c2 = distinctFunction.getOperands().get(1).getIdentifier();
@@ -1424,14 +1424,14 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "daysSinceEpoch");
     Assert.assertEquals(
-        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 18523);
+        pinotQuery.getFilterExpression().getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 18523);
     Assert.assertEquals(pinotQuery.getGroupByListSize(), 1);
     Assert.assertEquals(pinotQuery.getGroupByList().get(0).getFunctionCall().getOperator(), "divide");
     Assert.assertEquals(
         pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "secondsSinceEpoch");
     Assert.assertEquals(
-        pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 86400);
+        pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 86400);
     Assert.assertEquals(pinotQuery.getOrderByListSize(), 2);
 
     // Invalid groupBy clause shouldn't contain aggregate expression, like sum(rsvp_count), count(*).
@@ -1498,7 +1498,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(
         pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "C1");
     Assert.assertEquals(
-        pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 1);
+        pinotQuery.getGroupByList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 1);
   }
 
   @Test
@@ -1509,12 +1509,12 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(
         pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "b");
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 2);
+        pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 2);
     Assert.assertEquals(pinotQuery.getSelectList().get(2).getFunctionCall().getOperator(), "times");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(2).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "c");
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(2).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 5);
+        pinotQuery.getSelectList().get(2).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 5);
     Assert.assertEquals(pinotQuery.getSelectList().get(3).getFunctionCall().getOperator(), "times");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(3).getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(),
@@ -1524,9 +1524,9 @@ public class CalciteSqlCompilerTest {
             .getIdentifier().getName(), "d");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(3).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
-            .getLiteral().getLongValue(), 5);
+            .getLiteral().getIntValue(), 5);
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(3).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 2);
+        pinotQuery.getSelectList().get(3).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 2);
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("select a % 200 + b * 5  from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
@@ -1539,7 +1539,7 @@ public class CalciteSqlCompilerTest {
             .getIdentifier().getName(), "a");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
-            .getLiteral().getLongValue(), 200);
+            .getLiteral().getIntValue(), 200);
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperator(),
         "times");
@@ -1548,7 +1548,7 @@ public class CalciteSqlCompilerTest {
             .getIdentifier().getName(), "b");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1)
-            .getLiteral().getLongValue(), 5);
+            .getLiteral().getIntValue(), 5);
   }
 
   /**
@@ -1695,11 +1695,11 @@ public class CalciteSqlCompilerTest {
   public void testCastTransformation() {
     PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery("select CAST(25.65 AS int) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getLongValue(), 25);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getIntValue(), 25);
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT CAST('20170825' AS LONG) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
-    Assert.assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getLongValue(), 20170825);
+    Assert.assertEquals(pinotQuery.getSelectList().get(0).getLiteral().getLongValue(), 20170825L);
 
     pinotQuery = CalciteSqlParser.compileToPinotQuery("SELECT CAST(20170825.0 AS Float) from myTable");
     Assert.assertEquals(pinotQuery.getSelectListSize(), 1);
@@ -1979,7 +1979,7 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(
         pinotQuery.getGroupByList().get(1).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "b");
     Assert.assertEquals(
-        pinotQuery.getGroupByList().get(1).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 2L);
+        pinotQuery.getGroupByList().get(1).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 2);
     Assert.assertEquals(pinotQuery.getGroupByList().get(2).getFunctionCall().getOperator(), "arraysum");
     Assert.assertEquals(
         pinotQuery.getGroupByList().get(2).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "c");
@@ -2517,7 +2517,7 @@ public class CalciteSqlCompilerTest {
             .getFunctionCall().getOperands().get(0).getIdentifier().getName(), "col2");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(1)
-            .getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 5L);
+            .getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 5);
 
     query = "SELECT col1+col2*5 AS col3 FROM foo GROUP BY col3";
     pinotQuery = CalciteSqlParser.compileToPinotQuery(query);
@@ -2543,8 +2543,8 @@ public class CalciteSqlCompilerTest {
         "col2");
     Assert.assertEquals(
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
-            .getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(),
-        5L);
+            .getFunctionCall().getOperands().get(1).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(),
+        5);
   }
 
   @Test
@@ -2786,16 +2786,15 @@ public class CalciteSqlCompilerTest {
         pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0)
             .getIdentifier().getName(), "a");
     Assert.assertEquals(
-        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(), 1L);
+        pinotQuery.getSelectList().get(0).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(), 1);
   }
 
   /**
-   * This test shows that Calcite {@link SqlNumericLiteral#isInteger()} throws NPE. The issue has been fixed in
-   * Calcite through CALCITE-4199 (https://issues.apache.org/jira/browse/CALCITE-4199), but has not made it into a
-   * release yet.
+   * This test ensures that Calcite {@link SqlNumericLiteral#isInteger()} does not throw NPE. The issue has been fixed
+   * in Calcite through CALCITE-4199 (https://issues.apache.org/jira/browse/CALCITE-4199).
    */
   @Test
-  public void testSqlNumericalLiteralisIntegerNPE() {
+  public void testSqlNumericalLiteralIntegerNPE() {
     CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM testTable WHERE floatColumn > " + Double.MAX_VALUE);
   }
 
@@ -3007,8 +3006,8 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(fun.getOperands().get(0).getFunctionCall().getOperands().size(), 2);
     Assert.assertEquals(fun.getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(),
         "ts");
-    Assert.assertEquals(fun.getOperands().get(0).getFunctionCall().getOperands().get(1).getLiteral().getLongValue(),
-        123L);
+    Assert.assertEquals(fun.getOperands().get(0).getFunctionCall().getOperands().get(1).getLiteral().getIntValue(),
+        123);
     Assert.assertEquals(fun.getOperands().get(1).getLiteral().getStringValue(), "pst");
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
@@ -63,12 +63,11 @@ public class IntegerTupleSketchAggregationFunction
     _expressionContext = arguments.get(0);
     _setOps = new IntegerSummarySetOperations(mode, mode);
     if (arguments.size() == 2) {
-      FieldSpec.DataType dataType = arguments.get(1).getLiteral().getType();
-      Preconditions.checkArgument(dataType == FieldSpec.DataType.LONG || dataType == FieldSpec.DataType.INT,
-          "Tuple Sketch Aggregation Function expected the second argument to be a number of entries to keep, but it "
-              + "was of type %s",
-          dataType.toString());
-      _entries = ((Long) arguments.get(1).getLiteral().getValue()).intValue();
+      ExpressionContext secondArgument = arguments.get(1);
+      Preconditions.checkArgument(secondArgument.getType() == ExpressionContext.Type.LITERAL,
+          "Tuple Sketch Aggregation Function expects the second argument to be a literal (number of entries to keep),"
+              + " but got: ", secondArgument.getType());
+      _entries = secondArgument.getLiteral().getIntValue();
     } else {
       _entries = (int) Math.pow(2, CommonConstants.Helix.DEFAULT_TUPLE_SKETCH_LGK);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/QueryOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/QueryOptimizerTest.java
@@ -73,8 +73,8 @@ public class QueryOptimizerTest {
     assertEquals(secondChildFunction.getOperator(), FilterKind.AND.name());
     List<Expression> secondChildChildren = secondChildFunction.getOperands();
     assertEquals(secondChildChildren.size(), 3);
-    assertEquals(secondChildChildren.get(0), getEqFilterExpression("long", 5L));
-    assertEquals(secondChildChildren.get(1), getEqFilterExpression("float", 9f));
+    assertEquals(secondChildChildren.get(0), getEqFilterExpression("long", 5));
+    assertEquals(secondChildChildren.get(1), getEqFilterExpression("float", 9));
     assertEquals(secondChildChildren.get(2), getEqFilterExpression("double", 7.5));
   }
 
@@ -97,7 +97,7 @@ public class QueryOptimizerTest {
     List<Expression> children = filterFunction.getOperands();
     assertEquals(children.size(), 3);
     assertEquals(children.get(0), getEqFilterExpression("int", 1));
-    checkInFilterFunction(children.get(1).getFunctionCall(), "long", Arrays.asList(2L, 3L, 4L));
+    checkInFilterFunction(children.get(1).getFunctionCall(), "long", Arrays.asList(2, 3, 4));
 
     Function thirdChildFunction = children.get(2).getFunctionCall();
     assertEquals(thirdChildFunction.getOperator(), FilterKind.OR.name());
@@ -154,7 +154,7 @@ public class QueryOptimizerTest {
     assertEquals(secondChildFunction.getOperator(), FilterKind.AND.name());
     List<Expression> secondChildChildren = secondChildFunction.getOperands();
     assertEquals(secondChildChildren.size(), 2);
-    assertEquals(secondChildChildren.get(0), getEqFilterExpression("float", 6f));
+    assertEquals(secondChildChildren.get(0), getEqFilterExpression("float", 6));
     assertEquals(secondChildChildren.get(1), getRangeFilterExpression("float", "[6.0\0006.5)"));
 
     // Range filter on multi-value column should not be merged ([-5, 10] can match this filter)

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/optimizer/filter/NumericalFilterOptimizerTest.java
@@ -97,7 +97,7 @@ public class NumericalFilterOptimizerTest {
     // Test float column equals valid long value.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn = 5"),
         "Expression(type:FUNCTION, functionCall:Function(operator:EQUALS, operands:[Expression(type:IDENTIFIER, "
-            + "identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:5.0>)"
+            + "identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal intValue:5>)"
             + "]))");
 
     // Test float column equals invalid long value.
@@ -111,13 +111,13 @@ public class NumericalFilterOptimizerTest {
     // Test float column not equals valid long value
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE floatColumn != 5"),
         "Expression(type:FUNCTION, functionCall:Function(operator:NOT_EQUALS, operands:[Expression(type:IDENTIFIER, "
-            + "identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:5.0>)"
+            + "identifier:Identifier(name:floatColumn)), Expression(type:LITERAL, literal:<Literal intValue:5>)"
             + "]))");
 
     // test double column equals valid long value.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE doubleColumn = 5"),
         "Expression(type:FUNCTION, functionCall:Function(operator:EQUALS, operands:[Expression(type:IDENTIFIER, "
-            + "identifier:Identifier(name:doubleColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:5.0>)"
+            + "identifier:Identifier(name:doubleColumn)), Expression(type:LITERAL, literal:<Literal intValue:5>)"
             + "]))");
 
     // Test double column equals invalid long value.
@@ -131,7 +131,7 @@ public class NumericalFilterOptimizerTest {
     // Test double column not equals invalid long value.
     Assert.assertEquals(rewrite("SELECT * FROM testTable WHERE doubleColumn != 5"),
         "Expression(type:FUNCTION, functionCall:Function(operator:NOT_EQUALS, operands:[Expression(type:IDENTIFIER, "
-            + "identifier:Identifier(name:doubleColumn)), Expression(type:LITERAL, literal:<Literal doubleValue:5.0>)"
+            + "identifier:Identifier(name:doubleColumn)), Expression(type:LITERAL, literal:<Literal intValue:5>)"
             + "]))");
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -1026,7 +1026,7 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     assertEquals(columnNames.get(10).asText(), "fromBase64");
 
     JsonNode columnDataTypes = dataSchema.get("columnDataTypes");
-    assertEquals(columnDataTypes.get(0).asText(), "LONG");
+    assertEquals(columnDataTypes.get(0).asText(), "INT");
     assertEquals(columnDataTypes.get(1).asText(), "LONG");
     assertEquals(columnDataTypes.get(2).asText(), "LONG");
     assertEquals(columnDataTypes.get(3).asText(), "STRING");


### PR DESCRIPTION
Currently we always use long literal for all whole numbers. Change it to int to be SQL compatible.