### PR TITLE
groupBy Accuracy Reporting Improvements

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/querylog/QueryLogger.java
@@ -112,7 +112,7 @@ public class QueryLogger {
 
   private boolean shouldForceLog(QueryLogParams params) {
     return params._response.isNumGroupsLimitReached() || params._response.getExceptionsSize() > 0
-        || params._timeUsedMs > TimeUnit.SECONDS.toMillis(1);
+        || params._timeUsedMs > TimeUnit.SECONDS.toMillis(1) || !params._response.isAccurateGroupBy();
   }
 
   public static class QueryLogParams {
@@ -259,6 +259,12 @@ public class QueryLogger {
         } else {
           builder.append(CommonConstants.UNKNOWN);
         }
+      }
+    },
+    IS_ACCURATE_GROUPBY("isAccurateGroupBy") {
+      @Override
+      void doFormat(StringBuilder builder, QueryLogger logger, QueryLogParams params) {
+        builder.append(params._response.isAccurateGroupBy());
       }
     };
 

--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ExecutionStats.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/ExecutionStats.java
@@ -47,6 +47,7 @@ public class ExecutionStats {
   private static final String BROKER_REDUCE_TIME_MS = "brokerReduceTimeMs";
   private static final String TIME_USED_MS = "timeUsedMs";
   private static final String PARTIAL_RESULT = "partialResult";
+  private static final String IS_ACCURATE_GROUPBY = "isAccurateGroupBy";
 
   private final JsonNode _brokerResponse;
 
@@ -111,6 +112,10 @@ public class ExecutionStats {
     return _brokerResponse.has(NUM_GROUPS_LIMIT_REACHED) && _brokerResponse.get(NUM_GROUPS_LIMIT_REACHED).asBoolean();
   }
 
+  public boolean isAccurateGroupBy() {
+    return _brokerResponse.has(IS_ACCURATE_GROUPBY) && _brokerResponse.get(IS_ACCURATE_GROUPBY).asBoolean();
+  }
+
   public boolean isPartialResult() {
     return _brokerResponse.has(PARTIAL_RESULT) && _brokerResponse.get(PARTIAL_RESULT).asBoolean();
   }
@@ -141,6 +146,7 @@ public class ExecutionStats {
     map.put(BROKER_REDUCE_TIME_MS, getBrokerReduceTimeMs() + "ms");
     map.put(TIME_USED_MS, getTimeUsedMs() + "ms");
     map.put(PARTIAL_RESULT, isPartialResult());
+    map.put(IS_ACCURATE_GROUPBY, isAccurateGroupBy());
     return map.toString();
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
@@ -134,11 +134,12 @@ public interface DataTable {
     OPERATOR_EXECUTION_TIME_MS(30, "operatorExecutionTimeMs", MetadataValueType.LONG),
     OPERATOR_ID(31, "operatorId", MetadataValueType.STRING),
     OPERATOR_EXEC_START_TIME_MS(32, "operatorExecStartTimeMs", MetadataValueType.LONG),
-    OPERATOR_EXEC_END_TIME_MS(33, "operatorExecEndTimeMs", MetadataValueType.LONG);
+    OPERATOR_EXEC_END_TIME_MS(33, "operatorExecEndTimeMs", MetadataValueType.LONG),
+    IS_ACCURATE_GROUP_BY(34, "isAccurateGroupBy", MetadataValueType.STRING);
 
     // We keep this constant to track the max id added so far for backward compatibility.
     // Increase it when adding new keys, but NEVER DECREASE IT!!!
-    private static final int MAX_ID = 33;
+    private static final int MAX_ID = 34;
 
     private static final MetadataKey[] ID_TO_ENUM_KEY_MAP = new MetadataKey[MAX_ID + 1];
     private static final Map<String, MetadataKey> NAME_TO_ENUM_KEY_MAP = new HashMap<>();

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/BrokerMeter.java
@@ -99,7 +99,10 @@ public enum BrokerMeter implements AbstractMetrics.Meter {
   NETTY_CONNECTION_BYTES_RECEIVED("nettyConnection", true),
 
   PROACTIVE_CLUSTER_CHANGE_CHECK("proactiveClusterChangeCheck", true),
-  DIRECT_MEMORY_OOM("directMemoryOOMCount", true);
+  DIRECT_MEMORY_OOM("directMemoryOOMCount", true),
+
+  // This metric track the number of broker responses with potentially inaccurate groupby results
+  BROKER_RESPONSES_WITH_INACCURATE_GROUPBY("badResponses", false);
 
   private final String _brokerMeterName;
   private final String _unit;

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -134,6 +134,11 @@ public interface BrokerResponse {
   boolean isNumGroupsLimitReached();
 
   /**
+   * Returns whether the groupBy results are perfectly accurate
+   */
+  boolean isAccurateGroupBy();
+
+  /**
    * Get number of exceptions recorded in the response.
    */
   int getExceptionsSize();

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -47,7 +47,8 @@ import org.apache.pinot.spi.utils.JsonUtils;
     "numEntriesScannedPostFilter", "numGroupsLimitReached", "totalDocs", "timeUsedMs", "offlineThreadCpuTimeNs",
     "realtimeThreadCpuTimeNs", "offlineSystemActivitiesCpuTimeNs", "realtimeSystemActivitiesCpuTimeNs",
     "offlineResponseSerializationCpuTimeNs", "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs",
-    "realtimeTotalCpuTimeNs", "brokerReduceTimeMs", "segmentStatistics", "traceInfo", "partialResult"})
+    "realtimeTotalCpuTimeNs", "brokerReduceTimeMs", "segmentStatistics", "traceInfo", "partialResult",
+    "isAccurateGroupBy"})
 public class BrokerResponseNative implements BrokerResponse {
   public static final BrokerResponseNative EMPTY_RESULT = BrokerResponseNative.empty();
   public static final BrokerResponseNative NO_TABLE_RESULT =
@@ -98,6 +99,7 @@ public class BrokerResponseNative implements BrokerResponse {
   private Map<String, String> _traceInfo = new HashMap<>();
   private List<QueryProcessingException> _processingExceptions = new ArrayList<>();
   private List<String> _segmentStatistics = new ArrayList<>();
+  private boolean _isAccurateGroupBy = true;
 
   public BrokerResponseNative() {
   }
@@ -492,6 +494,17 @@ public class BrokerResponseNative implements BrokerResponse {
   @JsonProperty("numGroupsLimitReached")
   public void setNumGroupsLimitReached(boolean numGroupsLimitReached) {
     _numGroupsLimitReached = numGroupsLimitReached;
+  }
+
+  @JsonProperty("isAccurateGroupBy")
+  @Override
+  public boolean isAccurateGroupBy() {
+    return _isAccurateGroupBy;
+  }
+
+  @JsonProperty("isAccurateGroupBy")
+  public void setIsAccurateGroupBy(boolean isAccurateGroupBy) {
+    _isAccurateGroupBy = isAccurateGroupBy;
   }
 
   @JsonProperty("partialResult")

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -40,10 +40,11 @@ import org.apache.pinot.spi.utils.JsonUtils;
     "resultTable", "requestId", "stageStats", "exceptions", "numServersQueried", "numServersResponded",
     "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched", "numConsumingSegmentsQueried",
     "numConsumingSegmentsProcessed", "numConsumingSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter",
-    "numEntriesScannedPostFilter", "numGroupsLimitReached", "totalDocs", "timeUsedMs", "offlineThreadCpuTimeNs",
-    "realtimeThreadCpuTimeNs", "offlineSystemActivitiesCpuTimeNs", "realtimeSystemActivitiesCpuTimeNs",
-    "offlineResponseSerializationCpuTimeNs", "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs",
-    "realtimeTotalCpuTimeNs", "segmentStatistics", "traceInfo"
+    "numEntriesScannedPostFilter", "numGroupsLimitReached", "isAccurateGroupBy", "totalDocs", "timeUsedMs",
+    "offlineThreadCpuTimeNs", "realtimeThreadCpuTimeNs", "offlineSystemActivitiesCpuTimeNs",
+    "realtimeSystemActivitiesCpuTimeNs", "offlineResponseSerializationCpuTimeNs",
+    "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs", "realtimeTotalCpuTimeNs", "segmentStatistics",
+    "traceInfo"
 })
 public class BrokerResponseNativeV2 extends BrokerResponseNative {
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseStats.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseStats.java
@@ -33,14 +33,16 @@ import org.apache.pinot.spi.utils.JsonUtils;
 //  same metadataKey
 // TODO: Replace member fields with a simple map of <MetadataKey, Object>
 // TODO: Add a subStat field, stage level subStats will contain each operator stats
-@JsonPropertyOrder({"brokerId", "requestId", "exceptions", "numBlocks", "numRows", "stageExecutionTimeMs",
-    "stageExecutionUnit", "stageExecWallTimeMs", "stageExecEndTimeMs", "numServersQueried", "numServersResponded",
-    "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched", "numConsumingSegmentsQueried",
-    "numConsumingSegmentsProcessed", "numConsumingSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter",
-    "numEntriesScannedPostFilter", "numGroupsLimitReached", "totalDocs", "timeUsedMs", "offlineThreadCpuTimeNs",
+@JsonPropertyOrder({
+    "brokerId", "requestId", "exceptions", "numBlocks", "numRows", "stageExecutionTimeMs", "stageExecutionUnit",
+    "stageExecWallTimeMs", "stageExecEndTimeMs", "numServersQueried", "numServersResponded", "numSegmentsQueried",
+    "numSegmentsProcessed", "numSegmentsMatched", "numConsumingSegmentsQueried", "numConsumingSegmentsProcessed",
+    "numConsumingSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter",
+    "numGroupsLimitReached", "isAccurateGroupBy", "totalDocs", "timeUsedMs", "offlineThreadCpuTimeNs",
     "realtimeThreadCpuTimeNs", "offlineSystemActivitiesCpuTimeNs", "realtimeSystemActivitiesCpuTimeNs",
     "offlineResponseSerializationCpuTimeNs", "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs",
-    "realtimeTotalCpuTimeNs", "brokerReduceTimeMs", "traceInfo", "operatorStats", "tableNames"})
+    "realtimeTotalCpuTimeNs", "brokerReduceTimeMs", "traceInfo", "operatorStats", "tableNames"
+})
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class BrokerResponseStats extends BrokerResponseNative {
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/SqlResultComparator.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/SqlResultComparator.java
@@ -72,6 +72,7 @@ public class SqlResultComparator {
   private static final String FIELD_NUM_ENTRIES_SCANNED_IN_FILTER = "numEntriesScannedInFilter";
   private static final String FIELD_NUM_ENTRIES_SCANNED_POST_FILTER = "numEntriesScannedPostFilter";
   private static final String FIELD_NUM_GROUPS_LIMIT_REACHED = "numGroupsLimitReached";
+  private static final String FIELD_IS_ACCURATE_GROUP_BY = "isAccurateGroupBy";
 
   private static final String FIELD_TYPE_INT = "INT";
   private static final String FIELD_TYPE_LONG = "LONG";
@@ -310,6 +311,17 @@ public class SqlResultComparator {
     if (actualNumGroupsLimitReached != expectedNumGroupsLimitReached) {
       LOGGER.error("The numGroupsLimitReached don't match! Actual: {}, Expected: {}", actualNumGroupsLimitReached,
           expectedNumGroupsLimitReached);
+      return false;
+    }
+    return true;
+  }
+
+  private static boolean isAccurateGroupByEqual(JsonNode actual, JsonNode expected) {
+    boolean actualIsAccurateGroupBy = actual.get(FIELD_IS_ACCURATE_GROUP_BY).asBoolean();
+    boolean expectedIsAccurateGroupBy = expected.get(FIELD_IS_ACCURATE_GROUP_BY).asBoolean();
+    if (actualIsAccurateGroupBy != expectedIsAccurateGroupBy) {
+      LOGGER.error("The isAccurateGroupBy field doesn't match! Actual: {}, Expected: {}", actualIsAccurateGroupBy,
+          expectedIsAccurateGroupBy);
       return false;
     }
     return true;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
@@ -53,6 +53,7 @@ public class GroupByResultsBlock extends BaseResultsBlock {
   private final QueryContext _queryContext;
 
   private boolean _numGroupsLimitReached;
+  private boolean _isAccurateGroupBy;
   private int _numResizes;
   private long _resizeTimeMs;
 
@@ -118,8 +119,16 @@ public class GroupByResultsBlock extends BaseResultsBlock {
     return _numGroupsLimitReached;
   }
 
+  public boolean isAccurateGroupBy() {
+    return _isAccurateGroupBy;
+  }
+
   public void setNumGroupsLimitReached(boolean numGroupsLimitReached) {
     _numGroupsLimitReached = numGroupsLimitReached;
+  }
+
+  public void setIsAccurateGroupBy(boolean isAccurateGroupBy) {
+    _isAccurateGroupBy = isAccurateGroupBy;
   }
 
   public int getNumResizes() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/FilteredGroupByOperator.java
@@ -160,7 +160,7 @@ public class FilteredGroupByOperator extends BaseOperator<GroupByResultsBlock> {
     }
 
     // Check if the groups limit is reached
-    boolean numGroupsLimitReached = groupKeyGenerator.getNumKeys() >= _queryContext.getNumGroupsLimit();
+    boolean numGroupsLimitReached = groupKeyGenerator.globalGroupKeyLimitReached();
     Tracing.activeRecording().setNumGroups(_queryContext.getNumGroupsLimit(), groupKeyGenerator.getNumKeys());
 
     // Trim the groups when iff:
@@ -178,6 +178,7 @@ public class FilteredGroupByOperator extends BaseOperator<GroupByResultsBlock> {
             tableResizer.trimInSegmentResults(groupKeyGenerator, groupByResultHolders, trimSize);
         GroupByResultsBlock resultsBlock = new GroupByResultsBlock(_dataSchema, intermediateRecords, _queryContext);
         resultsBlock.setNumGroupsLimitReached(numGroupsLimitReached);
+        resultsBlock.setIsAccurateGroupBy(false);
         return resultsBlock;
       }
     }
@@ -186,6 +187,7 @@ public class FilteredGroupByOperator extends BaseOperator<GroupByResultsBlock> {
         new AggregationGroupByResult(groupKeyGenerator, _aggregationFunctions, groupByResultHolders);
     GroupByResultsBlock resultsBlock = new GroupByResultsBlock(_dataSchema, aggGroupByResult, _queryContext);
     resultsBlock.setNumGroupsLimitReached(numGroupsLimitReached);
+    resultsBlock.setIsAccurateGroupBy(!numGroupsLimitReached);
     return resultsBlock;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/query/GroupByOperator.java
@@ -108,7 +108,7 @@ public class GroupByOperator extends BaseOperator<GroupByResultsBlock> {
     }
 
     // Check if the groups limit is reached
-    boolean numGroupsLimitReached = groupByExecutor.getNumGroups() >= _queryContext.getNumGroupsLimit();
+    boolean numGroupsLimitReached = groupByExecutor.numGroupsLimitReached();
     Tracing.activeRecording().setNumGroups(_queryContext.getNumGroupsLimit(), groupByExecutor.getNumGroups());
 
     // Trim the groups when iff:
@@ -125,12 +125,14 @@ public class GroupByOperator extends BaseOperator<GroupByResultsBlock> {
         Collection<IntermediateRecord> intermediateRecords = groupByExecutor.trimGroupByResult(trimSize, tableResizer);
         GroupByResultsBlock resultsBlock = new GroupByResultsBlock(_dataSchema, intermediateRecords, _queryContext);
         resultsBlock.setNumGroupsLimitReached(numGroupsLimitReached);
+        resultsBlock.setIsAccurateGroupBy(false);
         return resultsBlock;
       }
     }
 
     GroupByResultsBlock resultsBlock = new GroupByResultsBlock(_dataSchema, groupByExecutor.getResult(), _queryContext);
     resultsBlock.setNumGroupsLimitReached(numGroupsLimitReached);
+    resultsBlock.setIsAccurateGroupBy(!numGroupsLimitReached);
     return resultsBlock;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/DefaultGroupByExecutor.java
@@ -86,8 +86,8 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
     _hasMVGroupByExpression = hasMVGroupByExpression;
 
     // Initialize group key generator
-    int numGroupsLimit = queryContext.getNumGroupsLimit();
-    int maxInitialResultHolderCapacity = queryContext.getMaxInitialResultHolderCapacity();
+    int numGroupsLimit = queryContext.getNumGroupsLimit();   // 100,000
+    int maxInitialResultHolderCapacity = queryContext.getMaxInitialResultHolderCapacity(); // 10,000
     if (groupKeyGenerator != null) {
       _groupKeyGenerator = groupKeyGenerator;
     } else {
@@ -168,6 +168,11 @@ public class DefaultGroupByExecutor implements GroupByExecutor {
   public int getNumGroups() {
     return _groupKeyGenerator.getNumKeys();
   }
+
+  @Override
+  public boolean numGroupsLimitReached() { return _groupKeyGenerator.globalGroupKeyLimitReached(); }
+
+
 
   @Override
   public Collection<IntermediateRecord> trimGroupByResult(int trimSize, TableResizer tableResizer) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupByExecutor.java
@@ -49,6 +49,8 @@ public interface GroupByExecutor {
    */
   int getNumGroups();
 
+  boolean numGroupsLimitReached();
+
   /**
    * Trim the GroupBy result up to the threshold max(configurable_threshold * 5, minTrimSize)
    * TODO: benchmark the performance of PQ vs. topK

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/GroupKeyGenerator.java
@@ -39,6 +39,13 @@ public interface GroupKeyGenerator {
   int getGlobalGroupKeyUpperBound();
 
   /**
+   * Returns whether the globalGroupKeyUpperBound was reached while processing the segment. This is used to indicate
+   * that the group by might not have perfectly accurate results.
+   * @return
+   */
+  boolean globalGroupKeyLimitReached();
+
+  /**
    * Generates group keys on the given value block and returns the result to the given buffer.
    * <p>This method is for situation where all the group-by columns are single-valued.
    *

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryMultiColumnGroupKeyGenerator.java
@@ -61,6 +61,7 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
   private final boolean _nullHandlingEnabled;
 
   private int _numGroups = 0;
+  private boolean _globalGroupKeyLimitReached;
 
   public NoDictionaryMultiColumnGroupKeyGenerator(BaseProjectOperator<?> projectOperator,
       ExpressionContext[] groupByExpressions, int numGroupsLimit, boolean nullHandlingEnabled) {
@@ -93,6 +94,11 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
   @Override
   public int getGlobalGroupKeyUpperBound() {
     return _globalGroupIdUpperBound;
+  }
+
+  @Override
+  public boolean globalGroupKeyLimitReached() {
+    return _globalGroupKeyLimitReached;
   }
 
   @Override
@@ -341,6 +347,8 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
       if (_numGroups < _globalGroupIdUpperBound) {
         groupId = _numGroups;
         _groupKeyMap.put(flyweight.clone(), _numGroups++);
+      } else {
+        _globalGroupKeyLimitReached = true;
       }
     }
     return groupId;
@@ -358,6 +366,8 @@ public class NoDictionaryMultiColumnGroupKeyGenerator implements GroupKeyGenerat
       if (_numGroups < _globalGroupIdUpperBound) {
         groupId = _numGroups;
         _groupKeyMap.put(keyList, _numGroups++);
+      } else {
+        _globalGroupKeyLimitReached = true;
       }
     }
     return groupId;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionarySingleColumnGroupKeyGenerator.java
@@ -62,6 +62,7 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
   private final boolean _isSingleValueExpression;
 
   private int _numGroups = 0;
+  private boolean _globalGroupKeyLimitReached;
 
   public NoDictionarySingleColumnGroupKeyGenerator(BaseProjectOperator<?> projectOperator,
       ExpressionContext groupByExpression, int numGroupsLimit, boolean nullHandlingEnabled) {
@@ -78,6 +79,9 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
   public int getGlobalGroupKeyUpperBound() {
     return _globalGroupIdUpperBound;
   }
+
+  @Override
+  public boolean globalGroupKeyLimitReached() { return _globalGroupKeyLimitReached; }
 
   @Override
   public void generateKeysForBlock(ValueBlock valueBlock, int[] groupKeys) {
@@ -401,11 +405,12 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
     if (_groupIdForNullValue != null) {
       return _groupIdForNullValue;
     }
-    if (_numGroups < _globalGroupIdUpperBound) {
-      _groupIdForNullValue = _numGroups++;
-      return _groupIdForNullValue;
+    if (_numGroups >= _globalGroupIdUpperBound) {
+      _globalGroupKeyLimitReached = true;
+      return INVALID_ID;
     }
-    return INVALID_ID;
+    _groupIdForNullValue = _numGroups++;
+    return _groupIdForNullValue;
   }
 
   @Override
@@ -416,56 +421,94 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
   private int getKeyForValue(int value) {
     Int2IntMap map = (Int2IntMap) _groupKeyMap;
     int groupId = map.get(value);
-    if (groupId == INVALID_ID && _numGroups < _globalGroupIdUpperBound) {
-      groupId = _numGroups++;
-      map.put(value, groupId);
+    if (groupId != INVALID_ID) {
+      return groupId;
     }
+    if (_numGroups >= _globalGroupIdUpperBound) {
+      _globalGroupKeyLimitReached = true;
+      return INVALID_ID;
+    }
+
+    groupId = _numGroups++;
+    map.put(value, groupId);
     return groupId;
   }
 
   private int getKeyForValue(long value) {
     Long2IntMap map = (Long2IntMap) _groupKeyMap;
     int groupId = map.get(value);
-    if (groupId == INVALID_ID && _numGroups < _globalGroupIdUpperBound) {
-      groupId = _numGroups++;
-      map.put(value, groupId);
+    if (groupId != INVALID_ID) {
+      return groupId;
     }
+    if (_numGroups >= _globalGroupIdUpperBound) {
+      _globalGroupKeyLimitReached = true;
+      return INVALID_ID;
+    }
+
+    groupId = _numGroups++;
+    map.put(value, groupId);
     return groupId;
   }
 
   private int getKeyForValue(float value) {
     Float2IntMap map = (Float2IntMap) _groupKeyMap;
     int groupId = map.get(value);
-    if (groupId == INVALID_ID && _numGroups < _globalGroupIdUpperBound) {
-      groupId = _numGroups++;
-      map.put(value, groupId);
+    if (groupId != INVALID_ID) {
+      return groupId;
     }
+    if (_numGroups >= _globalGroupIdUpperBound) {
+      _globalGroupKeyLimitReached = true;
+      return INVALID_ID;
+    }
+
+    groupId = _numGroups++;
+    map.put(value, groupId);
     return groupId;
   }
 
   private int getKeyForValue(double value) {
     Double2IntMap map = (Double2IntMap) _groupKeyMap;
     int groupId = map.get(value);
-    if (groupId == INVALID_ID && _numGroups < _globalGroupIdUpperBound) {
-      groupId = _numGroups++;
-      map.put(value, groupId);
+    if (groupId != INVALID_ID) {
+      return groupId;
     }
+    if (_numGroups >= _globalGroupIdUpperBound) {
+      _globalGroupKeyLimitReached = true;
+      return INVALID_ID;
+    }
+
+    groupId = _numGroups++;
+    map.put(value, groupId);
     return groupId;
   }
 
   private int getKeyForValue(BigDecimal value) {
     Object2IntMap<BigDecimal> map = (Object2IntMap<BigDecimal>) _groupKeyMap;
     int groupId = map.getInt(value);
-    if (groupId == INVALID_ID && _numGroups < _globalGroupIdUpperBound) {
-      groupId = _numGroups++;
-      map.put(value, groupId);
+    if (groupId != INVALID_ID) {
+      return groupId;
     }
+    if (_numGroups >= _globalGroupIdUpperBound) {
+      _globalGroupKeyLimitReached = true;
+      return INVALID_ID;
+    }
+
+    groupId = _numGroups++;
+    map.put(value, groupId);
     return groupId;
   }
 
   private int getKeyForValue(String value) {
     Object2IntMap<String> map = (Object2IntMap<String>) _groupKeyMap;
     int groupId = map.getInt(value);
+    if (groupId != INVALID_ID) {
+      return groupId;
+    }
+    if (_numGroups >= _globalGroupIdUpperBound) {
+      _globalGroupKeyLimitReached = true;
+      return INVALID_ID;
+    }
+
     if (groupId == INVALID_ID && _numGroups < _globalGroupIdUpperBound) {
       groupId = _numGroups++;
       map.put(value, groupId);
@@ -476,10 +519,16 @@ public class NoDictionarySingleColumnGroupKeyGenerator implements GroupKeyGenera
   private int getKeyForValue(ByteArray value) {
     Object2IntMap<ByteArray> map = (Object2IntMap<ByteArray>) _groupKeyMap;
     int groupId = map.getInt(value);
-    if (groupId == INVALID_ID && _numGroups < _globalGroupIdUpperBound) {
-      groupId = _numGroups++;
-      map.put(value, groupId);
+    if (groupId != INVALID_ID) {
+      return groupId;
     }
+    if (_numGroups >= _globalGroupIdUpperBound) {
+      _globalGroupKeyLimitReached = true;
+      return INVALID_ID;
+    }
+
+    groupId = _numGroups++;
+    map.put(value, groupId);
     return groupId;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
@@ -80,6 +80,8 @@ public class ExecutionStatsAggregator {
   private long _stageExecStartTimeMs = -1;
   private long _stageExecEndTimeMs = -1;
   private int _stageExecutionUnit = 0;
+  private boolean _isAccurateGroupBy = true;
+
 
   public ExecutionStatsAggregator(boolean enableTrace) {
     _enableTrace = enableTrace;
@@ -249,6 +251,7 @@ public class ExecutionStatsAggregator {
     }
     _numGroupsLimitReached |=
         Boolean.parseBoolean(metadata.get(DataTable.MetadataKey.NUM_GROUPS_LIMIT_REACHED.getName()));
+    _isAccurateGroupBy &= Boolean.parseBoolean(metadata.get(DataTable.MetadataKey.IS_ACCURATE_GROUP_BY.getName()));
 
 
     String numBlocksString = metadata.get(DataTable.MetadataKey.NUM_BLOCKS.getName());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/DefaultRequestContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/DefaultRequestContext.java
@@ -80,6 +80,7 @@ public class DefaultRequestContext implements RequestScope {
   private long _explainPlanNumMatchAllFilterSegments;
   private Map<String, String> _traceInfo = new HashMap<>();
   private List<String> _processingExceptions = new ArrayList<>();
+  private boolean _isAccurateGroupBy;
 
   public DefaultRequestContext() {
   }
@@ -338,6 +339,11 @@ public class DefaultRequestContext implements RequestScope {
   }
 
   @Override
+  public boolean isAccurateGroupBy() {
+    return _isAccurateGroupBy;
+  }
+
+  @Override
   public int getNumExceptions() {
     return _numExceptions;
   }
@@ -415,6 +421,11 @@ public class DefaultRequestContext implements RequestScope {
   @Override
   public void setNumGroupsLimitReached(boolean numGroupsLimitReached) {
     _isNumGroupsLimitReached = numGroupsLimitReached;
+  }
+
+  @Override
+  public void setIsAccurateGroupBy(boolean isAccurateGroupBy) {
+    _isAccurateGroupBy = isAccurateGroupBy;
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/RequestContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/RequestContext.java
@@ -127,6 +127,8 @@ public interface RequestContext {
 
   boolean isNumGroupsLimitReached();
 
+  boolean isAccurateGroupBy();
+
   int getNumExceptions();
 
   boolean hasValidTableName();
@@ -158,6 +160,8 @@ public interface RequestContext {
   void setNumServersResponded(int numServersResponded);
 
   void setNumGroupsLimitReached(boolean numGroupsLimitReached);
+
+  void setIsAccurateGroupBy(boolean isAccurateGroupBy);
 
   void setNumExceptions(int numExceptions);
 


### PR DESCRIPTION
This PR contains a couple of usability improvements for GroupBy queries

**Change1: `numGroupsLimitReached`**
* One of the uses of this metadata is to help users determine if their groupBy results could be partial or potentially inaccurate. 
* This metadata is currently set if the number of groupBy keys collected matches the `num.groups.limit` irrespective of whether some groupBy keys have been ignored or not.
* Added a fix for this in this PR

**Change2: Better Visibility for User for potentially inaccurate GroupBy**
* Due to segment trimming and server-level trimming, it's possible that the groupBy results are not perfectly accuracte. 
* In such case, we should expose a metadata to inform the user about this potential inaccuracy. 
* Added a metadata field called `isAccuracteGroupBy` which will be set to true only if no trimming/ignoring has taken place at the server or segment level.

**Change3: User option to fail query if groupBy is potentially inaccurate**
* The user should be able to optionally fail queries if they wish to perform perfectly accurate GroupBy. We can perhaps provide a queryOption for this.
* I'm working on this part. Will update PR with these changes. 

