### PR TITLE
[Draft] allow to fallback to a replica group for strictReplicaGroup

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorFactory.java
@@ -69,7 +69,7 @@ public class InstanceSelectorFactory {
           routingConfig.getInstanceSelectorType())) {
         LOGGER.info("Using StrictReplicaGroupInstanceSelector for table: {}", tableNameWithType);
         return new StrictReplicaGroupInstanceSelector(tableNameWithType, propertyStore, brokerMetrics,
-            adaptiveServerSelector, clock);
+            adaptiveServerSelector, routingConfig.getInstanceSelectorProperties(), clock);
       }
       if (RoutingConfig.MULTI_STAGE_REPLICA_GROUP_SELECTOR_TYPE.equalsIgnoreCase(
           routingConfig.getInstanceSelectorType())) {

--- a/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorTest.java
@@ -236,7 +236,8 @@ public class InstanceSelectorTest {
     ReplicaGroupInstanceSelector replicaGroupInstanceSelector =
         new ReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC());
     StrictReplicaGroupInstanceSelector strictReplicaGroupInstanceSelector =
-        new StrictReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC());
+        new StrictReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, null,
+            Clock.systemUTC());
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);
@@ -1091,7 +1092,8 @@ public class InstanceSelectorTest {
         new BalancedInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC());
     // ReplicaGroupInstanceSelector has the same behavior as BalancedInstanceSelector for the unavailable segments
     StrictReplicaGroupInstanceSelector strictReplicaGroupInstanceSelector =
-        new StrictReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, Clock.systemUTC());
+        new StrictReplicaGroupInstanceSelector(offlineTableName, propertyStore, brokerMetrics, null, null,
+            Clock.systemUTC());
 
     Set<String> enabledInstances = new HashSet<>();
     IdealState idealState = new IdealState(offlineTableName);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/RoutingConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/RoutingConfig.java
@@ -21,6 +21,7 @@ package org.apache.pinot.spi.config.table;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import java.util.List;
+import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.BaseJsonConfig;
 
@@ -39,14 +40,24 @@ public class RoutingConfig extends BaseJsonConfig {
 
   private final List<String> _segmentPrunerTypes;
   private final String _instanceSelectorType;
+  private final Map<String, String> _instanceSelectorProperties;
 
   @JsonCreator
   public RoutingConfig(@JsonProperty("routingTableBuilderName") @Nullable String routingTableBuilderName,
       @JsonProperty("segmentPrunerTypes") @Nullable List<String> segmentPrunerTypes,
       @JsonProperty("instanceSelectorType") @Nullable String instanceSelectorType) {
+    this(routingTableBuilderName, segmentPrunerTypes, instanceSelectorType, null);
+  }
+
+  @JsonCreator
+  public RoutingConfig(@JsonProperty("routingTableBuilderName") @Nullable String routingTableBuilderName,
+      @JsonProperty("segmentPrunerTypes") @Nullable List<String> segmentPrunerTypes,
+      @JsonProperty("instanceSelectorType") @Nullable String instanceSelectorType,
+      @JsonProperty("instanceSelectorProperties") @Nullable Map<String, String> instanceSelectorProperties) {
     _routingTableBuilderName = routingTableBuilderName;
     _segmentPrunerTypes = segmentPrunerTypes;
     _instanceSelectorType = instanceSelectorType;
+    _instanceSelectorProperties = instanceSelectorProperties;
   }
 
   @Nullable
@@ -62,5 +73,9 @@ public class RoutingConfig extends BaseJsonConfig {
   @Nullable
   public String getInstanceSelectorType() {
     return _instanceSelectorType;
+  }
+
+  public Map<String, String> getInstanceSelectorProperties() {
+    return _instanceSelectorProperties;
   }
 }


### PR DESCRIPTION
Add new configs for strictReplicaGroup routing policy to favor availability over completeness. 

Currently for strictReplicaGroup, if none of the replica groups have `all` segments available in it, all segments are marked as unavailable, as no replica group could execute the query with complete set of segments. This PR adds new configs so that we can fallback to a replica group and continue the query, with more specific error about which segments are unavailable in that replica group. By default, no fall back.

## Release Note ##
Added a new config section inside RoutingConfig as `"instanceSelectorProperties": {k:v, k:v}`
1. "allowFallback": "true" or "false", and false by default
2. "fallbackPolicy": "best" or "random", and "random" by default