### PR TITLE
11743: remove placeholder OBJECT column data type.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionUtils.java
@@ -126,7 +126,6 @@ public class FunctionUtils {
     put(float[].class, ColumnDataType.FLOAT_ARRAY);
     put(double[].class, ColumnDataType.DOUBLE_ARRAY);
     put(String[].class, ColumnDataType.STRING_ARRAY);
-    put(Object.class, ColumnDataType.OBJECT);
   }};
 
   /**


### PR DESCRIPTION
As per the [issue](https://github.com/apache/pinot/issues/11743), deleting the placeholder OBJECT data type.