### PR TITLE
Workarount to continue with log4j-2.17.0 by using slf4j18

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -257,7 +257,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
+      <artifactId>log4j-slf4j18-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/pinot-spi/pom.xml
+++ b/pinot-spi/pom.xml
@@ -110,7 +110,7 @@
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j2-impl</artifactId>
+      <artifactId>log4j-slf4j18-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>com.lmax</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -604,7 +604,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>1.7.25</version>
+        <version>2.0.9</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -604,7 +604,7 @@
       <dependency>
         <groupId>org.slf4j</groupId>
         <artifactId>slf4j-api</artifactId>
-        <version>2.0.9</version>
+        <version>1.7.25</version>
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -151,7 +151,7 @@
     <snappy-java.version>1.1.10.4</snappy-java.version>
     <zstd-jni.version>1.5.5-6</zstd-jni.version>
     <lz4-java.version>1.8.0</lz4-java.version>
-    <log4j.version>2.20.0</log4j.version>
+    <log4j.version>2.17.1</log4j.version>
     <netty.version>4.1.94.Final</netty.version>
     <reactivestreams.version>1.0.3</reactivestreams.version>
     <jts.version>1.19.0</jts.version>
@@ -618,7 +618,7 @@
       </dependency>
       <dependency>
         <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-slf4j2-impl</artifactId>
+        <artifactId>log4j-slf4j18-impl</artifactId>
         <version>${log4j.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
As per suggestioin in PR 11903, attempting to use slf4j18 so that we can avoid bumping log4j version
