### PR TITLE
When reading server to segments map, exclude OFFLINE segments

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotSegmentRestletResource.java
@@ -34,12 +34,12 @@ import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.TreeMap;
 import java.util.concurrent.Executor;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -661,13 +661,13 @@ public class PinotSegmentRestletResource {
         controllerJobZKMetadata.get(CommonConstants.ControllerJob.SEGMENT_RELOAD_JOB_SEGMENT_NAME);
     if (singleSegmentName != null) {
       // No need to query servers where this segment is not supposed to be hosted
-      serverToSegments = new HashMap<>();
-      List<String> segmentList = Arrays.asList(singleSegmentName);
+      serverToSegments = new TreeMap<>();
+      List<String> segmentList = Collections.singletonList(singleSegmentName);
       _pinotHelixResourceManager.getServers(tableNameWithType, singleSegmentName).forEach(server -> {
         serverToSegments.put(server, segmentList);
       });
     } else {
-      serverToSegments = _pinotHelixResourceManager.getServerToOnlineSegmentsMap(tableNameWithType);
+      serverToSegments = _pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType);
     }
 
     BiMap<String, String> serverEndPoints =

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
@@ -157,13 +157,13 @@ public class ConsumingSegmentInfoReader {
         }
 
         // Check if any responses are missing
-        Set<String> serversForSegment = _pinotHelixResourceManager.getServersForSegment(tableNameWithType, segmentName);
-        if (serversForSegment.size() != consumingSegmentInfoList.size()) {
+        Set<String> servers = _pinotHelixResourceManager.getServers(tableNameWithType, segmentName);
+        if (servers.size() != consumingSegmentInfoList.size()) {
           Set<String> serversResponded =
               consumingSegmentInfoList.stream().map(c -> c._serverName).collect(Collectors.toSet());
-          serversForSegment.removeAll(serversResponded);
+          servers.removeAll(serversResponded);
           String errorMessage =
-              "Not all servers responded for segment: " + segmentName + " Missing servers : " + serversForSegment;
+              "Not all servers responded for segment: " + segmentName + " Missing servers : " + servers;
           return TableStatus.IngestionStatus.newIngestionStatus(TableStatus.IngestionState.UNHEALTHY, errorMessage);
         }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/ConsumingSegmentInfoReaderStatelessTest.java
@@ -28,10 +28,10 @@ import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
@@ -197,11 +197,11 @@ public class ConsumingSegmentInfoReaderStatelessTest {
   private void mockSetup(final String[] servers, final Set<String> consumingSegments)
       throws InvalidConfigException {
     when(_helix.getServerToSegmentsMap(anyString())).thenAnswer(invocationOnMock -> subsetOfServerSegments(servers));
+    when(_helix.getServers(anyString(), anyString())).thenAnswer(
+        invocationOnMock -> new TreeSet<>(Arrays.asList(servers)));
     when(_helix.getDataInstanceAdminEndpoints(ArgumentMatchers.anySet())).thenAnswer(
         invocationOnMock -> serverEndpoints(servers));
     when(_helix.getConsumingSegments(anyString())).thenAnswer(invocationOnMock -> consumingSegments);
-    when(_helix.getServersForSegment(anyString(), anyString())).thenAnswer(
-        invocationOnMock -> new HashSet<>(Arrays.asList(servers)));
   }
 
   private ConsumingSegmentInfoReader.ConsumingSegmentsInfoMap testRunner(final String[] servers,


### PR DESCRIPTION
Context: When a consuming segment runs into problems, server might ask controller to set the segment to be OFFLINE in the ideal state. If all replicas are set to OFFLINE, controller will start a new consuming segment as keep the OFFLINE segments for debugging purpose.

OFFLINE segment in ideal state means the segment is not meant to be served, and we should not return it when trying to find the servers serving a segment.