### PR TITLE
Add Links to Instance in Table and Segment View

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
@@ -235,6 +235,8 @@ const SegmentDetails = ({ match }: RouteComponentProps<Props>) => {
           <CustomizedTables
             title="Replica Set"
             data={replica}
+            addLinks
+            baseURL="/instance/"
             showSearchBox={true}
             inAccordionFormat={true}
           />

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -601,6 +601,8 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
           <CustomizedTables
             title={"Instance Count - " + instanceCountData.records.length}
             data={instanceCountData}
+            addLinks
+            baseURL="/instance/"
             showSearchBox={true}
             inAccordionFormat={true}
           />


### PR DESCRIPTION
I don't know anything about frontend, but I have had to copy paste the Instance IDs from the Table and Segment view so many times I finally took a shot at this.

This seems to work on local. (screenshots below. links are also opening up correctly)

<img width="1452" alt="image" src="https://github.com/apache/pinot/assets/8644710/12fa25bf-5bd8-4411-8512-2f08728cfabc">

<img width="2004" alt="image" src="https://github.com/apache/pinot/assets/8644710/2ed54f47-e680-41b6-8c5f-27b0f49f3128">