### PR TITLE
Fix trivy CI issue

### DIFF
--- a/.github/workflows/pinot_vuln_check.yml
+++ b/.github/workflows/pinot_vuln_check.yml
@@ -39,18 +39,15 @@ jobs:
     steps:
       - uses: docker/setup-qemu-action@v2
         name: Set up QEMU
-      - uses: docker/setup-buildx-action@v2
-        name: Set up Docker Buildx
       - uses: actions/checkout@v3
       - name: Build the Docker image
         env:
           DOCKER_FILE_BASE_DIR: "docker/images/pinot"
           DOCKER_IMAGE_NAME: "apachepinot/pinot"
-          BUILD_PLATFORM: "linux/amd64"
           PINOT_GIT_URL: ${{ github.event.inputs.gitUrl }}
           PINOT_BRANCH: ${{ env.GITHUB_REF }}
-          TAGS: ${{ github.sha }}
-        run: .github/workflows/scripts/docker/.pinot_docker_image_build.sh
+          PINOT_SHA: ${{ github.sha }}
+        run: .github/workflows/scripts/.pinot_vuln_check.sh
 
       - name: Run Trivy vulnerability scanner (sarif)
         uses: aquasecurity/trivy-action@master

--- a/.github/workflows/scripts/.pinot_vuln_check.sh
+++ b/.github/workflows/scripts/.pinot_vuln_check.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -x
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+if [ -z "${DOCKER_IMAGE_NAME}" ]; then
+  DOCKER_IMAGE_NAME="apachepinot/pinot"
+fi
+if [ -z "${PINOT_GIT_URL}" ]; then
+  PINOT_GIT_URL="https://github.com/apache/pinot.git"
+fi
+if [ -z "${PINOT_BRANCH}" ]; then
+  PINOT_BRANCH="master"
+fi
+
+cd ${DOCKER_FILE_BASE_DIR}
+
+docker image ls
+
+docker build \
+    --no-cache \
+    --file Dockerfile \
+    --build-arg PINOT_GIT_URL=${PINOT_GIT_URL} \
+    --build-arg PINOT_BRANCH=${PINOT_BRANCH} \
+    --tag ${DOCKER_IMAGE_NAME}:${PINOT_SHA} \
+    .
+
+docker image ls

--- a/.github/workflows/scripts/.pinot_vuln_check.sh
+++ b/.github/workflows/scripts/.pinot_vuln_check.sh
@@ -30,8 +30,6 @@ fi
 
 cd ${DOCKER_FILE_BASE_DIR}
 
-docker image ls
-
 docker build \
     --no-cache \
     --file Dockerfile \


### PR DESCRIPTION
Recent docker buildx doesn't generate expected docker image with tag.
Separate trivy check script.