### PR TITLE
Add instrumentation for DataTable Creation

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/BaseDataTable.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/BaseDataTable.java
@@ -29,6 +29,7 @@ import javax.annotation.Nullable;
 import org.apache.pinot.common.CustomObject;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.HashUtil;
+import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
@@ -94,7 +95,9 @@ public abstract class BaseDataTable implements DataTable {
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
 
     dataOutputStream.writeInt(_dictionaryMap.size());
+    int numEntriesAdded = 0;
     for (Map.Entry<String, Map<Integer, String>> dictionaryMapEntry : _dictionaryMap.entrySet()) {
+      Tracing.ThreadAccountantOps.sampleAndCheckInterruptionPeriodically(numEntriesAdded);
       String columnName = dictionaryMapEntry.getKey();
       Map<Integer, String> dictionary = dictionaryMapEntry.getValue();
       byte[] bytes = columnName.getBytes(UTF_8);
@@ -108,6 +111,7 @@ public abstract class BaseDataTable implements DataTable {
         dataOutputStream.writeInt(valueBytes.length);
         dataOutputStream.write(valueBytes);
       }
+      numEntriesAdded++;
     }
 
     return byteArrayOutputStream.toByteArray();

--- a/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/datatable/DataTableImplV4.java
@@ -37,6 +37,7 @@ import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.annotations.InterfaceStability;
+import org.apache.pinot.spi.trace.Tracing;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.roaringbitmap.RoaringBitmap;
@@ -335,10 +336,13 @@ public class DataTableImplV4 implements DataTable {
     DataOutputStream dataOutputStream = new DataOutputStream(byteArrayOutputStream);
 
     dataOutputStream.writeInt(_stringDictionary.length);
+    int numEntriesAdded = 0;
     for (String entry : _stringDictionary) {
+      Tracing.ThreadAccountantOps.sampleAndCheckInterruptionPeriodically(numEntriesAdded);
       byte[] valueBytes = entry.getBytes(UTF_8);
       dataOutputStream.writeInt(valueBytes.length);
       dataOutputStream.write(valueBytes);
+      numEntriesAdded++;
     }
 
     return byteArrayOutputStream.toByteArray();

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/selection/SelectionOperatorUtils.java
@@ -383,7 +383,9 @@ public class SelectionOperatorUtils {
       }
     }
 
+    int numRowsAdded = 0;
     for (Object[] row : rows) {
+      Tracing.ThreadAccountantOps.sampleAndCheckInterruptionPeriodically(numRowsAdded);
       dataTableBuilder.startRow();
       for (int i = 0; i < numColumns; i++) {
         Object columnValue = row[i];
@@ -438,6 +440,7 @@ public class SelectionOperatorUtils {
         }
       }
       dataTableBuilder.finishRow();
+      numRowsAdded++;
     }
 
     if (nullHandlingEnabled) {


### PR DESCRIPTION
When the `InstanceResponseBlock` is creating DataTable based on the final results in the combine operator, that data table creation is hitting OOM (see examples below). This PR adds instrumentation for this path under the query killing framework.

Instrument is added the impl of `BaseResultsBlock.getDataTable()`, specially to `GroupByResultsBlock`, `SelectionResultsBlock`, and `DistinctResultsBlock` which are the most memory-intensive. 
Skipped `AggregationResultsBlock`, `ExceptionResultsBlock`, `ExplainResultsBlock`, `MetadataResultsBlock` as they don't have as much memory overhead.

Examples from heap dumps
**Selection**
```
java.lang.OutOfMemoryError.<init>(OutOfMemoryError.java:48)
java.util.Arrays.copyOf(Arrays.java:3745)
  Local variables
java.io.ByteArrayOutputStream.grow(ByteArrayOutputStream.java:120)
  Local variables
java.io.ByteArrayOutputStream.ensureCapacity(ByteArrayOutputStream.java:95)
java.io.ByteArrayOutputStream.write(ByteArrayOutputStream.java:156)
  Local variables
java.io.OutputStream.write(OutputStream.java:122)
org.apache.pinot.core.common.datatable.BaseDataTableBuilder.finishRow(BaseDataTableBuilder.java:163)
org.apache.pinot.core.query.selection.SelectionOperatorUtils.getDataTableFromRows(SelectionOperatorUtils.java:342)
  Local variables
org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock.getDataTable(SelectionResultsBlock.java:85)
org.apache.pinot.core.operator.blocks.InstanceResponseBlock.toDataOnlyDataTable(InstanceResponseBlock.java:128)
org.apache.pinot.core.operator.blocks.InstanceResponseBlock.toDataTable(InstanceResponseBlock.java:121)
  Local variables
org.apache.pinot.core.query.scheduler.QueryScheduler.serializeResponse(QueryScheduler.java:337)
```
**GroupBy**
```
java.lang.OutOfMemoryError.<init>(OutOfMemoryError.java:48)
java.util.Arrays.copyOf(Arrays.java:3745)
  Local variables
java.io.ByteArrayOutputStream.grow(ByteArrayOutputStream.java:120)
  Local variables
java.io.ByteArrayOutputStream.ensureCapacity(ByteArrayOutputStream.java:95)
java.io.ByteArrayOutputStream.write(ByteArrayOutputStream.java:156)
  Local variables
java.io.OutputStream.write(OutputStream.java:122)
org.apache.pinot.core.common.datatable.BaseDataTableBuilder.setColumn(BaseDataTableBuilder.java:112)
org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock.setDataTableColumn(GroupByResultsBlock.java:262)
org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock.getDataTable(GroupByResultsBlock.java:209)
  Local variables
org.apache.pinot.core.operator.blocks.InstanceResponseBlock.toDataOnlyDataTable(InstanceResponseBlock.java:117)
org.apache.pinot.core.operator.blocks.InstanceResponseBlock.toDataTable(InstanceResponseBlock.java:110)
  Local variables
org.apache.pinot.core.query.scheduler.QueryScheduler.serializeResponse(QueryScheduler.java:337)
  Local variables
```

**Testing**

- Tests added to`ResourceManagerAccountingTest` verify that memory usage is sampled, interruption is checked, and `EarlyTerminationException` is thrown in `getDataTable` by manually setting up the accountant **after** rows/result blocks are created (only samples for data table creation). Without instrumentation, tests will throw OOM exception.
- Deterministic integration tests to check that queries are killed exactly at data table creation can be hard. Reasons being that triggering threshold too low can cause queries to be killed at combine level before hitting data table creation while a higher threshold can only kill the query on the server nondeterministically. 

Below is an example of query exception in the response when a kill happened exactly at data table creation. While it is not deterministic, to reproduce this, you can set server `accounting.oom.critical.heap.usage.ratio` to be higher in `OfflineClusterMemBasedServerQueryKillingTest` and try running `testSelectionOnlyOOM` .

```
{"message":"QueryCancellationError:\norg.apache.pinot.spi.exception.QueryCancelledException: Cancelled while building data table java.lang.RuntimeException:  Query Broker_172.25.200.137_18099_752082720000000006_O got killed because using 2353711296 bytes of memory on SERVER: Server_localhost_8098, exceeding the quota\n\tat org.apache.pinot.core.query.scheduler.QueryScheduler.serializeResponse(QueryScheduler.java:227)\n\tat org.apache.pinot.core.query.scheduler.QueryScheduler.processQueryAndSerialize(QueryScheduler.java:156)\n\tat org.apache.pinot.core.query.scheduler.QueryScheduler.lambda$createQueryFutureTask$0(QueryScheduler.java:124)\n\tat java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)\n...\nCaused by: org.apache.pinot.spi.exception.EarlyTerminationException: Interrupted while merging records\n\tat org.apache.pinot.spi.trace.Tracing$ThreadAccountantOps.sampleAndCheckInterruption(Tracing.java:288)\n\tat org.apache.pinot.spi.trace.Tracing$ThreadAccountantOps.sampleAndCheckInterruptionPeriodically(Tracing.java:304)\n\tat org.apache.pinot.core.query.selection.SelectionOperatorUtils.getDataTableFromRows(SelectionOperatorUtils.java:388)\n\tat org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock.getDataTable(SelectionResultsBlock.java:84)","errorCode":503}
```
cc @jasperjiaguo @siddharthteotia 