### PR TITLE
[bugfix] Add check for illegal character '/' in taskName

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/task/AdhocTaskConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/task/AdhocTaskConfig.java
@@ -57,6 +57,7 @@ public class AdhocTaskConfig extends BaseJsonConfig {
       @JsonProperty("taskConfigs") @Nullable Map<String, String> taskConfigs) {
     Preconditions.checkArgument(taskType != null, "'taskType' must be configured");
     Preconditions.checkArgument(tableName != null, "'tableName' must be configured");
+    Preconditions.checkArgument(taskName == null || !taskName.contains("/"), "'taskName' must not contain '/'");
     _taskType = taskType;
     _tableName = tableName;
     _taskName = taskName;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/task/AdhocTaskConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/task/AdhocTaskConfig.java
@@ -57,7 +57,8 @@ public class AdhocTaskConfig extends BaseJsonConfig {
       @JsonProperty("taskConfigs") @Nullable Map<String, String> taskConfigs) {
     Preconditions.checkArgument(taskType != null, "'taskType' must be configured");
     Preconditions.checkArgument(tableName != null, "'tableName' must be configured");
-    Preconditions.checkArgument(taskName == null || !taskName.contains("/"), "'taskName' must not contain '/'");
+    Preconditions.checkArgument(taskName == null || !taskName.contains("/"),
+        "'taskName' must not contain path separator '/'");
     _taskType = taskType;
     _tableName = tableName;
     _taskName = taskName;

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/task/AdhocTaskConfigTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/task/AdhocTaskConfigTest.java
@@ -24,6 +24,7 @@ import org.apache.pinot.spi.utils.JsonUtils;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertThrows;
 
 
 public class AdhocTaskConfigTest {
@@ -39,5 +40,22 @@ public class AdhocTaskConfigTest {
     assertEquals(adhocTaskConfig.getTaskName(), "myTask-0");
     assertEquals(adhocTaskConfig.getTaskConfigs().size(), 1);
     assertEquals(adhocTaskConfig.getTaskConfigs().get("inputDirURI"), "s3://my-bucket/my-file.json");
+  }
+
+  @Test
+  public void testInvalidArgumentsForAdhocTaskConfig() {
+    // Test 1 : pass invalid taskType(null) to AdhocTaskConfig.
+    assertThrows(IllegalArgumentException.class, () -> new AdhocTaskConfig(null, "TestTable", "TestTaskName",
+        ImmutableMap.of("inputDirURI", "s3://my-bucket/my-file.json")));
+
+    // Test 2 : pass invalid tableName(null) to AdhocTaskConfig.
+    assertThrows(IllegalArgumentException.class,
+        () -> new AdhocTaskConfig("SegmentGenerationAndPushTask", null, "TestTaskName",
+            ImmutableMap.of("inputDirURI", "s3://my-bucket/my-file.json")));
+
+    //Test 3 : pass invalid taskName(String with path separator '/') to AdhocTaskConfig.
+    assertThrows(IllegalArgumentException.class,
+        () -> new AdhocTaskConfig("SegmentGenerationAndPushTask", "TestTable", "Invalid/TestTaskName",
+            ImmutableMap.of("inputDirURI", "s3://my-bucket/my-file.json")));
   }
 }


### PR DESCRIPTION
### Issue

If the taskName contains one or more '/' character in case of user generated tasks, the ZNode gets splits into a subdirectory resulting in the corresponding ZNode name not getting detected by Helix task executor. 

Controller generated tasks don’t have this issue because controller has it's own logic to generate the taskName(table name + UUID) which makes sure that the taskName does not contain '/'. 
 
### Solution

Addition of validation for taskName so that it does not contain the character '/'.