### PR TITLE
Add nullability to FieldSpec and use it in TypeFactory

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -354,6 +354,8 @@ public class SelectionOperatorUtils {
 
   /**
    * Build a {@link DataTable} from a {@link Collection} of selection rows with {@link DataSchema}. (Server side)
+   *
+   * This method is allowed to modify the given rows. Specifically, it may remove nulls cells from it.
    */
   public static DataTable getDataTableFromRows(Collection<Object[]> rows, DataSchema dataSchema,
       boolean nullHandlingEnabled)

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
@@ -57,8 +57,7 @@ public class TypeFactory extends JavaTypeFactoryImpl {
     if (isArray) {
       type = createArrayType(type, -1);
     }
-    boolean isNullable = fieldSpec.getNullable() != null && fieldSpec.getNullable();
-    if (isNullable) {
+    if (fieldSpec.isNullable()) {
       type = createTypeWithNullability(type, true);
     }
     return type;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
@@ -31,8 +31,8 @@ import org.apache.pinot.spi.data.Schema;
  * Extends Java-base TypeFactory from Calcite.
  *
  * <p>{@link JavaTypeFactoryImpl} is used here because we are not overriding much of the TypeFactory methods
- * required by Calcite. We will start extending {@link SqlTypeFactoryImpl} or even {@link RelDataTypeFactory}
- * when necessary for Pinot to override such mechanism.
+ * required by Calcite. We will start extending {@link org.apache.calcite.sql.type.SqlTypeFactoryImpl} or even
+ * {@link org.apache.calcite.rel.type.RelDataTypeFactory} when necessary for Pinot to override such mechanism.
  *
  * <p>Noted that {@link JavaTypeFactoryImpl} is subject to change. Please pay extra attention to this class when
  * upgrading Calcite versions.
@@ -52,13 +52,24 @@ public class TypeFactory extends JavaTypeFactoryImpl {
   }
 
   private RelDataType toRelDataType(FieldSpec fieldSpec) {
+    RelDataType type = createSqlType(getSqlTypeName(fieldSpec));
+    boolean isArray = !fieldSpec.isSingleValueField();
+    if (isArray) {
+      type = createArrayType(type, -1);
+    }
+    boolean isNullable = fieldSpec.getNullable() != null && fieldSpec.getNullable();
+    if (isNullable) {
+      type = createTypeWithNullability(type, true);
+    }
+    return type;
+  }
+
+  private SqlTypeName getSqlTypeName(FieldSpec fieldSpec) {
     switch (fieldSpec.getDataType()) {
       case INT:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.INTEGER)
-            : createArrayType(createSqlType(SqlTypeName.INTEGER), -1);
+        return SqlTypeName.INTEGER;
       case LONG:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.BIGINT)
-            : createArrayType(createSqlType(SqlTypeName.BIGINT), -1);
+        return SqlTypeName.BIGINT;
       // Map float and double to the same RelDataType so that queries like
       // `select count(*) from table where aFloatColumn = 0.05` works correctly in multi-stage query engine.
       //
@@ -71,34 +82,32 @@ public class TypeFactory extends JavaTypeFactoryImpl {
       // With float and double mapped to the same RelDataType, the behavior in multi-stage query engine will be the same
       // as the query in v1 query engine.
       case FLOAT:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.DOUBLE)
-            : createArrayType(createSqlType(SqlTypeName.REAL), -1);
+        if (fieldSpec.isSingleValueField()) {
+          return SqlTypeName.DOUBLE;
+        } else {
+          // TODO: This may be wrong. The reason why we want to use DOUBLE in single value float may also apply here
+          return SqlTypeName.REAL;
+        }
       case DOUBLE:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.DOUBLE)
-            : createArrayType(createSqlType(SqlTypeName.DOUBLE), -1);
+        return SqlTypeName.DOUBLE;
       case BOOLEAN:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.BOOLEAN)
-            : createArrayType(createSqlType(SqlTypeName.BOOLEAN), -1);
+        return SqlTypeName.BOOLEAN;
       case TIMESTAMP:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.TIMESTAMP)
-            : createArrayType(createSqlType(SqlTypeName.TIMESTAMP), -1);
+        return SqlTypeName.TIMESTAMP;
       case STRING:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.VARCHAR)
-            : createArrayType(createSqlType(SqlTypeName.VARCHAR), -1);
+        return SqlTypeName.VARCHAR;
       case BYTES:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.VARBINARY)
-            : createArrayType(createSqlType(SqlTypeName.VARBINARY), -1);
+        return SqlTypeName.VARBINARY;
       case BIG_DECIMAL:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.DECIMAL)
-            : createArrayType(createSqlType(SqlTypeName.DECIMAL), -1);
+        return SqlTypeName.DECIMAL;
       case JSON:
-        return createSqlType(SqlTypeName.VARCHAR);
+        return SqlTypeName.VARCHAR;
       case LIST:
         // TODO: support LIST, MV column should go fall into this category.
       case STRUCT:
       case MAP:
       default:
-        String message = String.format("Unsupported type: %s ", fieldSpec.getDataType().toString());
+        String message = String.format("Unsupported type: %s ", fieldSpec.getDataType());
         throw new UnsupportedOperationException(message);
     }
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeSystem.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeSystem.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.type;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
@@ -30,7 +31,8 @@ import org.apache.calcite.sql.type.SqlTypeUtil;
  */
 public class TypeSystem extends RelDataTypeSystemImpl {
   private static final int MAX_DECIMAL_SCALE = 1000;
-  private static final int MAX_DECIMAL_PRECISION = 1000;
+  @VisibleForTesting
+  static final int MAX_DECIMAL_PRECISION = 1000;
 
   /**
    * Default precision for derived arithmetic decimal types(plus/multiply/divide/mod). We won't allow the return

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeSystem.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeSystem.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.query.type;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
@@ -31,8 +30,7 @@ import org.apache.calcite.sql.type.SqlTypeUtil;
  */
 public class TypeSystem extends RelDataTypeSystemImpl {
   private static final int MAX_DECIMAL_SCALE = 1000;
-  @VisibleForTesting
-  static final int MAX_DECIMAL_PRECISION = 1000;
+  private static final int MAX_DECIMAL_PRECISION = 1000;
 
   /**
    * Default precision for derived arithmetic decimal types(plus/multiply/divide/mod). We won't allow the return

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -69,13 +69,32 @@ public class QueryEnvironmentTestBase {
 
   static Schema.SchemaBuilder getSchemaBuilder(String schemaName) {
     return new Schema.SchemaBuilder()
-        .addSingleValueDimension("col1", FieldSpec.DataType.STRING, "")
-        .addSingleValueDimension("col2", FieldSpec.DataType.STRING, "")
-        .addSingleValueDimension("col5", FieldSpec.DataType.BOOLEAN, false)
-        .addDateTime("ts", FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:HOURS")
-        .addMetric("col3", FieldSpec.DataType.INT, 0)
-        .addMetric("col4", FieldSpec.DataType.BIG_DECIMAL, 0)
-        .addMetric("col6", FieldSpec.DataType.INT, 0)
+        .addDimensionField("col1", FieldSpec.DataType.STRING, field -> {
+          field.setDefaultNullValue("");
+          field.setNullable(false);
+        })
+        .addDimensionField("col2", FieldSpec.DataType.STRING, field -> {
+          field.setDefaultNullValue("");
+          field.setNullable(false);
+        })
+        .addDimensionField("col5", FieldSpec.DataType.BOOLEAN, field -> {
+          field.setDefaultNullValue(false);
+          field.setNullable(false);
+        })
+        .addDateTimeField("ts", FieldSpec.DataType.LONG, "1:MILLISECONDS:EPOCH", "1:HOURS", field ->
+            field.setNullable(false))
+        .addMetricField("col3", FieldSpec.DataType.INT, field -> {
+          field.setDefaultNullValue(0);
+          field.setNullable(false);
+        })
+        .addMetricField("col4", FieldSpec.DataType.BIG_DECIMAL, field -> {
+          field.setDefaultNullValue(0);
+          field.setNullable(false);
+        })
+        .addMetricField("col6", FieldSpec.DataType.INT, field -> {
+          field.setDefaultNullValue(0);
+          field.setNullable(false);
+        })
         .setSchemaName(schemaName);
   }
 

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -219,7 +219,6 @@ public class QueryEnvironmentTestBase {
         Collections.emptyMap());
   }
 
-
   public static QueryEnvironment getQueryEnvironment(int reducerPort, int port1, int port2,
       Map<String, Schema> schemaMap, Map<String, List<String>> segmentMap1, Map<String, List<String>> segmentMap2,
       @Nullable Map<String, Pair<String, List<List<String>>>> partitionedSegmentsMap,

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -215,9 +215,18 @@ public class QueryEnvironmentTestBase {
   public static QueryEnvironment getQueryEnvironment(int reducerPort, int port1, int port2,
       Map<String, Schema> schemaMap, Map<String, List<String>> segmentMap1, Map<String, List<String>> segmentMap2,
       @Nullable Map<String, Pair<String, List<List<String>>>> partitionedSegmentsMap) {
+    return getQueryEnvironment(reducerPort, port1, port2, schemaMap, segmentMap1, segmentMap2, partitionedSegmentsMap,
+        Collections.emptyMap());
+  }
+
+
+  public static QueryEnvironment getQueryEnvironment(int reducerPort, int port1, int port2,
+      Map<String, Schema> schemaMap, Map<String, List<String>> segmentMap1, Map<String, List<String>> segmentMap2,
+      @Nullable Map<String, Pair<String, List<List<String>>>> partitionedSegmentsMap,
+      Map<String, Boolean> nullHandlingMap) {
     MockRoutingManagerFactory factory = new MockRoutingManagerFactory(port1, port2);
     for (Map.Entry<String, Schema> entry : schemaMap.entrySet()) {
-      factory.registerTable(entry.getValue(), entry.getKey());
+      factory.registerTable(entry.getValue(), entry.getKey(), nullHandlingMap.getOrDefault(entry.getKey(), false));
     }
     for (Map.Entry<String, List<String>> entry : segmentMap1.entrySet()) {
       for (String segment : entry.getValue()) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/queries/ResourceBasedQueryPlansTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/queries/ResourceBasedQueryPlansTest.java
@@ -45,12 +45,14 @@ public class ResourceBasedQueryPlansTest extends QueryEnvironmentTestBase {
   private static final String FILE_FILTER_PROPERTY = "pinot.fileFilter";
 
   @Test(dataProvider = "testResourceQueryPlannerTestCaseProviderHappyPath")
-  public void testQueryExplainPlansAndQueryPlanConversion(String testCaseName, String query, String output) {
+  public void testQueryExplainPlansAndQueryPlanConversion(String testCaseName, String description, String query,
+      String output) {
     try {
       long requestId = RANDOM_REQUEST_ID_GEN.nextLong();
       String explainedPlan = _queryEnvironment.explainQuery(query, requestId);
       Assert.assertEquals(explainedPlan, output,
-          String.format("Test case %s for query %s doesn't match expected output: %s", testCaseName, query, output));
+          String.format("Test case %s for query %s (%s) doesn't match expected output: %s", testCaseName, description,
+              query, output));
       String queryWithoutExplainPlan = query.replace("EXPLAIN PLAN FOR ", "");
       DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(queryWithoutExplainPlan);
       Assert.assertNotNull(dispatchableSubPlan,
@@ -102,7 +104,7 @@ public class ResourceBasedQueryPlansTest extends QueryEnvironmentTestBase {
           String sql = queryCase._sql;
           List<String> orgOutput = queryCase._output;
           String concatenatedOutput = StringUtils.join(orgOutput, "");
-          Object[] testEntry = new Object[]{testCaseName, sql, concatenatedOutput};
+          Object[] testEntry = new Object[]{testCaseName, queryCase._description, sql, concatenatedOutput};
           providerContent.add(testEntry);
         }
       }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/queries/ResourceBasedQueryPlansTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/queries/ResourceBasedQueryPlansTest.java
@@ -83,7 +83,7 @@ public class ResourceBasedQueryPlansTest extends QueryEnvironmentTestBase {
     }
   }
 
-  @DataProvider
+  @DataProvider(parallel = true)
   private static Object[][] testResourceQueryPlannerTestCaseProviderHappyPath()
       throws Exception {
     Map<String, QueryPlanTestCase> testCaseMap = getTestCases();
@@ -112,7 +112,7 @@ public class ResourceBasedQueryPlansTest extends QueryEnvironmentTestBase {
     return providerContent.toArray(new Object[][]{});
   }
 
-  @DataProvider
+  @DataProvider(parallel = true)
   private static Object[][] testResourceQueryPlannerTestCaseProviderExceptions()
       throws Exception {
     Map<String, QueryPlanTestCase> testCaseMap = getTestCases();

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/type/TypeFactoryTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/type/TypeFactoryTest.java
@@ -137,7 +137,7 @@ public class TypeFactoryTest {
   public void testNullableScalarTypes(FieldSpec.DataType dataType, RelDataType scalarType, RelDataType arrayType) {
     TypeFactory typeFactory = new TypeFactory(TYPE_SYSTEM);
     Schema testSchema = new Schema.SchemaBuilder()
-        .addSingleValueDimension("col", dataType, true)
+        .addDimensionField("col", dataType, field -> field.setNullable(true))
         .build();
     RelDataType relDataTypeFromSchema = typeFactory.createRelDataTypeFromSchema(testSchema);
     List<RelDataTypeField> fieldList = relDataTypeFromSchema.getFieldList();

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
@@ -168,7 +168,7 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
     ResultTable resultTable = queryRunner(sql, null);
     // query H2 for data
     List<Object[]> expectedRows = queryH2(sql);
-    compareRowEquals(resultTable, expectedRows);
+    compareRowEquals(resultTable, expectedRows, sql);
   }
 
   /**

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
@@ -587,7 +587,7 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
       @JsonProperty("isSingleValue")
       boolean _isSingleValue = true;
       @JsonProperty("nullable")
-      Boolean _nullable = null;
+      boolean _nullable = true;
     }
   }
 }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -59,6 +59,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -258,6 +259,9 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
   public void testQueryTestCasesWithH2(String testCaseName, String description, String sql, String h2Sql, String expect,
       boolean keepOutputRowOrder, boolean isIgnored)
       throws Exception {
+    if (isIgnored) {
+      throw new SkipException("Test " + testCaseName + " with description " + description + " ignored");
+    }
     // query pinot
     runQuery(sql, expect, null).ifPresent(resultTable -> {
       try {
@@ -272,6 +276,9 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
   public void testQueryTestCasesWithOutput(String testCaseName, String description, String sql,
       String h2Sql, List<Object[]> expectedRows, String expect, boolean keepOutputRowOrder, boolean isIgnored)
       throws Exception {
+    if (isIgnored) {
+      throw new SkipException("Test " + testCaseName + " with description " + description + " ignored");
+    }
     runQuery(sql, expect, null).ifPresent(
         resultTable -> compareRowEquals(resultTable, expectedRows, sql, keepOutputRowOrder));
   }
@@ -280,6 +287,9 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
   public void testQueryTestCasesWithMetadata(String testCaseName, String description, String sql,
       String h2Sql, String expect, int numSegments, boolean isIgnored)
       throws Exception {
+    if (isIgnored) {
+      throw new SkipException("Test " + testCaseName + " with description " + description + " ignored");
+    }
     Map<Integer, ExecutionStatsAggregator> executionStatsAggregatorMap = new HashMap<>();
     runQuery(sql, expect, executionStatsAggregatorMap).ifPresent(resultTable -> {
       BrokerResponseNativeV2 brokerResponseNative = new BrokerResponseNativeV2();
@@ -367,10 +377,6 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
 
       List<QueryTestCase.Query> queryCases = testCaseEntry.getValue()._queries;
       for (QueryTestCase.Query queryCase : queryCases) {
-        if (queryCase._ignored && !_isRunIgnored) {
-          continue;
-        }
-
         if (queryCase._outputs != null) {
           String sql = replaceTableName(testCaseName, queryCase._sql);
           String h2Sql = queryCase._h2Sql != null ? replaceTableName(testCaseName, queryCase._h2Sql)
@@ -382,7 +388,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
           }
           Object[] testEntry = new Object[]{
               testCaseName, queryCase._description, sql, h2Sql, expectedRows, queryCase._expectedException,
-              queryCase._keepOutputRowOrder, queryCase._ignored,
+              queryCase._keepOutputRowOrder, queryCase._ignored && !_isRunIgnored
           };
           providerContent.add(testEntry);
         }
@@ -411,11 +417,6 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
 
       List<QueryTestCase.Query> queryCases = testCaseEntry.getValue()._queries;
       for (QueryTestCase.Query queryCase : queryCases) {
-
-        if (queryCase._ignored && !_isRunIgnored) {
-          continue;
-        }
-
         if (queryCase._outputs == null) {
           String sql = replaceTableName(testCaseName, queryCase._sql);
           String h2Sql = queryCase._h2Sql != null ? replaceTableName(testCaseName, queryCase._h2Sql)
@@ -430,7 +431,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
 
           Object[] testEntry = new Object[]{
               testCaseName, queryCase._description, sql, h2Sql, queryCase._expectedException, segmentCount,
-              queryCase._ignored
+              queryCase._ignored && !_isRunIgnored
           };
           providerContent.add(testEntry);
         }
@@ -452,16 +453,13 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
       String testCaseName = testCaseEntry.getKey();
       List<QueryTestCase.Query> queryCases = testCaseEntry.getValue()._queries;
       for (QueryTestCase.Query queryCase : queryCases) {
-        if (queryCase._ignored && !_isRunIgnored) {
-          continue;
-        }
         if (queryCase._outputs == null) {
           String sql = replaceTableName(testCaseName, queryCase._sql);
           String h2Sql = queryCase._h2Sql != null ? replaceTableName(testCaseName, queryCase._h2Sql)
               : replaceTableName(testCaseName, queryCase._sql);
           Object[] testEntry = new Object[]{
               testCaseName, queryCase._description, sql, h2Sql, queryCase._expectedException,
-              queryCase._keepOutputRowOrder, queryCase._ignored
+              queryCase._keepOutputRowOrder, queryCase._ignored && !_isRunIgnored
           };
           providerContent.add(testEntry);
         }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
@@ -175,7 +175,7 @@ public class MockInstanceDataManagerFactory {
     // TODO: plugin table config constructor
     TableConfig tableConfig =
         new TableConfigBuilder(tableType).setTableName(rawTableName).setTimeColumnName("ts")
-            .setNullHandlingEnabled(true)
+            .setNullHandlingEnabled(_nullHandlingMap.getOrDefault(tableNameWithType, false))
             .build();
     Schema schema = _schemaMap.get(rawTableName);
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
@@ -187,7 +187,7 @@ public class MockInstanceDataManagerFactory {
     try (RecordReader recordReader = new GenericRowRecordReader(rows)) {
       driver.init(config, recordReader);
       driver.build();
-      return ImmutableSegmentLoader.load(new File(indexDir, segmentName), ReadMode.mmap);
+      return ImmutableSegmentLoader.load(new File(indexDir, segmentName), ReadMode.mmap, schema, tableConfig);
     } catch (Exception e) {
       throw new RuntimeException("Unable to construct immutable segment from records", e);
     }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
@@ -60,6 +60,7 @@ public class MockInstanceDataManagerFactory {
 
   // Key is raw table name
   private final Map<String, List<GenericRow>> _tableRowsMap;
+  private final Map<String, Boolean> _nullHandlingMap;
   private final Map<String, Schema> _schemaMap;
 
   // Key is registered table (with or without type)
@@ -75,6 +76,7 @@ public class MockInstanceDataManagerFactory {
     _tableRowsMap = new HashMap<>();
     _schemaMap = new HashMap<>();
     _registeredSchemaMap = new HashMap<>();
+    _nullHandlingMap = new HashMap<>();
   }
 
   public void registerTable(Schema schema, String tableName) {
@@ -87,6 +89,11 @@ public class MockInstanceDataManagerFactory {
       registerTableNameWithType(schema, TableNameBuilder.OFFLINE.tableNameWithType(tableName));
       registerTableNameWithType(schema, TableNameBuilder.REALTIME.tableNameWithType(tableName));
     }
+  }
+
+  public MockInstanceDataManagerFactory setNullHandlingForTable(String tableName) {
+    _nullHandlingMap.put(tableName, true);
+    return this;
   }
 
   private void registerTableNameWithType(Schema schema, String tableNameWithType) {
@@ -138,6 +145,10 @@ public class MockInstanceDataManagerFactory {
     return _schemaMap;
   }
 
+  public Map<String, Boolean> buildNullHandlingTableMap() {
+    return _nullHandlingMap;
+  }
+
   public Map<String, List<GenericRow>> buildTableRowsMap() {
     return _tableRowsMap;
   }
@@ -163,7 +174,9 @@ public class MockInstanceDataManagerFactory {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     // TODO: plugin table config constructor
     TableConfig tableConfig =
-        new TableConfigBuilder(tableType).setTableName(rawTableName).setTimeColumnName("ts").build();
+        new TableConfigBuilder(tableType).setTableName(rawTableName).setTimeColumnName("ts")
+            .setNullHandlingEnabled(true)
+            .build();
     Schema schema = _schemaMap.get(rawTableName);
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
     config.setOutDir(indexDir.getPath());

--- a/pinot-query-runtime/src/test/resources/queries/CountDistinct.json
+++ b/pinot-query-runtime/src/test/resources/queries/CountDistinct.json
@@ -119,11 +119,13 @@
       {
         "comments": "table aren't actually partitioned by val thus all segments can produce duplicate results, thus [[8]]",
         "sql": "SELECT SEGMENT_PARTITIONED_DISTINCT_COUNT(val) FROM {tbl1}",
+        "ignored": true,
         "outputs": [[8]]
       },
       {
         "comments": "table aren't actually partitioned by val thus all segments can produce duplicate results, thus [[b, 5], [a, 4]]",
         "sql": "SELECT groupingCol, SEGMENT_PARTITIONED_DISTINCT_COUNT(val) FROM {tbl1} GROUP BY groupingCol",
+        "ignored": true,
         "outputs": [["b", 5], ["a", 4]]
       },
       {
@@ -137,6 +139,7 @@
       {
         "comments": "table aren't actually partitioned by val thus all segments can produce duplicate results, thus [[b, 5], [a, 4]]",
         "sql": "SELECT /*+ aggOptions(is_skip_leaf_stage_aggregate='true') */ groupingCol, SEGMENT_PARTITIONED_DISTINCT_COUNT(val) FROM {tbl1} GROUP BY groupingCol",
+        "ignored": true,
         "outputs": [["b", 5], ["a", 4]]
       },
       {

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -67,6 +67,98 @@
       }
     ]
   },
+  "nullable_columns_when_nullHandling_disabled": {
+    "tables": {
+      "tbl1" : {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "intCol1", "type": "INT"},
+          {"name": "nIntCol1", "type": "INT", "nullable": true},
+          {"name": "nnIntCol1", "type": "INT", "nullable": false},
+          {"name": "strCol2", "type": "STRING"},
+          {"name": "nStrCol2", "type": "STRING", "nullable": true},
+          {"name": "nnStrCol2", "type": "STRING", "nullable": false}
+        ],
+        "inputs": [
+          ["foo", 1, 1, 1, "foo", "foo", "foo"],
+          ["bar", 2, 2, 2, "alice", "alice", "alice"],
+          ["alice", 2, 2, 2, null, null, null],
+          [null, 4, 4, 4, null, null, null],
+          ["bob", null, null, null, null, null, null]
+        ]
+      }
+    },
+    "extraProps": {
+      "EnableNullHandling": "false"
+    },
+    "queries": [
+      {
+        "description": "intCol1 IS NULL is always false",
+        "comment": "Even when tableConfig nullHandlingEnabled is false, V2 respects column nullability",
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE intCol1 IS NULL",
+        "h2Sql": "SELECT 0"
+      },
+      {
+        "description": "intCol1 IS NOT NULL is always true",
+        "comment": "Even when tableConfig nullHandlingEnabled is false, V2 respects column nullability",
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE intCol1 IS NOT NULL",
+        "h2Sql": "SELECT count(*) FROM {tbl1}"
+      },
+      {
+        "description": "nIntCol1 IS NULL is always false",
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nIntCol1 IS NULL",
+        "h2Sql": "SELECT 0"
+      },
+      {
+        "description": "nIntCol1 IS NOT NULL is always true",
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nIntCol1 IS NOT NULL",
+        "h2Sql": "SELECT count(*) FROM {tbl1}"
+      },
+      {
+        "description": "nnIntCol1 IS NULL is always false",
+        "comment": "Even when tableConfig nullHandlingEnabled is false, V2 respects column nullability",
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nnIntCol1 IS NULL",
+        "h2Sql": "SELECT 0"
+      },
+      {
+        "description": "nnIntCol1 IS NOT NULL is always true",
+        "comment": "Even when tableConfig nullHandlingEnabled is false, V2 respects column nullability",
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nnIntCol1 IS NOT NULL",
+        "h2Sql": "SELECT count(*) FROM {tbl1}"
+      },
+
+      {
+        "description": "When projected with enableNullHandling=true, intCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=true; SELECT intCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=false, intCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=false; SELECT intCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=true, nIntCol1 is considered null",
+        "sql": "SET enableNullHandling=true; SELECT nIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=false, nIntCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=false; SELECT nIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=true, nnIntCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=true; SELECT nnIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=false, nnIntCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=false; SELECT nnIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      }
+    ]
+  },
   "nullable_columns": {
     "tables": {
       "tbl1" : {
@@ -111,6 +203,9 @@
           ["bar", 2, "foo"]
         ]
       }
+    },
+    "extraProps": {
+      "EnableNullHandling": "true"
     },
     "queries": [
       {
@@ -157,13 +252,11 @@
 
       {
         "description": "When projected with enableNullHandling=true, intCol1 is considered -2147483648",
-        "comment": "This test fails when it shouldn't. We need to fix this before merging",
         "sql": "SET enableNullHandling=true; SELECT intCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
-        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+        "h2Sql": "SELECT null FROM {tbl1} WHERE strCol1 = 'bob'"
       },
       {
         "description": "When projected with enableNullHandling=false, intCol1 is considered -2147483648",
-        "comment": "this tests is not correctly working. Returned `intCol1` is actually null",
         "sql": "SET enableNullHandling=false; SELECT intCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
         "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
       },
@@ -214,10 +307,7 @@
         "description": "aggregate with null checkers on key from group set are honored on not nullable columns",
         "sql": "SET enableNullHandling=true; SELECT COUNT(*) FROM {tbl1} WHERE nStrCol2 IS NULL GROUP BY nStrCol2"
       }
-    ],
-    "extraProps": {
-      "EnableNullHandling": "true"
-    }
+    ]
   },
   "column_level_null_handling": {
     "tables": {
@@ -259,6 +349,9 @@
           ["bar", 2, "foo"]
         ]
       }
+    },
+    "extraProps": {
+      "EnableNullHandling": "true"
     },
     "queries": [
       {

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -128,31 +128,31 @@
 
       {
         "description": "intCol1 IS NULL is always false",
-        "sql": "SET enableNullHandling=true; SELECT 1 FROM {tbl1} WHERE intCol1 IS NULL",
-        "h2Sql": "SELECT 'empty' FROM {tbl1} WHERE 1 = 0"
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE intCol1 IS NULL",
+        "h2Sql": "SELECT 0"
       },
       {
         "description": "intCol1 IS NOT NULL is always true",
-        "sql": "SET enableNullHandling=true; SELECT intCol1 FROM {tbl1} WHERE intCol1 IS NOT NULL",
-        "h2Sql": "SELECT intCol1 FROM {tbl1} WHERE 1 = 1"
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE intCol1 IS NOT NULL",
+        "h2Sql": "SELECT count(*) FROM {tbl1}"
       },
       {
         "description": "nIntCol1 IS NULL is honored",
-        "sql": "SET enableNullHandling=true; SELECT nIntCol1 FROM {tbl1} WHERE nIntCol1 IS NULL"
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nIntCol1 IS NULL"
       },
       {
         "description": "nIntCol1 IS NOT NULL is honored",
-        "sql": "SET enableNullHandling=true; SELECT nIntCol1 FROM {tbl1} WHERE nIntCol1 IS NOT NULL"
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nIntCol1 IS NOT NULL"
       },
       {
         "description": "nnIntCol1 IS NULL is always false",
-        "sql": "SET enableNullHandling=true; SELECT 1 FROM {tbl1} WHERE nnIntCol1 IS NULL",
-        "h2Sql": "SELECT 'empty' FROM {tbl1} WHERE 1 = 0"
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nnIntCol1 IS NULL",
+        "h2Sql": "SELECT 0"
       },
       {
         "description": "nnIntCol1 IS NOT NULL is always true",
-        "sql": "SET enableNullHandling=true; SELECT nnIntCol1 FROM {tbl1} WHERE nnIntCol1 IS NOT NULL",
-        "h2Sql": "SELECT nnIntCol1 FROM {tbl1} WHERE 1 = 1"
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nnIntCol1 IS NOT NULL",
+        "h2Sql": "SELECT count(*) FROM {tbl1}"
       },
 
       {
@@ -179,7 +179,6 @@
       },
       {
         "description": "When projected with enableNullHandling=true, nnIntCol1 is considered -2147483648",
-        "comment": "This test fails when it shouldn't. We need to fix this before merging",
         "sql": "SET enableNullHandling=true; SELECT nnIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
         "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
       },

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -157,7 +157,7 @@
 
       {
         "description": "When projected with enableNullHandling=true, intCol1 is considered -2147483648",
-        "comment": "this tests is not correctly working. Returned `intCol1` is actually null",
+        "comment": "This test fails when it shouldn't. We need to fix this before merging",
         "sql": "SET enableNullHandling=true; SELECT intCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
         "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
       },
@@ -179,6 +179,7 @@
       },
       {
         "description": "When projected with enableNullHandling=true, nnIntCol1 is considered -2147483648",
+        "comment": "This test fails when it shouldn't. We need to fix this before merging",
         "sql": "SET enableNullHandling=true; SELECT nnIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
         "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
       },

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -66,5 +66,229 @@
         "keepOutputRowOrder": true
       }
     ]
+  },
+  "nullable_columns": {
+    "tables": {
+      "tbl1" : {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "intCol1", "type": "INT"},
+          {"name": "nIntCol1", "type": "INT", "nullable": true},
+          {"name": "nnIntCol1", "type": "INT", "nullable": false},
+          {"name": "strCol2", "type": "STRING"},
+          {"name": "nStrCol2", "type": "STRING", "nullable": true},
+          {"name": "nnStrCol2", "type": "STRING", "nullable": false}
+        ],
+        "inputs": [
+          ["foo", 1, 1, 1, "foo", "foo", "foo"],
+          ["bar", 2, 2, 2, "alice", "alice", "alice"],
+          ["alice", 2, 2, 2, null, null, null],
+          [null, 4, 4, 4, null, null, null],
+          ["bob", null, null, null, null, null, null]
+        ]
+      },
+      "tbl2" : {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "strCol2", "type": "STRING"},
+          {"name": "intCol1", "type": "INT"},
+          {"name": "doubleCol1", "type": "DOUBLE"}
+        ],
+        "inputs": [
+          ["foo", "bob", 3, 3.1416],
+          ["alice", "alice", 4, 2.7183],
+          [null, null, null, null]
+        ]
+      },
+      "tbl3": {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "intCol1", "type": "INT"},
+          {"name": "strCol2", "type": "STRING"}
+        ],
+        "inputs": [
+          ["foo", 1, "foo"],
+          ["bar", 2, "foo"]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "description": "join 3 tables, mixed join conditions with null non-matching",
+        "sql": "SET enableNullHandling=true; SELECT * FROM {tbl1} JOIN {tbl2} ON {tbl1}.intCol1 > {tbl2}.doubleCol1 JOIN {tbl3} ON {tbl1}.strCol1 = {tbl3}.strCol2"
+      },
+      {
+        "description": "join 3 tables, mixed join condition with null matching",
+        "sql": "SET enableNullHandling=true; SELECT * FROM {tbl1} JOIN {tbl2} ON {tbl1}.intCol1 != {tbl2}.doubleCol1 JOIN {tbl3} ON {tbl1}.strCol1 = {tbl3}.strCol2"
+      },
+      {
+        "description": "join 2 tables, mixed join conditions of null matching or non-matching",
+        "sql": "SET enableNullHandling=true; SELECT * FROM {tbl1} JOIN {tbl2} ON {tbl1}.intCol1 > {tbl2}.doubleCol1 AND {tbl1}.strCol1 = {tbl2}.strCol1"
+      },
+
+      {
+        "description": "intCol1 IS NULL is always false",
+        "sql": "SET enableNullHandling=true; SELECT 1 FROM {tbl1} WHERE intCol1 IS NULL",
+        "h2Sql": "SELECT 'empty' FROM {tbl1} WHERE 1 = 0"
+      },
+      {
+        "description": "intCol1 IS NOT NULL is always true",
+        "sql": "SET enableNullHandling=true; SELECT intCol1 FROM {tbl1} WHERE intCol1 IS NOT NULL",
+        "h2Sql": "SELECT intCol1 FROM {tbl1} WHERE 1 = 1"
+      },
+      {
+        "description": "nIntCol1 IS NULL is honored",
+        "sql": "SET enableNullHandling=true; SELECT nIntCol1 FROM {tbl1} WHERE nIntCol1 IS NULL"
+      },
+      {
+        "description": "nIntCol1 IS NOT NULL is honored",
+        "sql": "SET enableNullHandling=true; SELECT nIntCol1 FROM {tbl1} WHERE nIntCol1 IS NOT NULL"
+      },
+      {
+        "description": "nnIntCol1 IS NULL is always false",
+        "sql": "SET enableNullHandling=true; SELECT 1 FROM {tbl1} WHERE nnIntCol1 IS NULL",
+        "h2Sql": "SELECT 'empty' FROM {tbl1} WHERE 1 = 0"
+      },
+      {
+        "description": "nnIntCol1 IS NOT NULL is always true",
+        "sql": "SET enableNullHandling=true; SELECT nnIntCol1 FROM {tbl1} WHERE nnIntCol1 IS NOT NULL",
+        "h2Sql": "SELECT nnIntCol1 FROM {tbl1} WHERE 1 = 1"
+      },
+
+      {
+        "description": "When projected with enableNullHandling=true, intCol1 is considered -2147483648",
+        "comment": "this tests is not correctly working. Returned `intCol1` is actually null",
+        "sql": "SET enableNullHandling=true; SELECT intCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=false, intCol1 is considered -2147483648",
+        "comment": "this tests is not correctly working. Returned `intCol1` is actually null",
+        "sql": "SET enableNullHandling=false; SELECT intCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=true, nIntCol1 is considered null",
+        "sql": "SET enableNullHandling=true; SELECT nIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT null FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=false, nIntCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=false; SELECT nIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=true, nnIntCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=true; SELECT nnIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=false, nnIntCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=false; SELECT nnIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+
+      {
+        "description": "aggregate with null checkers",
+        "sql": "SET enableNullHandling=true; SELECT SUM(intCol1) FROM {tbl1} WHERE intCol1 IS NOT NULL GROUP BY strCol2"
+      },
+
+      {
+        "description": "null checks in aggregate are skipped on not nullable columns",
+        "comment": "Given intCol1 is not explicitly nullable, V2 removes the IS NOT NULL predicate",
+        "sql": "SET enableNullHandling=true; SELECT strCol2, COUNT(*) FROM {tbl1} WHERE intCol1 IS NOT NULL GROUP BY strCol2",
+        "h2Sql": "SELECT strCol2, COUNT(*) FROM {tbl1} GROUP BY strCol2"
+      },
+      {
+        "description": "null checks in aggregate are honored on nullable columns",
+        "sql": "SET enableNullHandling=true; SELECT strCol2, COUNT(*) FROM {tbl1} WHERE nIntCol1 IS NOT NULL GROUP BY strCol2"
+      },
+
+      {
+        "description": "aggregate with null checkers on key from group set are skipped on not nullable columns",
+        "comment": "Given strCol2 is not explicitly nullable, V2 returns empty set",
+        "sql": "SET enableNullHandling=true; SELECT COUNT(*) FROM {tbl1} WHERE strCol2 IS NULL GROUP BY strCol2",
+        "h2Sql": "SELECT COUNT(*) FROM {tbl1} WHERE 1 = 0 GROUP BY strCol2"
+      },
+      {
+        "description": "aggregate with null checkers on key from group set are honored on not nullable columns",
+        "sql": "SET enableNullHandling=true; SELECT COUNT(*) FROM {tbl1} WHERE nStrCol2 IS NULL GROUP BY nStrCol2"
+      }
+    ],
+    "extraProps": {
+      "EnableNullHandling": "true"
+    }
+  },
+  "column_level_null_handling": {
+    "tables": {
+      "tbl1" : {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "intCol1", "type": "INT", "nullable": true},
+          {"name": "strCol2", "type": "STRING", "nullable": true}
+        ],
+        "inputs": [
+          ["foo", 1, "foo"],
+          ["bar", 2, "alice"],
+          ["alice", 3, null],
+          ["bob", 4, null],
+          ["bob", null, null]
+        ]
+      },
+      "tbl2" : {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "strCol2", "type": "STRING", "nullable": true},
+          {"name": "intCol1", "type": "INT"},
+          {"name": "doubleCol1", "type": "DOUBLE", "nullable": true}
+        ],
+        "inputs": [
+          ["foo", "bob", 3, 3.1416],
+          ["alice", "alice", 4, 2.7183],
+          ["bob", null, 5, null]
+        ]
+      },
+      "tbl3" : {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "intCol1", "type": "INT"},
+          {"name": "strCol2", "type": "STRING"}
+        ],
+        "inputs": [
+          ["foo", 1, "foo"],
+          ["bar", 2, "foo"]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "description": "join 3 tables, mixed join conditions with null non-matching",
+        "sql": "SET enableNullHandling=true; SELECT * FROM {tbl1} JOIN {tbl2} ON {tbl1}.intCol1 > {tbl2}.doubleCol1 JOIN {tbl3} ON {tbl1}.strCol1 = {tbl3}.strCol2"
+      },
+      {
+        "description": "join 3 tables, mixed join condition with null matching",
+        "sql": "SET enableNullHandling=true; SELECT * FROM {tbl1} JOIN {tbl2} ON {tbl1}.intCol1 != {tbl2}.doubleCol1 JOIN {tbl3} ON {tbl1}.strCol1 = {tbl3}.strCol2"
+      },
+      {
+        "description": "join 2 tables, mixed join conditions of null matching or non-matching",
+        "sql": "SET enableNullHandling=true; SELECT * FROM {tbl1} JOIN {tbl2} ON {tbl1}.intCol1 > {tbl2}.doubleCol1 AND {tbl1}.strCol1 = {tbl2}.strCol1"
+      },
+      {
+        "description": "aggregate with null checkers",
+        "sql": "SET enableNullHandling=true; SELECT SUM(intCol1) FROM {tbl1} WHERE intCol1 IS NOT NULL GROUP BY strCol2"
+      },
+      {
+        "description": "aggregate with null checkers",
+        "sql": "SET enableNullHandling=true; SELECT COUNT(*) FROM {tbl1} WHERE intCol1 IS NOT NULL GROUP BY strCol2"
+      },
+      {
+        "description": "aggregate with null checkers on key from group set",
+        "sql": "SET enableNullHandling=true; SELECT COUNT(*) FROM {tbl1} WHERE strCol2 IS NULL GROUP BY strCol2"
+      },
+      {
+        "description": "select only with NULL handling",
+        "sql": "SET enableNullHandling=true; SELECT * FROM {tbl1} WHERE strCol2 IS NULL AND intCol1 IS NOT NULL"
+      }
+    ]
   }
 }

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -93,7 +93,7 @@
     },
     "queries": [
       {
-        "description": "intCol1 IS NULL is always false",
+        "description": "intCol1 conserves NULLs",
         "comment": "Even when tableConfig nullHandlingEnabled is false, V2 respects column nullability",
         "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE intCol1 IS NULL",
         "h2Sql": "SELECT 0"
@@ -222,14 +222,12 @@
       },
 
       {
-        "description": "intCol1 IS NULL is always false",
-        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE intCol1 IS NULL",
-        "h2Sql": "SELECT 0"
+        "description": "intCol1 IS NULL is honored",
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE intCol1 IS NULL"
       },
       {
-        "description": "intCol1 IS NOT NULL is always true",
-        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE intCol1 IS NOT NULL",
-        "h2Sql": "SELECT count(*) FROM {tbl1}"
+        "description": "intCol1 IS NOT NULL is honored",
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE intCol1 IS NOT NULL"
       },
       {
         "description": "nIntCol1 IS NULL is honored",
@@ -287,24 +285,28 @@
       },
 
       {
-        "description": "null checks in aggregate are skipped on not nullable columns",
-        "comment": "Given intCol1 is not explicitly nullable, V2 removes the IS NOT NULL predicate",
-        "sql": "SET enableNullHandling=true; SELECT strCol2, COUNT(*) FROM {tbl1} WHERE intCol1 IS NOT NULL GROUP BY strCol2",
-        "h2Sql": "SELECT strCol2, COUNT(*) FROM {tbl1} GROUP BY strCol2"
+        "description": "null checks in aggregate are honored on implicit nullable columns",
+        "sql": "SET enableNullHandling=true; SELECT strCol2, COUNT(*) FROM {tbl1} WHERE intCol1 IS NOT NULL GROUP BY strCol2"
       },
       {
-        "description": "null checks in aggregate are honored on nullable columns",
+        "description": "null checks in aggregate are honored on explicit nullable columns",
         "sql": "SET enableNullHandling=true; SELECT strCol2, COUNT(*) FROM {tbl1} WHERE nIntCol1 IS NOT NULL GROUP BY strCol2"
+      },
+      {
+        "description": "null checks in aggregate are skipped on not nullable columns",
+        "comment": "Given nnIntCol1 is not nullable, V2 removes the IS NOT NULL predicate",
+        "sql": "SET enableNullHandling=true; SELECT strCol2, COUNT(*) FROM {tbl1} WHERE nnIntCol1 IS NOT NULL GROUP BY strCol2",
+        "h2Sql": "SELECT strCol2, COUNT(*) FROM {tbl1} GROUP BY strCol2"
       },
 
       {
         "description": "aggregate with null checkers on key from group set are skipped on not nullable columns",
         "comment": "Given strCol2 is not explicitly nullable, V2 returns empty set",
-        "sql": "SET enableNullHandling=true; SELECT COUNT(*) FROM {tbl1} WHERE strCol2 IS NULL GROUP BY strCol2",
+        "sql": "SET enableNullHandling=true; SELECT COUNT(*) FROM {tbl1} WHERE nnStrCol2 IS NULL GROUP BY strCol2",
         "h2Sql": "SELECT COUNT(*) FROM {tbl1} WHERE 1 = 0 GROUP BY strCol2"
       },
       {
-        "description": "aggregate with null checkers on key from group set are honored on not nullable columns",
+        "description": "aggregate with null checkers on key from group set are honored on nullable columns",
         "sql": "SET enableNullHandling=true; SELECT COUNT(*) FROM {tbl1} WHERE nStrCol2 IS NULL GROUP BY nStrCol2"
       }
     ]

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -45,6 +45,7 @@ import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -69,6 +70,17 @@ public class ImmutableSegmentLoader {
     IndexLoadingConfig defaultIndexLoadingConfig = new IndexLoadingConfig();
     defaultIndexLoadingConfig.setReadMode(readMode);
     return load(indexDir, defaultIndexLoadingConfig, null, false);
+  }
+
+  /**
+   * Loads the segment with empty schema and IndexLoadingConfig. This method is used to
+   * access the segment without modifying it, i.e. in read-only mode.
+   */
+  public static ImmutableSegment load(File indexDir, ReadMode readMode, Schema schema, TableConfig tableConfig)
+      throws Exception {
+    IndexLoadingConfig defaultIndexLoadingConfig = new IndexLoadingConfig(tableConfig, schema);
+    defaultIndexLoadingConfig.setReadMode(readMode);
+    return load(indexDir, defaultIndexLoadingConfig, schema, false);
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -252,8 +252,8 @@ public class MutableSegmentImpl implements MutableSegment {
     }
 
     Set<IndexType> specialIndexes =
-        Sets.newHashSet(StandardIndexes.dictionary(), // dictionaries implement other contract
-            StandardIndexes.nullValueVector()); // null value vector implement other contract
+        Sets.newHashSet(StandardIndexes.dictionary(), // dictionaries implements other contract
+            StandardIndexes.nullValueVector()); // null value vector implements other contract
 
     // Initialize for each column
     for (FieldSpec fieldSpec : _physicalFieldSpecs) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -133,6 +133,10 @@ public class IndexLoadingConfig {
     this(instanceDataManagerConfig, tableConfig, null);
   }
 
+  public IndexLoadingConfig(TableConfig tableConfig, @Nullable Schema schema) {
+    extractFromTableConfigAndSchema(tableConfig, schema);
+  }
+
   public IndexLoadingConfig() {
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
@@ -19,8 +19,10 @@
 
 package org.apache.pinot.segment.local.segment.index.nullvalue;
 
+import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,15 +35,17 @@ import org.apache.pinot.segment.spi.creator.IndexCreationContext;
 import org.apache.pinot.segment.spi.index.AbstractIndexType;
 import org.apache.pinot.segment.spi.index.ColumnConfigDeserializer;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
-import org.apache.pinot.segment.spi.index.IndexConfigDeserializer;
 import org.apache.pinot.segment.spi.index.IndexHandler;
 import org.apache.pinot.segment.spi.index.IndexReaderFactory;
+import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.config.table.IndexConfig;
+import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 
 
@@ -77,11 +81,24 @@ public class NullValueIndexType extends AbstractIndexType<IndexConfig, NullValue
 
   @Override
   public ColumnConfigDeserializer<IndexConfig> createDeserializer() {
-    return IndexConfigDeserializer.ifIndexingConfig(
-        IndexConfigDeserializer.alwaysCall((TableConfig tableConfig, Schema schema) ->
-            tableConfig.getIndexingConfig().isNullHandlingEnabled()
-                ? IndexConfig.ENABLED
-                : IndexConfig.DISABLED));
+    return (TableConfig tableConfig, Schema schema) -> {
+      IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+      boolean nullHandlingEnabled = indexingConfig != null && indexingConfig.isNullHandlingEnabled();
+
+      Collection<FieldSpec> allFieldSpecs = schema.getAllFieldSpecs();
+      Map<String, IndexConfig> configMap = Maps.newHashMapWithExpectedSize(allFieldSpecs.size());
+
+      for (FieldSpec fieldSpec : allFieldSpecs) {
+        IndexConfig indexConfig;
+        if (fieldSpec.getNullable() == Boolean.TRUE || fieldSpec.getNullable() == null && nullHandlingEnabled) {
+          indexConfig = IndexConfig.ENABLED;
+        } else {
+          indexConfig = IndexConfig.DISABLED;
+        }
+        configMap.put(fieldSpec.getName(), indexConfig);
+      }
+      return configMap;
+    };
   }
 
   public NullValueVectorCreator createIndexCreator(File indexDir, String columnName) {
@@ -116,10 +133,14 @@ public class NullValueIndexType extends AbstractIndexType<IndexConfig, NullValue
     public NullValueVectorReader createIndexReader(SegmentDirectory.Reader segmentReader,
         FieldIndexConfigs fieldIndexConfigs, ColumnMetadata metadata)
           throws IOException {
-      if (!segmentReader.hasIndexFor(metadata.getColumnName(), StandardIndexes.nullValueVector())) {
+      IndexType<IndexConfig, NullValueVectorReader, ?> indexType = StandardIndexes.nullValueVector();
+      if (fieldIndexConfigs.getConfig(indexType).isDisabled()) {
         return null;
       }
-      PinotDataBuffer buffer = segmentReader.getIndexFor(metadata.getColumnName(), StandardIndexes.nullValueVector());
+      if (!segmentReader.hasIndexFor(metadata.getColumnName(), indexType)) {
+        return null;
+      }
+      PinotDataBuffer buffer = segmentReader.getIndexFor(metadata.getColumnName(), indexType);
       return new NullValueVectorReaderImpl(buffer);
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
@@ -71,7 +71,7 @@ public class NullValueIndexType extends AbstractIndexType<IndexConfig, NullValue
 
   @Override
   public IndexConfig getDefaultConfig() {
-    return IndexConfig.DISABLED;
+    return IndexConfig.ENABLED;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
@@ -43,7 +43,6 @@ import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.config.table.IndexConfig;
-import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
@@ -82,15 +81,12 @@ public class NullValueIndexType extends AbstractIndexType<IndexConfig, NullValue
   @Override
   public ColumnConfigDeserializer<IndexConfig> createDeserializer() {
     return (TableConfig tableConfig, Schema schema) -> {
-      IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
-      boolean nullHandlingEnabled = indexingConfig != null && indexingConfig.isNullHandlingEnabled();
-
       Collection<FieldSpec> allFieldSpecs = schema.getAllFieldSpecs();
       Map<String, IndexConfig> configMap = Maps.newHashMapWithExpectedSize(allFieldSpecs.size());
 
       for (FieldSpec fieldSpec : allFieldSpecs) {
         IndexConfig indexConfig;
-        if (fieldSpec.getNullable() == Boolean.TRUE || fieldSpec.getNullable() == null && nullHandlingEnabled) {
+        if (fieldSpec.isNullable()) {
           indexConfig = IndexConfig.ENABLED;
         } else {
           indexConfig = IndexConfig.DISABLED;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexTypeTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.nullvalue;
+
+import org.apache.pinot.segment.local.segment.index.AbstractSerdeIndexContract;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.spi.config.table.IndexConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class NullValueIndexTypeTest {
+
+  @DataProvider(name = "provideCases")
+  public Object[][] provideCases() {
+    return new Object[][] {
+        // setNullable  | nullHandlingEnabled | Index is enabled
+        new Object[] {true, null, IndexConfig.ENABLED},
+        new Object[] {true, true, IndexConfig.ENABLED},
+        new Object[] {true, false, IndexConfig.ENABLED},
+
+        new Object[] {false, null, IndexConfig.DISABLED},
+        new Object[] {false, true, IndexConfig.DISABLED},
+        new Object[] {false, false, IndexConfig.DISABLED},
+
+        new Object[] {null, null, IndexConfig.DISABLED},
+        new Object[] {null, true, IndexConfig.ENABLED},
+        new Object[] {null, false, IndexConfig.DISABLED}
+    };
+  }
+
+  public static class ConfTest extends AbstractSerdeIndexContract {
+
+    protected void assertEquals(IndexConfig expected) {
+      Assert.assertEquals(getActualConfig("dimStr", StandardIndexes.nullValueVector()), expected);
+    }
+
+    @Test(dataProvider = "provideCases", dataProviderClass = NullValueIndexTypeTest.class)
+    public void isEnabledWhenNullable(Boolean fieldNullable, Boolean nullHandlingEnabled, IndexConfig expected) {
+      FieldSpec dimStr = _schema.getFieldSpecFor("dimStr");
+      dimStr.setNullable(fieldNullable);
+
+      if (nullHandlingEnabled != null) {
+        _tableConfig.getIndexingConfig().setNullHandlingEnabled(nullHandlingEnabled);
+      }
+
+      assertEquals(expected);
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexTypeTest.java
@@ -56,7 +56,9 @@ public class NullValueIndexTypeTest {
     @Test(dataProvider = "provideCases", dataProviderClass = NullValueIndexTypeTest.class)
     public void isEnabledWhenNullable(Boolean fieldNullable, Boolean nullHandlingEnabled, IndexConfig expected) {
       FieldSpec dimStr = _schema.getFieldSpecFor("dimStr");
-      dimStr.setNullable(fieldNullable);
+      if (fieldNullable != null) {
+        dimStr.setNullable(fieldNullable);
+      }
 
       if (nullHandlingEnabled != null) {
         _tableConfig.getIndexingConfig().setNullHandlingEnabled(nullHandlingEnabled);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexTypeTest.java
@@ -41,9 +41,9 @@ public class NullValueIndexTypeTest {
         new Object[] {false, true, IndexConfig.DISABLED},
         new Object[] {false, false, IndexConfig.DISABLED},
 
-        new Object[] {null, null, IndexConfig.DISABLED},
+        new Object[] {null, null, IndexConfig.ENABLED},
         new Object[] {null, true, IndexConfig.ENABLED},
-        new Object[] {null, false, IndexConfig.DISABLED}
+        new Object[] {null, false, IndexConfig.ENABLED}
     };
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -27,7 +27,6 @@ import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.EqualityUtils;
@@ -101,7 +100,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   protected String _name;
   protected DataType _dataType;
   protected boolean _isSingleValueField = true;
-  protected Boolean _nullable = null;
+  protected boolean _nullable = true;
 
   // NOTE: This only applies to STRING column, which is the max number of characters
   private int _maxLength = DEFAULT_MAX_LENGTH;
@@ -305,22 +304,15 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
 
   /**
    * Returns whether the column is nullable or not.
-   *
-   * This Java property itself is nullable. In case null is returned, actual nullability depends on the value of
-   * {@link IndexingConfig#isNullHandlingEnabled()}.
-   *
-   * @return true if the field is nullable, false if it is not and null if column level nullability should be delegated
-   * to {@link IndexingConfig#isNullHandlingEnabled()}.
    */
-  @Nullable
-  public Boolean getNullable() {
+  public boolean isNullable() {
     return _nullable;
   }
 
   /**
-   * @see #getNullable()
+   * @see #isNullable()
    */
-  public void setNullable(@Nullable Boolean nullable) {
+  public void setNullable(boolean nullable) {
     _nullable = nullable;
   }
 
@@ -341,9 +333,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     }
     appendDefaultNullValue(jsonObject);
     appendTransformFunction(jsonObject);
-    if (_nullable != null) {
-      jsonObject.put("nullable", _nullable);
-    }
+    jsonObject.put("nullable", _nullable);
     return jsonObject;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -27,6 +27,7 @@ import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.EqualityUtils;
@@ -44,6 +45,7 @@ import org.apache.pinot.spi.utils.TimestampUtils;
  * <p>- <code>IsSingleValueField</code>: single-value or multi-value field.
  * <p>- <code>DefaultNullValue</code>: when no value found for this field, use this value. Stored in string format.
  * <p>- <code>VirtualColumnProvider</code>: the virtual column provider to use for this field.
+ * <p>- <code>Nullable</code>: whether the column is nullable or not. Defaults to null
  */
 @SuppressWarnings("unused")
 public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
@@ -99,6 +101,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   protected String _name;
   protected DataType _dataType;
   protected boolean _isSingleValueField = true;
+  protected Boolean _nullable = null;
 
   // NOTE: This only applies to STRING column, which is the max number of characters
   private int _maxLength = DEFAULT_MAX_LENGTH;
@@ -301,6 +304,27 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   }
 
   /**
+   * Returns whether the column is nullable or not.
+   *
+   * This Java property itself is nullable. In case null is returned, actual nullability depends on the value of
+   * {@link IndexingConfig#isNullHandlingEnabled()}.
+   *
+   * @return true if the field is nullable, false if it is not and null if column level nullability should be delegated
+   * to {@link IndexingConfig#isNullHandlingEnabled()}.
+   */
+  @Nullable
+  public Boolean getNullable() {
+    return _nullable;
+  }
+
+  /**
+   * @see #getNullable()
+   */
+  public void setNullable(@Nullable Boolean nullable) {
+    _nullable = nullable;
+  }
+
+  /**
    * Returns the {@link ObjectNode} representing the field spec.
    * <p>Only contains fields with non-default value.
    * <p>NOTE: here we use {@link ObjectNode} to preserve the insertion order.
@@ -317,6 +341,9 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     }
     appendDefaultNullValue(jsonObject);
     appendTransformFunction(jsonObject);
+    if (_nullable != null) {
+      jsonObject.put("nullable", _nullable);
+    }
     return jsonObject;
   }
 
@@ -381,7 +408,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
         .isEqual(_isSingleValueField, that._isSingleValueField) && EqualityUtils
         .isEqual(getStringValue(_defaultNullValue), getStringValue(that._defaultNullValue)) && EqualityUtils
         .isEqual(_maxLength, that._maxLength) && EqualityUtils.isEqual(_transformFunction, that._transformFunction)
-        && EqualityUtils.isEqual(_virtualColumnProvider, that._virtualColumnProvider);
+        && EqualityUtils.isEqual(_virtualColumnProvider, that._virtualColumnProvider)
+        && EqualityUtils.isEqual(_nullable, that._nullable);
   }
 
   @Override
@@ -393,6 +421,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     result = EqualityUtils.hashCodeOf(result, _maxLength);
     result = EqualityUtils.hashCodeOf(result, _transformFunction);
     result = EqualityUtils.hashCodeOf(result, _virtualColumnProvider);
+    result = EqualityUtils.hashCodeOf(result, _nullable);
     return result;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -37,6 +37,7 @@ import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
 import java.util.concurrent.TimeUnit;
+import java.util.function.Consumer;
 import javax.annotation.Nullable;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -520,26 +521,57 @@ public final class Schema implements Serializable {
       return this;
     }
 
-    /**
-     * Add single value dimensionFieldSpec
-     */
-    public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType) {
-      return addSingleValueDimension(dimensionName, dataType, null);
+    public SchemaBuilder addMetricField(String name, DataType dataType) {
+      return addMetricField(name, dataType, ignore -> {
+      });
     }
 
-    public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, Boolean nullable) {
-      DimensionFieldSpec dimensionFieldSpec = new DimensionFieldSpec(dimensionName, dataType, true);
-      dimensionFieldSpec.setNullable(nullable);
-      _schema.addField(dimensionFieldSpec);
+    public SchemaBuilder addMetricField(String name, DataType dataType, Consumer<MetricFieldSpec> customizer) {
+      MetricFieldSpec fieldSpec = new MetricFieldSpec();
+      return addFieldSpec(fieldSpec, name, dataType, customizer);
+    }
+
+    public SchemaBuilder addDimensionField(String name, DataType dataType) {
+      return addDimensionField(name, dataType, ignore -> {
+      });
+    }
+
+    public SchemaBuilder addDimensionField(String name, DataType dataType, Consumer<DimensionFieldSpec> customizer) {
+      DimensionFieldSpec fieldSpec = new DimensionFieldSpec();
+      return addFieldSpec(fieldSpec, name, dataType, customizer);
+    }
+
+    public SchemaBuilder addDateTimeField(String name, DataType dataType) {
+      return addDateTimeField(name, dataType, ignore -> {
+      });
+    }
+
+    public SchemaBuilder addDateTimeField(String name, DataType dataType, Consumer<DateTimeFieldSpec> customizer) {
+      DateTimeFieldSpec fieldSpec = new DateTimeFieldSpec();
+      return addFieldSpec(fieldSpec, name, dataType, customizer);
+    }
+
+    private <E extends FieldSpec> SchemaBuilder addFieldSpec(E fieldSpec, String name, DataType dataType,
+        Consumer<E> customizer) {
+      fieldSpec.setName(name);
+      fieldSpec.setDataType(dataType);
+      customizer.accept(fieldSpec);
+      _schema.addField(fieldSpec);
       return this;
     }
 
     /**
-     * Add single value dimensionFieldSpec with a defaultNullValue.
+     * Add single value dimensionFieldSpec
+     */
+    public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType) {
+      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true));
+      return this;
+    }
+    /**
+     * Add single value dimensionFieldSpec with a defaultNullValue
      */
     public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, Object defaultNullValue) {
-      DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, true, defaultNullValue);
-      _schema.addField(fieldSpec);
+      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true, defaultNullValue));
       return this;
     }
 
@@ -550,9 +582,7 @@ public final class Schema implements Serializable {
         Object defaultNullValue) {
       Preconditions.checkArgument(dataType == DataType.STRING,
           "The maxLength field only applies to STRING field right now");
-      DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, true, maxLength,
-          defaultNullValue);
-      _schema.addField(fieldSpec);
+      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true, maxLength, defaultNullValue));
       return this;
     }
 
@@ -560,13 +590,7 @@ public final class Schema implements Serializable {
      * Add multi value dimensionFieldSpec
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType) {
-      return addMultiValueDimension(dimensionName, dataType, null);
-    }
-
-    public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, Boolean nullable) {
-      DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, false);
-      fieldSpec.setNullable(nullable);
-      _schema.addField(fieldSpec);
+      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false));
       return this;
     }
 
@@ -574,21 +598,18 @@ public final class Schema implements Serializable {
      * Add multi value dimensionFieldSpec with defaultNullValue
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, Object defaultNullValue) {
-      DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, false, defaultNullValue);
-      _schema.addField(fieldSpec);
+      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, defaultNullValue));
       return this;
     }
 
     /**
-     * Add multi value dimensionFieldSpec with maxLength and a defaultNullValue*
+     * Add multi value dimensionFieldSpec with maxLength and a defaultNullValue
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, int maxLength,
         Object defaultNullValue) {
       Preconditions.checkArgument(dataType == DataType.STRING,
           "The maxLength field only applies to STRING field right now");
-      DimensionFieldSpec fieldSpec =
-          new DimensionFieldSpec(dimensionName, dataType, false, maxLength, defaultNullValue);
-      _schema.addField(fieldSpec);
+      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, maxLength, defaultNullValue));
       return this;
     }
 
@@ -596,13 +617,7 @@ public final class Schema implements Serializable {
      * Add metricFieldSpec
      */
     public SchemaBuilder addMetric(String metricName, DataType dataType) {
-      return addMetric(metricName, dataType, null);
-    }
-
-    public SchemaBuilder addMetric(String metricName, DataType dataType, Boolean nullable) {
-      MetricFieldSpec fieldSpec = new MetricFieldSpec(metricName, dataType);
-      fieldSpec.setNullable(nullable);
-      _schema.addField(fieldSpec);
+      _schema.addField(new MetricFieldSpec(metricName, dataType));
       return this;
     }
 
@@ -610,8 +625,7 @@ public final class Schema implements Serializable {
      * Add metricFieldSpec with defaultNullValue
      */
     public SchemaBuilder addMetric(String metricName, DataType dataType, Object defaultNullValue) {
-      MetricFieldSpec fieldSpec = new MetricFieldSpec(metricName, dataType, defaultNullValue);
-      _schema.addField(fieldSpec);
+      _schema.addField(new MetricFieldSpec(metricName, dataType, defaultNullValue));
       return this;
     }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -524,26 +524,41 @@ public final class Schema implements Serializable {
      * Add single value dimensionFieldSpec
      */
     public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType) {
-      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true));
+      return addSingleValueDimension(dimensionName, dataType, null);
+    }
+
+    public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, Boolean nullable) {
+      DimensionFieldSpec dimensionFieldSpec = new DimensionFieldSpec(dimensionName, dataType, true);
+      dimensionFieldSpec.setNullable(nullable);
+      _schema.addField(dimensionFieldSpec);
       return this;
     }
 
     /**
-     * Add single value dimensionFieldSpec with a defaultNullValue
+     * Add single value dimensionFieldSpec with a defaultNullValue.
+     *
+     * This method assumes the field is nullable.
      */
     public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, Object defaultNullValue) {
-      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true, defaultNullValue));
+      DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, true, defaultNullValue);
+      fieldSpec.setNullable(true);
+      _schema.addField(fieldSpec);
       return this;
     }
 
     /**
      * Add single value dimensionFieldSpec with maxLength and a defaultNullValue
+     *
+     * This method assumes the field is nullable.
      */
     public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, int maxLength,
         Object defaultNullValue) {
       Preconditions.checkArgument(dataType == DataType.STRING,
           "The maxLength field only applies to STRING field right now");
-      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true, maxLength, defaultNullValue));
+      DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, true, maxLength,
+          defaultNullValue);
+      fieldSpec.setNullable(true);
+      _schema.addField(fieldSpec);
       return this;
     }
 
@@ -551,26 +566,41 @@ public final class Schema implements Serializable {
      * Add multi value dimensionFieldSpec
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType) {
-      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false));
+      return addMultiValueDimension(dimensionName, dataType, null);
+    }
+
+    public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, Boolean nullable) {
+      DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, false);
+      fieldSpec.setNullable(nullable);
+      _schema.addField(fieldSpec);
       return this;
     }
 
     /**
      * Add multi value dimensionFieldSpec with defaultNullValue
+     *
+     * This method assumes the field is nullable.
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, Object defaultNullValue) {
-      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, defaultNullValue));
+      DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, false, defaultNullValue);
+      fieldSpec.setNullable(true);
+      _schema.addField(fieldSpec);
       return this;
     }
 
     /**
      * Add multi value dimensionFieldSpec with maxLength and a defaultNullValue
+     *
+     * This method assumes the field is nullable.
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, int maxLength,
         Object defaultNullValue) {
       Preconditions.checkArgument(dataType == DataType.STRING,
           "The maxLength field only applies to STRING field right now");
-      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, maxLength, defaultNullValue));
+      DimensionFieldSpec fieldSpec =
+          new DimensionFieldSpec(dimensionName, dataType, false, maxLength, defaultNullValue);
+      fieldSpec.setNullable(true);
+      _schema.addField(fieldSpec);
       return this;
     }
 
@@ -578,15 +608,25 @@ public final class Schema implements Serializable {
      * Add metricFieldSpec
      */
     public SchemaBuilder addMetric(String metricName, DataType dataType) {
-      _schema.addField(new MetricFieldSpec(metricName, dataType));
+      return addMetric(metricName, dataType, null);
+    }
+
+    public SchemaBuilder addMetric(String metricName, DataType dataType, Boolean nullable) {
+      MetricFieldSpec fieldSpec = new MetricFieldSpec(metricName, dataType);
+      fieldSpec.setNullable(nullable);
+      _schema.addField(fieldSpec);
       return this;
     }
 
     /**
      * Add metricFieldSpec with defaultNullValue
+     *
+     * This method assumes the field is nullable.
      */
     public SchemaBuilder addMetric(String metricName, DataType dataType, Object defaultNullValue) {
-      _schema.addField(new MetricFieldSpec(metricName, dataType, defaultNullValue));
+      MetricFieldSpec fieldSpec = new MetricFieldSpec(metricName, dataType, defaultNullValue);
+      fieldSpec.setNullable(true);
+      _schema.addField(fieldSpec);
       return this;
     }
 
@@ -618,11 +658,14 @@ public final class Schema implements Serializable {
 
     /**
      * Add dateTimeFieldSpec with basic fields plus defaultNullValue and transformFunction
+     *
+     * This method assumes the field is nullable.
      */
     public SchemaBuilder addDateTime(String name, DataType dataType, String format, String granularity,
         @Nullable Object defaultNullValue, @Nullable String transformFunction) {
       DateTimeFieldSpec dateTimeFieldSpec =
           new DateTimeFieldSpec(name, dataType, format, granularity, defaultNullValue, transformFunction);
+      dateTimeFieldSpec.setNullable(true);
       _schema.addField(dateTimeFieldSpec);
       return this;
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -541,13 +541,16 @@ public final class Schema implements Serializable {
       return addFieldSpec(fieldSpec, name, dataType, customizer);
     }
 
-    public SchemaBuilder addDateTimeField(String name, DataType dataType) {
-      return addDateTimeField(name, dataType, ignore -> {
+    public SchemaBuilder addDateTimeField(String name, DataType dataType, String format, String granularity) {
+      return addDateTimeField(name, dataType, format, granularity, ignore -> {
       });
     }
 
-    public SchemaBuilder addDateTimeField(String name, DataType dataType, Consumer<DateTimeFieldSpec> customizer) {
+    public SchemaBuilder addDateTimeField(String name, DataType dataType, String format, String granularity,
+        Consumer<DateTimeFieldSpec> customizer) {
       DateTimeFieldSpec fieldSpec = new DateTimeFieldSpec();
+      fieldSpec.setFormat(format);
+      fieldSpec.setGranularity(granularity);
       return addFieldSpec(fieldSpec, name, dataType, customizer);
     }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -536,20 +536,15 @@ public final class Schema implements Serializable {
 
     /**
      * Add single value dimensionFieldSpec with a defaultNullValue.
-     *
-     * This method assumes the field is nullable.
      */
     public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, Object defaultNullValue) {
       DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, true, defaultNullValue);
-      fieldSpec.setNullable(true);
       _schema.addField(fieldSpec);
       return this;
     }
 
     /**
      * Add single value dimensionFieldSpec with maxLength and a defaultNullValue
-     *
-     * This method assumes the field is nullable.
      */
     public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, int maxLength,
         Object defaultNullValue) {
@@ -557,7 +552,6 @@ public final class Schema implements Serializable {
           "The maxLength field only applies to STRING field right now");
       DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, true, maxLength,
           defaultNullValue);
-      fieldSpec.setNullable(true);
       _schema.addField(fieldSpec);
       return this;
     }
@@ -578,20 +572,15 @@ public final class Schema implements Serializable {
 
     /**
      * Add multi value dimensionFieldSpec with defaultNullValue
-     *
-     * This method assumes the field is nullable.
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, Object defaultNullValue) {
       DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, false, defaultNullValue);
-      fieldSpec.setNullable(true);
       _schema.addField(fieldSpec);
       return this;
     }
 
     /**
-     * Add multi value dimensionFieldSpec with maxLength and a defaultNullValue
-     *
-     * This method assumes the field is nullable.
+     * Add multi value dimensionFieldSpec with maxLength and a defaultNullValue*
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, int maxLength,
         Object defaultNullValue) {
@@ -599,7 +588,6 @@ public final class Schema implements Serializable {
           "The maxLength field only applies to STRING field right now");
       DimensionFieldSpec fieldSpec =
           new DimensionFieldSpec(dimensionName, dataType, false, maxLength, defaultNullValue);
-      fieldSpec.setNullable(true);
       _schema.addField(fieldSpec);
       return this;
     }
@@ -620,12 +608,9 @@ public final class Schema implements Serializable {
 
     /**
      * Add metricFieldSpec with defaultNullValue
-     *
-     * This method assumes the field is nullable.
      */
     public SchemaBuilder addMetric(String metricName, DataType dataType, Object defaultNullValue) {
       MetricFieldSpec fieldSpec = new MetricFieldSpec(metricName, dataType, defaultNullValue);
-      fieldSpec.setNullable(true);
       _schema.addField(fieldSpec);
       return this;
     }
@@ -658,14 +643,11 @@ public final class Schema implements Serializable {
 
     /**
      * Add dateTimeFieldSpec with basic fields plus defaultNullValue and transformFunction
-     *
-     * This method assumes the field is nullable.
      */
     public SchemaBuilder addDateTime(String name, DataType dataType, String format, String granularity,
         @Nullable Object defaultNullValue, @Nullable String transformFunction) {
       DateTimeFieldSpec dateTimeFieldSpec =
           new DateTimeFieldSpec(name, dataType, format, granularity, defaultNullValue, transformFunction);
-      dateTimeFieldSpec.setNullable(true);
       _schema.addField(dateTimeFieldSpec);
       return this;
     }


### PR DESCRIPTION
This is PR that has the intention of implementing column level nullability, as explained in https://github.com/apache/pinot/issues/10381.

Current status:
- [x] Add nullability to Schema.FieldSpec.
- [x] Use Schema.FieldSpec.getNullable to inform Calcite about actual column nullability.
- [x] Use Schema.FieldSpec.getNullable to somehow support column level nullability in V1.
    * To modify V1 to actually support column level nullability seems a long task
    * What we are going to do in the first place is to:
      - [x] Modify the leafs of the execution tree to ignore the actual null value vector for columns whose Schema.FieldSpec.getNullable is false. These columns will be treated as they were created with a TableConfig where `nullHandlingEnabled` was `false`.
      - [x] Keep the rest of the V1 engine stable, so the new null vectors will be calculated for transformations applied to non nullable colums. But given these columns will produce values that are not actually null, transformations should be also not null.
- [x] ~Modify V2 leaves to force `enableNullHandling=true`.~
   * For now we are not going to apply this change in this PR. Users will still need to provide this option at query time
- [x] Add tests that verify the changes.

Semantics in V1 are changed to:

| enableNullHandling  | Segment has null vector | FieldSpec\*         | in master | in PR        |
|---------------------|-------------------------|--------------------|-----------|--------------|
| false               | N/A                     | N/A                | not null  | not null     |
| true                | false                   | N/A                | not null  | not null     | 
| true                | true                    | true (default)     | null      | null         |
| true                | true                    | false              | null      | not null     |

*: Value of `FieldSpec.getNullable()`