### PR TITLE
Remove pinot-integration-tests from unit test suite 2

### DIFF
--- a/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
+++ b/.github/workflows/scripts/pr-tests/.pinot_tests_unit.sh
@@ -37,7 +37,7 @@ if [ "$RUN_TEST_SET" == "1" ]; then
       -pl 'pinot-core' \
       -pl 'pinot-query-planner' \
       -pl 'pinot-query-runtime' \
-      -P github-actions || exit 1
+      -P github-actions,no-integration-tests || exit 1
 fi
 if [ "$RUN_TEST_SET" == "2" ]; then
   mvn test \
@@ -48,5 +48,5 @@ if [ "$RUN_TEST_SET" == "2" ]; then
     -pl '!pinot-core' \
     -pl '!pinot-query-planner' \
     -pl '!pinot-query-runtime' \
-    -P github-actions || exit 1
+    -P github-actions,no-integration-tests || exit 1
 fi

--- a/pinot-integration-tests/pom.xml
+++ b/pinot-integration-tests/pom.xml
@@ -63,6 +63,23 @@
 
   <profiles>
     <profile>
+      <id>no-integration-tests</id>
+      <activation>
+        <activeByDefault>false</activeByDefault>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <configuration>
+              <skipTests>true</skipTests>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
       <id>integration-tests-set-1</id>
       <activation>
         <activeByDefault>false</activeByDefault>


### PR DESCRIPTION
Current unit test 2 also runs integration tests.