### PR TITLE
Providing the ability to close a reader after use

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorFramework.java
@@ -106,7 +106,8 @@ public class SegmentProcessorFramework {
     Preconditions.checkState(!recordReaders.isEmpty(), "No record reader is provided");
     List<RecordReaderFileConfig> recordReaderFileConfigs = new ArrayList<>();
     for (RecordReader recordReader : recordReaders) {
-      recordReaderFileConfigs.add(new RecordReaderFileConfig(recordReader));
+      // For backwards compatibility, we don't want to close readers passed from clients.
+      recordReaderFileConfigs.add(new RecordReaderFileConfig(recordReader, false));
     }
     return recordReaderFileConfigs;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/mapper/SegmentMapper.java
@@ -132,6 +132,7 @@ public class SegmentMapper {
     for (RecordReaderFileConfig recordReaderFileConfig : _recordReaderFileConfigs) {
       RecordReader recordReader = recordReaderFileConfig._recordReader;
       if (recordReader == null) {
+        // We create and use the recordReader here.
         try {
           recordReader =
               RecordReaderFactory.getRecordReader(recordReaderFileConfig._fileFormat, recordReaderFileConfig._dataFile,
@@ -143,7 +144,13 @@ public class SegmentMapper {
           }
         }
       } else {
+        // RecordReader was passed from the client. Check if we can close it
+        // here. This is to optimize memory usage because we no longer need these
+        // readers for segment generation.
         mapAndTransformRow(recordReader, reuse, observer, count, totalCount);
+        if (recordReaderFileConfig._closeRecordReaderAfterUse) {
+          recordReader.close();
+        }
       }
       count++;
     }

--- a/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentMapperTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/segment/processing/framework/SegmentMapperTest.java
@@ -142,7 +142,7 @@ public class SegmentMapperTest {
     PinotSegmentRecordReader segmentRecordReader = new PinotSegmentRecordReader();
     segmentRecordReader.init(_indexDir, null, null, true);
     SegmentMapper segmentMapper =
-        new SegmentMapper(Collections.singletonList(new RecordReaderFileConfig(segmentRecordReader)),
+        new SegmentMapper(Collections.singletonList(new RecordReaderFileConfig(segmentRecordReader, false)),
             processorConfig, mapperOutputDir);
     Map<String, GenericRowFileManager> partitionToFileManagerMap = segmentMapper.map();
     segmentRecordReader.close();

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFileConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFileConfig.java
@@ -34,7 +34,10 @@ public class RecordReaderFileConfig {
   public final File _dataFile;
   public final Set<String> _fieldsToRead;
   public final RecordReaderConfig _recordReaderConfig;
+  // Record Readers created/passed from clients.
   public final RecordReader _recordReader;
+  // Clients can indicate if the above reader can be closed, to optimize for memory usage.
+  public boolean _closeRecordReaderAfterUse = false;
 
   // Pass in the info needed to initialize the reader
   public RecordReaderFileConfig(FileFormat fileFormat, File dataFile, Set<String> fieldsToRead,
@@ -47,11 +50,12 @@ public class RecordReaderFileConfig {
   }
 
   // Pass in the reader instance directly
-  public RecordReaderFileConfig(RecordReader recordReader) {
+  public RecordReaderFileConfig(RecordReader recordReader, boolean closeRecordReaderAfterUse) {
     _recordReader = recordReader;
     _fileFormat = null;
     _dataFile = null;
     _fieldsToRead = null;
     _recordReaderConfig = null;
+    _closeRecordReaderAfterUse = closeRecordReaderAfterUse;
   }
 }


### PR DESCRIPTION
**Problem**:
This[ PR](https://github.com/startreedata/startree-pinot/pull/825) attempted to allocate & close a RecordReader only when its being used during the map phase of segment generation, when its actually needed. However when RecordReaders are created from outside, there's a situation, we end up with large list of readers which cannot be closed (since its created outside) which can result in holding up heap for the entire segment generation phase (eventually resulting in OOM) as well. 

This PR is provide the ability to close RecordReaders (custom readers) passed from clients after they are used, to hold only one reader in memory, at a time. 

 