### PR TITLE
Fix type cast issue with dateTimeConvert scalar function

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeConvert.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/DateTimeConvert.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.function.scalar;
 
+import java.util.concurrent.TimeUnit;
 import org.apache.pinot.spi.annotations.ScalarFunction;
 import org.apache.pinot.spi.data.DateTimeFieldSpec;
 import org.apache.pinot.spi.data.DateTimeFormatSpec;
@@ -35,7 +36,7 @@ public class DateTimeConvert {
   private DateTimeGranularitySpec _granularitySpec;
 
   @ScalarFunction(names = {"dateTimeConvert", "date_time_convert"})
-  public String dateTimeConvert(String timeValueStr, String inputFormatStr, String outputFormatStr,
+  public Object dateTimeConvert(String timeValueStr, String inputFormatStr, String outputFormatStr,
       String outputGranularityStr) {
     if (_inputFormatSpec == null) {
       _inputFormatSpec = new DateTimeFormatSpec(inputFormatStr);
@@ -74,6 +75,11 @@ public class DateTimeConvert {
     } else {
       long granularityMs = _granularitySpec.granularityToMillis();
       long roundedTimeValueMs = timeValueMs / granularityMs * granularityMs;
+      if (_outputFormatSpec.getTimeFormat() == DateTimeFieldSpec.TimeFormat.EPOCH) {
+        return _outputFormatSpec.getColumnUnit().convert(roundedTimeValueMs, TimeUnit.MILLISECONDS)
+            / _outputFormatSpec.getColumnSize();
+      }
+      // _outputFormatSpec.getTimeFormat() == DateTimeFieldSpec.TimeFormat.TIMESTAMP
       return _outputFormatSpec.fromMillisToFormat(roundedTimeValueMs);
     }
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/DateTimeFunctionsTest.java
@@ -592,7 +592,7 @@ public class DateTimeFunctionsTest {
     row.putValue("timeCol", timeValue);
     List<String> arguments = Collections.singletonList("timeCol");
     testFunction(String.format("dateTimeConvert(timeCol, '%s', '%s', '%s')", inputFormatStr, outputFormatStr,
-        outputGranularityStr), arguments, row, expectedResult == null ? null : expectedResult.toString());
+        outputGranularityStr), arguments, row, expectedResult == null ? null : expectedResult);
   }
 
   private void testMultipleInvocations(String functionExpression, List<GenericRow> rows, List<Object> expectedResults) {
@@ -600,7 +600,7 @@ public class DateTimeFunctionsTest {
     int numInvocations = rows.size();
     assertEquals(expectedResults.size(), numInvocations);
     for (int i = 0; i < numInvocations; i++) {
-      assertEquals(evaluator.evaluate(rows.get(i)), expectedResults.get(i).toString());
+      assertEquals(evaluator.evaluate(rows.get(i)), expectedResults.get(i));
     }
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -125,6 +125,10 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
       throws Exception {
     String query;
     String h2Query;
+    // Literal early evaluation
+    query = "SELECT DATETIMECONVERT(1697762729000, '1:MILLISECONDS:EPOCH', '1:DAYS:EPOCH', '1:DAYS') from mytable";
+    h2Query = "SELECT 19650";
+    testQuery(query, h2Query);
 
     // SUM INTEGER result will be BIGINT
     query = "SELECT SUM(ActualElapsedTime) FROM mytable";


### PR DESCRIPTION
Right now dateTimeConvert is always cast for STRING in scalar function.
The return type should be LONG(BIGINT) for EPOCH or TIMESTAMP type and STRING for SIMPLE_DATE_FORMAT

This is discovered when running a query in v2:
`SELECT DATETIMECONVERT(AGO('P32D'),'1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '1:SECONDS') from activity_full`

Error:
```
ProcessingException(errorCode:150, message:SQLParsingError:
java.lang.Exception: Unable to find table for this query
	at org.apache.pinot.controller.api.resources.PinotQueryResource.getMultiStageQueryResponse(PinotQueryResource.java:210)
	at org.apache.pinot.controller.api.resources.PinotQueryResource.executeSqlQuery(PinotQueryResource.java:173)
	at org.apache.pinot.controller.api.resources.PinotQueryResource.handlePostSql(PinotQueryResource.java:121)
	at jdk.internal.reflect.GeneratedMethodAccessor366.invoke(Unknown Source)
...
Caused by: java.lang.RuntimeException: Error composing query plan for: SELECT DATETIMECONVERT(AGO('P32D'),'1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '1:SECONDS') from activity_full
	at org.apache.pinot.query.QueryEnvironment.getTableNamesForQuery(QueryEnvironment.java:241)
	at org.apache.pinot.controller.api.resources.PinotQueryResource.getMultiStageQueryResponse(PinotQueryResource.java:208)
	... 27 more
Caused by: java.lang.UnsupportedOperationException: Cannot generate a valid execution plan for the given query: LogicalProject(EXPR$0=[DATETIMECONVERT(AGO('P32D'), '1:MILLISECONDS:EPOCH', '1:SECONDS:EPOCH', '1:SECONDS')])
  LogicalTableScan(table=[[activity_full]])
	at org.apache.pinot.query.QueryEnvironment.optimize(QueryEnvironment.java:342)
	at org.apache.pinot.query.QueryEnvironment.compileQuery(QueryEnvironment.java:284)
	at org.apache.pinot.query.QueryEnvironment.getTableNamesForQuery(QueryEnvironment.java:237)
...
Caused by: org.apache.pinot.sql.parsers.SqlCompilationException: Caught exception while making literal with value: 1695011538 and type: BIGINT
	at org.apache.calcite.rel.rules.PinotEvaluateLiteralRule.evaluateLiteralOnlyFunction(PinotEvaluateLiteralRule.java:176)
	at org.apache.calcite.rel.rules.PinotEvaluateLiteralRule$EvaluateLiteralShuttle.visitCall(PinotEvaluateLiteralRule.java:131)
	at org.apache.calcite.rel.rules.PinotEvaluateLiteralRule$EvaluateLiteralShuttle.visitCall(PinotEvaluateLiteralRule.java:119)
	at org.apache.calcite.rex.RexCall.accept(RexCall.java:189)
...
Caused by: java.lang.ClassCastException: class java.lang.String cannot be cast to class java.lang.Number (java.lang.String and java.lang.Number are in module java.base of loader 'bootstrap')
	at org.apache.calcite.rex.RexBuilder.clean(RexBuilder.java:1721)
	at org.apache.calcite.rex.RexBuilder.makeLiteral(RexBuilder.java:1558)
	at org.apache.calcite.rex.RexBuilder.makeLiteral(RexBuilder.java:1520)
	at org.apache.calcite.rel.rules.PinotEvaluateLiteralRule.evaluateLiteralOnlyFunction(PinotEvaluateLiteralRule.java:174))
```

After fix:
<img width="1162" alt="image" src="https://github.com/apache/pinot/assets/1202120/7fc19b11-dc55-4dd7-aa29-6416e5601cf6">
