### PR TITLE
Log query and emit metrics for grpc request and multi-stage leaf stage

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -112,6 +112,12 @@ rules:
   cache: true
   labels:
     table: "$1"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.numResizes.([^\\.]*?)_(OFFLINE|REALTIME)\"><>(\\w+)"
+  name: "pinot_server_numResizes_$3"
+  cache: true
+  labels:
+    table: "$1"
+    tableType: "$2"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.resizeTimeMs.([^\\.]*?)_(OFFLINE|REALTIME)\"><>(\\w+)"
   name: "pinot_server_resizeTimeMs_$3"
   cache: true

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -40,7 +40,6 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   REALTIME_OFFHEAP_MEMORY_USED("bytes", false),
   REALTIME_SEGMENT_NUM_PARTITIONS("realtimeSegmentNumPartitions", false),
   LLC_SIMULTANEOUS_SEGMENT_BUILDS("llcSimultaneousSegmentBuilds", true),
-  RESIZE_TIME_MS("milliseconds", false),
   // Upsert metrics
   UPSERT_PRIMARY_KEYS_COUNT("upsertPrimaryKeysCount", false),
   // Dedup metrics

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -81,6 +81,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   // Emitted only by Server to Deep-store segment uploader.
   SEGMENT_UPLOAD_TIMEOUT("segments", false),
   NUM_RESIZES("numResizes", false),
+  RESIZE_TIME_MS("resizeTimeMs", false),
   NO_TABLE_ACCESS("tables", true),
   INDEXING_FAILURES("attributeValues", true),
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/logger/ServerQueryLogger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/logger/ServerQueryLogger.java
@@ -1,0 +1,227 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.core.query.logger;
+
+import com.google.common.util.concurrent.RateLimiter;
+import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.datatable.DataTable.MetadataKey;
+import org.apache.pinot.common.metrics.ServerMeter;
+import org.apache.pinot.common.metrics.ServerMetrics;
+import org.apache.pinot.common.metrics.ServerQueryPhase;
+import org.apache.pinot.common.metrics.ServerTimer;
+import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;
+import org.apache.pinot.core.query.request.ServerQueryRequest;
+import org.apache.pinot.core.query.request.context.TimerContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+@SuppressWarnings("UnstableApiUsage")
+public class ServerQueryLogger {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ServerQueryLogger.class);
+  private static final AtomicReference<ServerQueryLogger> INSTANCE = new AtomicReference<>();
+
+  private final ServerMetrics _serverMetrics;
+  private final RateLimiter _queryLogRateLimiter;
+  private final RateLimiter _droppedReportRateLimiter;
+  private final AtomicInteger _numDroppedLogs = new AtomicInteger();
+
+  public static void init(double queryLogMaxRate, double droppedReportMaxRate, ServerMetrics serverMetrics) {
+    if (INSTANCE.compareAndSet(null, new ServerQueryLogger(queryLogMaxRate, droppedReportMaxRate, serverMetrics))) {
+      LOGGER.info("Initialized ServerQueryLogger with query log max rate: {}, dropped report max rate: {}",
+          queryLogMaxRate, droppedReportMaxRate);
+    } else {
+      LOGGER.error("ServerQueryLogger is already initialized, not initializing it again");
+    }
+  }
+
+  @Nullable
+  public static ServerQueryLogger getInstance() {
+    // NOTE: In some tests, ServerQueryLogger might not be initialized. Returns null when it is not initialized.
+    return INSTANCE.get();
+  }
+
+  private ServerQueryLogger(double queryLogMaxRate, double droppedReportMaxRate, ServerMetrics serverMetrics) {
+    _serverMetrics = serverMetrics;
+    _queryLogRateLimiter = RateLimiter.create(queryLogMaxRate);
+    _droppedReportRateLimiter = RateLimiter.create(droppedReportMaxRate);
+  }
+
+  public void logQuery(ServerQueryRequest request, InstanceResponseBlock response, String schedulerType) {
+    String tableNameWithType = request.getTableNameWithType();
+    Map<String, String> responseMetadata = response.getResponseMetadata();
+
+    long numDocsScanned = getLongValue(responseMetadata, MetadataKey.NUM_DOCS_SCANNED.getName(), -1);
+    addToTableMeter(tableNameWithType, ServerMeter.NUM_DOCS_SCANNED, numDocsScanned);
+
+    long numEntriesScannedInFilter =
+        getLongValue(responseMetadata, MetadataKey.NUM_ENTRIES_SCANNED_IN_FILTER.getName(), -1);
+    addToTableMeter(tableNameWithType, ServerMeter.NUM_ENTRIES_SCANNED_IN_FILTER, numEntriesScannedInFilter);
+
+    long numEntriesScannedPostFilter =
+        getLongValue(responseMetadata, MetadataKey.NUM_ENTRIES_SCANNED_POST_FILTER.getName(), -1);
+    addToTableMeter(tableNameWithType, ServerMeter.NUM_ENTRIES_SCANNED_POST_FILTER, numEntriesScannedPostFilter);
+
+    int numSegmentsQueried = request.getSegmentsToQuery().size();
+    addToTableMeter(tableNameWithType, ServerMeter.NUM_SEGMENTS_QUERIED, numSegmentsQueried);
+
+    long numSegmentsProcessed = getLongValue(responseMetadata, MetadataKey.NUM_SEGMENTS_PROCESSED.getName(), -1);
+    addToTableMeter(tableNameWithType, ServerMeter.NUM_SEGMENTS_PROCESSED, numSegmentsProcessed);
+
+    long numSegmentsMatched = getLongValue(responseMetadata, MetadataKey.NUM_SEGMENTS_MATCHED.getName(), -1);
+    addToTableMeter(tableNameWithType, ServerMeter.NUM_SEGMENTS_MATCHED, numSegmentsMatched);
+
+    long numSegmentsPrunedInvalid =
+        getLongValue(responseMetadata, MetadataKey.NUM_SEGMENTS_PRUNED_INVALID.getName(), -1);
+    addToTableMeter(tableNameWithType, ServerMeter.NUM_SEGMENTS_PRUNED_INVALID, numSegmentsPrunedInvalid);
+
+    long numSegmentsPrunedByLimit =
+        getLongValue(responseMetadata, MetadataKey.NUM_SEGMENTS_PRUNED_BY_LIMIT.getName(), -1);
+    addToTableMeter(tableNameWithType, ServerMeter.NUM_SEGMENTS_PRUNED_BY_LIMIT, numSegmentsPrunedByLimit);
+
+    long numSegmentsPrunedByValue =
+        getLongValue(responseMetadata, MetadataKey.NUM_SEGMENTS_PRUNED_BY_VALUE.getName(), -1);
+    addToTableMeter(tableNameWithType, ServerMeter.NUM_SEGMENTS_PRUNED_BY_VALUE, numSegmentsPrunedByValue);
+
+    long numConsumingSegmentsQueried =
+        getLongValue(responseMetadata, MetadataKey.NUM_CONSUMING_SEGMENTS_QUERIED.getName(), -1);
+    long numConsumingSegmentsProcessed =
+        getLongValue(responseMetadata, MetadataKey.NUM_CONSUMING_SEGMENTS_PROCESSED.getName(), -1);
+    long numConsumingSegmentsMatched =
+        getLongValue(responseMetadata, MetadataKey.NUM_CONSUMING_SEGMENTS_MATCHED.getName(), -1);
+
+    long minConsumingFreshnessMs =
+        getLongValue(responseMetadata, MetadataKey.MIN_CONSUMING_FRESHNESS_TIME_MS.getName(), -1);
+    if (minConsumingFreshnessMs > 0 && minConsumingFreshnessMs != Long.MAX_VALUE) {
+      _serverMetrics.addTimedTableValue(tableNameWithType, ServerTimer.FRESHNESS_LAG_MS,
+          (System.currentTimeMillis() - minConsumingFreshnessMs), TimeUnit.MILLISECONDS);
+    }
+
+    long numResizes = getLongValue(responseMetadata, MetadataKey.NUM_RESIZES.getName(), -1);
+    addToTableMeter(tableNameWithType, ServerMeter.NUM_RESIZES, numResizes);
+
+    long resizeTimeMs = getLongValue(responseMetadata, MetadataKey.RESIZE_TIME_MS.getName(), -1);
+    addToTableMeter(tableNameWithType, ServerMeter.RESIZE_TIME_MS, resizeTimeMs);
+
+    long threadCpuTimeNs = getLongValue(responseMetadata, MetadataKey.THREAD_CPU_TIME_NS.getName(), 0);
+    if (threadCpuTimeNs > 0) {
+      _serverMetrics.addTimedTableValue(tableNameWithType, ServerTimer.EXECUTION_THREAD_CPU_TIME_NS, threadCpuTimeNs,
+          TimeUnit.NANOSECONDS);
+      _serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.TOTAL_THREAD_CPU_TIME_MILLIS,
+          TimeUnit.MILLISECONDS.convert(threadCpuTimeNs, TimeUnit.NANOSECONDS));
+    }
+
+    long systemActivitiesCpuTimeNs =
+        getLongValue(responseMetadata, MetadataKey.SYSTEM_ACTIVITIES_CPU_TIME_NS.getName(), 0);
+    if (systemActivitiesCpuTimeNs > 0) {
+      _serverMetrics.addTimedTableValue(tableNameWithType, ServerTimer.SYSTEM_ACTIVITIES_CPU_TIME_NS,
+          systemActivitiesCpuTimeNs, TimeUnit.NANOSECONDS);
+    }
+
+    long responseSerializationCpuTimeNs =
+        getLongValue(responseMetadata, MetadataKey.RESPONSE_SER_CPU_TIME_NS.getName(), 0);
+    if (responseSerializationCpuTimeNs > 0) {
+      _serverMetrics.addTimedTableValue(tableNameWithType, ServerTimer.RESPONSE_SER_CPU_TIME_NS,
+          responseSerializationCpuTimeNs, TimeUnit.NANOSECONDS);
+    }
+
+    long totalCpuTimeNs = threadCpuTimeNs + systemActivitiesCpuTimeNs + responseSerializationCpuTimeNs;
+    if (totalCpuTimeNs > 0) {
+      _serverMetrics.addTimedTableValue(tableNameWithType, ServerTimer.TOTAL_CPU_TIME_NS, totalCpuTimeNs,
+          TimeUnit.NANOSECONDS);
+    }
+
+    TimerContext timerContext = request.getTimerContext();
+    long schedulerWaitMs = timerContext.getPhaseDurationMs(ServerQueryPhase.SCHEDULER_WAIT);
+
+    // Please keep the format as name=value comma-separated with no spaces
+    // Please add new entries at the end
+    if (_queryLogRateLimiter.tryAcquire() || forceLog(schedulerWaitMs, numDocsScanned, numSegmentsPrunedInvalid)) {
+      LOGGER.info("Processed requestId={},table={},"
+              + "segments(queried/processed/matched/consumingQueried/consumingProcessed/consumingMatched/"
+              + "invalid/limit/value)={}/{}/{}/{}/{}/{}/{}/{}/{},"
+              + "schedulerWaitMs={},reqDeserMs={},totalExecMs={},resSerMs={},totalTimeMs={},"
+              + "minConsumingFreshnessMs={},broker={},numDocsScanned={},scanInFilter={},scanPostFilter={},sched={},"
+              + "threadCpuTimeNs(total/thread/sysActivity/resSer)={}/{}/{}/{}", request.getRequestId(),
+          tableNameWithType,
+          numSegmentsQueried, numSegmentsProcessed, numSegmentsMatched, numConsumingSegmentsQueried,
+          numConsumingSegmentsProcessed, numConsumingSegmentsMatched, numSegmentsPrunedInvalid,
+          numSegmentsPrunedByLimit, numSegmentsPrunedByValue, schedulerWaitMs,
+          timerContext.getPhaseDurationMs(ServerQueryPhase.REQUEST_DESERIALIZATION),
+          timerContext.getPhaseDurationMs(ServerQueryPhase.QUERY_PROCESSING),
+          timerContext.getPhaseDurationMs(ServerQueryPhase.RESPONSE_SERIALIZATION),
+          timerContext.getPhaseDurationMs(ServerQueryPhase.TOTAL_QUERY_TIME), minConsumingFreshnessMs,
+          request.getBrokerId(), numDocsScanned, numEntriesScannedInFilter, numEntriesScannedPostFilter, schedulerType,
+          totalCpuTimeNs, threadCpuTimeNs, systemActivitiesCpuTimeNs, responseSerializationCpuTimeNs);
+
+      // Limit the dropping log message at most once per second.
+      if (_droppedReportRateLimiter.tryAcquire()) {
+        // NOTE: the reported number may not be accurate since we will be missing some increments happened between
+        // get() and set().
+        int numDroppedLogs = _numDroppedLogs.get();
+        if (numDroppedLogs > 0) {
+          LOGGER.info("{} logs were dropped. (log max rate per second: {})", numDroppedLogs,
+              _queryLogRateLimiter.getRate());
+          _numDroppedLogs.set(0);
+        }
+      }
+    } else {
+      _numDroppedLogs.getAndIncrement();
+    }
+  }
+
+  private static long getLongValue(Map<String, String> metadata, String key, long defaultValue) {
+    String value = metadata.get(key);
+    return value != null ? Long.parseLong(value) : defaultValue;
+  }
+
+  private void addToTableMeter(String tableNameWithType, ServerMeter meter, long value) {
+    if (value > 0) {
+      _serverMetrics.addMeteredTableValue(tableNameWithType, meter, value);
+    }
+  }
+
+  /**
+   * Returns {@code true} when the query should be logged even if the query log rate is reached.
+   *
+   * TODO: come up with other criteria for forcing a log and come up with better numbers.
+   */
+  private static boolean forceLog(long schedulerWaitMs, long numDocsScanned, long numSegmentsPrunedInvalid) {
+    // If scheduler wait time is larger than 100ms, force the log.
+    if (schedulerWaitMs > 100) {
+      return true;
+    }
+
+    // If the number of document scanned is larger than 1 million rows, force the log.
+    if (numDocsScanned > 1_000_000) {
+      return true;
+    }
+
+    // If there are invalid segments, force the log.
+    if (numSegmentsPrunedInvalid > 0) {
+      return true;
+    }
+
+    return false;
+  }
+}

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/LeafStageTransferableBlockOperator.java
@@ -46,6 +46,7 @@ import org.apache.pinot.core.operator.blocks.results.MetadataResultsBlock;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.query.executor.QueryExecutor;
 import org.apache.pinot.core.query.executor.ResultsBlockStreamer;
+import org.apache.pinot.core.query.logger.ServerQueryLogger;
 import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
@@ -149,12 +150,16 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
 
   private Future<Void> startExecution() {
     ResultsBlockConsumer resultsBlockConsumer = new ResultsBlockConsumer();
+    ServerQueryLogger queryLogger = ServerQueryLogger.getInstance();
     return _executorService.submit(() -> {
       try {
         if (_requests.size() == 1) {
           ServerQueryRequest request = _requests.get(0);
           InstanceResponseBlock instanceResponseBlock =
               _queryExecutor.execute(request, _executorService, resultsBlockConsumer);
+          if (queryLogger != null) {
+            queryLogger.logQuery(request, instanceResponseBlock, "MultistageEngine");
+          }
           // TODO: Revisit if we should treat all exceptions as query failure. Currently MERGE_RESPONSE_ERROR and
           //       SERVER_SEGMENT_MISSING_ERROR are counted as query failure.
           Map<Integer, String> exceptions = instanceResponseBlock.getExceptions();
@@ -180,6 +185,9 @@ public class LeafStageTransferableBlockOperator extends MultiStageOperator {
               try {
                 InstanceResponseBlock instanceResponseBlock =
                     _queryExecutor.execute(request, _executorService, resultsBlockConsumer);
+                if (queryLogger != null) {
+                  queryLogger.logQuery(request, instanceResponseBlock, "MultistageEngine");
+                }
                 Map<Integer, String> exceptions = instanceResponseBlock.getExceptions();
                 if (!exceptions.isEmpty()) {
                   // Drain the latch when receiving exception block and not wait for the other thread to finish

--- a/pinot-server/src/main/java/org/apache/pinot/server/conf/ServerConf.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/conf/ServerConf.java
@@ -103,6 +103,17 @@ public class ServerConf {
     return _serverConf.getProperty(CONFIG_OF_INSTANCE_DATA_MANAGER_CLASS, DEFAULT_DATA_MANAGER_CLASS);
   }
 
+  public double getQueryLogMaxRate() {
+    Double queryLogMaxRate = _serverConf.getProperty(CONFIG_OF_QUERY_LOG_MAX_RATE, Double.class);
+    return queryLogMaxRate != null ? queryLogMaxRate
+        : _serverConf.getProperty(DEPRECATED_CONFIG_OF_QUERY_LOG_MAX_RATE, DEFAULT_QUERY_LOG_MAX_RATE);
+  }
+
+  public double getQueryLogDroppedReportMaxRate() {
+    return _serverConf.getProperty(CONFIG_OF_QUERY_LOG_DROPPED_REPORT_MAX_RATE,
+        DEFAULT_QUERY_LOG_DROPPED_REPORT_MAX_RATE);
+  }
+
   public String getQueryExecutorClassName() {
     return _serverConf.getProperty(CONFIG_OF_QUERY_EXECUTOR_CLASS, DEFAULT_QUERY_EXECUTOR_CLASS);
   }

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/ServerInstance.java
@@ -36,6 +36,7 @@ import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
 import org.apache.pinot.core.operator.transform.function.TransformFunctionFactory;
 import org.apache.pinot.core.query.executor.QueryExecutor;
+import org.apache.pinot.core.query.logger.ServerQueryLogger;
 import org.apache.pinot.core.query.scheduler.QueryScheduler;
 import org.apache.pinot.core.query.scheduler.QuerySchedulerFactory;
 import org.apache.pinot.core.transport.ChannelHandlerFactory;
@@ -99,7 +100,9 @@ public class ServerInstance {
     _instanceDataManager = PluginManager.get().createInstance(instanceDataManagerClassName);
     _instanceDataManager.init(serverConf.getInstanceDataManagerConfig(), helixManager, _serverMetrics);
 
-    // Initialize FunctionRegistry before starting the query executor
+    // Initialize ServerQueryLogger and FunctionRegistry before starting the query executor
+    ServerQueryLogger.init(serverConf.getQueryLogMaxRate(), serverConf.getQueryLogDroppedReportMaxRate(),
+        _serverMetrics);
     FunctionRegistry.init();
     String queryExecutorClassName = serverConf.getQueryExecutorClassName();
     LOGGER.info("Initializing query executor of class: {}", queryExecutorClassName);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -521,6 +521,18 @@ public class CommonConstants {
     public static final String CONFIG_OF_INSTANCE_RELOAD_CONSUMING_SEGMENT =
         "pinot.server.instance.reload.consumingSegment";
     public static final String CONFIG_OF_INSTANCE_DATA_MANAGER_CLASS = "pinot.server.instance.data.manager.class";
+
+    // Query logger related configs
+    public static final String CONFIG_OF_QUERY_LOG_MAX_RATE = "pinot.server.query.log.maxRatePerSecond";
+    @Deprecated
+    public static final String DEPRECATED_CONFIG_OF_QUERY_LOG_MAX_RATE =
+        "pinot.query.scheduler.query.log.maxRatePerSecond";
+    public static final double DEFAULT_QUERY_LOG_MAX_RATE = 10_000;
+    public static final String CONFIG_OF_QUERY_LOG_DROPPED_REPORT_MAX_RATE =
+        "pinot.server.query.log.droppedReportMaxRatePerSecond";
+    public static final double DEFAULT_QUERY_LOG_DROPPED_REPORT_MAX_RATE = 1;
+
+    // Query executor related configs
     public static final String CONFIG_OF_QUERY_EXECUTOR_CLASS = "pinot.server.query.executor.class";
     public static final String CONFIG_OF_QUERY_EXECUTOR_PRUNER_CLASS = "pinot.server.query.executor.pruner.class";
     public static final String CONFIG_OF_QUERY_EXECUTOR_PLAN_MAKER_CLASS =
@@ -530,6 +542,7 @@ public class CommonConstants {
         "pinot.server.query.executor.num.groups.limit";
     public static final String CONFIG_OF_QUERY_EXECUTOR_MAX_INITIAL_RESULT_HOLDER_CAPACITY =
         "pinot.server.query.executor.max.init.group.holder.capacity";
+
     public static final String CONFIG_OF_TRANSFORM_FUNCTIONS = "pinot.server.transforms";
     public static final String CONFIG_OF_SERVER_QUERY_REWRITER_CLASS_NAMES = "pinot.server.query.rewriter.class.names";
     public static final String CONFIG_OF_ENABLE_QUERY_CANCELLATION = "pinot.server.enable.query.cancellation";


### PR DESCRIPTION
- Separate server query log and metric emitting into a separate class: `ServerQueryLogger`
- Allow logging query and emitting metric for GRPC request and multi-stage leaf stage
- Bugfixes:
  - Add `numResizes` into prometheus config
  - Change `resizeTimeMs` to be a meter instead of gauge
- Configuration change:
  - `pinot.server.query.log.maxRatePerSecond` to replace the deprecated `pinot.query.scheduler.query.log.maxRatePerSecond` (backward compatible)
  - `pinot.server.query.log.droppedReportMaxRatePerSecond` to configure the dropped log report frequency

# Release Notes
New config added for server:
- `pinot.server.query.log.maxRatePerSecond`: query log max rate (QPS, default 10K)
- `pinot.server.query.log.droppedReportMaxRatePerSecond`: dropped query log report max rate (QPS, default 1)