### PR TITLE
Enhance Broker reducer to handle expression format change

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -18,12 +18,16 @@
  */
 package org.apache.pinot.core.query.reduce;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
@@ -38,6 +42,8 @@ import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -46,6 +52,8 @@ import org.apache.pinot.spi.utils.builder.TableNameBuilder;
  */
 @ThreadSafe
 public class BrokerReduceService extends BaseReduceService {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BrokerReduceService.class);
+
   public BrokerReduceService(PinotConfiguration config) {
     super(config);
   }
@@ -65,7 +73,9 @@ public class BrokerReduceService extends BaseReduceService {
     BrokerResponseNative brokerResponseNative = new BrokerResponseNative();
 
     // Cache a data schema from data tables (try to cache one with data rows associated with it).
-    DataSchema cachedDataSchema = null;
+    DataSchema dataSchemaFromEmptyDataTable = null;
+    DataSchema dataSchemaFromNonEmptyDataTable = null;
+    List<ServerRoutingInstance> serversWithConflictingDataSchema = new ArrayList<>();
 
     // Process server response metadata.
     Iterator<Map.Entry<ServerRoutingInstance, DataTable>> iterator = dataTableMap.entrySet().iterator();
@@ -83,12 +93,22 @@ public class BrokerReduceService extends BaseReduceService {
       } else {
         // Try to cache a data table with data rows inside, or cache one with data schema inside.
         if (dataTable.getNumberOfRows() == 0) {
-          if (cachedDataSchema == null) {
-            cachedDataSchema = dataSchema;
+          if (dataSchemaFromEmptyDataTable == null) {
+            dataSchemaFromEmptyDataTable = dataSchema;
           }
           iterator.remove();
         } else {
-          cachedDataSchema = dataSchema;
+          if (dataSchemaFromNonEmptyDataTable == null) {
+            dataSchemaFromNonEmptyDataTable = dataSchema;
+          } else {
+            // Remove data tables with conflicting data schema.
+            // NOTE: Only compare the column data types, since the column names (string representation of expression)
+            //       can change across different versions.
+            if (!Arrays.equals(dataSchema.getColumnDataTypes(), dataSchemaFromNonEmptyDataTable.getColumnDataTypes())) {
+              serversWithConflictingDataSchema.add(entry.getKey());
+              iterator.remove();
+            }
+          }
         }
       }
     }
@@ -99,8 +119,23 @@ public class BrokerReduceService extends BaseReduceService {
     // Set execution statistics and Update broker metrics.
     aggregator.setStats(rawTableName, brokerResponseNative, brokerMetrics);
 
+    // Report the servers with conflicting data schema.
+    if (!serversWithConflictingDataSchema.isEmpty()) {
+      String errorMessage =
+          String.format("%s: responses for table: %s from servers: %s got dropped due to data schema inconsistency.",
+              QueryException.MERGE_RESPONSE_ERROR.getMessage(), tableName, serversWithConflictingDataSchema);
+      LOGGER.warn(errorMessage);
+      if (brokerMetrics != null) {
+        brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.RESPONSE_MERGE_EXCEPTIONS, 1L);
+      }
+      brokerResponseNative.addToExceptions(
+          new QueryProcessingException(QueryException.MERGE_RESPONSE_ERROR_CODE, errorMessage));
+    }
+
     // NOTE: When there is no cached data schema, that means all servers encountered exception. In such case, return the
     //       response with metadata only.
+    DataSchema cachedDataSchema =
+        dataSchemaFromNonEmptyDataTable != null ? dataSchemaFromNonEmptyDataTable : dataSchemaFromEmptyDataTable;
     if (cachedDataSchema == null) {
       return brokerResponseNative;
     }
@@ -124,8 +159,7 @@ public class BrokerReduceService extends BaseReduceService {
       if (gapfillType == null) {
         throw new BadQueryRequestException("Nested query is not supported without gapfill");
       }
-      BaseGapfillProcessor gapfillProcessor =
-          GapfillProcessorFactory.getGapfillProcessor(queryContext, gapfillType);
+      BaseGapfillProcessor gapfillProcessor = GapfillProcessorFactory.getGapfillProcessor(queryContext, gapfillType);
       gapfillProcessor.process(brokerResponseNative);
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -72,7 +72,6 @@ import org.roaringbitmap.RoaringBitmap;
 @SuppressWarnings({"rawtypes", "unchecked"})
 public class GroupByDataTableReducer implements DataTableReducer {
   private static final int MIN_DATA_TABLES_FOR_CONCURRENT_REDUCE = 2; // TBD, find a better value.
-  private static final int MAX_ROWS_UPSERT_PER_INTERRUPTION_CHECK = 10_000;
 
   private final QueryContext _queryContext;
   private final AggregationFunction[] _aggregationFunctions;
@@ -81,7 +80,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
   private final int _numGroupByExpressions;
   private final int _numColumns;
 
-  GroupByDataTableReducer(QueryContext queryContext) {
+  public GroupByDataTableReducer(QueryContext queryContext) {
     _queryContext = queryContext;
     _aggregationFunctions = queryContext.getAggregationFunctions();
     assert _aggregationFunctions != null;
@@ -99,7 +98,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
   public void reduceAndSetResults(String tableName, DataSchema dataSchema,
       Map<ServerRoutingInstance, DataTable> dataTableMap, BrokerResponseNative brokerResponse,
       DataTableReducerContext reducerContext, BrokerMetrics brokerMetrics) {
-    assert dataSchema != null;
+    dataSchema = ReducerDataSchemaUtils.canonicalizeDataSchemaForGroupBy(_queryContext, dataSchema);
 
     if (dataTableMap.isEmpty()) {
       PostAggregationHandler postAggregationHandler =

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ReducerDataSchemaUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ReducerDataSchemaUtils.java
@@ -1,0 +1,108 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.reduce;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.FilterContext;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunction;
+import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
+import org.apache.pinot.core.query.request.context.QueryContext;
+
+
+@SuppressWarnings("rawtypes")
+public class ReducerDataSchemaUtils {
+  private ReducerDataSchemaUtils() {
+  }
+
+  /**
+   * Returns the canonical data schema of the aggregation result based on the query and the data schema returned from
+   * the server.
+   * <p>Column names are re-generated in the canonical data schema to avoid the backward incompatibility caused by
+   * changing the string representation of the expression.
+   */
+  public static DataSchema canonicalizeDataSchemaForAggregation(QueryContext queryContext, DataSchema dataSchema) {
+    List<Pair<AggregationFunction, FilterContext>> filteredAggregationFunctions =
+        queryContext.getFilteredAggregationFunctions();
+    assert filteredAggregationFunctions != null;
+    int numAggregations = filteredAggregationFunctions.size();
+    Preconditions.checkState(dataSchema.size() == numAggregations,
+        "BUG: Expect same number of aggregations and columns in data schema, got %s aggregations, %s columns in data "
+            + "schema", numAggregations, dataSchema.size());
+    String[] columnNames = new String[numAggregations];
+    for (int i = 0; i < numAggregations; i++) {
+      Pair<AggregationFunction, FilterContext> pair = filteredAggregationFunctions.get(i);
+      AggregationFunction aggregationFunction = pair.getLeft();
+      columnNames[i] = AggregationFunctionUtils.getResultColumnName(aggregationFunction, pair.getRight());
+    }
+    return new DataSchema(columnNames, dataSchema.getColumnDataTypes());
+  }
+
+  /**
+   * Returns the canonical data schema of the group-by result based on the query and the data schema returned from the
+   * server. Group-by expressions are always at the beginning of the data schema, followed by the aggregations.
+   * <p>Column names are re-generated in the canonical data schema to avoid the backward incompatibility caused by
+   * changing the string representation of the expression.
+   */
+  public static DataSchema canonicalizeDataSchemaForGroupBy(QueryContext queryContext, DataSchema dataSchema) {
+    List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
+    List<Pair<AggregationFunction, FilterContext>> filteredAggregationFunctions =
+        queryContext.getFilteredAggregationFunctions();
+    assert groupByExpressions != null && filteredAggregationFunctions != null;
+    int numGroupByExpression = groupByExpressions.size();
+    int numAggregations = filteredAggregationFunctions.size();
+    int numColumns = numGroupByExpression + numAggregations;
+    String[] columnNames = new String[numColumns];
+    Preconditions.checkState(dataSchema.size() == numColumns,
+        "BUG: Expect same number of group-by expressions, aggregations and columns in data schema, got %s group-by "
+            + "expressions, %s aggregations, %s columns in data schema", numGroupByExpression, numAggregations,
+        dataSchema.size());
+    for (int i = 0; i < numGroupByExpression; i++) {
+      columnNames[i] = groupByExpressions.get(i).toString();
+    }
+    for (int i = 0; i < numAggregations; i++) {
+      Pair<AggregationFunction, FilterContext> pair = filteredAggregationFunctions.get(i);
+      columnNames[numGroupByExpression + i] =
+          AggregationFunctionUtils.getResultColumnName(pair.getLeft(), pair.getRight());
+    }
+    return new DataSchema(columnNames, dataSchema.getColumnDataTypes());
+  }
+
+  /**
+   * Returns the canonical data schema of the distinct result based on the query and the data schema returned from the
+   * server.
+   * <p>Column names are re-generated in the canonical data schema to avoid the backward incompatibility caused by
+   * changing the string representation of the expression.
+   */
+  public static DataSchema canonicalizeDataSchemaForDistinct(QueryContext queryContext, DataSchema dataSchema) {
+    List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
+    int numSelectExpressions = selectExpressions.size();
+    Preconditions.checkState(dataSchema.size() == numSelectExpressions,
+        "BUG: Expect same number of columns in SELECT clause and data schema, got %s in SELECT clause, %s in data "
+            + "schema", numSelectExpressions, dataSchema.size());
+    String[] columnNames = new String[numSelectExpressions];
+    for (int i = 0; i < numSelectExpressions; i++) {
+      columnNames[i] = selectExpressions.get(i).toString();
+    }
+    return new DataSchema(columnNames, dataSchema.getColumnDataTypes());
+  }
+}

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionDataTableReducer.java
@@ -18,38 +18,28 @@
  */
 package org.apache.pinot.core.query.reduce;
 
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.datatable.DataTable;
-import org.apache.pinot.common.exception.QueryException;
-import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
-import org.apache.pinot.common.response.broker.QueryProcessingException;
 import org.apache.pinot.common.response.broker.ResultTable;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorService;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
-import org.apache.pinot.spi.utils.builder.TableNameBuilder;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
  * Helper class to reduce and set Selection results into the BrokerResponseNative
  */
 public class SelectionDataTableReducer implements DataTableReducer {
-  private static final Logger LOGGER = LoggerFactory.getLogger(SelectionDataTableReducer.class);
-
   private final QueryContext _queryContext;
 
-  SelectionDataTableReducer(QueryContext queryContext) {
+  public SelectionDataTableReducer(QueryContext queryContext) {
     _queryContext = queryContext;
   }
 
@@ -60,55 +50,25 @@ public class SelectionDataTableReducer implements DataTableReducer {
   public void reduceAndSetResults(String tableName, DataSchema dataSchema,
       Map<ServerRoutingInstance, DataTable> dataTableMap, BrokerResponseNative brokerResponseNative,
       DataTableReducerContext reducerContext, BrokerMetrics brokerMetrics) {
-    if (dataTableMap.isEmpty()) {
-      // For empty data table map, construct empty result using the cached data schema for selection query
-      List<String> selectionColumns = SelectionOperatorUtils.getSelectionColumns(_queryContext, dataSchema);
-      DataSchema selectionDataSchema = SelectionOperatorUtils.getResultTableDataSchema(dataSchema, selectionColumns);
-      brokerResponseNative.setResultTable(new ResultTable(selectionDataSchema, Collections.emptyList()));
+    Pair<DataSchema, int[]> pair =
+        SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(_queryContext, dataSchema);
+    int limit = _queryContext.getLimit();
+    if (dataTableMap.isEmpty() || limit == 0) {
+      brokerResponseNative.setResultTable(new ResultTable(pair.getLeft(), Collections.emptyList()));
       return;
     }
-
-    // For data table map with more than one data tables, remove conflicting data tables
-    if (dataTableMap.size() > 1) {
-      DataSchema.ColumnDataType[] columnDataTypes = dataSchema.getColumnDataTypes();
-      List<ServerRoutingInstance> droppedServers = new ArrayList<>();
-      Iterator<Map.Entry<ServerRoutingInstance, DataTable>> iterator = dataTableMap.entrySet().iterator();
-      while (iterator.hasNext()) {
-        Map.Entry<ServerRoutingInstance, DataTable> entry = iterator.next();
-        DataSchema dataSchemaToCompare = entry.getValue().getDataSchema();
-        assert dataSchemaToCompare != null;
-        if (!Arrays.equals(columnDataTypes, dataSchemaToCompare.getColumnDataTypes())) {
-          droppedServers.add(entry.getKey());
-          iterator.remove();
-        }
-      }
-      if (!droppedServers.isEmpty()) {
-        String errorMessage =
-            QueryException.MERGE_RESPONSE_ERROR.getMessage() + ": responses for table: " + tableName + " from servers: "
-                + droppedServers + " got dropped due to data schema inconsistency.";
-        LOGGER.warn(errorMessage);
-        if (brokerMetrics != null) {
-          brokerMetrics.addMeteredTableValue(TableNameBuilder.extractRawTableName(tableName),
-              BrokerMeter.RESPONSE_MERGE_EXCEPTIONS, 1L);
-        }
-        brokerResponseNative.addToExceptions(
-            new QueryProcessingException(QueryException.MERGE_RESPONSE_ERROR_CODE, errorMessage));
-      }
-    }
-
-    int limit = _queryContext.getLimit();
-    if (limit > 0 && _queryContext.getOrderByExpressions() != null) {
-      // Selection order-by
-      SelectionOperatorService selectionService = new SelectionOperatorService(_queryContext, dataSchema);
-      selectionService.reduceWithOrdering(dataTableMap.values(), _queryContext.isNullHandlingEnabled());
-      brokerResponseNative.setResultTable(selectionService.renderResultTableWithOrdering());
-    } else {
+    if (_queryContext.getOrderByExpressions() == null) {
       // Selection only
-      List<String> selectionColumns = SelectionOperatorUtils.getSelectionColumns(_queryContext, dataSchema);
       List<Object[]> reducedRows = SelectionOperatorUtils.reduceWithoutOrdering(dataTableMap.values(), limit,
           _queryContext.isNullHandlingEnabled());
       brokerResponseNative.setResultTable(
-          SelectionOperatorUtils.renderResultTableWithoutOrdering(reducedRows, dataSchema, selectionColumns));
+          SelectionOperatorUtils.renderResultTableWithoutOrdering(reducedRows, pair.getLeft(), pair.getRight()));
+    } else {
+      // Selection order-by
+      SelectionOperatorService selectionService =
+          new SelectionOperatorService(_queryContext, pair.getLeft(), pair.getRight());
+      selectionService.reduceWithOrdering(dataTableMap.values());
+      brokerResponseNative.setResultTable(selectionService.renderResultTableWithOrdering());
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/ReducerDataSchemaUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/reduce/ReducerDataSchemaUtilsTest.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.reduce;
+
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class ReducerDataSchemaUtilsTest {
+
+  @Test
+  public void testCanonicalizeDataSchemaForAggregation() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT SUM(col1 + col2) FROM testTable");
+    // Intentionally make data schema not matching the string representation of the expression
+    DataSchema dataSchema = new DataSchema(new String[]{"sum(col1+col2)"}, new ColumnDataType[]{ColumnDataType.DOUBLE});
+    DataSchema canonicalDataSchema =
+        ReducerDataSchemaUtils.canonicalizeDataSchemaForAggregation(queryContext, dataSchema);
+    assertEquals(canonicalDataSchema,
+        new DataSchema(new String[]{"sum(plus(col1,col2))"}, new ColumnDataType[]{ColumnDataType.DOUBLE}));
+
+    queryContext = QueryContextConverterUtils.getQueryContext("SELECT SUM(col1 + 1), MIN(col2 + 2) FROM testTable");
+    // Intentionally make data schema not matching the string representation of the expression
+    dataSchema = new DataSchema(new String[]{"sum(col1+1)", "min(col2+2)"},
+        new ColumnDataType[]{ColumnDataType.DOUBLE, ColumnDataType.DOUBLE});
+    canonicalDataSchema = ReducerDataSchemaUtils.canonicalizeDataSchemaForAggregation(queryContext, dataSchema);
+    assertEquals(canonicalDataSchema, new DataSchema(new String[]{"sum(plus(col1,'1'))", "min(plus(col2,'2'))"},
+        new ColumnDataType[]{ColumnDataType.DOUBLE, ColumnDataType.DOUBLE}));
+
+    queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT MAX(col1 + 1) FILTER(WHERE col3 > 0) - MIN(col2 + 2) FILTER(WHERE col4 > 0) FROM testTable");
+    // Intentionally make data schema not matching the string representation of the expression
+    dataSchema = new DataSchema(new String[]{"max(col1+1)", "min(col2+2)"},
+        new ColumnDataType[]{ColumnDataType.DOUBLE, ColumnDataType.DOUBLE});
+    canonicalDataSchema = ReducerDataSchemaUtils.canonicalizeDataSchemaForAggregation(queryContext, dataSchema);
+    assertEquals(canonicalDataSchema, new DataSchema(
+        new String[]{"max(plus(col1,'1')) FILTER(WHERE col3 > '0')", "min(plus(col2,'2')) FILTER(WHERE col4 > '0')"},
+        new ColumnDataType[]{ColumnDataType.DOUBLE, ColumnDataType.DOUBLE}));
+  }
+
+  @Test
+  public void testCanonicalizeDataSchemaForGroupBy() {
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT SUM(col1 + col2) FROM testTable GROUP BY col3 + col4 ORDER BY col3 + col4");
+    // Intentionally make data schema not matching the string representation of the expression
+    DataSchema dataSchema = new DataSchema(new String[]{"add(col3+col4)", "sum(col1+col2)"},
+        new ColumnDataType[]{ColumnDataType.DOUBLE, ColumnDataType.DOUBLE});
+    DataSchema canonicalDataSchema = ReducerDataSchemaUtils.canonicalizeDataSchemaForGroupBy(queryContext, dataSchema);
+    assertEquals(canonicalDataSchema, new DataSchema(new String[]{"plus(col3,col4)", "sum(plus(col1,col2))"},
+        new ColumnDataType[]{ColumnDataType.DOUBLE, ColumnDataType.DOUBLE}));
+
+    queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT SUM(col1 + 1), MIN(col2 + 2), col4 FROM testTable GROUP BY col3, col4");
+    // Intentionally make data schema not matching the string representation of the expression
+    dataSchema = new DataSchema(new String[]{"col3", "col4", "sum(col1+1)", "min(col2+2)"},
+        new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE});
+    canonicalDataSchema = ReducerDataSchemaUtils.canonicalizeDataSchemaForGroupBy(queryContext, dataSchema);
+    assertEquals(canonicalDataSchema,
+        new DataSchema(new String[]{"col3", "col4", "sum(plus(col1,'1'))", "min(plus(col2,'2'))"}, new ColumnDataType[]{
+            ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
+        }));
+
+    queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT col3 + col4, MAX(col1 + 1) FILTER(WHERE col3 > 0) - MIN(col2 + 2) FILTER(WHERE col4 > 0) FROM "
+            + "testTable GROUP BY col3 + col4");
+    // Intentionally make data schema not matching the string representation of the expression
+    dataSchema = new DataSchema(new String[]{"add(col3+col4)", "max(col1+1)", "min(col2+2)"},
+        new ColumnDataType[]{ColumnDataType.DOUBLE, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE});
+    canonicalDataSchema = ReducerDataSchemaUtils.canonicalizeDataSchemaForGroupBy(queryContext, dataSchema);
+    assertEquals(canonicalDataSchema, new DataSchema(new String[]{
+        "plus(col3,col4)", "max(plus(col1,'1')) FILTER(WHERE col3 > '0')",
+        "min(plus(col2,'2')) FILTER" + "(WHERE col4 > '0')"
+    }, new ColumnDataType[]{ColumnDataType.DOUBLE, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE}));
+  }
+
+  @Test
+  public void testCanonicalizeDataSchemaForDistinct() {
+    QueryContext queryContext =
+        QueryContextConverterUtils.getQueryContext("SELECT DISTINCT col1, col2 + col3 FROM testTable");
+    // Intentionally make data schema not matching the string representation of the expression
+    DataSchema dataSchema = new DataSchema(new String[]{"col1", "add(col2+col3)"},
+        new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.DOUBLE});
+    DataSchema canonicalDataSchema = ReducerDataSchemaUtils.canonicalizeDataSchemaForDistinct(queryContext, dataSchema);
+    assertEquals(canonicalDataSchema, new DataSchema(new String[]{"col1", "plus(col2,col3)"},
+        new ColumnDataType[]{ColumnDataType.INT, ColumnDataType.DOUBLE}));
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOperatorUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOperatorUtilsTest.java
@@ -1,0 +1,210 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.selection;
+
+import org.apache.commons.lang3.tuple.Pair;
+import org.apache.pinot.common.utils.DataSchema;
+import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class SelectionOperatorUtilsTest {
+
+  @Test
+  public void testGetResultTableColumnIndices() {
+    // Select * without order-by
+    QueryContext queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable");
+    DataSchema dataSchema = new DataSchema(new String[]{"col1", "col2", "col3"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.DOUBLE
+    });
+    Pair<DataSchema, int[]> pair =
+        SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(), new DataSchema(new String[]{"col1", "col2", "col3"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.DOUBLE
+    }));
+    assertEquals(pair.getRight(), new int[]{0, 1, 2});
+
+    // Select * without order-by, all the segments are pruned on the server side
+    dataSchema = new DataSchema(new String[]{"*"}, new ColumnDataType[]{ColumnDataType.STRING});
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(), new DataSchema(new String[]{"*"}, new ColumnDataType[]{ColumnDataType.STRING}));
+
+    // Select * with order-by but LIMIT 0
+    queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable ORDER BY col1 LIMIT 0");
+    dataSchema = new DataSchema(new String[]{"col1", "col2", "col3"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.DOUBLE
+    });
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(), new DataSchema(new String[]{"col1", "col2", "col3"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.DOUBLE
+    }));
+    assertEquals(pair.getRight(), new int[]{0, 1, 2});
+
+    // Select * with order-by but LIMIT 0, all the segments are pruned on the server side
+    dataSchema = new DataSchema(new String[]{"*"}, new ColumnDataType[]{ColumnDataType.STRING});
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(), new DataSchema(new String[]{"*"}, new ColumnDataType[]{ColumnDataType.STRING}));
+
+    // Select columns without order-by
+    queryContext = QueryContextConverterUtils.getQueryContext("SELECT col1 + 1, col2 + 2 FROM testTable");
+    // Intentionally make data schema not matching the string representation of the expression
+    dataSchema = new DataSchema(new String[]{"add(col1+1)", "add(col2+2)"}, new ColumnDataType[]{
+        ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
+    });
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(), new DataSchema(new String[]{"plus(col1,'1')", "plus(col2,'2')"}, new ColumnDataType[]{
+        ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
+    }));
+    assertEquals(pair.getRight(), new int[]{0, 1});
+
+    // Select columns without order-by, all the segments are pruned on the server side
+    // Intentionally make data schema not matching the string representation of the expression
+    dataSchema = new DataSchema(new String[]{"add(col1+1)", "add(col2+2)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING
+    });
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(), new DataSchema(new String[]{"plus(col1,'1')", "plus(col2,'2')"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING
+    }));
+
+    // Select duplicate columns without order-by
+    queryContext = QueryContextConverterUtils.getQueryContext("SELECT col1 + 1, col2 + 2, col1 + 1 FROM testTable");
+    // Intentionally make data schema not matching the string representation of the expression
+    dataSchema = new DataSchema(new String[]{"add(col1+1)", "add(col2+2)"}, new ColumnDataType[]{
+        ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
+    });
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(),
+        new DataSchema(new String[]{"plus(col1,'1')", "plus(col2,'2')", "plus(col1,'1')"}, new ColumnDataType[]{
+            ColumnDataType.DOUBLE, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
+        }));
+    assertEquals(pair.getRight(), new int[]{0, 1, 0});
+
+    // Select duplicate columns without order-by, all the segments are pruned on the server side
+    // Intentionally make data schema not matching the string representation of the expression
+    dataSchema = new DataSchema(new String[]{"add(col1+1)", "add(col2+2)", "add(col1+1)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.STRING
+    });
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(),
+        new DataSchema(new String[]{"plus(col1,'1')", "plus(col2,'2')", "plus(col1,'1')"}, new ColumnDataType[]{
+            ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.STRING
+        }));
+
+    // Select * with order-by
+    queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable ORDER BY col3");
+    dataSchema = new DataSchema(new String[]{"col3", "col1", "col2"}, new ColumnDataType[]{
+        ColumnDataType.DOUBLE, ColumnDataType.INT, ColumnDataType.LONG
+    });
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(), new DataSchema(new String[]{"col1", "col2", "col3"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.DOUBLE
+    }));
+    assertEquals(pair.getRight(), new int[]{1, 2, 0});
+
+    // Select * with order-by, all the segments are pruned on the server side
+    dataSchema = new DataSchema(new String[]{"*"}, new ColumnDataType[]{ColumnDataType.STRING});
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(), new DataSchema(new String[]{"*"}, new ColumnDataType[]{ColumnDataType.STRING}));
+
+    // Select * ordering on function
+    queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable ORDER BY col1 + col2");
+    // Intentionally make data schema not matching the string representation of the expression
+    dataSchema = new DataSchema(new String[]{"add(col1+col2)", "col1", "col2", "col3"}, new ColumnDataType[]{
+        ColumnDataType.DOUBLE, ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.DOUBLE
+    });
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(), new DataSchema(new String[]{"col1", "col2", "col3"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.DOUBLE
+    }));
+    assertEquals(pair.getRight(), new int[]{1, 2, 3});
+
+    // Select * ordering on function, all the segments are pruned on the server side
+    dataSchema = new DataSchema(new String[]{"*"}, new ColumnDataType[]{ColumnDataType.STRING});
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(), new DataSchema(new String[]{"*"}, new ColumnDataType[]{ColumnDataType.STRING}));
+
+    // Select * ordering on both column and function
+    queryContext = QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable ORDER BY col1 + col2, col2");
+    // Intentionally make data schema not matching the string representation of the expression
+    dataSchema = new DataSchema(new String[]{"add(col1+col2)", "col2", "col1", "col3"}, new ColumnDataType[]{
+        ColumnDataType.DOUBLE, ColumnDataType.LONG, ColumnDataType.INT, ColumnDataType.DOUBLE
+    });
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(), new DataSchema(new String[]{"col1", "col2", "col3"}, new ColumnDataType[]{
+        ColumnDataType.INT, ColumnDataType.LONG, ColumnDataType.DOUBLE
+    }));
+    assertEquals(pair.getRight(), new int[]{2, 1, 3});
+
+    // Select * ordering on both column and function, all the segments are pruned on the server side
+    dataSchema = new DataSchema(new String[]{"*"}, new ColumnDataType[]{ColumnDataType.STRING});
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(), new DataSchema(new String[]{"*"}, new ColumnDataType[]{ColumnDataType.STRING}));
+
+    // Select columns with order-by
+    queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT col1 + 1, col3, col2 + 2 FROM testTable ORDER BY col2 + 2, col4");
+    // Intentionally make data schema not matching the string representation of the expression
+    dataSchema = new DataSchema(new String[]{"add(col2+2)", "col4", "add(col1+1)", "col3"}, new ColumnDataType[]{
+        ColumnDataType.DOUBLE, ColumnDataType.STRING, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
+    });
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(), new DataSchema(new String[]{"plus(col1,'1')", "col3", "plus(col2,'2')"},
+        new ColumnDataType[]{ColumnDataType.DOUBLE, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE}));
+    assertEquals(pair.getRight(), new int[]{2, 3, 0});
+
+    // Select columns with order-by, all the segments are pruned on the server side
+    // Intentionally make data schema not matching the string representation of the expression
+    dataSchema = new DataSchema(new String[]{"add(col1+1)", "col3", "add(col2+2)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.STRING
+    });
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(), new DataSchema(new String[]{"plus(col1,'1')", "col3", "plus(col2,'2')"},
+        new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.STRING}));
+
+    // Select duplicate columns with order-by
+    queryContext = QueryContextConverterUtils.getQueryContext(
+        "SELECT col1 + 1, col2 + 2, col1 + 1 FROM testTable ORDER BY col2 + 2, col4");
+    // Intentionally make data schema not matching the string representation of the expression
+    dataSchema = new DataSchema(new String[]{"add(col2+2)", "col4", "add(col1+1)"}, new ColumnDataType[]{
+        ColumnDataType.DOUBLE, ColumnDataType.STRING, ColumnDataType.DOUBLE
+    });
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(),
+        new DataSchema(new String[]{"plus(col1,'1')", "plus(col2,'2')", "plus(col1,'1')"}, new ColumnDataType[]{
+            ColumnDataType.DOUBLE, ColumnDataType.DOUBLE, ColumnDataType.DOUBLE
+        }));
+    assertEquals(pair.getRight(), new int[]{2, 0, 2});
+
+    // Select duplicate columns with order-by, all the segments are pruned on the server side
+    // Intentionally make data schema not matching the string representation of the expression
+    dataSchema = new DataSchema(new String[]{"add(col1+1)", "add(col2+2)", "add(col1+1)"}, new ColumnDataType[]{
+        ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.STRING
+    });
+    pair = SelectionOperatorUtils.getResultTableDataSchemaAndColumnIndices(queryContext, dataSchema);
+    assertEquals(pair.getLeft(),
+        new DataSchema(new String[]{"plus(col1,'1')", "plus(col2,'2')", "plus(col1,'1')"}, new ColumnDataType[]{
+            ColumnDataType.STRING, ColumnDataType.STRING, ColumnDataType.STRING
+        }));
+  }
+}

--- a/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/DistinctQueriesTest.java
@@ -1433,9 +1433,10 @@ public class DistinctQueriesTest extends BaseQueriesTest {
     {
       ResultTable resultTable = getBrokerResponse(queries[7]).getResultTable();
 
-      // Check data schema, where data type should be STRING for all columns
+      // Check data schema
+      // NOTE: Segment pruner is not wired up in QueriesTest, and the correct column data types should be returned.
       DataSchema expectedDataSchema = new DataSchema(new String[]{"floatColumn", "longMVColumn"},
-          new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.STRING});
+          new ColumnDataType[]{ColumnDataType.FLOAT, ColumnDataType.LONG});
       assertEquals(resultTable.getDataSchema(), expectedDataSchema);
 
       // Check values, where no record should be returned
@@ -1589,9 +1590,10 @@ public class DistinctQueriesTest extends BaseQueriesTest {
     {
       ResultTable resultTable = getBrokerResponse(queries[13]).getResultTable();
 
-      // Check data schema, where data type should be STRING for all columns
+      // Check data schema
+      // NOTE: Segment pruner is not wired up in QueriesTest, and the correct column data types should be returned.
       DataSchema expectedDataSchema = new DataSchema(new String[]{"floatColumn", "rawLongMVColumn"},
-          new ColumnDataType[]{ColumnDataType.STRING, ColumnDataType.STRING});
+          new ColumnDataType[]{ColumnDataType.FLOAT, ColumnDataType.LONG});
       assertEquals(resultTable.getDataSchema(), expectedDataSchema);
 
       // Check values, where no record should be returned

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -20,6 +20,7 @@ package org.apache.pinot.query.runtime.operator;
 
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -35,6 +36,7 @@ import java.util.concurrent.TimeoutException;
 import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.datablock.MetadataBlock;
 import org.apache.pinot.common.datatable.DataTable;
+import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.common.utils.config.QueryOptionsUtils;
@@ -45,7 +47,7 @@ import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.executor.ResultsBlockStreamer;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
-import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
+import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.utils.TypeUtils;
@@ -281,18 +283,33 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
   /**
    * For selection, we need to check if the columns are in order. If not, we need to re-arrange the columns.
    */
-  @SuppressWarnings("ConstantConditions")
   private static TransferableBlock composeSelectTransferableBlock(SelectionResultsBlock resultsBlock,
       DataSchema desiredDataSchema) {
-    DataSchema resultSchema = resultsBlock.getDataSchema();
-    List<String> selectionColumns =
-        SelectionOperatorUtils.getSelectionColumns(resultsBlock.getQueryContext(), resultSchema);
-    int[] columnIndices = SelectionOperatorUtils.getColumnIndices(selectionColumns, resultSchema);
+    int[] columnIndices = getColumnIndices(resultsBlock);
     if (!inOrder(columnIndices)) {
       return composeColumnIndexedTransferableBlock(resultsBlock, desiredDataSchema, columnIndices);
     } else {
       return composeDirectTransferableBlock(resultsBlock, desiredDataSchema);
     }
+  }
+
+  private static int[] getColumnIndices(SelectionResultsBlock resultsBlock) {
+    DataSchema dataSchema = resultsBlock.getDataSchema();
+    assert dataSchema != null;
+    String[] columnNames = dataSchema.getColumnNames();
+    Object2IntOpenHashMap<String> columnIndexMap = new Object2IntOpenHashMap<>(columnNames.length);
+    for (int i = 0; i < columnNames.length; i++) {
+      columnIndexMap.put(columnNames[i], i);
+    }
+    QueryContext queryContext = resultsBlock.getQueryContext();
+    assert queryContext != null;
+    List<ExpressionContext> selectExpressions = queryContext.getSelectExpressions();
+    int numSelectExpressions = selectExpressions.size();
+    int[] columnIndices = new int[numSelectExpressions];
+    for (int i = 0; i < numSelectExpressions; i++) {
+      columnIndices[i] = columnIndexMap.getInt(selectExpressions.get(i).toString());
+    }
+    return columnIndices;
   }
 
   private static boolean inOrder(int[] columnIndices) {


### PR DESCRIPTION
Enhance broker reducer to not rely on the column names returned from the servers. This is required to support future expression format change (e.g. do not include single quotes around numeric literals).
- Drop incompatible data tables for all query types to prevent type incompatible exceptions
- Remove special handling of distinct data table format introduced before releasing `0.12`