### PR TITLE
Upgrading Apache Helix to 1.3.1 version

### DIFF
--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -405,9 +405,10 @@ org.apache.flink:flink-shaded-zookeeper-3:3.4.14-12.0
 org.apache.flink:flink-streaming-java_2.12:1.12.0
 org.apache.flink:force-shading:1.12.0
 org.apache.helix:helix-core:1.3.1
-org.apache.helix:metadata-store-directory-common:1.0.4
-org.apache.helix:metrics-common:1.0.4
-org.apache.helix:zookeeper-api:1.0.4
+org.apache.helix:helix-core:1.3.1
+org.apache.helix:metadata-store-directory-common:1.3.1
+org.apache.helix:metrics-common:1.3.1
+org.apache.helix:zookeeper-api:1.3.1
 org.apache.hive:hive-storage-api:2.7.1
 org.apache.httpcomponents:httpclient:4.5.13
 org.apache.httpcomponents:httpcore:4.4.13

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -404,7 +404,7 @@ org.apache.flink:flink-shaded-netty:4.1.49.Final-12.0
 org.apache.flink:flink-shaded-zookeeper-3:3.4.14-12.0
 org.apache.flink:flink-streaming-java_2.12:1.12.0
 org.apache.flink:force-shading:1.12.0
-org.apache.helix:helix-core:1.3.1
+org.apache.helix:helix-common:1.3.1
 org.apache.helix:helix-core:1.3.1
 org.apache.helix:metadata-store-directory-common:1.3.1
 org.apache.helix:metrics-common:1.3.1

--- a/LICENSE-binary
+++ b/LICENSE-binary
@@ -404,8 +404,7 @@ org.apache.flink:flink-shaded-netty:4.1.49.Final-12.0
 org.apache.flink:flink-shaded-zookeeper-3:3.4.14-12.0
 org.apache.flink:flink-streaming-java_2.12:1.12.0
 org.apache.flink:force-shading:1.12.0
-org.apache.helix:helix-common:1.0.4
-org.apache.helix:helix-core:1.0.4
+org.apache.helix:helix-core:1.3.1
 org.apache.helix:metadata-store-directory-common:1.0.4
 org.apache.helix:metrics-common:1.0.4
 org.apache.helix:zookeeper-api:1.0.4

--- a/pom.xml
+++ b/pom.xml
@@ -123,7 +123,7 @@
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
     <avro.version>1.10.2</avro.version>
     <parquet.version>1.12.3</parquet.version>
-    <helix.version>1.0.4</helix.version>
+    <helix.version>1.3.1</helix.version>
     <zkclient.version>0.7</zkclient.version>
     <jackson.version>2.12.7.20221012</jackson.version>
     <zookeeper.version>3.6.3</zookeeper.version>


### PR DESCRIPTION
This PR is a followup to https://github.com/apache/pinot/pull/11450, which was reverted because of an Helix issue.