### PR TITLE
Prevent NPE when attempt to fetch partition information fails

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaStreamMetadataProvider.java
@@ -24,8 +24,11 @@ import java.time.Clock;
 import java.time.Duration;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import org.apache.commons.collections.CollectionUtils;
 import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.common.PartitionInfo;
 import org.apache.kafka.common.errors.TimeoutException;
 import org.apache.pinot.spi.stream.ConsumerPartitionState;
 import org.apache.pinot.spi.stream.LongMsgOffset;
@@ -57,7 +60,11 @@ public class KafkaStreamMetadataProvider extends KafkaPartitionLevelConnectionHa
   @Override
   public int fetchPartitionCount(long timeoutMillis) {
     try {
-      return _consumer.partitionsFor(_topic, Duration.ofMillis(timeoutMillis)).size();
+      List<PartitionInfo> partitionInfos = _consumer.partitionsFor(_topic, Duration.ofMillis(timeoutMillis));
+      if (CollectionUtils.isNotEmpty(partitionInfos)) {
+        return partitionInfos.size();
+      }
+      throw new RuntimeException(String.format("Failed to fetch partition information for topic: %s", _topic));
     } catch (TimeoutException e) {
       throw new TransientConsumerException(e);
     }


### PR DESCRIPTION

Changes are to prevent the NPE and provide a meaningful error message to the user when there is a failure to fetch the partition information.

NPE seen by the end user who created a Kafka topic without any partitions in a third-party managed Kafka cluster.
```
Caused by: java.lang.NullPointerException
        at org.apache.pinot.plugin.stream.kafka20.KafkaStreamMetadataProvider.fetchPartitionCount(KafkaStreamMetadataProvider.java:60) ~[startree-write-api-0.13.0-ST.98.3-shaded.jar:0.13.0-ST.98.3-1eb9c04b445be445d976f47c790dddaed274298d]
        at org.apache.pinot.spi.stream.StreamMetadataProvider.computePartitionGroupMetadata(StreamMetadataProvider.java:68) ~[startree-pinot-all-0.13.0-ST.98.3-jar-with-dependencies.jar:0.13.0-ST.98.3-1eb9c04b445be445d976f47c790dddaed274298d]
        at org.apache.pinot.spi.stream.PartitionGroupMetadataFetcher.call(PartitionGroupMetadataFetcher.java:70) ~[startree-pinot-all-0.13.0-ST.98.3-jar-with-dependencies.jar:0.13.0-ST.98.3-1eb9c04b445be445d976f47c790dddaed274298d]
        at org.apache.pinot.spi.stream.PartitionGroupMetadataFetcher.call(PartitionGroupMetadataFetcher.java:31) ~[startree-pinot-all-0.13.0-ST.98.3-jar-with-dependencies.jar:0.13.0-ST.98.3-1eb9c04b445be445d976f47c790dddaed274298d]
        at org.apache.pinot.spi.utils.retry.BaseRetryPolicy.attempt(BaseRetryPolicy.java:50) ~[startree-pinot-all-0.13.0-ST.98.3-jar-with-dependencies.jar:0.13.0-ST.98.3-1eb9c04b445be445d976f47c790dddaed274298d]
        at org.apache.pinot.controller.helix.core.PinotTableIdealStateBuilder.getPartitionGroupMetadataList(PinotTableIdealStateBuilder.java:160) ~[startree-pinot-all-0.13.0-ST.98.3-jar-with-dependencies.jar:0.13.0-ST.98.3-1eb9c04b445be445d976f47c790dddaed274298d]
        ... 31 more
```

**Notes:** Unable to add a test using mocks as the class `KafkaPartitionLevelConnectionHandler` declares the consumer as  final within it's constructor. Additionally, the Kafka library always creates a default partition (`0`) when creating the Kafka topic.