### PR TITLE
Ask server to directly return final result for queries hitting single server

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -699,6 +699,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         setMaxServerResponseSizeBytes(numServers, queryOptions, offlineTableConfig);
         // Set the query option to directly return final result for single server query unless it is explicitly disabled
         if (numServers == 1) {
+          // Set the same flag in the original server request to be used in the reduce phase for hybrid table
           if (queryOptions.putIfAbsent(QueryOptionKey.SERVER_RETURN_FINAL_RESULT, "true") == null
               && offlineBrokerRequest != serverBrokerRequest) {
             serverBrokerRequest.getPinotQuery().getQueryOptions()
@@ -711,8 +712,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         setMaxServerResponseSizeBytes(numServers, queryOptions, realtimeTableConfig);
         // Set the query option to directly return final result for single server query unless it is explicitly disabled
         if (numServers == 1) {
+          // Set the same flag in the original server request to be used in the reduce phase for hybrid table
           if (queryOptions.putIfAbsent(QueryOptionKey.SERVER_RETURN_FINAL_RESULT, "true") == null
-              && offlineBrokerRequest != serverBrokerRequest) {
+              && realtimeBrokerRequest != serverBrokerRequest) {
             serverBrokerRequest.getPinotQuery().getQueryOptions()
                 .put(QueryOptionKey.SERVER_RETURN_FINAL_RESULT, "true");
           }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/AggregationResultsBlock.java
@@ -207,7 +207,7 @@ public class AggregationResultsBlock extends BaseResultsBlock {
         dataTableBuilder.setColumn(index, ((DoubleArrayList) result).elements());
         break;
       case STRING_ARRAY:
-        dataTableBuilder.setColumn(index, ((ObjectArrayList<String>) result).toArray(new String[0]));
+        dataTableBuilder.setColumn(index, ((ObjectArrayList<String>) result).elements());
         break;
       default:
         throw new IllegalStateException("Illegal column data type in final result: " + columnDataType);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/blocks/results/GroupByResultsBlock.java
@@ -19,6 +19,10 @@
 package org.apache.pinot.core.operator.blocks.results;
 
 import it.unimi.dsi.fastutil.doubles.DoubleArrayList;
+import it.unimi.dsi.fastutil.floats.FloatArrayList;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
@@ -240,13 +244,25 @@ public class GroupByResultsBlock extends BaseResultsBlock {
         dataTableBuilder.setColumn(columnIndex, (ByteArray) value);
         break;
       case INT_ARRAY:
-        dataTableBuilder.setColumn(columnIndex, (int[]) value);
+        if (value instanceof IntArrayList) {
+          dataTableBuilder.setColumn(columnIndex, ((IntArrayList) value).elements());
+        } else {
+          dataTableBuilder.setColumn(columnIndex, (int[]) value);
+        }
         break;
       case LONG_ARRAY:
-        dataTableBuilder.setColumn(columnIndex, (long[]) value);
+        if (value instanceof LongArrayList) {
+          dataTableBuilder.setColumn(columnIndex, ((LongArrayList) value).elements());
+        } else {
+          dataTableBuilder.setColumn(columnIndex, (long[]) value);
+        }
         break;
       case FLOAT_ARRAY:
-        dataTableBuilder.setColumn(columnIndex, (float[]) value);
+        if (value instanceof FloatArrayList) {
+          dataTableBuilder.setColumn(columnIndex, ((FloatArrayList) value).elements());
+        } else {
+          dataTableBuilder.setColumn(columnIndex, (float[]) value);
+        }
         break;
       case DOUBLE_ARRAY:
         if (value instanceof DoubleArrayList) {
@@ -256,7 +272,12 @@ public class GroupByResultsBlock extends BaseResultsBlock {
         }
         break;
       case STRING_ARRAY:
-        dataTableBuilder.setColumn(columnIndex, (String[]) value);
+        if (value instanceof ObjectArrayList) {
+          //noinspection unchecked
+          dataTableBuilder.setColumn(columnIndex, ((ObjectArrayList<String>) value).elements());
+        } else {
+          dataTableBuilder.setColumn(columnIndex, (String[]) value);
+        }
         break;
       case OBJECT:
         dataTableBuilder.setColumn(columnIndex, value);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -178,8 +178,34 @@ public class AggregationFunctionUtils {
         return dataTable.getString(rowId, colId);
       case BYTES:
         return dataTable.getBytes(rowId, colId).getBytes();
+      case INT_ARRAY:
+        return dataTable.getIntArray(rowId, colId);
+      case LONG_ARRAY:
+        return dataTable.getLongArray(rowId, colId);
+      case FLOAT_ARRAY:
+        return dataTable.getFloatArray(rowId, colId);
       case DOUBLE_ARRAY:
         return dataTable.getDoubleArray(rowId, colId);
+      case BOOLEAN_ARRAY: {
+        int[] intValues = dataTable.getIntArray(rowId, colId);
+        int numValues = intValues.length;
+        boolean[] booleanValues = new boolean[numValues];
+        for (int i = 0; i < numValues; i++) {
+          booleanValues[i] = intValues[i] == 1;
+        }
+        return booleanValues;
+      }
+      case TIMESTAMP_ARRAY: {
+        long[] longValues = dataTable.getLongArray(rowId, colId);
+        int numValues = longValues.length;
+        Timestamp[] timestampValues = new Timestamp[numValues];
+        for (int i = 0; i < numValues; i++) {
+          timestampValues[i] = new Timestamp(longValues[i]);
+        }
+        return timestampValues;
+      }
+      case STRING_ARRAY:
+        return dataTable.getStringArray(rowId, colId);
       default:
         throw new IllegalStateException("Illegal column data type in final result: " + columnDataType);
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggStringFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/array/BaseArrayAggStringFunction.java
@@ -20,6 +20,7 @@ package org.apache.pinot.core.query.aggregation.function.array;
 
 import it.unimi.dsi.fastutil.objects.AbstractObjectCollection;
 import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import it.unimi.dsi.fastutil.objects.ObjectIterators;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.BlockValSet;
 import org.apache.pinot.core.query.aggregation.groupby.GroupByResultHolder;
@@ -93,6 +94,9 @@ public abstract class BaseArrayAggStringFunction<I extends AbstractObjectCollect
 
   @Override
   public ObjectArrayList<String> extractFinalResult(I stringArrayList) {
-    return new ObjectArrayList<>(stringArrayList);
+    // NOTE: Wrap a String[] to work around the bug of ObjectArrayList constructor creating Object[] internally.
+    String[] stringArray = new String[stringArrayList.size()];
+    ObjectIterators.unwrap(stringArrayList.iterator(), stringArray);
+    return ObjectArrayList.wrap(stringArray);
   }
 }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineClusterIntegrationTest.java
@@ -314,9 +314,6 @@ public class OfflineClusterIntegrationTest extends BaseClusterIntegrationTestSet
   @Override
   protected void testQuery(String pinotQuery, String h2Query)
       throws Exception {
-    if (getNumServers() == 1) {
-      pinotQuery = "SET serverReturnFinalResult = true;" + pinotQuery;
-    }
     super.testQuery(pinotQuery, h2Query);
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -324,11 +324,9 @@ public class CommonConstants {
     // Broker config indicating the maximum serialized response size across all servers for a query. This value is
     // equally divided across all servers processing the query.
     public static final String CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES = "pinot.broker.max.query.response.size.bytes";
-    public static final long DEFAULT_MAX_QUERY_RESPONSE_SIZE_BYTES = Long.MAX_VALUE;
 
     // Broker config indicating the maximum length of the serialized response per server for a query.
     public static final String CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES = "pinot.broker.max.server.response.size.bytes";
-    public static final long DEFAULT_MAX_SERVER_RESPONSE_SIZE_BYTES = Long.MAX_VALUE;
 
 
     public static class Request {


### PR DESCRIPTION
#9304 introduced the query option `serverReturnFinalResult` which can be used when no broker reduce is required, and ask server to directly return the final aggregation result.
This PR extends that by automatically applying this query option when only one server is queried.

This PR also contains some bug fixes:
- Fix server response size (#11710) to prevent NPE when table config is not loaded yet
- Fix missing final result type introduced in array functions (#11822)