### PR TITLE
[bugfix][multistage] explicit warning flags set on each stage stats

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -756,8 +756,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         _brokerMetrics.addMeteredTableValue(rawTableName, BrokerMeter.BROKER_RESPONSES_WITH_NUM_GROUPS_LIMIT_REACHED,
             1);
       }
-      brokerResponse.setPartialResult(
-          brokerResponse.isNumGroupsLimitReached() || brokerResponse.getExceptionsSize() > 0);
+      brokerResponse.setPartialResult(isPartialResult(brokerResponse));
 
       // Set total query processing time
       long totalTimeMs = TimeUnit.NANOSECONDS.toMillis(executionEndTimeNs - compilationStartTimeNs);
@@ -1811,6 +1810,11 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       @Nullable Map<ServerInstance, List<String>> realtimeRoutingTable, long timeoutMs, ServerStats serverStats,
       RequestContext requestContext)
       throws Exception;
+
+  protected static boolean isPartialResult(BrokerResponse brokerResponse) {
+    return brokerResponse.isNumGroupsLimitReached() || brokerResponse.isMaxRowsInJoinReached()
+        || brokerResponse.getExceptionsSize() > 0;
+  }
 
   protected static void augmentStatistics(RequestContext statistics, BrokerResponse response) {
     statistics.setTotalDocs(response.getTotalDocs());

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/MultiStageBrokerRequestHandler.java
@@ -232,6 +232,9 @@ public class MultiStageBrokerRequestHandler extends BaseBrokerRequestHandler {
       brokerResponse.addStageStat(entry.getKey(), brokerResponseStats);
     }
 
+    // Set partial result flag
+    brokerResponse.setPartialResult(isPartialResult(brokerResponse));
+
     // Set total query processing time
     // TODO: Currently we don't emit metric for QUERY_TOTAL_TIME_MS
     long totalTimeMs = TimeUnit.NANOSECONDS.toMillis(

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
@@ -134,11 +134,12 @@ public interface DataTable {
     OPERATOR_EXECUTION_TIME_MS(30, "operatorExecutionTimeMs", MetadataValueType.LONG),
     OPERATOR_ID(31, "operatorId", MetadataValueType.STRING),
     OPERATOR_EXEC_START_TIME_MS(32, "operatorExecStartTimeMs", MetadataValueType.LONG),
-    OPERATOR_EXEC_END_TIME_MS(33, "operatorExecEndTimeMs", MetadataValueType.LONG);
+    OPERATOR_EXEC_END_TIME_MS(33, "operatorExecEndTimeMs", MetadataValueType.LONG),
+    NUM_JOIN_LIMIT_REACHED(34, "numJoinsLimitReached", MetadataValueType.STRING);
 
     // We keep this constant to track the max id added so far for backward compatibility.
     // Increase it when adding new keys, but NEVER DECREASE IT!!!
-    private static final int MAX_ID = 33;
+    private static final int MAX_ID = 34;
 
     private static final MetadataKey[] ID_TO_ENUM_KEY_MAP = new MetadataKey[MAX_ID + 1];
     private static final Map<String, MetadataKey> NAME_TO_ENUM_KEY_MAP = new HashMap<>();

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
@@ -135,7 +135,7 @@ public interface DataTable {
     OPERATOR_ID(31, "operatorId", MetadataValueType.STRING),
     OPERATOR_EXEC_START_TIME_MS(32, "operatorExecStartTimeMs", MetadataValueType.LONG),
     OPERATOR_EXEC_END_TIME_MS(33, "operatorExecEndTimeMs", MetadataValueType.LONG),
-    MAX_ROWS_IN_JOIN_LIMIT_REACHED(34, "maxRowsInJoinLimitReached", MetadataValueType.STRING);
+    MAX_ROWS_IN_JOIN_REACHED(34, "maxRowsInJoinReached", MetadataValueType.STRING);
 
     // We keep this constant to track the max id added so far for backward compatibility.
     // Increase it when adding new keys, but NEVER DECREASE IT!!!

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTable.java
@@ -135,7 +135,7 @@ public interface DataTable {
     OPERATOR_ID(31, "operatorId", MetadataValueType.STRING),
     OPERATOR_EXEC_START_TIME_MS(32, "operatorExecStartTimeMs", MetadataValueType.LONG),
     OPERATOR_EXEC_END_TIME_MS(33, "operatorExecEndTimeMs", MetadataValueType.LONG),
-    NUM_JOIN_LIMIT_REACHED(34, "numJoinsLimitReached", MetadataValueType.STRING);
+    MAX_ROWS_IN_JOIN_LIMIT_REACHED(34, "maxRowsInJoinLimitReached", MetadataValueType.STRING);
 
     // We keep this constant to track the max id added so far for backward compatibility.
     // Increase it when adding new keys, but NEVER DECREASE IT!!!

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/BrokerResponse.java
@@ -134,6 +134,11 @@ public interface BrokerResponse {
   boolean isNumGroupsLimitReached();
 
   /**
+   * Returns whether the limit for max rows in join has been reached.
+   */
+  boolean isMaxRowsInJoinReached();
+
+  /**
    * Get number of exceptions recorded in the response.
    */
   int getExceptionsSize();

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -498,12 +498,12 @@ public class BrokerResponseNative implements BrokerResponse {
   }
 
   @JsonProperty("maxRowsInJoinReached")
-  public boolean ismaxRowsInJoinReached() {
+  public boolean isMaxRowsInJoinReached() {
     return _maxRowsInJoinReached;
   }
 
   @JsonProperty("maxRowsInJoinReached")
-  public void setmaxRowsInJoinReached(boolean maxRowsInJoinReached) {
+  public void setMaxRowsInJoinReached(boolean maxRowsInJoinReached) {
     _maxRowsInJoinReached = maxRowsInJoinReached;
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -44,7 +44,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
     "resultTable", "requestId", "brokerId", "exceptions", "numServersQueried", "numServersResponded",
     "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched", "numConsumingSegmentsQueried",
     "numConsumingSegmentsProcessed", "numConsumingSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter",
-    "numEntriesScannedPostFilter", "numGroupsLimitReached", "maxRowsInJoinLimitReached", "totalDocs", "timeUsedMs",
+    "numEntriesScannedPostFilter", "numGroupsLimitReached", "maxRowsInJoinReached", "totalDocs", "timeUsedMs",
     "offlineThreadCpuTimeNs", "realtimeThreadCpuTimeNs", "offlineSystemActivitiesCpuTimeNs",
     "realtimeSystemActivitiesCpuTimeNs", "offlineResponseSerializationCpuTimeNs",
     "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs", "realtimeTotalCpuTimeNs", "brokerReduceTimeMs",
@@ -78,7 +78,7 @@ public class BrokerResponseNative implements BrokerResponse {
 
   private long _totalDocs = 0L;
   private boolean _numGroupsLimitReached = false;
-  private boolean _maxRowsInJoinLimitReached = false;
+  private boolean _maxRowsInJoinReached = false;
   private boolean _partialResult = false;
   private long _timeUsedMs = 0L;
   private long _offlineThreadCpuTimeNs = 0L;
@@ -497,14 +497,14 @@ public class BrokerResponseNative implements BrokerResponse {
     _numGroupsLimitReached = numGroupsLimitReached;
   }
 
-  @JsonProperty("maxRowsInJoinLimitReached")
-  public boolean isMaxRowsInJoinLimitReached() {
-    return _maxRowsInJoinLimitReached;
+  @JsonProperty("maxRowsInJoinReached")
+  public boolean ismaxRowsInJoinReached() {
+    return _maxRowsInJoinReached;
   }
 
-  @JsonProperty("maxRowsInJoinLimitReached")
-  public void setMaxRowsInJoinLimitReached(boolean maxRowsInJoinLimitReached) {
-    _maxRowsInJoinLimitReached = maxRowsInJoinLimitReached;
+  @JsonProperty("maxRowsInJoinReached")
+  public void setmaxRowsInJoinReached(boolean maxRowsInJoinReached) {
+    _maxRowsInJoinReached = maxRowsInJoinReached;
   }
 
   @JsonProperty("partialResult")

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNative.java
@@ -44,10 +44,12 @@ import org.apache.pinot.spi.utils.JsonUtils;
     "resultTable", "requestId", "brokerId", "exceptions", "numServersQueried", "numServersResponded",
     "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched", "numConsumingSegmentsQueried",
     "numConsumingSegmentsProcessed", "numConsumingSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter",
-    "numEntriesScannedPostFilter", "numGroupsLimitReached", "totalDocs", "timeUsedMs", "offlineThreadCpuTimeNs",
-    "realtimeThreadCpuTimeNs", "offlineSystemActivitiesCpuTimeNs", "realtimeSystemActivitiesCpuTimeNs",
-    "offlineResponseSerializationCpuTimeNs", "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs",
-    "realtimeTotalCpuTimeNs", "brokerReduceTimeMs", "segmentStatistics", "traceInfo", "partialResult"})
+    "numEntriesScannedPostFilter", "numGroupsLimitReached", "maxRowsInJoinLimitReached", "totalDocs", "timeUsedMs",
+    "offlineThreadCpuTimeNs", "realtimeThreadCpuTimeNs", "offlineSystemActivitiesCpuTimeNs",
+    "realtimeSystemActivitiesCpuTimeNs", "offlineResponseSerializationCpuTimeNs",
+    "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs", "realtimeTotalCpuTimeNs", "brokerReduceTimeMs",
+    "segmentStatistics", "traceInfo", "partialResult"
+})
 public class BrokerResponseNative implements BrokerResponse {
   public static final BrokerResponseNative EMPTY_RESULT = BrokerResponseNative.empty();
   public static final BrokerResponseNative NO_TABLE_RESULT =
@@ -76,6 +78,7 @@ public class BrokerResponseNative implements BrokerResponse {
 
   private long _totalDocs = 0L;
   private boolean _numGroupsLimitReached = false;
+  private boolean _maxRowsInJoinLimitReached = false;
   private boolean _partialResult = false;
   private long _timeUsedMs = 0L;
   private long _offlineThreadCpuTimeNs = 0L;
@@ -492,6 +495,16 @@ public class BrokerResponseNative implements BrokerResponse {
   @JsonProperty("numGroupsLimitReached")
   public void setNumGroupsLimitReached(boolean numGroupsLimitReached) {
     _numGroupsLimitReached = numGroupsLimitReached;
+  }
+
+  @JsonProperty("maxRowsInJoinLimitReached")
+  public boolean isMaxRowsInJoinLimitReached() {
+    return _maxRowsInJoinLimitReached;
+  }
+
+  @JsonProperty("maxRowsInJoinLimitReached")
+  public void setMaxRowsInJoinLimitReached(boolean maxRowsInJoinLimitReached) {
+    _maxRowsInJoinLimitReached = maxRowsInJoinLimitReached;
   }
 
   @JsonProperty("partialResult")

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -40,7 +40,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
     "resultTable", "requestId", "stageStats", "brokerId", "exceptions", "numServersQueried", "numServersResponded",
     "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched", "numConsumingSegmentsQueried",
     "numConsumingSegmentsProcessed", "numConsumingSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter",
-    "numEntriesScannedPostFilter", "numGroupsLimitReached", "maxRowsInJoinLimitReached", "totalDocs", "timeUsedMs",
+    "numEntriesScannedPostFilter", "numGroupsLimitReached", "maxRowsInJoinReached", "totalDocs", "timeUsedMs",
     "offlineThreadCpuTimeNs", "realtimeThreadCpuTimeNs", "offlineSystemActivitiesCpuTimeNs",
     "realtimeSystemActivitiesCpuTimeNs", "offlineResponseSerializationCpuTimeNs",
     "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs", "realtimeTotalCpuTimeNs", "brokerReduceTimeMs",

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseNativeV2.java
@@ -37,13 +37,14 @@ import org.apache.pinot.spi.utils.JsonUtils;
  * Supports serialization via JSON.
  */
 @JsonPropertyOrder({
-    "resultTable", "requestId", "stageStats", "exceptions", "numServersQueried", "numServersResponded",
+    "resultTable", "requestId", "stageStats", "brokerId", "exceptions", "numServersQueried", "numServersResponded",
     "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched", "numConsumingSegmentsQueried",
     "numConsumingSegmentsProcessed", "numConsumingSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter",
-    "numEntriesScannedPostFilter", "numGroupsLimitReached", "totalDocs", "timeUsedMs", "offlineThreadCpuTimeNs",
-    "realtimeThreadCpuTimeNs", "offlineSystemActivitiesCpuTimeNs", "realtimeSystemActivitiesCpuTimeNs",
-    "offlineResponseSerializationCpuTimeNs", "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs",
-    "realtimeTotalCpuTimeNs", "segmentStatistics", "traceInfo"
+    "numEntriesScannedPostFilter", "numGroupsLimitReached", "maxRowsInJoinLimitReached", "totalDocs", "timeUsedMs",
+    "offlineThreadCpuTimeNs", "realtimeThreadCpuTimeNs", "offlineSystemActivitiesCpuTimeNs",
+    "realtimeSystemActivitiesCpuTimeNs", "offlineResponseSerializationCpuTimeNs",
+    "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs", "realtimeTotalCpuTimeNs", "brokerReduceTimeMs",
+    "segmentStatistics", "traceInfo", "partialResult"
 })
 public class BrokerResponseNativeV2 extends BrokerResponseNative {
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseStats.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseStats.java
@@ -33,14 +33,16 @@ import org.apache.pinot.spi.utils.JsonUtils;
 //  same metadataKey
 // TODO: Replace member fields with a simple map of <MetadataKey, Object>
 // TODO: Add a subStat field, stage level subStats will contain each operator stats
-@JsonPropertyOrder({"brokerId", "requestId", "exceptions", "numBlocks", "numRows", "stageExecutionTimeMs",
-    "stageExecutionUnit", "stageExecWallTimeMs", "stageExecEndTimeMs", "numServersQueried", "numServersResponded",
-    "numSegmentsQueried", "numSegmentsProcessed", "numSegmentsMatched", "numConsumingSegmentsQueried",
-    "numConsumingSegmentsProcessed", "numConsumingSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter",
-    "numEntriesScannedPostFilter", "numGroupsLimitReached", "totalDocs", "timeUsedMs", "offlineThreadCpuTimeNs",
+@JsonPropertyOrder({
+    "brokerId", "requestId", "exceptions", "numBlocks", "numRows", "stageExecutionTimeMs", "stageExecutionUnit",
+    "stageExecWallTimeMs", "stageExecEndTimeMs", "numServersQueried", "numServersResponded", "numSegmentsQueried",
+    "numSegmentsProcessed", "numSegmentsMatched", "numConsumingSegmentsQueried", "numConsumingSegmentsProcessed",
+    "numConsumingSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter",
+    "numGroupsLimitReached", "numJoinLimitReached", "totalDocs", "timeUsedMs", "offlineThreadCpuTimeNs",
     "realtimeThreadCpuTimeNs", "offlineSystemActivitiesCpuTimeNs", "realtimeSystemActivitiesCpuTimeNs",
     "offlineResponseSerializationCpuTimeNs", "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs",
-    "realtimeTotalCpuTimeNs", "brokerReduceTimeMs", "traceInfo", "operatorStats", "tableNames"})
+    "realtimeTotalCpuTimeNs", "brokerReduceTimeMs", "traceInfo", "operatorStats", "tableNames"
+})
 @JsonInclude(JsonInclude.Include.NON_DEFAULT)
 public class BrokerResponseStats extends BrokerResponseNative {
 
@@ -49,6 +51,7 @@ public class BrokerResponseStats extends BrokerResponseNative {
   private long _stageExecutionTimeMs = 0;
   private int _stageExecutionUnit = 0;
   private long _stageExecWallTimeMs = -1;
+  private boolean _numJoinLimitReached = false;
   private Map<String, Map<String, String>> _operatorStats = new HashMap<>();
   private List<String> _tableNames = new ArrayList<>();
 
@@ -105,6 +108,16 @@ public class BrokerResponseStats extends BrokerResponseNative {
   @JsonProperty("stageExecutionUnit")
   public void setStageExecutionUnit(int stageExecutionUnit) {
     _stageExecutionUnit = stageExecutionUnit;
+  }
+
+  @JsonProperty("numJoinLimitReached")
+  public boolean isNumJoinLimitReached() {
+    return _numJoinLimitReached;
+  }
+
+  @JsonProperty("numJoinLimitReached")
+  public void setNumJoinLimitReached(boolean numJoinLimitReached) {
+    _numJoinLimitReached = numJoinLimitReached;
   }
 
   public String toJsonString()

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseStats.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseStats.java
@@ -51,7 +51,6 @@ public class BrokerResponseStats extends BrokerResponseNative {
   private long _stageExecutionTimeMs = 0;
   private int _stageExecutionUnit = 0;
   private long _stageExecWallTimeMs = -1;
-  private boolean _maxRowsInJoinLimitReached = false;
   private Map<String, Map<String, String>> _operatorStats = new HashMap<>();
   private List<String> _tableNames = new ArrayList<>();
 
@@ -108,16 +107,6 @@ public class BrokerResponseStats extends BrokerResponseNative {
   @JsonProperty("stageExecutionUnit")
   public void setStageExecutionUnit(int stageExecutionUnit) {
     _stageExecutionUnit = stageExecutionUnit;
-  }
-
-  @JsonProperty("maxRowsInJoinLimitReached")
-  public boolean isMaxRowsInJoinLimitReached() {
-    return _maxRowsInJoinLimitReached;
-  }
-
-  @JsonProperty("maxRowsInJoinLimitReached")
-  public void setMaxRowsInJoinLimitReached(boolean maxRowsInJoinLimitReached) {
-    _maxRowsInJoinLimitReached = maxRowsInJoinLimitReached;
   }
 
   public String toJsonString()

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseStats.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseStats.java
@@ -38,7 +38,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
     "stageExecWallTimeMs", "stageExecEndTimeMs", "numServersQueried", "numServersResponded", "numSegmentsQueried",
     "numSegmentsProcessed", "numSegmentsMatched", "numConsumingSegmentsQueried", "numConsumingSegmentsProcessed",
     "numConsumingSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter",
-    "numGroupsLimitReached", "maxRowsInJoinLimitReached", "totalDocs", "timeUsedMs", "offlineThreadCpuTimeNs",
+    "numGroupsLimitReached", "maxRowsInJoinReached", "totalDocs", "timeUsedMs", "offlineThreadCpuTimeNs",
     "realtimeThreadCpuTimeNs", "offlineSystemActivitiesCpuTimeNs", "realtimeSystemActivitiesCpuTimeNs",
     "offlineResponseSerializationCpuTimeNs", "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs",
     "realtimeTotalCpuTimeNs", "brokerReduceTimeMs", "traceInfo", "operatorStats", "tableNames"

--- a/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseStats.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/response/broker/BrokerResponseStats.java
@@ -38,7 +38,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
     "stageExecWallTimeMs", "stageExecEndTimeMs", "numServersQueried", "numServersResponded", "numSegmentsQueried",
     "numSegmentsProcessed", "numSegmentsMatched", "numConsumingSegmentsQueried", "numConsumingSegmentsProcessed",
     "numConsumingSegmentsMatched", "numDocsScanned", "numEntriesScannedInFilter", "numEntriesScannedPostFilter",
-    "numGroupsLimitReached", "numJoinLimitReached", "totalDocs", "timeUsedMs", "offlineThreadCpuTimeNs",
+    "numGroupsLimitReached", "maxRowsInJoinLimitReached", "totalDocs", "timeUsedMs", "offlineThreadCpuTimeNs",
     "realtimeThreadCpuTimeNs", "offlineSystemActivitiesCpuTimeNs", "realtimeSystemActivitiesCpuTimeNs",
     "offlineResponseSerializationCpuTimeNs", "realtimeResponseSerializationCpuTimeNs", "offlineTotalCpuTimeNs",
     "realtimeTotalCpuTimeNs", "brokerReduceTimeMs", "traceInfo", "operatorStats", "tableNames"
@@ -51,7 +51,7 @@ public class BrokerResponseStats extends BrokerResponseNative {
   private long _stageExecutionTimeMs = 0;
   private int _stageExecutionUnit = 0;
   private long _stageExecWallTimeMs = -1;
-  private boolean _numJoinLimitReached = false;
+  private boolean _maxRowsInJoinLimitReached = false;
   private Map<String, Map<String, String>> _operatorStats = new HashMap<>();
   private List<String> _tableNames = new ArrayList<>();
 
@@ -110,14 +110,14 @@ public class BrokerResponseStats extends BrokerResponseNative {
     _stageExecutionUnit = stageExecutionUnit;
   }
 
-  @JsonProperty("numJoinLimitReached")
-  public boolean isNumJoinLimitReached() {
-    return _numJoinLimitReached;
+  @JsonProperty("maxRowsInJoinLimitReached")
+  public boolean isMaxRowsInJoinLimitReached() {
+    return _maxRowsInJoinLimitReached;
   }
 
-  @JsonProperty("numJoinLimitReached")
-  public void setNumJoinLimitReached(boolean numJoinLimitReached) {
-    _numJoinLimitReached = numJoinLimitReached;
+  @JsonProperty("maxRowsInJoinLimitReached")
+  public void setMaxRowsInJoinLimitReached(boolean maxRowsInJoinLimitReached) {
+    _maxRowsInJoinLimitReached = maxRowsInJoinLimitReached;
   }
 
   public String toJsonString()

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
@@ -74,6 +74,7 @@ public class ExecutionStatsAggregator {
   private long _explainPlanNumEmptyFilterSegments = 0L;
   private long _explainPlanNumMatchAllFilterSegments = 0L;
   private boolean _numGroupsLimitReached = false;
+  private boolean _numJoinLimitReached = false;
   private int _numBlocks = 0;
   private int _numRows = 0;
   private long _stageExecutionTimeMs = 0;
@@ -247,9 +248,12 @@ public class ExecutionStatsAggregator {
     if (numTotalDocsString != null) {
       _numTotalDocs += Long.parseLong(numTotalDocsString);
     }
+
     _numGroupsLimitReached |=
         Boolean.parseBoolean(metadata.get(DataTable.MetadataKey.NUM_GROUPS_LIMIT_REACHED.getName()));
 
+    _numJoinLimitReached |=
+        Boolean.parseBoolean(metadata.get(DataTable.MetadataKey.NUM_JOIN_LIMIT_REACHED.getName()));
 
     String numBlocksString = metadata.get(DataTable.MetadataKey.NUM_BLOCKS.getName());
     if (numBlocksString != null) {
@@ -369,6 +373,8 @@ public class ExecutionStatsAggregator {
 
     brokerResponseStats.setNumBlocks(_numBlocks);
     brokerResponseStats.setNumRows(_numRows);
+    brokerResponseStats.setNumJoinLimitReached(_numJoinLimitReached);
+    brokerResponseStats.setNumGroupsLimitReached(_numGroupsLimitReached);
     brokerResponseStats.setStageExecutionTimeMs(_stageExecutionTimeMs);
     brokerResponseStats.setStageExecutionUnit(_stageExecutionUnit);
     brokerResponseStats.setTableNames(new ArrayList<>(_tableNames));

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
@@ -309,7 +309,7 @@ public class ExecutionStatsAggregator {
     brokerResponseNative.setNumSegmentsMatched(_numSegmentsMatched);
     brokerResponseNative.setTotalDocs(_numTotalDocs);
     brokerResponseNative.setNumGroupsLimitReached(_numGroupsLimitReached);
-    brokerResponseNative.setmaxRowsInJoinReached(_maxRowsInJoinReached);
+    brokerResponseNative.setMaxRowsInJoinReached(_maxRowsInJoinReached);
     brokerResponseNative.setOfflineThreadCpuTimeNs(_offlineThreadCpuTimeNs);
     brokerResponseNative.setRealtimeThreadCpuTimeNs(_realtimeThreadCpuTimeNs);
     brokerResponseNative.setOfflineSystemActivitiesCpuTimeNs(_offlineSystemActivitiesCpuTimeNs);
@@ -373,7 +373,7 @@ public class ExecutionStatsAggregator {
 
     brokerResponseStats.setNumBlocks(_numBlocks);
     brokerResponseStats.setNumRows(_numRows);
-    brokerResponseStats.setmaxRowsInJoinReached(_maxRowsInJoinReached);
+    brokerResponseStats.setMaxRowsInJoinReached(_maxRowsInJoinReached);
     brokerResponseStats.setNumGroupsLimitReached(_numGroupsLimitReached);
     brokerResponseStats.setStageExecutionTimeMs(_stageExecutionTimeMs);
     brokerResponseStats.setStageExecutionUnit(_stageExecutionUnit);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
@@ -309,6 +309,7 @@ public class ExecutionStatsAggregator {
     brokerResponseNative.setNumSegmentsMatched(_numSegmentsMatched);
     brokerResponseNative.setTotalDocs(_numTotalDocs);
     brokerResponseNative.setNumGroupsLimitReached(_numGroupsLimitReached);
+    brokerResponseNative.setMaxRowsInJoinLimitReached(_maxRowsInJoinLimitReached);
     brokerResponseNative.setOfflineThreadCpuTimeNs(_offlineThreadCpuTimeNs);
     brokerResponseNative.setRealtimeThreadCpuTimeNs(_realtimeThreadCpuTimeNs);
     brokerResponseNative.setOfflineSystemActivitiesCpuTimeNs(_offlineSystemActivitiesCpuTimeNs);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
@@ -74,7 +74,7 @@ public class ExecutionStatsAggregator {
   private long _explainPlanNumEmptyFilterSegments = 0L;
   private long _explainPlanNumMatchAllFilterSegments = 0L;
   private boolean _numGroupsLimitReached = false;
-  private boolean _numJoinLimitReached = false;
+  private boolean _maxRowsInJoinLimitReached = false;
   private int _numBlocks = 0;
   private int _numRows = 0;
   private long _stageExecutionTimeMs = 0;
@@ -248,12 +248,11 @@ public class ExecutionStatsAggregator {
     if (numTotalDocsString != null) {
       _numTotalDocs += Long.parseLong(numTotalDocsString);
     }
-
     _numGroupsLimitReached |=
         Boolean.parseBoolean(metadata.get(DataTable.MetadataKey.NUM_GROUPS_LIMIT_REACHED.getName()));
 
-    _numJoinLimitReached |=
-        Boolean.parseBoolean(metadata.get(DataTable.MetadataKey.NUM_JOIN_LIMIT_REACHED.getName()));
+    _maxRowsInJoinLimitReached |=
+        Boolean.parseBoolean(metadata.get(DataTable.MetadataKey.MAX_ROWS_IN_JOIN_LIMIT_REACHED.getName()));
 
     String numBlocksString = metadata.get(DataTable.MetadataKey.NUM_BLOCKS.getName());
     if (numBlocksString != null) {
@@ -373,7 +372,7 @@ public class ExecutionStatsAggregator {
 
     brokerResponseStats.setNumBlocks(_numBlocks);
     brokerResponseStats.setNumRows(_numRows);
-    brokerResponseStats.setNumJoinLimitReached(_numJoinLimitReached);
+    brokerResponseStats.setMaxRowsInJoinLimitReached(_maxRowsInJoinLimitReached);
     brokerResponseStats.setNumGroupsLimitReached(_numGroupsLimitReached);
     brokerResponseStats.setStageExecutionTimeMs(_stageExecutionTimeMs);
     brokerResponseStats.setStageExecutionUnit(_stageExecutionUnit);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/ExecutionStatsAggregator.java
@@ -74,7 +74,7 @@ public class ExecutionStatsAggregator {
   private long _explainPlanNumEmptyFilterSegments = 0L;
   private long _explainPlanNumMatchAllFilterSegments = 0L;
   private boolean _numGroupsLimitReached = false;
-  private boolean _maxRowsInJoinLimitReached = false;
+  private boolean _maxRowsInJoinReached = false;
   private int _numBlocks = 0;
   private int _numRows = 0;
   private long _stageExecutionTimeMs = 0;
@@ -251,8 +251,8 @@ public class ExecutionStatsAggregator {
     _numGroupsLimitReached |=
         Boolean.parseBoolean(metadata.get(DataTable.MetadataKey.NUM_GROUPS_LIMIT_REACHED.getName()));
 
-    _maxRowsInJoinLimitReached |=
-        Boolean.parseBoolean(metadata.get(DataTable.MetadataKey.MAX_ROWS_IN_JOIN_LIMIT_REACHED.getName()));
+    _maxRowsInJoinReached |=
+        Boolean.parseBoolean(metadata.get(DataTable.MetadataKey.MAX_ROWS_IN_JOIN_REACHED.getName()));
 
     String numBlocksString = metadata.get(DataTable.MetadataKey.NUM_BLOCKS.getName());
     if (numBlocksString != null) {
@@ -309,7 +309,7 @@ public class ExecutionStatsAggregator {
     brokerResponseNative.setNumSegmentsMatched(_numSegmentsMatched);
     brokerResponseNative.setTotalDocs(_numTotalDocs);
     brokerResponseNative.setNumGroupsLimitReached(_numGroupsLimitReached);
-    brokerResponseNative.setMaxRowsInJoinLimitReached(_maxRowsInJoinLimitReached);
+    brokerResponseNative.setmaxRowsInJoinReached(_maxRowsInJoinReached);
     brokerResponseNative.setOfflineThreadCpuTimeNs(_offlineThreadCpuTimeNs);
     brokerResponseNative.setRealtimeThreadCpuTimeNs(_realtimeThreadCpuTimeNs);
     brokerResponseNative.setOfflineSystemActivitiesCpuTimeNs(_offlineSystemActivitiesCpuTimeNs);
@@ -373,7 +373,7 @@ public class ExecutionStatsAggregator {
 
     brokerResponseStats.setNumBlocks(_numBlocks);
     brokerResponseStats.setNumRows(_numRows);
-    brokerResponseStats.setMaxRowsInJoinLimitReached(_maxRowsInJoinLimitReached);
+    brokerResponseStats.setmaxRowsInJoinReached(_maxRowsInJoinReached);
     brokerResponseStats.setNumGroupsLimitReached(_numGroupsLimitReached);
     brokerResponseStats.setStageExecutionTimeMs(_stageExecutionTimeMs);
     brokerResponseStats.setStageExecutionUnit(_stageExecutionUnit);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
 import org.apache.calcite.rel.hint.PinotHintOptions;
 import org.apache.calcite.sql.SqlKind;
 import org.apache.pinot.common.datablock.DataBlock;
-import org.apache.pinot.common.exception.QueryException;
+import org.apache.pinot.common.datatable.DataTable;
 import org.apache.pinot.common.request.Literal;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
@@ -160,9 +160,8 @@ public class AggregateOperator extends MultiStageOperator {
       } else {
         TransferableBlock dataBlock = new TransferableBlock(rows, _resultSchema, DataBlock.Type.ROW);
         if (_groupByExecutor.isNumGroupsLimitReached()) {
-          dataBlock.addException(QueryException.SERVER_RESOURCE_LIMIT_EXCEEDED_ERROR_CODE,
-              String.format("Reached numGroupsLimit of: %d for group-by, ignoring the extra groups",
-                  _groupByExecutor.getNumGroupsLimit()));
+          OperatorStats operatorStats = _opChainStats.getOperatorStats(_context, _operatorId);
+          operatorStats.recordSingleStat(DataTable.MetadataKey.NUM_GROUPS_LIMIT_REACHED.getName(), "true");
         }
         return dataBlock;
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -162,6 +162,7 @@ public class AggregateOperator extends MultiStageOperator {
         if (_groupByExecutor.isNumGroupsLimitReached()) {
           OperatorStats operatorStats = _opChainStats.getOperatorStats(_context, _operatorId);
           operatorStats.recordSingleStat(DataTable.MetadataKey.NUM_GROUPS_LIMIT_REACHED.getName(), "true");
+          _inputOperator.earlyTerminate();
         }
         return dataBlock;
       }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -227,7 +227,7 @@ public class HashJoinOperator extends MultiStageOperator {
           int remainingRows = _maxRowsInHashTable - _currentRowsInHashTable;
           container = container.subList(0, remainingRows);
           OperatorStats operatorStats = _opChainStats.getOperatorStats(_context, _operatorId);
-          operatorStats.recordSingleStat(DataTable.MetadataKey.MAX_ROWS_IN_JOIN_LIMIT_REACHED.getName(), "true");
+          operatorStats.recordSingleStat(DataTable.MetadataKey.MAX_ROWS_IN_JOIN_REACHED.getName(), "true");
         }
       }
       // put all the rows into corresponding hash collections keyed by the key selector function.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -227,7 +227,7 @@ public class HashJoinOperator extends MultiStageOperator {
           int remainingRows = _maxRowsInHashTable - _currentRowsInHashTable;
           container = container.subList(0, remainingRows);
           OperatorStats operatorStats = _opChainStats.getOperatorStats(_context, _operatorId);
-          operatorStats.recordSingleStat(DataTable.MetadataKey.NUM_JOIN_LIMIT_REACHED.getName(), "true");
+          operatorStats.recordSingleStat(DataTable.MetadataKey.MAX_ROWS_IN_JOIN_LIMIT_REACHED.getName(), "true");
         }
       }
       // put all the rows into corresponding hash collections keyed by the key selector function.

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -228,6 +228,8 @@ public class HashJoinOperator extends MultiStageOperator {
           container = container.subList(0, remainingRows);
           OperatorStats operatorStats = _opChainStats.getOperatorStats(_context, _operatorId);
           operatorStats.recordSingleStat(DataTable.MetadataKey.MAX_ROWS_IN_JOIN_REACHED.getName(), "true");
+          // setting only the rightTableOperator to be early terminated and awaits EOS block next.
+          _rightTableOperator.earlyTerminate();
         }
       }
       // put all the rows into corresponding hash collections keyed by the key selector function.
@@ -241,10 +243,6 @@ public class HashJoinOperator extends MultiStageOperator {
         hashCollection.add(row);
       }
       _currentRowsInHashTable += container.size();
-      if (_currentRowsInHashTable == _maxRowsInHashTable) {
-        // setting only the rightTableOperator to be early terminated and awaits EOS block next.
-        _rightTableOperator.earlyTerminate();
-      }
       rightBlock = _rightTableOperator.nextBlock();
     }
     if (rightBlock.isErrorBlock()) {

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -657,8 +657,8 @@ public class HashJoinOperatorTest {
     String operatorId =
         Joiner.on("_").join(HashJoinOperator.class.getSimpleName(), context.getStageId(), context.getServer());
     OperatorStats operatorStats = context.getStats().getOperatorStats(context, operatorId);
-    Assert.assertEquals(operatorStats.getExecutionStats().get(DataTable.MetadataKey.NUM_JOIN_LIMIT_REACHED.getName()),
-        "true");
+    Assert.assertEquals(
+        operatorStats.getExecutionStats().get(DataTable.MetadataKey.MAX_ROWS_IN_JOIN_LIMIT_REACHED.getName()), "true");
   }
 }
 // TODO: Add more inequi join tests.

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/runtime/operator/HashJoinOperatorTest.java
@@ -658,7 +658,7 @@ public class HashJoinOperatorTest {
         Joiner.on("_").join(HashJoinOperator.class.getSimpleName(), context.getStageId(), context.getServer());
     OperatorStats operatorStats = context.getStats().getOperatorStats(context, operatorId);
     Assert.assertEquals(
-        operatorStats.getExecutionStats().get(DataTable.MetadataKey.MAX_ROWS_IN_JOIN_LIMIT_REACHED.getName()), "true");
+        operatorStats.getExecutionStats().get(DataTable.MetadataKey.MAX_ROWS_IN_JOIN_REACHED.getName()), "true");
   }
 }
 // TODO: Add more inequi join tests.


### PR DESCRIPTION
this fixes: #11927.

after this PR, when running 
```
SET maxRowsInJoin=1;
SET joinOverflowMode='BREAK';
WITH tmp AS (
  SELECT   /*+ aggOptions(num_groups_limit='2') */
	attr.userUUID,
	attr.deviceOS,
	min(attr.totalTrips)     min_total_trips,
	1                   agg_type 
  FROM userAttributes attr
  GROUP BY 1, 2
)
SELECT * FROM userGroups JOIN tmp ON userGroups.userUUID = tmp.userUUID
```
returns
```
  "stageStats": {
    "1": {
      "numBlocks": 28,
      "numRows": 1,
      "stageExecutionTimeMs": 136,
      "stageExecutionUnit": 7,
      "stageExecWallTimeMs": 35,
      "numJoinLimitReached": true        ------- show exactly which stage causes join limit reached
    },
    "2": {
      "numBlocks": 18,
      "numRows": 4988,
      "stageExecutionTimeMs": 40,
      "stageExecutionUnit": 4,
      "stageExecWallTimeMs": 15,
      "tableNames": [
        "userGroups"
      ]
    },
    "3": {
      "numBlocks": 4,
      "numRows": 8,
      "stageExecutionTimeMs": 102,
      "stageExecutionUnit": 8,
      "stageExecWallTimeMs": 29,
      "numGroupsLimitReached": true    ------- show exactly which stage causes group limit reached
    },
    "4": {
      "numBlocks": 6,
      "numRows": 20000,
      "stageExecutionTimeMs": 46,
      "stageExecutionUnit": 4,
      "stageExecWallTimeMs": 15,
      "tableNames": [
        "userAttributes"
      ]
    }
  },
```