### PR TITLE
Bump web server max header size to accommodate long urls

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/ZookeeperResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/ZookeeperResourceTest.java
@@ -84,7 +84,7 @@ public class ZookeeperResourceTest {
         + "proidentsuntinculpaquiofficiadeseruntmollitanimidestlaborum";
 
     // make the content even more larger
-    for (int i = 0; i < 5; i++) {
+    for (int i = 0; i < 10; i++) {
       lorem += lorem;
     }
     String largeData = "{\"id\" : \"QuickStartCluster\","

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java
@@ -62,6 +62,8 @@ public final class ListenerConfigUtil {
   private static final String DEFAULT_HOST = "0.0.0.0";
   private static final String DOT_ACCESS_PROTOCOLS = ".access.protocols";
   private static final String DOT_ACCESS_THREAD_POOL = ".http.server.thread.pool";
+  // some endpoints accept SQL as query string which may exceed the default 8K
+  private static final int MAX_HTTP_HEADER_SIZE = 64_000;
 
   private ListenerConfigUtil() {
     // left blank
@@ -239,6 +241,7 @@ public final class ListenerConfigUtil {
             .setUncaughtExceptionHandler(new JerseyProcessingUncaughtExceptionHandler()).build())
         .setCorePoolSize(listenerConfig.getThreadPoolConfig().getCorePoolSize())
         .setMaxPoolSize(listenerConfig.getThreadPoolConfig().getMaxPoolSize());
+    listener.setMaxHttpHeaderSize(MAX_HTTP_HEADER_SIZE);
 
     if (CommonConstants.HTTPS_PROTOCOL.equals(listenerConfig.getProtocol())) {
       listener.setSecure(true);


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Set max HTTP header size to 64K; adjust test for larger data\.

```mermaid
flowchart TD
  N0["Set max HTTP header size to 64K #40;F1#41;"]:::stAdded
  N1["Apply header size to Jetty listener #40;F1#41;"]:::stAdded
  N2["Increase test loop iterations to 10 #40;F2#41;"]:::stModified
  N0 -->|"constant used as argument"| N1
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil\.java — [before](https://github.com/apache/pinot/blob/2dca1411fbe76ff56ec04d7c4222cd879c7aec51/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java) · [after](https://github.com/apache/pinot/blob/64d194634aeff473df5ee5c3504160030e7ee971/pinot-core/src/main/java/org/apache/pinot/core/util/ListenerConfigUtil.java)
- F2: pinot\-controller/src/test/java/org/apache/pinot/controller/api/resources/ZookeeperResourceTest\.java — [before](https://github.com/apache/pinot/blob/2dca1411fbe76ff56ec04d7c4222cd879c7aec51/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/ZookeeperResourceTest.java) · [after](https://github.com/apache/pinot/blob/64d194634aeff473df5ee5c3504160030e7ee971/pinot-controller/src/test/java/org/apache/pinot/controller/api/resources/ZookeeperResourceTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjJkY2ExNDExZmJlNzZmZjU2ZWMwNGQ3YzQyMjJjZDg3OWM3YWVjNTEiLCJjb250ZXh0X2hhc2giOiJhMTc2ODBhZWVhNjFkZmIxYjIxNWQzZDU2ZDk1ZjRiNDRkNzlhNDg2Y2I2MzIzMzE2ODJkNTMzMDYzNTU5ZjA3IiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTMxNjc3LCJoZWFkX3NoYSI6IjY0ZDE5NDYzNGFlZmY0NzNkZjVlZTVjMzUwNDE2MDAzMGU3ZWU5NzEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJlZTRiODM0ZTVmYzcxOGRhMzY3NWE3YzIxMTAxNWRmMGE4ZWE5MjUwIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 12fa059f89e149507d922fd57badbdd87c4fa3b029a99baa2f57589974fdf1f1 -->
<!-- pinot-pr-flow:end -->

There are some endpoints (e.g. broker API `/debug/routingTable/sql`) which accept SQL as query string param. Default limit of 8K bytes can be too little for long queries so I'm bumping it to a more reasonable value, 64K.

Ideally this should be fixed by moving the parameter to request body (POST), but this change is also needed to help older clients.

`bugfix`
