### PR TITLE
Config Validation: upsert table should not assign COMPLETED segments to another server

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -723,6 +723,11 @@ public final class TableConfigUtils {
             "The delete record column must be a single-valued BOOLEAN column");
       }
     }
+
+    Preconditions.checkState(
+        tableConfig.getInstanceAssignmentConfigMap() == null || !tableConfig.getInstanceAssignmentConfigMap()
+            .containsKey(InstancePartitionsType.COMPLETED),
+        "InstanceAssignmentConfig for COMPLETED is not allowed for upsert tables");
     validateAggregateMetricsForUpsertConfig(tableConfig);
     validateTTLForUpsertConfig(tableConfig, schema);
   }


### PR DESCRIPTION
I have seen this issue a lot of times where users add some instance assignment config for COMPLETED segments to upsert tables and then it completely messes up their queries. 

Reason being, upsert tables require all segments of same partition to be available in same set of servers.