### PR TITLE
adding catch all logging for exception during DQL/DML process

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotClientRequest.java
@@ -328,7 +328,7 @@ public class PinotClientRequest {
               .forEach(entry -> headers.put(entry.getKey(), entry.getValue()));
           return _sqlQueryExecutor.executeDMLStatement(sqlNodeAndOptions, headers);
         } catch (Exception e) {
-          LOGGER.error("Error handling DQL request:\n{}\nException: {}", sqlRequestJson,
+          LOGGER.error("Error handling DML request:\n{}\nException: {}", sqlRequestJson,
               QueryException.getTruncatedStackTrace(e));
           throw e;
         }


### PR DESCRIPTION
previously b/c `BrokerRequestHandler#handleRequest` can throw exception. it is possible that there's only exception being and logged without the context such as what request content is being processed.

adding a catch, log then rethrow logic in the client side