### PR TITLE
Updated for commons-configuration2 in PinotConfiguartion

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/utils/ConnectionUtils.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/utils/ConnectionUtils.java
@@ -24,7 +24,7 @@ import java.util.Properties;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.net.ssl.SSLContext;
-import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.tuple.Pair;
 import org.apache.pinot.common.config.TlsConfig;

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/utils/DriverUtils.java
@@ -32,7 +32,7 @@ import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import javax.net.ssl.SSLContext;
-import org.apache.commons.configuration.MapConfiguration;
+import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.http.NameValuePair;
 import org.apache.http.client.utils.URLEncodedUtils;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/ControllerConf.java
@@ -26,7 +26,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.TimeUnit;
-import org.apache.commons.configuration.Configuration;
+import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.controller.rebalancer.strategy.AutoRebalanceStrategy;
 import org.apache.pinot.common.protocols.SegmentCompletionProtocol;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/config/QueryExecutorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/config/QueryExecutorConfig.java
@@ -18,7 +18,7 @@
  */
 package org.apache.pinot.core.query.config;
 
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants.Server;
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/QueryExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/QueryExecutor.java
@@ -21,7 +21,7 @@ package org.apache.pinot.core.query.executor;
 import java.util.concurrent.ExecutorService;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.operator.blocks.InstanceResponseBlock;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -28,7 +28,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.commons.configuration.ConfigurationException;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.common.datatable.DataTable.MetadataKey;
 import org.apache.pinot.common.exception.QueryException;

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorExceptionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorExceptionsTest.java
@@ -26,7 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.io.FileHandler;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.HelixManager;
@@ -155,8 +156,8 @@ public class QueryExecutorExceptionsTest {
     resourceUrl = getClass().getClassLoader().getResource(QUERY_EXECUTOR_CONFIG_PATH);
     assertNotNull(resourceUrl);
     PropertiesConfiguration queryExecutorConfig = new PropertiesConfiguration();
-    queryExecutorConfig.setDelimiterParsingDisabled(false);
-    queryExecutorConfig.load(new File(resourceUrl.getFile()));
+    FileHandler fileHandler = new FileHandler(queryExecutorConfig);
+    fileHandler.load(new File(resourceUrl.getFile()));
     _queryExecutor = new ServerQueryExecutorV1Impl();
     _queryExecutor.init(new PinotConfiguration(queryExecutorConfig), instanceDataManager, _serverMetrics);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorExceptionsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorExceptionsTest.java
@@ -27,7 +27,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.commons.configuration2.PropertiesConfiguration;
-import org.apache.commons.configuration2.io.FileHandler;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.helix.HelixManager;
@@ -54,6 +53,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.IngestionSchemaValidator;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.utils.ReadMode;
@@ -155,9 +155,8 @@ public class QueryExecutorExceptionsTest {
     // Set up the query executor
     resourceUrl = getClass().getClassLoader().getResource(QUERY_EXECUTOR_CONFIG_PATH);
     assertNotNull(resourceUrl);
-    PropertiesConfiguration queryExecutorConfig = new PropertiesConfiguration();
-    FileHandler fileHandler = new FileHandler(queryExecutorConfig);
-    fileHandler.load(new File(resourceUrl.getFile()));
+    PropertiesConfiguration queryExecutorConfig =
+        CommonsConfigurationUtils.loadFromFile(new File(resourceUrl.getFile()));
     _queryExecutor = new ServerQueryExecutorV1Impl();
     _queryExecutor.init(new PinotConfiguration(queryExecutorConfig), instanceDataManager, _serverMetrics);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorTest.java
@@ -24,7 +24,8 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.io.FileHandler;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -154,8 +155,8 @@ public class QueryExecutorTest {
     resourceUrl = getClass().getClassLoader().getResource(QUERY_EXECUTOR_CONFIG_PATH);
     Assert.assertNotNull(resourceUrl);
     PropertiesConfiguration queryExecutorConfig = new PropertiesConfiguration();
-    queryExecutorConfig.setDelimiterParsingDisabled(false);
-    queryExecutorConfig.load(new File(resourceUrl.getFile()));
+    FileHandler fileHandler = new FileHandler(queryExecutorConfig);
+    fileHandler.load(new File(resourceUrl.getFile()));
     _queryExecutor = new ServerQueryExecutorV1Impl();
     _queryExecutor.init(new PinotConfiguration(queryExecutorConfig), instanceDataManager, _serverMetrics);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/executor/QueryExecutorTest.java
@@ -25,7 +25,6 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.commons.configuration2.PropertiesConfiguration;
-import org.apache.commons.configuration2.io.FileHandler;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -51,6 +50,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.IngestionSchemaValidator;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.FileFormat;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.utils.ReadMode;
@@ -154,9 +154,8 @@ public class QueryExecutorTest {
     // Set up the query executor
     resourceUrl = getClass().getClassLoader().getResource(QUERY_EXECUTOR_CONFIG_PATH);
     Assert.assertNotNull(resourceUrl);
-    PropertiesConfiguration queryExecutorConfig = new PropertiesConfiguration();
-    FileHandler fileHandler = new FileHandler(queryExecutorConfig);
-    fileHandler.load(new File(resourceUrl.getFile()));
+    PropertiesConfiguration queryExecutorConfig =
+        CommonsConfigurationUtils.loadFromFile(new File(resourceUrl.getFile()));
     _queryExecutor = new ServerQueryExecutorV1Impl();
     _queryExecutor.init(new PinotConfiguration(queryExecutorConfig), instanceDataManager, _serverMetrics);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/PrioritySchedulerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/scheduler/PrioritySchedulerTest.java
@@ -36,7 +36,7 @@ import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.LongAccumulator;
 import javax.annotation.Nullable;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.datatable.DataTable.MetadataKey;
 import org.apache.pinot.common.datatable.DataTableFactory;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -30,7 +30,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.io.FileHandler;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -315,8 +316,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     URL resourceUrl = getClass().getClassLoader().getResource(QUERY_EXECUTOR_CONFIG_PATH);
     Assert.assertNotNull(resourceUrl);
     PropertiesConfiguration queryExecutorConfig = new PropertiesConfiguration();
-    queryExecutorConfig.setDelimiterParsingDisabled(false);
-    queryExecutorConfig.load(new File(resourceUrl.getFile()));
+    FileHandler fileHandler = new FileHandler(queryExecutorConfig);
+    fileHandler.load(new File(resourceUrl.getFile()));
     _queryExecutor = new ServerQueryExecutorV1Impl();
     _queryExecutor.init(new PinotConfiguration(queryExecutorConfig), instanceDataManager, _serverMetrics);
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/ExplainPlanQueriesTest.java
@@ -31,7 +31,6 @@ import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.commons.configuration2.PropertiesConfiguration;
-import org.apache.commons.configuration2.io.FileHandler;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -68,6 +67,7 @@ import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -315,9 +315,8 @@ public class ExplainPlanQueriesTest extends BaseQueriesTest {
     // Set up the query executor
     URL resourceUrl = getClass().getClassLoader().getResource(QUERY_EXECUTOR_CONFIG_PATH);
     Assert.assertNotNull(resourceUrl);
-    PropertiesConfiguration queryExecutorConfig = new PropertiesConfiguration();
-    FileHandler fileHandler = new FileHandler(queryExecutorConfig);
-    fileHandler.load(new File(resourceUrl.getFile()));
+    PropertiesConfiguration queryExecutorConfig =
+        CommonsConfigurationUtils.loadFromFile(new File(resourceUrl.getFile()));
     _queryExecutor = new ServerQueryExecutorV1Impl();
     _queryExecutor.init(new PinotConfiguration(queryExecutorConfig), instanceDataManager, _serverMetrics);
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SegmentWithNullValueVectorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SegmentWithNullValueVectorTest.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.apache.commons.configuration2.io.FileHandler;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -62,6 +61,7 @@ import org.apache.pinot.spi.data.IngestionSchemaValidator;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.metrics.PinotMetricUtils;
 import org.apache.pinot.spi.utils.ReadMode;
@@ -170,9 +170,8 @@ public class SegmentWithNullValueVectorTest {
     // Set up the query executor
     URL resourceUrl = getClass().getClassLoader().getResource(QUERY_EXECUTOR_CONFIG_PATH);
     Assert.assertNotNull(resourceUrl);
-    PropertiesConfiguration queryExecutorConfig = new PropertiesConfiguration();
-    FileHandler fileHandler = new FileHandler(queryExecutorConfig);
-    fileHandler.load(new File(resourceUrl.getFile()));
+    PropertiesConfiguration queryExecutorConfig =
+        CommonsConfigurationUtils.loadFromFile(new File(resourceUrl.getFile()));
     _queryExecutor = new ServerQueryExecutorV1Impl();
     _queryExecutor.init(new PinotConfiguration(queryExecutorConfig), _instanceDataManager, _serverMetrics);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/SegmentWithNullValueVectorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/SegmentWithNullValueVectorTest.java
@@ -30,8 +30,9 @@ import java.util.Map;
 import java.util.Random;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.io.FileHandler;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixManager;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
@@ -170,8 +171,8 @@ public class SegmentWithNullValueVectorTest {
     URL resourceUrl = getClass().getClassLoader().getResource(QUERY_EXECUTOR_CONFIG_PATH);
     Assert.assertNotNull(resourceUrl);
     PropertiesConfiguration queryExecutorConfig = new PropertiesConfiguration();
-    queryExecutorConfig.setDelimiterParsingDisabled(false);
-    queryExecutorConfig.load(new File(resourceUrl.getFile()));
+    FileHandler fileHandler = new FileHandler(queryExecutorConfig);
+    fileHandler.load(new File(resourceUrl.getFile()));
     _queryExecutor = new ServerQueryExecutorV1Impl();
     _queryExecutor.init(new PinotConfiguration(queryExecutorConfig), _instanceDataManager, _serverMetrics);
   }

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/MinionConfTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/MinionConfTest.java
@@ -52,11 +52,11 @@ public class MinionConfTest {
     }
 
     // Check configs with new names that have the pinot.minion prefix.
-    PropertiesConfiguration config1 = new PropertiesConfiguration();
+    config = new PropertiesConfiguration();
     CommonsConfigurationUtils.loadPropertiesConfiguration(config,
         PropertiesConfiguration.class.getClassLoader().getResource("pinot-configuration-new-minion.properties")
             .getFile());
-    rawCfg = new PinotConfiguration(config1);
+    rawCfg = new PinotConfiguration(config);
     final MinionConf newConfig = new MinionConf(rawCfg.toMap());
     for (String cfgKey : cfgKeys) {
       Assert.assertTrue(newConfig.subset(cfgKey).isEmpty(), cfgKey);

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/MinionConfTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/MinionConfTest.java
@@ -39,8 +39,7 @@ public class MinionConfTest {
         CommonConstants.Minion.DEPRECATED_PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER,
         CommonConstants.Minion.DEPRECATED_PREFIX_OF_CONFIG_OF_PINOT_CRYPTER
     };
-    PropertiesConfiguration config = new PropertiesConfiguration();
-    CommonsConfigurationUtils.loadPropertiesConfiguration(config,
+    PropertiesConfiguration config = CommonsConfigurationUtils.loadFromPath(
         PropertiesConfiguration.class.getClassLoader().getResource("pinot-configuration-old-minion.properties")
         .getFile());
     PinotConfiguration rawCfg = new PinotConfiguration(config);
@@ -52,8 +51,7 @@ public class MinionConfTest {
     }
 
     // Check configs with new names that have the pinot.minion prefix.
-    config = new PropertiesConfiguration();
-    CommonsConfigurationUtils.loadPropertiesConfiguration(config,
+    config = CommonsConfigurationUtils.loadFromPath(
         PropertiesConfiguration.class.getClassLoader().getResource("pinot-configuration-new-minion.properties")
             .getFile());
     rawCfg = new PinotConfiguration(config);

--- a/pinot-minion/src/test/java/org/apache/pinot/minion/MinionConfTest.java
+++ b/pinot-minion/src/test/java/org/apache/pinot/minion/MinionConfTest.java
@@ -18,8 +18,9 @@
  */
 package org.apache.pinot.minion;
 
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.testng.Assert;
@@ -38,9 +39,11 @@ public class MinionConfTest {
         CommonConstants.Minion.DEPRECATED_PREFIX_OF_CONFIG_OF_SEGMENT_UPLOADER,
         CommonConstants.Minion.DEPRECATED_PREFIX_OF_CONFIG_OF_PINOT_CRYPTER
     };
-    PinotConfiguration rawCfg = new PinotConfiguration(new PropertiesConfiguration(
+    PropertiesConfiguration config = new PropertiesConfiguration();
+    CommonsConfigurationUtils.loadPropertiesConfiguration(config,
         PropertiesConfiguration.class.getClassLoader().getResource("pinot-configuration-old-minion.properties")
-            .getFile()));
+        .getFile());
+    PinotConfiguration rawCfg = new PinotConfiguration(config);
     final MinionConf oldConfig = new MinionConf(rawCfg.toMap());
     Assert.assertEquals(oldConfig.getMetricsPrefix(), "pinot.minion.old.custom.metrics.");
     for (String cfgKey : cfgKeys) {
@@ -49,9 +52,11 @@ public class MinionConfTest {
     }
 
     // Check configs with new names that have the pinot.minion prefix.
-    rawCfg = new PinotConfiguration(new PropertiesConfiguration(
+    PropertiesConfiguration config1 = new PropertiesConfiguration();
+    CommonsConfigurationUtils.loadPropertiesConfiguration(config,
         PropertiesConfiguration.class.getClassLoader().getResource("pinot-configuration-new-minion.properties")
-            .getFile()));
+            .getFile());
+    rawCfg = new PinotConfiguration(config1);
     final MinionConf newConfig = new MinionConf(rawCfg.toMap());
     for (String cfgKey : cfgKeys) {
       Assert.assertTrue(newConfig.subset(cfgKey).isEmpty(), cfgKey);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -48,26 +48,48 @@ public class CommonsConfigurationUtils {
   private CommonsConfigurationUtils() {
   }
 
+  public static void setListDelimiterHandler(PropertiesConfiguration configuration, Character delimiter) {
+    configuration.setListDelimiterHandler(new DefaultListDelimiterHandler(delimiter));
+  }
+
   public static void setDefaultListDelimiterHandler(PropertiesConfiguration configuration) {
-    configuration.setListDelimiterHandler(new DefaultListDelimiterHandler(DEFAULT_LIST_DELIMITER));
+    setListDelimiterHandler(configuration, DEFAULT_LIST_DELIMITER);
   }
 
-  public static void loadPropertiesConfiguration(PropertiesConfiguration configuration, String path)
+  public static PropertiesConfiguration loadFromPath(String path) throws ConfigurationException {
+    return loadFromPath(path, false, false);
+  }
+
+  public static PropertiesConfiguration loadFromPath(String path, boolean setIOFactory, boolean setDefaultDelimiter)
       throws ConfigurationException {
-    FileHandler fileHandler = new FileHandler(configuration);
+    PropertiesConfiguration config = createPropertiesConfiguration(setIOFactory, setDefaultDelimiter);
+    FileHandler fileHandler = new FileHandler(config);
     fileHandler.load(path);
+    return config;
   }
 
-  public static void loadPropertiesConfiguration(PropertiesConfiguration configuration, InputStream stream)
-      throws ConfigurationException {
-    FileHandler fileHandler = new FileHandler(configuration);
+  public static PropertiesConfiguration loadFromInputStream(InputStream stream) throws ConfigurationException {
+    return loadFromInputStream(stream, false, false);
+  }
+
+  public static PropertiesConfiguration loadFromInputStream(InputStream stream, boolean setIOFactory,
+      boolean setDefaultDelimiter) throws ConfigurationException {
+    PropertiesConfiguration config = createPropertiesConfiguration(setIOFactory, setDefaultDelimiter);
+    FileHandler fileHandler = new FileHandler(config);
     fileHandler.load(stream);
+    return config;
   }
 
-  public static void loadPropertiesConfiguration(PropertiesConfiguration configuration, File file)
-      throws ConfigurationException {
-    FileHandler fileHandler = new FileHandler(configuration);
+  public static PropertiesConfiguration loadFromFile(File file) throws ConfigurationException {
+    return loadFromFile(file, false, false);
+  }
+
+  public static PropertiesConfiguration loadFromFile(File file, boolean setIOFactory,
+      boolean setDefaultDelimiter) throws ConfigurationException {
+    PropertiesConfiguration config = createPropertiesConfiguration(setIOFactory, setDefaultDelimiter);
+    FileHandler fileHandler = new FileHandler(config);
     fileHandler.load(file);
+    return config;
   }
 
   /**
@@ -293,5 +315,21 @@ public class CommonsConfigurationUtils {
       value = value.substring(0, value.length() - 1);
     }
     return value.replace("\0\0", ",");
+  }
+
+  private static PropertiesConfiguration createPropertiesConfiguration(boolean setIOFactory,
+      boolean setDefaultDelimiter) {
+    PropertiesConfiguration config = new PropertiesConfiguration();
+
+    // setting IO Reader Factory
+    if (setIOFactory) {
+      config.setIOFactory(new ConfigFilePropertyReaderFactory());
+    }
+
+    // setting DEFAULT_LIST_DELIMITER
+    if (setDefaultDelimiter) {
+      CommonsConfigurationUtils.setDefaultListDelimiterHandler(config);
+    }
+    return config;
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/ConfigFilePropertyReader.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/ConfigFilePropertyReader.java
@@ -19,13 +19,13 @@
 package org.apache.pinot.spi.env;
 
 import java.io.Reader;
-import org.apache.commons.configuration.PropertiesConfiguration.PropertiesReader;
+import org.apache.commons.configuration2.PropertiesConfiguration.PropertiesReader;
 
 
 public class ConfigFilePropertyReader extends PropertiesReader {
 
-  public ConfigFilePropertyReader(Reader reader, char listDelimiter) {
-    super(reader, listDelimiter);
+  public ConfigFilePropertyReader(Reader reader) {
+    super(reader);
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/ConfigFilePropertyReaderFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/ConfigFilePropertyReaderFactory.java
@@ -19,13 +19,13 @@
 package org.apache.pinot.spi.env;
 
 import java.io.Reader;
-import org.apache.commons.configuration.PropertiesConfiguration.DefaultIOFactory;
-import org.apache.commons.configuration.PropertiesConfiguration.PropertiesReader;
+import org.apache.commons.configuration2.PropertiesConfiguration.DefaultIOFactory;
+import org.apache.commons.configuration2.PropertiesConfiguration.PropertiesReader;
 
 
 public class ConfigFilePropertyReaderFactory extends DefaultIOFactory {
   @Override
-  public PropertiesReader createPropertiesReader(Reader in, char delimiter) {
-    return new ConfigFilePropertyReader(in, delimiter);
+  public PropertiesReader createPropertiesReader(Reader in) {
+    return new ConfigFilePropertyReader(in);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
@@ -30,6 +30,7 @@ import org.apache.commons.configuration2.CompositeConfiguration;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.MapConfiguration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.convert.DefaultListDelimiterHandler;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.utils.Obfuscator;
@@ -162,8 +163,11 @@ public class PinotConfiguration {
 
         .map(PinotConfiguration::loadProperties);
 
-    return Stream.concat(Stream.of(relaxedBaseProperties, relaxedEnvVariables).map(MapConfiguration::new),
-        propertiesFromConfigPaths).collect(Collectors.toList());
+    return Stream.concat(Stream.of(relaxedBaseProperties, relaxedEnvVariables).map(e -> {
+      MapConfiguration mapConfiguration = new MapConfiguration(e);
+      mapConfiguration.setListDelimiterHandler(new DefaultListDelimiterHandler(','));
+      return mapConfiguration;
+    }), propertiesFromConfigPaths).collect(Collectors.toList());
   }
 
   private static String getProperty(String name, Configuration configuration) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
@@ -184,17 +184,14 @@ public class PinotConfiguration {
 
   private static Configuration loadProperties(String configPath) {
     try {
-      PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
-
-      propertiesConfiguration.setIOFactory(new ConfigFilePropertyReaderFactory());
-      CommonsConfigurationUtils.setDefaultListDelimiterHandler(propertiesConfiguration);
+      PropertiesConfiguration propertiesConfiguration;
       if (configPath.startsWith("classpath:")) {
-        CommonsConfigurationUtils.loadPropertiesConfiguration(propertiesConfiguration,
-            PinotConfiguration.class.getResourceAsStream(configPath.substring("classpath:".length())));
+        propertiesConfiguration = CommonsConfigurationUtils.loadFromInputStream(
+            PinotConfiguration.class.getResourceAsStream(configPath.substring("classpath:".length())),
+            true, true);
       } else {
-        CommonsConfigurationUtils.loadPropertiesConfiguration(propertiesConfiguration, configPath);
+        propertiesConfiguration = CommonsConfigurationUtils.loadFromPath(configPath, true, true);
       }
-
       return propertiesConfiguration;
     } catch (ConfigurationException e) {
       throw new IllegalArgumentException("Could not read properties from " + configPath, e);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
@@ -26,11 +26,11 @@ import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
-import org.apache.commons.configuration.CompositeConfiguration;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.MapConfiguration;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.CompositeConfiguration;
+import org.apache.commons.configuration2.Configuration;
+import org.apache.commons.configuration2.MapConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.apache.pinot.spi.utils.Obfuscator;
 
@@ -183,11 +183,12 @@ public class PinotConfiguration {
       PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
 
       propertiesConfiguration.setIOFactory(new ConfigFilePropertyReaderFactory());
+      CommonsConfigurationUtils.setDefaultListDelimiterHandler(propertiesConfiguration);
       if (configPath.startsWith("classpath:")) {
-        propertiesConfiguration
-            .load(PinotConfiguration.class.getResourceAsStream(configPath.substring("classpath:".length())));
+        CommonsConfigurationUtils.loadPropertiesConfiguration(propertiesConfiguration,
+            PinotConfiguration.class.getResourceAsStream(configPath.substring("classpath:".length())));
       } else {
-        propertiesConfiguration.load(configPath);
+        CommonsConfigurationUtils.loadPropertiesConfiguration(propertiesConfiguration, configPath);
       }
 
       return propertiesConfiguration;

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java
@@ -28,8 +28,8 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.pinot.spi.ingestion.batch.spec.PinotFSSpec;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -179,8 +179,12 @@ public class PinotConfigurationTest {
   @Test
   public void assertPropertiesFromBaseConfiguration()
       throws ConfigurationException {
-    PinotConfiguration config = new PinotConfiguration(new PropertiesConfiguration(
-        PropertiesConfiguration.class.getClassLoader().getResource("pinot-configuration-1.properties").getFile()));
+    PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
+    propertiesConfiguration.setIOFactory(new ConfigFilePropertyReaderFactory());
+    CommonsConfigurationUtils.setDefaultListDelimiterHandler(propertiesConfiguration);
+    CommonsConfigurationUtils.loadPropertiesConfiguration(propertiesConfiguration,
+        PropertiesConfiguration.class.getClassLoader().getResource("pinot-configuration-1.properties").getFile());
+    PinotConfiguration config = new PinotConfiguration(propertiesConfiguration);
 
     Assert.assertEquals(config.getProperty("pinot.server.storage.factory.class.s3"),
         "org.apache.pinot.plugin.filesystem.S3PinotFS");

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/env/PinotConfigurationTest.java
@@ -179,11 +179,10 @@ public class PinotConfigurationTest {
   @Test
   public void assertPropertiesFromBaseConfiguration()
       throws ConfigurationException {
-    PropertiesConfiguration propertiesConfiguration = new PropertiesConfiguration();
-    propertiesConfiguration.setIOFactory(new ConfigFilePropertyReaderFactory());
-    CommonsConfigurationUtils.setDefaultListDelimiterHandler(propertiesConfiguration);
-    CommonsConfigurationUtils.loadPropertiesConfiguration(propertiesConfiguration,
-        PropertiesConfiguration.class.getClassLoader().getResource("pinot-configuration-1.properties").getFile());
+    PropertiesConfiguration propertiesConfiguration = CommonsConfigurationUtils.loadFromPath(
+        PropertiesConfiguration.class.getClassLoader().getResource("pinot-configuration-1.properties").getFile(),
+        true, true);
+
     PinotConfiguration config = new PinotConfiguration(propertiesConfiguration);
 
     Assert.assertEquals(config.getProperty("pinot.server.storage.factory.class.s3"),

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/filesystem/PinotFSBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/filesystem/PinotFSBenchmarkDriver.java
@@ -24,9 +24,9 @@ import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.net.URI;
 import java.net.URISyntaxException;
-import org.apache.commons.configuration.Configuration;
-import org.apache.commons.configuration.ConfigurationException;
-import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
+import org.apache.commons.configuration2.io.FileHandler;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
@@ -53,7 +53,9 @@ public class PinotFSBenchmarkDriver {
   public PinotFSBenchmarkDriver(String mode, String configFilePath, String baseDirectoryUri, String localTempDir,
       Integer numSegmentsForListFilesTest, Integer dataSizeInMBsForCopyTest, Integer numOps)
       throws ConfigurationException {
-    Configuration configuration = new PropertiesConfiguration(new File(configFilePath));
+    PropertiesConfiguration configuration = new PropertiesConfiguration();
+    FileHandler filehandler = new FileHandler(configuration);
+    filehandler.load(new File(configFilePath));
     PinotFSFactory.init(new PinotConfiguration(configuration));
     _mode = mode;
     _baseDirectoryUri = URI.create(baseDirectoryUri);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/filesystem/PinotFSBenchmarkDriver.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/filesystem/PinotFSBenchmarkDriver.java
@@ -26,8 +26,8 @@ import java.net.URI;
 import java.net.URISyntaxException;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.ex.ConfigurationException;
-import org.apache.commons.configuration2.io.FileHandler;
 import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.env.CommonsConfigurationUtils;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
@@ -53,9 +53,8 @@ public class PinotFSBenchmarkDriver {
   public PinotFSBenchmarkDriver(String mode, String configFilePath, String baseDirectoryUri, String localTempDir,
       Integer numSegmentsForListFilesTest, Integer dataSizeInMBsForCopyTest, Integer numOps)
       throws ConfigurationException {
-    PropertiesConfiguration configuration = new PropertiesConfiguration();
-    FileHandler filehandler = new FileHandler(configuration);
-    filehandler.load(new File(configFilePath));
+    PropertiesConfiguration configuration =
+        CommonsConfigurationUtils.loadFromFile(new File(configFilePath));
     PinotFSFactory.init(new PinotConfiguration(configuration));
     _mode = mode;
     _baseDirectoryUri = URI.create(baseDirectoryUri);


### PR DESCRIPTION
As per the [issue](https://github.com/apache/pinot/issues/11085) and in continuation of the previous work https://github.com/apache/pinot/pull/11792 & https://github.com/apache/pinot/pull/11868,  This PR upgrade the `PinotConfiguartion` to `commons-configuartion2`.

cc: @xiangfu0 / @Jackie-Jiang / @walterddr 