### PR TITLE
Add upsert config - outOfOrderRecordColumn to track out-of-order events

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1438,6 +1438,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
             .setPartitionDedupMetadataManager(partitionDedupMetadataManager)
             .setUpsertComparisonColumns(tableConfig.getUpsertComparisonColumns())
             .setUpsertDeleteRecordColumn(tableConfig.getUpsertDeleteRecordColumn())
+            .setUpsertOutOfOrderRecordColumn(tableConfig.getOutOfOrderRecordColumn())
+            .setUpsertDropOutOfOrderRecord(tableConfig.isDropOutOfOrderRecord())
             .setFieldConfigList(tableConfig.getFieldConfigList());
 
     // Create message decoder

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -131,8 +131,8 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     _upsertIndexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     ((ImmutableSegmentImpl) _upsertIndexSegment).enableUpsert(
         new ConcurrentMapPartitionUpsertMetadataManager("testTable_REALTIME", 0, Collections.singletonList("column6"),
-            Collections.singletonList("daysSinceEpoch"), null, null, HashFunction.NONE, null,
-            false, false, 0, INDEX_DIR, serverMetrics), new ThreadSafeMutableRoaringBitmap(), null);
+            Collections.singletonList("daysSinceEpoch"), null, HashFunction.NONE, null,
+            false, 0, INDEX_DIR, serverMetrics), new ThreadSafeMutableRoaringBitmap(), null);
   }
 
   @AfterClass

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -131,8 +131,8 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     _upsertIndexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
     ((ImmutableSegmentImpl) _upsertIndexSegment).enableUpsert(
         new ConcurrentMapPartitionUpsertMetadataManager("testTable_REALTIME", 0, Collections.singletonList("column6"),
-            Collections.singletonList("daysSinceEpoch"), null, HashFunction.NONE, null, false, false, 0, INDEX_DIR,
-            serverMetrics), new ThreadSafeMutableRoaringBitmap(), null);
+            Collections.singletonList("daysSinceEpoch"), null, null, HashFunction.NONE, null,
+            false, false, 0, INDEX_DIR, serverMetrics), new ThreadSafeMutableRoaringBitmap(), null);
   }
 
   @AfterClass

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -504,7 +504,7 @@ public class MutableSegmentImpl implements MutableSegment {
       // TODO fix this metadata mismatch scenario
       boolean isOutOfOrderRecord = !_partitionUpsertMetadataManager.addRecord(this, recordInfo);
       if (_upsertOutOfOrderRecordColumn != null) {
-        updatedRow.putValue(_upsertOutOfOrderRecordColumn, BooleanUtils.toInt(String.valueOf(isOutOfOrderRecord)));
+        updatedRow.putValue(_upsertOutOfOrderRecordColumn, BooleanUtils.toInt(isOutOfOrderRecord));
       }
       if (!isOutOfOrderRecord || !_upsertDropOutOfOrderRecord) {
         updateDictionary(updatedRow);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -384,7 +384,7 @@ public class MutableSegmentImpl implements MutableSegment {
           upsertComparisonColumns != null ? upsertComparisonColumns : Collections.singletonList(_timeColumnName);
       _deleteRecordColumn = config.getUpsertDeleteRecordColumn();
       _upsertOutOfOrderRecordColumn = config.getUpsertOutOfOrderRecordColumn();
-      _upsertDropOutOfOrderRecord = config.getUpsertDropOutOfOrderRecord();
+      _upsertDropOutOfOrderRecord = config.isUpsertDropOutOfOrderRecord();
       _validDocIds = new ThreadSafeMutableRoaringBitmap();
       if (_deleteRecordColumn != null) {
         _queryableDocIds = new ThreadSafeMutableRoaringBitmap();
@@ -502,7 +502,7 @@ public class MutableSegmentImpl implements MutableSegment {
       // segment indexing or addNewRow call errors out in those scenario, there can be metadata inconsistency where
       // a key is pointing to some other key's docID
       // TODO fix this metadata mismatch scenario
-      boolean isOutOfOrderRecord = _partitionUpsertMetadataManager.addRecord(this, recordInfo);
+      boolean isOutOfOrderRecord = !_partitionUpsertMetadataManager.addRecord(this, recordInfo);
       if (_upsertOutOfOrderRecordColumn != null) {
         updatedRow.putValue(_upsertOutOfOrderRecordColumn, isOutOfOrderRecord);
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -504,7 +504,7 @@ public class MutableSegmentImpl implements MutableSegment {
       // TODO fix this metadata mismatch scenario
       boolean isOutOfOrderRecord = !_partitionUpsertMetadataManager.addRecord(this, recordInfo);
       if (_upsertOutOfOrderRecordColumn != null) {
-        updatedRow.putValue(_upsertOutOfOrderRecordColumn, isOutOfOrderRecord);
+        updatedRow.putValue(_upsertOutOfOrderRecordColumn, BooleanUtils.toInt(String.valueOf(isOutOfOrderRecord)));
       }
       if (!isOutOfOrderRecord || !_upsertDropOutOfOrderRecord) {
         updateDictionary(updatedRow);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
@@ -63,6 +63,8 @@ public class RealtimeSegmentConfig {
   private final UpsertConfig.Mode _upsertMode;
   private final List<String> _upsertComparisonColumns;
   private final String _upsertDeleteRecordColumn;
+  private final String _upsertOutOfOrderRecordColumn;
+  private final boolean _upsertDropOutOfOrderRecord;
   private final PartitionUpsertMetadataManager _partitionUpsertMetadataManager;
   private final PartitionDedupMetadataManager _partitionDedupMetadataManager;
   private final String _consumerDir;
@@ -76,7 +78,8 @@ public class RealtimeSegmentConfig {
       PinotDataBufferMemoryManager memoryManager, RealtimeSegmentStatsHistory statsHistory, String partitionColumn,
       PartitionFunction partitionFunction, int partitionId, boolean aggregateMetrics, boolean nullHandlingEnabled,
       String consumerDir, UpsertConfig.Mode upsertMode, List<String> upsertComparisonColumns,
-      String upsertDeleteRecordColumn, PartitionUpsertMetadataManager partitionUpsertMetadataManager,
+      String upsertDeleteRecordColumn, String upsertOutOfOrderRecordColumn, boolean upsertDropOutOfOrderRecord,
+      PartitionUpsertMetadataManager partitionUpsertMetadataManager,
       PartitionDedupMetadataManager partitionDedupMetadataManager, List<FieldConfig> fieldConfigList,
       List<AggregationConfig> ingestionAggregationConfigs) {
     _tableNameWithType = tableNameWithType;
@@ -100,6 +103,8 @@ public class RealtimeSegmentConfig {
     _upsertMode = upsertMode != null ? upsertMode : UpsertConfig.Mode.NONE;
     _upsertComparisonColumns = upsertComparisonColumns;
     _upsertDeleteRecordColumn = upsertDeleteRecordColumn;
+    _upsertOutOfOrderRecordColumn = upsertOutOfOrderRecordColumn;
+    _upsertDropOutOfOrderRecord = upsertDropOutOfOrderRecord;
     _partitionUpsertMetadataManager = partitionUpsertMetadataManager;
     _partitionDedupMetadataManager = partitionDedupMetadataManager;
     _fieldConfigList = fieldConfigList;
@@ -195,6 +200,14 @@ public class RealtimeSegmentConfig {
     return _upsertDeleteRecordColumn;
   }
 
+  public String getUpsertOutOfOrderRecordColumn() {
+    return _upsertOutOfOrderRecordColumn;
+  }
+
+  public boolean getUpsertDropOutOfOrderRecord() {
+    return _upsertDropOutOfOrderRecord;
+  }
+
   public PartitionUpsertMetadataManager getPartitionUpsertMetadataManager() {
     return _partitionUpsertMetadataManager;
   }
@@ -233,6 +246,8 @@ public class RealtimeSegmentConfig {
     private UpsertConfig.Mode _upsertMode;
     private List<String> _upsertComparisonColumns;
     private String _upsertDeleteRecordColumn;
+    private String _upsertOutOfOrderRecordColumn;
+    private boolean _upsertDropOutOfOrderRecord;
     private PartitionUpsertMetadataManager _partitionUpsertMetadataManager;
     private PartitionDedupMetadataManager _partitionDedupMetadataManager;
     private List<FieldConfig> _fieldConfigList;
@@ -373,6 +388,16 @@ public class RealtimeSegmentConfig {
       return this;
     }
 
+    public Builder setUpsertOutOfOrderRecordColumn(String upsertOutOfOrderRecordColumn) {
+      _upsertOutOfOrderRecordColumn = upsertOutOfOrderRecordColumn;
+      return this;
+    }
+
+    public Builder setUpsertDropOutOfOrderRecord(boolean upsertDropOutOfOrderRecord) {
+      _upsertDropOutOfOrderRecord = upsertDropOutOfOrderRecord;
+      return this;
+    }
+
     public Builder setPartitionUpsertMetadataManager(PartitionUpsertMetadataManager partitionUpsertMetadataManager) {
       _partitionUpsertMetadataManager = partitionUpsertMetadataManager;
       return this;
@@ -403,6 +428,7 @@ public class RealtimeSegmentConfig {
           _capacity, _avgNumMultiValues, Collections.unmodifiableMap(indexConfigByCol), _segmentZKMetadata, _offHeap,
           _memoryManager, _statsHistory, _partitionColumn, _partitionFunction, _partitionId, _aggregateMetrics,
           _nullHandlingEnabled, _consumerDir, _upsertMode, _upsertComparisonColumns, _upsertDeleteRecordColumn,
+          _upsertOutOfOrderRecordColumn, _upsertDropOutOfOrderRecord,
           _partitionUpsertMetadataManager, _partitionDedupMetadataManager, _fieldConfigList,
           _ingestionAggregationConfigs);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/RealtimeSegmentConfig.java
@@ -204,7 +204,7 @@ public class RealtimeSegmentConfig {
     return _upsertOutOfOrderRecordColumn;
   }
 
-  public boolean getUpsertDropOutOfOrderRecord() {
+  public boolean isUpsertDropOutOfOrderRecord() {
     return _upsertDropOutOfOrderRecord;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -67,6 +67,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   protected final List<String> _primaryKeyColumns;
   protected final List<String> _comparisonColumns;
   protected final String _deleteRecordColumn;
+  protected final String _outOfOrderRecordColumn;
   protected final HashFunction _hashFunction;
   protected final PartialUpsertHandler _partialUpsertHandler;
   protected final boolean _enableSnapshot;
@@ -98,13 +99,15 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
 
   protected BasePartitionUpsertMetadataManager(String tableNameWithType, int partitionId,
       List<String> primaryKeyColumns, List<String> comparisonColumns, @Nullable String deleteRecordColumn,
-      HashFunction hashFunction, @Nullable PartialUpsertHandler partialUpsertHandler, boolean enableSnapshot,
+      @Nullable String outOfOrderRecordColumn, HashFunction hashFunction,
+      @Nullable PartialUpsertHandler partialUpsertHandler, boolean enableSnapshot,
       boolean dropOutOfOrderRecord, double metadataTTL, File tableIndexDir, ServerMetrics serverMetrics) {
     _tableNameWithType = tableNameWithType;
     _partitionId = partitionId;
     _primaryKeyColumns = primaryKeyColumns;
     _comparisonColumns = comparisonColumns;
     _deleteRecordColumn = deleteRecordColumn;
+    _outOfOrderRecordColumn = outOfOrderRecordColumn;
     _hashFunction = hashFunction;
     _partialUpsertHandler = partialUpsertHandler;
     _enableSnapshot = enableSnapshot;
@@ -547,7 +550,8 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   @Override
   public GenericRow updateRecord(GenericRow record, RecordInfo recordInfo) {
     // Directly return the record when partial-upsert is not enabled
-    if (_partialUpsertHandler == null) {
+    // in case of full-upsert check if _outOfOrderRecordColumn needs to be init
+    if (_partialUpsertHandler == null && _outOfOrderRecordColumn == null) {
       return record;
     }
     if (!startOperation()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -67,12 +67,10 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   protected final List<String> _primaryKeyColumns;
   protected final List<String> _comparisonColumns;
   protected final String _deleteRecordColumn;
-  protected final String _outOfOrderRecordColumn;
   protected final HashFunction _hashFunction;
   protected final PartialUpsertHandler _partialUpsertHandler;
   protected final boolean _enableSnapshot;
   protected final double _metadataTTL;
-  protected final boolean _dropOutOfOrderRecord;
   protected final File _tableIndexDir;
   protected final ServerMetrics _serverMetrics;
   protected final Logger _logger;
@@ -99,20 +97,17 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
 
   protected BasePartitionUpsertMetadataManager(String tableNameWithType, int partitionId,
       List<String> primaryKeyColumns, List<String> comparisonColumns, @Nullable String deleteRecordColumn,
-      @Nullable String outOfOrderRecordColumn, HashFunction hashFunction,
-      @Nullable PartialUpsertHandler partialUpsertHandler, boolean enableSnapshot,
-      boolean dropOutOfOrderRecord, double metadataTTL, File tableIndexDir, ServerMetrics serverMetrics) {
+      HashFunction hashFunction, @Nullable PartialUpsertHandler partialUpsertHandler, boolean enableSnapshot,
+      double metadataTTL, File tableIndexDir, ServerMetrics serverMetrics) {
     _tableNameWithType = tableNameWithType;
     _partitionId = partitionId;
     _primaryKeyColumns = primaryKeyColumns;
     _comparisonColumns = comparisonColumns;
     _deleteRecordColumn = deleteRecordColumn;
-    _outOfOrderRecordColumn = outOfOrderRecordColumn;
     _hashFunction = hashFunction;
     _partialUpsertHandler = partialUpsertHandler;
     _enableSnapshot = enableSnapshot;
     _metadataTTL = metadataTTL;
-    _dropOutOfOrderRecord = dropOutOfOrderRecord;
     _tableIndexDir = tableIndexDir;
     _snapshotLock = enableSnapshot ? new ReentrantReadWriteLock() : null;
     _serverMetrics = serverMetrics;
@@ -550,8 +545,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   @Override
   public GenericRow updateRecord(GenericRow record, RecordInfo recordInfo) {
     // Directly return the record when partial-upsert is not enabled
-    // in case of full-upsert check if _outOfOrderRecordColumn needs to be init
-    if (_partialUpsertHandler == null && _outOfOrderRecordColumn == null) {
+    if (_partialUpsertHandler == null) {
       return record;
     }
     if (!startOperation()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -360,7 +360,10 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     }
   }
 
-  // doAddRecord returns whether the event is out-of-order or not, if out-of-order returns false else true
+  /**
+   Returns {@code true} when the record is added to the upsert metadata manager,
+   {@code false} when the record is out-of-order thus not added.
+   */
   protected abstract boolean doAddRecord(MutableSegment segment, RecordInfo recordInfo);
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -360,6 +360,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     }
   }
 
+  // doAddRecord returns whether the event is out-of-order or not, if out-of-order returns false else true
   protected abstract boolean doAddRecord(MutableSegment segment, RecordInfo recordInfo);
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -65,6 +65,7 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
   protected List<String> _primaryKeyColumns;
   protected List<String> _comparisonColumns;
   protected String _deleteRecordColumn;
+  protected String _outOfOrderRecordColumn;
   protected HashFunction _hashFunction;
   protected PartialUpsertHandler _partialUpsertHandler;
   protected boolean _enableSnapshot;
@@ -99,6 +100,7 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
     }
 
     _deleteRecordColumn = upsertConfig.getDeleteRecordColumn();
+    _outOfOrderRecordColumn = upsertConfig.getOutOfOrderRecordColumn();
     _hashFunction = upsertConfig.getHashFunction();
 
     if (upsertConfig.getMode() == UpsertConfig.Mode.PARTIAL) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -65,7 +65,6 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
   protected List<String> _primaryKeyColumns;
   protected List<String> _comparisonColumns;
   protected String _deleteRecordColumn;
-  protected String _outOfOrderRecordColumn;
   protected HashFunction _hashFunction;
   protected PartialUpsertHandler _partialUpsertHandler;
   protected boolean _enableSnapshot;
@@ -74,7 +73,6 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
   protected ServerMetrics _serverMetrics;
   protected HelixManager _helixManager;
   protected ExecutorService _segmentPreloadExecutor;
-  protected boolean _dropOutOfOrderRecord;
 
   private volatile boolean _isPreloading = false;
 
@@ -100,7 +98,6 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
     }
 
     _deleteRecordColumn = upsertConfig.getDeleteRecordColumn();
-    _outOfOrderRecordColumn = upsertConfig.getOutOfOrderRecordColumn();
     _hashFunction = upsertConfig.getHashFunction();
 
     if (upsertConfig.getMode() == UpsertConfig.Mode.PARTIAL) {
@@ -114,7 +111,6 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
 
     _enableSnapshot = upsertConfig.isEnableSnapshot();
     _metadataTTL = upsertConfig.getMetadataTTL();
-    _dropOutOfOrderRecord = upsertConfig.isDropOutOfOrderRecord();
     _tableIndexDir = tableDataManager.getTableDataDir();
     _serverMetrics = serverMetrics;
     _helixManager = helixManager;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -240,6 +240,10 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
     persistWatermark(_largestSeenComparisonValue);
   }
 
+  /**
+   Returns {@code true} when the record is added to the upsert metadata manager,
+   {@code false} when the record is out-of-order thus not added.
+   */
   @Override
   protected boolean doAddRecord(MutableSegment segment, RecordInfo recordInfo) {
     AtomicBoolean isOutOfOrderRecord = new AtomicBoolean(false);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -36,7 +36,7 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   public ConcurrentMapPartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
     return _partitionMetadataManagerMap.computeIfAbsent(partitionId,
         k -> new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _primaryKeyColumns,
-            _comparisonColumns, _deleteRecordColumn, _hashFunction, _partialUpsertHandler,
+            _comparisonColumns, _deleteRecordColumn, _outOfOrderRecordColumn, _hashFunction, _partialUpsertHandler,
             _enableSnapshot, _dropOutOfOrderRecord, _metadataTTL, _tableIndexDir, _serverMetrics));
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -36,8 +36,8 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   public ConcurrentMapPartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
     return _partitionMetadataManagerMap.computeIfAbsent(partitionId,
         k -> new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _primaryKeyColumns,
-            _comparisonColumns, _deleteRecordColumn, _outOfOrderRecordColumn, _hashFunction, _partialUpsertHandler,
-            _enableSnapshot, _dropOutOfOrderRecord, _metadataTTL, _tableIndexDir, _serverMetrics));
+            _comparisonColumns, _deleteRecordColumn, _hashFunction, _partialUpsertHandler,
+            _enableSnapshot, _metadataTTL, _tableIndexDir, _serverMetrics));
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -724,9 +724,17 @@ public final class TableConfigUtils {
             "The delete record column must be a single-valued BOOLEAN column");
       }
 
+      String outOfOrderRecordColumn = upsertConfig.getOutOfOrderRecordColumn();
       Preconditions.checkState(
-          upsertConfig.getOutOfOrderRecordColumn() == null || !upsertConfig.isDropOutOfOrderRecord(),
+          outOfOrderRecordColumn == null || !upsertConfig.isDropOutOfOrderRecord(),
           "outOfOrderRecordColumn and dropOutOfOrderRecord shouldn't exist together for upsert table");
+
+      if (outOfOrderRecordColumn != null) {
+        FieldSpec fieldSpec = schema.getFieldSpecFor(outOfOrderRecordColumn);
+        Preconditions.checkState(
+            fieldSpec != null && fieldSpec.isSingleValueField() && fieldSpec.getDataType() == DataType.BOOLEAN,
+            "The outOfOrderRecordColumn must be a single-valued BOOLEAN column");
+      }
     }
 
     Preconditions.checkState(

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -723,6 +723,10 @@ public final class TableConfigUtils {
             fieldSpec != null && fieldSpec.isSingleValueField() && fieldSpec.getDataType() == DataType.BOOLEAN,
             "The delete record column must be a single-valued BOOLEAN column");
       }
+
+      Preconditions.checkState(
+          upsertConfig.getOutOfOrderRecordColumn() == null || !upsertConfig.isDropOutOfOrderRecord(),
+          "outOfOrderRecordColumn and dropOutOfOrderRecord shouldn't exist together for upsert table");
     }
 
     Preconditions.checkState(

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTestUtils.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplTestUtils.java
@@ -100,6 +100,8 @@ public class MutableSegmentImplTestUtils {
 
     UpsertConfig.Mode upsertMode = upsertConfig == null ? UpsertConfig.Mode.NONE : upsertConfig.getMode();
     List<String> comparisonColumns = upsertConfig == null ? null : upsertConfig.getComparisonColumns();
+    boolean isUpsertDropOutOfOrderRecord = upsertConfig == null ? false : upsertConfig.isDropOutOfOrderRecord();
+    String upsertOutOfOrderRecordColumn = upsertConfig == null ? null : upsertConfig.getOutOfOrderRecordColumn();
     DictionaryIndexConfig varLengthDictConf = new DictionaryIndexConfig(false, true);
     RealtimeSegmentConfig.Builder segmentConfBuilder = new RealtimeSegmentConfig.Builder()
         .setTableNameWithType(TABLE_NAME_WITH_TYPE).setSegmentName(SEGMENT_NAME)
@@ -114,7 +116,9 @@ public class MutableSegmentImplTestUtils {
         .setUpsertComparisonColumns(comparisonColumns)
         .setPartitionUpsertMetadataManager(partitionUpsertMetadataManager)
         .setPartitionDedupMetadataManager(partitionDedupMetadataManager)
-        .setIngestionAggregationConfigs(aggregationConfigs);
+        .setIngestionAggregationConfigs(aggregationConfigs)
+        .setUpsertDropOutOfOrderRecord(isUpsertDropOutOfOrderRecord)
+        .setUpsertOutOfOrderRecordColumn(upsertOutOfOrderRecordColumn);
     for (Map.Entry<String, JsonIndexConfig> entry : jsonIndexConfigs.entrySet()) {
       segmentConfBuilder.setIndex(entry.getKey(), StandardIndexes.json(), entry.getValue());
     }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImplUpsertComparisonColTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.segment.local.recordtransformer.CompositeTransformer;
 import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManagerFactory;
+import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.UpsertConfig;
@@ -37,10 +38,10 @@ import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
 import org.apache.pinot.spi.data.readers.RecordReaderFactory;
+import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.testng.Assert;
-import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
 import static org.mockito.Mockito.mock;
@@ -55,16 +56,20 @@ public class MutableSegmentImplUpsertComparisonColTest {
   private static MutableSegmentImpl _mutableSegmentImpl;
   private static PartitionUpsertMetadataManager _partitionUpsertMetadataManager;
 
-  @BeforeClass
-  public void setup()
+  private UpsertConfig createFullUpsertConfig(HashFunction hashFunction) {
+    UpsertConfig upsertConfigWithHash = new UpsertConfig(UpsertConfig.Mode.FULL);
+    upsertConfigWithHash.setHashFunction(hashFunction);
+    upsertConfigWithHash.setComparisonColumn("offset");
+    return upsertConfigWithHash;
+  }
+
+  public void setup(UpsertConfig upsertConfig)
       throws Exception {
     URL schemaResourceUrl = this.getClass().getClassLoader().getResource(SCHEMA_FILE_PATH);
     URL dataResourceUrl = this.getClass().getClassLoader().getResource(DATA_FILE_PATH);
     _schema = Schema.fromFile(new File(schemaResourceUrl.getFile()));
-    UpsertConfig offsetUpsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
-    offsetUpsertConfig.setComparisonColumn("offset");
     _tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName("testTable").setUpsertConfig(offsetUpsertConfig)
+        new TableConfigBuilder(TableType.REALTIME).setTableName("testTable").setUpsertConfig(upsertConfig)
             .build();
     _recordTransformer = CompositeTransformer.getDefaultTransformer(_tableConfig, _schema);
     File jsonFile = new File(dataResourceUrl.getFile());
@@ -74,7 +79,7 @@ public class MutableSegmentImplUpsertComparisonColTest {
     _partitionUpsertMetadataManager = tableUpsertMetadataManager.getOrCreatePartitionManager(0);
     _mutableSegmentImpl =
         MutableSegmentImplTestUtils.createMutableSegmentImpl(_schema, Collections.emptySet(), Collections.emptySet(),
-            Collections.emptySet(), false, true, offsetUpsertConfig, "secondsSinceEpoch",
+            Collections.emptySet(), false, true, upsertConfig, "secondsSinceEpoch",
             _partitionUpsertMetadataManager, null);
     GenericRow reuse = new GenericRow();
     try (RecordReader recordReader = RecordReaderFactory.getRecordReader(FileFormat.JSON, jsonFile,
@@ -89,12 +94,69 @@ public class MutableSegmentImplUpsertComparisonColTest {
   }
 
   @Test
-  public void testUpsertIngestion() {
+  public void testHashFunctions()
+      throws Exception {
+    testUpsertIngestion(createFullUpsertConfig(HashFunction.NONE));
+    testUpsertIngestion(createFullUpsertConfig(HashFunction.MD5));
+    testUpsertIngestion(createFullUpsertConfig(HashFunction.MURMUR3));
+  }
+
+  @Test
+  public void testUpsertDropOutOfOrderRecord()
+      throws Exception {
+    testUpsertDropOfOrderRecordIngestion(createFullUpsertConfig(HashFunction.NONE));
+    testUpsertDropOfOrderRecordIngestion(createFullUpsertConfig(HashFunction.MD5));
+    testUpsertDropOfOrderRecordIngestion(createFullUpsertConfig(HashFunction.MURMUR3));
+  }
+
+  @Test
+  public void testUpsertOutOfOrderRecordColumn()
+      throws Exception {
+    testUpsertOutOfOrderRecordColumnIngestion(createFullUpsertConfig(HashFunction.NONE));
+    testUpsertOutOfOrderRecordColumnIngestion(createFullUpsertConfig(HashFunction.MD5));
+    testUpsertOutOfOrderRecordColumnIngestion(createFullUpsertConfig(HashFunction.MURMUR3));
+  }
+
+  public void testUpsertIngestion(UpsertConfig upsertConfig)
+      throws Exception {
+    setup(upsertConfig);
     ImmutableRoaringBitmap bitmap = _mutableSegmentImpl.getValidDocIds().getMutableRoaringBitmap();
     // note offset column is used for determining sequence but not time column
+    Assert.assertEquals(_mutableSegmentImpl.getNumDocsIndexed(), 4);
     Assert.assertFalse(bitmap.contains(0));
     Assert.assertTrue(bitmap.contains(1));
     Assert.assertTrue(bitmap.contains(2));
     Assert.assertFalse(bitmap.contains(3));
+  }
+
+  public void testUpsertDropOfOrderRecordIngestion(UpsertConfig upsertConfig)
+      throws Exception {
+    upsertConfig.setDropOutOfOrderRecord(true);
+    setup(upsertConfig);
+    ImmutableRoaringBitmap bitmap = _mutableSegmentImpl.getValidDocIds().getMutableRoaringBitmap();
+    // note offset column is used for determining sequence but not time column
+    Assert.assertEquals(_mutableSegmentImpl.getNumDocsIndexed(), 3);
+    Assert.assertFalse(bitmap.contains(0));
+    Assert.assertTrue(bitmap.contains(1));
+    Assert.assertTrue(bitmap.contains(2));
+  }
+
+  public void testUpsertOutOfOrderRecordColumnIngestion(UpsertConfig upsertConfig)
+      throws Exception {
+    String outOfOrderRecordColumn = "outOfOrderRecordColumn";
+    upsertConfig.setOutOfOrderRecordColumn(outOfOrderRecordColumn);
+    setup(upsertConfig);
+    ImmutableRoaringBitmap bitmap = _mutableSegmentImpl.getValidDocIds().getMutableRoaringBitmap();
+    // note offset column is used for determining sequence but not time column
+    Assert.assertEquals(_mutableSegmentImpl.getNumDocsIndexed(), 4);
+    Assert.assertFalse(bitmap.contains(0));
+    Assert.assertTrue(bitmap.contains(1));
+    Assert.assertTrue(bitmap.contains(2));
+    Assert.assertFalse(bitmap.contains(3));
+
+    Assert.assertFalse(BooleanUtils.toBoolean(_mutableSegmentImpl.getValue(0, outOfOrderRecordColumn)));
+    Assert.assertFalse(BooleanUtils.toBoolean(_mutableSegmentImpl.getValue(1, outOfOrderRecordColumn)));
+    Assert.assertFalse(BooleanUtils.toBoolean(_mutableSegmentImpl.getValue(2, outOfOrderRecordColumn)));
+    Assert.assertTrue(BooleanUtils.toBoolean(_mutableSegmentImpl.getValue(3, outOfOrderRecordColumn)));
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -774,7 +774,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
     // new record, should return false for out of order event
     boolean isOutOfOrderRecord =
-        upsertMetadataManager.addRecord(segment2, new RecordInfo(makePrimaryKey(3), 0, new IntWrapper(100), false));
+        !upsertMetadataManager.addRecord(segment2, new RecordInfo(makePrimaryKey(3), 0, new IntWrapper(100), false));
     assertFalse(isOutOfOrderRecord);
 
     // segment1: 0 -> {0, 100}, 1 -> {1, 120}, 2 -> {2, 100}
@@ -788,12 +788,12 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
     // send an out-of-order event, should return true for orderness of event
     isOutOfOrderRecord =
-        upsertMetadataManager.addRecord(segment2, new RecordInfo(makePrimaryKey(2), 1, new IntWrapper(80), false));
+        !upsertMetadataManager.addRecord(segment2, new RecordInfo(makePrimaryKey(2), 1, new IntWrapper(80), false));
     assertTrue(isOutOfOrderRecord);
 
     // ordered event for an existing key
     isOutOfOrderRecord =
-        upsertMetadataManager.addRecord(segment2, new RecordInfo(makePrimaryKey(2), 1, new IntWrapper(150), false));
+        !upsertMetadataManager.addRecord(segment2, new RecordInfo(makePrimaryKey(2), 1, new IntWrapper(150), false));
     assertFalse(isOutOfOrderRecord);
 
     // segment1: 0 -> {0, 100}, 1 -> {1, 120}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -49,6 +49,7 @@ import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
@@ -91,7 +92,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   public void testStartFinishOperation() {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList("timeCol"), null, HashFunction.NONE, null, false, false, 0, INDEX_DIR,
+            Collections.singletonList("timeCol"), null, null, HashFunction.NONE, null, false, false, 0, INDEX_DIR,
             mock(ServerMetrics.class));
 
     // Start 2 operations
@@ -205,7 +206,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     String comparisonColumn = "timeCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, false, 0, INDEX_DIR,
+            Collections.singletonList(comparisonColumn), null, null, hashFunction, null, false, false, 0, INDEX_DIR,
             mock(ServerMetrics.class));
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
     Set<IndexSegment> trackedSegments = upsertMetadataManager._trackedSegments;
@@ -368,7 +369,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     String deleteRecordColumn = "deleteCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), deleteRecordColumn, hashFunction, null, false, false, 0,
+            Collections.singletonList(comparisonColumn), deleteRecordColumn, null, hashFunction, null, false, false, 0,
             INDEX_DIR, mock(ServerMetrics.class));
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
     Set<IndexSegment> trackedSegments = upsertMetadataManager._trackedSegments;
@@ -660,7 +661,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     String comparisonColumn = "timeCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, false, 0, INDEX_DIR,
+            Collections.singletonList(comparisonColumn), null, null, hashFunction, null, false, false, 0, INDEX_DIR,
             mock(ServerMetrics.class));
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
@@ -741,6 +742,62 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   }
 
   @Test
+  public void testAddOOORecordFullUpsert()
+      throws IOException {
+    verifyAddOOORecordFullUpsert(HashFunction.NONE);
+    verifyAddOOORecordFullUpsert(HashFunction.MD5);
+    verifyAddOOORecordFullUpsert(HashFunction.MURMUR3);
+  }
+
+  private void verifyAddOOORecordFullUpsert(HashFunction hashFunction)
+      throws IOException {
+    String comparisonColumn = "timeCol";
+    String outOfOrderRecordColumn = "outOfOrderRecordColumn";
+    String primaryKeyFieldName = "pk";
+    ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0,
+            Collections.singletonList(primaryKeyFieldName), Collections.singletonList(comparisonColumn), null,
+            outOfOrderRecordColumn, hashFunction, null, false, false, 0, INDEX_DIR,
+            mock(ServerMetrics.class));
+    Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
+
+    // Add records to the segment
+    ThreadSafeMutableRoaringBitmap validDocIds1 = new ThreadSafeMutableRoaringBitmap();
+    MutableSegment segment1 = mockMutableSegment(1, validDocIds1, null);
+    upsertMetadataManager.addRecord(segment1, new RecordInfo(makePrimaryKey(1), 0, new IntWrapper(100), false));
+    upsertMetadataManager.addRecord(segment1, new RecordInfo(makePrimaryKey(2), 1, new IntWrapper(120), false));
+
+    // segment1: 1 -> {0, 100}, 2 -> {1, 120}
+    checkRecordLocation(recordLocationMap, 1, segment1, 0, 100, hashFunction);
+    checkRecordLocation(recordLocationMap, 2, segment1, 1, 120, hashFunction);
+    assertEquals(validDocIds1.getMutableRoaringBitmap().toArray(), new int[]{0, 1});
+
+    // calling updateRecord with OOO event to validate if outOfOrderRecordColumn gets set to true
+    GenericRow row = new GenericRow();
+    row.putValue(primaryKeyFieldName, 1);
+    row.putValue(comparisonColumn, 80);
+    GenericRow updatedRow = upsertMetadataManager.updateRecord(row,
+        new RecordInfo(makePrimaryKey(1), 1, new IntWrapper(80), false));
+
+    assertEquals(updatedRow.getValue(outOfOrderRecordColumn), true);
+
+    // calling updateRecord with not an OOO event to validate if outOfOrderRecordColumn gets set to false
+    row = new GenericRow();
+    row.putValue(primaryKeyFieldName, 2);
+    row.putValue(comparisonColumn, 140);
+    updatedRow = upsertMetadataManager.updateRecord(row,
+        new RecordInfo(makePrimaryKey(2), 1, new IntWrapper(140), false));
+
+    assertEquals(updatedRow.getValue(outOfOrderRecordColumn), false);
+
+    // Stop the metadata manager
+    upsertMetadataManager.stop();
+
+    // Close the metadata manager
+    upsertMetadataManager.close();
+  }
+
+  @Test
   public void testAddOutOfOrderRecord()
       throws IOException {
     verifyAddOutOfOrderRecord(HashFunction.NONE);
@@ -754,7 +811,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     // here dropOutOfOrderRecord = true
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, true, 0, INDEX_DIR,
+            Collections.singletonList(comparisonColumn), null, null, hashFunction, null, false, true, 0, INDEX_DIR,
             mock(ServerMetrics.class));
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
@@ -822,7 +879,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     String comparisonColumn = "timeCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, false, 0, INDEX_DIR,
+            Collections.singletonList(comparisonColumn), null, null, hashFunction, null, false, false, 0, INDEX_DIR,
             mock(ServerMetrics.class));
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
@@ -878,8 +935,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     String deleteColumn = "deleteCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), deleteColumn, hashFunction, null, false, false, 0, INDEX_DIR,
-            mock(ServerMetrics.class));
+            Collections.singletonList(comparisonColumn), deleteColumn, null, hashFunction, null,
+            false, false, 0, INDEX_DIR, mock(ServerMetrics.class));
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // queryableDocIds is same as validDocIds in the absence of delete markers
@@ -980,7 +1037,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList("timeCol"), null, HashFunction.NONE, null, false, false, 30, tableDir,
+            Collections.singletonList("timeCol"), null, null, HashFunction.NONE, null, false, false, 30, tableDir,
             mock(ServerMetrics.class));
     Map<Object, ConcurrentMapPartitionUpsertMetadataManager.RecordLocation> recordLocationMap =
         upsertMetadataManager._primaryKeyToRecordLocationMap;
@@ -1048,7 +1105,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList("timeCol"), null, HashFunction.NONE, null, true, false, 30, tableDir,
+            Collections.singletonList("timeCol"), null, null, HashFunction.NONE, null, true, false, 30, tableDir,
             mock(ServerMetrics.class));
     Map<Object, ConcurrentMapPartitionUpsertMetadataManager.RecordLocation> recordLocationMap =
         upsertMetadataManager._primaryKeyToRecordLocationMap;
@@ -1238,7 +1295,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList("timeCol"), null, HashFunction.NONE, null, true, false, 30, tableDir,
+            Collections.singletonList("timeCol"), null, null, HashFunction.NONE, null, true, false, 30, tableDir,
             mock(ServerMetrics.class));
     Map<Object, ConcurrentMapPartitionUpsertMetadataManager.RecordLocation> recordLocationMap =
         upsertMetadataManager._primaryKeyToRecordLocationMap;
@@ -1299,7 +1356,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
       throws IOException {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList("timeCol"), null, HashFunction.NONE, null, true, false, 10, INDEX_DIR,
+            Collections.singletonList("timeCol"), null, null, HashFunction.NONE, null, true, false, 10, INDEX_DIR,
             mock(ServerMetrics.class));
 
     double currentTimeMs = System.currentTimeMillis();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1694,6 +1694,29 @@ public class TableConfigUtilsTest {
     } catch (IllegalStateException e) {
       Assert.fail("Shouldn't fail table creation when delete column type is boolean.");
     }
+
+    // upsert out-of-order configs
+    String outOfOrderRecordColumn = "outOfOrderRecordColumn";
+    boolean dropOutOfOrderRecord = true;
+    schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).setPrimaryKeyColumns(Lists.newArrayList("myPkCol"))
+        .addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
+        .addSingleValueDimension(outOfOrderRecordColumn, FieldSpec.DataType.BOOLEAN).build();
+    streamConfigs = getStreamConfigs();
+    streamConfigs.put("stream.kafka.consumer.type", "simple");
+
+    upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
+    upsertConfig.setDropOutOfOrderRecord(dropOutOfOrderRecord);
+    upsertConfig.setOutOfOrderRecordColumn(outOfOrderRecordColumn);
+    tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setStreamConfigs(streamConfigs)
+        .setUpsertConfig(upsertConfig)
+        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+        .build();
+    try {
+      TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
+    } catch (IllegalStateException e) {
+      Assert.assertEquals(e.getMessage(),
+          "outOfOrderRecordColumn and dropOutOfOrderRecord shouldn't exist together for upsert table");
+    }
   }
 
   @Test

--- a/pinot-segment-local/src/test/resources/data/test_upsert_comparison_col_schema.json
+++ b/pinot-segment-local/src/test/resources/data/test_upsert_comparison_col_schema.json
@@ -12,6 +12,10 @@
     {
       "name": "offset",
       "dataType": "LONG"
+    },
+    {
+      "name": "outOfOrderRecordColumn",
+      "dataType": "BOOLEAN"
     }
   ],
   "timeFieldSpec": {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/TableConfig.java
@@ -392,6 +392,17 @@ public class TableConfig extends BaseJsonConfig {
     return _upsertConfig == null ? null : _upsertConfig.getDeleteRecordColumn();
   }
 
+  @JsonIgnore
+  @Nullable
+  public String getOutOfOrderRecordColumn() {
+    return _upsertConfig == null ? null : _upsertConfig.getOutOfOrderRecordColumn();
+  }
+
+  @JsonIgnore
+  public boolean isDropOutOfOrderRecord() {
+    return _upsertConfig != null && _upsertConfig.isDropOutOfOrderRecord();
+  }
+
   @JsonProperty(TUNER_CONFIG_LIST_KEY)
   public List<TunerConfig> getTunerConfigsList() {
     return _tunerConfigList;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -192,15 +192,11 @@ public class UpsertConfig extends BaseJsonConfig {
   }
 
   public void setDeleteRecordColumn(String deleteRecordColumn) {
-    if (deleteRecordColumn != null) {
-      _deleteRecordColumn = deleteRecordColumn;
-    }
+    _deleteRecordColumn = deleteRecordColumn;
   }
 
   public void setOutOfOrderRecordColumn(String outOfOrderRecordColumn) {
-    if (outOfOrderRecordColumn != null) {
-      _outOfOrderRecordColumn = outOfOrderRecordColumn;
-    }
+    _outOfOrderRecordColumn = outOfOrderRecordColumn;
   }
 
   public void setEnableSnapshot(boolean enableSnapshot) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/UpsertConfig.java
@@ -57,6 +57,9 @@ public class UpsertConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Boolean column to indicate whether a records should be deleted")
   private String _deleteRecordColumn;
 
+  @JsonPropertyDescription("Boolean column to indicate whether a records is out-of-order")
+  private String _outOfOrderRecordColumn;
+
   @JsonPropertyDescription("Whether to use snapshot for fast upsert metadata recovery")
   private boolean _enableSnapshot;
 
@@ -111,6 +114,11 @@ public class UpsertConfig extends BaseJsonConfig {
   @Nullable
   public String getDeleteRecordColumn() {
     return _deleteRecordColumn;
+  }
+
+  @Nullable
+  public String getOutOfOrderRecordColumn() {
+    return _outOfOrderRecordColumn;
   }
 
   public boolean isEnableSnapshot() {
@@ -186,6 +194,12 @@ public class UpsertConfig extends BaseJsonConfig {
   public void setDeleteRecordColumn(String deleteRecordColumn) {
     if (deleteRecordColumn != null) {
       _deleteRecordColumn = deleteRecordColumn;
+    }
+  }
+
+  public void setOutOfOrderRecordColumn(String outOfOrderRecordColumn) {
+    if (outOfOrderRecordColumn != null) {
+      _outOfOrderRecordColumn = outOfOrderRecordColumn;
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BooleanUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/BooleanUtils.java
@@ -65,6 +65,17 @@ public class BooleanUtils {
   }
 
   /**
+   * Returns the int value (1 for true, 0 for false) for the given boolean value.
+   * <ul>
+   *   <li> 'true' -> '1'</li>
+   *   <li> 'false' -> '0'</li>
+   * </ul>
+   */
+  public static int toInt(boolean booleanValue) {
+    return booleanValue ? INTERNAL_TRUE : INTERNAL_FALSE;
+  }
+
+  /**
    * Returns the boolean value for the given non-null Integer object (internal value for BOOLEAN).
    */
   public static boolean fromNonNullInternalValue(Object value) {


### PR DESCRIPTION
label:
   1. `feature`
   2. `upsert`
  
Relates to #11796
This PR adds an upsert config `outOfOrderRecordColumn`. When set to a non-null value, we check whether an event is `OOO` or not and then accordingly update the corresponding column value to true / false. This will help in tracking which event is out-of-order while using `skipUpsert`.