### PR TITLE
Allow user specify local temp directory for quickstart

### DIFF
--- a/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/HybridQuickstart.java
@@ -106,7 +106,8 @@ public class HybridQuickstart extends Quickstart {
 
   public void execute()
       throws Exception {
-    File quickstartTmpDir = new File(_dataDir, String.valueOf(System.currentTimeMillis()));
+    File quickstartTmpDir =
+        _setCustomDataDir ? _dataDir : new File(_dataDir, String.valueOf(System.currentTimeMillis()));
     File quickstartRunnerDir = new File(quickstartTmpDir, "quickstart");
     Preconditions.checkState(quickstartRunnerDir.mkdirs());
     Set<QuickstartTableRequest> quickstartTableRequests = new HashSet<>();

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/QuickStartBase.java
@@ -89,6 +89,7 @@ public abstract class QuickStartBase {
       .build();
 
   protected File _dataDir = FileUtils.getTempDirectory();
+  protected boolean _setCustomDataDir;
   protected String[] _bootstrapDataDirs;
   protected String _zkExternalAddress;
   protected String _configFilePath;
@@ -97,6 +98,7 @@ public abstract class QuickStartBase {
 
   public QuickStartBase setDataDir(String dataDir) {
     _dataDir = new File(dataDir);
+    _setCustomDataDir = true;
     return this;
   }
 

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/Quickstart.java
@@ -59,7 +59,8 @@ public class Quickstart extends QuickStartBase {
 
   public void execute()
       throws Exception {
-    File quickstartTmpDir = new File(_dataDir, String.valueOf(System.currentTimeMillis()));
+    File quickstartTmpDir =
+        _setCustomDataDir ? _dataDir : new File(_dataDir, String.valueOf(System.currentTimeMillis()));
     File quickstartRunnerDir = new File(quickstartTmpDir, "quickstart");
     Preconditions.checkState(quickstartRunnerDir.mkdirs());
     List<QuickstartTableRequest> quickstartTableRequests = bootstrapOfflineTableDirectories(quickstartTmpDir);

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/RealtimeQuickStart.java
@@ -81,7 +81,8 @@ public class RealtimeQuickStart extends QuickStartBase {
 
   public void execute()
       throws Exception {
-    File quickstartTmpDir = new File(_dataDir, String.valueOf(System.currentTimeMillis()));
+    File quickstartTmpDir =
+        _setCustomDataDir ? _dataDir : new File(_dataDir, String.valueOf(System.currentTimeMillis()));
     File quickstartRunnerDir = new File(quickstartTmpDir, "quickstart");
     Preconditions.checkState(quickstartRunnerDir.mkdirs());
     List<QuickstartTableRequest> quickstartTableRequests = bootstrapStreamTableDirectories(quickstartTmpDir);


### PR DESCRIPTION
Current `QuickStart`, `RealtimeQuickStart`, `HybridQuickStart` data directory is not fixed after restart, so whatever changed won't be able to retrieve back.

The purpose of making data dir random is to keep local IDE running quickstart and debugging simpler. 

Considering normal users who may wanna keep the workspace for testing, benchmarking, etc.
I propose to change the behavior when user set customized dataDir and allow them to bring back the same quickstart again.

Sample quickstart usage could be:
```
bin/pinot-admin.sh QuickStart -type batch  -dataDir /tmp/pinot-quickstart-1 -zkAddress localhost:2181
```