### PR TITLE
Multiple JDBC Driver fixes to support Jetbrains Intellij/Datagrip database tooling

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotConnectionMetaData.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotConnectionMetaData.java
@@ -150,30 +150,34 @@ public class PinotConnectionMetaData extends AbstractBaseConnectionMetaData {
   public ResultSet getColumns(String catalog, String schemaPattern, String tableNamePattern, String columnNamePattern)
       throws SQLException {
 
+    if (tableNamePattern != null && tableNamePattern.equals("%")) {
+      LOGGER.warn("driver does not support pattern [{}] for table name", tableNamePattern);
+      return PinotResultSet.empty();
+    }
+
     SchemaResponse schemaResponse = _controllerTransport.getTableSchema(tableNamePattern, _controllerURL);
     PinotMeta pinotMeta = new PinotMeta();
     pinotMeta.setColumnNames(TABLE_SCHEMA_COLUMNS);
     pinotMeta.setColumnDataTypes(TABLE_SCHEMA_COLUMNS_DTYPES);
 
-    String tableName = schemaResponse.getSchemaName();
     int ordinalPosition = 1;
     if (schemaResponse.getDimensions() != null) {
       for (JsonNode columns : schemaResponse.getDimensions()) {
-        appendColumnMeta(pinotMeta, tableName, ordinalPosition, columns);
+        appendColumnMeta(pinotMeta, tableNamePattern, ordinalPosition, columns);
         ordinalPosition++;
       }
     }
 
     if (schemaResponse.getMetrics() != null) {
       for (JsonNode columns : schemaResponse.getMetrics()) {
-        appendColumnMeta(pinotMeta, tableName, ordinalPosition, columns);
+        appendColumnMeta(pinotMeta, tableNamePattern, ordinalPosition, columns);
         ordinalPosition++;
       }
     }
 
     if (schemaResponse.getDateTimeFieldSpecs() != null) {
       for (JsonNode columns : schemaResponse.getDateTimeFieldSpecs()) {
-        appendColumnMeta(pinotMeta, tableName, ordinalPosition, columns);
+        appendColumnMeta(pinotMeta, tableNamePattern, ordinalPosition, columns);
         ordinalPosition++;
       }
     }

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotPreparedStatement.java
@@ -203,7 +203,7 @@ public class PinotPreparedStatement extends AbstractBasePreparedStatement {
       }
       return _resultSet;
     } catch (PinotClientException e) {
-      throw new SQLException("Failed to execute query : {}", _query, e);
+      throw new SQLException(String.format("Failed to execute query : %s", _query), e);
     }
   }
 

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/base/AbstractBaseConnection.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/base/AbstractBaseConnection.java
@@ -51,7 +51,7 @@ public abstract class AbstractBaseConnection implements Connection {
   @Override
   public void clearWarnings()
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    // no-op
   }
 
   @Override
@@ -111,42 +111,43 @@ public abstract class AbstractBaseConnection implements Connection {
   @Override
   public boolean getAutoCommit()
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    return false;
   }
 
   @Override
   public void setAutoCommit(boolean autoCommit)
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    // no-op
   }
 
   @Override
   public String getCatalog()
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    return null;
   }
 
   @Override
   public void setCatalog(String catalog)
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    // no-op
   }
 
   @Override
   public String getClientInfo(String name)
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    return null;
   }
 
   @Override
   public Properties getClientInfo()
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    return null;
   }
 
   @Override
   public void setClientInfo(Properties properties)
       throws SQLClientInfoException {
+    // no-op
   }
 
   @Override
@@ -170,13 +171,13 @@ public abstract class AbstractBaseConnection implements Connection {
   @Override
   public String getSchema()
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    return null;
   }
 
   @Override
   public void setSchema(String schema)
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    // no-op
   }
 
   @Override
@@ -206,7 +207,7 @@ public abstract class AbstractBaseConnection implements Connection {
   @Override
   public SQLWarning getWarnings()
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    return null;
   }
 
   @Override
@@ -218,7 +219,7 @@ public abstract class AbstractBaseConnection implements Connection {
   @Override
   public void setReadOnly(boolean readOnly)
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    // no-op
   }
 
   @Override
@@ -310,6 +311,7 @@ public abstract class AbstractBaseConnection implements Connection {
   @Override
   public void setClientInfo(String name, String value)
       throws SQLClientInfoException {
+    // no-op
   }
 
   @Override

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/base/AbstractBaseStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/base/AbstractBaseStatement.java
@@ -50,7 +50,7 @@ public abstract class AbstractBaseStatement implements Statement {
   @Override
   public void clearWarnings()
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    // no-op
   }
 
   @Override
@@ -194,7 +194,7 @@ public abstract class AbstractBaseStatement implements Statement {
   @Override
   public SQLWarning getWarnings()
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    return null;
   }
 
   @Override
@@ -212,7 +212,7 @@ public abstract class AbstractBaseStatement implements Statement {
   @Override
   public void setPoolable(boolean poolable)
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    // no-op;
   }
 
   @Override
@@ -230,7 +230,7 @@ public abstract class AbstractBaseStatement implements Statement {
   @Override
   public void setEscapeProcessing(boolean enable)
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    // no-op
   }
 
   @Override

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransport.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransport.java
@@ -131,7 +131,6 @@ public class PinotControllerTransport {
         _headers.forEach((k, v) -> requestBuilder.addHeader(k, v));
       }
 
-
       final Future<Response> response =
           requestBuilder.addHeader("Content-Type", "application/json; charset=utf-8").execute();
 

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransport.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/controller/PinotControllerTransport.java
@@ -76,7 +76,7 @@ public class PinotControllerTransport {
       userAgentProperties.load(
           PinotControllerTransport.class.getClassLoader().getResourceAsStream("version.properties"));
     } catch (IOException e) {
-      LOGGER.warn("Unable to set user agent version");
+      LOGGER.warn("Unable to set user agent version", e);
     }
     String userAgentFromProperties = userAgentProperties.getProperty("ua", "unknown");
     if (StringUtils.isNotEmpty(appId)) {
@@ -130,6 +130,7 @@ public class PinotControllerTransport {
       if (_headers != null) {
         _headers.forEach((k, v) -> requestBuilder.addHeader(k, v));
       }
+
 
       final Future<Response> response =
           requestBuilder.addHeader("Content-Type", "application/json; charset=utf-8").execute();


### PR DESCRIPTION
fix for #11813 

This PR resolves multiple issues with the JDBC driver.  The changes mostly include adding sensible default values for various JDBC metadata methods instead of always throwing `SQLFeatureNotSupportedException` which tends to break Jetbrains Database tooling.  With these changes i was able to successfully add a custom driver/datasource to IntelliJ/Datagrip and browse a pinot database