### PR TITLE
[multistage][bugfix] fix mailbox visitor mismatch receive/send

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MailboxAssignmentVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/physical/MailboxAssignmentVisitor.java
@@ -67,7 +67,7 @@ public class MailboxAssignmentVisitor extends DefaultPostOrderTraversalVisitor<V
           senderMailboxesMap.computeIfAbsent(workerId, k -> new HashMap<>()).put(receiverFragmentId, mailboxMetadata);
           receiverMailboxesMap.computeIfAbsent(workerId, k -> new HashMap<>()).put(senderFragmentId, mailboxMetadata);
         }
-      } else if (senderMetadata.isPartitionedTableScan()) {
+      } else if (senderMetadata.isPartitionedTableScan() && (numReceivers / numSenders > 0)) {
         // For partitioned table scan, send the data to the worker with the same worker id (not necessary the same
         // instance). When partition parallelism is configured, send the data to the corresponding workers.
         // NOTE: Do not use partitionParallelism from the metadata because it might be configured only in the first

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTestBase.java
@@ -549,6 +549,8 @@ public abstract class QueryRunnerTestBase extends QueryTestSet {
       public List<List<Object>> _inputs;
       @JsonProperty("partitionColumns")
       public List<String> _partitionColumns;
+      @JsonProperty("partitionCount")
+      public Integer _partitionCount;
     }
 
     @JsonIgnoreProperties(ignoreUnknown = true)

--- a/pinot-query-runtime/src/test/resources/queries/QueryHints.json
+++ b/pinot-query-runtime/src/test/resources/queries/QueryHints.json
@@ -118,5 +118,81 @@
         "sql": "SELECT /*+ aggOptions(is_skip_leaf_stage_group_by='true') */ {tbl1}.name, COUNT(*), SUM({tbl1}.num), MIN({tbl1}.num) FROM {tbl1} WHERE {tbl1}.num >= 0 GROUP BY {tbl1}.name"
       }
     ]
+  },
+  "hint_option_queries_unmatched_partition": {
+    "tables": {
+      "tbl1": {
+        "schema": [
+          {"name": "num", "type": "INT"},
+          {"name": "name", "type": "STRING"}
+        ],
+        "inputs": [
+          [1, "a"],
+          [2, "b"],
+          [3, "c"],
+          [3, "yyy"],
+          [4, "e"],
+          [4, "e"],
+          [6, "e"],
+          [7, "d"],
+          [7, "f"],
+          [8, "z"]
+        ],
+        "partitionColumns": [
+          "num"
+        ],
+        "partitionCount": 2
+      },
+      "tbl2": {
+        "schema": [
+          {"name": "num", "type": "INT"},
+          {"name": "val", "type": "STRING"}
+        ],
+        "inputs": [
+          [1, "xxx"],
+          [1, "xxx"],
+          [3, "yyy"],
+          [3, "zzz"],
+          [5, "zzz"],
+          [6, "e"],
+          [7, "d"],
+          [8, "z"]
+        ],
+        "partitionColumns": [
+          "num"
+        ],
+        "partitionCount": 4
+      },
+      "tbl_empty": {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "intCol1", "type": "INT"},
+          {"name": "strCol2", "type": "STRING"}
+        ],
+        "inputs": []
+      }
+    },
+    "queries": [
+      {
+        "description": "Colocated, Dynamic broadcast SEMI-JOIN with partition column",
+        "sql": "SELECT /*+ joinOptions(join_strategy='dynamic_broadcast') */ {tbl1}.num, {tbl1}.name FROM {tbl1} /*+ tableOptions(partition_key='num', partition_size='2') */ WHERE {tbl1}.num IN (SELECT {tbl2}.num FROM {tbl2} /*+ tableOptions(partition_key='num', partition_size='4') */ WHERE {tbl2}.val IN ('xxx', 'yyy'))"
+      },
+      {
+        "description": "Colocated, Dynamic broadcast SEMI-JOIN with partition column and group by partition column",
+        "sql": "SELECT /*+ joinOptions(join_strategy='dynamic_broadcast'), aggOptions(is_partitioned_by_group_by_keys='true') */ {tbl1}.num, COUNT({tbl1}.name) FROM {tbl1} /*+ tableOptions(partition_key='num', partition_size='2') */ WHERE {tbl1}.num IN (SELECT {tbl2}.num FROM {tbl2} /*+ tableOptions(partition_key='num', partition_size='4') */ WHERE {tbl2}.val IN ('xxx', 'yyy')) GROUP BY {tbl1}.num, {tbl1}.name"
+      },
+      {
+        "description": "Colocated, Dynamic broadcast SEMI-JOIN with partition column and group by non-partitioned column",
+        "sql": "SELECT /*+ joinOptions(join_strategy='dynamic_broadcast') */ {tbl1}.name, COUNT(*) FROM {tbl1} /*+ tableOptions(partition_key='num', partition_size='2') */ WHERE {tbl1}.num IN (SELECT {tbl2}.num FROM {tbl2} /*+ tableOptions(partition_key='num', partition_size='4') */ WHERE {tbl2}.val IN ('xxx', 'yyy')) GROUP BY {tbl1}.name"
+      },
+      {
+        "description": "Dynamic broadcast SEMI-JOIN with empty right table result",
+        "sql": "SELECT /*+ joinOptions(join_strategy='dynamic_broadcast') */ {tbl1}.name, COUNT(*) FROM {tbl1} /*+ tableOptions(partition_key='num', partition_size='2') */ WHERE {tbl1}.num IN (SELECT {tbl2}.num FROM {tbl2} /*+ tableOptions(partition_key='num', partition_size='4') */ WHERE {tbl2}.val = 'non-exist') GROUP BY {tbl1}.name"
+      },
+      {
+        "description": "Colocated, Dynamic broadcast SEMI-JOIN with partially empty right table result for some servers",
+        "sql": "SELECT /*+ joinOptions(join_strategy='dynamic_broadcast') */ {tbl1}.name, COUNT(*) FROM {tbl1} /*+ tableOptions(partition_key='num', partition_size='2') */ WHERE {tbl1}.num IN (SELECT {tbl2}.num FROM {tbl2} /*+ tableOptions(partition_key='num', partition_size='4') */ WHERE {tbl2}.val = 'z') GROUP BY {tbl1}.name"
+      }
+    ]
   }
 }


### PR DESCRIPTION
Fixed in this PR
=== 
- when one side is more than another, partition semi join is suppose to fallback to normal shuffle (or throw properly) instead of returning NPE.

TODO
===
- when one side is less than another, the query still goes through but result is not shuffle properly --> due to the partition function in query (abs ObjectHash sum) is different from partition function in segments (murmur2). this will be fixed separately