### PR TITLE
11085: Pre PinotConfig commons-configuartions2 upgrade 

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
@@ -211,7 +211,7 @@ public class TlsIntegrationTest extends BaseClusterIntegrationTest {
         CertBasedTlsChannelAccessControlFactory.class.getName());
     prop.put("pinot.server.adminapi.access.protocols", "internal");
     prop.put("pinot.server.adminapi.access.protocols.internal.protocol", "https");
-    prop.put("pinot.server.adminapi.access.protocols.internal.port", "9443");
+    prop.put("pinot.server.adminapi.access.protocols.internal.port", "7443");
     prop.put("pinot.server.netty.enabled", "false");
     prop.put("pinot.server.nettytls.enabled", "true");
     prop.put("pinot.server.nettytls.port", "8089");

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/TlsIntegrationTest.java
@@ -33,7 +33,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Properties;
 import java.util.stream.Collectors;
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.http.Header;
@@ -211,7 +211,7 @@ public class TlsIntegrationTest extends BaseClusterIntegrationTest {
         CertBasedTlsChannelAccessControlFactory.class.getName());
     prop.put("pinot.server.adminapi.access.protocols", "internal");
     prop.put("pinot.server.adminapi.access.protocols.internal.protocol", "https");
-    prop.put("pinot.server.adminapi.access.protocols.internal.port", "7443");
+    prop.put("pinot.server.adminapi.access.protocols.internal.port", "9443");
     prop.put("pinot.server.netty.enabled", "false");
     prop.put("pinot.server.nettytls.enabled", "true");
     prop.put("pinot.server.nettytls.port", "8089");

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -63,6 +63,20 @@
       </exclusions>
     </dependency>
     <dependency>
+      <groupId>org.apache.commons</groupId>
+      <artifactId>commons-configuration2</artifactId>
+      <exclusions>
+        <exclusion>
+          <groupId>commons-logging</groupId>
+          <artifactId>commons-logging</artifactId>
+        </exclusion>
+        <exclusion>
+          <groupId>commons-lang</groupId>
+          <artifactId>commons-lang</artifactId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
     </dependency>

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -32,7 +32,7 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
 import org.apache.commons.lang3.StringUtils;
@@ -102,11 +102,11 @@ public class CommonsConfigurationUtils {
    * @return a stream of keys
    */
   @Deprecated
-  public static Stream<String> getKeysStream(Configuration configuration) {
+  public static Stream<String> getKeysStream(org.apache.commons.configuration.Configuration configuration) {
     return StreamSupport.stream(getIterable(configuration.getKeys()).spliterator(), false);
   }
 
-  public static Stream<String> getKeysStream(org.apache.commons.configuration2.Configuration configuration) {
+  public static Stream<String> getKeysStream(Configuration configuration) {
     return StreamSupport.stream(getIterable(configuration.getKeys()).spliterator(), false);
   }
 
@@ -124,16 +124,16 @@ public class CommonsConfigurationUtils {
    * @return a key-value {@link Map} found in the provided {@link Configuration}
    */
   @Deprecated
+  public static Map<String, Object> toMap(org.apache.commons.configuration.Configuration configuration) {
+    return getKeysStream(configuration).collect(Collectors.toMap(key -> key, key -> mapValue(key, configuration)));
+  }
+
   public static Map<String, Object> toMap(Configuration configuration) {
     return getKeysStream(configuration).collect(Collectors.toMap(key -> key, key -> mapValue(key, configuration)));
   }
 
-  public static Map<String, Object> toMap(org.apache.commons.configuration2.Configuration configuration) {
-    return getKeysStream(configuration).collect(Collectors.toMap(key -> key, key -> mapValue(key, configuration)));
-  }
-
   @Deprecated
-  private static Object mapValue(String key, Configuration configuration) {
+  private static Object mapValue(String key, org.apache.commons.configuration.Configuration configuration) {
     // For multi-value config, convert it to a single comma connected string value.
     // For single-value config, return its raw property, unless it needs interpolation.
     return Optional.of(configuration.getStringArray(key)).filter(values -> values.length > 1)
@@ -147,7 +147,7 @@ public class CommonsConfigurationUtils {
         });
   }
 
-  private static Object mapValue(String key, org.apache.commons.configuration2.Configuration configuration) {
+  private static Object mapValue(String key, Configuration configuration) {
     // For multi-value config, convert it to a single comma connected string value.
     // For single-value config, return its raw property, unless it needs interpolation.
     return Optional.of(configuration.getStringArray(key)).filter(values -> values.length > 1)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -101,6 +101,7 @@ public class CommonsConfigurationUtils {
    * @param configuration to iterate on keys
    * @return a stream of keys
    */
+  @Deprecated
   public static Stream<String> getKeysStream(Configuration configuration) {
     return StreamSupport.stream(getIterable(configuration.getKeys()).spliterator(), false);
   }
@@ -122,6 +123,7 @@ public class CommonsConfigurationUtils {
   /**
    * @return a key-value {@link Map} found in the provided {@link Configuration}
    */
+  @Deprecated
   public static Map<String, Object> toMap(Configuration configuration) {
     return getKeysStream(configuration).collect(Collectors.toMap(key -> key, key -> mapValue(key, configuration)));
   }
@@ -130,6 +132,7 @@ public class CommonsConfigurationUtils {
     return getKeysStream(configuration).collect(Collectors.toMap(key -> key, key -> mapValue(key, configuration)));
   }
 
+  @Deprecated
   private static Object mapValue(String key, Configuration configuration) {
     // For multi-value config, convert it to a single comma connected string value.
     // For single-value config, return its raw property, unless it needs interpolation.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -116,7 +116,7 @@ public class CommonsConfigurationUtils {
    * @param configuration to iterate on keys
    * @return a list of keys
    */
-  public static List<String> getKeys(Configuration configuration) {
+  public static List<String> getKeys(org.apache.commons.configuration.Configuration configuration) {
     return getKeysStream(configuration).collect(Collectors.toList());
   }
 
@@ -172,7 +172,9 @@ public class CommonsConfigurationUtils {
   }
 
   @SuppressWarnings("unchecked")
-  public static <T> T interpolate(Configuration configuration, String key, T defaultValue, Class<T> returnType) {
+  @Deprecated
+  public static <T> T interpolate(org.apache.commons.configuration.Configuration configuration,
+      String key, T defaultValue, Class<T> returnType) {
     // Different from the generic getProperty() method, those type specific getters do config interpolation.
     if (Integer.class.equals(returnType)) {
       return (T) configuration.getInteger(key, (Integer) defaultValue);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -32,9 +32,9 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
-import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.StringUtils;
 
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
@@ -31,7 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Properties;
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.LineIterator;
 import org.apache.commons.lang3.StringUtils;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
@@ -32,7 +32,7 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
 import org.apache.pinot.common.auth.AuthProviderUtils;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartBrokerCommand.java
@@ -24,7 +24,7 @@ import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.collections.MapUtils;
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.tools.Command;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartControllerCommand.java
@@ -23,7 +23,7 @@ import java.net.SocketException;
 import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.utils.NetUtils;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartMinionCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartMinionCommand.java
@@ -24,7 +24,7 @@ import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.collections.MapUtils;
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.tools.Command;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/StartServerCommand.java
@@ -24,7 +24,7 @@ import java.net.UnknownHostException;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.commons.collections.MapUtils;
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.pinot.spi.services.ServiceRole;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.tools.Command;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/service/api/resources/PinotServiceManagerInstanceResource.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/service/api/resources/PinotServiceManagerInstanceResource.java
@@ -45,7 +45,7 @@ import javax.ws.rs.WebApplicationException;
 import javax.ws.rs.core.HttpHeaders;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.services.ServiceRole;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/utils/PinotConfigUtils.java
@@ -27,8 +27,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.builder.fluent.Configurations;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.ControllerConf.ControllerPeriodicTasksConf;
@@ -98,7 +98,8 @@ public class PinotConfigUtils {
       return null;
     }
 
-    Map<String, Object> properties = CommonsConfigurationUtils.toMap(new PropertiesConfiguration(configFile));
+    Configurations configs = new Configurations();
+    Map<String, Object> properties = CommonsConfigurationUtils.toMap(configs.properties(configFile));
     ControllerConf conf = new ControllerConf(properties);
 
     conf.setPinotFSFactoryClasses(null);
@@ -142,7 +143,8 @@ public class PinotConfigUtils {
     }
     File configFile = new File(configFileName);
     if (configFile.exists()) {
-      return CommonsConfigurationUtils.toMap(new PropertiesConfiguration(configFile));
+      Configurations configs = new Configurations();
+      return CommonsConfigurationUtils.toMap(configs.properties(configFile));
     }
 
     return null;


### PR DESCRIPTION
- As per the [issue](https://github.com/apache/pinot/issues/11085), This is the pre-steps for upgrading the `PinotConfiguration` to commons-configuration2. 
- In continuation of the last [PR](https://github.com/apache/pinot/pull/11792) 

cc: @Jackie-Jiang / @xiangfu0 / @walterddr  