### PR TITLE
Reverting log4j changes from PR 11702

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -257,7 +257,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -110,7 +110,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
+      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>com.lmax</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <snappy-java.version>1.1.10.4</snappy-java.version>
     <zstd-jni.version>1.5.5-6</zstd-jni.version>
     <lz4-java.version>1.8.0</lz4-java.version>
-    <log4j.version>2.20.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
     <netty.version>4.1.94.Final</netty.version>
     <reactivestreams.version>1.0.3</reactivestreams.version>
     <jts.version>1.19.0</jts.version>
@@ -604,7 +604,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>2.0.9</version>
+        <version>1.7.25</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
@@ -618,19 +618,8 @@
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j2-impl</artifactId>
-        <version>${log4j.version}</version>
-      </dependency>
-      <dependency>
-        <!--
-         We don't use slf4j but slf4j2, so we can just ignore this dependency.
-         Instead of just remove this dependency, we set the scope as provided.
-         We cannot just remove the dependency because that would create conflicts in the enforcer
-        -->
-        <groupId>org.apache.logging.log4j</groupId>
         <artifactId>log4j-slf4j-impl</artifactId>
         <version>${log4j.version}</version>
-        <scope>provided</scope>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>


### PR DESCRIPTION
Moving to later versions of log4j causes thread contention, and multiple production systems have been affected. Backing out to use the older version of log4j