### PR TITLE
Extend strictReplicaGroup policy to pick a replica group even if there are unavaliable segments for more availablity

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelector.java
@@ -21,7 +21,6 @@ package org.apache.pinot.broker.routing.instanceselector;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
@@ -33,11 +32,8 @@ import org.apache.pinot.common.request.BrokerRequest;
  * The instance selector selects server instances to serve the query based on the selected segments.
  */
 public interface InstanceSelector {
-  long NEW_SEGMENT_EXPIRATION_MILLIS = TimeUnit.MINUTES.toMillis(5);
-
-  static boolean isNewSegment(long creationTimeMs, long currentTimeMs) {
-    return creationTimeMs > 0 && currentTimeMs - creationTimeMs <= NEW_SEGMENT_EXPIRATION_MILLIS;
-  }
+  // To prevent int overflow, reset the request id once it reaches this value
+  long MAX_REQUEST_ID = 1_000_000_000;
 
   /**
    * Initializes the instance selector with the enabled instances, ideal state, external view and online segments

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorUtils.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/InstanceSelectorUtils.java
@@ -1,0 +1,221 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.broker.routing.instanceselector;
+
+import java.time.Clock;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.SortedMap;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.concurrent.TimeUnit;
+import java.util.function.Predicate;
+import javax.annotation.Nullable;
+import org.apache.helix.AccessOption;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.IdealState;
+import org.apache.helix.store.zk.ZkHelixPropertyStore;
+import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.pinot.common.metadata.ZKMetadataProvider;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.utils.SegmentUtils;
+import org.apache.pinot.spi.utils.CommonConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+public class InstanceSelectorUtils {
+  private static final Logger LOGGER = LoggerFactory.getLogger(InstanceSelectorUtils.class);
+  public static final long NEW_SEGMENT_EXPIRATION_MILLIS = TimeUnit.MINUTES.toMillis(5);
+
+  private InstanceSelectorUtils() {
+  }
+
+  public static boolean isNewSegment(long creationTimeMs, long currentTimeMs) {
+    return creationTimeMs > 0 && currentTimeMs - creationTimeMs <= NEW_SEGMENT_EXPIRATION_MILLIS;
+  }
+
+  /**
+   * Returns whether the instance state is online for routing purpose (ONLINE/CONSUMING).
+   */
+  public static boolean isOnlineForRouting(@Nullable String state) {
+    return CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE.equals(state)
+        || CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING.equals(state);
+  }
+
+  public static List<SegmentInstanceCandidate> getEnabledCandidatesAndAddToServingInstances(
+      List<SegmentInstanceCandidate> candidates, Set<String> enabledInstances, Set<String> servingInstances) {
+    List<SegmentInstanceCandidate> enabledCandidates = new ArrayList<>(candidates.size());
+    for (SegmentInstanceCandidate candidate : candidates) {
+      String instance = candidate.getInstance();
+      if (enabledInstances.contains(instance)) {
+        enabledCandidates.add(candidate);
+        servingInstances.add(instance);
+      }
+    }
+    return enabledCandidates;
+  }
+
+  /**
+   * Returns the online instances for routing purpose.
+   */
+  public static TreeSet<String> getOnlineInstances(Map<String, String> idealStateInstanceStateMap,
+      Map<String, String> externalViewInstanceStateMap) {
+    TreeSet<String> onlineInstances = new TreeSet<>();
+    // Only track ONLINE/CONSUMING instances within the ideal state
+    for (Map.Entry<String, String> entry : idealStateInstanceStateMap.entrySet()) {
+      String instance = entry.getKey();
+      // NOTE: DO NOT check if EV matches IS because it is a valid state when EV is CONSUMING while IS is ONLINE
+      if (InstanceSelectorUtils.isOnlineForRouting(entry.getValue()) && InstanceSelectorUtils.isOnlineForRouting(
+          externalViewInstanceStateMap.get(instance))) {
+        onlineInstances.add(instance);
+      }
+    }
+    return onlineInstances;
+  }
+
+  /**
+   * Returns a map from new segment to their creation time based on the ZK metadata.
+   */
+  public static Map<String, Long> getNewSegmentCreationTimeMapFromZK(String tableNameWithType, IdealState idealState,
+      ExternalView externalView, Set<String> onlineSegments, ZkHelixPropertyStore<ZNRecord> propertyStore,
+      Clock clock) {
+    List<String> potentialNewSegments = new ArrayList<>();
+    Map<String, Map<String, String>> idealStateAssignment = idealState.getRecord().getMapFields();
+    Map<String, Map<String, String>> externalViewAssignment = externalView.getRecord().getMapFields();
+    for (String segment : onlineSegments) {
+      assert idealStateAssignment.containsKey(segment);
+      if (isPotentialNewSegment(idealStateAssignment.get(segment), externalViewAssignment.get(segment))) {
+        potentialNewSegments.add(segment);
+      }
+    }
+    Map<String, Long> newSegmentCreationTimeMap = new HashMap<>();
+    long currentTimeMs = clock.millis();
+    String segmentZKMetadataPathPrefix =
+        ZKMetadataProvider.constructPropertyStorePathForResource(tableNameWithType) + "/";
+    List<String> segmentZKMetadataPaths = new ArrayList<>(potentialNewSegments.size());
+    for (String segment : potentialNewSegments) {
+      segmentZKMetadataPaths.add(segmentZKMetadataPathPrefix + segment);
+    }
+    List<ZNRecord> znRecords = propertyStore.get(segmentZKMetadataPaths, null, AccessOption.PERSISTENT, false);
+    for (ZNRecord record : znRecords) {
+      if (record == null) {
+        continue;
+      }
+      SegmentZKMetadata segmentZKMetadata = new SegmentZKMetadata(record);
+      long creationTimeMs = SegmentUtils.getSegmentCreationTimeMs(segmentZKMetadata);
+      if (isNewSegment(creationTimeMs, currentTimeMs)) {
+        newSegmentCreationTimeMap.put(segmentZKMetadata.getSegmentName(), creationTimeMs);
+      }
+    }
+    LOGGER.info("Got {} new segments: {} for table: {} by reading ZK metadata, current time: {}",
+        newSegmentCreationTimeMap.size(), newSegmentCreationTimeMap, tableNameWithType, currentTimeMs);
+    return newSegmentCreationTimeMap;
+  }
+
+  /**
+   * Returns a map from new segment to their creation time based on the existing in-memory states.
+   */
+  public static Map<String, Long> getNewSegmentCreationTimeMapFromExistingStates(String tableNameWithType,
+      IdealState idealState, ExternalView externalView, Set<String> onlineSegments,
+      Map<String, NewSegmentState> newSegmentStateMap,
+      Map<String, List<SegmentInstanceCandidate>> oldSegmentCandidatesMap, Clock clock) {
+    Map<String, Long> newSegmentCreationTimeMap = new HashMap<>();
+    long currentTimeMs = clock.millis();
+    Map<String, Map<String, String>> idealStateAssignment = idealState.getRecord().getMapFields();
+    Map<String, Map<String, String>> externalViewAssignment = externalView.getRecord().getMapFields();
+    for (String segment : onlineSegments) {
+      NewSegmentState newSegmentState = newSegmentStateMap.get(segment);
+      long creationTimeMs = 0;
+      if (newSegmentState != null) {
+        // It was a new segment before, check the creation time and segment state to see if it is still a new segment
+        if (InstanceSelectorUtils.isNewSegment(newSegmentState.getCreationTimeMs(), currentTimeMs)) {
+          creationTimeMs = newSegmentState.getCreationTimeMs();
+        }
+      } else if (!oldSegmentCandidatesMap.containsKey(segment)) {
+        // This is the first time we see this segment, use the current time as the creation time
+        creationTimeMs = currentTimeMs;
+      }
+      // For recently created segment, check if it is qualified as new segment
+      if (creationTimeMs > 0) {
+        assert idealStateAssignment.containsKey(segment);
+        if (InstanceSelectorUtils.isPotentialNewSegment(idealStateAssignment.get(segment),
+            externalViewAssignment.get(segment))) {
+          newSegmentCreationTimeMap.put(segment, creationTimeMs);
+        }
+      }
+    }
+    LOGGER.info("Got {} new segments: {} for table: {} by processing existing states, current time: {}",
+        newSegmentCreationTimeMap.size(), newSegmentCreationTimeMap, tableNameWithType, currentTimeMs);
+    return newSegmentCreationTimeMap;
+  }
+
+  /**
+   * Returns whether a segment is qualified as a new segment.
+   * A segment is count as old when:
+   * - Any instance for the segment is in ERROR state
+   * - External view for the segment converges with ideal state
+   */
+  public static boolean isPotentialNewSegment(Map<String, String> idealStateInstanceStateMap,
+      @Nullable Map<String, String> externalViewInstanceStateMap) {
+    if (externalViewInstanceStateMap == null) {
+      return true;
+    }
+    boolean hasConverged = true;
+    // Only track ONLINE/CONSUMING instances within the ideal state
+    for (Map.Entry<String, String> entry : idealStateInstanceStateMap.entrySet()) {
+      if (isOnlineForRouting(entry.getValue())) {
+        String externalViewState = externalViewInstanceStateMap.get(entry.getKey());
+        if (externalViewState == null || externalViewState.equals(
+            CommonConstants.Helix.StateModel.SegmentStateModel.OFFLINE)) {
+          hasConverged = false;
+        } else if (externalViewState.equals(CommonConstants.Helix.StateModel.SegmentStateModel.ERROR)) {
+          return false;
+        }
+      }
+    }
+    return !hasConverged;
+  }
+
+  public static List<SegmentInstanceCandidate> getCandidatesForNewSegment(
+      Map<String, String> idealStateInstanceStateMap, Predicate<String> onlineChecker) {
+    List<SegmentInstanceCandidate> candidates = new ArrayList<>(idealStateInstanceStateMap.size());
+    for (Map.Entry<String, String> entry : convertToSortedMap(idealStateInstanceStateMap).entrySet()) {
+      if (isOnlineForRouting(entry.getValue())) {
+        String instance = entry.getKey();
+        candidates.add(new SegmentInstanceCandidate(instance, onlineChecker.test(instance)));
+      }
+    }
+    return candidates;
+  }
+
+  /**
+   * Converts the given map into a sorted map if needed.
+   */
+  private static SortedMap<String, String> convertToSortedMap(Map<String, String> map) {
+    if (map instanceof SortedMap) {
+      return (SortedMap<String, String>) map;
+    } else {
+      return new TreeMap<>(map);
+    }
+  }
+}

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/ReplicaGroupInstanceSelector.java
@@ -105,7 +105,6 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
       if (candidates == null) {
         continue;
       }
-      // Round robin selection.
       int numCandidates = candidates.size();
       int instanceIdx = (requestId + replicaOffset) % numCandidates;
       SegmentInstanceCandidate selectedInstance = candidates.get(instanceIdx);
@@ -119,6 +118,7 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
       if (numReplicaGroups > numCandidates) {
         numReplicaGroups = numCandidates;
       }
+      // Round robin selection across segment groups.
       replicaOffset = (replicaOffset + 1) % numReplicaGroups;
     }
     return Pair.of(segmentToSelectedInstanceMap, optionalSegmentToInstanceMap);
@@ -136,12 +136,11 @@ public class ReplicaGroupInstanceSelector extends BaseInstanceSelector {
       if (candidates == null) {
         continue;
       }
-      // Round Robin.
+      // TODO: Support round robin and numReplicaGroupsToQuery with Adaptive Server Selection.
       int numCandidates = candidates.size();
       int instanceIdx = requestId % numCandidates;
       SegmentInstanceCandidate selectedInstance = candidates.get(instanceIdx);
       // Adaptive Server Selection
-      // TODO: Support numReplicaGroupsToQuery with Adaptive Server Selection.
       if (!serverRankList.isEmpty()) {
         int minIdx = Integer.MAX_VALUE;
         for (SegmentInstanceCandidate candidate : candidates) {

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java
@@ -18,22 +18,30 @@
  */
 package org.apache.pinot.broker.routing.instanceselector;
 
+import com.google.common.base.Preconditions;
 import java.time.Clock;
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
 import org.apache.pinot.broker.routing.adaptiveserverselector.AdaptiveServerSelector;
 import org.apache.pinot.common.metrics.BrokerMetrics;
+import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.utils.HashUtil;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,112 +73,506 @@ import org.slf4j.LoggerFactory;
  * replica-group.
  *
  * Note that new segments won't be used to exclude instances from serving when the segment is unavailable.
+ *
+ * But the default behavior can be too strict for some use cases. In worst case, there can be an unavailable segment in
+ * every replica group, so instance selector is left no replica groups to use. Sometimes, it's better to continue to
+ * select a replica group to process the available segments and report unavailable ones in the selected replica group.
+ * So a new option, bestEffort, is added for such cases.
  * </pre>
  */
-public class StrictReplicaGroupInstanceSelector extends ReplicaGroupInstanceSelector {
+public class StrictReplicaGroupInstanceSelector implements InstanceSelector {
   private static final Logger LOGGER = LoggerFactory.getLogger(StrictReplicaGroupInstanceSelector.class);
+
+  private final String _tableNameWithType;
+  private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private final AdaptiveServerSelector _adaptiveServerSelector;
+  private final BrokerMetrics _brokerMetrics;
+  private final Clock _clock;
+
+  // These 3 variables are the cached states to help accelerate the change processing
+  private Set<String> _enabledInstances;
+  // For old segments, all candidates are online. Reduce this map to reduce garbage
+  private final Map<String, List<SegmentInstanceCandidate>> _oldSegmentCandidatesMap = new HashMap<>();
+  private Map<String, NewSegmentState> _newSegmentStateMap;
+
+  // The key is the set of instances hosting the same group of segments, like [S1, S2, S3] in the comment above.
+  private final Map<Set<String>, InstanceGroup> _instanceGroups = new HashMap<>();
+
+  // Use _segmentGroupStates to hold many segment states as needed for instance selection (multi-threaded) and make
+  // it volatile to update the states atomically, so that instance selection is done with a consistent view of states.
+  private volatile SegmentGroupStates _segmentGroupStates;
 
   public StrictReplicaGroupInstanceSelector(String tableNameWithType, ZkHelixPropertyStore<ZNRecord> propertyStore,
       BrokerMetrics brokerMetrics, @Nullable AdaptiveServerSelector adaptiveServerSelector, Clock clock) {
-    super(tableNameWithType, propertyStore, brokerMetrics, adaptiveServerSelector, clock);
+    _tableNameWithType = tableNameWithType;
+    _propertyStore = propertyStore;
+    _brokerMetrics = brokerMetrics;
+    _adaptiveServerSelector = adaptiveServerSelector;
+    _clock = clock;
+  }
+
+  @Override
+  public void init(Set<String> enabledInstances, IdealState idealState, ExternalView externalView,
+      Set<String> onlineSegments) {
+    _enabledInstances = enabledInstances;
+    Map<String, Long> newSegmentCreationTimeMap =
+        InstanceSelectorUtils.getNewSegmentCreationTimeMapFromZK(_tableNameWithType, idealState, externalView,
+            onlineSegments, _propertyStore, _clock);
+    updateSegmentMaps(idealState, externalView, onlineSegments, newSegmentCreationTimeMap);
+    refreshSegmentStates();
+  }
+
+  @Override
+  public void onInstancesChange(Set<String> enabledInstances, List<String> changedInstances) {
+    _enabledInstances = enabledInstances;
+    refreshSegmentStates();
+  }
+
+  @Override
+  public void onAssignmentChange(IdealState idealState, ExternalView externalView, Set<String> onlineSegments) {
+    Map<String, Long> newSegmentCreationTimeMap =
+        InstanceSelectorUtils.getNewSegmentCreationTimeMapFromExistingStates(_tableNameWithType, idealState,
+            externalView, onlineSegments, _newSegmentStateMap, _oldSegmentCandidatesMap, _clock);
+    updateSegmentMaps(idealState, externalView, onlineSegments, newSegmentCreationTimeMap);
+    refreshSegmentStates();
+  }
+
+  @Override
+  public SelectionResult select(BrokerRequest brokerRequest, List<String> segments, long requestId) {
+    Map<String, String> queryOptions =
+        (brokerRequest.getPinotQuery() != null && brokerRequest.getPinotQuery().getQueryOptions() != null)
+            ? brokerRequest.getPinotQuery().getQueryOptions() : Collections.emptyMap();
+    int requestIdInt = (int) (requestId % MAX_REQUEST_ID);
+    Set<String> unavailableSegments = new HashSet<>();
+    Map<String, String> segmentToInstanceMap = select(segments, requestIdInt, unavailableSegments, queryOptions);
+    if (unavailableSegments.isEmpty()) {
+      return new SelectionResult(segmentToInstanceMap, Collections.emptyList());
+    } else {
+      List<String> unavailableSegmentsForRequest = new ArrayList<>();
+      for (String segment : segments) {
+        if (unavailableSegments.contains(segment)) {
+          unavailableSegmentsForRequest.add(segment);
+        }
+      }
+      return new SelectionResult(segmentToInstanceMap, unavailableSegmentsForRequest);
+    }
+  }
+
+  @Override
+  public Set<String> getServingInstances() {
+    return _segmentGroupStates.getServingInstances();
   }
 
   /**
-   * {@inheritDoc}
-   *
-   * <pre>
-   * Instances unavailable for any old segment should not exist in _oldSegmentCandidatesMap or _newSegmentStateMap for
-   * segments with the same instances in ideal state.
-   *
-   * The maps are calculated in the following steps to meet the strict replica-group guarantee:
-   *   1. Compute the online instances for both old and new segments
-   *   2. Compare online instances for old segments with instances in ideal state and gather the unavailable instances
-   *   for each set of instances
-   *   3. Exclude the unavailable instances from the online instances map for both old and new segment map
-   * </pre>
+   * Override the default updateSegmentMaps method to identify new and old segments as before, but meanwhile to group
+   * segments up if they are hosted by same set of instances. For every such group of segments, we can also track the
+   * available and unavailable segments on each instance from the set of instances hosting them. This info allows us
+   * to pick instance at segment group level later on, and report unavailable segments on the selected instance quickly.
    */
-  @Override
-  void updateSegmentMaps(IdealState idealState, ExternalView externalView, Set<String> onlineSegments,
+  private void updateSegmentMaps(IdealState idealState, ExternalView externalView, Set<String> onlineSegments,
       Map<String, Long> newSegmentCreationTimeMap) {
+    // Continue to track sets of new/old segments so that the logic to change new to old segments continues to work.
     _oldSegmentCandidatesMap.clear();
-    int newSegmentMapCapacity = HashUtil.getHashMapCapacity(newSegmentCreationTimeMap.size());
-    _newSegmentStateMap = new HashMap<>(newSegmentMapCapacity);
+    _newSegmentStateMap = new HashMap<>(HashUtil.getHashMapCapacity(newSegmentCreationTimeMap.size()));
+    _instanceGroups.clear();
 
     Map<String, Map<String, String>> idealStateAssignment = idealState.getRecord().getMapFields();
     Map<String, Map<String, String>> externalViewAssignment = externalView.getRecord().getMapFields();
-
-    // Get the online instances for the segments
-    Map<String, Set<String>> oldSegmentToOnlineInstancesMap =
-        new HashMap<>(HashUtil.getHashMapCapacity(onlineSegments.size()));
-    Map<String, Set<String>> newSegmentToOnlineInstancesMap = new HashMap<>(newSegmentMapCapacity);
+    int instanceGroupId = 0;
     for (String segment : onlineSegments) {
       Map<String, String> idealStateInstanceStateMap = idealStateAssignment.get(segment);
       assert idealStateInstanceStateMap != null;
       Map<String, String> externalViewInstanceStateMap = externalViewAssignment.get(segment);
-      Set<String> onlineInstances;
-      if (externalViewInstanceStateMap == null) {
-        onlineInstances = Collections.emptySet();
-      } else {
-        onlineInstances = getOnlineInstances(idealStateInstanceStateMap, externalViewInstanceStateMap);
-      }
-      if (newSegmentCreationTimeMap.containsKey(segment)) {
-        newSegmentToOnlineInstancesMap.put(segment, onlineInstances);
-      } else {
-        oldSegmentToOnlineInstancesMap.put(segment, onlineInstances);
-      }
-    }
-
-    // Calculate the unavailable instances based on the old segments' online instances for each combination of instances
-    // in the ideal state
-    Map<Set<String>, Set<String>> unavailableInstancesMap = new HashMap<>();
-    for (Map.Entry<String, Set<String>> entry : oldSegmentToOnlineInstancesMap.entrySet()) {
-      String segment = entry.getKey();
-      Set<String> onlineInstances = entry.getValue();
-      Map<String, String> idealStateInstanceStateMap = idealStateAssignment.get(segment);
       Set<String> instancesInIdealState = idealStateInstanceStateMap.keySet();
-      Set<String> unavailableInstances =
-          unavailableInstancesMap.computeIfAbsent(instancesInIdealState, k -> new HashSet<>());
-      for (String instance : instancesInIdealState) {
-        if (!onlineInstances.contains(instance)) {
-          if (unavailableInstances.add(instance)) {
-            LOGGER.warn(
-                "Found unavailable instance: {} in instance group: {} for segment: {}, table: {} (IS: {}, EV: {})",
-                instance, instancesInIdealState, segment, _tableNameWithType, idealStateInstanceStateMap,
-                externalViewAssignment.get(segment));
-          }
+      InstanceGroup instanceGroup = _instanceGroups.get(instancesInIdealState);
+      if (instanceGroup == null) {
+        instanceGroup = new InstanceGroup(instanceGroupId++, instancesInIdealState);
+        _instanceGroups.put(instancesInIdealState, instanceGroup);
+      }
+      List<SegmentInstanceCandidate> candidates;
+      boolean isNewSegment = false;
+      if (externalViewInstanceStateMap == null) {
+        if (newSegmentCreationTimeMap.containsKey(segment)) {
+          // New segment
+          candidates = InstanceSelectorUtils.getCandidatesForNewSegment(idealStateInstanceStateMap, instance -> false);
+          _newSegmentStateMap.put(segment, new NewSegmentState(newSegmentCreationTimeMap.get(segment), candidates));
+          isNewSegment = true;
+        } else {
+          // Old segment
+          candidates = Collections.emptyList();
+          _oldSegmentCandidatesMap.put(segment, candidates);
+        }
+      } else {
+        TreeSet<String> onlineInstances =
+            InstanceSelectorUtils.getOnlineInstances(idealStateInstanceStateMap, externalViewInstanceStateMap);
+        if (newSegmentCreationTimeMap.containsKey(segment)) {
+          // New segment
+          candidates =
+              InstanceSelectorUtils.getCandidatesForNewSegment(idealStateInstanceStateMap, onlineInstances::contains);
+          _newSegmentStateMap.put(segment, new NewSegmentState(newSegmentCreationTimeMap.get(segment), candidates));
+          isNewSegment = true;
+        } else {
+          // Old segment
+          candidates = onlineInstances.stream().map(instance -> new SegmentInstanceCandidate(instance, true))
+              .collect(Collectors.toList());
+          _oldSegmentCandidatesMap.put(segment, candidates);
+        }
+      }
+      instanceGroup.addSegment(segment, candidates, isNewSegment);
+    }
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Got _newSegmentStateMap: {}, _oldSegmentCandidatesMap: {}", _newSegmentStateMap.keySet(),
+          _oldSegmentCandidatesMap.keySet());
+    }
+  }
+
+  private void refreshSegmentStates() {
+    // Continue to use the sets of new/old segments and their candidates to get the list of serving instances.
+    // The list of serving instances could be a bit more than needed for strict replica group policy.
+    Set<String> servingInstances = new HashSet<>();
+    for (Map.Entry<String, List<SegmentInstanceCandidate>> entry : _oldSegmentCandidatesMap.entrySet()) {
+      List<SegmentInstanceCandidate> candidates = entry.getValue();
+      InstanceSelectorUtils.getEnabledCandidatesAndAddToServingInstances(candidates, _enabledInstances,
+          servingInstances);
+    }
+    for (Map.Entry<String, NewSegmentState> entry : _newSegmentStateMap.entrySet()) {
+      NewSegmentState newSegmentState = entry.getValue();
+      List<SegmentInstanceCandidate> candidates = newSegmentState.getCandidates();
+      InstanceSelectorUtils.getEnabledCandidatesAndAddToServingInstances(candidates, _enabledInstances,
+          servingInstances);
+    }
+    _instanceGroups.values().forEach(ig -> ig.checkEnabledInstances(_enabledInstances));
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug("Got instanceGroups: {} after checking enabled instances: {}", _instanceGroups, _enabledInstances);
+    }
+    _segmentGroupStates = new SegmentGroupStates(_instanceGroups, servingInstances);
+  }
+
+  private Map<String, String> select(List<String> segments, int requestId, Set<String> unavailableSegments,
+      Map<String, String> queryOptions) {
+    SegmentGroupStates segmentGroupStates = _segmentGroupStates;
+    if (_adaptiveServerSelector == null) {
+      // Adaptive Server Selection is NOT enabled.
+      return selectServersUsingRoundRobin(segmentGroupStates, segments, requestId, unavailableSegments, queryOptions);
+    }
+    // Adaptive Server Selection is enabled.
+    List<String> serverRankList = new ArrayList<>();
+    List<String> candidateServers = fetchCandidateServersForQuery(segmentGroupStates, segments);
+    // Fetch serverRankList before looping through all the segments. This is important to make sure that we pick
+    // the least amount of instances for a query by referring to a single snapshot of the rankings.
+    List<Pair<String, Double>> serverRankListWithScores =
+        _adaptiveServerSelector.fetchServerRankingsWithScores(candidateServers);
+    for (Pair<String, Double> entry : serverRankListWithScores) {
+      serverRankList.add(entry.getLeft());
+    }
+    return selectServersUsingAdaptiveServerSelector(segmentGroupStates, segments, requestId, unavailableSegments,
+        serverRankList, queryOptions);
+  }
+
+  private static Map<String, String> selectServersUsingRoundRobin(SegmentGroupStates segmentGroupStates,
+      List<String> segments, int requestId, Set<String> unavailableSegments, Map<String, String> queryOptions) {
+    Map<String, String> selectedServers = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
+    boolean useCompleteReplicaGroup = QueryOptionsUtils.isUseCompleteReplicaGroup(queryOptions);
+    Integer numReplicaGroupsToQuery = QueryOptionsUtils.getNumReplicaGroupsToQuery(queryOptions);
+    int numReplicaGroups = numReplicaGroupsToQuery == null ? 1 : numReplicaGroupsToQuery;
+    int[] indexCache = initInstanceIndexCache(segmentGroupStates.getInstanceGroupCount());
+    Map<String, InstanceGroup> segmentInstanceGroupMap = segmentGroupStates.getSegmentInstanceGroupMap();
+    int replicaOffset = 0;
+    for (String segment : segments) {
+      InstanceGroup instanceGroup = segmentInstanceGroupMap.get(segment);
+      // In case the instance selector has not been updated.
+      if (instanceGroup == null) {
+        continue;
+      }
+      int selectedInstanceIdx = indexCache[instanceGroup.getId()];
+      if (selectedInstanceIdx == -1) {
+        int availableInstanceCnt = instanceGroup.getNumAvailableInstances(useCompleteReplicaGroup);
+        if (availableInstanceCnt == 0) {
+          continue;
+        }
+        selectedInstanceIdx = (requestId + replicaOffset) % availableInstanceCnt;
+        indexCache[instanceGroup.getId()] = selectedInstanceIdx;
+      }
+      String selectedInstance = instanceGroup.getInstance(selectedInstanceIdx, useCompleteReplicaGroup);
+      InstanceSegmentStates instanceSegmentStates = instanceGroup.getInstanceSegmentStates(selectedInstance);
+      if (instanceSegmentStates.isAvailableSegment(segment)) {
+        selectedServers.put(segment, selectedInstance);
+      }
+      // Round robin selection across segment groups.
+      replicaOffset = (replicaOffset + 1) % numReplicaGroups;
+    }
+    collectUnavailableSegments(unavailableSegments, segmentGroupStates.getInstanceGroups(), indexCache,
+        useCompleteReplicaGroup);
+    return selectedServers;
+  }
+
+  private static List<String> fetchCandidateServersForQuery(SegmentGroupStates segmentGroupStates,
+      List<String> segments) {
+    Set<String> candidateServers = new HashSet<>();
+    Map<String, InstanceGroup> segmentInstanceGroupMap = segmentGroupStates.getSegmentInstanceGroupMap();
+    for (String segment : segments) {
+      InstanceGroup instanceGroup = segmentInstanceGroupMap.get(segment);
+      candidateServers.addAll(instanceGroup._availableInstances);
+    }
+    return new ArrayList<>(candidateServers);
+  }
+
+  private static Map<String, String> selectServersUsingAdaptiveServerSelector(SegmentGroupStates segmentGroupStates,
+      List<String> segments, int requestId, Set<String> unavailableSegments, List<String> serverRankList,
+      Map<String, String> queryOptions) {
+    // Copy the volatile reference to get a consistent view of the states to complete the selection.
+    Map<String, String> selectedServers = new HashMap<>(HashUtil.getHashMapCapacity(segments.size()));
+    boolean useCompleteReplicaGroup = QueryOptionsUtils.isUseCompleteReplicaGroup(queryOptions);
+    int[] indexCache = initInstanceIndexCache(segmentGroupStates.getInstanceGroupCount());
+    Map<String, InstanceGroup> segmentInstanceGroupMap = segmentGroupStates.getSegmentInstanceGroupMap();
+    for (String segment : segments) {
+      InstanceGroup instanceGroup = segmentInstanceGroupMap.get(segment);
+      // In case the instance selector has not been updated.
+      if (instanceGroup == null) {
+        continue;
+      }
+      // TODO: Support round robin and numReplicaGroupsToQuery with Adaptive Server Selection.
+      int selectedInstanceIdx = indexCache[instanceGroup.getId()];
+      if (selectedInstanceIdx == -1) {
+        int availableInstanceCnt = instanceGroup.getNumAvailableInstances(useCompleteReplicaGroup);
+        if (availableInstanceCnt == 0) {
+          continue;
+        }
+        selectedInstanceIdx = selectInstanceAdaptively(instanceGroup, serverRankList, requestId % availableInstanceCnt,
+            useCompleteReplicaGroup);
+        indexCache[instanceGroup.getId()] = selectedInstanceIdx;
+      }
+      String selectedInstance = instanceGroup.getInstance(selectedInstanceIdx, useCompleteReplicaGroup);
+      InstanceSegmentStates instanceSegmentStates = instanceGroup.getInstanceSegmentStates(selectedInstance);
+      if (instanceSegmentStates.isAvailableSegment(segment)) {
+        selectedServers.put(segment, selectedInstance);
+      }
+    }
+    collectUnavailableSegments(unavailableSegments, segmentGroupStates.getInstanceGroups(), indexCache,
+        useCompleteReplicaGroup);
+    return selectedServers;
+  }
+
+  private static int selectInstanceAdaptively(InstanceGroup instanceGroup, List<String> serverRankList,
+      int defaultInstanceIdx, boolean useCompleteReplicaGroup) {
+    if (!serverRankList.isEmpty()) {
+      return defaultInstanceIdx;
+    }
+    int selectedInstanceIdx = defaultInstanceIdx;
+    int availableInstanceCnt = instanceGroup.getNumAvailableInstances(useCompleteReplicaGroup);
+    int minIdx = Integer.MAX_VALUE;
+    for (int instanceIdx = 0; instanceIdx < availableInstanceCnt; instanceIdx++) {
+      String candidateInstance = instanceGroup.getInstance(instanceIdx, useCompleteReplicaGroup);
+      int idx = serverRankList.indexOf(candidateInstance);
+      if (idx == -1) {
+        // Skip until stats for all servers are populated.
+        break;
+      }
+      if (idx < minIdx) {
+        minIdx = idx;
+        selectedInstanceIdx = instanceIdx;
+      }
+    }
+    return selectedInstanceIdx;
+  }
+
+  /**
+   * Get all unavailable segments based on which instances are used for each segment group.
+   */
+  private static void collectUnavailableSegments(Set<String> unavailableSegments,
+      Collection<InstanceGroup> instanceGroups, int[] indexCache, boolean useCompleteReplicaGroup) {
+    for (InstanceGroup instanceGroup : instanceGroups) {
+      int instanceIdx = indexCache[instanceGroup.getId()];
+      if (instanceIdx == -1) {
+        unavailableSegments.addAll(instanceGroup._allOldSegments);
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("Found no instances available for instanceGroup: {} so all oldSegments: {} are unavailable",
+              instanceGroup.getId(), instanceGroup._allOldSegments.size());
+        }
+      } else if (!useCompleteReplicaGroup) {
+        String instance = instanceGroup.getInstance(instanceIdx, false);
+        InstanceSegmentStates instanceSegmentStates = instanceGroup.getInstanceSegmentStates(instance);
+        unavailableSegments.addAll(instanceSegmentStates._unavailableSegments);
+        if (LOGGER.isDebugEnabled()) {
+          LOGGER.debug("Found instance: {} were available for instanceGroup: {} but with {} unavailable segments",
+              instance, instanceGroup.getId(), instanceSegmentStates._unavailableSegments.size());
+        }
+      } else {
+        // otherwise, all segments on the selected instance are completely available.
+        if (LOGGER.isDebugEnabled()) {
+          String instance = instanceGroup.getInstance(instanceIdx, true);
+          InstanceSegmentStates instanceSegmentStates = instanceGroup.getInstanceSegmentStates(instance);
+          LOGGER.debug(
+              "Found instance: {} were available for instanceGroup: {} and should have no unavailable segments: {}",
+              instance, instanceGroup.getId(), instanceSegmentStates._unavailableSegments.size());
+        }
+      }
+    }
+  }
+
+  private static int[] initInstanceIndexCache(int size) {
+    // TODO: make this instanceIndexCache thread-local to reuse.
+    int[] idxCache = new int[size];
+    Arrays.fill(idxCache, -1);
+    return idxCache;
+  }
+
+  private static class InstanceGroup {
+    private final int _id;
+    private final Set<String> _instancesInIdealState;
+    private final Set<String> _allSegments = new HashSet<>();
+    private final Set<String> _allOldSegments = new HashSet<>();
+    private final Map<String, InstanceSegmentStates> _instanceSegmentStatesMap = new HashMap<>();
+    // The available instances and fully available instances can be updated separately based on enabled instances.
+    private final List<String> _availableInstances = new ArrayList<>();
+    private final List<String> _fullyAvailableInstances = new ArrayList<>();
+
+    public InstanceGroup(int id, Set<String> instancesInIdealState) {
+      _id = id;
+      _instancesInIdealState = instancesInIdealState;
+    }
+
+    public void addSegment(String segment, List<SegmentInstanceCandidate> candidates, boolean isNewSegment) {
+      _allSegments.add(segment);
+      if (!isNewSegment) {
+        // In case no instances are enabled from this instance group, the unavailable segments are all old segments.
+        _allOldSegments.add(segment);
+      }
+      Set<String> candidateInstances =
+          candidates.stream().map(SegmentInstanceCandidate::getInstance).collect(Collectors.toSet());
+      Set<String> onlineInstances =
+          candidates.stream().filter(SegmentInstanceCandidate::isOnline).map(SegmentInstanceCandidate::getInstance)
+              .collect(Collectors.toSet());
+      for (String instance : _instancesInIdealState) {
+        InstanceSegmentStates instanceSegmentStates =
+            _instanceSegmentStatesMap.computeIfAbsent(instance, i -> new InstanceSegmentStates());
+        if (onlineInstances.contains(instance)) {
+          instanceSegmentStates._availableSegments.add(segment);
+        } else if (candidateInstances.contains(instance)) {
+          // New segments can have candidate instance that's offline, and those segments are not reported as
+          // unavailable segments in query response.
+          Preconditions.checkState(isNewSegment, "Only NewSegment can be offline on candidate instance: " + instance);
+          instanceSegmentStates._offlineNewSegments.add(segment);
+        } else {
+          // Old segments always have same set of onlineInstances and candidateInstances, otherwise, it's unavailable
+          // segment and reported back in query response.
+          instanceSegmentStates._unavailableSegments.add(segment);
         }
       }
     }
 
-    // Iterate over the maps and exclude the unavailable instances
-    for (Map.Entry<String, Set<String>> entry : oldSegmentToOnlineInstancesMap.entrySet()) {
-      String segment = entry.getKey();
-      // NOTE: onlineInstances is either a TreeSet or an EmptySet (sorted)
-      Set<String> onlineInstances = entry.getValue();
-      Map<String, String> idealStateInstanceStateMap = idealStateAssignment.get(segment);
-      Set<String> unavailableInstances = unavailableInstancesMap.get(idealStateInstanceStateMap.keySet());
-      List<SegmentInstanceCandidate> candidates = new ArrayList<>(onlineInstances.size());
-      for (String instance : onlineInstances) {
-        if (!unavailableInstances.contains(instance)) {
-          candidates.add(new SegmentInstanceCandidate(instance, true));
-        }
-      }
-      _oldSegmentCandidatesMap.put(segment, candidates);
+    public int getId() {
+      return _id;
     }
 
-    for (Map.Entry<String, Set<String>> entry : newSegmentToOnlineInstancesMap.entrySet()) {
-      String segment = entry.getKey();
-      Set<String> onlineInstances = entry.getValue();
-      Map<String, String> idealStateInstanceStateMap = idealStateAssignment.get(segment);
-      Set<String> unavailableInstances =
-          unavailableInstancesMap.getOrDefault(idealStateInstanceStateMap.keySet(), Collections.emptySet());
-      List<SegmentInstanceCandidate> candidates = new ArrayList<>(idealStateInstanceStateMap.size());
-      for (String instance : convertToSortedMap(idealStateInstanceStateMap).keySet()) {
-        if (!unavailableInstances.contains(instance)) {
-          candidates.add(new SegmentInstanceCandidate(instance, onlineInstances.contains(instance)));
+    public int getNumAvailableInstances(boolean useCompleteReplicaGroup) {
+      return useCompleteReplicaGroup ? _fullyAvailableInstances.size() : _availableInstances.size();
+    }
+
+    public String getInstance(int instanceIdx, boolean useCompleteReplicaGroup) {
+      return useCompleteReplicaGroup ? _fullyAvailableInstances.get(instanceIdx) : _availableInstances.get(instanceIdx);
+    }
+
+    public InstanceSegmentStates getInstanceSegmentStates(String instance) {
+      return _instanceSegmentStatesMap.get(instance);
+    }
+
+    public void checkEnabledInstances(Set<String> enabledInstances) {
+      _availableInstances.clear();
+      _fullyAvailableInstances.clear();
+      if (_instanceSegmentStatesMap.isEmpty()) {
+        return;
+      }
+      for (Map.Entry<String, InstanceSegmentStates> entry : _instanceSegmentStatesMap.entrySet()) {
+        String instance = entry.getKey();
+        if (!enabledInstances.contains(instance)) {
+          continue;
+        }
+        InstanceSegmentStates segmentStates = entry.getValue();
+        if (segmentStates._availableSegments.isEmpty()) {
+          continue;
+        }
+        _availableInstances.add(instance);
+      }
+      Collections.sort(_availableInstances);
+      for (String instance : _availableInstances) {
+        if (_instanceSegmentStatesMap.get(instance)._unavailableSegments.isEmpty()) {
+          _fullyAvailableInstances.add(instance);
         }
       }
-      _newSegmentStateMap.put(segment, new NewSegmentState(newSegmentCreationTimeMap.get(segment), candidates));
+    }
+
+    public InstanceGroup copyForSelection() {
+      InstanceGroup ig = new InstanceGroup(_id, _instancesInIdealState);
+      ig._allOldSegments.addAll(_allOldSegments);
+      ig._availableInstances.addAll(_availableInstances);
+      ig._fullyAvailableInstances.addAll(_fullyAvailableInstances);
+      _instanceSegmentStatesMap.forEach((k, v) -> ig._instanceSegmentStatesMap.put(k, v.copyForSelection()));
+      return ig;
+    }
+
+    @Override
+    public String toString() {
+      return "InstanceGroup{" + "_id=" + _id + ", _instancesInIdealState=" + _instancesInIdealState + ", _allSegments="
+          + _allSegments + ", _allOldSegments=" + _allOldSegments + ", _instanceSegmentStatesMap="
+          + _instanceSegmentStatesMap + ", _availableInstances=" + _availableInstances + ", _fullyAvailableInstances="
+          + _fullyAvailableInstances + '}';
+    }
+  }
+
+  private static class InstanceSegmentStates {
+    private final Set<String> _availableSegments = new HashSet<>();
+    private final Set<String> _unavailableSegments = new HashSet<>();
+    // TODO: treat offline NewSegments as optional segments according to PR#11978.
+    private final Set<String> _offlineNewSegments = new HashSet<>();
+
+    public InstanceSegmentStates copyForSelection() {
+      InstanceSegmentStates iss = new InstanceSegmentStates();
+      iss._availableSegments.addAll(_availableSegments);
+      iss._unavailableSegments.addAll(_unavailableSegments);
+      iss._offlineNewSegments.addAll(_offlineNewSegments);
+      return iss;
+    }
+
+    public boolean isAvailableSegment(String segment) {
+      return _availableSegments.contains(segment);
+    }
+
+    @Override
+    public String toString() {
+      return "InstanceSegmentStates{" + "_availableSegments=" + _availableSegments + ", _unavailableSegments="
+          + _unavailableSegments + ", _offlineNewSegments=" + _offlineNewSegments + '}';
+    }
+  }
+
+  private static class SegmentGroupStates {
+    private final List<InstanceGroup> _instanceGroups = new ArrayList<>();
+    private final Set<String> _servingInstances;
+    private final Map<String, InstanceGroup> _segmentInstanceGroupMap = new HashMap<>();
+
+    public SegmentGroupStates(Map<Set<String>, InstanceGroup> instanceGroups, Set<String> servingInstances) {
+      for (InstanceGroup instanceGroup : instanceGroups.values()) {
+        InstanceGroup copy = instanceGroup.copyForSelection();
+        _instanceGroups.add(copy);
+        instanceGroup._allSegments.forEach(segment -> _segmentInstanceGroupMap.put(segment, copy));
+      }
+      _servingInstances = servingInstances;
+    }
+
+    public int getInstanceGroupCount() {
+      return _instanceGroups.size();
+    }
+
+    public Set<String> getServingInstances() {
+      return _servingInstances;
+    }
+
+    public Map<String, InstanceGroup> getSegmentInstanceGroupMap() {
+      return _segmentInstanceGroupMap;
+    }
+
+    public List<InstanceGroup> getInstanceGroups() {
+      return _instanceGroups;
     }
     if (LOGGER.isDebugEnabled()) {
       LOGGER.debug("Got _newSegmentStateMap: {}, _oldSegmentCandidatesMap: {}", _newSegmentStateMap.keySet(),

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpartition/SegmentPartitionMetadataManager.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.IdealState;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
-import org.apache.pinot.broker.routing.instanceselector.InstanceSelector;
+import org.apache.pinot.broker.routing.instanceselector.InstanceSelectorUtils;
 import org.apache.pinot.broker.routing.segmentmetadata.SegmentZkMetadataFetchListener;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.SegmentUtils;
@@ -148,7 +148,7 @@ public class SegmentPartitionMetadataManager implements SegmentZkMetadataFetchLi
         continue;
       }
       // Process new segments in the end
-      if (InstanceSelector.isNewSegment(segmentInfo._creationTimeMs, currentTimeMs)) {
+      if (InstanceSelectorUtils.isNewSegment(segmentInfo._creationTimeMs, currentTimeMs)) {
         newSegmentInfoEntries.add(entry);
         continue;
       }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -145,6 +145,10 @@ public class QueryOptionsUtils {
     return "false".equalsIgnoreCase(queryOptions.get(QueryOptionKey.USE_SCAN_REORDER_OPTIMIZATION));
   }
 
+  public static boolean isUseCompleteReplicaGroup(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.getOrDefault(QueryOptionKey.USE_COMPLETE_REPLICA_GROUP, "true"));
+  }
+
   @Nullable
   public static Integer getNumReplicaGroupsToQuery(Map<String, String> queryOptions) {
     String numReplicaGroupsToQuery = queryOptions.get(QueryOptionKey.NUM_REPLICA_GROUPS_TO_QUERY);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -349,6 +349,7 @@ public class CommonConstants {
         public static final String MIN_SERVER_GROUP_TRIM_SIZE = "minServerGroupTrimSize";
         public static final String MIN_BROKER_GROUP_TRIM_SIZE = "minBrokerGroupTrimSize";
         public static final String NUM_REPLICA_GROUPS_TO_QUERY = "numReplicaGroupsToQuery";
+        public static final String USE_COMPLETE_REPLICA_GROUP = "useCompleteReplicaGroup";
         public static final String EXPLAIN_PLAN_VERBOSE = "explainPlanVerbose";
         public static final String USE_MULTISTAGE_ENGINE = "useMultistageEngine";
         public static final String ENABLE_NULL_HANDLING = "enableNullHandling";


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Shows the flow for selecting an instance in fallback mode \(useCompleteReplicaGroup=false\) in StrictReplicaGroupInstanceSelector\.

```mermaid
flowchart TD
  N0["Start select #40;F5#41;"]:::stModified
  N1["Get useCompleteReplicaGroup flag #40;F5#44; F7#41;"]:::stModified
  N2["Get segment group states #40;F5#41;"]:::stModified
  N3["Get instance group for segment #40;F5#41;"]:::stModified
  N4["Get available instance count #40;F5#41;"]:::stModified
  N5["Select instance from group #40;F5#41;"]:::stModified
  N6["Check segment state on instance #40;F5#41;"]:::stModified
  N0 --> N1
  N0 --> N2
  N1 --> N4
  N2 --> N3
  N3 --> N4
  N4 --> N5
  N5 --> N6
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

Partial evidence: 0 file patches omitted; 1 truncated.

<details>
<summary>Diff evidence</summary>

- F5: pinot\-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector\.java — [before](https://github.com/apache/pinot/blob/c57117a7503aa2fd0b9a7d3bd2de19f92d49ad9b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java) · [after](https://github.com/apache/pinot/blob/b8373198590e6814de191765894ffe835d72c23e/pinot-broker/src/main/java/org/apache/pinot/broker/routing/instanceselector/StrictReplicaGroupInstanceSelector.java)
- F7: pinot\-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils\.java — [before](https://github.com/apache/pinot/blob/c57117a7503aa2fd0b9a7d3bd2de19f92d49ad9b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java) · [after](https://github.com/apache/pinot/blob/b8373198590e6814de191765894ffe835d72c23e/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImM1NzExN2E3NTAzYWEyZmQwYjlhN2QzYmQyZGUxOWY5MmQ0OWFkOWIiLCJjb250ZXh0X2hhc2giOiI3YWFlMzBkN2M3ZGU2MTA4YTNlYmRkYzg1Mzg5YWNjMWY1NDM5OWEzZTQ4YTJlNmEzNDRjNTU1M2NkZjBlOTgxIiwiZ2VuZXJhdGVkX2F0IjoxNzg5NzA5MzE2LCJoZWFkX3NoYSI6ImI4MzczMTk4NTkwZTY4MTRkZTE5MTc2NTg5NGZmZTgzNWQ3MmMyM2UiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJiOWVkMzc4MzU1YWNjNTMxM2ViYzEwMzE1MTA2NzFmNzA0NWYyOWE5IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature e9aad7ae509ac7129e551d12339cec4e85f96f8774f9a5fe9b7beea2dd43835c -->
<!-- pinot-pr-flow:end -->

Currently, with strictReplicaGroup routing policy, instance selector skips a replica instance if there is a segment unavailable on the instance, even though all other segments are fine on it. If unfortunately, there is an unavailable segment on every replica instance, then instance selector skips all replica instances. And the query simply reports all segments on those replica instances as unavailable, which can be misleading.

This PR makes strictReplicaGroup less strict (more available) for such unlucky case. Basically, the instance selector continues to pick a replica instance, although there may be unavailable segments on it. Note that this fallback behavior is different from the replicaGroup policy, because segments that have same replica instances are ensured to use the same replica instance.

## Release Note ##
1. added a new query option `useCompleteReplicaGroup` to enable the fallback behavior. By default, it's true and continue to be very strict upon handling unavailable segments in replica groups.