### PR TITLE
make testInvalidateCachedControllerLeader times based on getMinInvalidateIntervalMs

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/server/realtime/ControllerLeaderLocatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/server/realtime/ControllerLeaderLocatorTest.java
@@ -92,7 +92,7 @@ public class ControllerLeaderLocatorTest {
 
     // invalidate within {@link ControllerLeaderLocator::getMinInvalidateIntervalMs()} millis
     // values should remain unchanged
-    currentTimeMs = 32_000L;
+    currentTimeMs = currentTimeMs + controllerLeaderLocator.getMinInvalidateIntervalMs() / 3;
     controllerLeaderLocator.setCurrentTimeMs(currentTimeMs);
     controllerLeaderLocator.invalidateCachedControllerLeader();
     Assert.assertFalse(controllerLeaderLocator.isCachedControllerLeaderValid());
@@ -105,7 +105,7 @@ public class ControllerLeaderLocatorTest {
 
     // invalidate within {@link ControllerLeaderLocator::getMinInvalidateIntervalMs()} millis
     // values should remain unchanged
-    currentTimeMs = 33_000L;
+    currentTimeMs = currentTimeMs + controllerLeaderLocator.getMinInvalidateIntervalMs() / 3;
     controllerLeaderLocator.setCurrentTimeMs(currentTimeMs);
     controllerLeaderLocator.invalidateCachedControllerLeader();
     Assert.assertTrue(controllerLeaderLocator.isCachedControllerLeaderValid());


### PR DESCRIPTION
This is a small fix for `testInvalidateCachedControllerLeader`. It makes the tests mock time based on `getMinInvalidateIntervalMs` rather than using 1000ms. We've updated `getMinInvalidateIntervalMs` internally to `1s` to minimize ingestion lag, and it caused these tests to fail. 