### PR TITLE
Expose GRPC metrics

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -144,6 +144,10 @@ rules:
     table: "$1"
     tableType: "$2"
     partition: "$3"
+#grpc related metrics
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.grpc(.+)\"><>(\\w+)"
+  name: "pinot_server_grpc$1_$2"
+  cache: true
 
   ## Metrics that fit the catch-all patterns above should not be added to this file.
   ## In case a metric does not fit the catch-all patterns, add them before this comment


### PR DESCRIPTION
We've three GRPC metric rn:

```
  // GRPC related metrics
  GRPC_QUERIES("grpcQueries", true),
  GRPC_BYTES_RECEIVED("grpcBytesReceived", true),
  GRPC_BYTES_SENT("grpcBytesSent", true),
```
Need to expose them for debugging grpc related issues, we're running on blind right now.

<img width="1714" alt="Screenshot 2023-10-20 at 2 46 00 PM" src="https://github.com/apache/pinot/assets/84911643/1c80484e-c3e6-4bf9-8809-e64adfd46b03">

<img width="1535" alt="Screenshot 2023-10-20 at 2 47 22 PM" src="https://github.com/apache/pinot/assets/84911643/ad94d292-c852-499f-bcbc-0701f1959e50">


<img width="1724" alt="Screenshot 2023-10-20 at 2 47 36 PM" src="https://github.com/apache/pinot/assets/84911643/b57f0121-c78c-4053-a749-78abc0db6859">


