### PR TITLE
Fix a flaky test

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/NotFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/NotFilterOperatorTest.java
@@ -23,6 +23,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.segment.spi.Constants;
@@ -35,7 +36,7 @@ public class NotFilterOperatorTest {
   @Test
   public void testNotOperator() {
     int[] docIds1 = new int[]{2, 3, 10, 15, 16, 17, 18, 21, 22, 23, 24, 26, 28};
-    Set<Integer> expectedResult = new HashSet();
+    Set<Integer> expectedResult = new LinkedHashSet();
     expectedResult.addAll(Arrays.asList(0, 1, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 19, 20, 25, 27, 29));
     Iterator<Integer> expectedIterator = expectedResult.iterator();
     NotFilterOperator notFilterOperator = new NotFilterOperator(new TestFilterOperator(docIds1, 30), 30, false);


### PR DESCRIPTION
This PR is to fix a flaky test `org.apache.pinot.core.operator.filter.NotFilterOperatorTest#testNotOperator` in `pinot-core`.

## Test failures
- Run the following commands to reproduce test failures:
```
mvn -pl pinot-core edu.illinois:nondex-maven-plugin:2.1.1:nondex -Dtest=org.apache.pinot.core.operator.filter.NotFilterOperatorTest#testNotOperator
```
- Then we get the following failures:
```
java.lang.AssertionError: expected [14] but found [0]
```

## Root cause and fix
In line 38, `expectedResult` is defined as a `HashSet`, which does not guarantee the orders of its elements, so in line 46, when iterating the elements of a `HashSet`, the elements returned are not in a consistent order, which leads to test failures. To fix the flakiness, use `LinkedHashSet` instead of `HashSet`.
