### PR TITLE
move jobId out of rebalanceConfig as it's more like a runtime context

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -3085,13 +3085,12 @@ public class PinotHelixResourceManager {
    * @throws TableNotFoundException
    */
   public RebalanceResult rebalanceTable(String tableNameWithType, RebalanceConfig rebalanceConfig,
-      boolean trackRebalanceProgress)
+      String rebalanceJobId, boolean trackRebalanceProgress)
       throws TableNotFoundException {
     TableConfig tableConfig = getTableConfig(tableNameWithType);
     if (tableConfig == null) {
       throw new TableNotFoundException("Failed to find table config for table: " + tableNameWithType);
     }
-    String rebalanceJobId = rebalanceConfig.getJobId();
     Preconditions.checkState(rebalanceJobId != null, "RebalanceId not populated in the rebalanceConfig");
     if (rebalanceConfig.isUpdateTargetTier()) {
       updateTargetTier(rebalanceJobId, tableNameWithType, tableConfig);
@@ -3102,7 +3101,7 @@ public class PinotHelixResourceManager {
     }
     TableRebalancer tableRebalancer =
         new TableRebalancer(_helixZkManager, zkBasedTableRebalanceObserver, _controllerMetrics);
-    return tableRebalancer.rebalance(tableConfig, rebalanceConfig);
+    return tableRebalancer.rebalance(tableConfig, rebalanceConfig, rebalanceJobId);
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceConfig.java
@@ -84,9 +84,6 @@ public class RebalanceConfig {
   @ApiModelProperty(example = "false")
   private boolean _updateTargetTier = false;
 
-  @JsonProperty("jobId")
-  private String _jobId = null;
-
   public boolean isDryRun() {
     return _dryRun;
   }
@@ -167,14 +164,6 @@ public class RebalanceConfig {
     _updateTargetTier = updateTargetTier;
   }
 
-  public String getJobId() {
-    return _jobId;
-  }
-
-  public void setJobId(String jobId) {
-    _jobId = jobId;
-  }
-
   public static RebalanceConfig copy(RebalanceConfig cfg) {
     RebalanceConfig rc = new RebalanceConfig();
     rc._dryRun = cfg._dryRun;
@@ -187,7 +176,6 @@ public class RebalanceConfig {
     rc._externalViewCheckIntervalInMs = cfg._externalViewCheckIntervalInMs;
     rc._externalViewStabilizationTimeoutInMs = cfg._externalViewStabilizationTimeoutInMs;
     rc._updateTargetTier = cfg._updateTargetTier;
-    rc._jobId = cfg._jobId;
     return rc;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancer.java
@@ -136,10 +136,10 @@ public class TableRebalancer {
     return UUID.randomUUID().toString();
   }
 
-  public RebalanceResult rebalance(TableConfig tableConfig, RebalanceConfig rebalanceConfig) {
+  public RebalanceResult rebalance(TableConfig tableConfig, RebalanceConfig rebalanceConfig,
+      @Nullable String rebalanceJobId) {
     long startTimeMs = System.currentTimeMillis();
     String tableNameWithType = tableConfig.getTableName();
-    String rebalanceJobId = rebalanceConfig.getJobId();
     if (rebalanceJobId == null) {
       // If not passed along, create one.
       // TODO - Add rebalanceJobId to all log messages for easy tracking.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -169,7 +169,6 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
     rebalanceConfig.setExternalViewCheckIntervalInMs(_externalViewCheckIntervalInMs);
     rebalanceConfig.setExternalViewStabilizationTimeoutInMs(_externalViewStabilizationTimeoutInMs);
     rebalanceConfig.setUpdateTargetTier(TierConfigUtils.shouldRelocateToTiers(tableConfig));
-    rebalanceConfig.setJobId(TableRebalancer.createUniqueRebalanceJobIdentifier());
 
     try {
       // Relocating segments to new tiers needs two sequential actions: table rebalance and local tier migration.
@@ -178,7 +177,8 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
       // all segments are put on the right servers. If any segments are not on their target tier, the server local
       // tier migration is triggered for them, basically asking the hosting servers to reload them. The segment
       // target tier may get changed between the two sequential actions, but cluster states converge eventually.
-      RebalanceResult rebalance = _pinotHelixResourceManager.rebalanceTable(tableNameWithType, rebalanceConfig, false);
+      RebalanceResult rebalance = _pinotHelixResourceManager.rebalanceTable(tableNameWithType, rebalanceConfig,
+          TableRebalancer.createUniqueRebalanceJobIdentifier(), false);
       switch (rebalance.getStatus()) {
         case NO_OP:
           LOGGER.info("All segments are already relocated for table: {}", tableNameWithType);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/rebalance/TableRebalancerClusterStatelessTest.java
@@ -97,7 +97,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setNumReplicas(NUM_REPLICAS).build();
 
     // Rebalance should fail without creating the table
-    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig());
+    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
 
     // Create the table
@@ -114,7 +114,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         _helixResourceManager.getTableIdealState(OFFLINE_TABLE_NAME).getRecord().getMapFields();
 
     // Rebalance should return NO_OP status
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig());
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
 
     // All servers should be assigned to the table
@@ -139,7 +139,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     // Rebalance in dry-run mode
     RebalanceConfig rebalanceConfig = new RebalanceConfig();
     rebalanceConfig.setDryRun(true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
 
     // All servers should be assigned to the table
@@ -169,7 +169,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     // Rebalance with 3 min available replicas should fail as the table only have 3 replicas
     rebalanceConfig = new RebalanceConfig();
     rebalanceConfig.setMinAvailableReplicas(3);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.FAILED);
 
     // IdealState should not change for FAILED rebalance
@@ -179,7 +179,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     // Rebalance with 2 min available replicas should succeed
     rebalanceConfig = new RebalanceConfig();
     rebalanceConfig.setMinAvailableReplicas(2);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
 
     // Result should be the same as the result in dry-run mode
@@ -199,7 +199,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     _helixResourceManager.updateTableConfig(tableConfig);
 
     // No need to reassign instances because instances should be automatically assigned when updating the table config
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig());
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
 
     // There should be 3 replica-groups, each with 2 servers
@@ -246,7 +246,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
 
     // Without instances reassignment, the rebalance should return status NO_OP, and the existing instance partitions
     // should be used
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig());
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
     assertEquals(rebalanceResult.getInstanceAssignment(), instanceAssignment);
     assertEquals(rebalanceResult.getSegmentAssignment(), newSegmentAssignment);
@@ -255,7 +255,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     // removed, and the default instance partitions should be used
     rebalanceConfig = new RebalanceConfig();
     rebalanceConfig.setReassignInstances(true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
     assertNull(InstancePartitionsUtils.fetchInstancePartitions(_propertyStore,
         InstancePartitionsType.OFFLINE.getInstancePartitionsName(RAW_TABLE_NAME)));
@@ -283,7 +283,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     // Rebalance with downtime should succeed
     rebalanceConfig = new RebalanceConfig();
     rebalanceConfig.setDowntime(true);
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig);
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
 
     // All servers with tag should be assigned to the table
@@ -347,7 +347,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         _helixResourceManager.getTableIdealState(OFFLINE_TIERED_TABLE_NAME).getRecord().getMapFields();
 
     TableRebalancer tableRebalancer = new TableRebalancer(_helixManager);
-    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig());
+    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
     // Segment assignment should not change
     assertEquals(rebalanceResult.getSegmentAssignment(), oldSegmentAssignment);
@@ -363,7 +363,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     _helixResourceManager.createServerTenant(new Tenant(TenantRole.SERVER, TIER_B_NAME, 3, 3, 0));
 
     // rebalance is NOOP and no change in assignment caused by new instances
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig());
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
     // Segment assignment should not change
     assertEquals(rebalanceResult.getSegmentAssignment(), oldSegmentAssignment);
@@ -381,7 +381,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     _helixResourceManager.updateTableConfig(tableConfig);
 
     // rebalance should change assignment
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig());
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
 
     // check that segments have moved to tiers
@@ -438,7 +438,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         _helixResourceManager.getTableIdealState(OFFLINE_TIERED_TABLE_NAME).getRecord().getMapFields();
 
     TableRebalancer tableRebalancer = new TableRebalancer(_helixManager);
-    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig());
+    RebalanceResult rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
     // Segment assignment should not change
     assertEquals(rebalanceResult.getSegmentAssignment(), oldSegmentAssignment);
@@ -450,7 +450,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     }
     _helixResourceManager.createServerTenant(new Tenant(TenantRole.SERVER, "replicaAssignment" + TIER_A_NAME, 6, 6, 0));
     // rebalance is NOOP and no change in assignment caused by new instances
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig());
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.NO_OP);
     // Segment assignment should not change
     assertEquals(rebalanceResult.getSegmentAssignment(), oldSegmentAssignment);
@@ -462,7 +462,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
     _helixResourceManager.updateTableConfig(tableConfig);
 
     // rebalance should change assignment
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig());
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
 
     // check that segments have moved to tier a
@@ -484,7 +484,7 @@ public class TableRebalancerClusterStatelessTest extends ControllerTest {
         new InstanceAssignmentConfig(tagPoolConfig, null, replicaGroupPartitionConfig)));
     _helixResourceManager.updateTableConfig(tableConfig);
 
-    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig());
+    rebalanceResult = tableRebalancer.rebalance(tableConfig, new RebalanceConfig(), null);
     assertEquals(rebalanceResult.getStatus(), RebalanceResult.Status.DONE);
     assertTrue(rebalanceResult.getTierInstanceAssignment().containsKey(TIER_A_NAME));
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
@@ -113,7 +113,7 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
 
     // Now we trigger a rebalance operation
     TableConfig tableConfig = _resourceManager.getTableConfig(REALTIME_TABLE_NAME);
-    RebalanceResult rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig);
+    RebalanceResult rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
 
     // Check the number of replicas after rebalancing
     int finalReplicas = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
@@ -128,7 +128,7 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
 
     // Add a new server
     BaseServerStarter serverStarter2 = startOneServer(4567);
-    rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig);
+    rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
 
     // Check the number of replicas after rebalancing
     finalReplicas = _resourceManager.getServerInstancesForTable(getTableName(), TableType.REALTIME).size();
@@ -148,8 +148,7 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
     rebalanceConfig.setReassignInstances(true);
     rebalanceConfig.setDowntime(true);
 
-
-    rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig);
+    rebalanceResult = _tableRebalancer.rebalance(tableConfig, rebalanceConfig, null);
 
     verifySegmentAssignment(rebalanceResult.getSegmentAssignment(), 5, NUM_SERVERS);
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/PinotTableRebalancer.java
@@ -45,12 +45,12 @@ public class PinotTableRebalancer extends PinotZKChanger {
     _rebalanceConfig.setBestEfforts(bestEffort);
     _rebalanceConfig.setExternalViewCheckIntervalInMs(externalViewCheckIntervalInMs);
     _rebalanceConfig.setExternalViewStabilizationTimeoutInMs(externalViewStabilizationTimeoutInMs);
-    _rebalanceConfig.setJobId(TableRebalancer.createUniqueRebalanceJobIdentifier());
   }
 
   public RebalanceResult rebalance(String tableNameWithType) {
     TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, tableNameWithType);
     Preconditions.checkState(tableConfig != null, "Failed to find table config for table: " + tableNameWithType);
-    return new TableRebalancer(_helixManager).rebalance(tableConfig, _rebalanceConfig);
+    return new TableRebalancer(_helixManager).rebalance(tableConfig, _rebalanceConfig,
+        TableRebalancer.createUniqueRebalanceJobIdentifier());
   }
 }


### PR DESCRIPTION
Move jobId out of rebalanceConfig as it's more like a runtime context. And as in the table rebalance restful API, jobId is not provided by caller but auto-gen'ed and returned to caller.