### PR TITLE
[SQL Compatible] Fix literal type handling

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
@@ -18,163 +18,127 @@
  */
 package org.apache.pinot.common.request.context;
 
-import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import java.math.BigDecimal;
-import java.math.BigInteger;
 import java.sql.Timestamp;
 import java.util.Objects;
 import javax.annotation.Nullable;
-import org.apache.commons.lang3.math.NumberUtils;
-import org.apache.commons.lang3.tuple.ImmutablePair;
-import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.utils.PinotDataType;
-import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
+import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
 
 
 /**
  * The {@code LiteralContext} class represents a literal in the query.
  * <p>This includes both value and type information. We translate thrift literal to this representation in server.
- * Currently, only Boolean literal is correctly encoded in thrift and passed in.
- * All integers are encoded as LONG in thrift, and the other numerical types are encoded as DOUBLE.
- * The remaining types are encoded as STRING.
  */
 public class LiteralContext {
   // TODO: Support all of the types for sql.
-  private final FieldSpec.DataType _type;
+  private final DataType _type;
   private final Object _value;
-  private final BigDecimal _bigDecimalValue;
 
-  private static BigDecimal getBigDecimalValue(FieldSpec.DataType type, Object value) {
-    switch (type) {
-      case BIG_DECIMAL:
-        return (BigDecimal) value;
-      case BOOLEAN:
-        return PinotDataType.BOOLEAN.toBigDecimal(value);
-      case TIMESTAMP:
-        return PinotDataType.TIMESTAMP.toBigDecimal(Timestamp.valueOf(value.toString()));
-      default:
-        if (type.isNumeric()) {
-          return new BigDecimal(value.toString());
-        }
-        return BigDecimal.ZERO;
-    }
-  }
+  /**
+   * A transient field used for the type conversion, and is not included in {@link #equals} and {@link #hashCode}.
+   */
+  private final transient PinotDataType _pinotDataType;
 
-  @VisibleForTesting
-  static Pair<FieldSpec.DataType, Object> inferLiteralDataTypeAndValue(String literal) {
-    // Try to interpret the literal as number
-    try {
-      Number number = NumberUtils.createNumber(literal);
-      if (number instanceof BigDecimal || number instanceof BigInteger) {
-        return ImmutablePair.of(FieldSpec.DataType.BIG_DECIMAL, new BigDecimal(literal));
-      } else {
-        return ImmutablePair.of(FieldSpec.DataType.STRING, literal);
-      }
-    } catch (Exception e) {
-      // Ignored
-    }
+  private Boolean _booleanValue;
+  private Integer _intValue;
+  private Long _longValue;
+  private Float _floatValue;
+  private Double _doubleValue;
+  private BigDecimal _bigDecimalValue;
+  private String _stringValue;
+  private byte[] _bytesValue;
 
-    // Try to interpret the literal as TIMESTAMP
-    try {
-      Timestamp timestamp = Timestamp.valueOf(literal);
-      return ImmutablePair.of(FieldSpec.DataType.TIMESTAMP, timestamp);
-    } catch (Exception e) {
-      // Ignored
-    }
-    return ImmutablePair.of(FieldSpec.DataType.STRING, literal);
+  public LiteralContext(DataType type, Object value) {
+    _type = type;
+    _value = value;
+    _pinotDataType = getPinotDataType(type);
   }
 
   public LiteralContext(Literal literal) {
-    Preconditions.checkState(literal.getFieldValue() != null,
-        "Field value cannot be null for field:" + literal.getSetField());
     switch (literal.getSetField()) {
       case BOOL_VALUE:
-        _type = FieldSpec.DataType.BOOLEAN;
-        _value = literal.getFieldValue();
-        _bigDecimalValue = PinotDataType.BOOLEAN.toBigDecimal(_value);
+        _type = DataType.BOOLEAN;
+        _value = literal.getBoolValue();
         break;
       case INT_VALUE:
-        _type = FieldSpec.DataType.INT;
+        _type = DataType.INT;
         _value = literal.getIntValue();
-        _bigDecimalValue = new BigDecimal((int) _value);
         break;
       case LONG_VALUE:
+        // TODO: Remove this special handling after broker uses INT type for integer literals.
+        //       https://github.com/apache/pinot/pull/11751
+//        _type = DataType.LONG;
+//        _value = literal.getLongValue();
         long longValue = literal.getLongValue();
-        if (longValue == (int) longValue) {
-          _type = FieldSpec.DataType.INT;
+        if (longValue >= Integer.MIN_VALUE && longValue <= Integer.MAX_VALUE) {
+          _type = DataType.INT;
           _value = (int) longValue;
         } else {
-          _type = FieldSpec.DataType.LONG;
+          _type = DataType.LONG;
           _value = longValue;
         }
-        _bigDecimalValue = new BigDecimal(longValue);
+        break;
+      case FLOAT_VALUE:
+        _type = DataType.FLOAT;
+        _value = Float.intBitsToFloat(literal.getFloatValue());
         break;
       case DOUBLE_VALUE:
-        String stringValue = literal.getFieldValue().toString();
-        Number floatingNumber = NumberUtils.createNumber(stringValue);
-        if (floatingNumber instanceof Float) {
-          _type = FieldSpec.DataType.FLOAT;
-          _value = floatingNumber;
-        } else {
-          _type = FieldSpec.DataType.DOUBLE;
-          _value = literal.getDoubleValue();
-        }
-        _bigDecimalValue = new BigDecimal(stringValue);
-        break;
-      case STRING_VALUE:
-        Pair<FieldSpec.DataType, Object> typeAndValue =
-            inferLiteralDataTypeAndValue(literal.getFieldValue().toString());
-        _type = typeAndValue.getLeft();
-        if (_type == FieldSpec.DataType.BIG_DECIMAL) {
-          _bigDecimalValue = (BigDecimal) typeAndValue.getRight();
-        } else if (_type == FieldSpec.DataType.TIMESTAMP) {
-          _bigDecimalValue = PinotDataType.TIMESTAMP.toBigDecimal(typeAndValue.getRight());
-        } else {
-          _bigDecimalValue = BigDecimal.ZERO;
-        }
-        _value = literal.getFieldValue().toString();
+        _type = DataType.DOUBLE;
+        _value = literal.getDoubleValue();
         break;
       case BIG_DECIMAL_VALUE:
-        _type = FieldSpec.DataType.BIG_DECIMAL;
-        _bigDecimalValue = BigDecimalUtils.deserialize(literal.getBigDecimalValue());
-        _value = _bigDecimalValue;
+        _type = DataType.BIG_DECIMAL;
+        _value = BigDecimalUtils.deserialize(literal.getBigDecimalValue());
+        break;
+      case STRING_VALUE:
+        _type = DataType.STRING;
+        _value = literal.getStringValue();
         break;
       case BINARY_VALUE:
-        _type = FieldSpec.DataType.BYTES;
+        _type = DataType.BYTES;
         _value = literal.getBinaryValue();
-        _bigDecimalValue = BigDecimal.ZERO;
         break;
       case NULL_VALUE:
-        _type = FieldSpec.DataType.UNKNOWN;
+        _type = DataType.UNKNOWN;
         _value = null;
-        _bigDecimalValue = BigDecimal.ZERO;
         break;
       default:
-        throw new UnsupportedOperationException("Unsupported data type:" + literal.getSetField());
+        throw new IllegalStateException("Unsupported field type: " + literal.getSetField());
+    }
+    _pinotDataType = getPinotDataType(_type);
+  }
+
+  private static PinotDataType getPinotDataType(DataType type) {
+    switch (type) {
+      case BOOLEAN:
+        return PinotDataType.BOOLEAN;
+      case INT:
+        return PinotDataType.INTEGER;
+      case LONG:
+        return PinotDataType.LONG;
+      case FLOAT:
+        return PinotDataType.FLOAT;
+      case DOUBLE:
+        return PinotDataType.DOUBLE;
+      case BIG_DECIMAL:
+        return PinotDataType.BIG_DECIMAL;
+      case STRING:
+        return PinotDataType.STRING;
+      case BYTES:
+        return PinotDataType.BYTES;
+      case UNKNOWN:
+        return null;
+      default:
+        throw new IllegalStateException("Unsupported data type: " + type);
     }
   }
 
-  public FieldSpec.DataType getType() {
+  public DataType getType() {
     return _type;
-  }
-
-  public int getIntValue() {
-    return _bigDecimalValue.intValue();
-  }
-
-  public double getDoubleValue() {
-    return _bigDecimalValue.doubleValue();
-  }
-
-  public BigDecimal getBigDecimalValue() {
-    return _bigDecimalValue;
-  }
-
-  public String getStringValue() {
-    return String.valueOf(_value);
   }
 
   @Nullable
@@ -182,15 +146,103 @@ public class LiteralContext {
     return _value;
   }
 
-  // This ctor is only used for special handling in subquery.
-  public LiteralContext(FieldSpec.DataType type, Object value) {
-    _type = type;
-    if (type == FieldSpec.DataType.UNKNOWN) {
-      _value = null;
-    } else {
-      _value = value;
+  public boolean getBooleanValue() {
+    Boolean booleanValue = _booleanValue;
+    if (booleanValue == null) {
+      booleanValue = _pinotDataType != null && _pinotDataType.toBoolean(_value);
+      _booleanValue = booleanValue;
     }
-    _bigDecimalValue = getBigDecimalValue(type, value);
+    return booleanValue;
+  }
+
+  public int getIntValue() {
+    Integer intValue = _intValue;
+    if (intValue == null) {
+      try {
+        intValue = _pinotDataType != null ? _pinotDataType.toInt(_value) : NullValuePlaceHolder.INT;
+      } catch (NumberFormatException e) {
+        // Pinot uses int to represent BOOLEAN value, so we need to handle the case when the value is the string
+        // representation of a BOOLEAN value.
+        String stringValue = (String) _value;
+        if (stringValue.equalsIgnoreCase("true")) {
+          intValue = 1;
+        } else if (stringValue.equalsIgnoreCase("false")) {
+          intValue = 0;
+        } else {
+          throw new IllegalArgumentException("Invalid int value: " + _value);
+        }
+      }
+      _intValue = intValue;
+    }
+    return intValue;
+  }
+
+  public long getLongValue() {
+    Long longValue = _longValue;
+    if (longValue == null) {
+      try {
+        longValue = _pinotDataType != null ? _pinotDataType.toLong(_value) : NullValuePlaceHolder.LONG;
+      } catch (NumberFormatException e) {
+        // Pinot uses long to represent TIMESTAMP value, so we need to handle the case when the value is the string
+        // representation of a TIMESTAMP value.
+        try {
+          longValue = Timestamp.valueOf((String) _value).getTime();
+        } catch (IllegalArgumentException e1) {
+          throw new IllegalArgumentException("Invalid long value: " + _value);
+        }
+      }
+      _longValue = longValue;
+    }
+    return longValue;
+  }
+
+  public float getFloatValue() {
+    Float floatValue = _floatValue;
+    if (floatValue == null) {
+      floatValue = _pinotDataType != null ? _pinotDataType.toFloat(_value) : NullValuePlaceHolder.FLOAT;
+      _floatValue = floatValue;
+    }
+    return floatValue;
+  }
+
+  public double getDoubleValue() {
+    Double doubleValue = _doubleValue;
+    if (doubleValue == null) {
+      doubleValue = _pinotDataType != null ? _pinotDataType.toDouble(_value) : NullValuePlaceHolder.DOUBLE;
+      _doubleValue = doubleValue;
+    }
+    return doubleValue;
+  }
+
+  public BigDecimal getBigDecimalValue() {
+    BigDecimal bigDecimalValue = _bigDecimalValue;
+    if (bigDecimalValue == null) {
+      bigDecimalValue = _pinotDataType != null ? _pinotDataType.toBigDecimal(_value) : NullValuePlaceHolder.BIG_DECIMAL;
+      _bigDecimalValue = bigDecimalValue;
+    }
+    return bigDecimalValue;
+  }
+
+  public String getStringValue() {
+    String stringValue = _stringValue;
+    if (stringValue == null) {
+      stringValue = _pinotDataType != null ? _pinotDataType.toString(_value) : NullValuePlaceHolder.STRING;
+      _stringValue = stringValue;
+    }
+    return stringValue;
+  }
+
+  public byte[] getBytesValue() {
+    byte[] bytesValue = _bytesValue;
+    if (bytesValue == null) {
+      bytesValue = _pinotDataType != null ? _pinotDataType.toBytes(_value) : NullValuePlaceHolder.BYTES;
+      _bytesValue = bytesValue;
+    }
+    return bytesValue;
+  }
+
+  public boolean isNull() {
+    return _value == null;
   }
 
   @Override
@@ -212,7 +264,12 @@ public class LiteralContext {
 
   @Override
   public String toString() {
-    // TODO: print out the type.
-    return '\'' + String.valueOf(_value) + '\'';
+    // TODO: Remove single quotes except for string and bytes after broker reducer supports expression format change.
+    //       https://github.com/apache/pinot/pull/11762)
+    if (isNull()) {
+      return "'null'";
+    } else {
+      return "'" + getStringValue() + "'";
+    }
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
@@ -39,9 +39,9 @@ public class LiteralContext {
   private final Object _value;
 
   /**
-   * A transient field used for the type conversion, and is not included in {@link #equals} and {@link #hashCode}.
+   * This is used for type conversion, and is not included in {@link #equals} and {@link #hashCode}.
    */
-  private final transient PinotDataType _pinotDataType;
+  private final PinotDataType _pinotDataType;
 
   private Boolean _booleanValue;
   private Integer _intValue;

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/RequestContextUtils.java
@@ -350,6 +350,9 @@ public class RequestContextUtils {
     }
   }
 
+  // TODO: Pass the literal context into the Predicate so that we can read the value based on the data type. Currently
+  //       literal context doesn't support float, and we cannot differentiate explicit string literal and literal
+  //       without explicit type, so we always convert the literal into string.
   private static String getStringValue(ExpressionContext expressionContext) {
     if(expressionContext.getType() != ExpressionContext.Type.LITERAL){
       throw new BadQueryRequestException(

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/PinotDataType.java
@@ -394,7 +394,9 @@ public enum PinotDataType {
 
     @Override
     public BigDecimal toBigDecimal(Object value) {
-      return BigDecimal.valueOf((Float) value);
+      // Use string representation of the value to create BigDecimal to avoid getting the exact floating-point value.
+      // new BigDecimal(123.45f) -> 123.4499969482421875
+      return new BigDecimal(value.toString());
     }
 
     @Override
@@ -446,11 +448,9 @@ public enum PinotDataType {
 
     @Override
     public BigDecimal toBigDecimal(Object value) {
-      // Note:
-      // - BigDecimal.valueOf(double): uses the canonical String representation of the double value passed
-      //     in to instantiate the BigDecimal object.
-      // - new BigDecimal(double): attempts to represent the double value as accurately as possible.
-      return BigDecimal.valueOf((Double) value);
+      // Use string representation of the value to create BigDecimal to avoid getting the exact floating-point value.
+      // new BigDecimal(123.45) -> 123.4500000000000028421709430404007434844970703125
+      return new BigDecimal(value.toString());
     }
 
     @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -493,9 +493,13 @@ public class HttpClient implements AutoCloseable {
     String reason;
     try {
       String entityStr = EntityUtils.toString(response.getEntity());
-      reason = JsonUtils.stringToObject(entityStr, SimpleHttpErrorInfo.class).getError();
+      try {
+        reason = JsonUtils.stringToObject(entityStr, SimpleHttpErrorInfo.class).getError();
+      } catch (Exception e) {
+        reason = entityStr;
+      }
     } catch (Exception e) {
-      reason = String.format("Failed to get a reason, exception: %s", e.toString());
+      reason = String.format("Failed to get a reason, exception: %s", e);
     }
     String errorMessage = String.format("Got error status code: %d (%s) with reason: \"%s\" while sending request: %s",
         statusLine.getStatusCode(), statusLine.getReasonPhrase(), reason, request.getURI());

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/request/RequestUtils.java
@@ -116,15 +116,22 @@ public class RequestUtils {
     Expression expression = new Expression(ExpressionType.LITERAL);
     Literal literal = new Literal();
     if (node instanceof SqlNumericLiteral) {
-      // TODO: support different integer and floating point type.
-      // Mitigate calcite NPE bug, we need to check if SqlNumericLiteral.getScale() is null before calling
-      // SqlNumericLiteral.isInteger(). TODO: Undo this fix once a Calcite release that contains CALCITE-4199 is
-      // available and Pinot has been upgraded to use such a release.
+      BigDecimal bigDecimalValue = node.bigDecimalValue();
+      assert bigDecimalValue != null;
       SqlNumericLiteral sqlNumericLiteral = (SqlNumericLiteral) node;
-      if (sqlNumericLiteral.getScale() != null && sqlNumericLiteral.isInteger()) {
-        literal.setLongValue(node.bigDecimalValue().longValue());
+      if (sqlNumericLiteral.isExact() && sqlNumericLiteral.isInteger()) {
+        long longValue = bigDecimalValue.longValue();
+        /* TODO: Uncomment this after releasing 1.1 because server side int support is added after releasing 1.0
+        if (longValue <= Integer.MAX_VALUE && longValue >= Integer.MIN_VALUE) {
+          literal.setIntValue((int) longValue);
+        } else {
+          literal.setLongValue(longValue);
+        }
+         */
+        literal.setLongValue(longValue);
       } else {
-        literal.setDoubleValue(node.bigDecimalValue().doubleValue());
+        // TODO: Support exact decimal value
+        literal.setDoubleValue(bigDecimalValue.doubleValue());
       }
     } else {
       switch (node.getTypeName()) {
@@ -156,11 +163,27 @@ public class RequestUtils {
     return expression;
   }
 
+  /* TODO: Uncomment this after releasing 1.1 because server side int support is added after releasing 1.0
+  public static Expression getLiteralExpression(int value) {
+    Expression expression = createNewLiteralExpression();
+    expression.getLiteral().setIntValue(value);
+    return expression;
+  }
+   */
+
   public static Expression getLiteralExpression(long value) {
     Expression expression = createNewLiteralExpression();
     expression.getLiteral().setLongValue(value);
     return expression;
   }
+
+  /* TODO: Uncomment this after releasing 1.1 because float is added after releasing 1.0
+  public static Expression getLiteralExpression(float value) {
+    Expression expression = createNewLiteralExpression();
+    expression.getLiteral().setFloatValue(Float.floatToRawIntBits(value));
+    return expression;
+  }
+   */
 
   public static Expression getLiteralExpression(double value) {
     Expression expression = createNewLiteralExpression();
@@ -198,6 +221,14 @@ public class RequestUtils {
     if (object == null) {
       return getNullLiteralExpression();
     }
+    /* TODO: Uncomment this after releasing 1.1 because server side int support is added after releasing 1.0
+    if (object instanceof Integer) {
+      return RequestUtils.getLiteralExpression((int) object);
+    }
+    if (object instanceof Long) {
+      return RequestUtils.getLiteralExpression((long) object);
+    }
+     */
     if (object instanceof Integer || object instanceof Long) {
       return RequestUtils.getLiteralExpression(((Number) object).longValue());
     }
@@ -206,16 +237,17 @@ public class RequestUtils {
       // or ((Float) object).doubleValue() because the latter two will return slightly different values
       // For example, if object is 0.06f, Double.parseDouble(object.toString()) will return 0.06, while
       // ((Number) object).doubleValue() or ((Float) object).doubleValue() will return 0.05999999865889549
+      // TODO: Switch to RequestUtils.getLiteralExpression(float value) after releasing 1.1
       return RequestUtils.getLiteralExpression(Double.parseDouble(object.toString()));
     }
     if (object instanceof Double) {
-      return RequestUtils.getLiteralExpression(((Double) object).doubleValue());
+      return RequestUtils.getLiteralExpression((double) object);
     }
     if (object instanceof byte[]) {
       return RequestUtils.getLiteralExpression((byte[]) object);
     }
     if (object instanceof Boolean) {
-      return RequestUtils.getLiteralExpression(((Boolean) object).booleanValue());
+      return RequestUtils.getLiteralExpression((boolean) object);
     }
     return RequestUtils.getLiteralExpression(object.toString());
   }
@@ -264,6 +296,11 @@ public class RequestUtils {
       return expression.getIdentifier().getName();
     }
     if (expression.getLiteral() != null) {
+      /* TODO: Uncomment this after releasing 1.1 because server side int support is added after releasing 1.0
+      if (expression.getLiteral().isSetIntValue()) {
+        return Integer.toString(expression.getLiteral().getIntValue());
+      )
+       */
       if (expression.getLiteral().isSetLongValue()) {
         return Long.toString(expression.getLiteral().getLongValue());
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StPointFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/geospatial/transform/function/StPointFunction.java
@@ -65,7 +65,7 @@ public class StPointFunction extends BaseTransformFunction {
     if (arguments.size() == 3) {
       transformFunction = arguments.get(2);
       Preconditions.checkArgument(transformFunction instanceof LiteralTransformFunction,
-          "Third argument must be a literal of integer: %s", getName());
+          "Third argument must be a literal of boolean: %s", getName());
       _isGeography = ((LiteralTransformFunction) transformFunction).getBooleanLiteral();
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
@@ -36,7 +36,6 @@ import org.apache.pinot.segment.local.utils.H3Utils;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
 import org.apache.pinot.spi.utils.BooleanUtils;
-import org.apache.pinot.spi.utils.BytesUtils;
 import org.locationtech.jts.geom.Geometry;
 import org.roaringbitmap.buffer.BufferFastAggregation;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
@@ -70,10 +69,10 @@ public class H3InclusionIndexFilterOperator extends BaseFilterOperator {
 
     if (arguments.get(0).getType() == ExpressionContext.Type.IDENTIFIER) {
       _h3IndexReader = segment.getDataSource(arguments.get(0).getIdentifier()).getH3Index();
-      _geometry = GeometrySerializer.deserialize(BytesUtils.toBytes(arguments.get(1).getLiteral().getStringValue()));
+      _geometry = GeometrySerializer.deserialize(arguments.get(1).getLiteral().getBytesValue());
     } else {
       _h3IndexReader = segment.getDataSource(arguments.get(1).getIdentifier()).getH3Index();
-      _geometry = GeometrySerializer.deserialize(BytesUtils.toBytes(arguments.get(0).getLiteral().getStringValue()));
+      _geometry = GeometrySerializer.deserialize(arguments.get(0).getLiteral().getBytesValue());
     }
     // must be some h3 index
     assert _h3IndexReader != null : "the column must have H3 index setup.";

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLiteralTransformFunction.java
@@ -84,7 +84,7 @@ public class ArrayLiteralTransformFunction implements TransformFunction {
       case LONG:
         _longArrayLiteral = new long[literalContexts.size()];
         for (int i = 0; i < _longArrayLiteral.length; i++) {
-          _longArrayLiteral[i] = Long.parseLong(literalContexts.get(i).getLiteral().getStringValue());
+          _longArrayLiteral[i] = literalContexts.get(i).getLiteral().getLongValue();
         }
         _intArrayLiteral = null;
         _floatArrayLiteral = null;
@@ -94,7 +94,7 @@ public class ArrayLiteralTransformFunction implements TransformFunction {
       case FLOAT:
         _floatArrayLiteral = new float[literalContexts.size()];
         for (int i = 0; i < _floatArrayLiteral.length; i++) {
-          _floatArrayLiteral[i] = Float.parseFloat(literalContexts.get(i).getLiteral().getStringValue());
+          _floatArrayLiteral[i] = literalContexts.get(i).getLiteral().getFloatValue();
         }
         _intArrayLiteral = null;
         _longArrayLiteral = null;
@@ -104,7 +104,7 @@ public class ArrayLiteralTransformFunction implements TransformFunction {
       case DOUBLE:
         _doubleArrayLiteral = new double[literalContexts.size()];
         for (int i = 0; i < _doubleArrayLiteral.length; i++) {
-          _doubleArrayLiteral[i] = Double.parseDouble(literalContexts.get(i).getLiteral().getStringValue());
+          _doubleArrayLiteral[i] = literalContexts.get(i).getLiteral().getDoubleValue();
         }
         _intArrayLiteral = null;
         _longArrayLiteral = null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunction.java
@@ -27,12 +27,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.MutablePair;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
+import org.apache.pinot.spi.utils.TimestampUtils;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -42,17 +45,18 @@ import org.roaringbitmap.RoaringBitmap;
  * The SQL Syntax is: CASE WHEN condition1 THEN result1 WHEN condition2 THEN result2 WHEN conditionN THEN resultN ELSE
  * result END;
  * <p>
- * Usage: case(${WHEN_STATEMENT_1}, ..., ${WHEN_STATEMENT_N}, ${THEN_EXPRESSION_1}, ..., ${THEN_EXPRESSION_N},
+ * Usage: case(${WHEN_STATEMENT_1}, ${THEN_EXPRESSION_1}, ..., ${WHEN_STATEMENT_N}, ${THEN_EXPRESSION_N}, ...,
  * ${ELSE_EXPRESSION})
  * <p>
  * There are 2 * N + 1 arguments:
- * <code>WHEN_STATEMENT_$i</code> is a <code>BinaryOperatorTransformFunction</code> represents
- * <code>condition$i</code>
+ * <code>WHEN_STATEMENT_$i</code> is a <code>BinaryOperatorTransformFunction</code> represents <code>condition$i</code>
  * <code>THEN_EXPRESSION_$i</code> is a <code>TransformFunction</code> represents <code>result$i</code>
  * <code>ELSE_EXPRESSION</code> is a <code>TransformFunction</code> represents <code>result</code>
  * <p>
  * ELSE_EXPRESSION can be omitted. When none of when statements is evaluated to be true, and there is no else
  * expression, we output null. Note that when statement is considered as false if it is evaluated to be null.
+ * <p>
+ * PostgreSQL documentation: <a href="https://www.postgresql.org/docs/current/typeconv-union-case.html">CASE</a>
  */
 public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEnabledTransformFunction {
   public static final String FUNCTION_NAME = "case";
@@ -60,9 +64,9 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
   private List<TransformFunction> _whenStatements = new ArrayList<>();
   private List<TransformFunction> _thenStatements = new ArrayList<>();
   private TransformFunction _elseStatement;
+  private TransformResultMetadata _resultMetadata;
 
   private boolean[] _computeThenStatements;
-  private TransformResultMetadata _resultMetadata;
   private int[] _selectedResults;
 
   @Override
@@ -82,158 +86,143 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
     int numWhenStatements = arguments.size() / 2;
     _whenStatements = new ArrayList<>(numWhenStatements);
     _thenStatements = new ArrayList<>(numWhenStatements);
-    constructStatementList(arguments);
-    _computeThenStatements = new boolean[_thenStatements.size()];
-    _resultMetadata = calculateResultMetadata();
-  }
-
-  private void constructStatementList(List<TransformFunction> arguments) {
-    int numWhenStatements = arguments.size() / 2;
-    // alternating WHEN and THEN clause, last one ELSE
+    // Alternating WHEN and THEN clause, last one ELSE
     for (int i = 0; i < numWhenStatements; i++) {
       _whenStatements.add(arguments.get(i * 2));
       _thenStatements.add(arguments.get(i * 2 + 1));
     }
-    if (arguments.size() % 2 != 0 && !isNullLiteralTransformation(arguments.get(arguments.size() - 1))) {
+    if (arguments.size() % 2 != 0 && !isNullLiteral(arguments.get(arguments.size() - 1))) {
       _elseStatement = arguments.get(arguments.size() - 1);
+    }
+    _resultMetadata = new TransformResultMetadata(calculateResultType(), true, false);
+    _computeThenStatements = new boolean[numWhenStatements];
+  }
+
+  private boolean isNullLiteral(TransformFunction function) {
+    return function instanceof LiteralTransformFunction && ((LiteralTransformFunction) function).isNull();
+  }
+
+  private DataType calculateResultType() {
+    MutablePair<DataType, List<String>> typeAndUnresolvedLiterals =
+        new MutablePair<>(DataType.UNKNOWN, new ArrayList<>());
+    for (TransformFunction thenStatement : _thenStatements) {
+      upcast(typeAndUnresolvedLiterals, thenStatement);
+    }
+    if (_elseStatement != null) {
+      upcast(typeAndUnresolvedLiterals, _elseStatement);
+    }
+    DataType dataType = typeAndUnresolvedLiterals.getLeft();
+    // If all inputs are of type UNKNOWN, resolve as type STRING
+    return dataType != DataType.UNKNOWN ? dataType : DataType.STRING;
+  }
+
+  private void upcast(MutablePair<DataType, List<String>> currentTypeAndUnresolvedLiterals,
+      TransformFunction newFunction) {
+    TransformResultMetadata newMetadata = newFunction.getResultMetadata();
+    Preconditions.checkArgument(newMetadata.isSingleValue(), "Unsupported multi-value expression in THEN/ELSE clause");
+    DataType newType = newMetadata.getDataType();
+    if (newType == DataType.UNKNOWN) {
+      return;
+    }
+    DataType currentType = currentTypeAndUnresolvedLiterals.getLeft();
+    if (currentType == newType) {
+      return;
+    }
+    List<String> unresolvedLiterals = currentTypeAndUnresolvedLiterals.getRight();
+    // Treat string literals as UNKNOWN type. Resolve them when we get a non-UNKNOWN type.
+    boolean isNewFunctionStringLiteral = newFunction instanceof LiteralTransformFunction && newType == DataType.STRING;
+    if (currentType == DataType.UNKNOWN) {
+      if (isNewFunctionStringLiteral) {
+        unresolvedLiterals.add(((LiteralTransformFunction) newFunction).getStringLiteral());
+      } else {
+        currentTypeAndUnresolvedLiterals.setLeft(newType);
+        for (String unresolvedLiteral : unresolvedLiterals) {
+          checkLiteral(newType, unresolvedLiteral);
+        }
+        unresolvedLiterals.clear();
+      }
+    } else {
+      assert unresolvedLiterals.isEmpty();
+      if (isNewFunctionStringLiteral) {
+        checkLiteral(currentType, ((LiteralTransformFunction) newFunction).getStringLiteral());
+      } else {
+        // Only allow upcast from numeric to numeric: INT -> LONG -> FLOAT -> DOUBLE -> BIG_DECIMAL
+        Preconditions.checkArgument(currentType.isNumeric() && newType.isNumeric(), "Cannot upcast from %s to %s",
+            currentType, newType);
+        if (newType.ordinal() > currentType.ordinal()) {
+          currentTypeAndUnresolvedLiterals.setLeft(newType);
+        }
+      }
     }
   }
 
-  private TransformResultMetadata calculateResultMetadata() {
-    DataType dataType;
-    if (_elseStatement == null) {
-      dataType = DataType.UNKNOWN;
-    } else {
-      TransformResultMetadata elseStatementResultMetadata = _elseStatement.getResultMetadata();
-      dataType = elseStatementResultMetadata.getDataType();
-      Preconditions.checkState(elseStatementResultMetadata.isSingleValue(),
-          "Unsupported multi-value expression in the ELSE clause");
+  private void checkLiteral(DataType dataType, String literal) {
+    switch (dataType) {
+      case INT:
+        try {
+          Integer.parseInt(literal);
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid literal: " + literal + " for INT");
+        }
+        break;
+      case LONG:
+        try {
+          Long.parseLong(literal);
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid literal: " + literal + " for LONG");
+        }
+        break;
+      case FLOAT:
+        try {
+          Float.parseFloat(literal);
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid literal: " + literal + " for FLOAT");
+        }
+        break;
+      case DOUBLE:
+        try {
+          Double.parseDouble(literal);
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid literal: " + literal + " for DOUBLE");
+        }
+        break;
+      case BIG_DECIMAL:
+        try {
+          new BigDecimal(literal);
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid literal: " + literal + " for BIG_DECIMAL");
+        }
+        break;
+      case BOOLEAN:
+        Preconditions.checkArgument(
+            literal.equalsIgnoreCase("true") || literal.equalsIgnoreCase("false") || literal.equals("1")
+                || literal.equals("0"), "Invalid literal: %s for BOOLEAN", literal);
+        break;
+      case TIMESTAMP:
+        try {
+          TimestampUtils.toTimestamp(literal);
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid literal: " + literal + " for TIMESTAMP");
+        }
+        break;
+      case STRING:
+      case JSON:
+        break;
+      case BYTES:
+        try {
+          BytesUtils.toBytes(literal);
+        } catch (Exception e) {
+          throw new IllegalArgumentException("Invalid literal: " + literal + " for BYTES");
+        }
+        break;
+      default:
+        throw new IllegalStateException("Unsupported data type: " + dataType);
     }
-    int numThenStatements = _thenStatements.size();
-    for (int i = 0; i < numThenStatements; i++) {
-      TransformFunction thenStatement = _thenStatements.get(i);
-      TransformResultMetadata thenStatementResultMetadata = thenStatement.getResultMetadata();
-      if (!thenStatementResultMetadata.isSingleValue()) {
-        throw new IllegalStateException("Unsupported multi-value expression in the THEN clause of index: " + i);
-      }
-      DataType thenStatementDataType = thenStatementResultMetadata.getDataType();
-
-      // Upcast the data type to cover all the data types in THEN and ELSE clauses if they don't match
-      // For numeric types:
-      // - INT & LONG -> LONG
-      // - INT & FLOAT/DOUBLE -> DOUBLE
-      // - LONG & FLOAT/DOUBLE -> DOUBLE (might lose precision)
-      // - FLOAT & DOUBLE -> DOUBLE
-      // - Any numeric data type with BIG_DECIMAL -> BIG_DECIMAL
-      // Use STRING to handle non-numeric types
-      // UNKNOWN data type is ignored unless all data types are unknown, we return unknown types.
-      if (thenStatementDataType == dataType) {
-        continue;
-      }
-      switch (dataType) {
-        case INT:
-          switch (thenStatementDataType) {
-            case LONG:
-              dataType = DataType.LONG;
-              break;
-            case FLOAT:
-            case DOUBLE:
-              dataType = DataType.DOUBLE;
-              break;
-            case BIG_DECIMAL:
-              dataType = DataType.BIG_DECIMAL;
-              break;
-            case UNKNOWN:
-              break;
-            default:
-              dataType = DataType.STRING;
-              break;
-          }
-          break;
-        case LONG:
-          switch (thenStatementDataType) {
-            case INT: // fall through
-            case UNKNOWN:
-              break;
-            case FLOAT:
-            case DOUBLE:
-              dataType = DataType.DOUBLE;
-              break;
-            case BIG_DECIMAL:
-              dataType = DataType.BIG_DECIMAL;
-              break;
-            default:
-              dataType = DataType.STRING;
-              break;
-          }
-          break;
-        case FLOAT:
-          switch (thenStatementDataType) {
-            case INT:
-            case LONG:
-            case DOUBLE:
-              dataType = DataType.DOUBLE;
-              break;
-            case BIG_DECIMAL:
-              dataType = DataType.BIG_DECIMAL;
-              break;
-            case UNKNOWN:
-              break;
-            default:
-              dataType = DataType.STRING;
-              break;
-          }
-          break;
-        case DOUBLE:
-          switch (thenStatementDataType) {
-            case INT:
-            case FLOAT:
-            case LONG:
-            case UNKNOWN:
-              break;
-            case BIG_DECIMAL:
-              dataType = DataType.BIG_DECIMAL;
-              break;
-            default:
-              dataType = DataType.STRING;
-              break;
-          }
-          break;
-        case BIG_DECIMAL:
-          switch (thenStatementDataType) {
-            case INT:
-            case FLOAT:
-            case LONG:
-            case DOUBLE:
-            case UNKNOWN:
-              break;
-            default:
-              dataType = DataType.STRING;
-              break;
-          }
-          break;
-        case UNKNOWN:
-          dataType = thenStatementDataType;
-          break;
-        default:
-          dataType = DataType.STRING;
-          break;
-      }
-    }
-    return new TransformResultMetadata(dataType, true, false);
   }
 
   @Override
   public TransformResultMetadata getResultMetadata() {
     return _resultMetadata;
-  }
-
-  private boolean isNullLiteralTransformation(TransformFunction function) {
-    if (function instanceof LiteralTransformFunction) {
-      LiteralTransformFunction literalFunction = (LiteralTransformFunction) function;
-      return literalFunction.isNull();
-    }
-    return false;
   }
 
   /**
@@ -315,9 +304,9 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           _intValuesSV[docId] = NullValuePlaceHolder.INT;
         }
       } else {
-        int[] intValuesSV = _elseStatement.transformToIntValuesSV(valueBlock);
+        int[] intValues = _elseStatement.transformToIntValuesSV(valueBlock);
         for (int docId = unselectedDocs.nextSetBit(0); docId >= 0; docId = unselectedDocs.nextSetBit(docId + 1)) {
-          _intValuesSV[docId] = intValuesSV[docId];
+          _intValuesSV[docId] = intValues[docId];
         }
       }
     }
@@ -400,9 +389,9 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           _longValuesSV[docId] = NullValuePlaceHolder.LONG;
         }
       } else {
-        long[] longValuesSV = _elseStatement.transformToLongValuesSV(valueBlock);
+        long[] longValues = _elseStatement.transformToLongValuesSV(valueBlock);
         for (int docId = unselectedDocs.nextSetBit(0); docId >= 0; docId = unselectedDocs.nextSetBit(docId + 1)) {
-          _longValuesSV[docId] = longValuesSV[docId];
+          _longValuesSV[docId] = longValues[docId];
         }
       }
     }
@@ -485,9 +474,9 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           _floatValuesSV[docId] = NullValuePlaceHolder.FLOAT;
         }
       } else {
-        float[] floatValuesSV = _elseStatement.transformToFloatValuesSV(valueBlock);
+        float[] floatValues = _elseStatement.transformToFloatValuesSV(valueBlock);
         for (int docId = unselectedDocs.nextSetBit(0); docId >= 0; docId = unselectedDocs.nextSetBit(docId + 1)) {
-          _floatValuesSV[docId] = floatValuesSV[docId];
+          _floatValuesSV[docId] = floatValues[docId];
         }
       }
     }
@@ -570,9 +559,9 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           _doubleValuesSV[docId] = NullValuePlaceHolder.DOUBLE;
         }
       } else {
-        float[] doubleValuesSV = _elseStatement.transformToFloatValuesSV(valueBlock);
+        double[] doubleValues = _elseStatement.transformToDoubleValuesSV(valueBlock);
         for (int docId = unselectedDocs.nextSetBit(0); docId >= 0; docId = unselectedDocs.nextSetBit(docId + 1)) {
-          _doubleValuesSV[docId] = doubleValuesSV[docId];
+          _doubleValuesSV[docId] = doubleValues[docId];
         }
       }
     }
@@ -656,9 +645,9 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           _bigDecimalValuesSV[docId] = NullValuePlaceHolder.BIG_DECIMAL;
         }
       } else {
-        BigDecimal[] bigDecimalValuesSV = _elseStatement.transformToBigDecimalValuesSV(valueBlock);
+        BigDecimal[] bigDecimalValues = _elseStatement.transformToBigDecimalValuesSV(valueBlock);
         for (int docId = unselectedDocs.nextSetBit(0); docId >= 0; docId = unselectedDocs.nextSetBit(docId + 1)) {
-          _bigDecimalValuesSV[docId] = bigDecimalValuesSV[docId];
+          _bigDecimalValuesSV[docId] = bigDecimalValues[docId];
         }
       }
     }
@@ -699,7 +688,7 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
     if (!unselectedDocs.isEmpty()) {
       if (_elseStatement == null) {
         for (int docId = unselectedDocs.nextSetBit(0); docId >= 0; docId = unselectedDocs.nextSetBit(docId + 1)) {
-            _bigDecimalValuesSV[docId] = NullValuePlaceHolder.BIG_DECIMAL;
+          _bigDecimalValuesSV[docId] = NullValuePlaceHolder.BIG_DECIMAL;
           bitmap.add(docId);
         }
       } else {
@@ -742,9 +731,9 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           _stringValuesSV[docId] = NullValuePlaceHolder.STRING;
         }
       } else {
-        String[] stringValuesSV = _elseStatement.transformToStringValuesSV(valueBlock);
+        String[] stringValues = _elseStatement.transformToStringValuesSV(valueBlock);
         for (int docId = unselectedDocs.nextSetBit(0); docId >= 0; docId = unselectedDocs.nextSetBit(docId + 1)) {
-          _stringValuesSV[docId] = stringValuesSV[docId];
+          _stringValuesSV[docId] = stringValues[docId];
         }
       }
     }
@@ -828,9 +817,9 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           _bytesValuesSV[docId] = NullValuePlaceHolder.BYTES;
         }
       } else {
-        byte[][] byteValuesSV = _elseStatement.transformToBytesValuesSV(valueBlock);
+        byte[][] bytesValues = _elseStatement.transformToBytesValuesSV(valueBlock);
         for (int docId = unselectedDocs.nextSetBit(0); docId >= 0; docId = unselectedDocs.nextSetBit(docId + 1)) {
-          _bytesValuesSV[docId] = byteValuesSV[docId];
+          _bytesValuesSV[docId] = bytesValues[docId];
         }
       }
     }
@@ -874,10 +863,10 @@ public class CaseTransformFunction extends ComputeDifferentlyWhenNullHandlingEna
           bitmap.add(docId);
         }
       } else {
-        byte[][] byteValues = _elseStatement.transformToBytesValuesSV(valueBlock);
+        byte[][] bytesValues = _elseStatement.transformToBytesValuesSV(valueBlock);
         RoaringBitmap nullBitmap = _elseStatement.getNullBitmap(valueBlock);
         for (int docId = unselectedDocs.nextSetBit(0); docId >= 0; docId = unselectedDocs.nextSetBit(docId + 1)) {
-          _bytesValuesSV[docId] = byteValues[docId];
+          _bytesValuesSV[docId] = bytesValues[docId];
           if (nullBitmap != null && nullBitmap.contains(docId)) {
             bitmap.add(docId);
           }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -111,8 +111,8 @@ public class AggregationFunctionFactory {
         } else if (numArguments == 2) {
           // Double arguments percentile (e.g. percentile(foo, 99), percentileTDigest(bar, 95), etc.) where the
           // second argument is a decimal number from 0.0 to 100.0.
-          // Have to use literal string because we need to cast int to double here.
-          double percentile = parsePercentileToDouble(arguments.get(1).getLiteral().getStringValue());
+          double percentile = arguments.get(1).getLiteral().getDoubleValue();
+          Preconditions.checkArgument(percentile >= 0 && percentile <= 100, "Invalid percentile: %s", percentile);
           if (remainingFunctionName.isEmpty()) {
             // Percentile
             return new PercentileAggregationFunction(firstArgument, percentile);
@@ -159,9 +159,10 @@ public class AggregationFunctionFactory {
           // the compression_factor for the TDigest. This can only be used for TDigest type percentile functions to
           // pass in a custom compression_factor. If the two argument version is used the default compression_factor
           // of 100.0 is used.
-          // Have to use literal string because we need to cast int to double here.
-          double percentile = parsePercentileToDouble(arguments.get(1).getLiteral().getStringValue());
-          int compressionFactor = parseCompressionFactorToInt(arguments.get(2).getLiteral().getStringValue());
+          double percentile = arguments.get(1).getLiteral().getDoubleValue();
+          Preconditions.checkArgument(percentile >= 0 && percentile <= 100, "Invalid percentile: %s", percentile);
+          int compressionFactor = arguments.get(2).getLiteral().getIntValue();
+          Preconditions.checkArgument(compressionFactor >= 0, "Invalid compressionFactor: %d", compressionFactor);
           if (remainingFunctionName.equals("TDIGEST")) {
             // PercentileTDigest
             return new PercentileTDigestAggregationFunction(firstArgument, percentile, compressionFactor);
@@ -377,17 +378,5 @@ public class AggregationFunctionFactory {
     int percentile = Integer.parseInt(percentileString);
     Preconditions.checkArgument(percentile >= 0 && percentile <= 100, "Invalid percentile: %s", percentile);
     return percentile;
-  }
-
-  private static double parsePercentileToDouble(String percentileString) {
-    double percentile = Double.parseDouble(percentileString);
-    Preconditions.checkArgument(percentile >= 0d && percentile <= 100d, "Invalid percentile: %s", percentile);
-    return percentile;
-  }
-
-  private static int parseCompressionFactorToInt(String compressionFactorString) {
-    int compressionFactor = Integer.parseInt(compressionFactorString);
-    Preconditions.checkArgument(compressionFactor >= 0, "Invalid compressionFactor: %d", compressionFactor);
-    return compressionFactor;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/IntegerTupleSketchAggregationFunction.java
@@ -63,12 +63,11 @@ public class IntegerTupleSketchAggregationFunction
     _expressionContext = arguments.get(0);
     _setOps = new IntegerSummarySetOperations(mode, mode);
     if (arguments.size() == 2) {
-      FieldSpec.DataType dataType = arguments.get(1).getLiteral().getType();
-      Preconditions.checkArgument(dataType == FieldSpec.DataType.LONG || dataType == FieldSpec.DataType.INT,
-          "Tuple Sketch Aggregation Function expected the second argument to be a number of entries to keep, but it "
-              + "was of type %s",
-          dataType.toString());
-      _entries = ((Long) arguments.get(1).getLiteral().getValue()).intValue();
+      ExpressionContext secondArgument = arguments.get(1);
+      Preconditions.checkArgument(secondArgument.getType() == ExpressionContext.Type.LITERAL,
+          "Tuple Sketch Aggregation Function expects the second argument to be a literal (number of entries to keep),"
+              + " but got: ", secondArgument.getType());
+      _entries = secondArgument.getLiteral().getIntValue();
     } else {
       _entries = (int) Math.pow(2, CommonConstants.Helix.DEFAULT_TUPLE_SKETCH_LGK);
     }

--- a/pinot-core/src/test/java/org/apache/pinot/common/request/context/LiteralContextTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/common/request/context/LiteralContextTest.java
@@ -19,80 +19,207 @@
 package org.apache.pinot.common.request.context;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import org.apache.pinot.common.request.Literal;
-import org.apache.pinot.spi.data.FieldSpec;
-import org.testng.Assert;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.BigDecimalUtils;
+import org.apache.pinot.spi.utils.BytesUtils;
+import org.apache.pinot.spi.utils.CommonConstants.NullValuePlaceHolder;
 import org.testng.annotations.Test;
+
+import static org.testng.Assert.*;
 
 
 public class LiteralContextTest {
+
   @Test
   public void testNullLiteralContext() {
     // Create literal context from thrift
     Literal literal = new Literal();
     literal.setNullValue(true);
     LiteralContext nullContext1 = new LiteralContext(literal);
-    Assert.assertEquals(nullContext1.getValue(), null);
-    Assert.assertEquals(nullContext1.toString(), "'null'");
-    Assert.assertEquals(nullContext1.getBigDecimalValue(), BigDecimal.ZERO);
-    // Create literal context from object and type
-    LiteralContext nullContext2 = new LiteralContext(FieldSpec.DataType.UNKNOWN, null);
-    Assert.assertEquals(nullContext2.getValue(), null);
-    Assert.assertEquals(nullContext2.toString(), "'null'");
-    Assert.assertEquals(nullContext2.getBigDecimalValue(), BigDecimal.ZERO);
-    // Check different literal objects are equal and have same hash code.
-    Assert.assertTrue(nullContext1.equals(nullContext2));
-    Assert.assertTrue(nullContext1.hashCode() == nullContext2.hashCode());
+    assertEquals(nullContext1.getType(), DataType.UNKNOWN);
+    assertNull(nullContext1.getValue());
+    assertFalse(nullContext1.getBooleanValue());
+    assertEquals(nullContext1.getIntValue(), NullValuePlaceHolder.INT);
+    assertEquals(nullContext1.getLongValue(), NullValuePlaceHolder.LONG);
+    assertEquals(nullContext1.getFloatValue(), NullValuePlaceHolder.FLOAT);
+    assertEquals(nullContext1.getDoubleValue(), NullValuePlaceHolder.DOUBLE);
+    assertEquals(nullContext1.getBigDecimalValue(), NullValuePlaceHolder.BIG_DECIMAL);
+    assertEquals(nullContext1.getStringValue(), NullValuePlaceHolder.STRING);
+    assertEquals(nullContext1.getBytesValue(), NullValuePlaceHolder.BYTES);
+    assertTrue(nullContext1.isNull());
+    assertEquals(nullContext1.toString(), "'null'");
+
+    // Create literal context from type and value
+    LiteralContext nullContext2 = new LiteralContext(DataType.UNKNOWN, null);
+    assertEquals(nullContext2, nullContext1);
+    assertEquals(nullContext2.hashCode(), nullContext1.hashCode());
   }
 
   @Test
-  public void testInferDataType(){
-    Assert.assertEquals(LiteralContext.inferLiteralDataTypeAndValue("abc").getLeft(), FieldSpec.DataType.STRING);
-    Assert.assertEquals(LiteralContext.inferLiteralDataTypeAndValue("123").getLeft(), FieldSpec.DataType.STRING);
-    Assert.assertEquals(LiteralContext.inferLiteralDataTypeAndValue("2147483649").getLeft(), FieldSpec.DataType.STRING);
-    Assert.assertEquals(LiteralContext.inferLiteralDataTypeAndValue("1.2").getLeft(), FieldSpec.DataType.STRING);
-    Assert.assertEquals(LiteralContext.inferLiteralDataTypeAndValue("41241241.2412").getLeft(),
-        FieldSpec.DataType.STRING);
-    // Only big decimal is allowed to pass in as string for numerical type.
-    Assert.assertEquals(LiteralContext.inferLiteralDataTypeAndValue("1.7976931348623159e+308").getLeft(),
-        FieldSpec.DataType.BIG_DECIMAL);
-    Assert.assertEquals(LiteralContext.inferLiteralDataTypeAndValue("2020-02-02 20:20:20.20").getLeft(),
-        FieldSpec.DataType.TIMESTAMP);
+  public void testBooleanLiteral() {
+    LiteralContext literalContext = new LiteralContext(DataType.BOOLEAN, true);
+    assertTrue(literalContext.getBooleanValue());
+    assertEquals(literalContext.getIntValue(), 1);
+    assertEquals(literalContext.getLongValue(), 1L);
+    assertEquals(literalContext.getFloatValue(), 1.0f);
+    assertEquals(literalContext.getDoubleValue(), 1.0);
+    assertEquals(literalContext.getBigDecimalValue(), BigDecimal.ONE);
+    assertEquals(literalContext.getStringValue(), "true");
+    assertThrows(literalContext::getBytesValue);
+    assertFalse(literalContext.isNull());
+    assertEquals(literalContext.toString(), "'true'");
+
+    literalContext = new LiteralContext(DataType.BOOLEAN, false);
+    assertFalse(literalContext.getBooleanValue());
+    assertEquals(literalContext.getIntValue(), 0);
+    assertEquals(literalContext.getLongValue(), 0L);
+    assertEquals(literalContext.getFloatValue(), 0.0f);
+    assertEquals(literalContext.getDoubleValue(), 0.0);
+    assertEquals(literalContext.getBigDecimalValue(), BigDecimal.ZERO);
+    assertEquals(literalContext.getStringValue(), "false");
+    assertThrows(literalContext::getBytesValue);
+    assertFalse(literalContext.isNull());
+    assertEquals(literalContext.toString(), "'false'");
   }
 
   @Test
-  public void testInferFloatDataType() {
-    Literal literalFloat = new Literal();
-    literalFloat.setDoubleValue(1.23);
-    LiteralContext floatContext = new LiteralContext(literalFloat);
-    Assert.assertEquals(floatContext.getType(), FieldSpec.DataType.FLOAT);
-    Assert.assertEquals(floatContext.getValue(), (float) literalFloat.getDoubleValue());
+  public void testIntLiteral() {
+    LiteralContext literalContext = new LiteralContext(DataType.INT, 123);
+    assertTrue(literalContext.getBooleanValue());
+    assertEquals(literalContext.getIntValue(), 123);
+    assertEquals(literalContext.getLongValue(), 123L);
+    assertEquals(literalContext.getFloatValue(), 123.0f);
+    assertEquals(literalContext.getDoubleValue(), 123.0);
+    assertEquals(literalContext.getBigDecimalValue(), new BigDecimal("123"));
+    assertEquals(literalContext.getStringValue(), "123");
+    assertThrows(literalContext::getBytesValue);
+    assertFalse(literalContext.isNull());
+    assertEquals(literalContext.toString(), "'123'");
+
+    assertFalse(new LiteralContext(DataType.INT, 0).getBooleanValue());
   }
 
   @Test
-  public void testInferDoubleDataType() {
-    Literal literalFloat = new Literal();
-    literalFloat.setDoubleValue(1.234567891011);
-    LiteralContext doubleContext = new LiteralContext(literalFloat);
-    Assert.assertEquals(doubleContext.getType(), FieldSpec.DataType.DOUBLE);
-    Assert.assertEquals(doubleContext.getValue(), literalFloat.getDoubleValue());
+  public void testLongLiteral() {
+    LiteralContext literalContext = new LiteralContext(DataType.LONG, 123L);
+    assertTrue(literalContext.getBooleanValue());
+    assertEquals(literalContext.getIntValue(), 123);
+    assertEquals(literalContext.getLongValue(), 123L);
+    assertEquals(literalContext.getFloatValue(), 123.0f);
+    assertEquals(literalContext.getDoubleValue(), 123.0);
+    assertEquals(literalContext.getBigDecimalValue(), new BigDecimal("123"));
+    assertEquals(literalContext.getStringValue(), "123");
+    assertThrows(literalContext::getBytesValue);
+    assertFalse(literalContext.isNull());
+    assertEquals(literalContext.toString(), "'123'");
+
+    assertFalse(new LiteralContext(DataType.LONG, 0L).getBooleanValue());
   }
 
   @Test
-  public void testInferIntDataType() {
-    Literal literalInt = new Literal();
-    literalInt.setLongValue(123);
-    LiteralContext floatContext = new LiteralContext(literalInt);
-    Assert.assertEquals(floatContext.getType(), FieldSpec.DataType.INT);
-    Assert.assertEquals(floatContext.getValue(), (int) literalInt.getLongValue());
+  public void testFloatLiteral() {
+    LiteralContext literalContext = new LiteralContext(DataType.FLOAT, 123.45f);
+    assertTrue(literalContext.getBooleanValue());
+    assertEquals(literalContext.getIntValue(), 123);
+    assertEquals(literalContext.getLongValue(), 123L);
+    assertEquals(literalContext.getFloatValue(), 123.45f);
+    assertEquals(literalContext.getDoubleValue(), (double) 123.45f);
+    assertEquals(literalContext.getBigDecimalValue(), new BigDecimal("123.45"));
+    assertEquals(literalContext.getStringValue(), "123.45");
+    assertThrows(literalContext::getBytesValue);
+    assertFalse(literalContext.isNull());
+    assertEquals(literalContext.toString(), "'123.45'");
+
+    assertFalse(new LiteralContext(DataType.FLOAT, 0.0f).getBooleanValue());
   }
 
   @Test
-  public void testInferLongDataType() {
-    Literal literalLong = new Literal();
-    literalLong.setLongValue(Integer.MAX_VALUE + 1L);
-    LiteralContext longContext = new LiteralContext(literalLong);
-    Assert.assertEquals(longContext.getType(), FieldSpec.DataType.LONG);
-    Assert.assertEquals(longContext.getValue(), literalLong.getLongValue());
+  public void testDoubleLiteral() {
+    LiteralContext literalContext = new LiteralContext(DataType.DOUBLE, 123.45);
+    assertTrue(literalContext.getBooleanValue());
+    assertEquals(literalContext.getIntValue(), 123);
+    assertEquals(literalContext.getLongValue(), 123L);
+    assertEquals(literalContext.getFloatValue(), (float) 123.45);
+    assertEquals(literalContext.getDoubleValue(), 123.45);
+    assertEquals(literalContext.getBigDecimalValue(), new BigDecimal("123.45"));
+    assertEquals(literalContext.getStringValue(), "123.45");
+    assertThrows(literalContext::getBytesValue);
+    assertFalse(literalContext.isNull());
+    assertEquals(literalContext.toString(), "'123.45'");
+
+    assertFalse(new LiteralContext(DataType.DOUBLE, 0.0).getBooleanValue());
+  }
+
+  @Test
+  public void testBigDecimalLiteral() {
+    LiteralContext literalContext = new LiteralContext(DataType.BIG_DECIMAL, new BigDecimal("123.45"));
+    assertTrue(literalContext.getBooleanValue());
+    assertEquals(literalContext.getIntValue(), 123);
+    assertEquals(literalContext.getLongValue(), 123L);
+    assertEquals(literalContext.getFloatValue(), 123.45f);
+    assertEquals(literalContext.getDoubleValue(), 123.45);
+    assertEquals(literalContext.getBigDecimalValue(), new BigDecimal("123.45"));
+    assertEquals(literalContext.getStringValue(), "123.45");
+    assertEquals(literalContext.getBytesValue(), BigDecimalUtils.serialize(new BigDecimal("123.45")));
+    assertFalse(literalContext.isNull());
+    assertEquals(literalContext.toString(), "'123.45'");
+
+    assertFalse(new LiteralContext(DataType.BIG_DECIMAL, BigDecimal.ZERO).getBooleanValue());
+  }
+
+  @Test
+  public void testStringLiteral() {
+    LiteralContext literalContext = new LiteralContext(DataType.STRING, "123");
+    assertFalse(literalContext.getBooleanValue());
+    assertEquals(literalContext.getIntValue(), 123);
+    assertEquals(literalContext.getLongValue(), 123L);
+    assertEquals(literalContext.getFloatValue(), 123.0f);
+    assertEquals(literalContext.getDoubleValue(), 123.0);
+    assertEquals(literalContext.getBigDecimalValue(), new BigDecimal("123"));
+    assertEquals(literalContext.getStringValue(), "123");
+    assertThrows(literalContext::getBytesValue);
+    assertFalse(literalContext.isNull());
+    assertEquals(literalContext.toString(), "'123'");
+
+    // Parse string as BOOLEAN
+    assertTrue(new LiteralContext(DataType.STRING, "true").getBooleanValue());
+    assertTrue(new LiteralContext(DataType.STRING, "TRUE").getBooleanValue());
+    assertTrue(new LiteralContext(DataType.STRING, "1").getBooleanValue());
+    assertFalse(new LiteralContext(DataType.STRING, "false").getBooleanValue());
+    assertFalse(new LiteralContext(DataType.STRING, "FALSE").getBooleanValue());
+    assertFalse(new LiteralContext(DataType.STRING, "0").getBooleanValue());
+    assertFalse(new LiteralContext(DataType.STRING, "foo").getBooleanValue());
+
+    // Parse string as INT
+    assertEquals(new LiteralContext(DataType.STRING, "true").getIntValue(), 1);
+    assertEquals(new LiteralContext(DataType.STRING, "TRUE").getIntValue(), 1);
+    assertEquals(new LiteralContext(DataType.STRING, "false").getIntValue(), 0);
+    assertEquals(new LiteralContext(DataType.STRING, "FALSE").getIntValue(), 0);
+    assertThrows(() -> new LiteralContext(DataType.STRING, "123.45").getIntValue());
+
+    // Parse string as LONG
+    assertEquals(new LiteralContext(DataType.STRING, "2022-02-02 22:22:22").getLongValue(),
+        Timestamp.valueOf("2022-02-02 22:22:22").getTime());
+    assertThrows(() -> new LiteralContext(DataType.STRING, "123.45").getLongValue());
+
+    // Parse string as BYTES
+    assertEquals(new LiteralContext(DataType.STRING, "deadbeef").getBytesValue(), BytesUtils.toBytes("deadbeef"));
+  }
+
+  @Test
+  public void testBytesLiteral() {
+    LiteralContext literalContext = new LiteralContext(DataType.BYTES, BytesUtils.toBytes("deadbeef"));
+    assertThrows(literalContext::getBooleanValue);
+    assertThrows(literalContext::getIntValue);
+    assertThrows(literalContext::getLongValue);
+    assertThrows(literalContext::getFloatValue);
+    assertThrows(literalContext::getDoubleValue);
+    assertEquals(literalContext.getBigDecimalValue(), BigDecimalUtils.deserialize(BytesUtils.toBytes("deadbeef")));
+    assertEquals(literalContext.getStringValue(), "deadbeef");
+    assertEquals(literalContext.getBytesValue(), BytesUtils.toBytes("deadbeef"));
+    assertFalse(literalContext.isNull());
+    assertEquals(literalContext.toString(), "'deadbeef'");
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/AdditionTransformFunctionTest.java
@@ -69,8 +69,8 @@ public class AdditionTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunction(transformFunction, expectedBigDecimalValues);
 
     expression = RequestContextUtils.getExpression(
-        String.format("add(add(12,%s),%s,add(add(%s,%s),'12110.34556677889901122335678',%s),%s)", STRING_SV_COLUMN,
-            DOUBLE_SV_COLUMN, FLOAT_SV_COLUMN, LONG_SV_COLUMN, INT_SV_COLUMN, BIG_DECIMAL_SV_COLUMN));
+        String.format("add(add(12,%s),%s,add(add(%s,%s),cast('12110.34556677889901122335678' as decimal),%s),%s)",
+            STRING_SV_COLUMN, DOUBLE_SV_COLUMN, FLOAT_SV_COLUMN, LONG_SV_COLUMN, INT_SV_COLUMN, BIG_DECIMAL_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof AdditionTransformFunction);
     BigDecimal val4 = new BigDecimal("12110.34556677889901122335678");

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ArrayLiteralTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/ArrayLiteralTransformFunctionTest.java
@@ -85,7 +85,7 @@ public class ArrayLiteralTransformFunctionTest {
   public void testFloatArrayLiteralTransformFunction() {
     List<ExpressionContext> arrayExpressions = new ArrayList<>();
     for (int i = 0; i < 10; i++) {
-      arrayExpressions.add(ExpressionContext.forLiteralContext(DataType.FLOAT, (double) i));
+      arrayExpressions.add(ExpressionContext.forLiteralContext(DataType.FLOAT, (float) i));
     }
 
     ArrayLiteralTransformFunction floatArray = new ArrayLiteralTransformFunction(arrayExpressions);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/CaseTransformFunctionTest.java
@@ -19,13 +19,17 @@
 package org.apache.pinot.core.operator.transform.function;
 
 import java.math.BigDecimal;
+import java.sql.Timestamp;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
 import java.util.Random;
 import java.util.stream.Stream;
 import org.apache.pinot.common.function.TransformFunctionType;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.utils.BytesUtils;
 import org.roaringbitmap.RoaringBitmap;
 import org.testng.Assert;
 import org.testng.annotations.DataProvider;
@@ -90,118 +94,65 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test
   public void testCaseTransformFunctionWithIntResults() {
-    int[] expectedIntResults = new int[NUM_ROWS];
-    Arrays.fill(expectedIntResults, 100);
-    testCaseQueryWithIntResults("true", expectedIntResults);
-    Arrays.fill(expectedIntResults, 10);
-    testCaseQueryWithIntResults("false", expectedIntResults);
+    boolean[] predicateResults = new boolean[NUM_ROWS];
+    Arrays.fill(predicateResults, true);
+    testCaseQueries("true", predicateResults);
+    Arrays.fill(predicateResults, false);
+    testCaseQueries("false", predicateResults);
 
     for (TransformFunctionType functionType : BINARY_OPERATOR_TRANSFORM_FUNCTIONS) {
-      testCaseQueryWithIntResults(String.format("%s(%s, %s)", functionType.getName(), INT_SV_COLUMN,
-          String.format("%d", _intSVValues[INDEX_TO_COMPARE])), getExpectedIntResults(INT_SV_COLUMN, functionType));
-      testCaseQueryWithIntResults(String.format("%s(%s, %s)", functionType.getName(), LONG_SV_COLUMN,
-          String.format("%d", _longSVValues[INDEX_TO_COMPARE])), getExpectedIntResults(LONG_SV_COLUMN, functionType));
-      testCaseQueryWithIntResults(String.format("%s(%s, %s)", functionType.getName(), FLOAT_SV_COLUMN,
-              String.format("%f", _floatSVValues[INDEX_TO_COMPARE])),
-          getExpectedIntResults(FLOAT_SV_COLUMN, functionType));
-      testCaseQueryWithIntResults(String.format("%s(%s, %s)", functionType.getName(), DOUBLE_SV_COLUMN,
+      testCaseQueries(String.format("%s(%s, %s)", functionType.getName(), INT_SV_COLUMN,
+          String.format("%d", _intSVValues[INDEX_TO_COMPARE])), getPredicateResults(INT_SV_COLUMN, functionType));
+      testCaseQueries(String.format("%s(%s, %s)", functionType.getName(), LONG_SV_COLUMN,
+          String.format("%d", _longSVValues[INDEX_TO_COMPARE])), getPredicateResults(LONG_SV_COLUMN, functionType));
+      testCaseQueries(String.format("%s(%s, %s)", functionType.getName(), FLOAT_SV_COLUMN,
+          String.format("%f", _floatSVValues[INDEX_TO_COMPARE])), getPredicateResults(FLOAT_SV_COLUMN, functionType));
+      testCaseQueries(String.format("%s(%s, %s)", functionType.getName(), DOUBLE_SV_COLUMN,
               String.format("%.20f", _doubleSVValues[INDEX_TO_COMPARE])),
-          getExpectedIntResults(DOUBLE_SV_COLUMN, functionType));
-      testCaseQueryWithIntResults(String.format("%s(%s, %s)", functionType.getName(), STRING_SV_COLUMN,
+          getPredicateResults(DOUBLE_SV_COLUMN, functionType));
+      testCaseQueries(String.format("%s(%s, %s)", functionType.getName(), STRING_SV_COLUMN,
               String.format("'%s'", _stringSVValues[INDEX_TO_COMPARE])),
-          getExpectedIntResults(STRING_SV_COLUMN, functionType));
+          getPredicateResults(STRING_SV_COLUMN, functionType));
     }
   }
 
-  @Test
-  public void testCaseTransformFunctionWithFloatResults() {
-    float[] expectedFloatResults = new float[NUM_ROWS];
-    Arrays.fill(expectedFloatResults, 100);
-    testCaseQueryWithFloatResults("true", expectedFloatResults);
-    Arrays.fill(expectedFloatResults, 10);
-    testCaseQueryWithFloatResults("false", expectedFloatResults);
-
-    for (TransformFunctionType functionType : BINARY_OPERATOR_TRANSFORM_FUNCTIONS) {
-      testCaseQueryWithFloatResults(String.format("%s(%s, %s)", functionType.getName(), INT_SV_COLUMN,
-          String.format("%d", _intSVValues[INDEX_TO_COMPARE])), getExpectedFloatResults(INT_SV_COLUMN, functionType));
-      testCaseQueryWithFloatResults(String.format("%s(%s, %s)", functionType.getName(), LONG_SV_COLUMN,
-              String.format("%d", _longSVValues[INDEX_TO_COMPARE])),
-          getExpectedFloatResults(LONG_SV_COLUMN, functionType));
-      testCaseQueryWithFloatResults(String.format("%s(%s, %s)", functionType.getName(), FLOAT_SV_COLUMN,
-              String.format("%f", _floatSVValues[INDEX_TO_COMPARE])),
-          getExpectedFloatResults(FLOAT_SV_COLUMN, functionType));
-      testCaseQueryWithFloatResults(String.format("%s(%s, %s)", functionType.getName(), DOUBLE_SV_COLUMN,
-              String.format("%.20f", _doubleSVValues[INDEX_TO_COMPARE])),
-          getExpectedFloatResults(DOUBLE_SV_COLUMN, functionType));
-      testCaseQueryWithFloatResults(String.format("%s(%s, %s)", functionType.getName(), STRING_SV_COLUMN,
-              String.format("'%s'", _stringSVValues[INDEX_TO_COMPARE])),
-          getExpectedFloatResults(STRING_SV_COLUMN, functionType));
-    }
+  @DataProvider
+  public static String[] illegalExpressions() {
+    //@formatter:off
+    return new String[] {
+        // '10.0' cannot be parsed as INT/LONG/TIMESTAMP/BYTES
+        String.format("CASE WHEN true THEN %s ELSE '10.0' END", INT_SV_COLUMN),
+        String.format("CASE WHEN true THEN %s ELSE '10.0' END", LONG_SV_COLUMN),
+        String.format("CASE WHEN true THEN %s ELSE '10.0' END", TIMESTAMP_COLUMN),
+        String.format("CASE WHEN true THEN %s ELSE '10.0' END", BYTES_SV_COLUMN),
+        // 'abc' cannot be parsed as any type other than STRING
+        String.format("CASE WHEN true THEN %s ELSE 'abc' END", INT_SV_COLUMN),
+        String.format("CASE WHEN true THEN %s ELSE 'abc' END", LONG_SV_COLUMN),
+        String.format("CASE WHEN true THEN %s ELSE 'abc' END", FLOAT_SV_COLUMN),
+        String.format("CASE WHEN true THEN %s ELSE 'abc' END", DOUBLE_SV_COLUMN),
+        String.format("CASE WHEN true THEN %s ELSE 'abc' END", BIG_DECIMAL_SV_COLUMN),
+        String.format("CASE WHEN true THEN %s ELSE 'abc' END", TIMESTAMP_COLUMN),
+        String.format("CASE WHEN true THEN %s ELSE 'abc' END", BYTES_SV_COLUMN),
+        // Cannot mix 2 types that are not both numeric
+        String.format("CASE WHEN true THEN %s ELSE %s END", INT_SV_COLUMN, TIMESTAMP_COLUMN),
+        String.format("CASE WHEN true THEN %s ELSE %s END", INT_SV_COLUMN, STRING_SV_COLUMN),
+        String.format("CASE WHEN true THEN %s ELSE %s END", INT_SV_COLUMN, BYTES_SV_COLUMN),
+        String.format("CASE WHEN true THEN 100 ELSE %s END", TIMESTAMP_COLUMN),
+        String.format("CASE WHEN true THEN 100 ELSE %s END", STRING_SV_COLUMN),
+        String.format("CASE WHEN true THEN 100 ELSE %s END", BYTES_SV_COLUMN)
+    };
+    //@formatter:on
   }
 
-  @Test
-  public void testCaseTransformFunctionWithBigDecimalResults() {
-    BigDecimal val1 = new BigDecimal("100.99887766554433221");
-    BigDecimal val2 = new BigDecimal("10.1122334455667788909");
-    BigDecimal[] expectedBigDecimalResults = new BigDecimal[NUM_ROWS];
-    Arrays.fill(expectedBigDecimalResults, val1);
-    testCaseQueryWithBigDecimalResults("true", expectedBigDecimalResults);
-    Arrays.fill(expectedBigDecimalResults, val2);
-    testCaseQueryWithBigDecimalResults("false", expectedBigDecimalResults);
-
-    for (TransformFunctionType functionType : BINARY_OPERATOR_TRANSFORM_FUNCTIONS) {
-      testCaseQueryWithBigDecimalResults(String.format("%s(%s, %s)", functionType.getName(), INT_SV_COLUMN,
-              String.format("%d", _intSVValues[INDEX_TO_COMPARE])),
-          getExpectedBigDecimalResults(INT_SV_COLUMN, functionType));
-      testCaseQueryWithBigDecimalResults(String.format("%s(%s, %s)", functionType.getName(), LONG_SV_COLUMN,
-              String.format("%d", _longSVValues[INDEX_TO_COMPARE])),
-          getExpectedBigDecimalResults(LONG_SV_COLUMN, functionType));
-      testCaseQueryWithBigDecimalResults(String.format("%s(%s, %s)", functionType.getName(), FLOAT_SV_COLUMN,
-              String.format("%f", _floatSVValues[INDEX_TO_COMPARE])),
-          getExpectedBigDecimalResults(FLOAT_SV_COLUMN, functionType));
-      testCaseQueryWithBigDecimalResults(String.format("%s(%s, %s)", functionType.getName(), DOUBLE_SV_COLUMN,
-              String.format("%.20f", _doubleSVValues[INDEX_TO_COMPARE])),
-          getExpectedBigDecimalResults(DOUBLE_SV_COLUMN, functionType));
-      testCaseQueryWithBigDecimalResults(String.format("%s(%s, %s)", functionType.getName(), BIG_DECIMAL_SV_COLUMN,
-              String.format("'%s'", _bigDecimalSVValues[INDEX_TO_COMPARE].toPlainString())),
-          getExpectedBigDecimalResults(BIG_DECIMAL_SV_COLUMN, functionType));
-      testCaseQueryWithBigDecimalResults(String.format("%s(%s, %s)", functionType.getName(), STRING_SV_COLUMN,
-              String.format("'%s'", _stringSVValues[INDEX_TO_COMPARE])),
-          getExpectedBigDecimalResults(STRING_SV_COLUMN, functionType));
-    }
-  }
-
-  @Test
-  public void testCaseTransformFunctionWithStringResults() {
-    String[] expectedStringResults = new String[NUM_ROWS];
-    Arrays.fill(expectedStringResults, "aaa");
-    testCaseQueryWithStringResults("true", expectedStringResults);
-    Arrays.fill(expectedStringResults, "bbb");
-    testCaseQueryWithStringResults("false", expectedStringResults);
-
-    for (TransformFunctionType functionType : BINARY_OPERATOR_TRANSFORM_FUNCTIONS) {
-      testCaseQueryWithStringResults(String.format("%s(%s, %s)", functionType.getName(), INT_SV_COLUMN,
-          String.format("%d", _intSVValues[INDEX_TO_COMPARE])), getExpectedStringResults(INT_SV_COLUMN, functionType));
-      testCaseQueryWithStringResults(String.format("%s(%s, %s)", functionType.getName(), LONG_SV_COLUMN,
-              String.format("%d", _longSVValues[INDEX_TO_COMPARE])),
-          getExpectedStringResults(LONG_SV_COLUMN, functionType));
-      testCaseQueryWithStringResults(String.format("%s(%s, %s)", functionType.getName(), FLOAT_SV_COLUMN,
-              String.format("%f", _floatSVValues[INDEX_TO_COMPARE])),
-          getExpectedStringResults(FLOAT_SV_COLUMN, functionType));
-      testCaseQueryWithStringResults(String.format("%s(%s, %s)", functionType.getName(), DOUBLE_SV_COLUMN,
-              String.format("%.20f", _doubleSVValues[INDEX_TO_COMPARE])),
-          getExpectedStringResults(DOUBLE_SV_COLUMN, functionType));
-      testCaseQueryWithStringResults(String.format("%s(%s, %s)", functionType.getName(), STRING_SV_COLUMN,
-              String.format("'%s'", _stringSVValues[INDEX_TO_COMPARE])),
-          getExpectedStringResults(STRING_SV_COLUMN, functionType));
-    }
+  @Test(dataProvider = "illegalExpressions", expectedExceptions = Exception.class)
+  public void testInvalidCaseTransformFunction(String expression) {
+    TransformFunctionFactory.get(RequestContextUtils.getExpression(expression), _dataSourceMap);
   }
 
   @Test
   public void testCaseTransformationWithNullColumn() {
-    ExpressionContext expression =
-        RequestContextUtils.getExpression(
-            String.format("CASE WHEN %s IS NULL THEN 'aaa' ELSE 'bbb' END", STRING_ALPHANUM_NULL_SV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("CASE WHEN %s IS NULL THEN 'aaa' ELSE 'bbb' END", STRING_ALPHANUM_NULL_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.getNullHandlingEnabled(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
     Assert.assertEquals(transformFunction.getName(), "case");
@@ -220,9 +171,8 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test
   public void testCaseTransformationWithNullThenClause() {
-    ExpressionContext expression =
-        RequestContextUtils.getExpression(
-            String.format("CASE WHEN %s IS NULL THEN NULL ELSE 'bbb' END", STRING_ALPHANUM_NULL_SV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("CASE WHEN %s IS NULL THEN NULL ELSE 'bbb' END", STRING_ALPHANUM_NULL_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.getNullHandlingEnabled(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
     Assert.assertEquals(transformFunction.getName(), "case");
@@ -241,9 +191,8 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
 
   @Test
   public void testCaseTransformationWithNullElseClause() {
-    ExpressionContext expression =
-        RequestContextUtils.getExpression(
-            String.format("CASE WHEN %s IS NULL THEN 'aaa' END", STRING_ALPHANUM_NULL_SV_COLUMN));
+    ExpressionContext expression = RequestContextUtils.getExpression(
+        String.format("CASE WHEN %s IS NULL THEN 'aaa' END", STRING_ALPHANUM_NULL_SV_COLUMN));
     TransformFunction transformFunction = TransformFunctionFactory.getNullHandlingEnabled(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
     Assert.assertEquals(transformFunction.getName(), "case");
@@ -261,595 +210,590 @@ public class CaseTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunctionWithNull(transformFunction, expectedValues, bitmap);
   }
 
+  private void testCaseQueries(String predicate, boolean[] predicateResults) {
+    // INT
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN %s ELSE 10 END", predicate, INT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN %s ELSE '10' END", predicate, INT_SV_COLUMN));
+      int[] expectedValues = new int[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _intSVValues[i] : 10;
+      }
+      testCaseQueryWithIntResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN 100 ELSE %s END", predicate, INT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN '100' ELSE %s END", predicate, INT_SV_COLUMN));
+      int[] expectedValues = new int[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? 100 : _intSVValues[i];
+      }
+      testCaseQueryWithIntResults(expressions, expectedValues);
+    }
 
-  private void testCaseQueryWithIntResults(String predicate, int[] expectedValues) {
-    ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("CASE WHEN %s THEN 100 ELSE 10 END", predicate));
-    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
-    assertEquals(transformFunction.getName(), CaseTransformFunction.FUNCTION_NAME);
-    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.INT);
-    testTransformFunction(transformFunction, expectedValues);
+    // LONG
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN %s ELSE 10 END", predicate, LONG_SV_COLUMN),
+              String.format("CASE WHEN %s THEN %s ELSE '10' END", predicate, LONG_SV_COLUMN));
+      long[] expectedValues = new long[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _longSVValues[i] : 10L;
+      }
+      testCaseQueryWithLongResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN 100 ELSE %s END", predicate, LONG_SV_COLUMN),
+              String.format("CASE WHEN %s THEN '100' ELSE %s END", predicate, LONG_SV_COLUMN));
+      long[] expectedValues = new long[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? 100L : _longSVValues[i];
+      }
+      testCaseQueryWithLongResults(expressions, expectedValues);
+    }
+    // Cast INT to LONG
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN CAST(%s AS LONG) ELSE 10 END", predicate, INT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS LONG) ELSE '10' END", predicate, INT_SV_COLUMN));
+      long[] expectedValues = new long[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _intSVValues[i] : 10L;
+      }
+      testCaseQueryWithLongResults(expressions, expectedValues);
+    }
+    // Literal upcast INT to LONG
+    {
+      List<String> expressions = Collections.singletonList(
+          String.format("CASE WHEN %s THEN %s ELSE %d END", predicate, INT_SV_COLUMN, 10L + Integer.MAX_VALUE));
+      long[] expectedValues = new long[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _intSVValues[i] : 10L + Integer.MAX_VALUE;
+      }
+      testCaseQueryWithLongResults(expressions, expectedValues);
+    }
+
+    // FLOAT
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN %s ELSE 10 END", predicate, FLOAT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN %s ELSE '10' END", predicate, FLOAT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN %s ELSE '10.0' END", predicate, FLOAT_SV_COLUMN));
+      float[] expectedValues = new float[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _floatSVValues[i] : 10.0f;
+      }
+      testCaseQueryWithFloatResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN 100 ELSE %s END", predicate, FLOAT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN '100' ELSE %s END", predicate, FLOAT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN '100.0' ELSE %s END", predicate, FLOAT_SV_COLUMN));
+      float[] expectedValues = new float[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? 100.0f : _floatSVValues[i];
+      }
+      testCaseQueryWithFloatResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Collections.singletonList(String.format("CASE WHEN %s THEN %s ELSE '1.23' END", predicate, FLOAT_SV_COLUMN));
+      float[] expectedValues = new float[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _floatSVValues[i] : 1.23f;
+      }
+      testCaseQueryWithFloatResults(expressions, expectedValues);
+    }
+    // Cast INT/LONG to FLOAT
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN CAST(%s AS FLOAT) ELSE 10 END", predicate, INT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS FLOAT) ELSE '10' END", predicate, INT_SV_COLUMN));
+      float[] expectedValues = new float[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _intSVValues[i] : 10.0f;
+      }
+      testCaseQueryWithFloatResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN CAST(%s AS FLOAT) ELSE 10 END", predicate, LONG_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS FLOAT) ELSE '10' END", predicate, LONG_SV_COLUMN));
+      float[] expectedValues = new float[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _longSVValues[i] : 10.0f;
+      }
+      testCaseQueryWithFloatResults(expressions, expectedValues);
+    }
+
+    // DOUBLE
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN %s ELSE 10 END", predicate, DOUBLE_SV_COLUMN),
+              String.format("CASE WHEN %s THEN %s ELSE 10.0 END", predicate, DOUBLE_SV_COLUMN),
+              String.format("CASE WHEN %s THEN %s ELSE '10' END", predicate, DOUBLE_SV_COLUMN),
+              String.format("CASE WHEN %s THEN %s ELSE '10.0' END", predicate, DOUBLE_SV_COLUMN));
+      double[] expectedValues = new double[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _doubleSVValues[i] : 10.0;
+      }
+      testCaseQueryWithDoubleResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN 100 ELSE %s END", predicate, DOUBLE_SV_COLUMN),
+              String.format("CASE WHEN %s THEN 100.0 ELSE %s END", predicate, DOUBLE_SV_COLUMN),
+              String.format("CASE WHEN %s THEN '100' ELSE %s END", predicate, DOUBLE_SV_COLUMN),
+              String.format("CASE WHEN %s THEN '100.0' ELSE %s END", predicate, DOUBLE_SV_COLUMN));
+      double[] expectedValues = new double[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? 100.0 : _doubleSVValues[i];
+      }
+      testCaseQueryWithDoubleResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN %s ELSE 1.23 END", predicate, DOUBLE_SV_COLUMN),
+              String.format("CASE WHEN %s THEN %s ELSE '1.23' END", predicate, DOUBLE_SV_COLUMN));
+      double[] expectedValues = new double[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _doubleSVValues[i] : 1.23;
+      }
+      testCaseQueryWithDoubleResults(expressions, expectedValues);
+    }
+    // Cast INT/LONG/FLOAT to DOUBLE
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN CAST(%s AS DOUBLE) ELSE 10 END", predicate, INT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DOUBLE) ELSE 10.0 END", predicate, INT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DOUBLE) ELSE '10' END", predicate, INT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DOUBLE) ELSE '10.0' END", predicate, INT_SV_COLUMN));
+      double[] expectedValues = new double[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _intSVValues[i] : 10.0;
+      }
+      testCaseQueryWithDoubleResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN CAST(%s AS DOUBLE) ELSE 10 END", predicate, LONG_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DOUBLE) ELSE 10.0 END", predicate, LONG_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DOUBLE) ELSE '10' END", predicate, LONG_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DOUBLE) ELSE '10.0' END", predicate, LONG_SV_COLUMN));
+      double[] expectedValues = new double[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _longSVValues[i] : 10.0;
+      }
+      testCaseQueryWithDoubleResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN CAST(%s AS DOUBLE) ELSE 10 END", predicate, FLOAT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DOUBLE) ELSE 10.0 END", predicate, FLOAT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DOUBLE) ELSE '10' END", predicate, FLOAT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DOUBLE) ELSE '10.0' END", predicate, FLOAT_SV_COLUMN));
+      double[] expectedValues = new double[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _floatSVValues[i] : 10.0;
+      }
+      testCaseQueryWithDoubleResults(expressions, expectedValues);
+    }
+    // Literal upcast INT/LONG/FLOAT to DOUBLE
+    {
+      List<String> expressions =
+          Collections.singletonList(String.format("CASE WHEN %s THEN %s ELSE 1.23 END", predicate, INT_SV_COLUMN));
+      double[] expectedValues = new double[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _intSVValues[i] : 1.23;
+      }
+      testCaseQueryWithDoubleResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Collections.singletonList(String.format("CASE WHEN %s THEN %s ELSE 1.23 END", predicate, LONG_SV_COLUMN));
+      double[] expectedValues = new double[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _longSVValues[i] : 1.23;
+      }
+      testCaseQueryWithDoubleResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Collections.singletonList(String.format("CASE WHEN %s THEN %s ELSE 1.23 END", predicate, FLOAT_SV_COLUMN));
+      double[] expectedValues = new double[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _floatSVValues[i] : 1.23;
+      }
+      testCaseQueryWithDoubleResults(expressions, expectedValues);
+    }
+
+    // BIG_DECIMAL
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN %s ELSE 10 END", predicate, BIG_DECIMAL_SV_COLUMN),
+              String.format("CASE WHEN %s THEN %s ELSE 10.0 END", predicate, BIG_DECIMAL_SV_COLUMN),
+              String.format("CASE WHEN %s THEN %s ELSE '10' END", predicate, BIG_DECIMAL_SV_COLUMN),
+              String.format("CASE WHEN %s THEN %s ELSE '10.0' END", predicate, BIG_DECIMAL_SV_COLUMN));
+      BigDecimal[] expectedValues = new BigDecimal[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _bigDecimalSVValues[i] : BigDecimal.TEN;
+      }
+      testCaseQueryWithBigDecimalResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN 100 ELSE %s END", predicate, BIG_DECIMAL_SV_COLUMN),
+              String.format("CASE WHEN %s THEN 100.0 ELSE %s END", predicate, BIG_DECIMAL_SV_COLUMN),
+              String.format("CASE WHEN %s THEN '100' ELSE %s END", predicate, BIG_DECIMAL_SV_COLUMN),
+              String.format("CASE WHEN %s THEN '100.0' ELSE %s END", predicate, BIG_DECIMAL_SV_COLUMN));
+      BigDecimal[] expectedValues = new BigDecimal[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? BigDecimal.valueOf(100) : _bigDecimalSVValues[i];
+      }
+      testCaseQueryWithBigDecimalResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN %s ELSE 1.23 END", predicate, BIG_DECIMAL_SV_COLUMN),
+              String.format("CASE WHEN %s THEN %s ELSE '1.23' END", predicate, BIG_DECIMAL_SV_COLUMN));
+      BigDecimal[] expectedValues = new BigDecimal[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _bigDecimalSVValues[i] : new BigDecimal("1.23");
+      }
+      testCaseQueryWithBigDecimalResults(expressions, expectedValues);
+    }
+    // Cast INT/LONG/FLOAT/DOUBLE to BIG_DECIMAL
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE 10 END", predicate, INT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE 10.0 END", predicate, INT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE '10' END", predicate, INT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE '10.0' END", predicate, INT_SV_COLUMN));
+      BigDecimal[] expectedValues = new BigDecimal[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? BigDecimal.valueOf(_intSVValues[i]) : BigDecimal.TEN;
+      }
+      testCaseQueryWithBigDecimalResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE 10 END", predicate, LONG_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE 10.0 END", predicate, LONG_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE '10' END", predicate, LONG_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE '10.0' END", predicate, LONG_SV_COLUMN));
+      BigDecimal[] expectedValues = new BigDecimal[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? BigDecimal.valueOf(_longSVValues[i]) : BigDecimal.TEN;
+      }
+      testCaseQueryWithBigDecimalResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE 10 END", predicate, FLOAT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE 10.0 END", predicate, FLOAT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE '10' END", predicate, FLOAT_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE '10.0' END", predicate, FLOAT_SV_COLUMN));
+      BigDecimal[] expectedValues = new BigDecimal[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? BigDecimal.valueOf(_floatSVValues[i]) : BigDecimal.TEN;
+      }
+      testCaseQueryWithBigDecimalResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE 10 END", predicate, DOUBLE_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE 10.0 END", predicate, DOUBLE_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE '10' END", predicate, DOUBLE_SV_COLUMN),
+              String.format("CASE WHEN %s THEN CAST(%s AS DECIMAL) ELSE '10.0' END", predicate, DOUBLE_SV_COLUMN));
+      BigDecimal[] expectedValues = new BigDecimal[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? BigDecimal.valueOf(_doubleSVValues[i]) : BigDecimal.TEN;
+      }
+      testCaseQueryWithBigDecimalResults(expressions, expectedValues);
+    }
+
+    // STRING
+    {
+      List<String> expressions =
+          Collections.singletonList(String.format("CASE WHEN %s THEN %s ELSE '10' END", predicate, STRING_SV_COLUMN));
+      String[] expectedValues = new String[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _stringSVValues[i] : "10";
+      }
+      testCaseQueryWithStringResults(expressions, expectedValues);
+    }
+    {
+      List<String> expressions =
+          Collections.singletonList(String.format("CASE WHEN %s THEN '100' ELSE %s END", predicate, STRING_SV_COLUMN));
+      String[] expectedValues = new String[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? "100" : _stringSVValues[i];
+      }
+      testCaseQueryWithStringResults(expressions, expectedValues);
+    }
+    // Cast INT to STRING
+    {
+      List<String> expressions = Collections.singletonList(
+          String.format("CASE WHEN %s THEN CAST(%s AS STRING) ELSE '10' END", predicate, INT_SV_COLUMN));
+      String[] expectedValues = new String[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? Integer.toString(_intSVValues[i]) : "10";
+      }
+      testCaseQueryWithStringResults(expressions, expectedValues);
+    }
+
+    // BYTES
+    {
+      List<String> expressions =
+          Collections.singletonList(String.format("CASE WHEN %s THEN %s ELSE '10' END", predicate, BYTES_SV_COLUMN));
+      byte[][] expectedValues = new byte[NUM_ROWS][];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _bytesSVValues[i] : BytesUtils.toBytes("10");
+      }
+      testCaseQueryWithBytesResults(expressions, expectedValues);
+    }
+
+    // TIMESTAMP
+    {
+      long currentTimeMs = System.currentTimeMillis();
+      String timestamp = new Timestamp(currentTimeMs).toString();
+      List<String> expressions =
+          Arrays.asList(String.format("CASE WHEN %s THEN %s ELSE '%s' END", predicate, TIMESTAMP_COLUMN, timestamp),
+              String.format("CASE WHEN %s THEN %s ELSE '%d' END", predicate, TIMESTAMP_COLUMN, currentTimeMs));
+      long[] expectedValues = new long[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _timeValues[i] : currentTimeMs;
+      }
+      testCaseQueryWithTimestampResults(expressions, expectedValues);
+    }
+    // Cast LONG to TIMESTAMP
+    {
+      long currentTimeMs = System.currentTimeMillis();
+      String timestamp = new Timestamp(currentTimeMs).toString();
+      List<String> expressions = Arrays.asList(
+          String.format("CASE WHEN %s THEN CAST(%s AS TIMESTAMP) ELSE '%s' END", predicate, LONG_SV_COLUMN, timestamp),
+          String.format("CASE WHEN %s THEN CAST(%s AS TIMESTAMP) ELSE '%d' END", predicate, LONG_SV_COLUMN,
+              currentTimeMs));
+      long[] expectedValues = new long[NUM_ROWS];
+      for (int i = 0; i < NUM_ROWS; i++) {
+        expectedValues[i] = predicateResults[i] ? _longSVValues[i] : currentTimeMs;
+      }
+      testCaseQueryWithTimestampResults(expressions, expectedValues);
+    }
   }
 
-  private void testCaseQueryWithFloatResults(String predicate, float[] expectedValues) {
-    ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("CASE WHEN %s THEN 100.0 ELSE 10.0 END", predicate));
-    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
-    assertEquals(transformFunction.getName(), CaseTransformFunction.FUNCTION_NAME);
-    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.FLOAT);
-    testTransformFunction(transformFunction, expectedValues);
+  private void testCaseQueryWithIntResults(List<String> expressions, int[] expectedValues) {
+    for (String expression : expressions) {
+      ExpressionContext expressionContext = RequestContextUtils.getExpression(expression);
+      TransformFunction transformFunction = TransformFunctionFactory.get(expressionContext, _dataSourceMap);
+      Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+      assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.INT);
+      testTransformFunction(transformFunction, expectedValues);
+    }
   }
 
-  private void testCaseQueryWithBigDecimalResults(String predicate, BigDecimal[] expectedValues) {
-    // Note: defining decimal literals within quotes preserves precision.
-    ExpressionContext expression = RequestContextUtils.getExpression(
-        String.format("CASE WHEN %s THEN '100.99887766554433221' ELSE '10.1122334455667788909' END", predicate));
-    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
-    assertEquals(transformFunction.getName(), CaseTransformFunction.FUNCTION_NAME);
-    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.BIG_DECIMAL);
-    testTransformFunction(transformFunction, expectedValues);
+  private void testCaseQueryWithLongResults(List<String> expressions, long[] expectedValues) {
+    for (String expression : expressions) {
+      ExpressionContext expressionContext = RequestContextUtils.getExpression(expression);
+      TransformFunction transformFunction = TransformFunctionFactory.get(expressionContext, _dataSourceMap);
+      Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+      assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.LONG);
+      testTransformFunction(transformFunction, expectedValues);
+    }
   }
 
-  private void testCaseQueryWithStringResults(String predicate, String[] expectedValues) {
-    ExpressionContext expression =
-        RequestContextUtils.getExpression(String.format("CASE WHEN %s THEN 'aaa' ELSE 'bbb' END", predicate));
-    TransformFunction transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
-    Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
-    assertEquals(transformFunction.getName(), CaseTransformFunction.FUNCTION_NAME);
-    assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.STRING);
-    testTransformFunction(transformFunction, expectedValues);
+  private void testCaseQueryWithFloatResults(List<String> expressions, float[] expectedValues) {
+    for (String expression : expressions) {
+      ExpressionContext expressionContext = RequestContextUtils.getExpression(expression);
+      TransformFunction transformFunction = TransformFunctionFactory.get(expressionContext, _dataSourceMap);
+      Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+      assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.FLOAT);
+      testTransformFunction(transformFunction, expectedValues);
+    }
   }
 
-  private int[] getExpectedIntResults(String column, TransformFunctionType type) {
-    int[] result = new int[NUM_ROWS];
+  private void testCaseQueryWithDoubleResults(List<String> expressions, double[] expectedValues) {
+    for (String expression : expressions) {
+      ExpressionContext expressionContext = RequestContextUtils.getExpression(expression);
+      TransformFunction transformFunction = TransformFunctionFactory.get(expressionContext, _dataSourceMap);
+      Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+      assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.DOUBLE);
+      testTransformFunction(transformFunction, expectedValues);
+    }
+  }
+
+  private void testCaseQueryWithBigDecimalResults(List<String> expressions, BigDecimal[] expectedValues) {
+    for (String expression : expressions) {
+      ExpressionContext expressionContext = RequestContextUtils.getExpression(expression);
+      TransformFunction transformFunction = TransformFunctionFactory.get(expressionContext, _dataSourceMap);
+      Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+      assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.BIG_DECIMAL);
+      testTransformFunction(transformFunction, expectedValues);
+    }
+  }
+
+  private void testCaseQueryWithStringResults(List<String> expressions, String[] expectedValues) {
+    for (String expression : expressions) {
+      ExpressionContext expressionContext = RequestContextUtils.getExpression(expression);
+      TransformFunction transformFunction = TransformFunctionFactory.get(expressionContext, _dataSourceMap);
+      Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+      assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.STRING);
+      testTransformFunction(transformFunction, expectedValues);
+    }
+  }
+
+  private void testCaseQueryWithBytesResults(List<String> expressions, byte[][] expectedValues) {
+    for (String expression : expressions) {
+      ExpressionContext expressionContext = RequestContextUtils.getExpression(expression);
+      TransformFunction transformFunction = TransformFunctionFactory.get(expressionContext, _dataSourceMap);
+      Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+      assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.BYTES);
+      testTransformFunction(transformFunction, expectedValues);
+    }
+  }
+
+  private void testCaseQueryWithTimestampResults(List<String> expressions, long[] expectedValues) {
+    for (String expression : expressions) {
+      ExpressionContext expressionContext = RequestContextUtils.getExpression(expression);
+      TransformFunction transformFunction = TransformFunctionFactory.get(expressionContext, _dataSourceMap);
+      Assert.assertTrue(transformFunction instanceof CaseTransformFunction);
+      assertEquals(transformFunction.getResultMetadata().getDataType(), DataType.TIMESTAMP);
+      testTransformFunction(transformFunction, expectedValues);
+    }
+  }
+
+  private boolean[] getPredicateResults(String column, TransformFunctionType type) {
+    boolean[] results = new boolean[NUM_ROWS];
     for (int i = 0; i < NUM_ROWS; i++) {
       switch (column) {
         case INT_SV_COLUMN:
           switch (type) {
             case EQUALS:
-              result[i] = (_intSVValues[i] == _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _intSVValues[i] == _intSVValues[INDEX_TO_COMPARE];
               break;
             case NOT_EQUALS:
-              result[i] = (_intSVValues[i] != _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _intSVValues[i] != _intSVValues[INDEX_TO_COMPARE];
               break;
             case GREATER_THAN:
-              result[i] = (_intSVValues[i] > _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _intSVValues[i] > _intSVValues[INDEX_TO_COMPARE];
               break;
             case GREATER_THAN_OR_EQUAL:
-              result[i] = (_intSVValues[i] >= _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _intSVValues[i] >= _intSVValues[INDEX_TO_COMPARE];
               break;
             case LESS_THAN:
-              result[i] = (_intSVValues[i] < _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _intSVValues[i] < _intSVValues[INDEX_TO_COMPARE];
               break;
             case LESS_THAN_OR_EQUAL:
-              result[i] = (_intSVValues[i] <= _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _intSVValues[i] <= _intSVValues[INDEX_TO_COMPARE];
               break;
             default:
-              throw new IllegalStateException("Not supported type - " + type);
+              throw new IllegalStateException();
           }
           break;
         case LONG_SV_COLUMN:
           switch (type) {
             case EQUALS:
-              result[i] = (_longSVValues[i] == _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _longSVValues[i] == _longSVValues[INDEX_TO_COMPARE];
               break;
             case NOT_EQUALS:
-              result[i] = (_longSVValues[i] != _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _longSVValues[i] != _longSVValues[INDEX_TO_COMPARE];
               break;
             case GREATER_THAN:
-              result[i] = (_longSVValues[i] > _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _longSVValues[i] > _longSVValues[INDEX_TO_COMPARE];
               break;
             case GREATER_THAN_OR_EQUAL:
-              result[i] = (_longSVValues[i] >= _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _longSVValues[i] >= _longSVValues[INDEX_TO_COMPARE];
               break;
             case LESS_THAN:
-              result[i] = (_longSVValues[i] < _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _longSVValues[i] < _longSVValues[INDEX_TO_COMPARE];
               break;
             case LESS_THAN_OR_EQUAL:
-              result[i] = (_longSVValues[i] <= _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _longSVValues[i] <= _longSVValues[INDEX_TO_COMPARE];
               break;
             default:
-              throw new IllegalStateException("Not supported type - " + type);
+              throw new IllegalStateException();
           }
           break;
         case FLOAT_SV_COLUMN:
           switch (type) {
             case EQUALS:
-              result[i] = (_floatSVValues[i] == _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _floatSVValues[i] == _floatSVValues[INDEX_TO_COMPARE];
               break;
             case NOT_EQUALS:
-              result[i] = (_floatSVValues[i] != _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _floatSVValues[i] != _floatSVValues[INDEX_TO_COMPARE];
               break;
             case GREATER_THAN:
-              result[i] = (_floatSVValues[i] > _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _floatSVValues[i] > _floatSVValues[INDEX_TO_COMPARE];
               break;
             case GREATER_THAN_OR_EQUAL:
-              result[i] = (_floatSVValues[i] >= _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _floatSVValues[i] >= _floatSVValues[INDEX_TO_COMPARE];
               break;
             case LESS_THAN:
-              result[i] = (_floatSVValues[i] < _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _floatSVValues[i] < _floatSVValues[INDEX_TO_COMPARE];
               break;
             case LESS_THAN_OR_EQUAL:
-              result[i] = (_floatSVValues[i] <= _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _floatSVValues[i] <= _floatSVValues[INDEX_TO_COMPARE];
               break;
             default:
-              throw new IllegalStateException("Not supported type - " + type);
+              throw new IllegalStateException();
           }
           break;
         case DOUBLE_SV_COLUMN:
           switch (type) {
             case EQUALS:
-              result[i] = (_doubleSVValues[i] == _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _doubleSVValues[i] == _doubleSVValues[INDEX_TO_COMPARE];
               break;
             case NOT_EQUALS:
-              result[i] = (_doubleSVValues[i] != _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _doubleSVValues[i] != _doubleSVValues[INDEX_TO_COMPARE];
               break;
             case GREATER_THAN:
-              result[i] = (_doubleSVValues[i] > _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _doubleSVValues[i] > _doubleSVValues[INDEX_TO_COMPARE];
               break;
             case GREATER_THAN_OR_EQUAL:
-              result[i] = (_doubleSVValues[i] >= _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _doubleSVValues[i] >= _doubleSVValues[INDEX_TO_COMPARE];
               break;
             case LESS_THAN:
-              result[i] = (_doubleSVValues[i] < _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _doubleSVValues[i] < _doubleSVValues[INDEX_TO_COMPARE];
               break;
             case LESS_THAN_OR_EQUAL:
-              result[i] = (_doubleSVValues[i] <= _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
+              results[i] = _doubleSVValues[i] <= _doubleSVValues[INDEX_TO_COMPARE];
               break;
             default:
-              throw new IllegalStateException("Not supported type - " + type);
+              throw new IllegalStateException();
           }
           break;
         case STRING_SV_COLUMN:
           switch (type) {
             case EQUALS:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) == 0) ? 100 : 10;
+              results[i] = _stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) == 0;
               break;
             case NOT_EQUALS:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) != 0) ? 100 : 10;
+              results[i] = _stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) != 0;
               break;
             case GREATER_THAN:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) > 0) ? 100 : 10;
+              results[i] = _stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) > 0;
               break;
             case GREATER_THAN_OR_EQUAL:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) >= 0) ? 100 : 10;
+              results[i] = _stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) >= 0;
               break;
             case LESS_THAN:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) < 0) ? 100 : 10;
+              results[i] = _stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) < 0;
               break;
             case LESS_THAN_OR_EQUAL:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) <= 0) ? 100 : 10;
+              results[i] = _stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) <= 0;
               break;
             default:
-              throw new IllegalStateException("Not supported type - " + type);
+              throw new IllegalStateException();
           }
           break;
         default:
-          break;
+          throw new IllegalStateException();
       }
     }
-    return result;
-  }
-
-  private float[] getExpectedFloatResults(String column, TransformFunctionType type) {
-    float[] result = new float[NUM_ROWS];
-    for (int i = 0; i < NUM_ROWS; i++) {
-      switch (column) {
-        case INT_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_intSVValues[i] == _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case NOT_EQUALS:
-              result[i] = (_intSVValues[i] != _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case GREATER_THAN:
-              result[i] = (_intSVValues[i] > _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_intSVValues[i] >= _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case LESS_THAN:
-              result[i] = (_intSVValues[i] < _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_intSVValues[i] <= _intSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        case LONG_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_longSVValues[i] == _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case NOT_EQUALS:
-              result[i] = (_longSVValues[i] != _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case GREATER_THAN:
-              result[i] = (_longSVValues[i] > _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_longSVValues[i] >= _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case LESS_THAN:
-              result[i] = (_longSVValues[i] < _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_longSVValues[i] <= _longSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        case FLOAT_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_floatSVValues[i] == _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case NOT_EQUALS:
-              result[i] = (_floatSVValues[i] != _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case GREATER_THAN:
-              result[i] = (_floatSVValues[i] > _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_floatSVValues[i] >= _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case LESS_THAN:
-              result[i] = (_floatSVValues[i] < _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_floatSVValues[i] <= _floatSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        case DOUBLE_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_doubleSVValues[i] == _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case NOT_EQUALS:
-              result[i] = (_doubleSVValues[i] != _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case GREATER_THAN:
-              result[i] = (_doubleSVValues[i] > _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_doubleSVValues[i] >= _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case LESS_THAN:
-              result[i] = (_doubleSVValues[i] < _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_doubleSVValues[i] <= _doubleSVValues[INDEX_TO_COMPARE]) ? 100 : 10;
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        case STRING_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) == 0) ? 100 : 10;
-              break;
-            case NOT_EQUALS:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) != 0) ? 100 : 10;
-              break;
-            case GREATER_THAN:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) > 0) ? 100 : 10;
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) >= 0) ? 100 : 10;
-              break;
-            case LESS_THAN:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) < 0) ? 100 : 10;
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) <= 0) ? 100 : 10;
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        default:
-          break;
-      }
-    }
-    return result;
-  }
-
-  private BigDecimal[] getExpectedBigDecimalResults(String column, TransformFunctionType type) {
-    BigDecimal[] result = new BigDecimal[NUM_ROWS];
-    BigDecimal val1 = new BigDecimal("100.99887766554433221");
-    BigDecimal val2 = new BigDecimal("10.1122334455667788909");
-    for (int i = 0; i < NUM_ROWS; i++) {
-      switch (column) {
-        case INT_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_intSVValues[i] == _intSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case NOT_EQUALS:
-              result[i] = (_intSVValues[i] != _intSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case GREATER_THAN:
-              result[i] = (_intSVValues[i] > _intSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_intSVValues[i] >= _intSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case LESS_THAN:
-              result[i] = (_intSVValues[i] < _intSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_intSVValues[i] <= _intSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        case LONG_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_longSVValues[i] == _longSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case NOT_EQUALS:
-              result[i] = (_longSVValues[i] != _longSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case GREATER_THAN:
-              result[i] = (_longSVValues[i] > _longSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_longSVValues[i] >= _longSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case LESS_THAN:
-              result[i] = (_longSVValues[i] < _longSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_longSVValues[i] <= _longSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        case FLOAT_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_floatSVValues[i] == _floatSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case NOT_EQUALS:
-              result[i] = (_floatSVValues[i] != _floatSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case GREATER_THAN:
-              result[i] = (_floatSVValues[i] > _floatSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_floatSVValues[i] >= _floatSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case LESS_THAN:
-              result[i] = (_floatSVValues[i] < _floatSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_floatSVValues[i] <= _floatSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        case DOUBLE_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_doubleSVValues[i] == _doubleSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case NOT_EQUALS:
-              result[i] = (_doubleSVValues[i] != _doubleSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case GREATER_THAN:
-              result[i] = (_doubleSVValues[i] > _doubleSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_doubleSVValues[i] >= _doubleSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case LESS_THAN:
-              result[i] = (_doubleSVValues[i] < _doubleSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_doubleSVValues[i] <= _doubleSVValues[INDEX_TO_COMPARE]) ? val1 : val2;
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        case BIG_DECIMAL_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = _bigDecimalSVValues[i].compareTo(_bigDecimalSVValues[INDEX_TO_COMPARE]) == 0 ? val1 : val2;
-              break;
-            case NOT_EQUALS:
-              result[i] = _bigDecimalSVValues[i].compareTo(_bigDecimalSVValues[INDEX_TO_COMPARE]) != 0 ? val1 : val2;
-              break;
-            case GREATER_THAN:
-              result[i] = _bigDecimalSVValues[i].compareTo(_bigDecimalSVValues[INDEX_TO_COMPARE]) > 0 ? val1 : val2;
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = _bigDecimalSVValues[i].compareTo(_bigDecimalSVValues[INDEX_TO_COMPARE]) >= 0 ? val1 : val2;
-              break;
-            case LESS_THAN:
-              result[i] = _bigDecimalSVValues[i].compareTo(_bigDecimalSVValues[INDEX_TO_COMPARE]) < 0 ? val1 : val2;
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = _bigDecimalSVValues[i].compareTo(_bigDecimalSVValues[INDEX_TO_COMPARE]) <= 0 ? val1 : val2;
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        case STRING_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) == 0) ? val1 : val2;
-              break;
-            case NOT_EQUALS:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) != 0) ? val1 : val2;
-              break;
-            case GREATER_THAN:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) > 0) ? val1 : val2;
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) >= 0) ? val1 : val2;
-              break;
-            case LESS_THAN:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) < 0) ? val1 : val2;
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) <= 0) ? val1 : val2;
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        default:
-          break;
-      }
-    }
-    return result;
-  }
-
-  private String[] getExpectedStringResults(String column, TransformFunctionType type) {
-    String[] result = new String[NUM_ROWS];
-    for (int i = 0; i < NUM_ROWS; i++) {
-      switch (column) {
-        case INT_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_intSVValues[i] == _intSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case NOT_EQUALS:
-              result[i] = (_intSVValues[i] != _intSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case GREATER_THAN:
-              result[i] = (_intSVValues[i] > _intSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_intSVValues[i] >= _intSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case LESS_THAN:
-              result[i] = (_intSVValues[i] < _intSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_intSVValues[i] <= _intSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        case LONG_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_longSVValues[i] == _longSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case NOT_EQUALS:
-              result[i] = (_longSVValues[i] != _longSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case GREATER_THAN:
-              result[i] = (_longSVValues[i] > _longSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_longSVValues[i] >= _longSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case LESS_THAN:
-              result[i] = (_longSVValues[i] < _longSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_longSVValues[i] <= _longSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        case FLOAT_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_floatSVValues[i] == _floatSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case NOT_EQUALS:
-              result[i] = (_floatSVValues[i] != _floatSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case GREATER_THAN:
-              result[i] = (_floatSVValues[i] > _floatSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_floatSVValues[i] >= _floatSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case LESS_THAN:
-              result[i] = (_floatSVValues[i] < _floatSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_floatSVValues[i] <= _floatSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        case DOUBLE_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_doubleSVValues[i] == _doubleSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case NOT_EQUALS:
-              result[i] = (_doubleSVValues[i] != _doubleSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case GREATER_THAN:
-              result[i] = (_doubleSVValues[i] > _doubleSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_doubleSVValues[i] >= _doubleSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case LESS_THAN:
-              result[i] = (_doubleSVValues[i] < _doubleSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_doubleSVValues[i] <= _doubleSVValues[INDEX_TO_COMPARE]) ? "aaa" : "bbb";
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        case STRING_SV_COLUMN:
-          switch (type) {
-            case EQUALS:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) == 0) ? "aaa" : "bbb";
-              break;
-            case NOT_EQUALS:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) != 0) ? "aaa" : "bbb";
-              break;
-            case GREATER_THAN:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) > 0) ? "aaa" : "bbb";
-              break;
-            case GREATER_THAN_OR_EQUAL:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) >= 0) ? "aaa" : "bbb";
-              break;
-            case LESS_THAN:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) < 0) ? "aaa" : "bbb";
-              break;
-            case LESS_THAN_OR_EQUAL:
-              result[i] = (_stringSVValues[i].compareTo(_stringSVValues[INDEX_TO_COMPARE]) <= 0) ? "aaa" : "bbb";
-              break;
-            default:
-              throw new IllegalStateException("Not supported type - " + type);
-          }
-          break;
-        default:
-          break;
-      }
-    }
-    return result;
+    return results;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/DivisionTransformFunctionTest.java
@@ -100,7 +100,7 @@ public class DivisionTransformFunctionTest extends BaseTransformFunctionTest {
     testTransformFunction(transformFunction, expectedBigDecimalValues);
 
     expression = RequestContextUtils.getExpression(
-        String.format("div(div(div('3430.34473923874923809',div(%s,0.34)),%s),%s)", STRING_SV_COLUMN,
+        String.format("div(div(div(cast('3430.34473923874923809' as decimal),div(%s,0.34)),%s),%s)", STRING_SV_COLUMN,
             BIG_DECIMAL_SV_COLUMN, INT_SV_COLUMN));
     transformFunction = TransformFunctionFactory.get(expression, _dataSourceMap);
     Assert.assertTrue(transformFunction instanceof DivisionTransformFunction);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/QueriesTestUtils.java
@@ -133,8 +133,16 @@ public class QueriesTestUtils {
   private static void validateRows(List<Object[]> actual, List<Object[]> expected) {
     assertEquals(actual.size(), expected.size());
     for (int i = 0; i < actual.size(); i++) {
-      // Generic assertEquals delegates to assertArrayEquals, which can test for equality of array values in rows.
-      assertEquals((Object) actual.get(i), (Object) expected.get(i));
+      // NOTE: Do not use 'assertEquals(actual.get(i), expected.get(i))' because for array within the row, it only
+      //       compares the reference of the array, instead of the content of the array.
+      validateRow(actual.get(i), expected.get(i));
+    }
+  }
+
+  private static void validateRow(Object[] actual, Object[] expected) {
+    assertEquals(actual.length, expected.length);
+    for (int i = 0; i < actual.length; i++) {
+      assertEquals(actual[i], expected[i]);
     }
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -998,6 +998,18 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
     }
   }
 
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testFunctionWithLiteral(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+
+    testQuery("SELECT SUM(10) FROM mytable");
+    testQuery("SELECT ArrDelay + 10 FROM mytable");
+    testQuery("SELECT ArrDelay + '10' FROM mytable");
+    testQuery("SELECT SUM(ArrDelay + 10) FROM mytable");
+    testQuery("SELECT SUM(ArrDelay + '10') FROM mytable");
+  }
+
   @Test
   public void testLiteralOnlyFuncV1()
       throws Exception {

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/GeoSpatialTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/GeoSpatialTest.java
@@ -304,11 +304,11 @@ public class GeoSpatialTest extends CustomDataQueryClusterIntegrationTest {
     {
       String query =
           String.format("Select "
-                  + "ST_Point(a.st_x, a.st_y, -1), "
+                  + "ST_Point(a.st_x, a.st_y, 0), "
                   + "ST_Point(a.st_x, a.st_y, 1), "
                   + "b.st_point, "
                   + "b.st_point_1, "
-                  + "ST_DISTANCE(ST_Point(a.st_x, a.st_y, -1), b.st_point), "
+                  + "ST_DISTANCE(ST_Point(a.st_x, a.st_y, 0), b.st_point), "
                   + "ST_DISTANCE(ST_Point(a.st_x, a.st_y, 1), b.st_point_1), "
                   + "ST_DISTANCE(ST_Point(a.st_x, a.st_y, 0), ST_Point(40, -40, 0)), "
                   + "ST_DISTANCE(ST_Point(a.st_x, a.st_y, 1), ST_Point(40, -40, 1)) "

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -256,6 +256,9 @@ public class ServerPlanRequestUtils {
         Arrays.sort(arrFloat);
         for (int rowIdx = 0; rowIdx < numRows; rowIdx++) {
           // TODO: Create float literal when it is supported
+          // NOTE: We cannot directly cast float to double here because we want to preserve the exact value. E.g. 0.05f
+          //       will be casted to 0.05000000074505806. Predicate evaluation uses string format to match the values,
+          //       so here we need to create the double value based on the string format of the float value.
           expressions.add(RequestUtils.getLiteralExpression(Double.parseDouble(Float.toString(arrFloat[rowIdx]))));
         }
         break;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/plan/server/ServerPlanRequestUtils.java
@@ -255,7 +255,8 @@ public class ServerPlanRequestUtils {
         }
         Arrays.sort(arrFloat);
         for (int rowIdx = 0; rowIdx < numRows; rowIdx++) {
-          expressions.add(RequestUtils.getLiteralExpression(arrFloat[rowIdx]));
+          // TODO: Create float literal when it is supported
+          expressions.add(RequestUtils.getLiteralExpression(Double.parseDouble(Float.toString(arrFloat[rowIdx]))));
         }
         break;
       case DOUBLE:

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BooleanUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BooleanUtils.java
@@ -65,13 +65,6 @@ public class BooleanUtils {
   }
 
   /**
-   * Returns the int value (1 for true, 0 for false) for the given boolean value.
-   */
-  public static int toInt(boolean booleanValue) {
-    return booleanValue ? INTERNAL_TRUE : INTERNAL_FALSE;
-  }
-
-  /**
    * Returns the boolean value for the given non-null Integer object (internal value for BOOLEAN).
    */
   public static boolean fromNonNullInternalValue(Object value) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BooleanUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BooleanUtils.java
@@ -65,6 +65,13 @@ public class BooleanUtils {
   }
 
   /**
+   * Returns the int value (1 for true, 0 for false) for the given boolean value.
+   */
+  public static int toInt(boolean booleanValue) {
+    return booleanValue ? INTERNAL_TRUE : INTERNAL_FALSE;
+  }
+
+  /**
    * Returns the boolean value for the given non-null Integer object (internal value for BOOLEAN).
    */
   public static boolean fromNonNullInternalValue(Object value) {


### PR DESCRIPTION
Currently when literal is single quoted (e.g. 'abc', '123', '1.23'), the type is auto-derived based on the literal itself. Also, it can only derive to big-decimal, timestamp or string but not other numeric types.
In Standard SQL (we reference PostgreSQL convention as standard), single quoted literal has unknown type and the type should be resolved based on the context around the literal (read more [here](https://www.postgresql.org/docs/current/typeconv-overview.html)).

This PR:
- Preserve the literal type, and only resolve the type when the context is clear
- Fix the wrong behavior when quoted string is used as number (currently it will be resolved as 0)
- Fix `CASE` to follow the PostgreSQL convention (read more [here](https://www.postgresql.org/docs/current/typeconv-union-case.html)), and fix a bug of reading float value as double type

# Incompatible
Following standard SQL, single quoted literal won't have its type auto-derived. In order to create big-decimal literal, user should use `cast('12345.6789' AS DECIMAL)` explicitly