### PR TITLE
Make groupBy trim size configurable at Broker

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseReduceService.java
@@ -51,15 +51,15 @@ public abstract class BaseReduceService {
   protected final ExecutorService _reduceExecutorService;
   protected final int _maxReduceThreadsPerQuery;
   protected final int _groupByTrimThreshold;
-  protected final int _minGroupByTrimSize;
+  protected final int _minGroupTrimSize;
 
   public BaseReduceService(PinotConfiguration config) {
     _maxReduceThreadsPerQuery = config.getProperty(CommonConstants.Broker.CONFIG_OF_MAX_REDUCE_THREADS_PER_QUERY,
         CommonConstants.Broker.DEFAULT_MAX_REDUCE_THREADS_PER_QUERY);
     _groupByTrimThreshold = config.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_GROUPBY_TRIM_THRESHOLD,
         CommonConstants.Broker.DEFAULT_BROKER_GROUPBY_TRIM_THRESHOLD);
-    _minGroupByTrimSize = config.getProperty(CommonConstants.Broker.CONFIG_OF_MIN_BROKER_GROUPBY_TRIM_SIZE,
-        CommonConstants.Broker.DEFAULT_MIN_BROKER_GROUPBY_TRIM_SIZE);
+    _minGroupTrimSize = config.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_MIN_GROUP_TRIM_SIZE,
+        CommonConstants.Broker.DEFAULT_BROKER_MIN_GROUP_TRIM_SIZE);
 
     int numThreadsInExecutorService = Runtime.getRuntime().availableProcessors();
     LOGGER.info("Initializing BrokerReduceService with {} threads, and {} max reduce threads.",

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BaseReduceService.java
@@ -51,12 +51,15 @@ public abstract class BaseReduceService {
   protected final ExecutorService _reduceExecutorService;
   protected final int _maxReduceThreadsPerQuery;
   protected final int _groupByTrimThreshold;
+  protected final int _minGroupByTrimSize;
 
   public BaseReduceService(PinotConfiguration config) {
     _maxReduceThreadsPerQuery = config.getProperty(CommonConstants.Broker.CONFIG_OF_MAX_REDUCE_THREADS_PER_QUERY,
         CommonConstants.Broker.DEFAULT_MAX_REDUCE_THREADS_PER_QUERY);
     _groupByTrimThreshold = config.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_GROUPBY_TRIM_THRESHOLD,
         CommonConstants.Broker.DEFAULT_BROKER_GROUPBY_TRIM_THRESHOLD);
+    _minGroupByTrimSize = config.getProperty(CommonConstants.Broker.CONFIG_OF_MIN_BROKER_GROUPBY_TRIM_SIZE,
+        CommonConstants.Broker.DEFAULT_MIN_BROKER_GROUPBY_TRIM_SIZE);
 
     int numThreadsInExecutorService = Runtime.getRuntime().availableProcessors();
     LOGGER.info("Initializing BrokerReduceService with {} threads, and {} max reduce threads.",

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -110,7 +110,7 @@ public class BrokerReduceService extends BaseReduceService {
     try {
       dataTableReducer.reduceAndSetResults(rawTableName, cachedDataSchema, dataTableMap, brokerResponseNative,
           new DataTableReducerContext(_reduceExecutorService, _maxReduceThreadsPerQuery, reduceTimeOutMs,
-              _groupByTrimThreshold), brokerMetrics);
+              _groupByTrimThreshold, _minGroupByTrimSize), brokerMetrics);
     } catch (EarlyTerminationException e) {
       brokerResponseNative.addToExceptions(
           new QueryProcessingException(QueryException.QUERY_CANCELLATION_ERROR_CODE, e.toString()));

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/BrokerReduceService.java
@@ -110,7 +110,7 @@ public class BrokerReduceService extends BaseReduceService {
     try {
       dataTableReducer.reduceAndSetResults(rawTableName, cachedDataSchema, dataTableMap, brokerResponseNative,
           new DataTableReducerContext(_reduceExecutorService, _maxReduceThreadsPerQuery, reduceTimeOutMs,
-              _groupByTrimThreshold, _minGroupByTrimSize), brokerMetrics);
+              _groupByTrimThreshold, _minGroupTrimSize), brokerMetrics);
     } catch (EarlyTerminationException e) {
       brokerResponseNative.addToExceptions(
           new QueryProcessingException(QueryException.QUERY_CANCELLATION_ERROR_CODE, e.toString()));

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DataTableReducerContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DataTableReducerContext.java
@@ -31,7 +31,7 @@ public class DataTableReducerContext {
   private final long _reduceTimeOutMs;
   // used for SQL GROUP BY
   private final int _groupByTrimThreshold;
-  private final int _minGroupByTrimSize;
+  private final int _minGroupTrimSize;
 
   /**
    * Constructor for the class.
@@ -42,12 +42,12 @@ public class DataTableReducerContext {
    * @param groupByTrimThreshold trim threshold for SQL group by
    */
   public DataTableReducerContext(ExecutorService executorService, int maxReduceThreadsPerQuery, long reduceTimeOutMs,
-      int groupByTrimThreshold, int minGroupByTrimSize) {
+      int groupByTrimThreshold, int minGroupTrimSize) {
     _executorService = executorService;
     _maxReduceThreadsPerQuery = maxReduceThreadsPerQuery;
     _reduceTimeOutMs = reduceTimeOutMs;
     _groupByTrimThreshold = groupByTrimThreshold;
-    _minGroupByTrimSize = minGroupByTrimSize;
+    _minGroupTrimSize = minGroupTrimSize;
   }
 
   public ExecutorService getExecutorService() {
@@ -66,7 +66,7 @@ public class DataTableReducerContext {
     return _groupByTrimThreshold;
   }
 
-  public int getMinGroupByTrimSize() {
-    return _minGroupByTrimSize;
+  public int getMinGroupTrimSize() {
+    return _minGroupTrimSize;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DataTableReducerContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/DataTableReducerContext.java
@@ -31,6 +31,7 @@ public class DataTableReducerContext {
   private final long _reduceTimeOutMs;
   // used for SQL GROUP BY
   private final int _groupByTrimThreshold;
+  private final int _minGroupByTrimSize;
 
   /**
    * Constructor for the class.
@@ -41,11 +42,12 @@ public class DataTableReducerContext {
    * @param groupByTrimThreshold trim threshold for SQL group by
    */
   public DataTableReducerContext(ExecutorService executorService, int maxReduceThreadsPerQuery, long reduceTimeOutMs,
-      int groupByTrimThreshold) {
+      int groupByTrimThreshold, int minGroupByTrimSize) {
     _executorService = executorService;
     _maxReduceThreadsPerQuery = maxReduceThreadsPerQuery;
     _reduceTimeOutMs = reduceTimeOutMs;
     _groupByTrimThreshold = groupByTrimThreshold;
+    _minGroupByTrimSize = minGroupByTrimSize;
   }
 
   public ExecutorService getExecutorService() {
@@ -62,5 +64,9 @@ public class DataTableReducerContext {
 
   public int getGroupByTrimThreshold() {
     return _groupByTrimThreshold;
+  }
+
+  public int getMinGroupByTrimSize() {
+    return _minGroupByTrimSize;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -250,8 +250,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
     // In case of single reduce thread, fall back to SimpleIndexedTable to avoid redundant locking/unlocking calls.
     int numReduceThreadsToUse = getNumReduceThreadsToUse(numDataTables, reducerContext.getMaxReduceThreadsPerQuery());
     int limit = _queryContext.getLimit();
-    // TODO: Make minTrimSize configurable
-    int trimSize = GroupByUtils.getTableCapacity(limit);
+    int trimSize = GroupByUtils.getTableCapacity(limit, reducerContext.getMinGroupByTrimSize());
     // NOTE: For query with HAVING clause, use trimSize as resultSize to ensure the result accuracy.
     // TODO: Resolve the HAVING clause within the IndexedTable before returning the result
     int resultSize = _queryContext.getHavingFilter() != null ? trimSize : limit;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/GroupByDataTableReducer.java
@@ -250,7 +250,7 @@ public class GroupByDataTableReducer implements DataTableReducer {
     // In case of single reduce thread, fall back to SimpleIndexedTable to avoid redundant locking/unlocking calls.
     int numReduceThreadsToUse = getNumReduceThreadsToUse(numDataTables, reducerContext.getMaxReduceThreadsPerQuery());
     int limit = _queryContext.getLimit();
-    int trimSize = GroupByUtils.getTableCapacity(limit, reducerContext.getMinGroupByTrimSize());
+    int trimSize = GroupByUtils.getTableCapacity(limit, reducerContext.getMinGroupTrimSize());
     // NOTE: For query with HAVING clause, use trimSize as resultSize to ensure the result accuracy.
     // TODO: Resolve the HAVING clause within the IndexedTable before returning the result
     int resultSize = _queryContext.getHavingFilter() != null ? trimSize : limit;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/StreamingReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/StreamingReduceService.java
@@ -81,7 +81,7 @@ public class StreamingReduceService extends BaseReduceService {
     // Process server response.
     DataTableReducerContext dataTableReducerContext =
         new DataTableReducerContext(_reduceExecutorService, _maxReduceThreadsPerQuery, reduceTimeOutMs,
-            _groupByTrimThreshold, _minGroupByTrimSize);
+            _groupByTrimThreshold, _minGroupTrimSize);
     StreamingReducer streamingReducer = ResultReducerFactory.getStreamingReducer(queryContext);
 
     streamingReducer.init(dataTableReducerContext);

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/StreamingReduceService.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/reduce/StreamingReduceService.java
@@ -81,7 +81,7 @@ public class StreamingReduceService extends BaseReduceService {
     // Process server response.
     DataTableReducerContext dataTableReducerContext =
         new DataTableReducerContext(_reduceExecutorService, _maxReduceThreadsPerQuery, reduceTimeOutMs,
-            _groupByTrimThreshold);
+            _groupByTrimThreshold, _minGroupByTrimSize);
     StreamingReducer streamingReducer = ResultReducerFactory.getStreamingReducer(queryContext);
 
     streamingReducer.init(dataTableReducerContext);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineGRPCServerIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/OfflineGRPCServerIntegrationTest.java
@@ -60,7 +60,7 @@ import static org.testng.Assert.*;
 public class OfflineGRPCServerIntegrationTest extends BaseClusterIntegrationTest {
   private static final ExecutorService EXECUTOR_SERVICE = Executors.newFixedThreadPool(2);
   private static final DataTableReducerContext DATATABLE_REDUCER_CONTEXT = new DataTableReducerContext(
-      EXECUTOR_SERVICE, 2, 10000, 10000);
+      EXECUTOR_SERVICE, 2, 10000, 10000, 5000);
 
   @BeforeClass
   public void setUp()

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -267,8 +267,8 @@ public class CommonConstants {
     // used for SQL GROUP BY during broker reduce
     public static final String CONFIG_OF_BROKER_GROUPBY_TRIM_THRESHOLD = "pinot.broker.groupby.trim.threshold";
     public static final int DEFAULT_BROKER_GROUPBY_TRIM_THRESHOLD = 1_000_000;
-    public static final String CONFIG_OF_MIN_BROKER_GROUPBY_TRIM_SIZE = "pinot.broker.min.groupby.trim.size";
-    public static final int DEFAULT_MIN_BROKER_GROUPBY_TRIM_SIZE = 5000;
+    public static final String CONFIG_OF_BROKER_MIN_GROUP_TRIM_SIZE = "pinot.broker.min.group.trim.size";
+    public static final int DEFAULT_BROKER_MIN_GROUP_TRIM_SIZE = 5000;
 
     // Configure the request handler type used by broker to handler inbound query request.
     // NOTE: the request handler type refers to the communication between Broker and Server.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -267,6 +267,8 @@ public class CommonConstants {
     // used for SQL GROUP BY during broker reduce
     public static final String CONFIG_OF_BROKER_GROUPBY_TRIM_THRESHOLD = "pinot.broker.groupby.trim.threshold";
     public static final int DEFAULT_BROKER_GROUPBY_TRIM_THRESHOLD = 1_000_000;
+    public static final String CONFIG_OF_MIN_BROKER_GROUPBY_TRIM_SIZE = "pinot.broker.min.groupby.trim.size";
+    public static final int DEFAULT_MIN_BROKER_GROUPBY_TRIM_SIZE = 5000;
 
     // Configure the request handler type used by broker to handler inbound query request.
     // NOTE: the request handler type refers to the communication between Broker and Server.


### PR DESCRIPTION
- Currently, the groupBy trim size for groupByDataTableReducer is determined as `Math.max(limit * 5, DEFAULT_MIN_NUM_GROUPS)`
- DEFAULT_MIN_NUM_GROUPS is hardcoded to 5000 and it's not configurable. 

This PR makes it configurable so that users can control the accuracy of their groupBy queries.
