### PR TITLE
track rebalance status when instance assignment already correct

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/ZkBasedTableRebalanceObserver.java
@@ -98,7 +98,8 @@ public class ZkBasedTableRebalanceObserver implements TableRebalanceObserver {
 
   @Override
   public void onSuccess(String msg) {
-    Preconditions.checkState(_tableRebalanceProgressStats.getStatus() != RebalanceResult.Status.DONE.toString(),
+    Preconditions.checkState(
+        !_tableRebalanceProgressStats.getStatus().equals(RebalanceResult.Status.DONE.toString()),
         "Table Rebalance already completed");
     long timeToFinishInSeconds =
          (System.currentTimeMillis() - _tableRebalanceProgressStats.getStartTimeMs()) / 1000L;


### PR DESCRIPTION
This is a small `bugfix` for the table rebalancer. This triggers the start of the rebalance observer earlier. It then sets it to success when instance assignment is already complete. If you rebalance a table with "reassignAssignments" and the instance assignment doesn't change, you will get "IN_PROGRESS" back, but the id won't exist in zk. So polling that id will just give you a 404, but the logs will say the table is already balanced.

After this fix, the id will get updated in ZK, so you can poll it. I updated existing unit tests, and I also tested with the hybrid quickstart. Though testing with code from 5 months ago vs latest master seems to get different results. The older code would return "IN_PROGRESS" consistently, and now I'm getting back "NO_OP" which is also correct. I think #11073 actually fixed this, but there's likely still some cases where this helps.