### PR TITLE
UI: show partial index in reload status

### DIFF
--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/ReloadStatusOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/ReloadStatusOp.tsx
@@ -81,7 +81,6 @@ export default function ReloadStatusOp({
   const classes = useStyles();
   const reloadStatusKey = "columnToIndexesCount"
   const indexes = reloadStatusData && reloadStatusData[reloadStatusKey];
-  if(indexes) indexes["Quarter"]["h3_index"] = 10;
   const indexesKeys = indexes && Object.keys(indexes);
   const indexObjKeys = indexes && indexes[indexesKeys[0]] && Object.keys(indexes[indexesKeys[0]]) || [];
   const [activeTab, setActiveTab] = useState(0);
@@ -240,7 +239,7 @@ export default function ReloadStatusOp({
                             } else if(indexObj[o] === reloadStatusData?.["totalOnlineSegments"]) {
                               iconElement = <CheckIcon className={classes.greenColor}/>;
                             } else {
-                              const tooltipText = `Partial Index, present on ${indexObj[o]} / ${reloadStatusData?.["totalOnlineSegments"]} segments`;
+                              const tooltipText = `Index present in ${indexObj[o]} / ${reloadStatusData?.["totalOnlineSegments"]} segments`;
                               iconElement = <Tooltip placement='top' title={tooltipText}><RemoveCircleIcon className={classes.yellowColor} /></Tooltip>
                             }
                             return (

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/ReloadStatusOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/ReloadStatusOp.tsx
@@ -18,7 +18,7 @@
  */
 
 import React, { useEffect, useState } from 'react';
-import { CircularProgress, createStyles, DialogContent, DialogContentText, Link, makeStyles, Paper, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, Theme, withStyles} from '@material-ui/core';
+import { CircularProgress, createStyles, DialogContent, DialogContentText, Link, makeStyles, Paper, Tab, Table, TableBody, TableCell, TableContainer, TableHead, TableRow, Tabs, Theme, Tooltip, withStyles} from '@material-ui/core';
 import Dialog from '../../CustomDialog';
 import CloseIcon from '@material-ui/icons/Close';
 import CheckIcon from '@material-ui/icons/Check';
@@ -29,6 +29,7 @@ import CustomDialog from '../../CustomDialog';
 import PinotMethodUtils from '../../../utils/PinotMethodUtils';
 import CustomCodemirror from '../../CustomCodemirror';
 import SearchBar from '../../SearchBar';
+import RemoveCircleIcon from '@material-ui/icons/RemoveCircle';
 
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
@@ -49,6 +50,9 @@ const useStyles = makeStyles((theme: Theme) =>
     },
     jobDetailsLoading: {
       alignSelf: "center"
+    },
+    yellowColor: {
+      color: theme.palette.warning.main
     }
   })
 );
@@ -77,6 +81,7 @@ export default function ReloadStatusOp({
   const classes = useStyles();
   const reloadStatusKey = "columnToIndexesCount"
   const indexes = reloadStatusData && reloadStatusData[reloadStatusKey];
+  if(indexes) indexes["Quarter"]["h3_index"] = 10;
   const indexesKeys = indexes && Object.keys(indexes);
   const indexObjKeys = indexes && indexes[indexesKeys[0]] && Object.keys(indexes[indexesKeys[0]]) || [];
   const [activeTab, setActiveTab] = useState(0);
@@ -232,8 +237,11 @@ export default function ReloadStatusOp({
                             let iconElement = null;
                             if(indexObj[o] === 0){
                               iconElement = <CloseIcon className={classes.redColor}/>;
-                            } else {
+                            } else if(indexObj[o] === reloadStatusData?.["totalOnlineSegments"]) {
                               iconElement = <CheckIcon className={classes.greenColor}/>;
+                            } else {
+                              const tooltipText = `Partial Index, present on ${indexObj[o]} / ${reloadStatusData?.["totalOnlineSegments"]} segments`;
+                              iconElement = <Tooltip placement='top' title={tooltipText}><RemoveCircleIcon className={classes.yellowColor} /></Tooltip>
                             }
                             return (
                               <StyledTableCell align="center" key={i}>


### PR DESCRIPTION
Description 
- There was a missing case in reload status UI where partial index where not shown
- The API returns total segments and the segments that index is applied
- if the index is partial then show a yellow icon which when hovered will show a text shown in the image below.

<img width="1339" alt="image" src="https://github.com/apache/pinot/assets/41536903/f602621a-2d7a-421d-98ca-bda5070bdead">
