### PR TITLE
Add cache for Bcrypt password

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
@@ -117,26 +117,23 @@ public class ZkBasicAuthAccessControlFactory extends AccessControlFactory {
     }
 
     private Optional<ZkBasicAuthPrincipal> getPrincipalAuth(RequesterIdentity requesterIdentity) {
-      Preconditions.checkArgument(requesterIdentity instanceof HttpRequesterIdentity,
-          "HttpRequesterIdentity required");
+      Preconditions.checkArgument(requesterIdentity instanceof HttpRequesterIdentity, "HttpRequesterIdentity required");
       HttpRequesterIdentity identity = (HttpRequesterIdentity) requesterIdentity;
 
       Collection<String> tokens = identity.getHttpHeaders().get(HEADER_AUTHORIZATION);
 
-      _name2principal = BasicAuthUtils.extractBasicAuthPrincipals(_userCache.getAllBrokerUserConfig())
-          .stream().collect(Collectors.toMap(BasicAuthPrincipal::getName, p -> p));
+      _name2principal = BasicAuthUtils.extractBasicAuthPrincipals(_userCache.getAllBrokerUserConfig()).stream()
+          .collect(Collectors.toMap(BasicAuthPrincipal::getName, p -> p));
 
-      Map<String, String> name2password = tokens.stream().collect(Collectors
-          .toMap(
-              org.apache.pinot.common.auth.BasicAuthUtils::extractUsername,
+      Map<String, String> name2password = tokens.stream().collect(
+          Collectors.toMap(org.apache.pinot.common.auth.BasicAuthUtils::extractUsername,
               org.apache.pinot.common.auth.BasicAuthUtils::extractPassword));
-      Map<String, ZkBasicAuthPrincipal> password2principal = name2password.keySet().stream()
-          .collect(Collectors.toMap(name2password::get, _name2principal::get));
+      Map<String, ZkBasicAuthPrincipal> password2principal =
+          name2password.keySet().stream().collect(Collectors.toMap(name2password::get, _name2principal::get));
 
-      Optional<ZkBasicAuthPrincipal> principalOpt =
-          password2principal.entrySet().stream()
-              .filter(entry -> BcryptUtils.checkpw(entry.getKey(), entry.getValue().getPassword()))
-              .map(u -> u.getValue()).filter(Objects::nonNull).findFirst();
+      Optional<ZkBasicAuthPrincipal> principalOpt = password2principal.entrySet().stream().filter(
+          entry -> BcryptUtils.checkpwWithCache(entry.getKey(), entry.getValue().getPassword(),
+              _userCache.getUserPasswordAuthCache())).map(u -> u.getValue()).filter(Objects::nonNull).findFirst();
       return principalOpt;
     }
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/provider/AccessControlUserCache.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/provider/AccessControlUserCache.java
@@ -18,10 +18,13 @@
  */
 package org.apache.pinot.common.config.provider;
 
+import com.google.common.cache.Cache;
+import com.google.common.cache.CacheBuilder;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
@@ -36,142 +39,152 @@ import org.apache.pinot.spi.config.user.UserConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+
 /**
  * The {@code AccessControlUserCache} caches all the user configs within the cluster, and listens on ZK changes to keep
  * them in sync. It also maintains several component user config maps.
  */
 public class AccessControlUserCache {
 
-    private static final Logger LOGGER = LoggerFactory.getLogger(AccessControlUserCache.class);
-    private static final String USER_CONFIG_PARENT_PATH = "/CONFIGS/USER";
-    private static final String USER_CONFIG_PATH_PREFIX = "/CONFIGS/USER/";
+  private static final Logger LOGGER = LoggerFactory.getLogger(AccessControlUserCache.class);
+  private static final String USER_CONFIG_PARENT_PATH = "/CONFIGS/USER";
+  private static final String USER_CONFIG_PATH_PREFIX = "/CONFIGS/USER/";
+  private static final int USER_PASSWORD_EXPIRE_TIME = 24 * 60 * 60;
 
-    private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
+  private final ZkHelixPropertyStore<ZNRecord> _propertyStore;
 
-    private final UserConfigChangeListener _userConfigChangeListener = new UserConfigChangeListener();
+  private final UserConfigChangeListener _userConfigChangeListener = new UserConfigChangeListener();
 
-    private final Map<String, UserConfig> _userConfigMap = new ConcurrentHashMap<>();
-    private final Map<String, UserConfig> _userControllerConfigMap = new ConcurrentHashMap<>();
-    private final Map<String, UserConfig> _userBrokerConfigMap = new ConcurrentHashMap<>();
-    private final Map<String, UserConfig> _userServerConfigMap = new ConcurrentHashMap<>();
+  private final Map<String, UserConfig> _userConfigMap = new ConcurrentHashMap<>();
+  private final Map<String, UserConfig> _userControllerConfigMap = new ConcurrentHashMap<>();
+  private final Map<String, UserConfig> _userBrokerConfigMap = new ConcurrentHashMap<>();
+  private final Map<String, UserConfig> _userServerConfigMap = new ConcurrentHashMap<>();
+  private Cache<String, String> _userPasswordAuthCache =
+      CacheBuilder.newBuilder().expireAfterWrite(USER_PASSWORD_EXPIRE_TIME, TimeUnit.SECONDS).build();
 
-    public AccessControlUserCache(ZkHelixPropertyStore<ZNRecord> propertyStore) {
-        _propertyStore = propertyStore;
-        _propertyStore.subscribeChildChanges(USER_CONFIG_PARENT_PATH, _userConfigChangeListener);
+  public AccessControlUserCache(ZkHelixPropertyStore<ZNRecord> propertyStore) {
+    _propertyStore = propertyStore;
+    _propertyStore.subscribeChildChanges(USER_CONFIG_PARENT_PATH, _userConfigChangeListener);
 
-        List<String> users = _propertyStore.getChildNames(USER_CONFIG_PARENT_PATH, AccessOption.PERSISTENT);
-        if (CollectionUtils.isNotEmpty(users)) {
-            List<String> pathsToAdd = new ArrayList<>(users.size());
-            for (String user : users) {
-                pathsToAdd.add(USER_CONFIG_PATH_PREFIX + user);
-            }
-            addUserConfigs(pathsToAdd);
+    List<String> users = _propertyStore.getChildNames(USER_CONFIG_PARENT_PATH, AccessOption.PERSISTENT);
+    if (CollectionUtils.isNotEmpty(users)) {
+      List<String> pathsToAdd = new ArrayList<>(users.size());
+      for (String user : users) {
+        pathsToAdd.add(USER_CONFIG_PATH_PREFIX + user);
+      }
+      addUserConfigs(pathsToAdd);
+    }
+  }
+
+  public Cache<String, String> getUserPasswordAuthCache() {
+    return _userPasswordAuthCache;
+  }
+
+  @Nullable
+  public List<UserConfig> getAllUserConfig() {
+    return _userConfigMap.values().stream().collect(Collectors.toList());
+  }
+
+  public List<UserConfig> getAllControllerUserConfig() {
+    return _userControllerConfigMap.values().stream().collect(Collectors.toList());
+  }
+
+  public List<UserConfig> getAllBrokerUserConfig() {
+    return _userBrokerConfigMap.values().stream().collect(Collectors.toList());
+  }
+
+  public List<UserConfig> getAllServerUserConfig() {
+    return _userServerConfigMap.values().stream().collect(Collectors.toList());
+  }
+
+  @Nullable
+  public List<String> getAllUserName() {
+    return _userConfigMap.keySet().stream().collect(Collectors.toList());
+  }
+
+  private void addUserConfigs(List<String> allUserZKStorePath) {
+    for (String userStoreZKPath : allUserZKStorePath) {
+      _propertyStore.subscribeDataChanges(userStoreZKPath, _userConfigChangeListener);
+    }
+    List<ZNRecord> allUserRecords = _propertyStore.get(allUserZKStorePath, null, AccessOption.PERSISTENT, false);
+    for (ZNRecord userRecord : allUserRecords) {
+      if (userRecord != null) {
+        try {
+          UserConfig userConfig = AccessControlUserConfigUtils.fromZNRecord(userRecord);
+          String username = userConfig.getUsernameWithComponent();
+
+          if (userConfig.getComponentType().equals(ComponentType.CONTROLLER)) {
+            _userControllerConfigMap.put(username, userConfig);
+          } else if (userConfig.getComponentType().equals(ComponentType.BROKER)) {
+            _userBrokerConfigMap.put(username, userConfig);
+          } else if (userConfig.getComponentType().equals(ComponentType.SERVER)) {
+            _userServerConfigMap.put(username, userConfig);
+          }
+        } catch (Exception e) {
+          LOGGER.error("Caught exception while adding user config for ZNRecord:{}", userRecord.getId(), e);
         }
+      }
     }
+  }
 
-    @Nullable
-    public List<UserConfig> getAllUserConfig() {
-        return _userConfigMap.values().stream().collect(Collectors.toList());
+  private void removeUserConfig(String userStoreZKPath) {
+    _propertyStore.unsubscribeDataChanges(userStoreZKPath, _userConfigChangeListener);
+    String usernameWithComponentType = userStoreZKPath.substring(USER_CONFIG_PATH_PREFIX.length());
+    if (usernameWithComponentType.endsWith("BROKER")) {
+      _userBrokerConfigMap.remove(usernameWithComponentType);
+    } else if (usernameWithComponentType.endsWith("CONTROLLER")) {
+      _userControllerConfigMap.remove(usernameWithComponentType);
+    } else if (usernameWithComponentType.endsWith("SERVER")) {
+      _userServerConfigMap.remove(usernameWithComponentType);
     }
+  }
 
-    public List<UserConfig> getAllControllerUserConfig() {
-        return _userControllerConfigMap.values().stream().collect(Collectors.toList());
-    }
+  private class UserConfigChangeListener implements IZkChildListener, IZkDataListener {
+    @Override
+    public void handleChildChange(String userStoreZKPath, List<String> allUserList)
+        throws Exception {
+      if (CollectionUtils.isEmpty(allUserList)) {
+        return;
+      }
 
-    public List<UserConfig> getAllBrokerUserConfig() {
-        return _userBrokerConfigMap.values().stream().collect(Collectors.toList());
-    }
-
-    public List<UserConfig> getAllServerUserConfig() {
-        return _userServerConfigMap.values().stream().collect(Collectors.toList());
-    }
-
-    @Nullable
-    public List<String> getAllUserName() {
-        return _userConfigMap.keySet().stream().collect(Collectors.toList());
-    }
-
-    private void addUserConfigs(List<String> allUserZKStorePath) {
-        for (String userStoreZKPath : allUserZKStorePath) {
-            _propertyStore.subscribeDataChanges(userStoreZKPath, _userConfigChangeListener);
+      List<String> newUserPathToAdd = new ArrayList<>();
+      for (String user : allUserList) {
+        if (!_userControllerConfigMap.containsKey(user) && !_userBrokerConfigMap.containsKey(user)
+            && !_userServerConfigMap.containsKey(user)) {
+          newUserPathToAdd.add(USER_CONFIG_PATH_PREFIX + user);
         }
-        List<ZNRecord> allUserRecords = _propertyStore.get(allUserZKStorePath, null, AccessOption.PERSISTENT, false);
-        for (ZNRecord userRecord : allUserRecords) {
-            if (userRecord != null) {
-                try {
-                    UserConfig userConfig = AccessControlUserConfigUtils.fromZNRecord(userRecord);
-                    String username = userConfig.getUsernameWithComponent();
-
-                    if (userConfig.getComponentType().equals(ComponentType.CONTROLLER)) {
-                        _userControllerConfigMap.put(username, userConfig);
-                    } else if (userConfig.getComponentType().equals(ComponentType.BROKER)) {
-                        _userBrokerConfigMap.put(username, userConfig);
-                    } else if (userConfig.getComponentType().equals(ComponentType.SERVER)) {
-                        _userServerConfigMap.put(username, userConfig);
-                    }
-                } catch (Exception e) {
-                    LOGGER.error("Caught exception while adding user config for ZNRecord:{}", userRecord.getId(), e);
-                }
-            }
-        }
+      }
+      if (!newUserPathToAdd.isEmpty()) {
+        addUserConfigs(newUserPathToAdd);
+      }
     }
 
-    private void removeUserConfig(String userStoreZKPath) {
-        _propertyStore.unsubscribeDataChanges(userStoreZKPath, _userConfigChangeListener);
-        String usernameWithComponentType = userStoreZKPath.substring(USER_CONFIG_PATH_PREFIX.length());
-        if (usernameWithComponentType.endsWith("BROKER")) {
-            _userBrokerConfigMap.remove(usernameWithComponentType);
-        } else if (usernameWithComponentType.endsWith("CONTROLLER")) {
-            _userControllerConfigMap.remove(usernameWithComponentType);
-        } else if (usernameWithComponentType.endsWith("SERVER")) {
-            _userServerConfigMap.remove(usernameWithComponentType);
+    @Override
+    public void handleDataChange(String userStoreZKPath, Object changedUserConfig)
+        throws Exception {
+      if (changedUserConfig != null) {
+        ZNRecord userRecord = (ZNRecord) changedUserConfig;
+        try {
+          UserConfig userConfig = AccessControlUserConfigUtils.fromZNRecord(userRecord);
+          String usernameWithComponentType = userConfig.getUsernameWithComponent();
+          if (userConfig.getComponentType().equals(ComponentType.CONTROLLER)) {
+            _userControllerConfigMap.put(usernameWithComponentType, userConfig);
+          } else if (userConfig.getComponentType().equals(ComponentType.BROKER)) {
+            _userBrokerConfigMap.put(usernameWithComponentType, userConfig);
+          } else if (userConfig.getComponentType().equals(ComponentType.SERVER)) {
+            _userServerConfigMap.put(usernameWithComponentType, userConfig);
+          }
+        } catch (Exception e) {
+          LOGGER.error("caught exception while refreshing table config for ZNRecord: {}", userRecord.getId(), e);
         }
+      }
     }
 
-    private class UserConfigChangeListener implements IZkChildListener, IZkDataListener {
-        @Override
-        public void handleChildChange(String userStoreZKPath, List<String> allUserList) throws Exception {
-            if (CollectionUtils.isEmpty(allUserList)) {
-                return;
-            }
-
-            List<String> newUserPathToAdd = new ArrayList<>();
-            for (String user : allUserList) {
-                if (!_userControllerConfigMap.containsKey(user) && !_userBrokerConfigMap.containsKey(user)
-                && !_userServerConfigMap.containsKey(user)) {
-                    newUserPathToAdd.add(USER_CONFIG_PATH_PREFIX + user);
-                }
-            }
-            if (!newUserPathToAdd.isEmpty()) {
-                addUserConfigs(newUserPathToAdd);
-            }
-        }
-
-        @Override
-        public void handleDataChange(String userStoreZKPath, Object changedUserConfig) throws Exception {
-            if (changedUserConfig != null) {
-                ZNRecord userRecord = (ZNRecord) changedUserConfig;
-                try {
-                    UserConfig userConfig = AccessControlUserConfigUtils.fromZNRecord(userRecord);
-                    String usernameWithComponentType = userConfig.getUsernameWithComponent();
-                    if (userConfig.getComponentType().equals(ComponentType.CONTROLLER)) {
-                        _userControllerConfigMap.put(usernameWithComponentType, userConfig);
-                    } else if (userConfig.getComponentType().equals(ComponentType.BROKER)) {
-                        _userBrokerConfigMap.put(usernameWithComponentType, userConfig);
-                    } else if (userConfig.getComponentType().equals(ComponentType.SERVER)) {
-                        _userServerConfigMap.put(usernameWithComponentType, userConfig);
-                    }
-                } catch (Exception e) {
-                    LOGGER.error("caught exception while refreshing table config for ZNRecord: {}",
-                        userRecord.getId(), e);
-                }
-            }
-        }
-
-        @Override
-        public void handleDataDeleted(String path) throws Exception {
-            String username = path.substring(path.lastIndexOf('/') + 1);
-            removeUserConfig(USER_CONFIG_PATH_PREFIX + username);
-        }
+    @Override
+    public void handleDataDeleted(String path)
+        throws Exception {
+      String username = path.substring(path.lastIndexOf('/') + 1);
+      removeUserConfig(USER_CONFIG_PATH_PREFIX + username);
     }
+  }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/ZkBasicAuthAccessControlFactory.java
@@ -52,8 +52,8 @@ public class ZkBasicAuthAccessControlFactory implements AccessControlFactory {
   public void init(PinotConfiguration pinotConfiguration, PinotHelixResourceManager pinotHelixResourceManager)
       throws IOException {
     pinotHelixResourceManager.initUserACLConfig((ControllerConf) pinotConfiguration);
-    _accessControl = new BasicAuthAccessControl(new AccessControlUserCache(
-        pinotHelixResourceManager.getPropertyStore()));
+    _accessControl =
+        new BasicAuthAccessControl(new AccessControlUserCache(pinotHelixResourceManager.getPropertyStore()));
   }
 
   @Override
@@ -84,8 +84,8 @@ public class ZkBasicAuthAccessControlFactory implements AccessControlFactory {
 
     @Override
     public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
-      return getPrincipal(httpHeaders)
-          .filter(p -> p.hasTable(tableName) && p.hasPermission(Objects.toString(accessType))).isPresent();
+      return getPrincipal(httpHeaders).filter(
+          p -> p.hasTable(tableName) && p.hasPermission(Objects.toString(accessType))).isPresent();
     }
 
     @Override
@@ -98,23 +98,22 @@ public class ZkBasicAuthAccessControlFactory implements AccessControlFactory {
         return Optional.empty();
       }
 
-      _name2principal = BasicAuthUtils.extractBasicAuthPrincipals(_userCache.getAllControllerUserConfig())
-          .stream().collect(Collectors.toMap(ZkBasicAuthPrincipal::getName, p -> p));
+      _name2principal = BasicAuthUtils.extractBasicAuthPrincipals(_userCache.getAllControllerUserConfig()).stream()
+          .collect(Collectors.toMap(ZkBasicAuthPrincipal::getName, p -> p));
 
       List<String> authHeaders = headers.getRequestHeader(HEADER_AUTHORIZATION);
       if (authHeaders == null) {
         return Optional.empty();
       }
-      Map<String, String> name2password = authHeaders.stream().collect(Collectors
-          .toMap(
-              org.apache.pinot.common.auth.BasicAuthUtils::extractUsername,
+      Map<String, String> name2password = authHeaders.stream().collect(
+          Collectors.toMap(org.apache.pinot.common.auth.BasicAuthUtils::extractUsername,
               org.apache.pinot.common.auth.BasicAuthUtils::extractPassword));
-      Map<String, ZkBasicAuthPrincipal> password2principal = name2password.keySet().stream()
-          .collect(Collectors.toMap(name2password::get, _name2principal::get));
+      Map<String, ZkBasicAuthPrincipal> password2principal =
+          name2password.keySet().stream().collect(Collectors.toMap(name2password::get, _name2principal::get));
 
-      return password2principal.entrySet().stream()
-          .filter(entry -> BcryptUtils.checkpw(entry.getKey(), entry.getValue().getPassword()))
-          .map(u -> u.getValue()).filter(Objects::nonNull).findFirst();
+      return password2principal.entrySet().stream().filter(
+          entry -> BcryptUtils.checkpwWithCache(entry.getKey(), entry.getValue().getPassword(),
+              _userCache.getUserPasswordAuthCache())).map(u -> u.getValue()).filter(Objects::nonNull).findFirst();
     }
 
     @Override


### PR DESCRIPTION
Cisco Wap Storage Team add cache to optimize query logic. Bcrypt decrypt is a time-consuming operator. So we could add cache to reduce query time. And We set expire time of each password is 24h.

Fix: [Issue 11902](https://github.com/apache/pinot/issues/11902)

Hi @xiangfu0 ， please help to review this pr.