### PR TITLE
[Flaky-test] Fix LLCRealtimeClusterIntegrationTest.testReset

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -618,7 +618,7 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
         resetTable(rawTableName, tableType, null);
         return true;
       } catch (IOException e) {
-        assertTrue(e.toString().contains("pending message"));
+        assertTrue(e.toString().contains("pending message"), "Got unexpected exception: " + e);
         return false;
       }
     }, 30_000L, "Failed to reset table: " + tableNameWithType);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/LLCRealtimeClusterIntegrationTest.java
@@ -313,9 +313,8 @@ public class LLCRealtimeClusterIntegrationTest extends BaseRealtimeClusterIntegr
   }
 
   @Test
-  public void testReset()
-      throws Exception {
-    super.testReset(TableType.REALTIME);
+  public void testReset() {
+    testReset(TableType.REALTIME);
   }
 
   @Test

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -2972,9 +2972,8 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   }
 
   @Test
-  public void testReset()
-      throws Exception {
-    super.testReset(TableType.OFFLINE);
+  public void testReset() {
+    testReset(TableType.OFFLINE);
   }
 
   @Test


### PR DESCRIPTION
Fix #11766

It is flaky because reset is expected to throw exception when there are pending messages. For real-time test, there can be pending CONSUMING -> ONLINE and OFFLINE -> CONSUMING (segment commit) messages even though all docs are loaded