### PR TITLE
free up more disk for trivy job

### DIFF
--- a/.github/workflows/scripts/.pinot_vuln_check.sh
+++ b/.github/workflows/scripts/.pinot_vuln_check.sh
@@ -39,3 +39,5 @@ docker build \
     .
 
 docker image ls
+docker image prune --all --filter "until=1h" -f
+docker image ls

--- a/.github/workflows/scripts/.pinot_vuln_check.sh
+++ b/.github/workflows/scripts/.pinot_vuln_check.sh
@@ -30,6 +30,8 @@ fi
 
 cd ${DOCKER_FILE_BASE_DIR}
 
+docker image prune --all -f
+
 docker build \
     --no-cache \
     --file Dockerfile \
@@ -38,6 +40,4 @@ docker build \
     --tag ${DOCKER_IMAGE_NAME}:${PINOT_SHA} \
     .
 
-docker image ls
-docker image prune --all --filter "until=1h" -f
 docker image ls

--- a/.github/workflows/scripts/.pinot_vuln_check.sh
+++ b/.github/workflows/scripts/.pinot_vuln_check.sh
@@ -30,7 +30,7 @@ fi
 
 cd ${DOCKER_FILE_BASE_DIR}
 
-docker image prune --all -f
+docker image prune --all --filter "until=1h" -f
 
 docker build \
     --no-cache \


### PR DESCRIPTION
Trying to free up more disk space for trivy job.
```
Found ignorefile '.trivyignore':
Building SARIF report with options:  --vuln-type  os,library --timeout  10m  apachepinot/pinot:6055f09b3d0cd84c7ac44ce88ac402d69297e523
2023-10-09T21:42:15.569Z	FATAL	image scan error: scan error: scan failed: failed analysis: analyze error: pipeline error: failed to analyze layer (sha256:f9e20a6d0abf7589d6cf2c00a55297377487acd46b6d399c[17](https://github.com/apache/pinot/actions/runs/6461544862/job/17542154205?pr=11767#step:6:18)3972ed[1](https://github.com/apache/pinot/actions/runs/6461544862/job/17542154205?pr=11767#step:7:1)9e213ee): unable to get uncompressed layer sha256:f9e20a6d0abf75[8](https://github.com/apache/pinot/actions/runs/6461544862/job/17542154205?pr=11767#step:7:9)[9](https://github.com/apache/pinot/actions/runs/6461544862/job/17542154205?pr=11767#step:7:10)d6cf2c00a55297377487acd46b6d399c173972ed19e213ee: failed to get the layer (sha256:f9e20a6d0abf7589d6cf2c00a55297377487acd46b6d399c173972ed19e213ee): unable to populate: unable to open: failed to copy the image: write /tmp/fanal-3948847380: no space left on device
```