### PR TITLE
Optimize segment commit to not read partition group metadata

### DIFF
--- a/pinot-broker/src/test/java/org/apache/pinot/broker/broker/FakeStreamConsumerFactory.java
+++ b/pinot-broker/src/test/java/org/apache/pinot/broker/broker/FakeStreamConsumerFactory.java
@@ -21,6 +21,7 @@ package org.apache.pinot.broker.broker;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import org.apache.pinot.spi.stream.LongMsgOffset;
 import org.apache.pinot.spi.stream.MessageBatch;
@@ -75,6 +76,11 @@ public class FakeStreamConsumerFactory extends StreamConsumerFactory {
     @Override
     public int fetchPartitionCount(long timeoutMillis) {
       return 1;
+    }
+
+    @Override
+    public Set<Integer> fetchPartitionIds(long timeoutMillis) {
+      return Collections.singleton(0);
     }
 
     @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/DefaultFlushThresholdUpdater.java
@@ -19,10 +19,8 @@
 package org.apache.pinot.controller.helix.core.realtime.segment;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
-import org.apache.pinot.spi.stream.PartitionGroupMetadata;
 import org.apache.pinot.spi.stream.StreamConfig;
 
 
@@ -40,7 +38,7 @@ public class DefaultFlushThresholdUpdater implements FlushThresholdUpdater {
   @Override
   public void updateFlushThreshold(StreamConfig streamConfig, SegmentZKMetadata newSegmentZKMetadata,
       CommittingSegmentDescriptor committingSegmentDescriptor, @Nullable SegmentZKMetadata committingSegmentZKMetadata,
-      int maxNumPartitionsPerInstance, List<PartitionGroupMetadata> partitionGroupMetadataList) {
+      int maxNumPartitionsPerInstance) {
     // Configure the segment size flush limit based on the maximum number of partitions allocated to an instance
     newSegmentZKMetadata.setSizeThresholdToFlushSegment(_tableFlushSize / maxNumPartitionsPerInstance);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdater.java
@@ -18,10 +18,8 @@
  */
 package org.apache.pinot.controller.helix.core.realtime.segment;
 
-import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
-import org.apache.pinot.spi.stream.PartitionGroupMetadata;
 import org.apache.pinot.spi.stream.StreamConfig;
 
 
@@ -36,5 +34,5 @@ public interface FlushThresholdUpdater {
    */
   void updateFlushThreshold(StreamConfig streamConfig, SegmentZKMetadata newSegmentZKMetadata,
       CommittingSegmentDescriptor committingSegmentDescriptor, @Nullable SegmentZKMetadata committingSegmentZKMetadata,
-      int maxNumPartitionsPerInstance, List<PartitionGroupMetadata> partitionGroupMetadataList);
+      int maxNumPartitionsPerInstance);
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentFlushThresholdComputer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentFlushThresholdComputer.java
@@ -20,11 +20,8 @@ package org.apache.pinot.controller.helix.core.realtime.segment;
 
 import com.google.common.annotations.VisibleForTesting;
 import java.time.Clock;
-import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
-import org.apache.pinot.common.utils.LLCSegmentName;
-import org.apache.pinot.spi.stream.PartitionGroupMetadata;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.utils.TimeUtils;
 
@@ -58,8 +55,7 @@ class SegmentFlushThresholdComputer {
   }
 
   public int computeThreshold(StreamConfig streamConfig, CommittingSegmentDescriptor committingSegmentDescriptor,
-      @Nullable SegmentZKMetadata committingSegmentZKMetadata, List<PartitionGroupMetadata> partitionGroupMetadataList,
-      String newSegmentName) {
+      @Nullable SegmentZKMetadata committingSegmentZKMetadata, String newSegmentName) {
     final long desiredSegmentSizeBytes = streamConfig.getFlushThresholdSegmentSizeBytes();
     final long optimalSegmentSizeBytesMin = desiredSegmentSizeBytes / 2;
     final double optimalSegmentSizeBytesMax = desiredSegmentSizeBytes * 1.5;
@@ -99,24 +95,11 @@ class SegmentFlushThresholdComputer {
         committingSegmentSizeBytes);
 
     double currentRatio = (double) numRowsConsumed / committingSegmentSizeBytes;
-    // Compute segment size to rows ratio only from the lowest available partition id.
-    // If we consider all partitions then it is likely that we will assign a much higher weight to the most
-    // recent trend in the table (since it is usually true that all partitions of the same table follow more or
-    // less same characteristics at any one point in time).
-    // However, when we start a new table or change controller mastership, we can have any partition completing first.
-    // It is best to learn the ratio as quickly as we can, so we allow any partition to supply the value.
-    int smallestAvailablePartitionGroupId =
-        partitionGroupMetadataList.stream().mapToInt(PartitionGroupMetadata::getPartitionGroupId).min().orElse(0);
-
-    if (new LLCSegmentName(newSegmentName).getPartitionGroupId() == smallestAvailablePartitionGroupId
-        || _latestSegmentRowsToSizeRatio == 0) {
-      if (_latestSegmentRowsToSizeRatio > 0) {
-        _latestSegmentRowsToSizeRatio =
-            CURRENT_SEGMENT_RATIO_WEIGHT * currentRatio
-                + PREVIOUS_SEGMENT_RATIO_WEIGHT * _latestSegmentRowsToSizeRatio;
-      } else {
-        _latestSegmentRowsToSizeRatio = currentRatio;
-      }
+    if (_latestSegmentRowsToSizeRatio > 0) {
+      _latestSegmentRowsToSizeRatio =
+          CURRENT_SEGMENT_RATIO_WEIGHT * currentRatio + PREVIOUS_SEGMENT_RATIO_WEIGHT * _latestSegmentRowsToSizeRatio;
+    } else {
+      _latestSegmentRowsToSizeRatio = currentRatio;
     }
 
     // If the number of rows consumed is less than what we set as target in metadata, then the segment hit time limit.

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentSizeBasedFlushThresholdUpdater.java
@@ -18,11 +18,8 @@
  */
 package org.apache.pinot.controller.helix.core.realtime.segment;
 
-import com.google.common.annotations.VisibleForTesting;
-import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
-import org.apache.pinot.spi.stream.PartitionGroupMetadata;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -33,17 +30,12 @@ import org.slf4j.LoggerFactory;
  * previous segment
  * The formula used to compute new number of rows is:
  * targetNumRows = ideal_segment_size * (a * current_rows_to_size_ratio + b * previous_rows_to_size_ratio)
- * where a = 0.25, b = 0.75, prev ratio= ratio collected over all previous segment completions
+ * where a = 0.1, b = 0.9, prev ratio= ratio collected over all previous segment completions
  * This ensures that we take into account the history of the segment size and number rows
  */
 public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpdater {
   public static final Logger LOGGER = LoggerFactory.getLogger(SegmentSizeBasedFlushThresholdUpdater.class);
   private final SegmentFlushThresholdComputer _flushThresholdComputer;
-
-  @VisibleForTesting
-  double getLatestSegmentRowsToSizeRatio() {
-    return _flushThresholdComputer.getLatestSegmentRowsToSizeRatio();
-  }
 
   public SegmentSizeBasedFlushThresholdUpdater() {
     _flushThresholdComputer = new SegmentFlushThresholdComputer();
@@ -53,10 +45,10 @@ public class SegmentSizeBasedFlushThresholdUpdater implements FlushThresholdUpda
   @Override
   public synchronized void updateFlushThreshold(StreamConfig streamConfig, SegmentZKMetadata newSegmentZKMetadata,
       CommittingSegmentDescriptor committingSegmentDescriptor, @Nullable SegmentZKMetadata committingSegmentZKMetadata,
-      int maxNumPartitionsPerInstance, List<PartitionGroupMetadata> partitionGroupMetadataList) {
+      int maxNumPartitionsPerInstance) {
     int threshold =
         _flushThresholdComputer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
-            partitionGroupMetadataList, newSegmentZKMetadata.getSegmentName());
+            newSegmentZKMetadata.getSegmentName());
     newSegmentZKMetadata.setSizeThresholdToFlushSegment(threshold);
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManagerTest.java
@@ -31,6 +31,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 import java.util.TreeMap;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
@@ -1218,6 +1219,14 @@ public class PinotLLCRealtimeSegmentManagerTest {
           segmentAssignment, instancePartitionsMap);
       updateInstanceStatesForNewConsumingSegment(_idealState.getRecord().getMapFields(), null, newSegmentName,
           segmentAssignment, instancePartitionsMap);
+    }
+
+    @Override
+    Set<Integer> getPartitionIds(StreamConfig streamConfig) {
+      if (_partitionGroupMetadataList != null) {
+        throw new UnsupportedOperationException();
+      }
+      return IntStream.range(0, _numPartitions).boxed().collect(Collectors.toSet());
     }
 
     @Override

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -18,14 +18,10 @@
  */
 package org.apache.pinot.controller.helix.core.realtime.segment;
 
-import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
-import java.util.List;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.spi.stream.LongMsgOffset;
-import org.apache.pinot.spi.stream.PartitionGroupMetadata;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.annotations.Test;
@@ -134,9 +130,8 @@ public class FlushThresholdUpdaterTest {
       // Start consumption
       SegmentZKMetadata newSegmentZKMetadata = getNewSegmentZKMetadata(0);
       CommittingSegmentDescriptor committingSegmentDescriptor = getCommittingSegmentDescriptor(0L);
-      flushThresholdUpdater
-          .updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor, null, 1,
-              Collections.emptyList());
+      flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor, null,
+          1);
       assertEquals(newSegmentZKMetadata.getSizeThresholdToFlushSegment(), streamConfig.getFlushAutotuneInitialRows());
 
       int numRuns = 500;
@@ -148,7 +143,7 @@ public class FlushThresholdUpdaterTest {
         SegmentZKMetadata committingSegmentZKMetadata =
             getCommittingSegmentZKMetadata(System.currentTimeMillis(), numRowsConsumed, numRowsConsumed);
         flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor,
-            committingSegmentZKMetadata, 1, Collections.emptyList());
+            committingSegmentZKMetadata, 1);
 
         // Assert that segment size is in limits
         if (run > checkRunsAfter) {
@@ -172,9 +167,8 @@ public class FlushThresholdUpdaterTest {
       // Start consumption
       SegmentZKMetadata newSegmentZKMetadata = getNewSegmentZKMetadata(1);
       CommittingSegmentDescriptor committingSegmentDescriptor = getCommittingSegmentDescriptor(0L);
-      flushThresholdUpdater
-          .updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor, null, 1,
-              getPartitionGroupMetadataList(3, 1));
+      flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor, null,
+          1);
       assertEquals(newSegmentZKMetadata.getSizeThresholdToFlushSegment(), streamConfig.getFlushAutotuneInitialRows());
 
       int numRuns = 500;
@@ -186,7 +180,7 @@ public class FlushThresholdUpdaterTest {
         SegmentZKMetadata committingSegmentZKMetadata =
             getCommittingSegmentZKMetadata(System.currentTimeMillis(), numRowsConsumed, numRowsConsumed);
         flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor,
-            committingSegmentZKMetadata, 1, getPartitionGroupMetadataList(3, 1));
+            committingSegmentZKMetadata, 1);
 
         // Assert that segment size is in limits
         if (run > checkRunsAfter) {
@@ -199,16 +193,6 @@ public class FlushThresholdUpdaterTest {
   private SegmentZKMetadata getNewSegmentZKMetadata(int partitionId) {
     return new SegmentZKMetadata(
         new LLCSegmentName(RAW_TABLE_NAME, partitionId, 0, System.currentTimeMillis()).getSegmentName());
-  }
-
-  private List<PartitionGroupMetadata> getPartitionGroupMetadataList(int numPartitions, int startPartitionId) {
-    List<PartitionGroupMetadata> newPartitionGroupMetadataList = new ArrayList<>();
-
-    for (int i = 0; i < numPartitions; i++) {
-      newPartitionGroupMetadataList.add(new PartitionGroupMetadata(startPartitionId + i, null));
-    }
-
-    return newPartitionGroupMetadataList;
   }
 
   private CommittingSegmentDescriptor getCommittingSegmentDescriptor(long segmentSizeBytes) {
@@ -244,8 +228,8 @@ public class FlushThresholdUpdaterTest {
     // Start consumption
     SegmentZKMetadata newSegmentZKMetadata = getNewSegmentZKMetadata(0);
     CommittingSegmentDescriptor committingSegmentDescriptor = getCommittingSegmentDescriptor(0L);
-    flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor, null, 1,
-        Collections.emptyList());
+    flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor, null,
+        1);
     int sizeThreshold = newSegmentZKMetadata.getSizeThresholdToFlushSegment();
 
     // First segment consumes rows less than the threshold
@@ -254,7 +238,7 @@ public class FlushThresholdUpdaterTest {
     SegmentZKMetadata committingSegmentZKMetadata =
         getCommittingSegmentZKMetadata(System.currentTimeMillis(), sizeThreshold, numRowsConsumed);
     flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor,
-        committingSegmentZKMetadata, 1, Collections.emptyList());
+        committingSegmentZKMetadata, 1);
     sizeThreshold = newSegmentZKMetadata.getSizeThresholdToFlushSegment();
     assertEquals(sizeThreshold,
         (int) (numRowsConsumed * SegmentFlushThresholdComputer.ROWS_MULTIPLIER_WHEN_TIME_THRESHOLD_HIT));
@@ -264,7 +248,7 @@ public class FlushThresholdUpdaterTest {
     committingSegmentZKMetadata =
         getCommittingSegmentZKMetadata(System.currentTimeMillis(), sizeThreshold, numRowsConsumed);
     flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor,
-        committingSegmentZKMetadata, 1, Collections.emptyList());
+        committingSegmentZKMetadata, 1);
     assertNotEquals(newSegmentZKMetadata.getSizeThresholdToFlushSegment(),
         (int) (numRowsConsumed * SegmentFlushThresholdComputer.ROWS_MULTIPLIER_WHEN_TIME_THRESHOLD_HIT));
   }
@@ -277,8 +261,8 @@ public class FlushThresholdUpdaterTest {
     // Start consumption
     SegmentZKMetadata newSegmentZKMetadata = getNewSegmentZKMetadata(0);
     CommittingSegmentDescriptor committingSegmentDescriptor = getCommittingSegmentDescriptor(0L);
-    flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor, null, 1,
-        Collections.emptyList());
+    flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor, null,
+        1);
     int sizeThreshold = newSegmentZKMetadata.getSizeThresholdToFlushSegment();
 
     // First segment only consumed 15 rows, so next segment should have size threshold of 10_000
@@ -287,7 +271,7 @@ public class FlushThresholdUpdaterTest {
     SegmentZKMetadata committingSegmentZKMetadata =
         getCommittingSegmentZKMetadata(System.currentTimeMillis(), sizeThreshold, numRowsConsumed);
     flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor,
-        committingSegmentZKMetadata, 1, Collections.emptyList());
+        committingSegmentZKMetadata, 1);
     sizeThreshold = newSegmentZKMetadata.getSizeThresholdToFlushSegment();
     assertEquals(sizeThreshold, SegmentFlushThresholdComputer.MINIMUM_NUM_ROWS_THRESHOLD);
 
@@ -296,61 +280,9 @@ public class FlushThresholdUpdaterTest {
     committingSegmentZKMetadata =
         getCommittingSegmentZKMetadata(System.currentTimeMillis(), sizeThreshold, numRowsConsumed);
     flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor,
-        committingSegmentZKMetadata, 1, Collections.emptyList());
+        committingSegmentZKMetadata, 1);
     sizeThreshold = newSegmentZKMetadata.getSizeThresholdToFlushSegment();
     assertEquals(sizeThreshold, SegmentFlushThresholdComputer.MINIMUM_NUM_ROWS_THRESHOLD);
-  }
-
-  @Test
-  public void testNonZeroPartitionUpdates() {
-    SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater = new SegmentSizeBasedFlushThresholdUpdater();
-    StreamConfig streamConfig = mockDefaultAutotuneStreamConfig();
-
-    // Start consumption for 2 partitions
-    SegmentZKMetadata newSegmentZKMetadataForPartition0 = getNewSegmentZKMetadata(0);
-    SegmentZKMetadata newSegmentZKMetadataForPartition1 = getNewSegmentZKMetadata(1);
-    CommittingSegmentDescriptor committingSegmentDescriptor = getCommittingSegmentDescriptor(0L);
-    flushThresholdUpdater
-        .updateFlushThreshold(streamConfig, newSegmentZKMetadataForPartition0, committingSegmentDescriptor, null, 1,
-            Collections.emptyList());
-    flushThresholdUpdater
-        .updateFlushThreshold(streamConfig, newSegmentZKMetadataForPartition1, committingSegmentDescriptor, null, 1,
-            Collections.emptyList());
-    int sizeThresholdForPartition0 = newSegmentZKMetadataForPartition0.getSizeThresholdToFlushSegment();
-    int sizeThresholdForPartition1 = newSegmentZKMetadataForPartition1.getSizeThresholdToFlushSegment();
-    double sizeRatio = flushThresholdUpdater.getLatestSegmentRowsToSizeRatio();
-    assertEquals(sizeThresholdForPartition0, streamConfig.getFlushAutotuneInitialRows());
-    assertEquals(sizeThresholdForPartition1, streamConfig.getFlushAutotuneInitialRows());
-    assertEquals(sizeRatio, 0.0);
-
-    // First segment from partition 1 should change the size ratio
-    committingSegmentDescriptor = getCommittingSegmentDescriptor(128_000_000L);
-    SegmentZKMetadata committingSegmentZKMetadata =
-        getCommittingSegmentZKMetadata(System.currentTimeMillis(), sizeThresholdForPartition1,
-            sizeThresholdForPartition1);
-    flushThresholdUpdater
-        .updateFlushThreshold(streamConfig, newSegmentZKMetadataForPartition1, committingSegmentDescriptor,
-            committingSegmentZKMetadata, 1, Collections.emptyList());
-    sizeThresholdForPartition1 = newSegmentZKMetadataForPartition1.getSizeThresholdToFlushSegment();
-    sizeRatio = flushThresholdUpdater.getLatestSegmentRowsToSizeRatio();
-    assertTrue(sizeRatio > 0.0);
-
-    // Second segment update from partition 1 should not change the size ratio
-    committingSegmentDescriptor = getCommittingSegmentDescriptor(256_000_000L);
-    committingSegmentZKMetadata = getCommittingSegmentZKMetadata(System.currentTimeMillis(), sizeThresholdForPartition1,
-        sizeThresholdForPartition1);
-    flushThresholdUpdater
-        .updateFlushThreshold(streamConfig, newSegmentZKMetadataForPartition1, committingSegmentDescriptor,
-            committingSegmentZKMetadata, 1, Collections.emptyList());
-    assertEquals(flushThresholdUpdater.getLatestSegmentRowsToSizeRatio(), sizeRatio);
-
-    // First segment update from partition 0 should change the size ratio
-    committingSegmentZKMetadata = getCommittingSegmentZKMetadata(System.currentTimeMillis(), sizeThresholdForPartition0,
-        sizeThresholdForPartition0);
-    flushThresholdUpdater
-        .updateFlushThreshold(streamConfig, newSegmentZKMetadataForPartition0, committingSegmentDescriptor,
-            committingSegmentZKMetadata, 1, Collections.emptyList());
-    assertNotEquals(flushThresholdUpdater.getLatestSegmentRowsToSizeRatio(), sizeRatio);
   }
 
   @Test
@@ -367,8 +299,8 @@ public class FlushThresholdUpdaterTest {
     // Start consumption
     SegmentZKMetadata newSegmentZKMetadata = getNewSegmentZKMetadata(0);
     CommittingSegmentDescriptor committingSegmentDescriptor = getCommittingSegmentDescriptor(0L);
-    flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor, null, 1,
-        Collections.emptyList());
+    flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor, null,
+        1);
     int sizeThreshold = newSegmentZKMetadata.getSizeThresholdToFlushSegment();
     assertEquals(sizeThreshold, flushAutotuneInitialRows);
 
@@ -382,7 +314,7 @@ public class FlushThresholdUpdaterTest {
     SegmentZKMetadata committingSegmentZKMetadata =
         getCommittingSegmentZKMetadata(creationTime, sizeThreshold, numRowsConsumed);
     flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor,
-        committingSegmentZKMetadata, 1, Collections.emptyList());
+        committingSegmentZKMetadata, 1);
     sizeThreshold = newSegmentZKMetadata.getSizeThresholdToFlushSegment();
     assertTrue(sizeThreshold > numRowsConsumed);
 
@@ -395,7 +327,7 @@ public class FlushThresholdUpdaterTest {
         mockAutotuneStreamConfig(flushSegmentDesiredSizeBytes, flushThresholdTimeMillis, flushAutotuneInitialRows);
     committingSegmentZKMetadata = getCommittingSegmentZKMetadata(creationTime, sizeThreshold, numRowsConsumed);
     flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor,
-        committingSegmentZKMetadata, 1, Collections.emptyList());
+        committingSegmentZKMetadata, 1);
     sizeThreshold = newSegmentZKMetadata.getSizeThresholdToFlushSegment();
     assertTrue(sizeThreshold < numRowsConsumed);
 
@@ -406,7 +338,7 @@ public class FlushThresholdUpdaterTest {
     committingSegmentDescriptor = getCommittingSegmentDescriptor(committingSegmentSize);
     committingSegmentZKMetadata = getCommittingSegmentZKMetadata(creationTime, sizeThreshold, numRowsConsumed);
     flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor,
-        committingSegmentZKMetadata, 1, Collections.emptyList());
+        committingSegmentZKMetadata, 1);
     sizeThreshold = newSegmentZKMetadata.getSizeThresholdToFlushSegment();
     assertEquals(sizeThreshold,
         (long) (numRowsConsumed * SegmentFlushThresholdComputer.ROWS_MULTIPLIER_WHEN_TIME_THRESHOLD_HIT));
@@ -419,7 +351,7 @@ public class FlushThresholdUpdaterTest {
         mockAutotuneStreamConfig(flushSegmentDesiredSizeBytes, flushThresholdTimeMillis, flushAutotuneInitialRows);
     committingSegmentZKMetadata = getCommittingSegmentZKMetadata(creationTime, sizeThreshold, numRowsConsumed);
     flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor,
-        committingSegmentZKMetadata, 1, Collections.emptyList());
+        committingSegmentZKMetadata, 1);
     sizeThreshold = newSegmentZKMetadata.getSizeThresholdToFlushSegment();
     assertTrue(sizeThreshold < numRowsConsumed);
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentFlushThresholdComputerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentFlushThresholdComputerTest.java
@@ -20,11 +20,8 @@ package org.apache.pinot.controller.helix.core.realtime.segment;
 
 import java.time.Clock;
 import java.time.ZoneId;
-import java.util.ArrayList;
-import java.util.List;
 import java.util.concurrent.TimeUnit;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
-import org.apache.pinot.spi.stream.PartitionGroupMetadata;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.testng.annotations.Test;
 
@@ -35,6 +32,7 @@ import static org.testng.Assert.assertEquals;
 
 
 public class SegmentFlushThresholdComputerTest {
+
   @Test
   public void testUseAutoTuneInitialRowsIfFirstSegmentInPartition() {
     int autoTuneInitialRows = 1_000;
@@ -44,11 +42,8 @@ public class SegmentFlushThresholdComputerTest {
     when(streamConfig.getFlushAutotuneInitialRows()).thenReturn(autoTuneInitialRows);
 
     CommittingSegmentDescriptor committingSegmentDescriptor = mock(CommittingSegmentDescriptor.class);
-    SegmentZKMetadata committingSegmentZKMetadata = null;
 
-    List<PartitionGroupMetadata> partitionGroupMetadataList = new ArrayList<>();
-    int threshold = computer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
-        partitionGroupMetadataList, "newSegmentName");
+    int threshold = computer.computeThreshold(streamConfig, committingSegmentDescriptor, null, "newSegmentName");
 
     assertEquals(threshold, autoTuneInitialRows);
   }
@@ -64,11 +59,8 @@ public class SegmentFlushThresholdComputerTest {
     when(streamConfig.getFlushThresholdSegmentSizeBytes()).thenReturn(segmentSizeBytes);
 
     CommittingSegmentDescriptor committingSegmentDescriptor = mock(CommittingSegmentDescriptor.class);
-    SegmentZKMetadata committingSegmentZKMetadata = null;
 
-    List<PartitionGroupMetadata> partitionGroupMetadataList = new ArrayList<>();
-    int threshold = computer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
-        partitionGroupMetadataList, "newSegmentName");
+    int threshold = computer.computeThreshold(streamConfig, committingSegmentDescriptor, null, "newSegmentName");
 
     // segmentSize * 1.5
     // 20000 * 1.5
@@ -86,11 +78,8 @@ public class SegmentFlushThresholdComputerTest {
     when(streamConfig.getFlushThresholdSegmentSizeBytes()).thenReturn(segmentSizeBytes);
 
     CommittingSegmentDescriptor committingSegmentDescriptor = mock(CommittingSegmentDescriptor.class);
-    SegmentZKMetadata committingSegmentZKMetadata = null;
 
-    List<PartitionGroupMetadata> partitionGroupMetadataList = new ArrayList<>();
-    int threshold = computer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
-        partitionGroupMetadataList, "newSegmentName");
+    int threshold = computer.computeThreshold(streamConfig, committingSegmentDescriptor, null, "newSegmentName");
 
     assertEquals(threshold, 10000);
   }
@@ -110,9 +99,8 @@ public class SegmentFlushThresholdComputerTest {
     SegmentZKMetadata committingSegmentZKMetadata = mock(SegmentZKMetadata.class);
     when(committingSegmentZKMetadata.getSizeThresholdToFlushSegment()).thenReturn(segmentSizeThreshold);
 
-    List<PartitionGroupMetadata> partitionGroupMetadataList = new ArrayList<>();
     int threshold = computer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
-        partitionGroupMetadataList, "newSegmentName");
+        "newSegmentName");
 
     assertEquals(threshold, segmentSizeThreshold);
   }
@@ -137,9 +125,8 @@ public class SegmentFlushThresholdComputerTest {
     when(committingSegmentZKMetadata.getCreationTime()).thenReturn(
         currentTime - MILLISECONDS.convert(1, TimeUnit.HOURS));
 
-    List<PartitionGroupMetadata> partitionGroupMetadataList = new ArrayList<>();
     int threshold = computer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
-        partitionGroupMetadataList, "events3__0__0__20211222T1646Z");
+        "events3__0__0__20211222T1646Z");
 
     // totalDocs * 1.1
     // 10000 * 1.1
@@ -166,9 +153,8 @@ public class SegmentFlushThresholdComputerTest {
     when(committingSegmentZKMetadata.getCreationTime()).thenReturn(
         currentTime - MILLISECONDS.convert(2, TimeUnit.HOURS));
 
-    List<PartitionGroupMetadata> partitionGroupMetadataList = new ArrayList<>();
     int threshold = computer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
-        partitionGroupMetadataList, "events3__0__0__20211222T1646Z");
+        "events3__0__0__20211222T1646Z");
 
     // (totalDocs / 2) * 1.1
     // (30000 / 2) * 1.1
@@ -190,9 +176,8 @@ public class SegmentFlushThresholdComputerTest {
     when(committingSegmentZKMetadata.getTotalDocs()).thenReturn(30_000L);
     when(committingSegmentZKMetadata.getSizeThresholdToFlushSegment()).thenReturn(20_000);
 
-    List<PartitionGroupMetadata> partitionGroupMetadataList = new ArrayList<>();
     int threshold = computer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
-        partitionGroupMetadataList, "events3__0__0__20211222T1646Z");
+        "events3__0__0__20211222T1646Z");
 
     // totalDocs / 2
     // 30000 / 2
@@ -213,9 +198,8 @@ public class SegmentFlushThresholdComputerTest {
     when(committingSegmentZKMetadata.getTotalDocs()).thenReturn(30_000L);
     when(committingSegmentZKMetadata.getSizeThresholdToFlushSegment()).thenReturn(20_000);
 
-    List<PartitionGroupMetadata> partitionGroupMetadataList = new ArrayList<>();
     int threshold = computer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
-        partitionGroupMetadataList, "events3__0__0__20211222T1646Z");
+        "events3__0__0__20211222T1646Z");
 
     // totalDocs + (totalDocs / 2)
     // 30000 + (30000 / 2)
@@ -236,9 +220,8 @@ public class SegmentFlushThresholdComputerTest {
     when(committingSegmentZKMetadata.getTotalDocs()).thenReturn(30_000L);
     when(committingSegmentZKMetadata.getSizeThresholdToFlushSegment()).thenReturn(20_000);
 
-    List<PartitionGroupMetadata> partitionGroupMetadataList = new ArrayList<>();
     int threshold = computer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
-        partitionGroupMetadataList, "events3__0__0__20211222T1646Z");
+        "events3__0__0__20211222T1646Z");
 
     // (totalDocs / segmentSize) * flushThresholdSegmentSize
     // (30000 / 250000) * 300000
@@ -259,9 +242,8 @@ public class SegmentFlushThresholdComputerTest {
     when(committingSegmentZKMetadata.getTotalDocs()).thenReturn(0L);
     when(committingSegmentZKMetadata.getSizeThresholdToFlushSegment()).thenReturn(0);
 
-    List<PartitionGroupMetadata> partitionGroupMetadataList = new ArrayList<>();
     int threshold = computer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
-        partitionGroupMetadataList, "events3__0__0__20211222T1646Z");
+        "events3__0__0__20211222T1646Z");
 
     // max((totalDocs / segmentSize) * flushThresholdSegmentSize, 10000)
     // max(0, 10000)
@@ -282,17 +264,15 @@ public class SegmentFlushThresholdComputerTest {
     when(committingSegmentZKMetadata.getTotalDocs()).thenReturn(30_000L, 50_000L);
     when(committingSegmentZKMetadata.getSizeThresholdToFlushSegment()).thenReturn(60_000);
 
-    List<PartitionGroupMetadata> partitionGroupMetadataList = new ArrayList<>();
-
     computer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
-        partitionGroupMetadataList, "events3__0__0__20211222T1646Z");
+        "events3__0__0__20211222T1646Z");
 
     // (totalDocs / segmentSize)
     // (30000 / 200000)
     assertEquals(computer.getLatestSegmentRowsToSizeRatio(), 0.15);
 
     computer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
-        partitionGroupMetadataList, "events3__0__0__20211222T1646Z");
+        "events3__0__0__20211222T1646Z");
 
     // (0.1 * (totalDocs / segmentSize)) + (0.9 * lastRatio)
     // (0.1 * (50000 / 200000)) + (0.9 * 0.15)

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamMetadataProvider.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/impl/fakestream/FakeStreamMetadataProvider.java
@@ -19,6 +19,9 @@
 package org.apache.pinot.core.realtime.impl.fakestream;
 
 import java.io.IOException;
+import java.util.Set;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
@@ -38,6 +41,11 @@ public class FakeStreamMetadataProvider implements StreamMetadataProvider {
   @Override
   public int fetchPartitionCount(long timeoutMillis) {
     return _numPartitions;
+  }
+
+  @Override
+  public Set<Integer> fetchPartitionIds(long timeoutMillis) {
+    return IntStream.range(0, _numPartitions).boxed().collect(Collectors.toSet());
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamMetadataProvider.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.TimeoutException;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
@@ -42,6 +43,13 @@ public interface StreamMetadataProvider extends Closeable {
    * @return number of partitions
    */
   int fetchPartitionCount(long timeoutMillis);
+
+  /**
+   * Fetches the partition ids for a topic given the stream configs.
+   */
+  default Set<Integer> fetchPartitionIds(long timeoutMillis) {
+    throw new UnsupportedOperationException();
+  }
 
   /**
    * Fetches the offset for a given partition and offset criteria
@@ -98,5 +106,6 @@ public interface StreamMetadataProvider extends Closeable {
     return result;
   }
 
-  class UnknownLagState extends PartitionLagState { }
+  class UnknownLagState extends PartitionLagState {
+  }
 }


### PR DESCRIPTION
Solves #11812 
Currently when committing a real-time segment, controller needs to read partition group metadata for all partitions from upstream, which can be very slow for stream with lots of partitions.
The partition group metadata is used only to extract the partition ids, which can be simply derived from partition count except for stream that closes partitions such as Kinesis.

In this PR, we made the following changes:
1. Only read partition count from upstream if available
2. If partition count is not available, fall back to the current approach
3. Log the time spent in each step for debugging
4. In `SegmentFlushThresholdComputer`, remove the logic of only counting the segments with smallest partition id for the size ratio because it complicates the handling (quite anti-pattern as any segment commit requires info from all partitions) a lot, and I don't see much value from it. Quickly converging to the size ratio of recent data trend should be a pro instead of a con because this ratio is used to decide the segment size to consume data for the same period of time