### PR TITLE
Upgrade confluent libraries to 7.2.6 to fix some errors related to optional proto fields

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
@@ -82,7 +82,6 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
-      <version>1.18.1</version>
     </dependency>
     <dependency>
       <groupId>com.google.api.grpc</groupId>

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/resources/sample.proto
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/src/test/resources/sample.proto
@@ -25,4 +25,5 @@ message SampleRecord {
   int32 id = 2;
   string email = 3;
   repeated string friends = 4;
+  optional string optionalField = 5;
 }

--- a/pom.xml
+++ b/pom.xml
@@ -190,6 +190,10 @@
 
     <flink.version>1.12.0</flink.version>
     <commons-configuration2.version>2.9.0</commons-configuration2.version>
+
+    <proto.google.common.protos.version>2.9.6</proto.google.common.protos.version>
+
+    <kotlin.stdlib.version>1.7.22</kotlin.stdlib.version>
   </properties>
 
   <profiles>
@@ -1248,7 +1252,7 @@
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-common-protos</artifactId>
-        <version>2.9.6</version>
+        <version>${proto.google.common.protos.version}</version>
       </dependency>
       <!-- geo dependencies -->
       <dependency>
@@ -1350,12 +1354,12 @@
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-stdlib-jdk8</artifactId>
-        <version>1.7.22</version>
+        <version>${kotlin.stdlib.version}</version>
       </dependency>
       <dependency>
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-stdlib</artifactId>
-        <version>1.7.22</version>
+        <version>${kotlin.stdlib.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <argLine>-Xms4g -Xmx4g</argLine>
     <protobuf.version>3.24.3</protobuf.version>
     <grpc.version>1.53.0</grpc.version>
-    <confluent.version>5.5.3</confluent.version>
+    <confluent.version>7.4.0</confluent.version>
 
     <!-- Checkstyle violation prop.-->
     <checkstyle.violation.severity>warning</checkstyle.violation.severity>
@@ -1226,6 +1226,11 @@
         <version>${protobuf.version}</version>
       </dependency>
       <dependency>
+        <groupId>com.google.protobuf</groupId>
+        <artifactId>protobuf-java-util</artifactId>
+        <version>${protobuf.version}</version>
+      </dependency>
+      <dependency>
         <groupId>io.grpc</groupId>
         <artifactId>grpc-netty-shaded</artifactId>
         <version>${grpc.version}</version>
@@ -1239,6 +1244,11 @@
         <groupId>io.grpc</groupId>
         <artifactId>grpc-stub</artifactId>
         <version>${grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.api.grpc</groupId>
+        <artifactId>proto-google-common-protos</artifactId>
+        <version>2.9.6</version>
       </dependency>
       <!-- geo dependencies -->
       <dependency>
@@ -1334,6 +1344,18 @@
         <groupId>org.apache.flink</groupId>
         <artifactId>flink-streaming-java_${scala.compat.version}</artifactId>
         <version>${flink.version}</version>
+      </dependency>
+
+      <!-- used by some projects like kafka-protobuf-serializer-->
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-jdk8</artifactId>
+        <version>1.7.22</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib</artifactId>
+        <version>1.7.22</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -168,7 +168,7 @@
     <argLine>-Xms4g -Xmx4g</argLine>
     <protobuf.version>3.24.3</protobuf.version>
     <grpc.version>1.53.0</grpc.version>
-    <confluent.version>7.4.0</confluent.version>
+    <confluent.version>7.2.6</confluent.version>
 
     <!-- Checkstyle violation prop.-->
     <checkstyle.violation.severity>warning</checkstyle.violation.severity>


### PR DESCRIPTION
Recently we had some issues reading nulls from optional proto fields.

After several tests, we found that the actual issue was using a very old confluent version (5.5.3). Before 7.1.x, `kafka-protobuf-serializer` was not able to read optional fields in proto3 and instead relay on the producer rewriting the proto descriptor in order to change all optional fields to oneof. That is a requirement in older versions of proto but it is not a requirement in modern ones. This transformation is not required in `kafka-protobuf-serializer` in 7.1.x and higher and therefore if the producer uses one of these modern versions, the rewrite is not applied.

That means that if the consumer used `kafka-protobuf-serializer` >= 7.1.x, Pinot is not able to recognize optional fields, which had the lateral effect of either detecting default values (like 0 for ints) as null (which happened before https://github.com/apache/pinot/pull/11723) or transforming actual nulls to default values (which happened after https://github.com/apache/pinot/pull/11723)