### PR TITLE
Support auth for QueryRunner

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthProviderUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/auth/AuthProviderUtils.java
@@ -168,4 +168,59 @@ public final class AuthProviderUtils {
     }
     throw new IllegalArgumentException("Expected String but got " + config.getProperties().get(key).getClass());
   }
+
+  /**
+   * Generate an (optional) HTTP Authorization header given an auth config
+   *
+   * @param authProvider auth provider
+   * @return list of headers
+   */
+  public static List<Header> makeAuthHeaders(AuthProvider authProvider) {
+    return toRequestHeaders(authProvider);
+  }
+
+  /**
+   * Generate an (optional) HTTP Authorization header given an auth config
+   *
+   * @param authProvider auth provider
+   * @return Map of headers
+   */
+  public static Map<String, String> makeAuthHeadersMap(AuthProvider authProvider) {
+    if (authProvider == null) {
+      return Collections.emptyMap();
+    }
+    return authProvider.getRequestHeaders().entrySet().stream()
+        .collect(Collectors.toMap(Map.Entry::getKey, e -> e.getValue().toString()));
+  }
+
+  /**
+   * Generate auth token from pass-thru token or generate basic auth from user/password pair
+   *
+   * @param provider optional provider
+   * @param tokenUrl optional token url
+   * @param authToken optional pass-thru token
+   * @param user optional username
+   * @param password optional password
+   * @return auth provider, or NullauthProvider if neither pass-thru token nor user info available
+   */
+  public static AuthProvider makeAuthProvider(@Nullable AuthProvider provider, String tokenUrl, String authToken,
+      String user, String password) {
+    if (provider != null) {
+      return provider;
+    }
+
+    if (StringUtils.isNotBlank(tokenUrl)) {
+      return new UrlAuthProvider(tokenUrl);
+    }
+
+    if (StringUtils.isNotBlank(authToken)) {
+      return new StaticTokenAuthProvider(authToken);
+    }
+
+    if (StringUtils.isNotBlank(user)) {
+      return new StaticTokenAuthProvider(BasicAuthUtils.toBasicAuthToken(user, password));
+    }
+
+    return new NullAuthProvider();
+  }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AbstractBaseAdminCommand.java
@@ -31,16 +31,8 @@ import java.nio.charset.StandardCharsets;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
-import javax.annotation.Nullable;
 import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.http.Header;
-import org.apache.pinot.common.auth.AuthProviderUtils;
-import org.apache.pinot.common.auth.BasicAuthUtils;
-import org.apache.pinot.common.auth.NullAuthProvider;
-import org.apache.pinot.common.auth.StaticTokenAuthProvider;
-import org.apache.pinot.common.auth.UrlAuthProvider;
-import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.tools.AbstractBaseCommand;
 import org.apache.pinot.tools.utils.PinotConfigUtils;
 
@@ -129,47 +121,5 @@ public class AbstractBaseAdminCommand extends AbstractBaseCommand {
   Map<String, Object> readConfigFromFile(String configFileName)
       throws ConfigurationException {
     return PinotConfigUtils.readConfigFromFile(configFileName);
-  }
-
-  /**
-   * Generate an (optional) HTTP Authorization header given an auth config
-   *
-   * @param authProvider auth provider
-   * @return list of headers
-   */
-  static List<Header> makeAuthHeaders(AuthProvider authProvider) {
-    return AuthProviderUtils.toRequestHeaders(authProvider);
-  }
-
-  /**
-   * Generate auth token from pass-thru token or generate basic auth from user/password pair
-   *
-   * @param provider optional provider
-   * @param tokenUrl optional token url
-   * @param authToken optional pass-thru token
-   * @param user optional username
-   * @param password optional password
-   * @return auth provider, or NullauthProvider if neither pass-thru token nor user info available
-   */
-  @Nullable
-  static AuthProvider makeAuthProvider(AuthProvider provider, String tokenUrl, String authToken, String user,
-      String password) {
-    if (provider != null) {
-      return provider;
-    }
-
-    if (StringUtils.isNotBlank(tokenUrl)) {
-      return new UrlAuthProvider(tokenUrl);
-    }
-
-    if (StringUtils.isNotBlank(authToken)) {
-      return new StaticTokenAuthProvider(authToken);
-    }
-
-    if (StringUtils.isNotBlank(user)) {
-      return new StaticTokenAuthProvider(BasicAuthUtils.toBasicAuthToken(user, password));
-    }
-
-    return new NullAuthProvider();
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddSchemaCommand.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.net.URI;
 import java.util.Collections;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.data.Schema;
@@ -178,7 +179,8 @@ public class AddSchemaCommand extends AbstractBaseAdminCommand implements Comman
           .getUploadSchemaURI(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort));
       schemaURI = new URI(schemaURI + "?override=" + _override + "?force=" + _force);
       fileUploadDownloadClient.addSchema(schemaURI,
-          schema.getSchemaName(), schemaFile, makeAuthHeaders(makeAuthProvider(_authProvider, _authTokenUrl, _authToken,
+          schema.getSchemaName(), schemaFile, AuthProviderUtils.makeAuthHeaders(
+              AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken,
               _user, _password)), Collections.emptyList());
     } catch (Exception e) {
       LOGGER.error("Got Exception to upload Pinot Schema: " + schema.getSchemaName(), e);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTableCommand.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import java.util.concurrent.Callable;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.TableConfigs;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -188,7 +189,8 @@ public class AddTableCommand extends AbstractBaseAdminCommand implements Command
       throws IOException {
     String res = AbstractBaseAdminCommand.sendRequest("POST",
         ControllerRequestURLBuilder.baseUrl(_controllerAddress).forTableConfigsCreate(), node.toString(),
-        makeAuthHeaders(makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password)));
+        AuthProviderUtils.makeAuthHeaders(
+            AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password)));
     LOGGER.info(res);
     return res.contains("successfully added");
   }
@@ -197,7 +199,8 @@ public class AddTableCommand extends AbstractBaseAdminCommand implements Command
       throws IOException {
     String res = AbstractBaseAdminCommand.sendRequest("PUT",
         ControllerRequestURLBuilder.baseUrl(_controllerAddress).forTableConfigsUpdate(tableName), node.toString(),
-        makeAuthHeaders(makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password)));
+        AuthProviderUtils.makeAuthHeaders(
+            AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password)));
     LOGGER.info(res);
     return res.contains("TableConfigs updated");
   }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/AddTenantCommand.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.tools.admin.command;
 
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.config.tenant.Tenant;
 import org.apache.pinot.spi.config.tenant.TenantRole;
@@ -153,7 +154,8 @@ public class AddTenantCommand extends AbstractBaseAdminCommand implements Comman
     Tenant tenant = new Tenant(_role, _name, _instanceCount, _offlineInstanceCount, _realtimeInstanceCount);
     String res = AbstractBaseAdminCommand
         .sendRequest("POST", ControllerRequestURLBuilder.baseUrl(_controllerAddress).forTenantCreate(),
-            tenant.toJsonString(), makeAuthHeaders(makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user,
+            tenant.toJsonString(), AuthProviderUtils.makeAuthHeaders(
+                AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user,
                 _password)));
 
     LOGGER.info(res);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BootstrapTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/BootstrapTableCommand.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.tools.admin.command;
 
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -139,6 +140,6 @@ public class BootstrapTableCommand extends AbstractBaseAdminCommand implements C
       _controllerHost = NetUtils.getHostAddress();
     }
     return new BootstrapTableTool(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort), _dir,
-        makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password)).execute();
+        AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password)).execute();
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ChangeTableState.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ChangeTableState.java
@@ -25,6 +25,7 @@ import org.apache.http.client.methods.HttpGet;
 import org.apache.http.impl.client.CloseableHttpClient;
 import org.apache.http.impl.client.HttpClientBuilder;
 import org.apache.http.util.EntityUtils;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.NetUtils;
@@ -93,7 +94,8 @@ public class ChangeTableState extends AbstractBaseAdminCommand implements Comman
           URI_TABLES_PATH + _tableName, "state=" + stateValue, null);
 
       HttpGet httpGet = new HttpGet(uri);
-      makeAuthHeaders(makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password))
+      AuthProviderUtils.makeAuthHeaders(
+              AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password))
           .forEach(header -> httpGet.addHeader(header.getName(), header.getValue()));
 
       HttpResponse response = httpClient.execute(httpGet);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteSchemaCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteSchemaCommand.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.tools.admin.command;
 
 import java.util.Collections;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -150,7 +151,7 @@ public class DeleteSchemaCommand extends AbstractBaseAdminCommand implements Com
       fileUploadDownloadClient.getHttpClient().sendDeleteRequest(
           FileUploadDownloadClient.getDeleteSchemaURI(_controllerProtocol, _controllerHost,
               Integer.parseInt(_controllerPort), _schemaName), Collections.emptyMap(),
-          makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password));
+          AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password));
     } catch (Exception e) {
       LOGGER.error("Got Exception while deleting Pinot Schema: " + _schemaName, e);
       return false;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteTableCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/DeleteTableCommand.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.tools.admin.command;
 
 import java.util.Collections;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -172,7 +173,7 @@ public class DeleteTableCommand extends AbstractBaseAdminCommand implements Comm
     try (FileUploadDownloadClient fileUploadDownloadClient = new FileUploadDownloadClient()) {
       fileUploadDownloadClient.getHttpClient().sendDeleteRequest(FileUploadDownloadClient
           .getDeleteTableURI(_controllerProtocol, _controllerHost, Integer.parseInt(_controllerPort),
-              _tableName, _type, _retention), Collections.emptyMap(), makeAuthProvider(_authProvider,
+              _tableName, _type, _retention), Collections.emptyMap(), AuthProviderUtils.makeAuthProvider(_authProvider,
           _authTokenUrl, _authToken, _user, _password));
     } catch (Exception e) {
       LOGGER.error("Got Exception while deleting Pinot Table: " + _tableName, e);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ImportDataCommand.java
@@ -30,6 +30,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.commons.codec.digest.DigestUtils;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.data.readers.FileFormat;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
@@ -259,7 +260,8 @@ public class ImportDataCommand extends AbstractBaseAdminCommand implements Comma
     spec.setCleanUpOutputDir(true);
     spec.setOverwriteOutput(true);
     spec.setJobType("SegmentCreationAndTarPush");
-    spec.setAuthToken(makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password).getTaskToken());
+    spec.setAuthToken(
+        AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password).getTaskToken());
 
     // set ExecutionFrameworkSpec
     ExecutionFrameworkSpec executionFrameworkSpec = new ExecutionFrameworkSpec();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/LaunchDataIngestionJobCommand.java
@@ -21,6 +21,7 @@ package org.apache.pinot.tools.admin.command;
 import java.util.Arrays;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.utils.TlsUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.ingestion.batch.IngestionJobLauncher;
@@ -123,7 +124,8 @@ public class LaunchDataIngestionJobCommand extends AbstractBaseAdminCommand impl
     }
 
     if (StringUtils.isBlank(spec.getAuthToken())) {
-      spec.setAuthToken(makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password).getTaskToken());
+      spec.setAuthToken(AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password)
+          .getTaskToken());
     }
 
     try {

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OperateClusterConfigCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/OperateClusterConfigCommand.java
@@ -24,6 +24,7 @@ import java.util.Iterator;
 import java.util.List;
 import org.apache.commons.lang.StringUtils;
 import org.apache.http.Header;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -154,7 +155,8 @@ public class OperateClusterConfigCommand extends AbstractBaseAdminCommand implem
     }
     String clusterConfigUrl =
         _controllerProtocol + "://" + _controllerHost + ":" + _controllerPort + "/cluster/configs";
-    List<Header> headers = makeAuthHeaders(makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user,
+    List<Header> headers = AuthProviderUtils.makeAuthHeaders(
+        AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user,
         _password));
     switch (_operation.toUpperCase()) {
       case "ADD":

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/PostQueryCommand.java
@@ -20,6 +20,7 @@ package org.apache.pinot.tools.admin.command;
 
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request;
@@ -146,8 +147,8 @@ public class PostQueryCommand extends AbstractBaseAdminCommand implements Comman
       payload.putAll(_additionalOptions);
     }
     String request = JsonUtils.objectToString(payload);
-    return sendRequest("POST", url, request, makeAuthHeaders(makeAuthProvider(_authProvider,
-            _authTokenUrl, _authToken, _user, _password)));
+    return sendRequest("POST", url, request, AuthProviderUtils.makeAuthHeaders(
+        AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password)));
   }
 
   @Override

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/UploadSegmentCommand.java
@@ -25,6 +25,7 @@ import java.net.URI;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.http.Header;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.utils.FileUploadDownloadClient;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.spi.auth.AuthProvider;
@@ -187,7 +188,8 @@ public class UploadSegmentCommand extends AbstractBaseAdminCommand implements Co
 
         LOGGER.info("Uploading segment tar file: {}", segmentTarFile);
         List<Header> headerList =
-            makeAuthHeaders(makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password));
+            AuthProviderUtils.makeAuthHeaders(
+                AuthProviderUtils.makeAuthProvider(_authProvider, _authTokenUrl, _authToken, _user, _password));
 
         FileInputStream fileInputStream = new FileInputStream(segmentTarFile);
         fileUploadDownloadClient.uploadSegment(uploadSegmentHttpURI, segmentTarFile.getName(),

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriver.java
@@ -31,7 +31,6 @@ import java.io.OutputStreamWriter;
 import java.net.URL;
 import java.net.URLConnection;
 import java.nio.charset.StandardCharsets;
-import java.util.Collections;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -45,6 +44,7 @@ import org.apache.helix.InstanceType;
 import org.apache.helix.manager.zk.ZKHelixAdmin;
 import org.apache.helix.tools.ClusterVerifiers.StrictMatchExternalViewVerifier;
 import org.apache.pinot.broker.broker.helix.HelixBrokerStarter;
+import org.apache.pinot.common.auth.AuthProviderUtils;
 import org.apache.pinot.common.utils.ZkStarter;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.ControllerStarter;
@@ -102,6 +102,7 @@ public class PerfBenchmarkDriver {
   // updates ZKSegmentMetadata only, is not exposed from controller API so we need to update segments directly via
   // PinotHelixResourceManager.
   private PinotHelixResourceManager _helixResourceManager;
+  private Map<String, String> _headers;
 
   public PerfBenchmarkDriver(PerfBenchmarkDriverConf conf) {
     this(conf, "/tmp/", "HEAP", null, conf.isVerbose());
@@ -120,6 +121,9 @@ public class PerfBenchmarkDriver {
     _loadMode = loadMode;
     _segmentFormatVersion = segmentFormatVersion;
     _verbose = verbose;
+    _headers = AuthProviderUtils.makeAuthHeadersMap(
+        AuthProviderUtils.makeAuthProvider(null, _conf.getAuthTokenUrl(), _conf.getAuthToken(), _conf.getUser(),
+            _conf.getPassword()));
     init();
   }
 
@@ -407,7 +411,7 @@ public class PerfBenchmarkDriver {
 
   public JsonNode postQuery(String query)
       throws Exception {
-    return postQuery(query, Collections.emptyMap());
+    return postQuery(query, _headers);
   }
 
   public JsonNode postQuery(String query, Map<String, String> headers)

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriverConf.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkDriverConf.java
@@ -71,6 +71,10 @@ public class PerfBenchmarkDriverConf {
   String _resultsOutputDirectory;
 
   boolean _verbose = false;
+  private String _user;
+  private String _password;
+  private String _authToken;
+  private String _authTokenUrl;
 
   public String getClusterName() {
     return _clusterName;
@@ -278,5 +282,37 @@ public class PerfBenchmarkDriverConf {
 
   public void setVerbose(boolean verbose) {
     _verbose = verbose;
+  }
+
+  public void setUser(String user) {
+    _user = user;
+  }
+
+  public String getUser() {
+    return _user;
+  }
+
+  public void setPassword(String password) {
+    _password = password;
+  }
+
+  public String getPassword() {
+    return _password;
+  }
+
+  public void setAuthToken(String authToken) {
+    _authToken = authToken;
+  }
+
+  public String getAuthToken() {
+    return _authToken;
+  }
+
+  public void setAuthTokenUrl(String authTokenUrl) {
+    _authTokenUrl = authTokenUrl;
+  }
+
+  public String getAuthTokenUrl() {
+    return _authTokenUrl;
   }
 }

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/perf/PerfBenchmarkRunner.java
@@ -80,6 +80,18 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
       description = "Comma separated bloom filter columns to be created (non-batch load).")
   private String _bloomFilterColumns;
 
+  @CommandLine.Option(names = {"-user"}, required = false, description = "Username for basic auth.")
+  private String _user;
+
+  @CommandLine.Option(names = {"-password"}, required = false, description = "Password for basic auth.")
+  private String _password;
+
+  @CommandLine.Option(names = {"-authToken"}, required = false, description = "Http auth token.")
+  private String _authToken;
+
+  @CommandLine.Option(names = {"-authTokenUrl"}, required = false, description = "Http auth token url.")
+  private String _authTokenUrl;
+
   @CommandLine.Option(names = {"-help", "-h", "--h", "--help"}, required = false, usageHelp = true,
       description = "Print this message.")
   private boolean _help = false;
@@ -115,6 +127,10 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
       throws Exception {
     PerfBenchmarkDriverConf perfBenchmarkDriverConf = new PerfBenchmarkDriverConf();
     perfBenchmarkDriverConf.setStartServer(false);
+    perfBenchmarkDriverConf.setUser(_user);
+    perfBenchmarkDriverConf.setPassword(_password);
+    perfBenchmarkDriverConf.setAuthToken(_authToken);
+    perfBenchmarkDriverConf.setAuthTokenUrl(_authTokenUrl);
     PerfBenchmarkDriver driver =
         new PerfBenchmarkDriver(perfBenchmarkDriverConf, _tempDir, _loadMode, _segmentFormatVersion, false);
     driver.run();
@@ -127,6 +143,10 @@ public class PerfBenchmarkRunner extends AbstractBaseCommand implements Command 
     perfBenchmarkDriverConf.setStartController(false);
     perfBenchmarkDriverConf.setStartBroker(false);
     perfBenchmarkDriverConf.setServerInstanceDataDir(_dataDir);
+    perfBenchmarkDriverConf.setUser(_user);
+    perfBenchmarkDriverConf.setPassword(_password);
+    perfBenchmarkDriverConf.setAuthToken(_authToken);
+    perfBenchmarkDriverConf.setAuthTokenUrl(_authTokenUrl);
     final PerfBenchmarkDriver driver =
         new PerfBenchmarkDriver(perfBenchmarkDriverConf, _tempDir, _loadMode, _segmentFormatVersion, false);
     driver.run();


### PR DESCRIPTION
- Support auth for QueryRunner
- Some refactor

Sample usage:
Run `org.apache.pinot.tools.AuthQuickstart`, 
Make a `queryFile.txt` file with content: `select count(*) from airlineStats limit 10`

Then run the queryRunner with command:
```
bin/query-runner.sh -mode=singleThread -queryFile=queryFile.txt -user admin -password verysecret -brokerPort 8000 
```

and sample output:
```
2023/10/30 13:49:18.908 INFO [QueryRunner] [main] --------------------------------------------------------------------------------
2023/10/30 13:49:18.909 INFO [QueryRunner] [main] FINAL REPORT:
2023/10/30 13:49:18.910 INFO [QueryRunner] [main] Time Passed: 787ms
Queries Executed: 59
Exceptions: 0
Average QPS: 74.96823379923761
Average Broker Time: 2.7457627118644066ms
Average Client Time: 7.627118644067797ms
2023/10/30 13:49:18.911 INFO [QueryRunner] [main] --------------------------------------------------------------------------------
2023/10/30 13:49:18.911 INFO [QueryRunner] [main] CLIENT TIME STATISTICS:
2023/10/30 13:49:18.911 INFO [QueryRunner] [main] DescriptiveStatistics:
n: 59
min: 3.0
max: 83.0
mean: 7.627118644067796
std dev: 11.113673319748722
median: 5.0
skewness: 5.844161475062559
kurtosis: 38.03544930725383

2023/10/30 13:49:18.912 INFO [QueryRunner] [main] 10th percentile: 3.0
2023/10/30 13:49:18.912 INFO [QueryRunner] [main] 25th percentile: 4.0
2023/10/30 13:49:18.913 INFO [QueryRunner] [main] 50th percentile: 5.0
2023/10/30 13:49:18.913 INFO [QueryRunner] [main] 90th percentile: 9.0
2023/10/30 13:49:18.913 INFO [QueryRunner] [main] 95th percentile: 19.0
2023/10/30 13:49:18.913 INFO [QueryRunner] [main] 99th percentile: 83.0
2023/10/30 13:49:18.913 INFO [QueryRunner] [main] 99.9th percentile: 83.0
2023/10/30 13:49:18.913 INFO [QueryRunner] [main] --------------------------------------------------------------------------------
```