### PR TITLE
[draft] Null mode at query time

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/config/QueryOptionsUtils.java
@@ -177,6 +177,10 @@ public class QueryOptionsUtils {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.ENABLE_NULL_HANDLING));
   }
 
+  public static boolean useColumnNulability(Map<String, String> queryOptions) {
+    return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.USE_COLUMN_NULLABILITY));
+  }
+
   public static boolean isServerReturnFinalResult(Map<String, String> queryOptions) {
     return Boolean.parseBoolean(queryOptions.get(QueryOptionKey.SERVER_RETURN_FINAL_RESULT));
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/BlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/BlockValSet.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.common;
 
 import java.math.BigDecimal;
 import javax.annotation.Nullable;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.roaringbitmap.RoaringBitmap;
@@ -32,10 +33,20 @@ import org.roaringbitmap.RoaringBitmap;
 public interface BlockValSet {
 
   /**
+   * An alias to {@link #getNullBitmap(NullMode) getNullBitmap(NullMode.ALL_NULLABLE)}
+   * @deprecated Use {@link #getNullBitmap(NullMode) getNullBitmap(NullMode.ALL_NULLABLE)} instead
+   */
+  @Nullable
+  @Deprecated
+  default RoaringBitmap getNullBitmap() {
+    return getNullBitmap(NullMode.ALL_NULLABLE);
+  }
+
+  /**
    * Returns the null value bitmap in the value set.
    */
   @Nullable
-  RoaringBitmap getNullBitmap();
+  RoaringBitmap getNullBitmap(NullMode nullMode);
 
   /**
    * Returns the data type of the values in the value set.

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/table/TableResizer.java
@@ -93,7 +93,7 @@ public class TableResizer {
       comparators[i] = orderByExpression.isAsc() ? Comparator.naturalOrder() : Comparator.reverseOrder();
       nullComparisonResults[i] = orderByExpression.isNullsLast() ? -1 : 1;
     }
-    boolean nullHandlingEnabled = queryContext.isNullHandlingEnabled();
+    boolean nullHandlingEnabled = queryContext.getNullMode().nullAtQueryTime();
     if (nullHandlingEnabled) {
       _intermediateRecordComparator = (o1, o2) -> {
         for (int i = 0; i < _numOrderByExpressions; i++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
@@ -108,7 +108,7 @@ public class AggregationResultsBlock extends BaseResultsBlock {
     int numColumns = columnDataTypes.length;
     DataTableBuilder dataTableBuilder = DataTableBuilderFactory.getDataTableBuilder(dataSchema);
     boolean returnFinalResult = _queryContext.isServerReturnFinalResult();
-    if (_queryContext.isNullHandlingEnabled()) {
+    if (_queryContext.getNullMode().nullAtQueryTime()) {
       RoaringBitmap[] nullBitmaps = new RoaringBitmap[numColumns];
       for (int i = 0; i < numColumns; i++) {
         nullBitmaps[i] = new RoaringBitmap();

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/DistinctResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/DistinctResultsBlock.java
@@ -80,6 +80,6 @@ public class DistinctResultsBlock extends BaseResultsBlock {
       throws IOException {
     Collection<Object[]> rows = getRows();
     return SelectionOperatorUtils.getDataTableFromRows(rows, _distinctTable.getDataSchema(),
-        _queryContext.isNullHandlingEnabled());
+        _queryContext.getNullMode());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
@@ -176,7 +176,7 @@ public class GroupByResultsBlock extends BaseResultsBlock {
     ColumnDataType[] storedColumnDataTypes = _dataSchema.getStoredColumnDataTypes();
     int numColumns = _dataSchema.size();
     Iterator<Record> iterator = _table.iterator();
-    if (_queryContext.isNullHandlingEnabled()) {
+    if (_queryContext.getNullMode().nullAtQueryTime()) {
       RoaringBitmap[] nullBitmaps = new RoaringBitmap[numColumns];
       Object[] nullPlaceholders = new Object[numColumns];
       for (int colId = 0; colId < numColumns; colId++) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/ResultsBlockUtils.java
@@ -114,7 +114,7 @@ public class ResultsBlockUtils {
     // NOTE: Use STRING column data type as default for distinct query
     Arrays.fill(columnDataTypes, ColumnDataType.STRING);
     DistinctTable distinctTable = new DistinctTable(new DataSchema(columns, columnDataTypes), Collections.emptySet(),
-        queryContext.isNullHandlingEnabled());
+        queryContext.getNullMode());
     return new DistinctResultsBlock(distinctTable, queryContext);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/SelectionResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/SelectionResultsBlock.java
@@ -81,6 +81,7 @@ public class SelectionResultsBlock extends BaseResultsBlock {
   @Override
   public DataTable getDataTable()
       throws IOException {
-    return SelectionOperatorUtils.getDataTableFromRows(_rows, _dataSchema, _queryContext.isNullHandlingEnabled());
+    return SelectionOperatorUtils.getDataTableFromRows(_rows, _dataSchema,
+        _queryContext.getNullMode());
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/merger/DistinctResultsBlockMerger.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/combine/merger/DistinctResultsBlockMerger.java
@@ -50,7 +50,7 @@ public class DistinctResultsBlockMerger implements ResultsBlockMerger<DistinctRe
     if (!mergedDistinctTable.isMainTable()) {
       DistinctTable mainDistinctTable =
           new DistinctTable(distinctTableToMerge.getDataSchema(), _queryContext.getOrderByExpressions(),
-              _queryContext.getLimit(), _queryContext.isNullHandlingEnabled());
+              _queryContext.getLimit(), _queryContext.getNullMode());
       mainDistinctTable.mergeTable(mergedDistinctTable);
       mergedBlock.setDistinctTable(mainDistinctTable);
       mergedDistinctTable = mainDistinctTable;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/ExpressionDocIdSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docidsets/ExpressionDocIdSet.java
@@ -24,6 +24,7 @@ import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.operator.dociditerators.ExpressionScanDocIdIterator;
 import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.operator.transform.function.TransformFunction;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 
 
@@ -31,10 +32,10 @@ public final class ExpressionDocIdSet implements BlockDocIdSet {
   private final ExpressionScanDocIdIterator _docIdIterator;
 
   public ExpressionDocIdSet(TransformFunction transformFunction, @Nullable PredicateEvaluator predicateEvaluator,
-      Map<String, DataSource> dataSourceMap, int numDocs, boolean nullHandlingEnabled,
+      Map<String, DataSource> dataSourceMap, int numDocs, NullMode nullMode,
       ExpressionScanDocIdIterator.PredicateEvaluationResult predicateEvaluationResult) {
     _docIdIterator = new ExpressionScanDocIdIterator(transformFunction, predicateEvaluator, dataSourceMap, numDocs,
-        nullHandlingEnabled, predicateEvaluationResult);
+        nullMode, predicateEvaluationResult);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/DataBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/DataBlockValSet.java
@@ -24,6 +24,7 @@ import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.util.DataBlockExtractUtils;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.roaringbitmap.RoaringBitmap;
@@ -53,8 +54,15 @@ public class DataBlockValSet implements BlockValSet {
 
   @Nullable
   @Override
-  public RoaringBitmap getNullBitmap() {
-    return _nullBitmap;
+  public RoaringBitmap getNullBitmap(NullMode nullMode) {
+    switch (nullMode) {
+      case ALL_NULLABLE:
+      case COLUMN_BASED:
+        return _nullBitmap;
+      case NONE_NULLABLE:
+      default:
+        throw new IllegalArgumentException("Null mode " + nullMode + " is not supported in multistage");
+    }
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/FilteredDataBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/FilteredDataBlockValSet.java
@@ -24,6 +24,7 @@ import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.util.DataBlockExtractUtils;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.roaringbitmap.PeekableIntIterator;
@@ -71,13 +72,17 @@ public class FilteredDataBlockValSet implements BlockValSet {
     }
   }
 
-  /**
-   * Returns a bitmap of indices where null values are found.
-   */
   @Nullable
   @Override
-  public RoaringBitmap getNullBitmap() {
-    return _matchedNullBitmap;
+  public RoaringBitmap getNullBitmap(NullMode nullMode) {
+    switch (nullMode) {
+      case ALL_NULLABLE:
+      case COLUMN_BASED:
+        return _matchedNullBitmap;
+      case NONE_NULLABLE:
+      default:
+        throw new IllegalArgumentException("Null mode " + nullMode + " is not supported in multistage");
+    }
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/FilteredRowBasedBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/FilteredRowBasedBlockValSet.java
@@ -25,6 +25,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
@@ -74,8 +75,15 @@ public class FilteredRowBasedBlockValSet implements BlockValSet {
 
   @Nullable
   @Override
-  public RoaringBitmap getNullBitmap() {
-    return _matchedNullBitmap;
+  public RoaringBitmap getNullBitmap(NullMode nullMode) {
+    switch (nullMode) {
+      case ALL_NULLABLE:
+      case COLUMN_BASED:
+      case NONE_NULLABLE:
+        return _matchedNullBitmap;
+      default:
+        throw new IllegalArgumentException("Null mode " + nullMode + " is not supported in multistage");
+    }
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/ProjectionBlockValSet.java
@@ -24,6 +24,7 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.common.DataBlockCache;
 import org.apache.pinot.core.operator.ProjectionOperator;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
@@ -60,9 +61,9 @@ public class ProjectionBlockValSet implements BlockValSet {
 
   @Nullable
   @Override
-  public RoaringBitmap getNullBitmap() {
+  public RoaringBitmap getNullBitmap(NullMode nullMode) {
     if (!_nullBitmapSet) {
-      NullValueVectorReader nullValueReader = _dataSource.getNullValueVector();
+      NullValueVectorReader nullValueReader = _dataSource.getNullValueVector(nullMode);
       ImmutableRoaringBitmap nullBitmap = nullValueReader != null ? nullValueReader.getNullBitmap() : null;
       if (nullBitmap != null && !nullBitmap.isEmpty()) {
         // Project null bitmap.

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/RowBasedBlockValSet.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/docvalsets/RowBasedBlockValSet.java
@@ -24,6 +24,7 @@ import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.BlockValSet;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
@@ -73,8 +74,16 @@ public class RowBasedBlockValSet implements BlockValSet {
 
   @Nullable
   @Override
-  public RoaringBitmap getNullBitmap() {
-    return _nullBitmap;
+  public RoaringBitmap getNullBitmap(NullMode nullMode) {
+    switch (nullMode) {
+      case COLUMN_BASED:
+      case ALL_NULLABLE:
+        return _nullBitmap;
+      case NONE_NULLABLE:
+        return null;
+      default:
+        throw new IllegalArgumentException("Null mode " + nullMode + " is not supported");
+    }
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/AndFilterOperator.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.docidsets.AndDocIdSet;
 import org.apache.pinot.core.operator.docidsets.MatchAllDocIdSet;
 import org.apache.pinot.core.operator.docidsets.OrDocIdSet;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.trace.Tracing;
 import org.roaringbitmap.buffer.BufferFastAggregation;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
@@ -39,8 +40,8 @@ public class AndFilterOperator extends BaseFilterOperator {
   private final Map<String, String> _queryOptions;
 
   public AndFilterOperator(List<BaseFilterOperator> filterOperators, @Nullable Map<String, String> queryOptions,
-      int numDocs, boolean nullHandlingEnabled) {
-    super(numDocs, nullHandlingEnabled);
+      int numDocs, NullMode nullMode) {
+    super(numDocs, nullMode);
     _filterOperators = filterOperators;
     _queryOptions = queryOptions;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseColumnFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseColumnFilterOperator.java
@@ -35,7 +35,7 @@ public abstract class BaseColumnFilterOperator extends BaseFilterOperator {
   protected final DataSource _dataSource;
 
   protected BaseColumnFilterOperator(QueryContext queryContext, DataSource dataSource, int numDocs) {
-    super(numDocs, queryContext.isNullHandlingEnabled());
+    super(numDocs, queryContext.getNullMode());
     _queryContext = queryContext;
     _dataSource = dataSource;
   }
@@ -44,7 +44,7 @@ public abstract class BaseColumnFilterOperator extends BaseFilterOperator {
 
   @Override
   protected BlockDocIdSet getTrues() {
-    if (_nullHandlingEnabled) {
+    if (_nullMode.nullAtQueryTime()) {
       ImmutableRoaringBitmap nullBitmap = getNullBitmap();
       if (nullBitmap != null && !nullBitmap.isEmpty()) {
         return excludeNulls(getNextBlockWithoutNullHandling(), nullBitmap);
@@ -71,7 +71,7 @@ public abstract class BaseColumnFilterOperator extends BaseFilterOperator {
 
   @Nullable
   private ImmutableRoaringBitmap getNullBitmap() {
-    NullValueVectorReader nullValueVector = _dataSource.getNullValueVector();
+    NullValueVectorReader nullValueVector = _dataSource.getNullValueVector(_nullMode);
     if (nullValueVector != null) {
       return nullValueVector.getNullBitmap();
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BaseFilterOperator.java
@@ -25,6 +25,7 @@ import org.apache.pinot.core.operator.blocks.FilterBlock;
 import org.apache.pinot.core.operator.docidsets.EmptyDocIdSet;
 import org.apache.pinot.core.operator.docidsets.NotDocIdSet;
 import org.apache.pinot.core.operator.docidsets.OrDocIdSet;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 /**
@@ -32,11 +33,11 @@ import org.apache.pinot.core.operator.docidsets.OrDocIdSet;
  */
 public abstract class BaseFilterOperator extends BaseOperator<FilterBlock> {
   protected final int _numDocs;
-  protected final boolean _nullHandlingEnabled;
+  protected final NullMode _nullMode;
 
-  public BaseFilterOperator(int numDocs, boolean nullHandlingEnabled) {
+  public BaseFilterOperator(int numDocs, NullMode nullMode) {
     _numDocs = numDocs;
-    _nullHandlingEnabled = nullHandlingEnabled;
+    _nullMode = nullMode;
   }
 
   /**
@@ -102,7 +103,7 @@ public abstract class BaseFilterOperator extends BaseOperator<FilterBlock> {
    * @return document IDs in which the predicate evaluates to false.
    */
   protected BlockDocIdSet getFalses() {
-    if (_nullHandlingEnabled) {
+    if (_nullMode.nullAtQueryTime()) {
       return new NotDocIdSet(new OrDocIdSet(Arrays.asList(getTrues(), getNulls()), _numDocs),
           _numDocs);
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BitmapBasedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/BitmapBasedFilterOperator.java
@@ -23,6 +23,7 @@ import java.util.List;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.docidsets.BitmapDocIdSet;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 
 
@@ -33,7 +34,7 @@ public class BitmapBasedFilterOperator extends BaseFilterOperator {
   private final boolean _exclusive;
 
   public BitmapBasedFilterOperator(ImmutableRoaringBitmap docIds, boolean exclusive, int numDocs) {
-    super(numDocs, false);
+    super(numDocs, NullMode.NONE_NULLABLE);
     _docIds = docIds;
     _exclusive = exclusive;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/CombinedFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/CombinedFilterOperator.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.operator.docidsets.AndDocIdSet;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.trace.Tracing;
 
 
@@ -40,7 +41,7 @@ public class CombinedFilterOperator extends BaseFilterOperator {
   public CombinedFilterOperator(BaseFilterOperator mainFilterOperator, BaseFilterOperator subFilterOperator,
       Map<String, String> queryOptions) {
     // This filter operator does not support AND/OR/NOT operations.
-    super(0, false);
+    super(0, NullMode.NONE_NULLABLE);
     assert !mainFilterOperator.isResultEmpty() && !mainFilterOperator.isResultMatchingAll()
         && !subFilterOperator.isResultEmpty() && !subFilterOperator.isResultMatchingAll();
     _mainFilterOperator = mainFilterOperator;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/EmptyFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/EmptyFilterOperator.java
@@ -24,6 +24,7 @@ import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.ExplainPlanRows;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.docidsets.EmptyDocIdSet;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 /**
@@ -32,7 +33,7 @@ import org.apache.pinot.core.operator.docidsets.EmptyDocIdSet;
 public final class EmptyFilterOperator extends BaseFilterOperator {
   private EmptyFilterOperator() {
     // We will never call its getFalses() method.
-    super(0, false);
+    super(0, NullMode.NONE_NULLABLE);
   }
 
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/ExpressionFilterOperator.java
@@ -52,7 +52,7 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
   private final PredicateEvaluator _predicateEvaluator;
 
   public ExpressionFilterOperator(IndexSegment segment, QueryContext queryContext, Predicate predicate, int numDocs) {
-    super(numDocs, queryContext.isNullHandlingEnabled());
+    super(numDocs, queryContext.getNullMode());
     _queryContext = queryContext;
 
     Set<String> columns = new HashSet<>();
@@ -85,14 +85,14 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
       return new NotDocIdSet(getNulls(), _numDocs);
     } else {
       return new ExpressionDocIdSet(_transformFunction, _predicateEvaluator, _dataSourceMap, _numDocs,
-          _queryContext.isNullHandlingEnabled(), ExpressionScanDocIdIterator.PredicateEvaluationResult.TRUE);
+          _queryContext.getNullMode(), ExpressionScanDocIdIterator.PredicateEvaluationResult.TRUE);
     }
   }
 
   @Override
   protected BlockDocIdSet getNulls() {
     return new ExpressionDocIdSet(_transformFunction, null, _dataSourceMap, _numDocs,
-        _queryContext.isNullHandlingEnabled(), ExpressionScanDocIdIterator.PredicateEvaluationResult.NULL);
+        _queryContext.getNullMode(), ExpressionScanDocIdIterator.PredicateEvaluationResult.NULL);
   }
 
   @Override
@@ -103,7 +103,7 @@ public class ExpressionFilterOperator extends BaseFilterOperator {
       return getNulls();
     } else {
       return new ExpressionDocIdSet(_transformFunction, _predicateEvaluator, _dataSourceMap, _numDocs,
-          _queryContext.isNullHandlingEnabled(), ExpressionScanDocIdIterator.PredicateEvaluationResult.FALSE);
+          _queryContext.getNullMode(), ExpressionScanDocIdIterator.PredicateEvaluationResult.FALSE);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/FilterOperatorUtils.java
@@ -75,8 +75,8 @@ public class FilterOperatorUtils {
       if (predicateEvaluator.isAlwaysFalse()) {
         return EmptyFilterOperator.getInstance();
       } else if (predicateEvaluator.isAlwaysTrue()) {
-        if (queryContext.isNullHandlingEnabled()) {
-          NullValueVectorReader nullValueVectorReader = dataSource.getNullValueVector();
+        if (queryContext.getNullMode().nullAtQueryTime()) {
+          NullValueVectorReader nullValueVectorReader = dataSource.getNullValueVector(queryContext.getNullMode());
           if (nullValueVectorReader != null) {
             ImmutableRoaringBitmap nullBitmap = nullValueVectorReader.getNullBitmap();
             if (nullBitmap != null && !nullBitmap.isEmpty()) {
@@ -146,7 +146,7 @@ public class FilterOperatorUtils {
         // Return the AND filter operator with re-ordered child filter operators
         reorderAndFilterChildOperators(queryContext, childFilterOperators);
         return new AndFilterOperator(childFilterOperators, queryContext.getQueryOptions(), numDocs,
-            queryContext.isNullHandlingEnabled());
+            queryContext.getNullMode());
       }
     }
 
@@ -171,7 +171,7 @@ public class FilterOperatorUtils {
       } else {
         // Return the OR filter operator with child filter operators
         return new OrFilterOperator(childFilterOperators, queryContext.getQueryOptions(), numDocs,
-            queryContext.isNullHandlingEnabled());
+            queryContext.getNullMode());
       }
     }
 
@@ -184,7 +184,7 @@ public class FilterOperatorUtils {
         return new MatchAllFilterOperator(numDocs);
       }
 
-      return new NotFilterOperator(filterOperator, numDocs, queryContext.isNullHandlingEnabled());
+      return new NotFilterOperator(filterOperator, numDocs, queryContext.getNullMode());
     }
 
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
@@ -34,6 +34,7 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.local.utils.GeometrySerializer;
 import org.apache.pinot.segment.local.utils.H3Utils;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.locationtech.jts.geom.Geometry;
@@ -58,7 +59,7 @@ public class H3InclusionIndexFilterOperator extends BaseFilterOperator {
 
   public H3InclusionIndexFilterOperator(IndexSegment segment, QueryContext queryContext, Predicate predicate,
       int numDocs) {
-    super(numDocs, false);
+    super(numDocs, NullMode.NONE_NULLABLE);
     _segment = segment;
     _queryContext = queryContext;
     _predicate = predicate;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3IndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3IndexFilterOperator.java
@@ -37,6 +37,7 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.local.utils.GeometrySerializer;
 import org.apache.pinot.segment.local.utils.H3Utils;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.H3IndexReader;
 import org.locationtech.jts.geom.Coordinate;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
@@ -58,7 +59,7 @@ public class H3IndexFilterOperator extends BaseFilterOperator {
   private final double _upperBound;
 
   public H3IndexFilterOperator(IndexSegment segment, QueryContext queryContext, Predicate predicate, int numDocs) {
-    super(numDocs, false);
+    super(numDocs, NullMode.NONE_NULLABLE);
     _segment = segment;
     _queryContext = queryContext;
     _predicate = predicate;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/JsonMatchFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/JsonMatchFilterOperator.java
@@ -24,6 +24,7 @@ import org.apache.pinot.common.request.context.predicate.JsonMatchPredicate;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.docidsets.BitmapDocIdSet;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
 import org.apache.pinot.spi.trace.FilterType;
 import org.apache.pinot.spi.trace.InvocationRecording;
@@ -42,7 +43,7 @@ public class JsonMatchFilterOperator extends BaseFilterOperator {
 
   public JsonMatchFilterOperator(JsonIndexReader jsonIndex, JsonMatchPredicate predicate,
       int numDocs) {
-    super(numDocs, false);
+    super(numDocs, NullMode.NONE_NULLABLE);
     _jsonIndex = jsonIndex;
     _predicate = predicate;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/MatchAllFilterOperator.java
@@ -24,13 +24,14 @@ import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.ExplainPlanRows;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.docidsets.MatchAllDocIdSet;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 public class MatchAllFilterOperator extends BaseFilterOperator {
   public static final String EXPLAIN_NAME = "FILTER_MATCH_ENTIRE_SEGMENT";
 
   public MatchAllFilterOperator(int numDocs) {
-    super(numDocs, false);
+    super(numDocs, NullMode.NONE_NULLABLE);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/NotFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/NotFilterOperator.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.docidsets.MatchAllDocIdSet;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 public class NotFilterOperator extends BaseFilterOperator {
@@ -32,8 +33,8 @@ public class NotFilterOperator extends BaseFilterOperator {
   private static final String EXPLAIN_NAME = "FILTER_NOT";
   private final BaseFilterOperator _filterOperator;
 
-  public NotFilterOperator(BaseFilterOperator filterOperator, int numDocs, boolean nullHandlingEnabled) {
-    super(numDocs, nullHandlingEnabled);
+  public NotFilterOperator(BaseFilterOperator filterOperator, int numDocs, NullMode nullMode) {
+    super(numDocs, nullMode);
     _filterOperator = filterOperator;
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/OrFilterOperator.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.docidsets.AndDocIdSet;
 import org.apache.pinot.core.operator.docidsets.MatchAllDocIdSet;
 import org.apache.pinot.core.operator.docidsets.OrDocIdSet;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.trace.Tracing;
 import org.roaringbitmap.buffer.BufferFastAggregation;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
@@ -39,8 +40,8 @@ public class OrFilterOperator extends BaseFilterOperator {
   private final Map<String, String> _queryOptions;
 
   public OrFilterOperator(List<BaseFilterOperator> filterOperators, @Nullable Map<String, String> queryOptions,
-      int numDocs, boolean nullHandlingEnabled) {
-    super(numDocs, nullHandlingEnabled);
+      int numDocs, NullMode nullMode) {
+    super(numDocs, nullMode);
     _filterOperators = filterOperators;
     _queryOptions = queryOptions;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/TestFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/TestFilterOperator.java
@@ -24,6 +24,7 @@ import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.segment.spi.Constants;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 public class TestFilterOperator extends BaseFilterOperator {
@@ -33,13 +34,13 @@ public class TestFilterOperator extends BaseFilterOperator {
   private final int[] _nullDocIds;
 
   public TestFilterOperator(int[] trueDocIds, int[] nullDocIds, int numDocs) {
-    super(numDocs, true);
+    super(numDocs, NullMode.ALL_NULLABLE);
     _trueDocIds = trueDocIds;
     _nullDocIds = nullDocIds;
   }
 
   public TestFilterOperator(int[] docIds, int numDocs) {
-    super(numDocs, false);
+    super(numDocs, NullMode.NONE_NULLABLE);
     _trueDocIds = docIds;
     _nullDocIds = new int[0];
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/TextContainsFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/TextContainsFilterOperator.java
@@ -24,6 +24,7 @@ import org.apache.pinot.common.request.context.predicate.TextContainsPredicate;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.docidsets.BitmapDocIdSet;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
 import org.apache.pinot.spi.trace.FilterType;
 import org.apache.pinot.spi.trace.InvocationRecording;
@@ -41,7 +42,7 @@ public class TextContainsFilterOperator extends BaseFilterOperator {
   private final TextContainsPredicate _predicate;
 
   public TextContainsFilterOperator(TextIndexReader textIndexReader, TextContainsPredicate predicate, int numDocs) {
-    super(numDocs, false);
+    super(numDocs, NullMode.NONE_NULLABLE);
     _textIndexReader = textIndexReader;
     _predicate = predicate;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/TextMatchFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/TextMatchFilterOperator.java
@@ -24,6 +24,7 @@ import org.apache.pinot.common.request.context.predicate.TextMatchPredicate;
 import org.apache.pinot.core.common.BlockDocIdSet;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.docidsets.BitmapDocIdSet;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
 import org.apache.pinot.spi.trace.FilterType;
 import org.apache.pinot.spi.trace.InvocationRecording;
@@ -44,7 +45,7 @@ public class TextMatchFilterOperator extends BaseFilterOperator {
 
   public TextMatchFilterOperator(TextIndexReader textIndexReader, TextMatchPredicate predicate, int numDocs) {
     // This filter operator does not support AND/OR/NOT operations.
-    super(0, false);
+    super(0, NullMode.NONE_NULLABLE);
     _textIndexReader = textIndexReader;
     _predicate = predicate;
     _numDocs = numDocs;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunction.java
@@ -26,6 +26,7 @@ import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.evaluator.TransformEvaluator;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.roaringbitmap.RoaringBitmap;
@@ -39,12 +40,14 @@ public class IdentifierTransformFunction implements TransformFunction, PushDownT
   private final String _columnName;
   private final Dictionary _dictionary;
   private final TransformResultMetadata _resultMetadata;
+  private final NullMode _nullMode;
 
-  public IdentifierTransformFunction(String columnName, ColumnContext columnContext) {
+  public IdentifierTransformFunction(String columnName, ColumnContext columnContext, NullMode nullMode) {
     _columnName = columnName;
     _dictionary = columnContext.getDictionary();
     _resultMetadata =
         new TransformResultMetadata(columnContext.getDataType(), columnContext.isSingleValue(), _dictionary != null);
+    _nullMode = nullMode;
   }
 
   public String getColumnName() {
@@ -210,6 +213,6 @@ public class IdentifierTransformFunction implements TransformFunction, PushDownT
 
   @Override
   public RoaringBitmap getNullBitmap(ValueBlock valueBlock) {
-    return valueBlock.getBlockValueSet(_columnName).getNullBitmap();
+    return valueBlock.getBlockValueSet(_columnName).getNullBitmap(_nullMode);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -322,7 +322,8 @@ public class TransformFunctionFactory {
           transformFunctionArguments.add(TransformFunctionFactory.get(argument, columnContextMap, queryContext));
         }
         try {
-          transformFunction.init(transformFunctionArguments, columnContextMap, queryContext.isNullHandlingEnabled());
+          transformFunction.init(transformFunctionArguments, columnContextMap,
+              queryContext.getNullMode().nullAtQueryTime());
         } catch (Exception e) {
           throw new BadQueryRequestException("Caught exception while initializing transform function: " + functionName,
               e);
@@ -330,7 +331,8 @@ public class TransformFunctionFactory {
         return transformFunction;
       case IDENTIFIER:
         String columnName = expression.getIdentifier();
-        return new IdentifierTransformFunction(columnName, columnContextMap.get(columnName));
+        return new IdentifierTransformFunction(columnName, columnContextMap.get(columnName),
+            queryContext.getNullMode());
       case LITERAL:
         return queryContext.getOrComputeSharedValue(LiteralTransformFunction.class, expression.getLiteral(),
             LiteralTransformFunction::new);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -101,11 +101,12 @@ public class AggregationPlanNode implements PlanNode {
     FilterPlanNode filterPlanNode = new FilterPlanNode(_indexSegment, _queryContext);
     BaseFilterOperator filterOperator = filterPlanNode.run();
 
-    if (canOptimizeFilteredCount(filterOperator, aggregationFunctions) && !_queryContext.isNullHandlingEnabled()) {
+    if (canOptimizeFilteredCount(filterOperator, aggregationFunctions)
+        && !_queryContext.getNullMode().nullAtQueryTime()) {
       return new FastFilteredCountOperator(_queryContext, filterOperator, _indexSegment.getSegmentMetadata());
     }
 
-    if (filterOperator.isResultMatchingAll() && !_queryContext.isNullHandlingEnabled()) {
+    if (filterOperator.isResultMatchingAll() && !_queryContext.getNullMode().nullAtQueryTime()) {
       if (isFitForNonScanBasedPlan(aggregationFunctions, _indexSegment)) {
         DataSource[] dataSources = new DataSource[aggregationFunctions.length];
         for (int i = 0; i < aggregationFunctions.length; i++) {
@@ -121,7 +122,7 @@ public class AggregationPlanNode implements PlanNode {
 
     // Use star-tree to solve the query if possible
     List<StarTreeV2> starTrees = _indexSegment.getStarTrees();
-    if (starTrees != null && !_queryContext.isSkipStarTree() && !_queryContext.isNullHandlingEnabled()) {
+    if (starTrees != null && !_queryContext.isSkipStarTree() && !_queryContext.getNullMode().nullAtQueryTime()) {
       AggregationFunctionColumnPair[] aggregationFunctionColumnPairs =
           StarTreeUtils.extractAggregationFunctionPairs(aggregationFunctions);
       if (aggregationFunctionColumnPairs != null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -292,14 +292,14 @@ public class FilterPlanNode implements PlanNode {
                   column);
               return new JsonMatchFilterOperator(jsonIndex, (JsonMatchPredicate) predicate, numDocs);
             case IS_NULL:
-              NullValueVectorReader nullValueVector = dataSource.getNullValueVector();
+              NullValueVectorReader nullValueVector = dataSource.getNullValueVector(_queryContext.getNullMode());
               if (nullValueVector != null) {
                 return new BitmapBasedFilterOperator(nullValueVector.getNullBitmap(), false, numDocs);
               } else {
                 return EmptyFilterOperator.getInstance();
               }
             case IS_NOT_NULL:
-              nullValueVector = dataSource.getNullValueVector();
+              nullValueVector = dataSource.getNullValueVector(_queryContext.getNullMode());
               if (nullValueVector != null) {
                 return new BitmapBasedFilterOperator(nullValueVector.getNullBitmap(), true, numDocs);
               } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactory.java
@@ -35,6 +35,7 @@ import org.apache.pinot.core.query.aggregation.function.array.ArrayAggLongFuncti
 import org.apache.pinot.core.query.aggregation.function.array.ArrayAggStringFunction;
 import org.apache.pinot.core.query.aggregation.function.funnel.FunnelCountAggregationFunctionFactory;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 
@@ -51,7 +52,7 @@ public class AggregationFunctionFactory {
    * Given the function information, returns a new instance of the corresponding aggregation function.
    * <p>NOTE: Underscores in the function name are ignored.
    */
-  public static AggregationFunction getAggregationFunction(FunctionContext function, boolean nullHandlingEnabled) {
+  public static AggregationFunction getAggregationFunction(FunctionContext function, NullMode nullMode) {
     try {
       String upperCaseFunctionName =
           AggregationFunctionType.getNormalizedAggregationFunctionName(function.getFunctionName());
@@ -195,18 +196,18 @@ public class AggregationFunctionFactory {
         AggregationFunctionType functionType = AggregationFunctionType.valueOf(upperCaseFunctionName);
         switch (functionType) {
           case COUNT:
-            return new CountAggregationFunction(arguments, nullHandlingEnabled);
+            return new CountAggregationFunction(arguments, nullMode);
           case MIN:
-            return new MinAggregationFunction(arguments, nullHandlingEnabled);
+            return new MinAggregationFunction(arguments, nullMode);
           case MAX:
-            return new MaxAggregationFunction(arguments, nullHandlingEnabled);
+            return new MaxAggregationFunction(arguments, nullMode);
           case SUM:
           case SUM0:
-            return new SumAggregationFunction(arguments, nullHandlingEnabled);
+            return new SumAggregationFunction(arguments, nullMode);
           case SUMPRECISION:
-            return new SumPrecisionAggregationFunction(arguments, nullHandlingEnabled);
+            return new SumPrecisionAggregationFunction(arguments, nullMode);
           case AVG:
-            return new AvgAggregationFunction(arguments, nullHandlingEnabled);
+            return new AvgAggregationFunction(arguments, nullMode);
           case MODE:
             return new ModeAggregationFunction(arguments);
           case FIRSTWITHTIME: {
@@ -257,16 +258,16 @@ public class AggregationFunctionFactory {
               switch (dataType) {
                 case BOOLEAN:
                 case INT:
-                  return new ArrayAggDistinctIntFunction(firstArgument, dataType, nullHandlingEnabled);
+                  return new ArrayAggDistinctIntFunction(firstArgument, dataType, nullMode);
                 case LONG:
                 case TIMESTAMP:
-                  return new ArrayAggDistinctLongFunction(firstArgument, dataType, nullHandlingEnabled);
+                  return new ArrayAggDistinctLongFunction(firstArgument, dataType, nullMode);
                 case FLOAT:
-                  return new ArrayAggDistinctFloatFunction(firstArgument, nullHandlingEnabled);
+                  return new ArrayAggDistinctFloatFunction(firstArgument, nullMode);
                 case DOUBLE:
-                  return new ArrayAggDistinctDoubleFunction(firstArgument, nullHandlingEnabled);
+                  return new ArrayAggDistinctDoubleFunction(firstArgument, nullMode);
                 case STRING:
-                  return new ArrayAggDistinctStringFunction(firstArgument, nullHandlingEnabled);
+                  return new ArrayAggDistinctStringFunction(firstArgument, nullMode);
                 default:
                   throw new IllegalArgumentException("Unsupported data type for ARRAY_AGG: " + dataType);
               }
@@ -274,16 +275,16 @@ public class AggregationFunctionFactory {
             switch (dataType) {
               case BOOLEAN:
               case INT:
-                return new ArrayAggIntFunction(firstArgument, dataType, nullHandlingEnabled);
+                return new ArrayAggIntFunction(firstArgument, dataType, nullMode);
               case LONG:
               case TIMESTAMP:
-                return new ArrayAggLongFunction(firstArgument, dataType, nullHandlingEnabled);
+                return new ArrayAggLongFunction(firstArgument, dataType, nullMode);
               case FLOAT:
-                return new ArrayAggFloatFunction(firstArgument, nullHandlingEnabled);
+                return new ArrayAggFloatFunction(firstArgument, nullMode);
               case DOUBLE:
-                return new ArrayAggDoubleFunction(firstArgument, nullHandlingEnabled);
+                return new ArrayAggDoubleFunction(firstArgument, nullMode);
               case STRING:
-                return new ArrayAggStringFunction(firstArgument, nullHandlingEnabled);
+                return new ArrayAggStringFunction(firstArgument, nullMode);
               default:
                 throw new IllegalArgumentException("Unsupported data type for ARRAY_AGG: " + dataType);
             }
@@ -318,7 +319,7 @@ public class AggregationFunctionFactory {
           case MINMAXRANGE:
             return new MinMaxRangeAggregationFunction(arguments);
           case DISTINCTCOUNT:
-            return new DistinctCountAggregationFunction(arguments, nullHandlingEnabled);
+            return new DistinctCountAggregationFunction(arguments, nullMode);
           case DISTINCTCOUNTBITMAP:
             return new DistinctCountBitmapAggregationFunction(arguments);
           case SEGMENTPARTITIONEDDISTINCTCOUNT:
@@ -336,9 +337,9 @@ public class AggregationFunctionFactory {
           case DISTINCTCOUNTRAWTHETASKETCH:
             return new DistinctCountRawThetaSketchAggregationFunction(arguments);
           case DISTINCTSUM:
-            return new DistinctSumAggregationFunction(arguments, nullHandlingEnabled);
+            return new DistinctSumAggregationFunction(arguments, nullMode);
           case DISTINCTAVG:
-            return new DistinctAvgAggregationFunction(arguments, nullHandlingEnabled);
+            return new DistinctAvgAggregationFunction(arguments, nullMode);
           case IDSET:
             return new IdSetAggregationFunction(arguments);
           case COUNTMV:
@@ -382,17 +383,17 @@ public class AggregationFunctionFactory {
           case COVARSAMP:
             return new CovarianceAggregationFunction(arguments, true);
           case BOOLAND:
-            return new BooleanAndAggregationFunction(arguments, nullHandlingEnabled);
+            return new BooleanAndAggregationFunction(arguments, nullMode);
           case BOOLOR:
-            return new BooleanOrAggregationFunction(arguments, nullHandlingEnabled);
+            return new BooleanOrAggregationFunction(arguments, nullMode);
           case VARPOP:
-            return new VarianceAggregationFunction(arguments, false, false, nullHandlingEnabled);
+            return new VarianceAggregationFunction(arguments, false, false, nullMode);
           case VARSAMP:
-            return new VarianceAggregationFunction(arguments, true, false, nullHandlingEnabled);
+            return new VarianceAggregationFunction(arguments, true, false, nullMode);
           case STDDEVPOP:
-            return new VarianceAggregationFunction(arguments, false, true, nullHandlingEnabled);
+            return new VarianceAggregationFunction(arguments, false, true, nullMode);
           case STDDEVSAMP:
-            return new VarianceAggregationFunction(arguments, true, true, nullHandlingEnabled);
+            return new VarianceAggregationFunction(arguments, true, true, nullMode);
           case SKEWNESS:
             return new FourthMomentAggregationFunction(arguments, FourthMomentAggregationFunction.Type.SKEWNESS);
           case KURTOSIS:

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AvgMVAggregationFunction.java
@@ -25,12 +25,13 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 public class AvgMVAggregationFunction extends AvgAggregationFunction {
 
   public AvgMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "AVG_MV"), false);
+    super(verifySingleArgument(arguments, "AVG_MV"), NullMode.NONE_NULLABLE);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctAggregateAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BaseDistinctAggregateAggregationFunction.java
@@ -33,6 +33,7 @@ import org.apache.pinot.core.query.aggregation.ObjectAggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.trace.Tracing;
@@ -49,13 +50,13 @@ import org.roaringbitmap.RoaringBitmap;
 public abstract class BaseDistinctAggregateAggregationFunction<T extends Comparable>
     extends BaseSingleInputAggregationFunction<Set, T> {
   private final AggregationFunctionType _functionType;
-  private final boolean _nullHandlingEnabled;
+  private final NullMode _nullMode;
 
   protected BaseDistinctAggregateAggregationFunction(ExpressionContext expression,
-      AggregationFunctionType aggregationFunctionType, boolean nullHandlingEnabled) {
+      AggregationFunctionType aggregationFunctionType, NullMode nullMode) {
     super(expression);
     _functionType = aggregationFunctionType;
-    _nullHandlingEnabled = nullHandlingEnabled;
+    _nullMode = nullMode;
   }
 
   @Override
@@ -151,8 +152,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
     // For dictionary-encoded expression, store dictionary ids into the bitmap
     Dictionary dictionary = blockValSet.getDictionary();
     if (dictionary != null) {
-      if (_nullHandlingEnabled) {
-        nullBitmap = blockValSet.getNullBitmap();
+      if (_nullMode.nullAtQueryTime()) {
+        nullBitmap = blockValSet.getNullBitmap(_nullMode);
       }
       int[] dictIds = blockValSet.getDictionaryIdsSV();
       if (nullBitmap != null && !nullBitmap.isEmpty()) {
@@ -175,8 +176,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
       case INT:
         IntOpenHashSet intSet = (IntOpenHashSet) valueSet;
         int[] intValues = blockValSet.getIntValuesSV();
-        if (_nullHandlingEnabled) {
-          nullBitmap = blockValSet.getNullBitmap();
+        if (_nullMode.nullAtQueryTime()) {
+          nullBitmap = blockValSet.getNullBitmap(_nullMode);
         }
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
@@ -193,8 +194,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
       case LONG:
         LongOpenHashSet longSet = (LongOpenHashSet) valueSet;
         long[] longValues = blockValSet.getLongValuesSV();
-        if (_nullHandlingEnabled) {
-          nullBitmap = blockValSet.getNullBitmap();
+        if (_nullMode.nullAtQueryTime()) {
+          nullBitmap = blockValSet.getNullBitmap(_nullMode);
         }
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
@@ -211,8 +212,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
       case FLOAT:
         FloatOpenHashSet floatSet = (FloatOpenHashSet) valueSet;
         float[] floatValues = blockValSet.getFloatValuesSV();
-        if (_nullHandlingEnabled) {
-          nullBitmap = blockValSet.getNullBitmap();
+        if (_nullMode.nullAtQueryTime()) {
+          nullBitmap = blockValSet.getNullBitmap(_nullMode);
         }
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
@@ -229,8 +230,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
       case DOUBLE:
         DoubleOpenHashSet doubleSet = (DoubleOpenHashSet) valueSet;
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        if (_nullHandlingEnabled) {
-          nullBitmap = blockValSet.getNullBitmap();
+        if (_nullMode.nullAtQueryTime()) {
+          nullBitmap = blockValSet.getNullBitmap(_nullMode);
         }
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
@@ -248,8 +249,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
         ObjectOpenHashSet<String> stringSet = (ObjectOpenHashSet<String>) valueSet;
         String[] stringValues = blockValSet.getStringValuesSV();
         //noinspection ManualArrayToCollectionCopy
-        if (_nullHandlingEnabled) {
-          nullBitmap = blockValSet.getNullBitmap();
+        if (_nullMode.nullAtQueryTime()) {
+          nullBitmap = blockValSet.getNullBitmap(_nullMode);
         }
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
@@ -266,8 +267,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
       case BYTES:
         ObjectOpenHashSet<ByteArray> bytesSet = (ObjectOpenHashSet<ByteArray>) valueSet;
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        if (_nullHandlingEnabled) {
-          nullBitmap = blockValSet.getNullBitmap();
+        if (_nullMode.nullAtQueryTime()) {
+          nullBitmap = blockValSet.getNullBitmap(_nullMode);
         }
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
@@ -373,8 +374,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
     // For dictionary-encoded expression, store dictionary ids into the bitmap
     Dictionary dictionary = blockValSet.getDictionary();
     if (dictionary != null) {
-      if (_nullHandlingEnabled) {
-        nullBitmap = blockValSet.getNullBitmap();
+      if (_nullMode.nullAtQueryTime()) {
+        nullBitmap = blockValSet.getNullBitmap(_nullMode);
       }
       int[] dictIds = blockValSet.getDictionaryIdsSV();
       if (nullBitmap != null && !nullBitmap.isEmpty()) {
@@ -396,8 +397,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        if (_nullHandlingEnabled) {
-          nullBitmap = blockValSet.getNullBitmap();
+        if (_nullMode.nullAtQueryTime()) {
+          nullBitmap = blockValSet.getNullBitmap(_nullMode);
         }
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
@@ -413,8 +414,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        if (_nullHandlingEnabled) {
-          nullBitmap = blockValSet.getNullBitmap();
+        if (_nullMode.nullAtQueryTime()) {
+          nullBitmap = blockValSet.getNullBitmap(_nullMode);
         }
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
@@ -430,8 +431,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        if (_nullHandlingEnabled) {
-          nullBitmap = blockValSet.getNullBitmap();
+        if (_nullMode.nullAtQueryTime()) {
+          nullBitmap = blockValSet.getNullBitmap(_nullMode);
         }
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
@@ -448,8 +449,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        if (_nullHandlingEnabled) {
-          nullBitmap = blockValSet.getNullBitmap();
+        if (_nullMode.nullAtQueryTime()) {
+          nullBitmap = blockValSet.getNullBitmap(_nullMode);
         }
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
@@ -467,8 +468,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        if (_nullHandlingEnabled) {
-          nullBitmap = blockValSet.getNullBitmap();
+        if (_nullMode.nullAtQueryTime()) {
+          nullBitmap = blockValSet.getNullBitmap(_nullMode);
         }
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
@@ -486,8 +487,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        if (_nullHandlingEnabled) {
-          nullBitmap = blockValSet.getNullBitmap();
+        if (_nullMode.nullAtQueryTime()) {
+          nullBitmap = blockValSet.getNullBitmap(_nullMode);
         }
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
@@ -596,8 +597,8 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
     // For dictionary-encoded expression, store dictionary ids into the bitmap
     Dictionary dictionary = blockValSet.getDictionary();
     if (dictionary != null) {
-      if (_nullHandlingEnabled) {
-        nullBitmap = blockValSet.getNullBitmap();
+      if (_nullMode.nullAtQueryTime()) {
+        nullBitmap = blockValSet.getNullBitmap(_nullMode);
       }
       int[] dictIds = blockValSet.getDictionaryIdsSV();
       if (nullBitmap != null && !nullBitmap.isEmpty()) {
@@ -619,7 +620,7 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
     switch (storedType) {
       case INT:
         int[] intValues = blockValSet.getIntValuesSV();
-        nullBitmap = blockValSet.getNullBitmap();
+        nullBitmap = blockValSet.getNullBitmap(_nullMode);
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
             if (!nullBitmap.contains(i)) {
@@ -634,7 +635,7 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
         break;
       case LONG:
         long[] longValues = blockValSet.getLongValuesSV();
-        nullBitmap = blockValSet.getNullBitmap();
+        nullBitmap = blockValSet.getNullBitmap(_nullMode);
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
             if (!nullBitmap.contains(i)) {
@@ -649,7 +650,7 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
         break;
       case FLOAT:
         float[] floatValues = blockValSet.getFloatValuesSV();
-        nullBitmap = blockValSet.getNullBitmap();
+        nullBitmap = blockValSet.getNullBitmap(_nullMode);
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
             if (!nullBitmap.contains(i)) {
@@ -664,7 +665,7 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
         break;
       case DOUBLE:
         double[] doubleValues = blockValSet.getDoubleValuesSV();
-        nullBitmap = blockValSet.getNullBitmap();
+        nullBitmap = blockValSet.getNullBitmap(_nullMode);
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
             if (!nullBitmap.contains(i)) {
@@ -679,7 +680,7 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
         break;
       case STRING:
         String[] stringValues = blockValSet.getStringValuesSV();
-        nullBitmap = blockValSet.getNullBitmap();
+        nullBitmap = blockValSet.getNullBitmap(_nullMode);
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
             if (!nullBitmap.contains(i)) {
@@ -694,7 +695,7 @@ public abstract class BaseDistinctAggregateAggregationFunction<T extends Compara
         break;
       case BYTES:
         byte[][] bytesValues = blockValSet.getBytesValuesSV();
-        nullBitmap = blockValSet.getNullBitmap();
+        nullBitmap = blockValSet.getNullBitmap(_nullMode);
         if (nullBitmap != null && !nullBitmap.isEmpty()) {
           for (int i = 0; i < length; i++) {
             if (!nullBitmap.contains(i)) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BooleanAndAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BooleanAndAggregationFunction.java
@@ -22,12 +22,13 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.util.List;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 public class BooleanAndAggregationFunction extends BaseBooleanAggregationFunction {
 
-  public BooleanAndAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
-    super(verifySingleArgument(arguments, "BOOL_AND"), nullHandlingEnabled, BooleanMerge.AND);
+  public BooleanAndAggregationFunction(List<ExpressionContext> arguments, NullMode nullMode) {
+    super(verifySingleArgument(arguments, "BOOL_AND"), nullMode, BooleanMerge.AND);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BooleanOrAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/BooleanOrAggregationFunction.java
@@ -22,12 +22,13 @@ package org.apache.pinot.core.query.aggregation.function;
 import java.util.List;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 public class BooleanOrAggregationFunction extends BaseBooleanAggregationFunction {
 
-  public BooleanOrAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
-    super(verifySingleArgument(arguments, "BOOL_OR"), nullHandlingEnabled, BooleanMerge.OR);
+  public BooleanOrAggregationFunction(List<ExpressionContext> arguments, NullMode nullMode) {
+    super(verifySingleArgument(arguments, "BOOL_OR"), nullMode, BooleanMerge.OR);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/CountMVAggregationFunction.java
@@ -26,13 +26,14 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 public class CountMVAggregationFunction extends CountAggregationFunction {
 
   public CountMVAggregationFunction(List<ExpressionContext> arguments) {
     // TODO(nhejazi): support proper null handling for aggregation functions on MV columns.
-    super(verifySingleArgument(arguments, "COUNT_MV"), false);
+    super(verifySingleArgument(arguments, "COUNT_MV"), NullMode.NONE_NULLABLE);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAvgAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAvgAggregationFunction.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 /**
@@ -34,8 +35,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
  */
 public class DistinctAvgAggregationFunction extends BaseDistinctAggregateAggregationFunction<Double> {
 
-  public DistinctAvgAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
-    super(verifySingleArgument(arguments, "DISTINCT_AVG"), AggregationFunctionType.DISTINCTAVG, nullHandlingEnabled);
+  public DistinctAvgAggregationFunction(List<ExpressionContext> arguments, NullMode nullMode) {
+    super(verifySingleArgument(arguments, "DISTINCT_AVG"), AggregationFunctionType.DISTINCTAVG, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAvgMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctAvgMVAggregationFunction.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 /**
@@ -35,7 +36,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 public class DistinctAvgMVAggregationFunction extends BaseDistinctAggregateAggregationFunction<Double> {
 
   public DistinctAvgMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "DISTINCT_AVG_MV"), AggregationFunctionType.DISTINCTAVGMV, false);
+    super(verifySingleArgument(arguments, "DISTINCT_AVG_MV"), AggregationFunctionType.DISTINCTAVGMV,
+        NullMode.NONE_NULLABLE);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountAggregationFunction.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 /**
@@ -34,9 +35,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
  */
 public class DistinctCountAggregationFunction extends BaseDistinctAggregateAggregationFunction<Integer> {
 
-  public DistinctCountAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
-    super(verifySingleArgument(arguments, "DISTINCT_COUNT"), AggregationFunctionType.DISTINCTCOUNT,
-        nullHandlingEnabled);
+  public DistinctCountAggregationFunction(List<ExpressionContext> arguments, NullMode nullMode) {
+    super(verifySingleArgument(arguments, "DISTINCT_COUNT"), AggregationFunctionType.DISTINCTCOUNT, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountMVAggregationFunction.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 /**
@@ -35,7 +36,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 public class DistinctCountMVAggregationFunction extends BaseDistinctAggregateAggregationFunction<Integer> {
 
   public DistinctCountMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "DISTINCT_COUNT_MV"), AggregationFunctionType.DISTINCTCOUNTMV, false);
+    super(verifySingleArgument(arguments, "DISTINCT_COUNT_MV"), AggregationFunctionType.DISTINCTCOUNTMV,
+        NullMode.NONE_NULLABLE);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctSumAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctSumAggregationFunction.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 /**
@@ -34,8 +35,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
  */
 public class DistinctSumAggregationFunction extends BaseDistinctAggregateAggregationFunction<Double> {
 
-  public DistinctSumAggregationFunction(List<ExpressionContext> arguments, boolean nullHandlingEnabled) {
-    super(verifySingleArgument(arguments, "DISTINCT_SUM"), AggregationFunctionType.DISTINCTSUM, nullHandlingEnabled);
+  public DistinctSumAggregationFunction(List<ExpressionContext> arguments, NullMode nullMode) {
+    super(verifySingleArgument(arguments, "DISTINCT_SUM"), AggregationFunctionType.DISTINCTSUM, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctSumMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctSumMVAggregationFunction.java
@@ -27,6 +27,7 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 /**
@@ -35,7 +36,8 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 public class DistinctSumMVAggregationFunction extends BaseDistinctAggregateAggregationFunction<Double> {
 
   public DistinctSumMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "DISTINCT_SUM_MV"), AggregationFunctionType.DISTINCTSUMMV, false);
+    super(verifySingleArgument(arguments, "DISTINCT_SUM_MV"), AggregationFunctionType.DISTINCTSUMMV,
+        NullMode.NONE_NULLABLE);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MaxMVAggregationFunction.java
@@ -25,12 +25,13 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 public class MaxMVAggregationFunction extends MaxAggregationFunction {
 
   public MaxMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "MAX_MV"), false);
+    super(verifySingleArgument(arguments, "MAX_MV"), NullMode.NONE_NULLABLE);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/MinMVAggregationFunction.java
@@ -25,12 +25,13 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 public class MinMVAggregationFunction extends MinAggregationFunction {
 
   public MinMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "MIN_MV"), false);
+    super(verifySingleArgument(arguments, "MIN_MV"), NullMode.NONE_NULLABLE);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/SumMVAggregationFunction.java
@@ -25,12 +25,13 @@ import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 
 
 public class SumMVAggregationFunction extends SumAggregationFunction {
 
   public SumMVAggregationFunction(List<ExpressionContext> arguments) {
-    super(verifySingleArgument(arguments, "SUM_MV"), false);
+    super(verifySingleArgument(arguments, "SUM_MV"), NullMode.NONE_NULLABLE);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctDoubleFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctDoubleFunction.java
@@ -23,12 +23,13 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public class ArrayAggDistinctDoubleFunction extends BaseArrayAggDoubleFunction<DoubleOpenHashSet> {
-  public ArrayAggDistinctDoubleFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, nullHandlingEnabled);
+  public ArrayAggDistinctDoubleFunction(ExpressionContext expression, NullMode nullMode) {
+    super(expression, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctFloatFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctFloatFunction.java
@@ -23,12 +23,13 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public class ArrayAggDistinctFloatFunction extends BaseArrayAggFloatFunction<FloatOpenHashSet> {
-  public ArrayAggDistinctFloatFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, nullHandlingEnabled);
+  public ArrayAggDistinctFloatFunction(ExpressionContext expression, NullMode nullMode) {
+    super(expression, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctIntFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctIntFunction.java
@@ -23,14 +23,15 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public class ArrayAggDistinctIntFunction extends BaseArrayAggIntFunction<IntOpenHashSet> {
   public ArrayAggDistinctIntFunction(ExpressionContext expression, FieldSpec.DataType dataType,
-      boolean nullHandlingEnabled) {
-    super(expression, dataType, nullHandlingEnabled);
+      NullMode nullMode) {
+    super(expression, dataType, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctLongFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctLongFunction.java
@@ -23,14 +23,15 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public class ArrayAggDistinctLongFunction extends BaseArrayAggLongFunction<LongOpenHashSet> {
   public ArrayAggDistinctLongFunction(ExpressionContext expression, FieldSpec.DataType dataType,
-      boolean nullHandlingEnabled) {
-    super(expression, dataType, nullHandlingEnabled);
+      NullMode nullMode) {
+    super(expression, dataType, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctStringFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDistinctStringFunction.java
@@ -24,12 +24,13 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public class ArrayAggDistinctStringFunction extends BaseArrayAggStringFunction<ObjectOpenHashSet<String>> {
-  public ArrayAggDistinctStringFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, nullHandlingEnabled);
+  public ArrayAggDistinctStringFunction(ExpressionContext expression, NullMode nullMode) {
+    super(expression, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDoubleFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggDoubleFunction.java
@@ -23,12 +23,13 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public class ArrayAggDoubleFunction extends BaseArrayAggDoubleFunction<DoubleArrayList> {
-  public ArrayAggDoubleFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, nullHandlingEnabled);
+  public ArrayAggDoubleFunction(ExpressionContext expression, NullMode nullMode) {
+    super(expression, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggFloatFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggFloatFunction.java
@@ -23,12 +23,13 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public class ArrayAggFloatFunction extends BaseArrayAggFloatFunction<FloatArrayList> {
-  public ArrayAggFloatFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, nullHandlingEnabled);
+  public ArrayAggFloatFunction(ExpressionContext expression, NullMode nullMode) {
+    super(expression, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggIntFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggIntFunction.java
@@ -23,13 +23,14 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public class ArrayAggIntFunction extends BaseArrayAggIntFunction<IntArrayList> {
-  public ArrayAggIntFunction(ExpressionContext expression, FieldSpec.DataType dataType, boolean nullHandlingEnabled) {
-    super(expression, dataType, nullHandlingEnabled);
+  public ArrayAggIntFunction(ExpressionContext expression, FieldSpec.DataType dataType, NullMode nullMode) {
+    super(expression, dataType, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggLongFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggLongFunction.java
@@ -23,13 +23,14 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public class ArrayAggLongFunction extends BaseArrayAggLongFunction<LongArrayList> {
-  public ArrayAggLongFunction(ExpressionContext expression, FieldSpec.DataType dataType, boolean nullHandlingEnabled) {
-    super(expression, dataType, nullHandlingEnabled);
+  public ArrayAggLongFunction(ExpressionContext expression, FieldSpec.DataType dataType, NullMode nullMode) {
+    super(expression, dataType, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggStringFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/ArrayAggStringFunction.java
@@ -24,12 +24,13 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.AggregationResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public class ArrayAggStringFunction extends BaseArrayAggStringFunction<ObjectArrayList<String>> {
-  public ArrayAggStringFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, nullHandlingEnabled);
+  public ArrayAggStringFunction(ExpressionContext expression, NullMode nullMode) {
+    super(expression, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggDoubleFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggDoubleFunction.java
@@ -23,14 +23,15 @@ import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public abstract class BaseArrayAggDoubleFunction<I extends AbstractDoubleCollection>
     extends BaseArrayAggFunction<I, DoubleArrayList> {
-  public BaseArrayAggDoubleFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, FieldSpec.DataType.DOUBLE, nullHandlingEnabled);
+  public BaseArrayAggDoubleFunction(ExpressionContext expression, NullMode nullMode) {
+    super(expression, FieldSpec.DataType.DOUBLE, nullMode);
   }
 
   abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, double value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggFloatFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggFloatFunction.java
@@ -23,14 +23,15 @@ import it.unimi.dsi.fastutil.floats.FloatArrayList;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public abstract class BaseArrayAggFloatFunction<I extends AbstractFloatCollection>
     extends BaseArrayAggFunction<I, FloatArrayList> {
-  public BaseArrayAggFloatFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, FieldSpec.DataType.FLOAT, nullHandlingEnabled);
+  public BaseArrayAggFloatFunction(ExpressionContext expression, NullMode nullMode) {
+    super(expression, FieldSpec.DataType.FLOAT, nullMode);
   }
 
   abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, float value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggFunction.java
@@ -28,18 +28,19 @@ import org.apache.pinot.core.query.aggregation.function.BaseSingleInputAggregati
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
 import org.apache.pinot.core.query.aggregation.groupby.ObjectGroupByResultHolder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public abstract class BaseArrayAggFunction<I, F extends Comparable> extends BaseSingleInputAggregationFunction<I, F> {
 
-  protected final boolean _nullHandlingEnabled;
+  protected final NullMode _nullMode;
   private final DataSchema.ColumnDataType _resultColumnType;
 
-  public BaseArrayAggFunction(ExpressionContext expression, FieldSpec.DataType dataType, boolean nullHandlingEnabled) {
+  public BaseArrayAggFunction(ExpressionContext expression, FieldSpec.DataType dataType, NullMode nullMode) {
     super(expression);
-    _nullHandlingEnabled = nullHandlingEnabled;
+    _nullMode = nullMode;
     _resultColumnType = DataSchema.ColumnDataType.fromDataTypeMV(dataType);
   }
 
@@ -72,8 +73,8 @@ public abstract class BaseArrayAggFunction<I, F extends Comparable> extends Base
   public void aggregate(int length, AggregationResultHolder aggregationResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
-    if (_nullHandlingEnabled) {
-      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
+    if (_nullMode.nullAtQueryTime()) {
+      RoaringBitmap nullBitmap = blockValSet.getNullBitmap(_nullMode);
       if (nullBitmap != null && !nullBitmap.isEmpty()) {
         aggregateArrayWithNull(length, aggregationResultHolder, blockValSet, nullBitmap);
         return;
@@ -92,8 +93,8 @@ public abstract class BaseArrayAggFunction<I, F extends Comparable> extends Base
   public void aggregateGroupBySV(int length, int[] groupKeyArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
-    if (_nullHandlingEnabled) {
-      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
+    if (_nullMode.nullAtQueryTime()) {
+      RoaringBitmap nullBitmap = blockValSet.getNullBitmap(_nullMode);
       if (nullBitmap != null && !nullBitmap.isEmpty()) {
         aggregateArrayGroupBySVWithNull(length, groupKeyArray, groupByResultHolder, blockValSet, nullBitmap);
         return;
@@ -112,8 +113,8 @@ public abstract class BaseArrayAggFunction<I, F extends Comparable> extends Base
   public void aggregateGroupByMV(int length, int[][] groupKeysArray, GroupByResultHolder groupByResultHolder,
       Map<ExpressionContext, BlockValSet> blockValSetMap) {
     BlockValSet blockValSet = blockValSetMap.get(_expression);
-    if (_nullHandlingEnabled) {
-      RoaringBitmap nullBitmap = blockValSet.getNullBitmap();
+    if (_nullMode.nullAtQueryTime()) {
+      RoaringBitmap nullBitmap = blockValSet.getNullBitmap(_nullMode);
       if (nullBitmap != null && !nullBitmap.isEmpty()) {
         aggregateArrayGroupByMVWithNull(length, groupKeysArray, groupByResultHolder, blockValSet, nullBitmap);
         return;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggIntFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggIntFunction.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntArrayList;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -30,8 +31,8 @@ import org.roaringbitmap.RoaringBitmap;
 public abstract class BaseArrayAggIntFunction<I extends AbstractIntCollection>
     extends BaseArrayAggFunction<I, IntArrayList> {
   public BaseArrayAggIntFunction(ExpressionContext expression, FieldSpec.DataType dataType,
-      boolean nullHandlingEnabled) {
-    super(expression, dataType, nullHandlingEnabled);
+      NullMode nullMode) {
+    super(expression, dataType, nullMode);
   }
 
   abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, int value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggLongFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggLongFunction.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.longs.LongArrayList;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -30,8 +31,8 @@ import org.roaringbitmap.RoaringBitmap;
 public abstract class BaseArrayAggLongFunction<I extends AbstractLongCollection>
     extends BaseArrayAggFunction<I, LongArrayList> {
   public BaseArrayAggLongFunction(ExpressionContext expression, FieldSpec.DataType dataType,
-      boolean nullHandlingEnabled) {
-    super(expression, dataType, nullHandlingEnabled);
+      NullMode nullMode) {
+    super(expression, dataType, nullMode);
   }
 
   abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, long value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggStringFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggStringFunction.java
@@ -23,14 +23,15 @@ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.roaringbitmap.RoaringBitmap;
 
 
 public abstract class BaseArrayAggStringFunction<I extends AbstractObjectCollection<String>>
     extends BaseArrayAggFunction<I, ObjectArrayList<String>> {
-  public BaseArrayAggStringFunction(ExpressionContext expression, boolean nullHandlingEnabled) {
-    super(expression, FieldSpec.DataType.STRING, nullHandlingEnabled);
+  public BaseArrayAggStringFunction(ExpressionContext expression, NullMode nullMode) {
+    super(expression, FieldSpec.DataType.STRING, nullMode);
   }
 
   abstract void setGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey, String value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/DistinctTable.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/DistinctTable.java
@@ -40,6 +40,7 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.common.datatable.DataTableBuilder;
 import org.apache.pinot.core.common.datatable.DataTableBuilderFactory;
 import org.apache.pinot.core.data.table.Record;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.RoaringBitmap;
@@ -77,11 +78,11 @@ public class DistinctTable {
    * Constructor of the main DistinctTable which can be used to add records and merge other DistinctTables.
    */
   public DistinctTable(DataSchema dataSchema, @Nullable List<OrderByExpressionContext> orderByExpressions, int limit,
-      boolean nullHandlingEnabled) {
+      NullMode nullMode) {
     _dataSchema = dataSchema;
     _isMainTable = true;
     _limit = limit;
-    _nullHandlingEnabled = nullHandlingEnabled;
+    _nullHandlingEnabled = nullMode.nullAtQueryTime();
 
     // NOTE: When LIMIT is smaller than or equal to the MAX_INITIAL_CAPACITY, no resize is required.
     int initialCapacity = Math.min(limit, DistinctExecutor.MAX_INITIAL_CAPACITY);
@@ -147,10 +148,10 @@ public class DistinctTable {
   /**
    * Constructor of the wrapper DistinctTable which can only be merged into the main DistinctTable.
    */
-  public DistinctTable(DataSchema dataSchema, Collection<Record> records, boolean nullHandlingEnabled) {
+  public DistinctTable(DataSchema dataSchema, Collection<Record> records, NullMode nullMode) {
     _dataSchema = dataSchema;
     _records = records;
-    _nullHandlingEnabled = nullHandlingEnabled;
+    _nullHandlingEnabled = nullMode.nullAtQueryTime();
     _isMainTable = false;
     _limit = Integer.MIN_VALUE;
     _recordSet = null;
@@ -161,7 +162,7 @@ public class DistinctTable {
    * Constructor of the wrapper DistinctTable which can only be merged into the main DistinctTable.
    */
   public DistinctTable(DataSchema dataSchema, Collection<Record> records) {
-    this(dataSchema, records, false);
+    this(dataSchema, records, NullMode.NONE_NULLABLE);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/dictionary/BaseDictionaryBasedSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/dictionary/BaseDictionaryBasedSingleColumnDistinctExecutor.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
 import org.apache.pinot.core.query.distinct.DistinctTable;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -41,17 +42,17 @@ abstract class BaseDictionaryBasedSingleColumnDistinctExecutor implements Distin
   final Dictionary _dictionary;
   final DataType _dataType;
   final int _limit;
-  final boolean _nullHandlingEnabled;
+  final NullMode _nullMode;
 
   final IntSet _dictIdSet;
 
   BaseDictionaryBasedSingleColumnDistinctExecutor(ExpressionContext expression, Dictionary dictionary,
-      DataType dataType, int limit, boolean nullHandlingEnabled) {
+      DataType dataType, int limit, NullMode nullMode) {
     _expression = expression;
     _dictionary = dictionary;
     _dataType = dataType;
     _limit = limit;
-    _nullHandlingEnabled = nullHandlingEnabled;
+    _nullMode = nullMode;
 
     _dictIdSet = new IntOpenHashSet(Math.min(limit, MAX_INITIAL_CAPACITY));
   }
@@ -65,6 +66,6 @@ abstract class BaseDictionaryBasedSingleColumnDistinctExecutor implements Distin
     while (dictIdIterator.hasNext()) {
       records.add(new Record(new Object[]{_dictionary.getInternal(dictIdIterator.nextInt())}));
     }
-    return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
+    return new DistinctTable(dataSchema, records, _nullMode);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/dictionary/DictionaryBasedSingleColumnDistinctOnlyExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/dictionary/DictionaryBasedSingleColumnDistinctOnlyExecutor.java
@@ -22,6 +22,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -33,7 +34,7 @@ public class DictionaryBasedSingleColumnDistinctOnlyExecutor extends BaseDiction
 
   public DictionaryBasedSingleColumnDistinctOnlyExecutor(ExpressionContext expression, Dictionary dictionary,
       DataType dataType, int limit) {
-    super(expression, dictionary, dataType, limit, false);
+    super(expression, dictionary, dataType, limit, NullMode.NONE_NULLABLE);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/dictionary/DictionaryBasedSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/dictionary/DictionaryBasedSingleColumnDistinctOrderByExecutor.java
@@ -25,6 +25,7 @@ import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
@@ -38,7 +39,7 @@ public class DictionaryBasedSingleColumnDistinctOrderByExecutor
 
   public DictionaryBasedSingleColumnDistinctOrderByExecutor(ExpressionContext expression, Dictionary dictionary,
       DataType dataType, OrderByExpressionContext orderByExpressionContext, int limit) {
-    super(expression, dictionary, dataType, limit, false);
+    super(expression, dictionary, dataType, limit, NullMode.NONE_NULLABLE);
 
     assert orderByExpressionContext.getExpression().equals(expression);
     int comparisonFactor = orderByExpressionContext.isAsc() ? -1 : 1;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBytesSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawBytesSingleColumnDistinctExecutor.java
@@ -30,6 +30,7 @@ import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
 import org.apache.pinot.core.query.distinct.DistinctTable;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.RoaringBitmap;
@@ -42,17 +43,17 @@ abstract class BaseRawBytesSingleColumnDistinctExecutor implements DistinctExecu
   final ExpressionContext _expression;
   final DataType _dataType;
   final int _limit;
-  final boolean _nullHandlingEnabled;
+  final NullMode _nullMode;
 
   final ObjectSet<ByteArray> _valueSet;
   private boolean _hasNull;
 
   BaseRawBytesSingleColumnDistinctExecutor(ExpressionContext expression, DataType dataType, int limit,
-      boolean nullHandlingEnabled) {
+      NullMode nullMode) {
     _expression = expression;
     _dataType = dataType;
     _limit = limit;
-    _nullHandlingEnabled = nullHandlingEnabled;
+    _nullMode = nullMode;
 
     _valueSet = new ObjectOpenHashSet<>(Math.min(limit, MAX_INITIAL_CAPACITY));
   }
@@ -69,7 +70,7 @@ abstract class BaseRawBytesSingleColumnDistinctExecutor implements DistinctExecu
       records.add(new Record(new Object[]{null}));
     }
     assert records.size() - (_hasNull ? 1 : 0) <= _limit;
-    return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
+    return new DistinctTable(dataSchema, records, _nullMode);
   }
 
   @Override
@@ -77,8 +78,8 @@ abstract class BaseRawBytesSingleColumnDistinctExecutor implements DistinctExecu
     BlockValSet blockValueSet = valueBlock.getBlockValueSet(_expression);
     byte[][] values = blockValueSet.getBytesValuesSV();
     int numDocs = valueBlock.getNumDocs();
-    if (_nullHandlingEnabled) {
-      RoaringBitmap nullBitmap = blockValueSet.getNullBitmap();
+    if (_nullMode.nullAtQueryTime()) {
+      RoaringBitmap nullBitmap = blockValueSet.getNullBitmap(_nullMode);
       for (int i = 0; i < numDocs; i++) {
         if (nullBitmap != null && nullBitmap.contains(i)) {
           _hasNull = true;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawFloatSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawFloatSingleColumnDistinctExecutor.java
@@ -31,6 +31,7 @@ import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
 import org.apache.pinot.core.query.distinct.DistinctTable;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -42,17 +43,17 @@ abstract class BaseRawFloatSingleColumnDistinctExecutor implements DistinctExecu
   final ExpressionContext _expression;
   final DataType _dataType;
   final int _limit;
-  final boolean _nullHandlingEnabled;
+  final NullMode _nullMode;
 
   final FloatSet _valueSet;
   protected boolean _hasNull;
 
   BaseRawFloatSingleColumnDistinctExecutor(ExpressionContext expression, DataType dataType, int limit,
-      boolean nullHandlingEnabled) {
+      NullMode nullMode) {
     _expression = expression;
     _dataType = dataType;
     _limit = limit;
-    _nullHandlingEnabled = nullHandlingEnabled;
+    _nullMode = nullMode;
 
     _valueSet = new FloatOpenHashSet(Math.min(limit, MAX_INITIAL_CAPACITY));
   }
@@ -70,7 +71,7 @@ abstract class BaseRawFloatSingleColumnDistinctExecutor implements DistinctExecu
       records.add(new Record(new Object[]{null}));
     }
     assert records.size() - (_hasNull ? 1 : 0) <= _limit;
-    return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
+    return new DistinctTable(dataSchema, records, _nullMode);
   }
 
   @Override
@@ -79,8 +80,8 @@ abstract class BaseRawFloatSingleColumnDistinctExecutor implements DistinctExecu
     int numDocs = valueBlock.getNumDocs();
     if (blockValueSet.isSingleValue()) {
       float[] values = blockValueSet.getFloatValuesSV();
-      if (_nullHandlingEnabled) {
-        RoaringBitmap nullBitmap = blockValueSet.getNullBitmap();
+      if (_nullMode.nullAtQueryTime()) {
+        RoaringBitmap nullBitmap = blockValueSet.getNullBitmap(_nullMode);
         for (int i = 0; i < numDocs; i++) {
           if (nullBitmap != null && nullBitmap.contains(i)) {
             _hasNull = true;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawLongSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawLongSingleColumnDistinctExecutor.java
@@ -31,6 +31,7 @@ import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
 import org.apache.pinot.core.query.distinct.DistinctTable;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -42,17 +43,17 @@ abstract class BaseRawLongSingleColumnDistinctExecutor implements DistinctExecut
   final ExpressionContext _expression;
   final DataType _dataType;
   final int _limit;
-  final boolean _nullHandlingEnabled;
+  final NullMode _nullMode;
 
   final LongSet _valueSet;
   protected boolean _hasNull;
 
   BaseRawLongSingleColumnDistinctExecutor(ExpressionContext expression, DataType dataType, int limit,
-      boolean nullHandlingEnabled) {
+      NullMode nullMode) {
     _expression = expression;
     _dataType = dataType;
     _limit = limit;
-    _nullHandlingEnabled = nullHandlingEnabled;
+    _nullMode = nullMode;
 
     _valueSet = new LongOpenHashSet(Math.min(limit, MAX_INITIAL_CAPACITY));
   }
@@ -70,7 +71,7 @@ abstract class BaseRawLongSingleColumnDistinctExecutor implements DistinctExecut
       records.add(new Record(new Object[]{null}));
     }
     assert records.size() - (_hasNull ? 1 : 0) <= _limit;
-    return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
+    return new DistinctTable(dataSchema, records, _nullMode);
   }
 
   @Override
@@ -79,8 +80,8 @@ abstract class BaseRawLongSingleColumnDistinctExecutor implements DistinctExecut
     int numDocs = valueBlock.getNumDocs();
     if (blockValueSet.isSingleValue()) {
       long[] values = blockValueSet.getLongValuesSV();
-      if (_nullHandlingEnabled) {
-        RoaringBitmap nullBitmap = blockValueSet.getNullBitmap();
+      if (_nullMode.nullAtQueryTime()) {
+        RoaringBitmap nullBitmap = blockValueSet.getNullBitmap(_nullMode);
         for (int i = 0; i < numDocs; i++) {
           if (nullBitmap != null && nullBitmap.contains(i)) {
             _hasNull = true;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawStringSingleColumnDistinctExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/BaseRawStringSingleColumnDistinctExecutor.java
@@ -30,6 +30,7 @@ import org.apache.pinot.core.data.table.Record;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
 import org.apache.pinot.core.query.distinct.DistinctTable;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.roaringbitmap.RoaringBitmap;
 
@@ -41,17 +42,17 @@ abstract class BaseRawStringSingleColumnDistinctExecutor implements DistinctExec
   final ExpressionContext _expression;
   final DataType _dataType;
   final int _limit;
-  final boolean _nullHandlingEnabled;
+  final NullMode _nullMode;
 
   final ObjectSet<String> _valueSet;
   private boolean _hasNull;
 
   BaseRawStringSingleColumnDistinctExecutor(ExpressionContext expression, DataType dataType, int limit,
-      boolean nullHandlingEnabled) {
+      NullMode nullMode) {
     _expression = expression;
     _dataType = dataType;
     _limit = limit;
-    _nullHandlingEnabled = nullHandlingEnabled;
+    _nullMode = nullMode;
 
     _valueSet = new ObjectOpenHashSet<>(Math.min(limit, MAX_INITIAL_CAPACITY));
   }
@@ -68,7 +69,7 @@ abstract class BaseRawStringSingleColumnDistinctExecutor implements DistinctExec
       records.add(new Record(new Object[]{null}));
     }
     assert records.size() - (_hasNull ? 1 : 0) <= _limit;
-    return new DistinctTable(dataSchema, records, _nullHandlingEnabled);
+    return new DistinctTable(dataSchema, records, _nullMode);
   }
 
   @Override
@@ -77,8 +78,8 @@ abstract class BaseRawStringSingleColumnDistinctExecutor implements DistinctExec
     int numDocs = valueBlock.getNumDocs();
     if (blockValueSet.isSingleValue()) {
       String[] values = blockValueSet.getStringValuesSV();
-      if (_nullHandlingEnabled) {
-        RoaringBitmap nullBitmap = blockValueSet.getNullBitmap();
+      if (_nullMode.nullAtQueryTime()) {
+        RoaringBitmap nullBitmap = blockValueSet.getNullBitmap(_nullMode);
         for (int i = 0; i < numDocs; i++) {
           if (nullBitmap != null && nullBitmap.contains(i)) {
             _hasNull = true;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBigDecimalSingleColumnDistinctOnlyExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBigDecimalSingleColumnDistinctOnlyExecutor.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.distinct.raw;
 import java.math.BigDecimal;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -30,8 +31,8 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 public class RawBigDecimalSingleColumnDistinctOnlyExecutor extends BaseRawBigDecimalSingleColumnDistinctExecutor {
 
   public RawBigDecimalSingleColumnDistinctOnlyExecutor(ExpressionContext expression, DataType dataType, int limit,
-      boolean nullHandlingEnabled) {
-    super(expression, dataType, limit, nullHandlingEnabled);
+      NullMode nullMode) {
+    super(expression, dataType, limit, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBigDecimalSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBigDecimalSingleColumnDistinctOrderByExecutor.java
@@ -24,6 +24,7 @@ import java.math.BigDecimal;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -34,8 +35,8 @@ public class RawBigDecimalSingleColumnDistinctOrderByExecutor extends BaseRawBig
   private final PriorityQueue<BigDecimal> _priorityQueue;
 
   public RawBigDecimalSingleColumnDistinctOrderByExecutor(ExpressionContext expression, DataType dataType,
-      OrderByExpressionContext orderByExpression, int limit, boolean nullHandlingEnabled) {
-    super(expression, dataType, limit, nullHandlingEnabled);
+      OrderByExpressionContext orderByExpression, int limit, NullMode nullMode) {
+    super(expression, dataType, limit, nullMode);
 
     assert orderByExpression.getExpression().equals(expression);
     int comparisonFactor = orderByExpression.isAsc() ? -1 : 1;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBytesSingleColumnDistinctOnlyExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBytesSingleColumnDistinctOnlyExecutor.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.distinct.raw;
 
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 
@@ -30,8 +31,8 @@ import org.apache.pinot.spi.utils.ByteArray;
 public class RawBytesSingleColumnDistinctOnlyExecutor extends BaseRawBytesSingleColumnDistinctExecutor {
 
   public RawBytesSingleColumnDistinctOnlyExecutor(ExpressionContext expression, DataType dataType, int limit,
-      boolean nullHandlingEnabled) {
-    super(expression, dataType, limit, nullHandlingEnabled);
+      NullMode nullMode) {
+    super(expression, dataType, limit, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBytesSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawBytesSingleColumnDistinctOrderByExecutor.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.objects.ObjectHeapPriorityQueue;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.ByteArray;
 
@@ -34,8 +35,8 @@ public class RawBytesSingleColumnDistinctOrderByExecutor extends BaseRawBytesSin
   private final PriorityQueue<ByteArray> _priorityQueue;
 
   public RawBytesSingleColumnDistinctOrderByExecutor(ExpressionContext expression, DataType dataType,
-      OrderByExpressionContext orderByExpression, int limit, boolean nullHandlingEnabled) {
-    super(expression, dataType, limit, nullHandlingEnabled);
+      OrderByExpressionContext orderByExpression, int limit, NullMode nullMode) {
+    super(expression, dataType, limit, nullMode);
 
     assert orderByExpression.getExpression().equals(expression);
     int comparisonFactor = orderByExpression.isAsc() ? -1 : 1;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawDoubleSingleColumnDistinctOnlyExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawDoubleSingleColumnDistinctOnlyExecutor.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.distinct.raw;
 
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -29,8 +30,8 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 public class RawDoubleSingleColumnDistinctOnlyExecutor extends BaseRawDoubleSingleColumnDistinctExecutor {
 
   public RawDoubleSingleColumnDistinctOnlyExecutor(ExpressionContext expression, DataType dataType, int limit,
-      boolean nullHandlingEnabled) {
-    super(expression, dataType, limit, nullHandlingEnabled);
+      NullMode nullMode) {
+    super(expression, dataType, limit, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawDoubleSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawDoubleSingleColumnDistinctOrderByExecutor.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.doubles.DoublePriorityQueue;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -33,8 +34,8 @@ public class RawDoubleSingleColumnDistinctOrderByExecutor extends BaseRawDoubleS
   private final DoublePriorityQueue _priorityQueue;
 
   public RawDoubleSingleColumnDistinctOrderByExecutor(ExpressionContext expression, DataType dataType,
-      OrderByExpressionContext orderByExpression, int limit, boolean nullHandlingEnabled) {
-    super(expression, dataType, limit, nullHandlingEnabled);
+      OrderByExpressionContext orderByExpression, int limit, NullMode nullMode) {
+    super(expression, dataType, limit, nullMode);
 
     assert orderByExpression.getExpression().equals(expression);
     int comparisonFactor = orderByExpression.isAsc() ? -1 : 1;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawFloatSingleColumnDistinctOnlyExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawFloatSingleColumnDistinctOnlyExecutor.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.distinct.raw;
 
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -29,8 +30,8 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 public class RawFloatSingleColumnDistinctOnlyExecutor extends BaseRawFloatSingleColumnDistinctExecutor {
 
   public RawFloatSingleColumnDistinctOnlyExecutor(ExpressionContext expression, DataType dataType, int limit,
-      boolean nullHandlingEnabled) {
-    super(expression, dataType, limit, nullHandlingEnabled);
+      NullMode nullMode) {
+    super(expression, dataType, limit, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawFloatSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawFloatSingleColumnDistinctOrderByExecutor.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.floats.FloatPriorityQueue;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -33,8 +34,8 @@ public class RawFloatSingleColumnDistinctOrderByExecutor extends BaseRawFloatSin
   private final FloatPriorityQueue _priorityQueue;
 
   public RawFloatSingleColumnDistinctOrderByExecutor(ExpressionContext expression, DataType dataType,
-      OrderByExpressionContext orderByExpression, int limit, boolean nullHandlingEnabled) {
-    super(expression, dataType, limit, nullHandlingEnabled);
+      OrderByExpressionContext orderByExpression, int limit, NullMode nullMode) {
+    super(expression, dataType, limit, nullMode);
 
     assert orderByExpression.getExpression().equals(expression);
     int comparisonFactor = orderByExpression.isAsc() ? -1 : 1;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawIntSingleColumnDistinctOnlyExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawIntSingleColumnDistinctOnlyExecutor.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.distinct.raw;
 
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -29,8 +30,8 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 public class RawIntSingleColumnDistinctOnlyExecutor extends BaseRawIntSingleColumnDistinctExecutor {
 
   public RawIntSingleColumnDistinctOnlyExecutor(ExpressionContext expression, DataType dataType, int limit,
-      boolean nullHandlingEnabled) {
-    super(expression, dataType, limit, nullHandlingEnabled);
+      NullMode nullMode) {
+    super(expression, dataType, limit, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawIntSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawIntSingleColumnDistinctOrderByExecutor.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntPriorityQueue;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -33,8 +34,8 @@ public class RawIntSingleColumnDistinctOrderByExecutor extends BaseRawIntSingleC
   private final IntPriorityQueue _priorityQueue;
 
   public RawIntSingleColumnDistinctOrderByExecutor(ExpressionContext expression, DataType dataType,
-      OrderByExpressionContext orderByExpression, int limit, boolean nullHandlingEnabled) {
-    super(expression, dataType, limit, nullHandlingEnabled);
+      OrderByExpressionContext orderByExpression, int limit, NullMode nullMode) {
+    super(expression, dataType, limit, nullMode);
 
     assert orderByExpression.getExpression().equals(expression);
     int comparisonFactor = orderByExpression.isAsc() ? -1 : 1;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawLongSingleColumnDistinctOnlyExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawLongSingleColumnDistinctOnlyExecutor.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.distinct.raw;
 
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -29,8 +30,8 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 public class RawLongSingleColumnDistinctOnlyExecutor extends BaseRawLongSingleColumnDistinctExecutor {
 
   public RawLongSingleColumnDistinctOnlyExecutor(ExpressionContext expression, DataType dataType, int limit,
-      boolean nullHandlingEnabled) {
-    super(expression, dataType, limit, nullHandlingEnabled);
+      NullMode nullMode) {
+    super(expression, dataType, limit, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawLongSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawLongSingleColumnDistinctOrderByExecutor.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.longs.LongPriorityQueue;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -33,8 +34,8 @@ public class RawLongSingleColumnDistinctOrderByExecutor extends BaseRawLongSingl
   private final LongPriorityQueue _priorityQueue;
 
   public RawLongSingleColumnDistinctOrderByExecutor(ExpressionContext expression, DataType dataType,
-      OrderByExpressionContext orderByExpression, int limit, boolean nullHandlingEnabled) {
-    super(expression, dataType, limit, nullHandlingEnabled);
+      OrderByExpressionContext orderByExpression, int limit, NullMode nullMode) {
+    super(expression, dataType, limit, nullMode);
 
     assert orderByExpression.getExpression().equals(expression);
     int comparisonFactor = orderByExpression.isAsc() ? -1 : 1;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawStringSingleColumnDistinctOnlyExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawStringSingleColumnDistinctOnlyExecutor.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.distinct.raw;
 
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -29,8 +30,8 @@ import org.apache.pinot.spi.data.FieldSpec.DataType;
 public class RawStringSingleColumnDistinctOnlyExecutor extends BaseRawStringSingleColumnDistinctExecutor {
 
   public RawStringSingleColumnDistinctOnlyExecutor(ExpressionContext expression, DataType dataType, int limit,
-      boolean nullHandlingEnabled) {
-    super(expression, dataType, limit, nullHandlingEnabled);
+      NullMode nullMode) {
+    super(expression, dataType, limit, nullMode);
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawStringSingleColumnDistinctOrderByExecutor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/distinct/raw/RawStringSingleColumnDistinctOrderByExecutor.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.objects.ObjectHeapPriorityQueue;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.query.distinct.DistinctExecutor;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
@@ -33,8 +34,8 @@ public class RawStringSingleColumnDistinctOrderByExecutor extends BaseRawStringS
   private final PriorityQueue<String> _priorityQueue;
 
   public RawStringSingleColumnDistinctOrderByExecutor(ExpressionContext expression, DataType dataType,
-      OrderByExpressionContext orderByExpression, int limit, boolean nullHandlingEnabled) {
-    super(expression, dataType, limit, nullHandlingEnabled);
+      OrderByExpressionContext orderByExpression, int limit, NullMode nullMode) {
+    super(expression, dataType, limit, nullMode);
 
     assert orderByExpression.getExpression().equals(expression);
     int comparisonFactor = orderByExpression.isAsc() ? -1 : 1;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/AggregationDataTableReducer.java
@@ -85,7 +85,7 @@ public class AggregationDataTableReducer implements DataTableReducer {
       for (int i = 0; i < numAggregationFunctions; i++) {
         Object intermediateResultToMerge;
         ColumnDataType columnDataType = dataSchema.getColumnDataType(i);
-        if (_queryContext.isNullHandlingEnabled()) {
+        if (_queryContext.getNullMode().nullAtQueryTime()) {
           RoaringBitmap nullBitmap = dataTable.getNullRowIds(i);
           if (nullBitmap != null && nullBitmap.contains(0)) {
             intermediateResultToMerge = null;
@@ -119,7 +119,7 @@ public class AggregationDataTableReducer implements DataTableReducer {
     Object[] finalResults = new Object[numAggregationFunctions];
     for (int i = 0; i < numAggregationFunctions; i++) {
       ColumnDataType columnDataType = dataSchema.getColumnDataType(i);
-      if (_queryContext.isNullHandlingEnabled()) {
+      if (_queryContext.getNullMode().nullAtQueryTime()) {
         RoaringBitmap nullBitmap = dataTable.getNullRowIds(i);
         if (nullBitmap != null && nullBitmap.contains(0)) {
           finalResults[i] = null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseGapfillProcessor.java
@@ -201,7 +201,7 @@ abstract class BaseGapfillProcessor {
       } else {
         FunctionContext functionContext = expressionContext.getFunction();
         AggregationFunction aggregationFunction =
-            AggregationFunctionFactory.getAggregationFunction(functionContext, _queryContext.isNullHandlingEnabled());
+            AggregationFunctionFactory.getAggregationFunction(functionContext, _queryContext.getNullMode());
         columnDataTypes[i] = aggregationFunction.getFinalResultColumnType();
         columnNames[i] = functionContext.toString();
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DistinctDataTableReducer.java
@@ -54,7 +54,7 @@ public class DistinctDataTableReducer implements DataTableReducer {
     dataSchema = ReducerDataSchemaUtils.canonicalizeDataSchemaForDistinct(_queryContext, dataSchema);
     DistinctTable distinctTable =
         new DistinctTable(dataSchema, _queryContext.getOrderByExpressions(), _queryContext.getLimit(),
-            _queryContext.isNullHandlingEnabled());
+            _queryContext.getNullMode());
     if (distinctTable.hasOrderBy()) {
       addToOrderByDistinctTable(dataSchema, dataTableMap, distinctTable);
     } else {
@@ -69,7 +69,7 @@ public class DistinctDataTableReducer implements DataTableReducer {
       Tracing.ThreadAccountantOps.sampleAndCheckInterruption();
       int numColumns = dataSchema.size();
       int numRows = dataTable.getNumberOfRows();
-      if (_queryContext.isNullHandlingEnabled()) {
+      if (_queryContext.getNullMode().nullAtQueryTime()) {
         RoaringBitmap[] nullBitmaps = new RoaringBitmap[numColumns];
         for (int coldId = 0; coldId < numColumns; coldId++) {
           nullBitmaps[coldId] = dataTable.getNullRowIds(coldId);
@@ -92,7 +92,7 @@ public class DistinctDataTableReducer implements DataTableReducer {
       Tracing.ThreadAccountantOps.sampleAndCheckInterruption();
       int numColumns = dataSchema.size();
       int numRows = dataTable.getNumberOfRows();
-      if (_queryContext.isNullHandlingEnabled()) {
+      if (_queryContext.getNullMode().nullAtQueryTime()) {
         RoaringBitmap[] nullBitmaps = new RoaringBitmap[numColumns];
         for (int coldId = 0; coldId < numColumns; coldId++) {
           nullBitmaps[coldId] = dataTable.getNullRowIds(coldId);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GapfillProcessor.java
@@ -274,7 +274,7 @@ public class GapfillProcessor extends BaseGapfillProcessor {
     for (int i = 1; i < dataSchema.getColumnNames().length; i++) {
       blockValSetMap.put(ExpressionContext.forIdentifier(dataSchema.getColumnName(i)),
           new RowBasedBlockValSet(dataSchema.getColumnDataType(i), bucketedRows, i,
-              _queryContext.isNullHandlingEnabled()));
+              _queryContext.getNullMode().nullAtQueryTime()));
     }
 
     for (int i = 0; i < _queryContext.getSelectExpressions().size(); i++) {
@@ -282,7 +282,7 @@ public class GapfillProcessor extends BaseGapfillProcessor {
       if (expressionContext.getType() == ExpressionContext.Type.FUNCTION) {
         FunctionContext functionContext = expressionContext.getFunction();
         AggregationFunction aggregationFunction =
-            AggregationFunctionFactory.getAggregationFunction(functionContext, _queryContext.isNullHandlingEnabled());
+            AggregationFunctionFactory.getAggregationFunction(functionContext, _queryContext.getNullMode());
         GroupByResultHolder groupByResultHolder =
             aggregationFunction.createGroupByResultHolder(groupKeyIndexes.size(), groupKeyIndexes.size());
         if (aggregationFunction instanceof CountAggregationFunction) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -171,7 +171,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
     if (havingFilter != null) {
       rows = new ArrayList<>();
       HavingFilterHandler havingFilterHandler =
-          new HavingFilterHandler(havingFilter, postAggregationHandler, _queryContext.isNullHandlingEnabled());
+          new HavingFilterHandler(havingFilter, postAggregationHandler, _queryContext.getNullMode().nullAtQueryTime());
       int processedRows = 0;
       while (rows.size() < limit && sortedIterator.hasNext()) {
         Object[] row = sortedIterator.next().getValues();
@@ -296,7 +296,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
           try {
             for (DataTable dataTable : reduceGroup) {
               try {
-                boolean nullHandlingEnabled = _queryContext.isNullHandlingEnabled();
+                boolean nullHandlingEnabled = _queryContext.getNullMode().nullAtQueryTime();
                 RoaringBitmap[] nullBitmaps = null;
                 if (nullHandlingEnabled) {
                   nullBitmaps = new RoaringBitmap[_numColumns];
@@ -428,7 +428,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
     if (havingFilter != null) {
       rows = new ArrayList<>();
       HavingFilterHandler havingFilterHandler =
-          new HavingFilterHandler(havingFilter, postAggregationHandler, _queryContext.isNullHandlingEnabled());
+          new HavingFilterHandler(havingFilter, postAggregationHandler, _queryContext.getNullMode().nullAtQueryTime());
       for (int i = 0; i < numRows; i++) {
         Object[] row = getConvertedRowWithFinalResult(dataTable, i);
         if (havingFilterHandler.isMatch(row)) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionDataTableReducer.java
@@ -60,7 +60,7 @@ public class SelectionDataTableReducer implements DataTableReducer {
     if (_queryContext.getOrderByExpressions() == null) {
       // Selection only
       List<Object[]> reducedRows = SelectionOperatorUtils.reduceWithoutOrdering(dataTableMap.values(), limit,
-          _queryContext.isNullHandlingEnabled());
+          _queryContext.getNullMode());
       brokerResponseNative.setResultTable(
           SelectionOperatorUtils.renderResultTableWithoutOrdering(reducedRows, pair.getLeft(), pair.getRight()));
     } else {

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionOnlyStreamingReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/SelectionOnlyStreamingReducer.java
@@ -29,6 +29,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.core.transport.ServerRoutingInstance;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -52,13 +53,13 @@ public class SelectionOnlyStreamingReducer implements StreamingReducer {
     // get dataSchema
     _dataSchema = _dataSchema == null ? dataTable.getDataSchema() : _dataSchema;
     // TODO: For data table map with more than one data tables, remove conflicting data tables
-    reduceWithoutOrdering(dataTable, _queryContext.getLimit(), _queryContext.isNullHandlingEnabled());
+    reduceWithoutOrdering(dataTable, _queryContext.getLimit(), _queryContext.getNullMode());
   }
 
-  private void reduceWithoutOrdering(DataTable dataTable, int limit, boolean nullHandlingEnabled) {
+  private void reduceWithoutOrdering(DataTable dataTable, int limit, NullMode nullMode) {
     int numColumns = dataTable.getDataSchema().size();
     int numRows = dataTable.getNumberOfRows();
-    if (nullHandlingEnabled) {
+    if (nullMode.nullAtQueryTime()) {
       RoaringBitmap[] nullBitmaps = new RoaringBitmap[numColumns];
       for (int coldId = 0; coldId < numColumns; coldId++) {
         nullBitmaps[coldId] = dataTable.getNullRowIds(coldId);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/ServerQueryRequest.java
@@ -108,7 +108,7 @@ public class ServerQueryRequest {
 
   private static QueryContext getQueryContext(PinotQuery pinotQuery) {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(pinotQuery);
-    if (queryContext.isNullHandlingEnabled()) {
+    if (queryContext.getNullMode().nullAtQueryTime()) {
       Preconditions.checkState(DataTableBuilderFactory.getDataTableVersion() >= DataTableFactory.VERSION_4,
           "Null handling cannot be enabled for data table version smaller than 4");
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorService.java
@@ -73,7 +73,7 @@ public class SelectionOperatorService {
     assert queryContext.getOrderByExpressions() != null;
     _rows = new PriorityQueue<>(Math.min(_numRowsToKeep, SelectionOperatorUtils.MAX_ROW_HOLDER_INITIAL_CAPACITY),
         OrderByComparatorFactory.getComparator(queryContext.getOrderByExpressions(),
-            _queryContext.isNullHandlingEnabled()).reversed());
+            _queryContext.getNullMode()).reversed());
   }
 
   /**
@@ -84,7 +84,7 @@ public class SelectionOperatorService {
   public void reduceWithOrdering(Collection<DataTable> dataTables) {
     for (DataTable dataTable : dataTables) {
       int numRows = dataTable.getNumberOfRows();
-      if (_queryContext.isNullHandlingEnabled()) {
+      if (_queryContext.getNullMode().nullAtQueryTime()) {
         RoaringBitmap[] nullBitmaps = new RoaringBitmap[dataTable.getDataSchema().size()];
         for (int colId = 0; colId < nullBitmaps.length; colId++) {
           nullBitmaps[colId] = dataTable.getNullRowIds(colId);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -354,6 +354,8 @@ public class SelectionOperatorUtils {
 
   /**
    * Build a {@link DataTable} from a {@link Collection} of selection rows with {@link DataSchema}. (Server side)
+   *
+   * This method is allowed to modify the given rows. Specifically, it may remove nulls cells from it.
    */
   public static DataTable getDataTableFromRows(Collection<Object[]> rows, DataSchema dataSchema,
       boolean nullHandlingEnabled)

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/utils/OrderByComparatorFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/utils/OrderByComparatorFactory.java
@@ -22,6 +22,7 @@ import java.util.Comparator;
 import java.util.List;
 import org.apache.pinot.common.request.context.OrderByExpressionContext;
 import org.apache.pinot.core.operator.ColumnContext;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 
 
@@ -33,8 +34,19 @@ public class OrderByComparatorFactory {
   }
 
   public static Comparator<Object[]> getComparator(List<OrderByExpressionContext> orderByExpressions,
+      ColumnContext[] orderByColumnContexts, NullMode nullMode) {
+    return getComparator(orderByExpressions, orderByColumnContexts, nullMode.nullAtQueryTime(), 0,
+        orderByExpressions.size());
+  }
+
+  public static Comparator<Object[]> getComparator(List<OrderByExpressionContext> orderByExpressions,
       ColumnContext[] orderByColumnContexts, boolean nullHandlingEnabled) {
     return getComparator(orderByExpressions, orderByColumnContexts, nullHandlingEnabled, 0, orderByExpressions.size());
+  }
+
+  public static Comparator<Object[]> getComparator(List<OrderByExpressionContext> orderByExpressions,
+      ColumnContext[] orderByColumnContexts, NullMode nullMode, int from, int to) {
+    return getComparator(orderByExpressions, orderByColumnContexts, nullMode.nullAtQueryTime(), from, to);
   }
 
   public static Comparator<Object[]> getComparator(List<OrderByExpressionContext> orderByExpressions,
@@ -55,8 +67,19 @@ public class OrderByComparatorFactory {
   }
 
   public static Comparator<Object[]> getComparator(List<OrderByExpressionContext> orderByExpressions,
+      NullMode nullMode) {
+    return getComparator(orderByExpressions, nullMode, 0, orderByExpressions.size());
+  }
+
+  public static Comparator<Object[]> getComparator(List<OrderByExpressionContext> orderByExpressions,
       boolean nullHandlingEnabled) {
     return getComparator(orderByExpressions, nullHandlingEnabled, 0, orderByExpressions.size());
+  }
+
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  public static Comparator<Object[]> getComparator(List<OrderByExpressionContext> orderByExpressions,
+      NullMode nullMode, int from, int to) {
+    return getComparator(orderByExpressions, nullMode.nullAtQueryTime(), from, to);
   }
 
   @SuppressWarnings({"rawtypes", "unchecked"})

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/operator/StarTreeFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/operator/StarTreeFilterOperator.java
@@ -44,6 +44,7 @@ import org.apache.pinot.core.operator.filter.predicate.PredicateEvaluator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.CompositePredicateEvaluator;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.startree.StarTree;
 import org.apache.pinot.segment.spi.index.startree.StarTreeNode;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
@@ -116,7 +117,7 @@ public class StarTreeFilterOperator extends BaseFilterOperator {
   public StarTreeFilterOperator(QueryContext queryContext, StarTreeV2 starTreeV2,
       Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap, @Nullable Set<String> groupByColumns) {
     // This filter operator does not support AND/OR/NOT operations.
-    super(0, false);
+    super(0, NullMode.NONE_NULLABLE);
     _queryContext = queryContext;
     _starTreeV2 = starTreeV2;
     _predicateEvaluatorsMap = predicateEvaluatorsMap;

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/AndFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/AndFilterOperatorTest.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.pinot.core.common.BlockDocIdIterator;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.Constants;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.Assert;
@@ -41,7 +42,7 @@ public class AndFilterOperatorTest {
     List<BaseFilterOperator> operators = new ArrayList<>();
     operators.add(new TestFilterOperator(docIds1, numDocs));
     operators.add(new TestFilterOperator(docIds2, numDocs));
-    AndFilterOperator andOperator = new AndFilterOperator(operators, null, numDocs, false);
+    AndFilterOperator andOperator = new AndFilterOperator(operators, null, numDocs, NullMode.NONE_NULLABLE);
 
     BlockDocIdIterator iterator = andOperator.nextBlock().getBlockDocIdSet().iterator();
     Assert.assertEquals(iterator.next(), 3);
@@ -60,7 +61,7 @@ public class AndFilterOperatorTest {
     operators.add(new TestFilterOperator(docIds1, numDocs));
     operators.add(new TestFilterOperator(docIds2, numDocs));
     operators.add(new TestFilterOperator(docIds3, numDocs));
-    AndFilterOperator andOperator = new AndFilterOperator(operators, null, numDocs, false);
+    AndFilterOperator andOperator = new AndFilterOperator(operators, null, numDocs, NullMode.NONE_NULLABLE);
 
     BlockDocIdIterator iterator = andOperator.nextBlock().getBlockDocIdSet().iterator();
     Assert.assertEquals(iterator.next(), 3);
@@ -78,12 +79,12 @@ public class AndFilterOperatorTest {
     List<BaseFilterOperator> childOperators = new ArrayList<>();
     childOperators.add(new TestFilterOperator(docIds1, numDocs));
     childOperators.add(new TestFilterOperator(docIds2, numDocs));
-    AndFilterOperator childAndOperator = new AndFilterOperator(childOperators, null, numDocs, false);
+    AndFilterOperator childAndOperator = new AndFilterOperator(childOperators, null, numDocs, NullMode.NONE_NULLABLE);
 
     List<BaseFilterOperator> operators = new ArrayList<>();
     operators.add(childAndOperator);
     operators.add(new TestFilterOperator(docIds3, numDocs));
-    AndFilterOperator andOperator = new AndFilterOperator(operators, null, numDocs, false);
+    AndFilterOperator andOperator = new AndFilterOperator(operators, null, numDocs, NullMode.NONE_NULLABLE);
 
     BlockDocIdIterator iterator = andOperator.nextBlock().getBlockDocIdSet().iterator();
     Assert.assertEquals(iterator.next(), 3);
@@ -118,8 +119,10 @@ public class AndFilterOperatorTest {
               numDocs));
     }
 
-    AndFilterOperator andFilterOperator1 = new AndFilterOperator(childOperators1, null, numDocs, false);
-    AndFilterOperator andFilterOperator2 = new AndFilterOperator(childOperators2, null, numDocs, false);
+    AndFilterOperator andFilterOperator1 = new AndFilterOperator(childOperators1, null, numDocs,
+        NullMode.NONE_NULLABLE);
+    AndFilterOperator andFilterOperator2 = new AndFilterOperator(childOperators2, null, numDocs,
+        NullMode.NONE_NULLABLE);
     BlockDocIdIterator iterator1 = andFilterOperator1.getNextBlock().getBlockDocIdSet().iterator();
     BlockDocIdIterator iterator2 = andFilterOperator2.getNextBlock().getBlockDocIdSet().iterator();
     Assert.assertEquals(iterator1.next(), 0);
@@ -147,12 +150,12 @@ public class AndFilterOperatorTest {
     List<BaseFilterOperator> childOperators = new ArrayList<>();
     childOperators.add(new TestFilterOperator(docIds3, numDocs));
     childOperators.add(new TestFilterOperator(docIds2, numDocs));
-    OrFilterOperator childOrOperator = new OrFilterOperator(childOperators, null, numDocs, false);
+    OrFilterOperator childOrOperator = new OrFilterOperator(childOperators, null, numDocs, NullMode.NONE_NULLABLE);
 
     List<BaseFilterOperator> operators = new ArrayList<>();
     operators.add(childOrOperator);
     operators.add(new TestFilterOperator(docIds1, numDocs));
-    AndFilterOperator andOperator = new AndFilterOperator(operators, null, numDocs, false);
+    AndFilterOperator andOperator = new AndFilterOperator(operators, null, numDocs, NullMode.NONE_NULLABLE);
 
     BlockDocIdIterator iterator = andOperator.nextBlock().getBlockDocIdSet().iterator();
     Assert.assertEquals(iterator.next(), 2);
@@ -172,7 +175,7 @@ public class AndFilterOperatorTest {
 
     AndFilterOperator andFilterOperator = new AndFilterOperator(
         Arrays.asList(new TestFilterOperator(docIds1, nullDocIds1, numDocs),
-            new TestFilterOperator(docIds2, nullDocIds2, numDocs)), null, numDocs, true);
+            new TestFilterOperator(docIds2, nullDocIds2, numDocs)), null, numDocs, NullMode.ALL_NULLABLE);
 
     Assert.assertEquals(TestUtils.getDocIds(andFilterOperator.getTrues()), ImmutableList.of(1, 2));
     Assert.assertEquals(TestUtils.getDocIds(andFilterOperator.getFalses()), ImmutableList.of(0, 7, 8, 9));
@@ -186,7 +189,7 @@ public class AndFilterOperatorTest {
 
     AndFilterOperator andFilterOperator = new AndFilterOperator(
         Arrays.asList(new TestFilterOperator(docIds1, nullDocIds1, numDocs), EmptyFilterOperator.getInstance()), null,
-        numDocs, true);
+        numDocs, NullMode.ALL_NULLABLE);
 
     Assert.assertEquals(TestUtils.getDocIds(andFilterOperator.getTrues()), Collections.emptyList());
     Assert.assertEquals(TestUtils.getDocIds(andFilterOperator.getFalses()),

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/FilterOperatorUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/FilterOperatorUtilsTest.java
@@ -27,6 +27,7 @@ import java.util.OptionalInt;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.FilterBlock;
 import org.apache.pinot.core.query.request.context.QueryContext;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
@@ -124,8 +125,8 @@ public class FilterOperatorUtilsTest {
     H3InclusionIndexFilterOperator h3Inclusion = mock(H3InclusionIndexFilterOperator.class);
     AndFilterOperator andFilterOperator = mock(AndFilterOperator.class);
     OrFilterOperator orFilterOperator = mock(OrFilterOperator.class);
-    NotFilterOperator notWithHighPriority = new NotFilterOperator(sorted, NUM_DOCS, false);
-    NotFilterOperator notWithLowPriority = new NotFilterOperator(orFilterOperator, NUM_DOCS, false);
+    NotFilterOperator notWithHighPriority = new NotFilterOperator(sorted, NUM_DOCS, NullMode.NONE_NULLABLE);
+    NotFilterOperator notWithLowPriority = new NotFilterOperator(orFilterOperator, NUM_DOCS, NullMode.NONE_NULLABLE);
 
     ExpressionFilterOperator expression = mock(ExpressionFilterOperator.class);
     BaseFilterOperator unknown = mock(BaseFilterOperator.class);
@@ -188,7 +189,7 @@ public class FilterOperatorUtilsTest {
       implements PrioritizedFilterOperator<FilterBlock> {
     public MockedPrioritizedFilterOperator() {
       // This filter operator does not support AND/OR/NOT operations.
-      super(0, false);
+      super(0, NullMode.NONE_NULLABLE);
     }
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/NotFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/NotFilterOperatorTest.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.segment.spi.Constants;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -36,7 +37,8 @@ public class NotFilterOperatorTest {
     int[] docIds1 = new int[]{2, 3, 10, 15, 16, 17, 18, 21, 22, 23, 24, 26, 28};
     List<Integer> expectedResult = Arrays.asList(0, 1, 4, 5, 6, 7, 8, 9, 11, 12, 13, 14, 19, 20, 25, 27, 29);
     Iterator<Integer> expectedIterator = expectedResult.iterator();
-    NotFilterOperator notFilterOperator = new NotFilterOperator(new TestFilterOperator(docIds1, 30), 30, false);
+    NotFilterOperator notFilterOperator = new NotFilterOperator(new TestFilterOperator(docIds1, 30), 30,
+        NullMode.NONE_NULLABLE);
     BlockDocIdIterator iterator = notFilterOperator.nextBlock().getBlockDocIdSet().iterator();
     int docId;
     while ((docId = iterator.next()) != Constants.EOF) {
@@ -51,7 +53,7 @@ public class NotFilterOperatorTest {
     int[] nullDocIds = new int[]{4, 5, 6};
 
     NotFilterOperator notFilterOperator =
-        new NotFilterOperator(new TestFilterOperator(docIds, nullDocIds, numDocs), numDocs, true);
+        new NotFilterOperator(new TestFilterOperator(docIds, nullDocIds, numDocs), numDocs, NullMode.ALL_NULLABLE);
 
     Assert.assertEquals(TestUtils.getDocIds(notFilterOperator.getTrues()), ImmutableList.of(7, 8, 9));
     Assert.assertEquals(TestUtils.getDocIds(notFilterOperator.getFalses()), ImmutableList.of(0, 1, 2, 3));
@@ -61,7 +63,8 @@ public class NotFilterOperatorTest {
   public void testNotEmptyFilterOperator() {
     int numDocs = 5;
 
-    NotFilterOperator notFilterOperator = new NotFilterOperator(EmptyFilterOperator.getInstance(), numDocs, true);
+    NotFilterOperator notFilterOperator = new NotFilterOperator(EmptyFilterOperator.getInstance(), numDocs,
+        NullMode.ALL_NULLABLE);
 
     Assert.assertEquals(TestUtils.getDocIds(notFilterOperator.getTrues()), ImmutableList.of(0, 1, 2, 3, 4));
     Assert.assertEquals(TestUtils.getDocIds(notFilterOperator.getFalses()), Collections.emptyList());

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/OrFilterOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/filter/OrFilterOperatorTest.java
@@ -27,6 +27,7 @@ import java.util.TreeSet;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pinot.core.common.BlockDocIdIterator;
 import org.apache.pinot.segment.spi.Constants;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.testng.Assert;
 import org.testng.annotations.Test;
 
@@ -46,7 +47,7 @@ public class OrFilterOperatorTest {
     List<BaseFilterOperator> operators = new ArrayList<>();
     operators.add(new TestFilterOperator(docIds1, numDocs));
     operators.add(new TestFilterOperator(docIds2, numDocs));
-    OrFilterOperator orOperator = new OrFilterOperator(operators, null, numDocs, false);
+    OrFilterOperator orOperator = new OrFilterOperator(operators, null, numDocs, NullMode.NONE_NULLABLE);
 
     BlockDocIdIterator iterator = orOperator.nextBlock().getBlockDocIdSet().iterator();
     int docId;
@@ -71,7 +72,7 @@ public class OrFilterOperatorTest {
     operators.add(new TestFilterOperator(docIds1, numDocs));
     operators.add(new TestFilterOperator(docIds2, numDocs));
     operators.add(new TestFilterOperator(docIds3, numDocs));
-    OrFilterOperator orOperator = new OrFilterOperator(operators, null, numDocs, false);
+    OrFilterOperator orOperator = new OrFilterOperator(operators, null, numDocs, NullMode.NONE_NULLABLE);
 
     BlockDocIdIterator iterator = orOperator.nextBlock().getBlockDocIdSet().iterator();
     int docId;
@@ -95,12 +96,12 @@ public class OrFilterOperatorTest {
     List<BaseFilterOperator> childOperators = new ArrayList<>();
     childOperators.add(new TestFilterOperator(docIds1, numDocs));
     childOperators.add(new TestFilterOperator(docIds2, numDocs));
-    OrFilterOperator childOrOperator = new OrFilterOperator(childOperators, null, numDocs, false);
+    OrFilterOperator childOrOperator = new OrFilterOperator(childOperators, null, numDocs, NullMode.NONE_NULLABLE);
 
     List<BaseFilterOperator> operators = new ArrayList<>();
     operators.add(childOrOperator);
     operators.add(new TestFilterOperator(docIds3, numDocs));
-    OrFilterOperator orOperator = new OrFilterOperator(operators, null, numDocs, false);
+    OrFilterOperator orOperator = new OrFilterOperator(operators, null, numDocs, NullMode.NONE_NULLABLE);
 
     BlockDocIdIterator iterator = orOperator.nextBlock().getBlockDocIdSet().iterator();
     int docId;
@@ -119,7 +120,7 @@ public class OrFilterOperatorTest {
 
     OrFilterOperator orFilterOperator = new OrFilterOperator(
         Arrays.asList(new TestFilterOperator(docIds1, nullDocIds1, numDocs),
-            new TestFilterOperator(docIds2, nullDocIds2, numDocs)), null, numDocs, true);
+            new TestFilterOperator(docIds2, nullDocIds2, numDocs)), null, numDocs, NullMode.ALL_NULLABLE);
 
     Assert.assertEquals(TestUtils.getDocIds(orFilterOperator.getTrues()), ImmutableList.of(0, 1, 2, 3));
     Assert.assertEquals(TestUtils.getDocIds(orFilterOperator.getFalses()), ImmutableList.of(8, 9));
@@ -133,7 +134,7 @@ public class OrFilterOperatorTest {
 
     OrFilterOperator orFilterOperator = new OrFilterOperator(
         Arrays.asList(new TestFilterOperator(docIds1, nullDocIds1, numDocs), EmptyFilterOperator.getInstance()), null,
-        numDocs, true);
+        numDocs, NullMode.ALL_NULLABLE);
 
     Assert.assertEquals(TestUtils.getDocIds(orFilterOperator.getTrues()), Arrays.asList(1, 2, 3));
     Assert.assertEquals(TestUtils.getDocIds(orFilterOperator.getFalses()), Arrays.asList(0, 7, 8, 9));

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/query/SelectionOrderByOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/query/SelectionOrderByOperatorTest.java
@@ -29,6 +29,7 @@ import org.apache.pinot.core.operator.BaseProjectOperator;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.plan.ProjectPlanNode;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
@@ -83,7 +84,7 @@ public class SelectionOrderByOperatorTest {
             + "FROM testTable "
             + "ORDER BY col1, col2 "
             + "LIMIT 1");
-    queryContext.setNullHandlingEnabled(true);
+    queryContext.setNullMode(NullMode.ALL_NULLABLE);
     List<Object[]> rows = executeQuery(queryContext);
     assertNull(rows.get(0)[0], "Column 'col1' value should be 'null' when null handling is enabled");
     assertNull(rows.get(0)[1], "Column 'col2' value should be 'null' when null handling is enabled");
@@ -96,7 +97,7 @@ public class SelectionOrderByOperatorTest {
             + "FROM testTable "
             + "ORDER BY col1, col2 "
             + "LIMIT 1");
-    queryContext.setNullHandlingEnabled(false);
+    queryContext.setNullMode(NullMode.NONE_NULLABLE);
     List<Object[]> rows = executeQuery(queryContext);
     assertNotNull(rows.get(0)[0], "Column 'col1' value should not be 'null' when null handling is disabled");
     assertNotNull(rows.get(0)[1], "Column 'col2' value should not be 'null' when null handling is disabled");
@@ -109,7 +110,7 @@ public class SelectionOrderByOperatorTest {
             + "FROM testTable "
             + "ORDER BY col1 "
             + "LIMIT 1");
-    queryContext.setNullHandlingEnabled(true);
+    queryContext.setNullMode(NullMode.ALL_NULLABLE);
     List<Object[]> rows = executeQuery(queryContext);
     assertNull(rows.get(0)[0], "Column 'col1' value should be 'null' when null handling is enabled");
     assertNull(rows.get(0)[1], "Column 'col2' value should be 'null' when null handling is enabled");
@@ -122,7 +123,7 @@ public class SelectionOrderByOperatorTest {
             + "FROM testTable "
             + "ORDER BY col1 "
             + "LIMIT 1");
-    queryContext.setNullHandlingEnabled(false);
+    queryContext.setNullMode(NullMode.NONE_NULLABLE);
     List<Object[]> rows = executeQuery(queryContext);
     assertNotNull(rows.get(0)[0], "Column 'col1' value should not be 'null' when null handling is disabled");
     assertNotNull(rows.get(0)[1], "Column 'col2' value should not be 'null' when null handling is disabled");

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyOperatorTest.java
@@ -28,6 +28,7 @@ import org.apache.pinot.core.operator.BaseProjectOperator;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.plan.DocIdSetPlanNode;
 import org.apache.pinot.core.plan.ProjectPlanNode;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
@@ -73,7 +74,7 @@ public class StreamingSelectionOnlyOperatorTest {
   public void testNullHandling() {
     QueryContext queryContext =
         QueryContextConverterUtils.getQueryContext("SELECT * FROM testTable WHERE intColumn IS NULL");
-    queryContext.setNullHandlingEnabled(true);
+    queryContext.setNullMode(NullMode.ALL_NULLABLE);
     List<ExpressionContext> expressions =
         SelectionOperatorUtils.extractExpressions(queryContext, _segmentWithNullValues);
     BaseProjectOperator<?> projectOperator = new ProjectPlanNode(_segmentWithNullValues, queryContext, expressions,

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/transform/function/IdentifierTransformFunctionTest.java
@@ -23,6 +23,7 @@ import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ProjectionBlock;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.mockito.Mock;
@@ -82,6 +83,9 @@ public class IdentifierTransformFunctionTest {
     when(_projectionBlock.getNumDocs()).thenReturn(NUM_DOCS);
     when(_blockValSet.getIntValuesSV()).thenReturn(INT_VALUES);
     when(_blockValSet.getNullBitmap()).thenReturn(NULL_BITMAP);
+    when(_blockValSet.getNullBitmap(NullMode.NONE_NULLABLE)).thenReturn(null);
+    when(_blockValSet.getNullBitmap(NullMode.ALL_NULLABLE)).thenReturn(NULL_BITMAP);
+    when(_blockValSet.getNullBitmap(NullMode.COLUMN_BASED)).thenReturn(NULL_BITMAP);
     when(_projectionBlock.getBlockValueSet(TEST_COLUMN_NAME)).thenReturn(_blockValSet);
     when(_columnContext.getDataSource()).thenReturn(_dataSource);
     when(_dataSource.getDictionary()).thenReturn(_dictionary);
@@ -99,7 +103,7 @@ public class IdentifierTransformFunctionTest {
   @Test
   public void testNullBitmap() {
     IdentifierTransformFunction identifierTransformFunction =
-        new IdentifierTransformFunction(TEST_COLUMN_NAME, _columnContext);
+        new IdentifierTransformFunction(TEST_COLUMN_NAME, _columnContext, NullMode.ALL_NULLABLE);
     RoaringBitmap bitmap = identifierTransformFunction.getNullBitmap(_projectionBlock);
     Assert.assertEquals(bitmap, NULL_BITMAP);
     Assert.assertEquals(identifierTransformFunction.transformToIntValuesSV(_projectionBlock), INT_VALUES);

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionFactoryTest.java
@@ -21,6 +21,7 @@ package org.apache.pinot.core.query.aggregation.function;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
@@ -35,433 +36,505 @@ public class AggregationFunctionFactoryTest {
   @Test
   public void testGetAggregationFunction() {
     FunctionContext function = getFunction("CoUnT", ARGUMENT_STAR);
-    AggregationFunction aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    AggregationFunction aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof CountAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.COUNT);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("MiN");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof MinAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.MIN);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("MaX");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof MaxAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.MAX);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("SuM");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof SumAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.SUM);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("SuMPreCIsiON");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof SumPrecisionAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.SUMPRECISION);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("AvG");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof AvgAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVG);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("MoDe");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof ModeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.MODE);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("FiRsTwItHtImE", "(column,timeColumn,'BOOLEAN')");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof FirstIntValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.FIRSTWITHTIME);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("FiRsTwItHtImE", "(column,timeColumn,'INT')");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof FirstIntValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.FIRSTWITHTIME);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("FiRsTwItHtImE", "(column,timeColumn,'LONG')");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof FirstLongValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.FIRSTWITHTIME);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("FiRsTwItHtImE", "(column,timeColumn,'FLOAT')");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof FirstFloatValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.FIRSTWITHTIME);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("FiRsTwItHtImE", "(column,timeColumn,'DOUBLE')");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof FirstDoubleValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.FIRSTWITHTIME);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("FiRsTwItHtImE", "(column,timeColumn,'STRING')");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof FirstStringValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.FIRSTWITHTIME);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("LaStWiThTiMe", "(column,timeColumn,'BOOLEAN')");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof LastIntValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.LASTWITHTIME);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("LaStWiThTiMe", "(column,timeColumn,'INT')");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof LastIntValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.LASTWITHTIME);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("LaStWiThTiMe", "(column,timeColumn,'LONG')");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof LastLongValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.LASTWITHTIME);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("LaStWiThTiMe", "(column,timeColumn,'FLOAT')");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof LastFloatValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.LASTWITHTIME);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("LaStWiThTiMe", "(column,timeColumn,'DOUBLE')");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof LastDoubleValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.LASTWITHTIME);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("LaStWiThTiMe", "(column,timeColumn,'STRING')");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof LastStringValueWithTimeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.LASTWITHTIME);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("MiNmAxRaNgE");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof MinMaxRangeAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMAXRANGE);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnT");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof DistinctCountAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNT);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnThLl");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof DistinctCountHLLAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLL);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnTrAwHlL");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof DistinctCountRawHLLAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTRAWHLL);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnThLlPlUs");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof DistinctCountHLLPlusAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLLPLUS);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnTrAwHlLpLuS");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof DistinctCountRawHLLPlusAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTRAWHLLPLUS);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("FaStHlL");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof FastHLLAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.FASTHLL);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLe5");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILE);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLeEsT50");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileEstAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEEST);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLeRaWEsT50");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileRawEstAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILERAWEST);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLeTdIgEsT99");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGEST);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLeRaWTdIgEsT99");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileRawTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILERAWTDIGEST);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLe", "(column, 5)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILE);
     assertEquals(aggregationFunction.getResultColumnName(), "percentile(column, 5.0)");
 
     function = getFunction("PeRcEnTiLe", "(column, 5.5)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILE);
     assertEquals(aggregationFunction.getResultColumnName(), "percentile(column, 5.5)");
 
     function = getFunction("PeRcEnTiLeEsT", "(column, 50)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileEstAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEEST);
     assertEquals(aggregationFunction.getResultColumnName(), "percentileest(column, 50.0)");
 
     function = getFunction("PeRcEnTiLeRaWeSt", "(column, 50)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileRawEstAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILERAWEST);
     assertEquals(aggregationFunction.getResultColumnName(), "percentilerawest(column, 50.0)");
 
     function = getFunction("PeRcEnTiLeEsT", "(column, 55.555)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileEstAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEEST);
     assertEquals(aggregationFunction.getResultColumnName(), "percentileest(column, 55.555)");
 
     function = getFunction("PeRcEnTiLeRaWeSt", "(column, 55.555)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileRawEstAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILERAWEST);
     assertEquals(aggregationFunction.getResultColumnName(), "percentilerawest(column, 55.555)");
 
     function = getFunction("PeRcEnTiLeTdIgEsT", "(column, 99)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGEST);
     assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigest(column, 99.0)");
 
     function = getFunction("PeRcEnTiLeTdIgEsT", "(column, 99.9999)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGEST);
     assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigest(column, 99.9999)");
 
     function = getFunction("PeRcEnTiLeTdIgEsT", "(column, 99.9999, 1000)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGEST);
     assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigest(column, 99.9999, 1000)");
 
     function = getFunction("PeRcEnTiLeRaWtDiGeSt", "(column, 99)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileRawTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILERAWTDIGEST);
     assertEquals(aggregationFunction.getResultColumnName(), "percentilerawtdigest(column, 99.0)");
 
     function = getFunction("PeRcEnTiLeRaWtDiGeSt", "(column, 99.9999)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileRawTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILERAWTDIGEST);
     assertEquals(aggregationFunction.getResultColumnName(), "percentilerawtdigest(column, 99.9999)");
 
     function = getFunction("PeRcEntiLEkll", "(column, 99.9999)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileKLLAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEKLL);
     assertEquals(aggregationFunction.getResultColumnName(), "percentilekll(column, 99.9999)");
 
     function = getFunction("PeRcEnTiLeRaWtDiGeSt", "(column, 99.9999, 500)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileRawTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILERAWTDIGEST);
     assertEquals(aggregationFunction.getResultColumnName(), "percentilerawtdigest(column, 99.9999, 500)");
 
     function = getFunction("PeRcEnTiLeRaWtDiGeSt", "(column, 99.9999, 100)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileRawTDigestAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILERAWTDIGEST);
     assertEquals(aggregationFunction.getResultColumnName(), "percentilerawtdigest(column, 99.9999)");
 
     function = getFunction("CoUnTmV");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof CountMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.COUNTMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("MiNmV");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof MinMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("MaXmV");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof MaxMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.MAXMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("SuMmV");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof SumMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.SUMMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("AvGmV");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof AvgMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVGMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("AvG_mV");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof AvgMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.AVGMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("MiNmAxRaNgEmV");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof MinMaxRangeMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.MINMAXRANGEMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnTmV");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof DistinctCountMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnThLlMv");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof DistinctCountHLLMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLLMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCt_CoUnT_hLl_Mv");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof DistinctCountHLLMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLLMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnTrAwHlLmV");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof DistinctCountRawHLLMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTRAWHLLMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCt_CoUnT_hLl_PlUs_Mv");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof DistinctCountHLLPlusMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTHLLPLUSMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("DiStInCtCoUnTrAwHlLpLuS_mV");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof DistinctCountRawHLLPlusMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.DISTINCTCOUNTRAWHLLPLUSMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLe10Mv");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLeEsT90mV");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileEstMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEESTMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLeTdIgEsT95mV");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLe_TdIgEsT_95_mV");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("PeRcEnTiLeMv", "(column, 10)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEMV);
     assertEquals(aggregationFunction.getResultColumnName(), "percentilemv(column, 10.0)");
 
     function = getFunction("PeRcEnTiLeEsTmV", "(column, 90)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileEstMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILEESTMV);
     assertEquals(aggregationFunction.getResultColumnName(), "percentileestmv(column, 90.0)");
 
     function = getFunction("PeRcEnTiLeTdIgEsTmV", "(column, 95)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
     assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigestmv(column, 95.0)");
 
     function = getFunction("PeRcEnTiLeTdIgEsTmV", "(column, 95, 1000)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
     assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigestmv(column, 95.0, 1000)");
 
     function = getFunction("PeRcEnTiLe_TdIgEsT_mV", "(column, 95)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
     assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigestmv(column, 95.0)");
 
     function = getFunction("PeRcEnTiLe_TdIgEsT_mV", "(column, 95, 200)");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof PercentileTDigestMVAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.PERCENTILETDIGESTMV);
     assertEquals(aggregationFunction.getResultColumnName(), "percentiletdigestmv(column, 95.0, 200)");
 
     function = getFunction("bool_and");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof BooleanAndAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.BOOLAND);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("bool_or");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof BooleanOrAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.BOOLOR);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("skewness");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof FourthMomentAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.SKEWNESS);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());
 
     function = getFunction("kurtosis");
-    aggregationFunction = AggregationFunctionFactory.getAggregationFunction(function, false);
+    aggregationFunction =
+        AggregationFunctionFactory.getAggregationFunction(function, NullMode.NONE_NULLABLE);
     assertTrue(aggregationFunction instanceof FourthMomentAggregationFunction);
     assertEquals(aggregationFunction.getType(), AggregationFunctionType.KURTOSIS);
     assertEquals(aggregationFunction.getResultColumnName(), function.toString());

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
@@ -43,6 +43,7 @@ import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationD
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -199,14 +200,14 @@ public class NoDictionaryGroupKeyGeneratorTest {
     if (numGroupByColumns == 1) {
       groupKeyGenerator = new NoDictionarySingleColumnGroupKeyGenerator(_projectOperator,
           ExpressionContext.forIdentifier(COLUMNS.get(groupByColumnIndexes[0])),
-          InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, false);
+          InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, NullMode.NONE_NULLABLE);
     } else {
       ExpressionContext[] groupByExpressions = new ExpressionContext[numGroupByColumns];
       for (int i = 0; i < numGroupByColumns; i++) {
         groupByExpressions[i] = ExpressionContext.forIdentifier(COLUMNS.get(groupByColumnIndexes[i]));
       }
       groupKeyGenerator = new NoDictionaryMultiColumnGroupKeyGenerator(_projectOperator, groupByExpressions,
-          InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, false);
+          InstancePlanMakerImplV2.DEFAULT_NUM_GROUPS_LIMIT, NullMode.NONE_NULLABLE);
     }
     groupKeyGenerator.generateKeysForBlock(_valueBlock, new int[NUM_RECORDS]);
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOperatorServiceTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/selection/SelectionOperatorServiceTest.java
@@ -31,6 +31,7 @@ import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.core.query.utils.OrderByComparatorFactory;
@@ -202,7 +203,7 @@ public class SelectionOperatorServiceTest {
     Collection<Object[]> rows = new ArrayList<>(2);
     rows.add(_row1);
     rows.add(_row2);
-    DataTable dataTable = SelectionOperatorUtils.getDataTableFromRows(rows, _dataSchema, false);
+    DataTable dataTable = SelectionOperatorUtils.getDataTableFromRows(rows, _dataSchema, NullMode.NONE_NULLABLE);
     assertTrue(Arrays.deepEquals(SelectionOperatorUtils.extractRowFromDataTable(dataTable, 0), _row1));
     assertTrue(Arrays.deepEquals(SelectionOperatorUtils.extractRowFromDataTable(dataTable, 1), _row2));
   }

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkAndDocIdIterator.java
@@ -25,6 +25,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.pinot.core.operator.filter.AndFilterOperator;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.operator.filter.BitmapBasedFilterOperator;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.openjdk.jmh.annotations.Benchmark;
 import org.openjdk.jmh.annotations.BenchmarkMode;
 import org.openjdk.jmh.annotations.Level;
@@ -61,7 +62,9 @@ public class BenchmarkAndDocIdIterator {
   @OutputTimeUnit(TimeUnit.MILLISECONDS)
   public void benchAndFilterOperator(MyState myState, Blackhole bh) {
     for (int i = 0; i < 100; i++) {
-      bh.consume(new AndFilterOperator(myState._childOperators, null, NUM_DOCS, false).nextBlock().getBlockDocIdSet()
+      bh.consume(new AndFilterOperator(myState._childOperators, null, NUM_DOCS, NullMode.NONE_NULLABLE)
+          .nextBlock()
+          .getBlockDocIdSet()
           .iterator());
     }
   }
@@ -72,7 +75,9 @@ public class BenchmarkAndDocIdIterator {
   public void benchAndFilterOperatorDegenerate(MyState myState, Blackhole bh) {
     for (int i = 0; i < 100; i++) {
       bh.consume(
-          new AndFilterOperator(myState._childOperatorsNoOrdering, null, NUM_DOCS, false).nextBlock().getBlockDocIdSet()
+          new AndFilterOperator(myState._childOperatorsNoOrdering, null, NUM_DOCS, NullMode.NONE_NULLABLE)
+              .nextBlock()
+              .getBlockDocIdSet()
               .iterator());
     }
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
@@ -57,7 +57,7 @@ public class TypeFactory extends JavaTypeFactoryImpl {
     if (isArray) {
       type = createArrayType(type, -1);
     }
-    boolean isNullable = fieldSpec.getNullable() != null && fieldSpec.getNullable();
+    boolean isNullable = fieldSpec.getNullable();
     if (isNullable) {
       type = createTypeWithNullability(type, true);
     }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
@@ -31,8 +31,8 @@ import org.apache.pinot.spi.data.Schema;
  * Extends Java-base TypeFactory from Calcite.
  *
  * <p>{@link JavaTypeFactoryImpl} is used here because we are not overriding much of the TypeFactory methods
- * required by Calcite. We will start extending {@link SqlTypeFactoryImpl} or even {@link RelDataTypeFactory}
- * when necessary for Pinot to override such mechanism.
+ * required by Calcite. We will start extending {@link org.apache.calcite.sql.type.SqlTypeFactoryImpl} or even
+ * {@link org.apache.calcite.rel.type.RelDataTypeFactory} when necessary for Pinot to override such mechanism.
  *
  * <p>Noted that {@link JavaTypeFactoryImpl} is subject to change. Please pay extra attention to this class when
  * upgrading Calcite versions.
@@ -52,13 +52,24 @@ public class TypeFactory extends JavaTypeFactoryImpl {
   }
 
   private RelDataType toRelDataType(FieldSpec fieldSpec) {
+    RelDataType type = createSqlType(getSqlTypeName(fieldSpec));
+    boolean isArray = !fieldSpec.isSingleValueField();
+    if (isArray) {
+      type = createArrayType(type, -1);
+    }
+    boolean isNullable = fieldSpec.getNullable() != null && fieldSpec.getNullable();
+    if (isNullable) {
+      type = createTypeWithNullability(type, true);
+    }
+    return type;
+  }
+
+  private SqlTypeName getSqlTypeName(FieldSpec fieldSpec) {
     switch (fieldSpec.getDataType()) {
       case INT:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.INTEGER)
-            : createArrayType(createSqlType(SqlTypeName.INTEGER), -1);
+        return SqlTypeName.INTEGER;
       case LONG:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.BIGINT)
-            : createArrayType(createSqlType(SqlTypeName.BIGINT), -1);
+        return SqlTypeName.BIGINT;
       // Map float and double to the same RelDataType so that queries like
       // `select count(*) from table where aFloatColumn = 0.05` works correctly in multi-stage query engine.
       //
@@ -71,34 +82,32 @@ public class TypeFactory extends JavaTypeFactoryImpl {
       // With float and double mapped to the same RelDataType, the behavior in multi-stage query engine will be the same
       // as the query in v1 query engine.
       case FLOAT:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.DOUBLE)
-            : createArrayType(createSqlType(SqlTypeName.REAL), -1);
+        if (fieldSpec.isSingleValueField()) {
+          return SqlTypeName.DOUBLE;
+        } else {
+          // TODO: This may be wrong. The reason why we want to use DOUBLE in single value float may also apply here
+          return SqlTypeName.REAL;
+        }
       case DOUBLE:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.DOUBLE)
-            : createArrayType(createSqlType(SqlTypeName.DOUBLE), -1);
+        return SqlTypeName.DOUBLE;
       case BOOLEAN:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.BOOLEAN)
-            : createArrayType(createSqlType(SqlTypeName.BOOLEAN), -1);
+        return SqlTypeName.BOOLEAN;
       case TIMESTAMP:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.TIMESTAMP)
-            : createArrayType(createSqlType(SqlTypeName.TIMESTAMP), -1);
+        return SqlTypeName.TIMESTAMP;
       case STRING:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.VARCHAR)
-            : createArrayType(createSqlType(SqlTypeName.VARCHAR), -1);
+        return SqlTypeName.VARCHAR;
       case BYTES:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.VARBINARY)
-            : createArrayType(createSqlType(SqlTypeName.VARBINARY), -1);
+        return SqlTypeName.VARBINARY;
       case BIG_DECIMAL:
-        return fieldSpec.isSingleValueField() ? createSqlType(SqlTypeName.DECIMAL)
-            : createArrayType(createSqlType(SqlTypeName.DECIMAL), -1);
+        return SqlTypeName.DECIMAL;
       case JSON:
-        return createSqlType(SqlTypeName.VARCHAR);
+        return SqlTypeName.VARCHAR;
       case LIST:
         // TODO: support LIST, MV column should go fall into this category.
       case STRUCT:
       case MAP:
       default:
-        String message = String.format("Unsupported type: %s ", fieldSpec.getDataType().toString());
+        String message = String.format("Unsupported type: %s ", fieldSpec.getDataType());
         throw new UnsupportedOperationException(message);
     }
   }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeSystem.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeSystem.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.type;
 
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
@@ -30,7 +31,8 @@ import org.apache.calcite.sql.type.SqlTypeUtil;
  */
 public class TypeSystem extends RelDataTypeSystemImpl {
   private static final int MAX_DECIMAL_SCALE = 1000;
-  private static final int MAX_DECIMAL_PRECISION = 1000;
+  @VisibleForTesting
+  static final int MAX_DECIMAL_PRECISION = 1000;
 
   /**
    * Default precision for derived arithmetic decimal types(plus/multiply/divide/mod). We won't allow the return

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeSystem.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeSystem.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.query.type;
 
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.calcite.rel.type.RelDataType;
 import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.rel.type.RelDataTypeSystemImpl;
@@ -31,8 +30,7 @@ import org.apache.calcite.sql.type.SqlTypeUtil;
  */
 public class TypeSystem extends RelDataTypeSystemImpl {
   private static final int MAX_DECIMAL_SCALE = 1000;
-  @VisibleForTesting
-  static final int MAX_DECIMAL_PRECISION = 1000;
+  private static final int MAX_DECIMAL_PRECISION = 1000;
 
   /**
    * Default precision for derived arithmetic decimal types(plus/multiply/divide/mod). We won't allow the return

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -219,7 +219,6 @@ public class QueryEnvironmentTestBase {
         Collections.emptyMap());
   }
 
-
   public static QueryEnvironment getQueryEnvironment(int reducerPort, int port1, int port2,
       Map<String, Schema> schemaMap, Map<String, List<String>> segmentMap1, Map<String, List<String>> segmentMap2,
       @Nullable Map<String, Pair<String, List<List<String>>>> partitionedSegmentsMap,

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryEnvironmentTestBase.java
@@ -215,9 +215,18 @@ public class QueryEnvironmentTestBase {
   public static QueryEnvironment getQueryEnvironment(int reducerPort, int port1, int port2,
       Map<String, Schema> schemaMap, Map<String, List<String>> segmentMap1, Map<String, List<String>> segmentMap2,
       @Nullable Map<String, Pair<String, List<List<String>>>> partitionedSegmentsMap) {
+    return getQueryEnvironment(reducerPort, port1, port2, schemaMap, segmentMap1, segmentMap2, partitionedSegmentsMap,
+        Collections.emptyMap());
+  }
+
+
+  public static QueryEnvironment getQueryEnvironment(int reducerPort, int port1, int port2,
+      Map<String, Schema> schemaMap, Map<String, List<String>> segmentMap1, Map<String, List<String>> segmentMap2,
+      @Nullable Map<String, Pair<String, List<List<String>>>> partitionedSegmentsMap,
+      Map<String, Boolean> nullHandlingMap) {
     MockRoutingManagerFactory factory = new MockRoutingManagerFactory(port1, port2);
     for (Map.Entry<String, Schema> entry : schemaMap.entrySet()) {
-      factory.registerTable(entry.getValue(), entry.getKey());
+      factory.registerTable(entry.getValue(), entry.getKey(), nullHandlingMap.getOrDefault(entry.getKey(), false));
     }
     for (Map.Entry<String, List<String>> entry : segmentMap1.entrySet()) {
       for (String segment : entry.getValue()) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/queries/ResourceBasedQueryPlansTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/queries/ResourceBasedQueryPlansTest.java
@@ -45,12 +45,14 @@ public class ResourceBasedQueryPlansTest extends QueryEnvironmentTestBase {
   private static final String FILE_FILTER_PROPERTY = "pinot.fileFilter";
 
   @Test(dataProvider = "testResourceQueryPlannerTestCaseProviderHappyPath")
-  public void testQueryExplainPlansAndQueryPlanConversion(String testCaseName, String query, String output) {
+  public void testQueryExplainPlansAndQueryPlanConversion(String testCaseName, String description, String query,
+      String output) {
     try {
       long requestId = RANDOM_REQUEST_ID_GEN.nextLong();
       String explainedPlan = _queryEnvironment.explainQuery(query, requestId);
       Assert.assertEquals(explainedPlan, output,
-          String.format("Test case %s for query %s doesn't match expected output: %s", testCaseName, query, output));
+          String.format("Test case %s for query %s (%s) doesn't match expected output: %s", testCaseName, description,
+              query, output));
       String queryWithoutExplainPlan = query.replace("EXPLAIN PLAN FOR ", "");
       DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(queryWithoutExplainPlan);
       Assert.assertNotNull(dispatchableSubPlan,
@@ -102,7 +104,7 @@ public class ResourceBasedQueryPlansTest extends QueryEnvironmentTestBase {
           String sql = queryCase._sql;
           List<String> orgOutput = queryCase._output;
           String concatenatedOutput = StringUtils.join(orgOutput, "");
-          Object[] testEntry = new Object[]{testCaseName, sql, concatenatedOutput};
+          Object[] testEntry = new Object[]{testCaseName, queryCase._description, sql, concatenatedOutput};
           providerContent.add(testEntry);
         }
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -50,6 +50,7 @@ import org.apache.pinot.query.planner.plannode.AggregateNode.AggType;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
 import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.roaringbitmap.RoaringBitmap;
 
 
@@ -61,7 +62,8 @@ import org.roaringbitmap.RoaringBitmap;
 public class AggregateOperator extends MultiStageOperator {
   private static final String EXPLAIN_NAME = "AGGREGATE_OPERATOR";
   private static final CountAggregationFunction COUNT_STAR_AGG_FUNCTION =
-      new CountAggregationFunction(Collections.singletonList(ExpressionContext.forIdentifier("*")), false);
+      new CountAggregationFunction(Collections.singletonList(ExpressionContext.forIdentifier("*")),
+          NullMode.NONE_NULLABLE);
   private static final ExpressionContext PLACEHOLDER_IDENTIFIER = ExpressionContext.forIdentifier("__PLACEHOLDER__");
 
   private final MultiStageOperator _inputOperator;
@@ -248,7 +250,7 @@ public class AggregateOperator extends MultiStageOperator {
     }
 
     return AggregationFunctionFactory.getAggregationFunction(
-        new FunctionContext(FunctionContext.Type.AGGREGATION, functionName, arguments), true);
+        new FunctionContext(FunctionContext.Type.AGGREGATION, functionName, arguments), NullMode.ALL_NULLABLE);
   }
 
   private static AggregationFunction<?, ?> getAggFunctionForIntermediateInput(RexExpression.FunctionCall functionCall,
@@ -266,7 +268,7 @@ public class AggregateOperator extends MultiStageOperator {
       return AggregationFunctionFactory.getAggregationFunction(
           new FunctionContext(FunctionContext.Type.AGGREGATION, functionName, Collections.singletonList(
               ExpressionContext.forIdentifier(fromColIdToIdentifier(((RexExpression.InputRef) operand).getIndex())))),
-          true);
+          NullMode.ALL_NULLABLE);
     } else {
       int numExpectedArguments = numArgumentsLiteral.getIntValue();
       List<ExpressionContext> arguments = new ArrayList<>(numExpectedArguments);
@@ -281,7 +283,7 @@ public class AggregateOperator extends MultiStageOperator {
         }
       }
       return AggregationFunctionFactory.getAggregationFunction(
-          new FunctionContext(FunctionContext.Type.AGGREGATION, functionName, arguments), true);
+          new FunctionContext(FunctionContext.Type.AGGREGATION, functionName, arguments), NullMode.ALL_NULLABLE);
     }
   }
 

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/QueryRunnerTest.java
@@ -168,7 +168,7 @@ public class QueryRunnerTest extends QueryRunnerTestBase {
     ResultTable resultTable = queryRunner(sql, null);
     // query H2 for data
     List<Object[]> expectedRows = queryH2(sql);
-    compareRowEquals(resultTable, expectedRows);
+    compareRowEquals(resultTable, expectedRows, sql);
   }
 
   /**

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/queries/ResourceBasedQueriesTest.java
@@ -59,6 +59,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.Assert;
+import org.testng.SkipException;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.DataProvider;
@@ -258,6 +259,9 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
   public void testQueryTestCasesWithH2(String testCaseName, String description, String sql, String h2Sql, String expect,
       boolean keepOutputRowOrder, boolean isIgnored)
       throws Exception {
+    if (isIgnored) {
+      throw new SkipException("Test " + testCaseName + " with description " + description + " ignored");
+    }
     // query pinot
     runQuery(sql, expect, null).ifPresent(resultTable -> {
       try {
@@ -272,6 +276,9 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
   public void testQueryTestCasesWithOutput(String testCaseName, String description, String sql,
       String h2Sql, List<Object[]> expectedRows, String expect, boolean keepOutputRowOrder, boolean isIgnored)
       throws Exception {
+    if (isIgnored) {
+      throw new SkipException("Test " + testCaseName + " with description " + description + " ignored");
+    }
     runQuery(sql, expect, null).ifPresent(
         resultTable -> compareRowEquals(resultTable, expectedRows, sql, keepOutputRowOrder));
   }
@@ -280,6 +287,9 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
   public void testQueryTestCasesWithMetadata(String testCaseName, String description, String sql,
       String h2Sql, String expect, int numSegments, boolean isIgnored)
       throws Exception {
+    if (isIgnored) {
+      throw new SkipException("Test " + testCaseName + " with description " + description + " ignored");
+    }
     Map<Integer, ExecutionStatsAggregator> executionStatsAggregatorMap = new HashMap<>();
     runQuery(sql, expect, executionStatsAggregatorMap).ifPresent(resultTable -> {
       BrokerResponseNativeV2 brokerResponseNative = new BrokerResponseNativeV2();
@@ -367,10 +377,6 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
 
       List<QueryTestCase.Query> queryCases = testCaseEntry.getValue()._queries;
       for (QueryTestCase.Query queryCase : queryCases) {
-        if (queryCase._ignored && !_isRunIgnored) {
-          continue;
-        }
-
         if (queryCase._outputs != null) {
           String sql = replaceTableName(testCaseName, queryCase._sql);
           String h2Sql = queryCase._h2Sql != null ? replaceTableName(testCaseName, queryCase._h2Sql)
@@ -382,7 +388,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
           }
           Object[] testEntry = new Object[]{
               testCaseName, queryCase._description, sql, h2Sql, expectedRows, queryCase._expectedException,
-              queryCase._keepOutputRowOrder, queryCase._ignored,
+              queryCase._keepOutputRowOrder, queryCase._ignored && !_isRunIgnored
           };
           providerContent.add(testEntry);
         }
@@ -411,11 +417,6 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
 
       List<QueryTestCase.Query> queryCases = testCaseEntry.getValue()._queries;
       for (QueryTestCase.Query queryCase : queryCases) {
-
-        if (queryCase._ignored && !_isRunIgnored) {
-          continue;
-        }
-
         if (queryCase._outputs == null) {
           String sql = replaceTableName(testCaseName, queryCase._sql);
           String h2Sql = queryCase._h2Sql != null ? replaceTableName(testCaseName, queryCase._h2Sql)
@@ -430,7 +431,7 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
 
           Object[] testEntry = new Object[]{
               testCaseName, queryCase._description, sql, h2Sql, queryCase._expectedException, segmentCount,
-              queryCase._ignored
+              queryCase._ignored && !_isRunIgnored
           };
           providerContent.add(testEntry);
         }
@@ -452,16 +453,13 @@ public class ResourceBasedQueriesTest extends QueryRunnerTestBase {
       String testCaseName = testCaseEntry.getKey();
       List<QueryTestCase.Query> queryCases = testCaseEntry.getValue()._queries;
       for (QueryTestCase.Query queryCase : queryCases) {
-        if (queryCase._ignored && !_isRunIgnored) {
-          continue;
-        }
         if (queryCase._outputs == null) {
           String sql = replaceTableName(testCaseName, queryCase._sql);
           String h2Sql = queryCase._h2Sql != null ? replaceTableName(testCaseName, queryCase._h2Sql)
               : replaceTableName(testCaseName, queryCase._sql);
           Object[] testEntry = new Object[]{
               testCaseName, queryCase._description, sql, h2Sql, queryCase._expectedException,
-              queryCase._keepOutputRowOrder, queryCase._ignored
+              queryCase._keepOutputRowOrder, queryCase._ignored && !_isRunIgnored
           };
           providerContent.add(testEntry);
         }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
@@ -175,7 +175,7 @@ public class MockInstanceDataManagerFactory {
     // TODO: plugin table config constructor
     TableConfig tableConfig =
         new TableConfigBuilder(tableType).setTableName(rawTableName).setTimeColumnName("ts")
-            .setNullHandlingEnabled(true)
+            .setNullHandlingEnabled(_nullHandlingMap.getOrDefault(tableNameWithType, false))
             .build();
     Schema schema = _schemaMap.get(rawTableName);
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
@@ -187,7 +187,7 @@ public class MockInstanceDataManagerFactory {
     try (RecordReader recordReader = new GenericRowRecordReader(rows)) {
       driver.init(config, recordReader);
       driver.build();
-      return ImmutableSegmentLoader.load(new File(indexDir, segmentName), ReadMode.mmap);
+      return ImmutableSegmentLoader.load(new File(indexDir, segmentName), ReadMode.mmap, schema, tableConfig);
     } catch (Exception e) {
       throw new RuntimeException("Unable to construct immutable segment from records", e);
     }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
@@ -60,6 +60,7 @@ public class MockInstanceDataManagerFactory {
 
   // Key is raw table name
   private final Map<String, List<GenericRow>> _tableRowsMap;
+  private final Map<String, Boolean> _nullHandlingMap;
   private final Map<String, Schema> _schemaMap;
 
   // Key is registered table (with or without type)
@@ -75,6 +76,7 @@ public class MockInstanceDataManagerFactory {
     _tableRowsMap = new HashMap<>();
     _schemaMap = new HashMap<>();
     _registeredSchemaMap = new HashMap<>();
+    _nullHandlingMap = new HashMap<>();
   }
 
   public void registerTable(Schema schema, String tableName) {
@@ -87,6 +89,11 @@ public class MockInstanceDataManagerFactory {
       registerTableNameWithType(schema, TableNameBuilder.OFFLINE.tableNameWithType(tableName));
       registerTableNameWithType(schema, TableNameBuilder.REALTIME.tableNameWithType(tableName));
     }
+  }
+
+  public MockInstanceDataManagerFactory setNullHandlingForTable(String tableName) {
+    _nullHandlingMap.put(tableName, true);
+    return this;
   }
 
   private void registerTableNameWithType(Schema schema, String tableNameWithType) {
@@ -138,6 +145,10 @@ public class MockInstanceDataManagerFactory {
     return _schemaMap;
   }
 
+  public Map<String, Boolean> buildNullHandlingTableMap() {
+    return _nullHandlingMap;
+  }
+
   public Map<String, List<GenericRow>> buildTableRowsMap() {
     return _tableRowsMap;
   }
@@ -163,7 +174,9 @@ public class MockInstanceDataManagerFactory {
     TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
     // TODO: plugin table config constructor
     TableConfig tableConfig =
-        new TableConfigBuilder(tableType).setTableName(rawTableName).setTimeColumnName("ts").build();
+        new TableConfigBuilder(tableType).setTableName(rawTableName).setTimeColumnName("ts")
+            .setNullHandlingEnabled(true)
+            .build();
     Schema schema = _schemaMap.get(rawTableName);
     SegmentGeneratorConfig config = new SegmentGeneratorConfig(tableConfig, schema);
     config.setOutDir(indexDir.getPath());

--- a/pinot-query-runtime/src/test/resources/queries/CountDistinct.json
+++ b/pinot-query-runtime/src/test/resources/queries/CountDistinct.json
@@ -119,11 +119,13 @@
       {
         "comments": "table aren't actually partitioned by val thus all segments can produce duplicate results, thus [[8]]",
         "sql": "SELECT SEGMENT_PARTITIONED_DISTINCT_COUNT(val) FROM {tbl1}",
+        "ignored": true,
         "outputs": [[8]]
       },
       {
         "comments": "table aren't actually partitioned by val thus all segments can produce duplicate results, thus [[b, 5], [a, 4]]",
         "sql": "SELECT groupingCol, SEGMENT_PARTITIONED_DISTINCT_COUNT(val) FROM {tbl1} GROUP BY groupingCol",
+        "ignored": true,
         "outputs": [["b", 5], ["a", 4]]
       },
       {
@@ -137,6 +139,7 @@
       {
         "comments": "table aren't actually partitioned by val thus all segments can produce duplicate results, thus [[b, 5], [a, 4]]",
         "sql": "SELECT /*+ aggOptions(is_skip_leaf_stage_aggregate='true') */ groupingCol, SEGMENT_PARTITIONED_DISTINCT_COUNT(val) FROM {tbl1} GROUP BY groupingCol",
+        "ignored": true,
         "outputs": [["b", 5], ["a", 4]]
       },
       {

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -67,6 +67,98 @@
       }
     ]
   },
+  "nullable_columns_when_nullHandling_disabled": {
+    "tables": {
+      "tbl1" : {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "intCol1", "type": "INT"},
+          {"name": "nIntCol1", "type": "INT", "nullable": true},
+          {"name": "nnIntCol1", "type": "INT", "nullable": false},
+          {"name": "strCol2", "type": "STRING"},
+          {"name": "nStrCol2", "type": "STRING", "nullable": true},
+          {"name": "nnStrCol2", "type": "STRING", "nullable": false}
+        ],
+        "inputs": [
+          ["foo", 1, 1, 1, "foo", "foo", "foo"],
+          ["bar", 2, 2, 2, "alice", "alice", "alice"],
+          ["alice", 2, 2, 2, null, null, null],
+          [null, 4, 4, 4, null, null, null],
+          ["bob", null, null, null, null, null, null]
+        ]
+      }
+    },
+    "extraProps": {
+      "EnableNullHandling": "false"
+    },
+    "queries": [
+      {
+        "description": "intCol1 IS NULL is always false",
+        "comment": "Even when tableConfig nullHandlingEnabled is false, V2 respects column nullability",
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE intCol1 IS NULL",
+        "h2Sql": "SELECT 0"
+      },
+      {
+        "description": "intCol1 IS NOT NULL is always true",
+        "comment": "Even when tableConfig nullHandlingEnabled is false, V2 respects column nullability",
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE intCol1 IS NOT NULL",
+        "h2Sql": "SELECT count(*) FROM {tbl1}"
+      },
+      {
+        "description": "nIntCol1 IS NULL is always false",
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nIntCol1 IS NULL",
+        "h2Sql": "SELECT 0"
+      },
+      {
+        "description": "nIntCol1 IS NOT NULL is always true",
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nIntCol1 IS NOT NULL",
+        "h2Sql": "SELECT count(*) FROM {tbl1}"
+      },
+      {
+        "description": "nnIntCol1 IS NULL is always false",
+        "comment": "Even when tableConfig nullHandlingEnabled is false, V2 respects column nullability",
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nnIntCol1 IS NULL",
+        "h2Sql": "SELECT 0"
+      },
+      {
+        "description": "nnIntCol1 IS NOT NULL is always true",
+        "comment": "Even when tableConfig nullHandlingEnabled is false, V2 respects column nullability",
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nnIntCol1 IS NOT NULL",
+        "h2Sql": "SELECT count(*) FROM {tbl1}"
+      },
+
+      {
+        "description": "When projected with enableNullHandling=true, intCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=true; SELECT intCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=false, intCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=false; SELECT intCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=true, nIntCol1 is considered null",
+        "sql": "SET enableNullHandling=true; SELECT nIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=false, nIntCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=false; SELECT nIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=true, nnIntCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=true; SELECT nnIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=false, nnIntCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=false; SELECT nnIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      }
+    ]
+  },
   "nullable_columns": {
     "tables": {
       "tbl1" : {
@@ -111,6 +203,9 @@
           ["bar", 2, "foo"]
         ]
       }
+    },
+    "extraProps": {
+      "EnableNullHandling": "true"
     },
     "queries": [
       {
@@ -157,13 +252,11 @@
 
       {
         "description": "When projected with enableNullHandling=true, intCol1 is considered -2147483648",
-        "comment": "This test fails when it shouldn't. We need to fix this before merging",
         "sql": "SET enableNullHandling=true; SELECT intCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
-        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+        "h2Sql": "SELECT null FROM {tbl1} WHERE strCol1 = 'bob'"
       },
       {
         "description": "When projected with enableNullHandling=false, intCol1 is considered -2147483648",
-        "comment": "this tests is not correctly working. Returned `intCol1` is actually null",
         "sql": "SET enableNullHandling=false; SELECT intCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
         "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
       },
@@ -214,10 +307,7 @@
         "description": "aggregate with null checkers on key from group set are honored on not nullable columns",
         "sql": "SET enableNullHandling=true; SELECT COUNT(*) FROM {tbl1} WHERE nStrCol2 IS NULL GROUP BY nStrCol2"
       }
-    ],
-    "extraProps": {
-      "EnableNullHandling": "true"
-    }
+    ]
   },
   "column_level_null_handling": {
     "tables": {
@@ -259,6 +349,9 @@
           ["bar", 2, "foo"]
         ]
       }
+    },
+    "extraProps": {
+      "EnableNullHandling": "true"
     },
     "queries": [
       {

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -128,31 +128,31 @@
 
       {
         "description": "intCol1 IS NULL is always false",
-        "sql": "SET enableNullHandling=true; SELECT 1 FROM {tbl1} WHERE intCol1 IS NULL",
-        "h2Sql": "SELECT 'empty' FROM {tbl1} WHERE 1 = 0"
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE intCol1 IS NULL",
+        "h2Sql": "SELECT 0"
       },
       {
         "description": "intCol1 IS NOT NULL is always true",
-        "sql": "SET enableNullHandling=true; SELECT intCol1 FROM {tbl1} WHERE intCol1 IS NOT NULL",
-        "h2Sql": "SELECT intCol1 FROM {tbl1} WHERE 1 = 1"
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE intCol1 IS NOT NULL",
+        "h2Sql": "SELECT count(*) FROM {tbl1}"
       },
       {
         "description": "nIntCol1 IS NULL is honored",
-        "sql": "SET enableNullHandling=true; SELECT nIntCol1 FROM {tbl1} WHERE nIntCol1 IS NULL"
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nIntCol1 IS NULL"
       },
       {
         "description": "nIntCol1 IS NOT NULL is honored",
-        "sql": "SET enableNullHandling=true; SELECT nIntCol1 FROM {tbl1} WHERE nIntCol1 IS NOT NULL"
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nIntCol1 IS NOT NULL"
       },
       {
         "description": "nnIntCol1 IS NULL is always false",
-        "sql": "SET enableNullHandling=true; SELECT 1 FROM {tbl1} WHERE nnIntCol1 IS NULL",
-        "h2Sql": "SELECT 'empty' FROM {tbl1} WHERE 1 = 0"
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nnIntCol1 IS NULL",
+        "h2Sql": "SELECT 0"
       },
       {
         "description": "nnIntCol1 IS NOT NULL is always true",
-        "sql": "SET enableNullHandling=true; SELECT nnIntCol1 FROM {tbl1} WHERE nnIntCol1 IS NOT NULL",
-        "h2Sql": "SELECT nnIntCol1 FROM {tbl1} WHERE 1 = 1"
+        "sql": "SET enableNullHandling=true; SELECT count(*) FROM {tbl1} WHERE nnIntCol1 IS NOT NULL",
+        "h2Sql": "SELECT count(*) FROM {tbl1}"
       },
 
       {
@@ -179,7 +179,6 @@
       },
       {
         "description": "When projected with enableNullHandling=true, nnIntCol1 is considered -2147483648",
-        "comment": "This test fails when it shouldn't. We need to fix this before merging",
         "sql": "SET enableNullHandling=true; SELECT nnIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
         "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
       },

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -157,7 +157,7 @@
 
       {
         "description": "When projected with enableNullHandling=true, intCol1 is considered -2147483648",
-        "comment": "this tests is not correctly working. Returned `intCol1` is actually null",
+        "comment": "This test fails when it shouldn't. We need to fix this before merging",
         "sql": "SET enableNullHandling=true; SELECT intCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
         "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
       },
@@ -179,6 +179,7 @@
       },
       {
         "description": "When projected with enableNullHandling=true, nnIntCol1 is considered -2147483648",
+        "comment": "This test fails when it shouldn't. We need to fix this before merging",
         "sql": "SET enableNullHandling=true; SELECT nnIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
         "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
       },

--- a/pinot-query-runtime/src/test/resources/queries/NullHandling.json
+++ b/pinot-query-runtime/src/test/resources/queries/NullHandling.json
@@ -66,5 +66,229 @@
         "keepOutputRowOrder": true
       }
     ]
+  },
+  "nullable_columns": {
+    "tables": {
+      "tbl1" : {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "intCol1", "type": "INT"},
+          {"name": "nIntCol1", "type": "INT", "nullable": true},
+          {"name": "nnIntCol1", "type": "INT", "nullable": false},
+          {"name": "strCol2", "type": "STRING"},
+          {"name": "nStrCol2", "type": "STRING", "nullable": true},
+          {"name": "nnStrCol2", "type": "STRING", "nullable": false}
+        ],
+        "inputs": [
+          ["foo", 1, 1, 1, "foo", "foo", "foo"],
+          ["bar", 2, 2, 2, "alice", "alice", "alice"],
+          ["alice", 2, 2, 2, null, null, null],
+          [null, 4, 4, 4, null, null, null],
+          ["bob", null, null, null, null, null, null]
+        ]
+      },
+      "tbl2" : {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "strCol2", "type": "STRING"},
+          {"name": "intCol1", "type": "INT"},
+          {"name": "doubleCol1", "type": "DOUBLE"}
+        ],
+        "inputs": [
+          ["foo", "bob", 3, 3.1416],
+          ["alice", "alice", 4, 2.7183],
+          [null, null, null, null]
+        ]
+      },
+      "tbl3": {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "intCol1", "type": "INT"},
+          {"name": "strCol2", "type": "STRING"}
+        ],
+        "inputs": [
+          ["foo", 1, "foo"],
+          ["bar", 2, "foo"]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "description": "join 3 tables, mixed join conditions with null non-matching",
+        "sql": "SET enableNullHandling=true; SELECT * FROM {tbl1} JOIN {tbl2} ON {tbl1}.intCol1 > {tbl2}.doubleCol1 JOIN {tbl3} ON {tbl1}.strCol1 = {tbl3}.strCol2"
+      },
+      {
+        "description": "join 3 tables, mixed join condition with null matching",
+        "sql": "SET enableNullHandling=true; SELECT * FROM {tbl1} JOIN {tbl2} ON {tbl1}.intCol1 != {tbl2}.doubleCol1 JOIN {tbl3} ON {tbl1}.strCol1 = {tbl3}.strCol2"
+      },
+      {
+        "description": "join 2 tables, mixed join conditions of null matching or non-matching",
+        "sql": "SET enableNullHandling=true; SELECT * FROM {tbl1} JOIN {tbl2} ON {tbl1}.intCol1 > {tbl2}.doubleCol1 AND {tbl1}.strCol1 = {tbl2}.strCol1"
+      },
+
+      {
+        "description": "intCol1 IS NULL is always false",
+        "sql": "SET enableNullHandling=true; SELECT 1 FROM {tbl1} WHERE intCol1 IS NULL",
+        "h2Sql": "SELECT 'empty' FROM {tbl1} WHERE 1 = 0"
+      },
+      {
+        "description": "intCol1 IS NOT NULL is always true",
+        "sql": "SET enableNullHandling=true; SELECT intCol1 FROM {tbl1} WHERE intCol1 IS NOT NULL",
+        "h2Sql": "SELECT intCol1 FROM {tbl1} WHERE 1 = 1"
+      },
+      {
+        "description": "nIntCol1 IS NULL is honored",
+        "sql": "SET enableNullHandling=true; SELECT nIntCol1 FROM {tbl1} WHERE nIntCol1 IS NULL"
+      },
+      {
+        "description": "nIntCol1 IS NOT NULL is honored",
+        "sql": "SET enableNullHandling=true; SELECT nIntCol1 FROM {tbl1} WHERE nIntCol1 IS NOT NULL"
+      },
+      {
+        "description": "nnIntCol1 IS NULL is always false",
+        "sql": "SET enableNullHandling=true; SELECT 1 FROM {tbl1} WHERE nnIntCol1 IS NULL",
+        "h2Sql": "SELECT 'empty' FROM {tbl1} WHERE 1 = 0"
+      },
+      {
+        "description": "nnIntCol1 IS NOT NULL is always true",
+        "sql": "SET enableNullHandling=true; SELECT nnIntCol1 FROM {tbl1} WHERE nnIntCol1 IS NOT NULL",
+        "h2Sql": "SELECT nnIntCol1 FROM {tbl1} WHERE 1 = 1"
+      },
+
+      {
+        "description": "When projected with enableNullHandling=true, intCol1 is considered -2147483648",
+        "comment": "this tests is not correctly working. Returned `intCol1` is actually null",
+        "sql": "SET enableNullHandling=true; SELECT intCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=false, intCol1 is considered -2147483648",
+        "comment": "this tests is not correctly working. Returned `intCol1` is actually null",
+        "sql": "SET enableNullHandling=false; SELECT intCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=true, nIntCol1 is considered null",
+        "sql": "SET enableNullHandling=true; SELECT nIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT null FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=false, nIntCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=false; SELECT nIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=true, nnIntCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=true; SELECT nnIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+      {
+        "description": "When projected with enableNullHandling=false, nnIntCol1 is considered -2147483648",
+        "sql": "SET enableNullHandling=false; SELECT nnIntCol1 FROM {tbl1} WHERE strCol1 = 'bob'",
+        "h2Sql": "SELECT -2147483648 FROM {tbl1} WHERE strCol1 = 'bob'"
+      },
+
+      {
+        "description": "aggregate with null checkers",
+        "sql": "SET enableNullHandling=true; SELECT SUM(intCol1) FROM {tbl1} WHERE intCol1 IS NOT NULL GROUP BY strCol2"
+      },
+
+      {
+        "description": "null checks in aggregate are skipped on not nullable columns",
+        "comment": "Given intCol1 is not explicitly nullable, V2 removes the IS NOT NULL predicate",
+        "sql": "SET enableNullHandling=true; SELECT strCol2, COUNT(*) FROM {tbl1} WHERE intCol1 IS NOT NULL GROUP BY strCol2",
+        "h2Sql": "SELECT strCol2, COUNT(*) FROM {tbl1} GROUP BY strCol2"
+      },
+      {
+        "description": "null checks in aggregate are honored on nullable columns",
+        "sql": "SET enableNullHandling=true; SELECT strCol2, COUNT(*) FROM {tbl1} WHERE nIntCol1 IS NOT NULL GROUP BY strCol2"
+      },
+
+      {
+        "description": "aggregate with null checkers on key from group set are skipped on not nullable columns",
+        "comment": "Given strCol2 is not explicitly nullable, V2 returns empty set",
+        "sql": "SET enableNullHandling=true; SELECT COUNT(*) FROM {tbl1} WHERE strCol2 IS NULL GROUP BY strCol2",
+        "h2Sql": "SELECT COUNT(*) FROM {tbl1} WHERE 1 = 0 GROUP BY strCol2"
+      },
+      {
+        "description": "aggregate with null checkers on key from group set are honored on not nullable columns",
+        "sql": "SET enableNullHandling=true; SELECT COUNT(*) FROM {tbl1} WHERE nStrCol2 IS NULL GROUP BY nStrCol2"
+      }
+    ],
+    "extraProps": {
+      "EnableNullHandling": "true"
+    }
+  },
+  "column_level_null_handling": {
+    "tables": {
+      "tbl1" : {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "intCol1", "type": "INT", "nullable": true},
+          {"name": "strCol2", "type": "STRING", "nullable": true}
+        ],
+        "inputs": [
+          ["foo", 1, "foo"],
+          ["bar", 2, "alice"],
+          ["alice", 3, null],
+          ["bob", 4, null],
+          ["bob", null, null]
+        ]
+      },
+      "tbl2" : {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "strCol2", "type": "STRING", "nullable": true},
+          {"name": "intCol1", "type": "INT"},
+          {"name": "doubleCol1", "type": "DOUBLE", "nullable": true}
+        ],
+        "inputs": [
+          ["foo", "bob", 3, 3.1416],
+          ["alice", "alice", 4, 2.7183],
+          ["bob", null, 5, null]
+        ]
+      },
+      "tbl3" : {
+        "schema": [
+          {"name": "strCol1", "type": "STRING"},
+          {"name": "intCol1", "type": "INT"},
+          {"name": "strCol2", "type": "STRING"}
+        ],
+        "inputs": [
+          ["foo", 1, "foo"],
+          ["bar", 2, "foo"]
+        ]
+      }
+    },
+    "queries": [
+      {
+        "description": "join 3 tables, mixed join conditions with null non-matching",
+        "sql": "SET enableNullHandling=true; SELECT * FROM {tbl1} JOIN {tbl2} ON {tbl1}.intCol1 > {tbl2}.doubleCol1 JOIN {tbl3} ON {tbl1}.strCol1 = {tbl3}.strCol2"
+      },
+      {
+        "description": "join 3 tables, mixed join condition with null matching",
+        "sql": "SET enableNullHandling=true; SELECT * FROM {tbl1} JOIN {tbl2} ON {tbl1}.intCol1 != {tbl2}.doubleCol1 JOIN {tbl3} ON {tbl1}.strCol1 = {tbl3}.strCol2"
+      },
+      {
+        "description": "join 2 tables, mixed join conditions of null matching or non-matching",
+        "sql": "SET enableNullHandling=true; SELECT * FROM {tbl1} JOIN {tbl2} ON {tbl1}.intCol1 > {tbl2}.doubleCol1 AND {tbl1}.strCol1 = {tbl2}.strCol1"
+      },
+      {
+        "description": "aggregate with null checkers",
+        "sql": "SET enableNullHandling=true; SELECT SUM(intCol1) FROM {tbl1} WHERE intCol1 IS NOT NULL GROUP BY strCol2"
+      },
+      {
+        "description": "aggregate with null checkers",
+        "sql": "SET enableNullHandling=true; SELECT COUNT(*) FROM {tbl1} WHERE intCol1 IS NOT NULL GROUP BY strCol2"
+      },
+      {
+        "description": "aggregate with null checkers on key from group set",
+        "sql": "SET enableNullHandling=true; SELECT COUNT(*) FROM {tbl1} WHERE strCol2 IS NULL GROUP BY strCol2"
+      },
+      {
+        "description": "select only with NULL handling",
+        "sql": "SET enableNullHandling=true; SELECT * FROM {tbl1} WHERE strCol2 IS NULL AND intCol1 IS NOT NULL"
+      }
+    ]
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -45,6 +45,7 @@ import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderContext;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoaderRegistry;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -69,6 +70,17 @@ public class ImmutableSegmentLoader {
     IndexLoadingConfig defaultIndexLoadingConfig = new IndexLoadingConfig();
     defaultIndexLoadingConfig.setReadMode(readMode);
     return load(indexDir, defaultIndexLoadingConfig, null, false);
+  }
+
+  /**
+   * Loads the segment with empty schema and IndexLoadingConfig. This method is used to
+   * access the segment without modifying it, i.e. in read-only mode.
+   */
+  public static ImmutableSegment load(File indexDir, ReadMode readMode, Schema schema, TableConfig tableConfig)
+      throws Exception {
+    IndexLoadingConfig defaultIndexLoadingConfig = new IndexLoadingConfig(tableConfig, schema);
+    defaultIndexLoadingConfig.setReadMode(readMode);
+    return load(indexDir, defaultIndexLoadingConfig, schema, false);
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -252,8 +252,8 @@ public class MutableSegmentImpl implements MutableSegment {
     }
 
     Set<IndexType> specialIndexes =
-        Sets.newHashSet(StandardIndexes.dictionary(), // dictionaries implement other contract
-            StandardIndexes.nullValueVector()); // null value vector implement other contract
+        Sets.newHashSet(StandardIndexes.dictionary(), // dictionaries implements other contract
+            StandardIndexes.nullValueVector()); // null value vector implements other contract
 
     // Initialize for each column
     for (FieldSpec fieldSpec : _physicalFieldSpecs) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/BaseDataSource.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/datasource/BaseDataSource.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.local.segment.index.datasource;
 import javax.annotation.Nullable;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.datasource.DataSourceMetadata;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.IndexReader;
 import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
@@ -110,7 +111,24 @@ public abstract class BaseDataSource implements DataSource {
 
   @Nullable
   @Override
-  public NullValueVectorReader getNullValueVector() {
-    return getIndex(StandardIndexes.nullValueVector());
+  public NullValueVectorReader getNullValueVector(NullMode nullMode) {
+    switch (nullMode) {
+      case NONE_NULLABLE: {
+        return null;
+      }
+      case ALL_NULLABLE: {
+        return getIndex(StandardIndexes.nullValueVector());
+      }
+      case COLUMN_BASED: {
+        if (_dataSourceMetadata.getFieldSpec().getNullable()) {
+          return getIndex(StandardIndexes.nullValueVector());
+        } else {
+          return null;
+        }
+      }
+      default: {
+        throw new IllegalArgumentException("Mode " + nullMode + " is not recognized");
+      }
+    }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -133,6 +133,10 @@ public class IndexLoadingConfig {
     this(instanceDataManagerConfig, tableConfig, null);
   }
 
+  public IndexLoadingConfig(TableConfig tableConfig, @Nullable Schema schema) {
+    extractFromTableConfigAndSchema(tableConfig, schema);
+  }
+
   public IndexLoadingConfig() {
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
@@ -19,8 +19,10 @@
 
 package org.apache.pinot.segment.local.segment.index.nullvalue;
 
+import com.google.common.collect.Maps;
 import java.io.File;
 import java.io.IOException;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -33,15 +35,17 @@ import org.apache.pinot.segment.spi.creator.IndexCreationContext;
 import org.apache.pinot.segment.spi.index.AbstractIndexType;
 import org.apache.pinot.segment.spi.index.ColumnConfigDeserializer;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
-import org.apache.pinot.segment.spi.index.IndexConfigDeserializer;
 import org.apache.pinot.segment.spi.index.IndexHandler;
 import org.apache.pinot.segment.spi.index.IndexReaderFactory;
+import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.spi.config.table.IndexConfig;
+import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 
 
@@ -77,11 +81,24 @@ public class NullValueIndexType extends AbstractIndexType<IndexConfig, NullValue
 
   @Override
   public ColumnConfigDeserializer<IndexConfig> createDeserializer() {
-    return IndexConfigDeserializer.ifIndexingConfig(
-        IndexConfigDeserializer.alwaysCall((TableConfig tableConfig, Schema schema) ->
-            tableConfig.getIndexingConfig().isNullHandlingEnabled()
-                ? IndexConfig.ENABLED
-                : IndexConfig.DISABLED));
+    return (TableConfig tableConfig, Schema schema) -> {
+      IndexingConfig indexingConfig = tableConfig.getIndexingConfig();
+      boolean nullHandlingEnabled = indexingConfig != null && indexingConfig.isNullHandlingEnabled();
+
+      Collection<FieldSpec> allFieldSpecs = schema.getAllFieldSpecs();
+      Map<String, IndexConfig> configMap = Maps.newHashMapWithExpectedSize(allFieldSpecs.size());
+
+      for (FieldSpec fieldSpec : allFieldSpecs) {
+        IndexConfig indexConfig;
+        if (fieldSpec.getNullable() == Boolean.TRUE || fieldSpec.getNullable() == null && nullHandlingEnabled) {
+          indexConfig = IndexConfig.ENABLED;
+        } else {
+          indexConfig = IndexConfig.DISABLED;
+        }
+        configMap.put(fieldSpec.getName(), indexConfig);
+      }
+      return configMap;
+    };
   }
 
   public NullValueVectorCreator createIndexCreator(File indexDir, String columnName) {
@@ -116,10 +133,14 @@ public class NullValueIndexType extends AbstractIndexType<IndexConfig, NullValue
     public NullValueVectorReader createIndexReader(SegmentDirectory.Reader segmentReader,
         FieldIndexConfigs fieldIndexConfigs, ColumnMetadata metadata)
           throws IOException {
-      if (!segmentReader.hasIndexFor(metadata.getColumnName(), StandardIndexes.nullValueVector())) {
+      IndexType<IndexConfig, NullValueVectorReader, ?> indexType = StandardIndexes.nullValueVector();
+      if (fieldIndexConfigs.getConfig(indexType).isDisabled()) {
         return null;
       }
-      PinotDataBuffer buffer = segmentReader.getIndexFor(metadata.getColumnName(), StandardIndexes.nullValueVector());
+      if (!segmentReader.hasIndexFor(metadata.getColumnName(), indexType)) {
+        return null;
+      }
+      PinotDataBuffer buffer = segmentReader.getIndexFor(metadata.getColumnName(), indexType);
       return new NullValueVectorReaderImpl(buffer);
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexType.java
@@ -71,7 +71,7 @@ public class NullValueIndexType extends AbstractIndexType<IndexConfig, NullValue
 
   @Override
   public IndexConfig getDefaultConfig() {
-    return IndexConfig.DISABLED;
+    return IndexConfig.ENABLED;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReader.java
@@ -25,6 +25,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.lang.ArrayUtils;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
@@ -48,7 +49,8 @@ public class PinotSegmentColumnReader implements Closeable {
     Preconditions.checkArgument(_forwardIndexReader != null, "Forward index disabled for column: %s", column);
     _forwardIndexReaderContext = _forwardIndexReader.createContext();
     _dictionary = dataSource.getDictionary();
-    _nullValueVectorReader = dataSource.getNullValueVector();
+    // TODO: Verify whether this is the correct behavior
+    _nullValueVectorReader = dataSource.getNullValueVector(NullMode.ALL_NULLABLE);
     if (_forwardIndexReader.isSingleValue()) {
       _dictIdBuffer = null;
       _maxNumValuesPerMVEntry = -1;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/nullvalue/NullValueIndexTypeTest.java
@@ -1,0 +1,68 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.nullvalue;
+
+import org.apache.pinot.segment.local.segment.index.AbstractSerdeIndexContract;
+import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.spi.config.table.IndexConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.testng.Assert;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+
+public class NullValueIndexTypeTest {
+
+  @DataProvider(name = "provideCases")
+  public Object[][] provideCases() {
+    return new Object[][] {
+        // setNullable  | nullHandlingEnabled | Index is enabled
+        new Object[] {true, null, IndexConfig.ENABLED},
+        new Object[] {true, true, IndexConfig.ENABLED},
+        new Object[] {true, false, IndexConfig.ENABLED},
+
+        new Object[] {false, null, IndexConfig.DISABLED},
+        new Object[] {false, true, IndexConfig.DISABLED},
+        new Object[] {false, false, IndexConfig.DISABLED},
+
+        new Object[] {null, null, IndexConfig.DISABLED},
+        new Object[] {null, true, IndexConfig.ENABLED},
+        new Object[] {null, false, IndexConfig.DISABLED}
+    };
+  }
+
+  public static class ConfTest extends AbstractSerdeIndexContract {
+
+    protected void assertEquals(IndexConfig expected) {
+      Assert.assertEquals(getActualConfig("dimStr", StandardIndexes.nullValueVector()), expected);
+    }
+
+    @Test(dataProvider = "provideCases", dataProviderClass = NullValueIndexTypeTest.class)
+    public void isEnabledWhenNullable(Boolean fieldNullable, Boolean nullHandlingEnabled, IndexConfig expected) {
+      FieldSpec dimStr = _schema.getFieldSpecFor("dimStr");
+      dimStr.setNullable(fieldNullable);
+
+      if (nullHandlingEnabled != null) {
+        _tableConfig.getIndexingConfig().setNullHandlingEnabled(nullHandlingEnabled);
+      }
+
+      assertEquals(expected);
+    }
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/DataSource.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/DataSource.java
@@ -30,6 +30,7 @@ import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 import org.apache.pinot.segment.spi.index.reader.RangeIndexReader;
 import org.apache.pinot.segment.spi.index.reader.TextIndexReader;
+import org.apache.pinot.spi.data.FieldSpec;
 
 
 /**
@@ -100,7 +101,27 @@ public interface DataSource {
 
   /**
    * Returns null value vector for the column if exists, or {@code null} if not.
+   *
+   * The result is modified by the given null mode:
+   * <ol>
+   *   <li>In {@link NullMode#NONE_NULLABLE}, null is always returned.</li>
+   *   <li>In {@link NullMode#ALL_NULLABLE}, the null vector of the segment is returned.</li>
+   *   <li>In {@link NullMode#COLUMN_BASED}, the null vector of the segment is returned if and only if the field schema
+   *   is declared as {@link FieldSpec#getNullable() nullable}.</li>
+   * </ol>
    */
   @Nullable
-  NullValueVectorReader getNullValueVector();
+  NullValueVectorReader getNullValueVector(NullMode nullMode);
+
+  /**
+   * Like {@link #getNullValueVector(NullMode) getNullValueVector(NullMode.ALL_NULL}.
+   *
+   * This is the older method that didn't care about the null mode and instead delegated on whether there was a null
+   * vector in the segment or not.
+   *
+   * Ideally older code should be migrated to specify which null mode should be used.
+   */
+  default NullValueVectorReader getNullValueVector() {
+    return getNullValueVector(NullMode.ALL_NULLABLE);
+  }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/NullMode.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/NullMode.java
@@ -1,0 +1,44 @@
+package org.apache.pinot.segment.spi.datasource;
+
+import org.apache.pinot.spi.config.table.IndexingConfig;
+import org.apache.pinot.spi.data.FieldSpec;
+
+
+/**
+ * This enum specify the null semantics that should be used, usually in the context of a query.
+ */
+public enum NullMode {
+  /**
+   * In this mode columns are considered not nullable. Null vectors stored in the segments are ignored and V1 query
+   * engine does not expect to see null values in the blocks.
+   */
+  NONE_NULLABLE,
+  /**
+   * In this mode all columns are considerable nullable (even if {@link FieldSpec#getNullable()}) is false.
+   *
+   * Columns will have a null vector if and only if the segment contains a null vector for the column.
+   * This is not always true, given that depends on the value of {@link IndexingConfig#isNullHandlingEnabled()} at the
+   * time the segment was created.
+   *
+   * In this mode, V1 engine must expect to receive null blocks.
+   */
+  ALL_NULLABLE,
+  /**
+   * In this mode a column is considered nullable if and only if {@link FieldSpec#getNullable()}) is true.
+   *
+   * Columns will have a null vector if and only if the column is nullable and the segment contains a null vector for
+   * the column.
+   * This is not always true, given that depends on the value of {@link IndexingConfig#isNullHandlingEnabled()} at the
+   * time the segment was created.
+   *
+   * In this mode, V1 engine must expect to receive null blocks.
+   */
+  COLUMN_BASED;
+
+  /**
+   * Returns true if and only if V1 query engine must expect nulls in their values.
+   */
+  public boolean nullAtQueryTime() {
+    return this != NullMode.NONE_NULLABLE;
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/NullMode.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/datasource/NullMode.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.segment.spi.datasource;
 
 import org.apache.pinot.spi.config.table.IndexingConfig;

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/SegmentMetadataFetcher.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/SegmentMetadataFetcher.java
@@ -32,6 +32,7 @@ import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.segment.spi.datasource.DataSource;
+import org.apache.pinot.segment.spi.datasource.NullMode;
 import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2;
 import org.apache.pinot.segment.spi.index.startree.StarTreeV2Metadata;
@@ -137,7 +138,7 @@ public class SegmentMetadataFetcher {
       indexStatus.put(INVERTED_INDEX, INDEX_AVAILABLE);
     }
 
-    if (Objects.isNull(dataSource.getNullValueVector())) {
+    if (Objects.isNull(dataSource.getNullValueVector(NullMode.ALL_NULLABLE))) {
       indexStatus.put(NULL_VALUE_VECTOR_READER, INDEX_NOT_AVAILABLE);
     } else {
       indexStatus.put(NULL_VALUE_VECTOR_READER, INDEX_AVAILABLE);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -27,7 +27,6 @@ import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
-import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.EqualityUtils;
@@ -101,7 +100,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   protected String _name;
   protected DataType _dataType;
   protected boolean _isSingleValueField = true;
-  protected Boolean _nullable = null;
+  protected boolean _nullable = false;
 
   // NOTE: This only applies to STRING column, which is the max number of characters
   private int _maxLength = DEFAULT_MAX_LENGTH;
@@ -305,22 +304,15 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
 
   /**
    * Returns whether the column is nullable or not.
-   *
-   * This Java property itself is nullable. In case null is returned, actual nullability depends on the value of
-   * {@link IndexingConfig#isNullHandlingEnabled()}.
-   *
-   * @return true if the field is nullable, false if it is not and null if column level nullability should be delegated
-   * to {@link IndexingConfig#isNullHandlingEnabled()}.
    */
-  @Nullable
-  public Boolean getNullable() {
+  public boolean getNullable() {
     return _nullable;
   }
 
   /**
    * @see #getNullable()
    */
-  public void setNullable(@Nullable Boolean nullable) {
+  public void setNullable(boolean nullable) {
     _nullable = nullable;
   }
 
@@ -341,9 +333,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     }
     appendDefaultNullValue(jsonObject);
     appendTransformFunction(jsonObject);
-    if (_nullable != null) {
-      jsonObject.put("nullable", _nullable);
-    }
+    jsonObject.put("nullable", _nullable);
     return jsonObject;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -27,6 +27,7 @@ import java.sql.Timestamp;
 import java.util.HashMap;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.EqualityUtils;
@@ -44,6 +45,7 @@ import org.apache.pinot.spi.utils.TimestampUtils;
  * <p>- <code>IsSingleValueField</code>: single-value or multi-value field.
  * <p>- <code>DefaultNullValue</code>: when no value found for this field, use this value. Stored in string format.
  * <p>- <code>VirtualColumnProvider</code>: the virtual column provider to use for this field.
+ * <p>- <code>Nullable</code>: whether the column is nullable or not. Defaults to null
  */
 @SuppressWarnings("unused")
 public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
@@ -99,6 +101,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   protected String _name;
   protected DataType _dataType;
   protected boolean _isSingleValueField = true;
+  protected Boolean _nullable = null;
 
   // NOTE: This only applies to STRING column, which is the max number of characters
   private int _maxLength = DEFAULT_MAX_LENGTH;
@@ -301,6 +304,27 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
   }
 
   /**
+   * Returns whether the column is nullable or not.
+   *
+   * This Java property itself is nullable. In case null is returned, actual nullability depends on the value of
+   * {@link IndexingConfig#isNullHandlingEnabled()}.
+   *
+   * @return true if the field is nullable, false if it is not and null if column level nullability should be delegated
+   * to {@link IndexingConfig#isNullHandlingEnabled()}.
+   */
+  @Nullable
+  public Boolean getNullable() {
+    return _nullable;
+  }
+
+  /**
+   * @see #getNullable()
+   */
+  public void setNullable(@Nullable Boolean nullable) {
+    _nullable = nullable;
+  }
+
+  /**
    * Returns the {@link ObjectNode} representing the field spec.
    * <p>Only contains fields with non-default value.
    * <p>NOTE: here we use {@link ObjectNode} to preserve the insertion order.
@@ -317,6 +341,9 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     }
     appendDefaultNullValue(jsonObject);
     appendTransformFunction(jsonObject);
+    if (_nullable != null) {
+      jsonObject.put("nullable", _nullable);
+    }
     return jsonObject;
   }
 
@@ -381,7 +408,8 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
         .isEqual(_isSingleValueField, that._isSingleValueField) && EqualityUtils
         .isEqual(getStringValue(_defaultNullValue), getStringValue(that._defaultNullValue)) && EqualityUtils
         .isEqual(_maxLength, that._maxLength) && EqualityUtils.isEqual(_transformFunction, that._transformFunction)
-        && EqualityUtils.isEqual(_virtualColumnProvider, that._virtualColumnProvider);
+        && EqualityUtils.isEqual(_virtualColumnProvider, that._virtualColumnProvider)
+        && EqualityUtils.isEqual(_nullable, that._nullable);
   }
 
   @Override
@@ -393,6 +421,7 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
     result = EqualityUtils.hashCodeOf(result, _maxLength);
     result = EqualityUtils.hashCodeOf(result, _transformFunction);
     result = EqualityUtils.hashCodeOf(result, _virtualColumnProvider);
+    result = EqualityUtils.hashCodeOf(result, _nullable);
     return result;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -524,26 +524,41 @@ public final class Schema implements Serializable {
      * Add single value dimensionFieldSpec
      */
     public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType) {
-      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true));
+      return addSingleValueDimension(dimensionName, dataType, null);
+    }
+
+    public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, Boolean nullable) {
+      DimensionFieldSpec dimensionFieldSpec = new DimensionFieldSpec(dimensionName, dataType, true);
+      dimensionFieldSpec.setNullable(nullable);
+      _schema.addField(dimensionFieldSpec);
       return this;
     }
 
     /**
-     * Add single value dimensionFieldSpec with a defaultNullValue
+     * Add single value dimensionFieldSpec with a defaultNullValue.
+     *
+     * This method assumes the field is nullable.
      */
     public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, Object defaultNullValue) {
-      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true, defaultNullValue));
+      DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, true, defaultNullValue);
+      fieldSpec.setNullable(true);
+      _schema.addField(fieldSpec);
       return this;
     }
 
     /**
      * Add single value dimensionFieldSpec with maxLength and a defaultNullValue
+     *
+     * This method assumes the field is nullable.
      */
     public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, int maxLength,
         Object defaultNullValue) {
       Preconditions.checkArgument(dataType == DataType.STRING,
           "The maxLength field only applies to STRING field right now");
-      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, true, maxLength, defaultNullValue));
+      DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, true, maxLength,
+          defaultNullValue);
+      fieldSpec.setNullable(true);
+      _schema.addField(fieldSpec);
       return this;
     }
 
@@ -551,26 +566,41 @@ public final class Schema implements Serializable {
      * Add multi value dimensionFieldSpec
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType) {
-      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false));
+      return addMultiValueDimension(dimensionName, dataType, null);
+    }
+
+    public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, Boolean nullable) {
+      DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, false);
+      fieldSpec.setNullable(nullable);
+      _schema.addField(fieldSpec);
       return this;
     }
 
     /**
      * Add multi value dimensionFieldSpec with defaultNullValue
+     *
+     * This method assumes the field is nullable.
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, Object defaultNullValue) {
-      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, defaultNullValue));
+      DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, false, defaultNullValue);
+      fieldSpec.setNullable(true);
+      _schema.addField(fieldSpec);
       return this;
     }
 
     /**
      * Add multi value dimensionFieldSpec with maxLength and a defaultNullValue
+     *
+     * This method assumes the field is nullable.
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, int maxLength,
         Object defaultNullValue) {
       Preconditions.checkArgument(dataType == DataType.STRING,
           "The maxLength field only applies to STRING field right now");
-      _schema.addField(new DimensionFieldSpec(dimensionName, dataType, false, maxLength, defaultNullValue));
+      DimensionFieldSpec fieldSpec =
+          new DimensionFieldSpec(dimensionName, dataType, false, maxLength, defaultNullValue);
+      fieldSpec.setNullable(true);
+      _schema.addField(fieldSpec);
       return this;
     }
 
@@ -578,15 +608,25 @@ public final class Schema implements Serializable {
      * Add metricFieldSpec
      */
     public SchemaBuilder addMetric(String metricName, DataType dataType) {
-      _schema.addField(new MetricFieldSpec(metricName, dataType));
+      return addMetric(metricName, dataType, null);
+    }
+
+    public SchemaBuilder addMetric(String metricName, DataType dataType, Boolean nullable) {
+      MetricFieldSpec fieldSpec = new MetricFieldSpec(metricName, dataType);
+      fieldSpec.setNullable(nullable);
+      _schema.addField(fieldSpec);
       return this;
     }
 
     /**
      * Add metricFieldSpec with defaultNullValue
+     *
+     * This method assumes the field is nullable.
      */
     public SchemaBuilder addMetric(String metricName, DataType dataType, Object defaultNullValue) {
-      _schema.addField(new MetricFieldSpec(metricName, dataType, defaultNullValue));
+      MetricFieldSpec fieldSpec = new MetricFieldSpec(metricName, dataType, defaultNullValue);
+      fieldSpec.setNullable(true);
+      _schema.addField(fieldSpec);
       return this;
     }
 
@@ -618,11 +658,14 @@ public final class Schema implements Serializable {
 
     /**
      * Add dateTimeFieldSpec with basic fields plus defaultNullValue and transformFunction
+     *
+     * This method assumes the field is nullable.
      */
     public SchemaBuilder addDateTime(String name, DataType dataType, String format, String granularity,
         @Nullable Object defaultNullValue, @Nullable String transformFunction) {
       DateTimeFieldSpec dateTimeFieldSpec =
           new DateTimeFieldSpec(name, dataType, format, granularity, defaultNullValue, transformFunction);
+      dateTimeFieldSpec.setNullable(true);
       _schema.addField(dateTimeFieldSpec);
       return this;
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -536,20 +536,15 @@ public final class Schema implements Serializable {
 
     /**
      * Add single value dimensionFieldSpec with a defaultNullValue.
-     *
-     * This method assumes the field is nullable.
      */
     public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, Object defaultNullValue) {
       DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, true, defaultNullValue);
-      fieldSpec.setNullable(true);
       _schema.addField(fieldSpec);
       return this;
     }
 
     /**
      * Add single value dimensionFieldSpec with maxLength and a defaultNullValue
-     *
-     * This method assumes the field is nullable.
      */
     public SchemaBuilder addSingleValueDimension(String dimensionName, DataType dataType, int maxLength,
         Object defaultNullValue) {
@@ -557,7 +552,6 @@ public final class Schema implements Serializable {
           "The maxLength field only applies to STRING field right now");
       DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, true, maxLength,
           defaultNullValue);
-      fieldSpec.setNullable(true);
       _schema.addField(fieldSpec);
       return this;
     }
@@ -578,20 +572,15 @@ public final class Schema implements Serializable {
 
     /**
      * Add multi value dimensionFieldSpec with defaultNullValue
-     *
-     * This method assumes the field is nullable.
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, Object defaultNullValue) {
       DimensionFieldSpec fieldSpec = new DimensionFieldSpec(dimensionName, dataType, false, defaultNullValue);
-      fieldSpec.setNullable(true);
       _schema.addField(fieldSpec);
       return this;
     }
 
     /**
-     * Add multi value dimensionFieldSpec with maxLength and a defaultNullValue
-     *
-     * This method assumes the field is nullable.
+     * Add multi value dimensionFieldSpec with maxLength and a defaultNullValue*
      */
     public SchemaBuilder addMultiValueDimension(String dimensionName, DataType dataType, int maxLength,
         Object defaultNullValue) {
@@ -599,7 +588,6 @@ public final class Schema implements Serializable {
           "The maxLength field only applies to STRING field right now");
       DimensionFieldSpec fieldSpec =
           new DimensionFieldSpec(dimensionName, dataType, false, maxLength, defaultNullValue);
-      fieldSpec.setNullable(true);
       _schema.addField(fieldSpec);
       return this;
     }
@@ -620,12 +608,9 @@ public final class Schema implements Serializable {
 
     /**
      * Add metricFieldSpec with defaultNullValue
-     *
-     * This method assumes the field is nullable.
      */
     public SchemaBuilder addMetric(String metricName, DataType dataType, Object defaultNullValue) {
       MetricFieldSpec fieldSpec = new MetricFieldSpec(metricName, dataType, defaultNullValue);
-      fieldSpec.setNullable(true);
       _schema.addField(fieldSpec);
       return this;
     }
@@ -658,14 +643,11 @@ public final class Schema implements Serializable {
 
     /**
      * Add dateTimeFieldSpec with basic fields plus defaultNullValue and transformFunction
-     *
-     * This method assumes the field is nullable.
      */
     public SchemaBuilder addDateTime(String name, DataType dataType, String format, String granularity,
         @Nullable Object defaultNullValue, @Nullable String transformFunction) {
       DateTimeFieldSpec dateTimeFieldSpec =
           new DateTimeFieldSpec(name, dataType, format, granularity, defaultNullValue, transformFunction);
-      dateTimeFieldSpec.setNullable(true);
       _schema.addField(dateTimeFieldSpec);
       return this;
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -351,6 +351,7 @@ public class CommonConstants {
         public static final String EXPLAIN_PLAN_VERBOSE = "explainPlanVerbose";
         public static final String USE_MULTISTAGE_ENGINE = "useMultistageEngine";
         public static final String ENABLE_NULL_HANDLING = "enableNullHandling";
+        public static final String USE_COLUMN_NULLABILITY = "useColumnNullability";
         public static final String SERVER_RETURN_FINAL_RESULT = "serverReturnFinalResult";
         // Reorder scan based predicates based on cardinality and number of selected values
         public static final String AND_SCAN_REORDERING = "AndScanReordering";

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/EmptyQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/EmptyQuickstart.java
@@ -20,7 +20,9 @@ package org.apache.pinot.tools;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 import org.apache.pinot.tools.admin.PinotAdministrator;
 
 
@@ -32,6 +34,12 @@ public class EmptyQuickstart extends Quickstart {
 
   public String[] getDefaultBatchTableDirectories() {
     return new String[]{};
+  }
+
+  protected Map<String, Object> getConfigOverrides() {
+    Map<String, Object> result = new HashMap<>(super.getConfigOverrides());
+    result.put("controller.disable.ingestion.groovy", "false");
+    return result;
   }
 
   public static void main(String[] args)


### PR DESCRIPTION
This PR is an attempt to implement an alternative implementation to correctly support null in V2. Changes were build on top of https://github.com/apache/pinot/pull/11824, but NullValueIndexType was reverted to what we have in master

Semantic table:

| nullMode | Segment has null vector | FieldSpec*      | in master | in PR     |
|----------|-------------------------|-----------------|-----------|-----------|
| none     | N/A                     | N/A             | not null  | not null  |
| all      | false                   | N/A             | not null  | not null  | 
| all      | true                    | N/A             | null      | null      | 
| column   | false                   | N/A             | N/A       | null      |
| column   | true                    | false (default) | N/A       | not null  |
| column   | true                    | true            | N/A       | null      |

It is to be defined how to change nullMode. At this time what I choose was:
- If `useColumnNullability` query option is true, then use `column` nullMode
- else if `enableNullHandling` query option is true, then use `all` nullMode
- else use `none` null mode