### PR TITLE
Early release AcquireReleaseColumnsSegmentOperator during explain plan

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/Operator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/Operator.java
@@ -51,6 +51,9 @@ public interface Operator<T extends Block> {
   default void prepareForExplainPlan(ExplainPlanRows explainPlanRows) {
   }
 
+  default void postExplainPlan(ExplainPlanRows explainPlanRows) {
+  }
+
   default void explainPlan(ExplainPlanRows explainPlanRows, int[] globalId, int parentId) {
     prepareForExplainPlan(explainPlanRows);
     String explainPlanString = toExplainString();
@@ -66,6 +69,7 @@ public interface Operator<T extends Block> {
         child.explainPlan(explainPlanRows, globalId, parentId);
       }
     }
+    postExplainPlan(explainPlanRows);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/AcquireReleaseColumnsSegmentOperator.java
@@ -93,6 +93,11 @@ public class AcquireReleaseColumnsSegmentOperator extends BaseOperator<BaseResul
   }
 
   @Override
+  public void postExplainPlan(ExplainPlanRows explainPlanRows) {
+    release();
+  }
+
+  @Override
   public String toExplainString() {
     return EXPLAIN_NAME;
   }


### PR DESCRIPTION
During explain plan query execution, once all the child operators of the AcquireReleaseColumnsSegmentOperator have been processed, we may call release() early and not defer until all segments are processed.