### PR TITLE
Capture auth phase timing even if access is denied

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -417,14 +417,16 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       boolean hasTableAccess =
           accessControl.hasAccess(requesterIdentity, serverBrokerRequest) && accessControl.hasAccess(httpHeaders,
               TargetType.TABLE, tableName, Actions.Table.QUERY);
+
+      _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.AUTHORIZATION,
+          System.nanoTime() - compilationEndTimeNs);
+
       if (!hasTableAccess) {
         _brokerMetrics.addMeteredTableValue(tableName, BrokerMeter.REQUEST_DROPPED_DUE_TO_ACCESS_ERROR, 1);
         LOGGER.info("Access denied for request {}: {}, table: {}", requestId, query, tableName);
         requestContext.setErrorCode(QueryException.ACCESS_DENIED_ERROR_CODE);
         throw new WebApplicationException("Permission denied", Response.Status.FORBIDDEN);
       }
-      _brokerMetrics.addPhaseTiming(rawTableName, BrokerQueryPhase.AUTHORIZATION,
-          System.nanoTime() - compilationEndTimeNs);
 
       // Get the tables hit by the request
       String offlineTableName = null;


### PR DESCRIPTION
`bugfix`

This PR fixes the AUTHORIZATION phase metric during query execution, even if the access has been denied.