### PR TITLE
Adding support for listing dimension tables in /tables API

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/config/provider/TableCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/provider/TableCache.java
@@ -389,6 +389,20 @@ public class TableCache implements PinotConfigProvider {
     return tableConfigs;
   }
 
+  /**
+   * Get all dimension table names.
+   * @return List of dimension table names
+   */
+  public List<String> getAllDimensionTables() {
+    List<String> dimensionTables = new ArrayList<>();
+    for (TableConfigInfo tableConfigInfo : _tableConfigInfoMap.values()) {
+      if (tableConfigInfo._tableConfig.isDimTable()) {
+        dimensionTables.add(tableConfigInfo._tableConfig.getTableName());
+      }
+    }
+    return dimensionTables;
+  }
+
   private void notifySchemaChangeListeners() {
     if (!_schemaChangeListeners.isEmpty()) {
       List<Schema> schemas = getSchemas();

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/provider/TableCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/provider/TableCache.java
@@ -156,6 +156,20 @@ public class TableCache implements PinotConfigProvider {
   }
 
   /**
+   * Get all dimension table names.
+   * @return List of dimension table names
+   */
+  public List<String> getAllDimensionTables() {
+    List<String> dimensionTables = new ArrayList<>();
+    for (TableConfigInfo tableConfigInfo : _tableConfigInfoMap.values()) {
+      if (tableConfigInfo._tableConfig.isDimTable()) {
+        dimensionTables.add(tableConfigInfo._tableConfig.getTableName());
+      }
+    }
+    return dimensionTables;
+  }
+
+  /**
    * Returns a map from column name to actual column name for the given table, or {@code null} if the table schema does
    * not exist. For case-insensitive case, the keys of the map are in lower case.
    */
@@ -387,20 +401,6 @@ public class TableCache implements PinotConfigProvider {
       tableConfigs.add(tableConfigInfo._tableConfig);
     }
     return tableConfigs;
-  }
-
-  /**
-   * Get all dimension table names.
-   * @return List of dimension table names
-   */
-  public List<String> getAllDimensionTables() {
-    List<String> dimensionTables = new ArrayList<>();
-    for (TableConfigInfo tableConfigInfo : _tableConfigInfoMap.values()) {
-      if (tableConfigInfo._tableConfig.isDimTable()) {
-        dimensionTables.add(tableConfigInfo._tableConfig.getTableName());
-      }
-    }
-    return dimensionTables;
   }
 
   private void notifySchemaChangeListeners() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -276,7 +276,7 @@ public class PinotTableRestletResource {
       final boolean isDimensionTable = StringUtils.equalsIgnoreCase(tableTypeStr, "dimension");
       TableType tableType = null;
       if (isDimensionTable) {
-        // Set the table type to OFFLINE for all sorting related operations
+        // Dimension is a property (isDimTable) of an OFFLINE table.
         tableType = TableType.OFFLINE;
       } else if (tableTypeStr != null) {
         tableType = TableType.valueOf(tableTypeStr.toUpperCase());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -273,7 +273,7 @@ public class PinotTableRestletResource {
       @ApiParam(value = "name|creationTime|lastModifiedTime") @QueryParam("sortType") String sortTypeStr,
       @ApiParam(value = "true|false") @QueryParam("sortAsc") @DefaultValue("true") boolean sortAsc) {
     try {
-      final boolean isDimensionTable = StringUtils.equalsIgnoreCase(tableTypeStr, "dimension");
+      final boolean isDimensionTable = "dimension".equalsIgnoreCase(tableTypeStr);
       TableType tableType = null;
       if (isDimensionTable) {
         // Dimension is a property (isDimTable) of an OFFLINE table.
@@ -285,10 +285,11 @@ public class PinotTableRestletResource {
 
       // If tableTypeStr is dimension, then tableType is set to TableType.OFFLINE.
       // So, checking the isDimensionTable to get the list of dimension tables only.
-      List<String> tableNamesWithType = isDimensionTable ? _pinotHelixResourceManager.getAllDimensionTables()
-          : tableType == null ? _pinotHelixResourceManager.getAllTables()
-              : (tableType == TableType.REALTIME ? _pinotHelixResourceManager.getAllRealtimeTables()
-                  : _pinotHelixResourceManager.getAllOfflineTables());
+      List<String> tableNamesWithType =
+          isDimensionTable ? _pinotHelixResourceManager.getTableCache().getAllDimensionTables()
+              : tableType == null ? _pinotHelixResourceManager.getAllTables()
+                  : (tableType == TableType.REALTIME ? _pinotHelixResourceManager.getAllRealtimeTables()
+                      : _pinotHelixResourceManager.getAllOfflineTables());
 
       if (StringUtils.isNotBlank(taskType)) {
         Set<String> tableNamesForTaskType = new HashSet<>();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -273,7 +273,7 @@ public class PinotTableRestletResource {
       @ApiParam(value = "name|creationTime|lastModifiedTime") @QueryParam("sortType") String sortTypeStr,
       @ApiParam(value = "true|false") @QueryParam("sortAsc") @DefaultValue("true") boolean sortAsc) {
     try {
-      final boolean isDimensionTable = "dimension".equalsIgnoreCase(tableTypeStr);
+      boolean isDimensionTable = "dimension".equalsIgnoreCase(tableTypeStr);
       TableType tableType = null;
       if (isDimensionTable) {
         // Dimension is a property (isDimTable) of an OFFLINE table.
@@ -286,7 +286,7 @@ public class PinotTableRestletResource {
       // If tableTypeStr is dimension, then tableType is set to TableType.OFFLINE.
       // So, checking the isDimensionTable to get the list of dimension tables only.
       List<String> tableNamesWithType =
-          isDimensionTable ? _pinotHelixResourceManager.getTableCache().getAllDimensionTables()
+          isDimensionTable ? _pinotHelixResourceManager.getAllDimensionTables()
               : tableType == null ? _pinotHelixResourceManager.getAllTables()
                   : (tableType == TableType.REALTIME ? _pinotHelixResourceManager.getAllRealtimeTables()
                       : _pinotHelixResourceManager.getAllOfflineTables());

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -730,6 +730,15 @@ public class PinotHelixResourceManager {
   }
 
   /**
+   * Get all dimension table names.
+   *
+   * @return List of dimension table names
+   */
+  public List<String> getAllDimensionTables() {
+    return _tableCache.getAllDimensionTables();
+  }
+
+  /**
    * Get all realtime table names.
    *
    * @return List of realtime table names

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -730,6 +730,24 @@ public class PinotHelixResourceManager {
   }
 
   /**
+   * Get all dimension table names.
+   *
+   * @return List of dimension table names
+   */
+  public List<String> getAllDimensionTables() {
+    List<String> dimensionTableNames = new ArrayList<>();
+    for (String resourceName : getAllResources()) {
+      if (TableNameBuilder.isOfflineTableResource(resourceName)) {
+        final TableConfig tableConfig = getTableConfig(resourceName);
+        if (tableConfig != null && tableConfig.isDimTable()) {
+          dimensionTableNames.add(resourceName);
+        }
+      }
+    }
+    return dimensionTableNames;
+  }
+
+  /**
    * Get all realtime table names.
    *
    * @return List of realtime table names

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -730,24 +730,6 @@ public class PinotHelixResourceManager {
   }
 
   /**
-   * Get all dimension table names.
-   *
-   * @return List of dimension table names
-   */
-  public List<String> getAllDimensionTables() {
-    List<String> dimensionTableNames = new ArrayList<>();
-    for (String resourceName : getAllResources()) {
-      if (TableNameBuilder.isOfflineTableResource(resourceName)) {
-        final TableConfig tableConfig = getTableConfig(resourceName);
-        if (tableConfig != null && tableConfig.isDimTable()) {
-          dimensionTableNames.add(resourceName);
-        }
-      }
-    }
-    return dimensionTableNames;
-  }
-
-  /**
    * Get all realtime table names.
    *
    * @return List of realtime table names


### PR DESCRIPTION
`feature`

Added "dimension" as a valid option to "type" option to list the dimension tables only.

Tested using quick-start-batch.sh:

Get dimension tables:
<img width="721" alt="Screenshot 2023-10-23 at 12 08 57 PM" src="https://github.com/apache/pinot/assets/127247229/b448bcfc-7f9b-4a65-97c7-5b64dcef6636">


Get offline tables:
<img width="719" alt="Screenshot 2023-10-23 at 12 08 14 PM" src="https://github.com/apache/pinot/assets/127247229/d013e5f1-c909-4b76-a70b-e4d5bfde193a">
