### PR TITLE
Allow server level configuration for Upsert metadata class

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -207,7 +207,9 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       Preconditions.checkState(schema != null, "Failed to find schema for table: %s", _tableNameWithType);
       // NOTE: Set _tableUpsertMetadataManager before initializing it because when preloading is enabled, we need to
       //       load segments into it
-      _tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(tableConfig);
+      String defaultMetadataManagerClass =
+          _tableDataManagerConfig.getInstanceDataManagerConfig().getUpsertDefaultMetadataManagerClass();
+      _tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(tableConfig, defaultMetadataManagerClass);
       _tableUpsertMetadataManager.init(tableConfig, schema, this, _helixManager, _segmentPreloadExecutor);
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -207,9 +207,8 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       Preconditions.checkState(schema != null, "Failed to find schema for table: %s", _tableNameWithType);
       // NOTE: Set _tableUpsertMetadataManager before initializing it because when preloading is enabled, we need to
       //       load segments into it
-      String defaultMetadataManagerClass =
-          _tableDataManagerConfig.getInstanceDataManagerConfig().getUpsertDefaultMetadataManagerClass();
-      _tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(tableConfig, defaultMetadataManagerClass);
+      _tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(tableConfig,
+          _tableDataManagerConfig.getInstanceDataManagerConfig().getUpsertConfigs());
       _tableUpsertMetadataManager.init(tableConfig, schema, this, _helixManager, _segmentPreloadExecutor);
     }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -699,6 +699,11 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     return _instanceId;
   }
 
+  @VisibleForTesting
+  public TableUpsertMetadataManager getTableUpsertMetadataManager() {
+    return _tableUpsertMetadataManager;
+  }
+
   /**
    * Validate a schema against the table config for real-time record consumption.
    * Ideally, we should validate these things when schema is added or table is created, but either of these

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.integration.tests;
 
+import com.google.common.base.Joiner;
 import com.google.common.collect.ImmutableList;
 import java.io.File;
 import java.io.IOException;
@@ -37,6 +38,7 @@ import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
 import org.apache.pinot.integration.tests.models.DummyTableUpsertMetadataManager;
+import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManagerFactory;
 import org.apache.pinot.server.starter.helix.BaseServerStarter;
 import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -386,8 +388,9 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
   public void testDefaultMetadataManagerClass()
       throws Exception {
     PinotConfiguration config = getServerConf(12345);
-    config.setProperty(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX + "."
-            + HelixInstanceDataManagerConfig.UPSERT_DEFAULT_METADATA_MANAGER_CLASS,
+    config.setProperty(Joiner.on(".").join(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX,
+            HelixInstanceDataManagerConfig.PREFIX_OF_CONFIG_OF_UPSERT,
+            TableUpsertMetadataManagerFactory.UPSERT_DEFAULT_METADATA_MANAGER_CLASS),
         DummyTableUpsertMetadataManager.class.getName());
 
     BaseServerStarter serverStarter = null;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
@@ -383,23 +383,31 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
             + HelixInstanceDataManagerConfig.UPSERT_DEFAULT_METADATA_MANAGER_CLASS,
         DummyTableUpsertMetadataManager.class.getName());
 
-    BaseServerStarter serverStarter = startOneServer(config);
-    String dummyTableName = "dummyTable123";
-    Map<String, String> csvDecoderProperties = getCSVDecoderProperties(CSV_DELIMITER, CSV_SCHEMA_HEADER);
+    BaseServerStarter serverStarter = null;
+    try {
+      serverStarter = startOneServer(config);
+      String dummyTableName = "dummyTable123";
+      Map<String, String> csvDecoderProperties = getCSVDecoderProperties(CSV_DELIMITER, CSV_SCHEMA_HEADER);
 
-    TableConfig tableConfig =
-        createCSVUpsertTableConfig(dummyTableName, getKafkaTopic(), getNumKafkaPartitions(), csvDecoderProperties, null,
-            PRIMARY_KEY_COL);
-    Schema schema = createSchema();
-    schema.setSchemaName(dummyTableName);
-    addSchema(schema);
-    addTableConfig(tableConfig);
+      TableConfig tableConfig =
+          createCSVUpsertTableConfig(dummyTableName, getKafkaTopic(), getNumKafkaPartitions(), csvDecoderProperties,
+              null, PRIMARY_KEY_COL);
+      Schema schema = createSchema();
+      schema.setSchemaName(dummyTableName);
+      addSchema(schema);
+      addTableConfig(tableConfig);
 
-    Thread.sleep(10000L);
-    RealtimeTableDataManager tableDataManager =
-        (RealtimeTableDataManager) serverStarter.getServerInstance().getInstanceDataManager()
-            .getTableDataManager(TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(dummyTableName));
-    Assert.assertTrue(tableDataManager.getTableUpsertMetadataManager() instanceof DummyTableUpsertMetadataManager);
-    serverStarter.stop();
+      Thread.sleep(10000L);
+      RealtimeTableDataManager tableDataManager =
+          (RealtimeTableDataManager) serverStarter.getServerInstance().getInstanceDataManager()
+              .getTableDataManager(TableNameBuilder.forType(TableType.REALTIME).tableNameWithType(dummyTableName));
+      Assert.assertTrue(tableDataManager.getTableUpsertMetadataManager() instanceof DummyTableUpsertMetadataManager);
+      dropRealtimeTable(dummyTableName);
+      deleteSchema(dummyTableName);
+    } finally {
+      if (serverStarter != null) {
+        serverStarter.stop();
+      }
+    }
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.server.starter.helix.BaseServerStarter;
+import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.UpsertConfig;
@@ -87,8 +88,6 @@ public class UpsertTableSegmentPreloadIntegrationTest extends BaseClusterIntegra
     TableConfig tableConfig = createUpsertTableConfig(avroFiles.get(0), PRIMARY_KEY_COL, null, getNumKafkaPartitions());
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
     assertNotNull(upsertConfig);
-    upsertConfig.setEnableSnapshot(true);
-    upsertConfig.setEnablePreload(true);
     addTableConfig(tableConfig);
 
     // Create and upload segments
@@ -104,6 +103,10 @@ public class UpsertTableSegmentPreloadIntegrationTest extends BaseClusterIntegra
   protected void overrideServerConf(PinotConfiguration serverConf) {
     serverConf.setProperty(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX + ".max.segment.preload.threads",
         "1");
+    serverConf.setProperty(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX + "."
+        + HelixInstanceDataManagerConfig.UPSERT_DEFAULT_ENABLE_PRELOAD, "true");
+    serverConf.setProperty(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX + "."
+        + HelixInstanceDataManagerConfig.UPSERT_DEFAULT_ENABLE_SNAPSHOT, "true");
   }
 
   @AfterClass

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableSegmentPreloadIntegrationTest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.integration.tests;
 
+import com.google.common.base.Joiner;
 import java.io.File;
 import java.io.IOException;
 import java.util.List;
@@ -26,6 +27,7 @@ import org.apache.commons.io.FileUtils;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.helix.HelixHelper;
+import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManagerFactory;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.server.starter.helix.BaseServerStarter;
 import org.apache.pinot.server.starter.helix.HelixInstanceDataManagerConfig;
@@ -103,10 +105,12 @@ public class UpsertTableSegmentPreloadIntegrationTest extends BaseClusterIntegra
   protected void overrideServerConf(PinotConfiguration serverConf) {
     serverConf.setProperty(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX + ".max.segment.preload.threads",
         "1");
-    serverConf.setProperty(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX + "."
-        + HelixInstanceDataManagerConfig.UPSERT_DEFAULT_ENABLE_PRELOAD, "true");
-    serverConf.setProperty(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX + "."
-        + HelixInstanceDataManagerConfig.UPSERT_DEFAULT_ENABLE_SNAPSHOT, "true");
+    serverConf.setProperty(Joiner.on(".").join(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX,
+        HelixInstanceDataManagerConfig.PREFIX_OF_CONFIG_OF_UPSERT,
+        TableUpsertMetadataManagerFactory.UPSERT_DEFAULT_ENABLE_SNAPSHOT), "true");
+    serverConf.setProperty(Joiner.on(".").join(CommonConstants.Server.INSTANCE_DATA_MANAGER_CONFIG_PREFIX,
+        HelixInstanceDataManagerConfig.PREFIX_OF_CONFIG_OF_UPSERT,
+        TableUpsertMetadataManagerFactory.UPSERT_DEFAULT_ENABLE_PRELOAD), "true");
   }
 
   @AfterClass

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/models/DummyTableUpsertMetadataManager.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/models/DummyTableUpsertMetadataManager.java
@@ -1,0 +1,115 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.models;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.concurrent.ExecutorService;
+import org.apache.helix.HelixManager;
+import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
+import org.apache.pinot.segment.local.upsert.BasePartitionUpsertMetadataManager;
+import org.apache.pinot.segment.local.upsert.BaseTableUpsertMetadataManager;
+import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
+import org.apache.pinot.segment.local.upsert.RecordInfo;
+import org.apache.pinot.segment.local.upsert.UpsertContext;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.MutableSegment;
+import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
+import org.apache.pinot.spi.config.table.HashFunction;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+
+public class DummyTableUpsertMetadataManager extends BaseTableUpsertMetadataManager {
+
+  private TableConfig _tableConfig;
+  private Schema _schema;
+
+  public DummyTableUpsertMetadataManager() {
+    super();
+  }
+
+  @Override
+  public void init(TableConfig tableConfig, Schema schema, TableDataManager tableDataManager, HelixManager helixManager,
+      @org.jetbrains.annotations.Nullable ExecutorService segmentPreloadExecutor) {
+    super.init(tableConfig, schema, tableDataManager, helixManager, segmentPreloadExecutor);
+    _tableConfig = tableConfig;
+    _schema = schema;
+  }
+
+  @Override
+  public PartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
+    UpsertContext context = new UpsertContext.Builder().setTableConfig(_tableConfig).setSchema(_schema)
+        .setPrimaryKeyColumns(_schema.getPrimaryKeyColumns())
+        .setComparisonColumns(Collections.singletonList(_tableConfig.getValidationConfig().getTimeColumnName()))
+        .setHashFunction(HashFunction.NONE).setTableIndexDir(new File("/tmp/tableIndexDirDummy")).build();
+
+    return new DummyPartitionUpsertMetadataManager("dummy", partitionId, context);
+  }
+
+  @Override
+  public void stop() {
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+  }
+
+  class DummyPartitionUpsertMetadataManager extends BasePartitionUpsertMetadataManager {
+    public DummyPartitionUpsertMetadataManager(String tableNameWithType, int partitionId, UpsertContext context) {
+      super(tableNameWithType, partitionId, context);
+    }
+
+    @Override
+    protected long getNumPrimaryKeys() {
+      return 0;
+    }
+
+    @Override
+    protected void addOrReplaceSegment(ImmutableSegmentImpl segment, ThreadSafeMutableRoaringBitmap validDocIds,
+        @org.jetbrains.annotations.Nullable ThreadSafeMutableRoaringBitmap queryableDocIds,
+        Iterator<RecordInfo> recordInfoIterator, @org.jetbrains.annotations.Nullable IndexSegment oldSegment,
+        @org.jetbrains.annotations.Nullable MutableRoaringBitmap validDocIdsForOldSegment) {
+    }
+
+    @Override
+    protected boolean doAddRecord(MutableSegment segment, RecordInfo recordInfo) {
+      return false;
+    }
+
+    @Override
+    protected void removeSegment(IndexSegment segment, MutableRoaringBitmap validDocIds) {
+    }
+
+    @Override
+    protected GenericRow doUpdateRecord(GenericRow record, RecordInfo recordInfo) {
+      return null;
+    }
+
+    @Override
+    protected void doRemoveExpiredPrimaryKeys() {
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -102,39 +102,39 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
     double deletedKeysTTL = upsertConfig.getDeletedKeysTTL();
     File tableIndexDir = tableDataManager.getTableDataDir();
 
+    // Server level config honoured only when table level config is not set to true
+    if (tableDataManager.getTableDataManagerConfig() != null
+        && tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig() != null
+        && tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig().getUpsertDefaultEnableSnapshot()
+        != null && !enableSnapshot) {
+      enableSnapshot = Boolean.parseBoolean(
+          tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig().getUpsertDefaultEnableSnapshot());
+    }
+
+    // Server level config honoured only when table level config is not set to true
+    if (tableDataManager.getTableDataManagerConfig() != null
+        && tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig() != null
+        && tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig().getUpsertDefaultEnablePreload()
+        != null && !enablePreload) {
+      enablePreload = Boolean.parseBoolean(
+          tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig().getUpsertDefaultEnablePreload());
+    }
+
+    _context = new UpsertContext.Builder().setTableConfig(tableConfig).setSchema(schema)
+        .setPrimaryKeyColumns(primaryKeyColumns).setComparisonColumns(comparisonColumns)
+        .setDeleteRecordColumn(deleteRecordColumn).setHashFunction(hashFunction)
+        .setPartialUpsertHandler(partialUpsertHandler).setEnableSnapshot(enableSnapshot).setEnablePreload(enablePreload)
+        .setMetadataTTL(metadataTTL).setDeletedKeysTTL(deletedKeysTTL).setTableIndexDir(tableIndexDir).build();
+    LOGGER.info(
+        "Initialized {} for table: {} with primary key columns: {}, comparison columns: {}, delete record column: {},"
+            + " hash function: {}, upsert mode: {}, enable snapshot: {}, enable preload: {}, metadata TTL: {},"
+            + " deleted Keys TTL: {}, table index dir: {}", getClass().getSimpleName(), _tableNameWithType,
+        primaryKeyColumns, comparisonColumns, deleteRecordColumn, hashFunction, upsertConfig.getMode(), enableSnapshot,
+        enablePreload, metadataTTL, deletedKeysTTL, tableIndexDir);
+
+    initCustomVariables();
+
     if (enableSnapshot && enablePreload && segmentPreloadExecutor != null) {
-      // Server level config honoured only when table level config is not set to true
-      enableSnapshot = upsertConfig.isEnableSnapshot();
-      if (tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig().getUpsertDefaultEnableSnapshot()
-          != null && !enableSnapshot) {
-        enableSnapshot = Boolean.parseBoolean(
-            tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig()
-                .getUpsertDefaultEnableSnapshot());
-      }
-
-      enablePreload = upsertConfig.isEnablePreload();
-
-      // Server level config honoured only when table level config is not set to true
-      if (tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig().getUpsertDefaultEnablePreload()
-          != null && !enablePreload) {
-        enablePreload = Boolean.parseBoolean(tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig()
-            .getUpsertDefaultEnablePreload());
-      }
-
-      _context = new UpsertContext.Builder().setTableConfig(tableConfig).setSchema(schema)
-          .setPrimaryKeyColumns(primaryKeyColumns).setComparisonColumns(comparisonColumns)
-          .setDeleteRecordColumn(deleteRecordColumn).setHashFunction(hashFunction)
-          .setPartialUpsertHandler(partialUpsertHandler).setEnableSnapshot(enableSnapshot)
-          .setEnablePreload(enablePreload).setMetadataTTL(metadataTTL).setDeletedKeysTTL(deletedKeysTTL)
-          .setTableIndexDir(tableIndexDir).build();
-      LOGGER.info(
-          "Initialized {} for table: {} with primary key columns: {}, comparison columns: {}, delete record column: {},"
-              + " hash function: {}, upsert mode: {}, enable snapshot: {}, enable preload: {}, metadata TTL: {},"
-              + " deleted Keys TTL: {}, table index dir: {}", getClass().getSimpleName(), _tableNameWithType,
-          primaryKeyColumns, comparisonColumns, deleteRecordColumn, hashFunction, upsertConfig.getMode(),
-          enableSnapshot, enablePreload, metadataTTL, deletedKeysTTL, tableIndexDir);
-
-      initCustomVariables();
 
       // Preloading the segments with snapshots for fast upsert metadata recovery.
       // Note that there is an implicit waiting logic between the thread doing the segment preloading here and the

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -102,24 +102,6 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
     double deletedKeysTTL = upsertConfig.getDeletedKeysTTL();
     File tableIndexDir = tableDataManager.getTableDataDir();
 
-    // Server level config honoured only when table level config is not set to true
-    if (tableDataManager.getTableDataManagerConfig() != null
-        && tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig() != null
-        && tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig().getUpsertDefaultEnableSnapshot()
-        != null && !enableSnapshot) {
-      enableSnapshot = Boolean.parseBoolean(
-          tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig().getUpsertDefaultEnableSnapshot());
-    }
-
-    // Server level config honoured only when table level config is not set to true
-    if (tableDataManager.getTableDataManagerConfig() != null
-        && tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig() != null
-        && tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig().getUpsertDefaultEnablePreload()
-        != null && !enablePreload) {
-      enablePreload = Boolean.parseBoolean(
-          tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig().getUpsertDefaultEnablePreload());
-    }
-
     _context = new UpsertContext.Builder().setTableConfig(tableConfig).setSchema(schema)
         .setPrimaryKeyColumns(primaryKeyColumns).setComparisonColumns(comparisonColumns)
         .setDeleteRecordColumn(deleteRecordColumn).setHashFunction(hashFunction)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -101,21 +101,41 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
     double metadataTTL = upsertConfig.getMetadataTTL();
     double deletedKeysTTL = upsertConfig.getDeletedKeysTTL();
     File tableIndexDir = tableDataManager.getTableDataDir();
-    _context = new UpsertContext.Builder().setTableConfig(tableConfig).setSchema(schema)
-        .setPrimaryKeyColumns(primaryKeyColumns).setComparisonColumns(comparisonColumns)
-        .setDeleteRecordColumn(deleteRecordColumn).setHashFunction(hashFunction)
-        .setPartialUpsertHandler(partialUpsertHandler).setEnableSnapshot(enableSnapshot).setEnablePreload(enablePreload)
-        .setMetadataTTL(metadataTTL).setDeletedKeysTTL(deletedKeysTTL).setTableIndexDir(tableIndexDir).build();
-    LOGGER.info(
-        "Initialized {} for table: {} with primary key columns: {}, comparison columns: {}, delete record column: {},"
-            + " hash function: {}, upsert mode: {}, enable snapshot: {}, enable preload: {}, metadata TTL: {},"
-            + " deleted Keys TTL: {}, table index dir: {}", getClass().getSimpleName(), _tableNameWithType,
-        primaryKeyColumns, comparisonColumns, deleteRecordColumn, hashFunction, upsertConfig.getMode(), enableSnapshot,
-        enablePreload, metadataTTL, deletedKeysTTL, tableIndexDir);
-
-    initCustomVariables();
 
     if (enableSnapshot && enablePreload && segmentPreloadExecutor != null) {
+      // Server level config honoured only when table level config is not set to true
+      enableSnapshot = upsertConfig.isEnableSnapshot();
+      if (tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig().getUpsertDefaultEnableSnapshot()
+          != null && !enableSnapshot) {
+        enableSnapshot = Boolean.parseBoolean(
+            tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig()
+                .getUpsertDefaultEnableSnapshot());
+      }
+
+      enablePreload = upsertConfig.isEnablePreload();
+
+      // Server level config honoured only when table level config is not set to true
+      if (tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig().getUpsertDefaultEnablePreload()
+          != null && !enablePreload) {
+        enablePreload = Boolean.parseBoolean(tableDataManager.getTableDataManagerConfig().getInstanceDataManagerConfig()
+            .getUpsertDefaultEnablePreload());
+      }
+
+      _context = new UpsertContext.Builder().setTableConfig(tableConfig).setSchema(schema)
+          .setPrimaryKeyColumns(primaryKeyColumns).setComparisonColumns(comparisonColumns)
+          .setDeleteRecordColumn(deleteRecordColumn).setHashFunction(hashFunction)
+          .setPartialUpsertHandler(partialUpsertHandler).setEnableSnapshot(enableSnapshot)
+          .setEnablePreload(enablePreload).setMetadataTTL(metadataTTL).setDeletedKeysTTL(deletedKeysTTL)
+          .setTableIndexDir(tableIndexDir).build();
+      LOGGER.info(
+          "Initialized {} for table: {} with primary key columns: {}, comparison columns: {}, delete record column: {},"
+              + " hash function: {}, upsert mode: {}, enable snapshot: {}, enable preload: {}, metadata TTL: {},"
+              + " deleted Keys TTL: {}, table index dir: {}", getClass().getSimpleName(), _tableNameWithType,
+          primaryKeyColumns, comparisonColumns, deleteRecordColumn, hashFunction, upsertConfig.getMode(),
+          enableSnapshot, enablePreload, metadataTTL, deletedKeysTTL, tableIndexDir);
+
+      initCustomVariables();
+
       // Preloading the segments with snapshots for fast upsert metadata recovery.
       // Note that there is an implicit waiting logic between the thread doing the segment preloading here and the
       // other helix threads about to process segment state transitions (e.g. taking segments from OFFLINE to ONLINE).

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -101,7 +101,6 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
     double metadataTTL = upsertConfig.getMetadataTTL();
     double deletedKeysTTL = upsertConfig.getDeletedKeysTTL();
     File tableIndexDir = tableDataManager.getTableDataDir();
-
     _context = new UpsertContext.Builder().setTableConfig(tableConfig).setSchema(schema)
         .setPrimaryKeyColumns(primaryKeyColumns).setComparisonColumns(comparisonColumns)
         .setDeleteRecordColumn(deleteRecordColumn).setHashFunction(hashFunction)

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
@@ -50,7 +50,7 @@ public class TableUpsertMetadataManagerFactory {
           tableNameWithType);
       try {
         metadataManager =
-            (TableUpsertMetadataManager) Class.forName(metadataManagerClass).getConstructor().newInstance();
+            (TableUpsertMetadataManager) Class.forName(metadataManagerClass).newInstance();
       } catch (Exception e) {
         throw new RuntimeException(
             String.format("Caught exception while constructing TableUpsertMetadataManager with class: %s for table: %s",

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.upsert;
 
 import com.google.common.base.Preconditions;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
@@ -32,13 +33,18 @@ public class TableUpsertMetadataManagerFactory {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(TableUpsertMetadataManagerFactory.class);
 
-  public static TableUpsertMetadataManager create(TableConfig tableConfig) {
+  public static TableUpsertMetadataManager create(TableConfig tableConfig,
+      @Nullable String defaultMetadataManagerClass) {
     String tableNameWithType = tableConfig.getTableName();
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
     Preconditions.checkArgument(upsertConfig != null, "Must provide upsert config for table: %s", tableNameWithType);
 
     TableUpsertMetadataManager metadataManager;
-    String metadataManagerClass = upsertConfig.getMetadataManagerClass();
+    String tableMetadataManagerClass = upsertConfig.getMetadataManagerClass();
+
+    // Use the default metadata manager class mentioned in the server config if the table config does not specify one.
+    String metadataManagerClass = tableMetadataManagerClass != null ? tableMetadataManagerClass
+        : defaultMetadataManagerClass;
     if (StringUtils.isNotEmpty(metadataManagerClass)) {
       LOGGER.info("Creating TableUpsertMetadataManager with class: {} for table: {}", metadataManagerClass,
           tableNameWithType);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManagerFactory.java
@@ -44,15 +44,12 @@ public class TableUpsertMetadataManagerFactory {
     Preconditions.checkArgument(upsertConfig != null, "Must provide upsert config for table: %s", tableNameWithType);
 
     TableUpsertMetadataManager metadataManager;
-    String tableMetadataManagerClass = upsertConfig.getMetadataManagerClass();
-
-    String defaultMetadataManagerClass =
-        instanceUpsertConfigs != null ? instanceUpsertConfigs.getProperty(UPSERT_DEFAULT_METADATA_MANAGER_CLASS) : null;
-    // Use the default metadata manager class mentioned in the server config if the table config does not specify one.
-    String metadataManagerClass = tableMetadataManagerClass != null ? tableMetadataManagerClass
-        : defaultMetadataManagerClass;
+    String metadataManagerClass = upsertConfig.getMetadataManagerClass();
 
     if (instanceUpsertConfigs != null) {
+      if (metadataManagerClass == null) {
+        metadataManagerClass = instanceUpsertConfigs.getProperty(UPSERT_DEFAULT_METADATA_MANAGER_CLASS);
+      }
       // Server level config honoured only when table level config is not set to true
       if (!upsertConfig.isEnableSnapshot()) {
         upsertConfig.setEnableSnapshot(

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
@@ -86,7 +86,8 @@ public class MutableSegmentImplUpsertComparisonColTest {
     _schema = Schema.fromFile(new File(schemaResourceUrl.getFile()));
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
-    TableUpsertMetadataManager tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(_tableConfig, null);
+    TableUpsertMetadataManager tableUpsertMetadataManager =
+        TableUpsertMetadataManagerFactory.create(_tableConfig, null);
     tableUpsertMetadataManager.init(_tableConfig, _schema, _tableDataManager, mock(HelixManager.class),
         mock(ExecutorService.class));
     _partitionUpsertMetadataManager = tableUpsertMetadataManager.getOrCreatePartitionManager(0);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
@@ -86,7 +86,7 @@ public class MutableSegmentImplUpsertComparisonColTest {
     _schema = Schema.fromFile(new File(schemaResourceUrl.getFile()));
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
-    TableUpsertMetadataManager tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(_tableConfig);
+    TableUpsertMetadataManager tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(_tableConfig, null);
     tableUpsertMetadataManager.init(_tableConfig, _schema, _tableDataManager, mock(HelixManager.class),
         mock(ExecutorService.class));
     _partitionUpsertMetadataManager = tableUpsertMetadataManager.getOrCreatePartitionManager(0);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -96,7 +96,7 @@ public class MutableSegmentImplUpsertTest {
     _schema = Schema.fromFile(new File(schemaResourceUrl.getFile()));
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
-    TableUpsertMetadataManager tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(_tableConfig);
+    TableUpsertMetadataManager tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(_tableConfig, null);
     tableUpsertMetadataManager.init(_tableConfig, _schema, _tableDataManager, mock(HelixManager.class),
         mock(ExecutorService.class));
     _partitionUpsertMetadataManager = tableUpsertMetadataManager.getOrCreatePartitionManager(0);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertTest.java
@@ -96,7 +96,8 @@ public class MutableSegmentImplUpsertTest {
     _schema = Schema.fromFile(new File(schemaResourceUrl.getFile()));
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
-    TableUpsertMetadataManager tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(_tableConfig, null);
+    TableUpsertMetadataManager tableUpsertMetadataManager =
+        TableUpsertMetadataManagerFactory.create(_tableConfig, null);
     tableUpsertMetadataManager.init(_tableConfig, _schema, _tableDataManager, mock(HelixManager.class),
         mock(ExecutorService.class));
     _partitionUpsertMetadataManager = tableUpsertMetadataManager.getOrCreatePartitionManager(0);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -131,9 +131,7 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   private static final String EXTERNAL_VIEW_DROPPED_MAX_WAIT_MS = "external.view.dropped.max.wait.ms";
   private static final String EXTERNAL_VIEW_DROPPED_CHECK_INTERVAL_MS = "external.view.dropped.check.interval.ms";
 
-  public static final String UPSERT_DEFAULT_METADATA_MANAGER_CLASS = "upsert.default.metadata.manager.class";
-  public static final String UPSERT_DEFAULT_ENABLE_SNAPSHOT = "upsert.default.enable.snapshot";
-  public static final String UPSERT_DEFAULT_ENABLE_PRELOAD = "upsert.default.enable.preload";
+  public static final String PREFIX_OF_CONFIG_OF_UPSERT = "upsert";
 
   private final static String[] REQUIRED_KEYS = {INSTANCE_ID};
   private static final long DEFAULT_ERROR_CACHE_SIZE = 100L;
@@ -299,18 +297,8 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   }
 
   @Override
-  public String getUpsertDefaultMetadataManagerClass() {
-    return _instanceDataManagerConfiguration.getProperty(UPSERT_DEFAULT_METADATA_MANAGER_CLASS);
-  }
-
-  @Override
-  public String getUpsertDefaultEnableSnapshot() {
-    return _instanceDataManagerConfiguration.getProperty(UPSERT_DEFAULT_ENABLE_SNAPSHOT);
-  }
-
-  @Override
-  public String getUpsertDefaultEnablePreload() {
-    return _instanceDataManagerConfiguration.getProperty(UPSERT_DEFAULT_ENABLE_PRELOAD);
+  public PinotConfiguration getUpsertConfigs() {
+    return _instanceDataManagerConfiguration.subset(PREFIX_OF_CONFIG_OF_UPSERT);
   }
 
   @Override

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/HelixInstanceDataManagerConfig.java
@@ -131,6 +131,10 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   private static final String EXTERNAL_VIEW_DROPPED_MAX_WAIT_MS = "external.view.dropped.max.wait.ms";
   private static final String EXTERNAL_VIEW_DROPPED_CHECK_INTERVAL_MS = "external.view.dropped.check.interval.ms";
 
+  public static final String UPSERT_DEFAULT_METADATA_MANAGER_CLASS = "upsert.default.metadata.manager.class";
+  public static final String UPSERT_DEFAULT_ENABLE_SNAPSHOT = "upsert.default.enable.snapshot";
+  public static final String UPSERT_DEFAULT_ENABLE_PRELOAD = "upsert.default.enable.preload";
+
   private final static String[] REQUIRED_KEYS = {INSTANCE_ID};
   private static final long DEFAULT_ERROR_CACHE_SIZE = 100L;
   private static final int DEFAULT_DELETED_SEGMENTS_CACHE_SIZE = 10_000;
@@ -292,6 +296,21 @@ public class HelixInstanceDataManagerConfig implements InstanceDataManagerConfig
   public long getExternalViewDroppedCheckIntervalMs() {
     return _instanceDataManagerConfiguration.getProperty(EXTERNAL_VIEW_DROPPED_CHECK_INTERVAL_MS,
         DEFAULT_EXTERNAL_VIEW_DROPPED_CHECK_INTERVAL_MS);
+  }
+
+  @Override
+  public String getUpsertDefaultMetadataManagerClass() {
+    return _instanceDataManagerConfiguration.getProperty(UPSERT_DEFAULT_METADATA_MANAGER_CLASS);
+  }
+
+  @Override
+  public String getUpsertDefaultEnableSnapshot() {
+    return _instanceDataManagerConfiguration.getProperty(UPSERT_DEFAULT_ENABLE_SNAPSHOT);
+  }
+
+  @Override
+  public String getUpsertDefaultEnablePreload() {
+    return _instanceDataManagerConfiguration.getProperty(UPSERT_DEFAULT_ENABLE_PRELOAD);
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -68,4 +68,10 @@ public interface InstanceDataManagerConfig {
   long getExternalViewDroppedMaxWaitMs();
 
   long getExternalViewDroppedCheckIntervalMs();
+
+  String getUpsertDefaultMetadataManagerClass();
+
+  String getUpsertDefaultEnableSnapshot();
+
+  String getUpsertDefaultEnablePreload();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/instance/InstanceDataManagerConfig.java
@@ -69,9 +69,5 @@ public interface InstanceDataManagerConfig {
 
   long getExternalViewDroppedCheckIntervalMs();
 
-  String getUpsertDefaultMetadataManagerClass();
-
-  String getUpsertDefaultEnableSnapshot();
-
-  String getUpsertDefaultEnablePreload();
+  PinotConfiguration getUpsertConfigs();
 }


### PR DESCRIPTION
The Objective of the PR is as follows:
* Allow a single source of truth for upsert configs - Currently multiple tables can have multiple configs for snapshot, preload and metadata managaer class which can lead to maintenance overhead in production
* Honour table level configs first thus retaining existing behavior.