### PR TITLE
Adding support for generating data in JSON format.

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/DataGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/DataGenerator.java
@@ -135,7 +135,7 @@ public class DataGenerator {
     final ObjectMapper mapper = new ObjectMapper();
     for (int i = 0; i < numFiles; i++) {
       try (FileWriter writer = new FileWriter(new File(_outDir, String.format("output_%d.json", i)))) {
-        for(int j = 0; j < numPerFiles; j++) {
+        for (int j = 0; j < numPerFiles; j++) {
           Map<String, Object> row = new HashMap<>();
           for (int k = 0; k < _genSpec.getColumns().size(); k++) {
             String key = _genSpec.getColumns().get(k);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/DataGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/DataGenerator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.controller.recommender.data.generator;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.File;
 import java.io.FileWriter;
 import java.io.IOException;
@@ -123,6 +124,24 @@ public class DataGenerator {
             values[k] = serializeIfMultiValue(next);
           }
           writer.append(StringUtils.join(values, ",")).append('\n');
+        }
+      }
+    }
+  }
+
+  public void generateJson(long totalDocs, int numFiles)
+      throws IOException {
+    final int numPerFiles = (int) (totalDocs / numFiles);
+    final ObjectMapper mapper = new ObjectMapper();
+    for (int i = 0; i < numFiles; i++) {
+      try (FileWriter writer = new FileWriter(new File(_outDir, String.format("output_%d.json", i)))) {
+        for(int j = 0; j < numPerFiles; j++) {
+          Map<String, Object> row = new HashMap<>();
+          for (int k = 0; k < _genSpec.getColumns().size(); k++) {
+            String key = _genSpec.getColumns().get(k);
+            row.put(key, _generators.get(key).next());
+          }
+          writer.append(mapper.writeValueAsString(row)).append('\n');
         }
       }
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GenerateDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GenerateDataCommand.java
@@ -54,6 +54,7 @@ public class GenerateDataCommand extends AbstractBaseAdminCommand implements Com
 
   private final static String FORMAT_AVRO = "avro";
   private final static String FORMAT_CSV = "csv";
+  private final static String FORMAT_JSON = "json";
 
   @CommandLine.Option(names = {"-numRecords"}, required = true, description = "Number of records to generate.")
   private int _numRecords = 0;
@@ -79,7 +80,7 @@ public class GenerateDataCommand extends AbstractBaseAdminCommand implements Com
   private boolean _help = false;
 
   @CommandLine.Option(names = {"-format"}, required = false, help = true,
-      description = "Output format ('AVRO' or 'CSV').")
+      description = "Output format ('AVRO' or 'CSV' or 'JSON').")
   private String _format = FORMAT_AVRO;
 
   @Override
@@ -150,6 +151,8 @@ public class GenerateDataCommand extends AbstractBaseAdminCommand implements Com
       gen.generateAvro(_numRecords, _numFiles);
     } else if (FORMAT_CSV.equalsIgnoreCase(_format)) {
       gen.generateCsv(_numRecords, _numFiles);
+    } else if(FORMAT_JSON.equalsIgnoreCase(_format)) {
+      gen.generateJson(_numRecords, _numFiles);
     } else {
       throw new IllegalArgumentException(String.format("Invalid output format '%s'", _format));
     }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GenerateDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/GenerateDataCommand.java
@@ -151,7 +151,7 @@ public class GenerateDataCommand extends AbstractBaseAdminCommand implements Com
       gen.generateAvro(_numRecords, _numFiles);
     } else if (FORMAT_CSV.equalsIgnoreCase(_format)) {
       gen.generateCsv(_numRecords, _numFiles);
-    } else if(FORMAT_JSON.equalsIgnoreCase(_format)) {
+    } else if (FORMAT_JSON.equalsIgnoreCase(_format)) {
       gen.generateJson(_numRecords, _numFiles);
     } else {
       throw new IllegalArgumentException(String.format("Invalid output format '%s'", _format));


### PR DESCRIPTION
GenerateData command is an existing utility to generate random dataset based on a schema. This PR adds support for writing data in JSON format in addition to AVRO and CSV.

`feature`