### PR TITLE
Resolve dependency conflict in pinot-protobuf module

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
@@ -53,6 +53,12 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+          <artifactId>j2objc-annotations</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.os72</groupId>
@@ -131,6 +137,10 @@
         <exclusion>
           <groupId>com.google.errorprone</groupId>
           <artifactId>error_prone_annotations</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>com.google.j2objc</groupId>
+          <artifactId>j2objc-annotations</artifactId>
         </exclusion>
       </exclusions>
     </dependency>


### PR DESCRIPTION
In LinkedIn, a lower version of protobuf is needed. While there is more than 1 version of that got pulled:
```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-enforcer-plugin:3.4.1:enforce (default-cli) on project pinot-protobuf: 
[ERROR] Rule 0: org.apache.maven.enforcer.rules.dependency.DependencyConvergence failed with message:
[ERROR] Failed while enforcing releasability.
[ERROR] 
[ERROR] Dependency convergence error for com.google.j2objc:j2objc-annotations:jar:2.8 paths to dependency are:
[ERROR] +-org.apache.pinot:pinot-protobuf:jar:1.1.0-SNAPSHOT
[ERROR]   +-io.confluent:kafka-schema-registry-client:jar:7.2.6:compile
[ERROR]     +-com.google.guava:guava:jar:32.0.1-jre:compile
[ERROR]       +-com.google.j2objc:j2objc-annotations:jar:2.8:compile
[ERROR] and
[ERROR] +-org.apache.pinot:pinot-protobuf:jar:1.1.0-SNAPSHOT
[ERROR]   +-io.confluent:kafka-protobuf-serializer:jar:7.2.6:compile
[ERROR]     +-com.google.protobuf:protobuf-java-util:jar:3.22.0:compile
[ERROR]       +-com.google.j2objc:j2objc-annotations:jar:1.3:compile
```

This PR tries to resolve the dependency conflict in pinot-protobuf module. Plus, there is no harm to exclude the dependency which is declared in multiple places.

Tested by running `mvn clean install -DskipTests -Pbin-dist -Pbuild-shaded-jar -Ppresto-driver --no-transfer-progress -Djdk.version=11`
