### PR TITLE
Do not allow partial-upsert tables without default-partial-upsert-strategy

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -849,6 +849,10 @@ public final class TableConfigUtils {
 
     UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
     assert upsertConfig != null;
+
+    Preconditions.checkState(upsertConfig.getDefaultPartialUpsertStrategy() != null,
+        "Partial-upsert table requires default-strategy");
+
     Map<String, UpsertConfig.Strategy> partialUpsertStrategies = upsertConfig.getPartialUpsertStrategies();
 
     List<String> primaryKeyColumns = schema.getPrimaryKeyColumns();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1710,9 +1710,21 @@ public class TableConfigUtilsTest {
     partialUpsertStratgies.put("myCol2", UpsertConfig.Strategy.IGNORE);
     UpsertConfig partialUpsertConfig = new UpsertConfig(UpsertConfig.Mode.PARTIAL);
     partialUpsertConfig.setPartialUpsertStrategies(partialUpsertStratgies);
-    partialUpsertConfig.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.OVERWRITE);
     partialUpsertConfig.setComparisonColumn("myCol2");
     TableConfig tableConfig =
+        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(partialUpsertConfig)
+            .setNullHandlingEnabled(true)
+            .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+            .setStreamConfigs(streamConfigs).build();
+    try {
+      TableConfigUtils.validatePartialUpsertStrategies(tableConfig, schema);
+      Assert.fail();
+    } catch (IllegalStateException e) {
+      Assert.assertEquals(e.getMessage(), "Partial-upsert table requires default-strategy");
+    }
+
+    partialUpsertConfig.setDefaultPartialUpsertStrategy(UpsertConfig.Strategy.OVERWRITE);
+    tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setUpsertConfig(partialUpsertConfig)
             .setNullHandlingEnabled(true)
             .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))


### PR DESCRIPTION
We should not allow partial-upsert tables to be created without a default partial-upsert-strategy. Adding a check during table-creation to take care of this scenario.

Without default-partial-upsert strategy, we get the following NPE after the table is created:

```
java.lang.NullPointerException: null
	at org.apache.pinot.segment.local.upsert.merger.PartialUpsertMergerFactory.getMerger(PartialUpsertMergerFactory.java:37)
	at org.apache.pinot.segment.local.upsert.PartialUpsertHandler.<init>(PartialUpsertHandler.java:43)
	at org.apache.pinot.segment.local.upsert.BaseTableUpsertMetadataManager.init(BaseTableUpsertMetadataManager.java:70)
	at org.apache.pinot.segment.local.upsert.TableUpsertMetadataManagerFactory.create(TableUpsertMetadataManagerFactory.java:62)
	at org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager.doInit(RealtimeTableDataManager.java:195)
	at org.apache.pinot.core.data.manager.BaseTableDataManager.init(BaseTableDataManager.java:165)
	at org.apache.pinot.core.data.manager.offline.TableDataManagerProvider.getTableDataManager(TableDataManagerProvider.java:72)
	at org.apache.pinot.server.starter.helix.HelixInstanceDataManager.createTableDataManager(HelixInstanceDataManager.java:260)
	at org.apache.pinot.server.starter.helix.HelixInstanceDataManager.lambda$addRealtimeSegment$2(HelixInstanceDataManager.java:220)
	at java.base/java.util.concurrent.ConcurrentHashMap.computeIfAbsent(ConcurrentHashMap.java:1705)
	at org.apache.pinot.server.starter.helix.HelixInstanceDataManager.addRealtimeSegment(HelixInstanceDataManager.java:220)
	at org.apache.pinot.server.starter.helix.SegmentOnlineOfflineStateModelFactory$SegmentOnlineOfflineStateModel.onBecomeOnlineFromOffline(SegmentOnlineOfflineStateModelFactory.java:161)
	at org.apache.pinot.server.starter.helix.SegmentOnlineOfflineStateModelFactory$SegmentOnlineOfflineStateModel.onBecomeConsumingFromOffline(SegmentOnlineOfflineStateModelFactory.java:83)
```

Table config was:
```
"upsertConfig": {
      "mode": "PARTIAL",
      "hashFunction": "NONE",
      "partialUpsertStrategies": {},
      "enableSnapshot": false
    },
```