### PR TITLE
fixing flaky test for SelectionCombineOperatorTest

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
@@ -21,12 +21,10 @@ package org.apache.pinot.core.operator.combine;
 import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import org.apache.commons.io.FileUtils;
-import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.core.operator.blocks.results.SelectionResultsBlock;
 import org.apache.pinot.core.plan.CombinePlanNode;
@@ -37,14 +35,9 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.core.util.QueryMultiThreadingUtils;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
-import org.apache.pinot.segment.local.indexsegment.mutable.MutableSegmentImpl;
-import org.apache.pinot.segment.local.io.writer.impl.DirectMemoryManager;
-import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentConfig;
-import org.apache.pinot.segment.local.realtime.impl.RealtimeSegmentStatsHistory;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.IndexSegment;
-import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -58,9 +51,6 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.mockito.ArgumentMatchers.anyString;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
@@ -76,8 +66,6 @@ public class SelectionCombineOperatorTest {
 
   // Create (MAX_NUM_THREADS_PER_QUERY * 2) segments so that each thread needs to process 2 segments
   private static final int NUM_SEGMENTS = QueryMultiThreadingUtils.MAX_NUM_THREADS_PER_QUERY * 2;
-  private static final int NUM_CONSUMING_SEGMENTS = NUM_SEGMENTS / 2;
-  private static final String REALTIME_TABLE_NAME = RAW_TABLE_NAME + "_REALTIME";
   private static final int NUM_RECORDS_PER_SEGMENT = 100;
 
   private static final String INT_COLUMN = "intColumn";
@@ -96,36 +84,9 @@ public class SelectionCombineOperatorTest {
       throws Exception {
     FileUtils.deleteDirectory(TEMP_DIR);
     _indexSegments = new ArrayList<>(NUM_SEGMENTS);
-    for (int i = 0; i < NUM_SEGMENTS / 2; i++) {
+    for (int i = 0; i < NUM_SEGMENTS; i++) {
       _indexSegments.add(createOfflineSegment(i));
     }
-
-    for (int i = NUM_CONSUMING_SEGMENTS; i < NUM_SEGMENTS; i++) {
-      _indexSegments.add(createRealtimeSegment(i));
-    }
-  }
-
-  private IndexSegment createRealtimeSegment(int index)
-      throws Exception {
-    RealtimeSegmentStatsHistory statsHistory = mock(RealtimeSegmentStatsHistory.class);
-    when(statsHistory.getEstimatedCardinality(anyString())).thenReturn(200);
-    when(statsHistory.getEstimatedAvgColSize(anyString())).thenReturn(32);
-
-    String segmentName = SEGMENT_NAME_PREFIX + index;
-
-    RealtimeSegmentConfig realtimeSegmentConfig = new RealtimeSegmentConfig.Builder()
-        .setTableNameWithType(REALTIME_TABLE_NAME).setSegmentName(segmentName).setSchema(SCHEMA).setCapacity(100000)
-        .setAvgNumMultiValues(2).setSegmentZKMetadata(new SegmentZKMetadata(segmentName))
-        .setMemoryManager(new DirectMemoryManager(segmentName)).setStatsHistory(statsHistory).setAggregateMetrics(false)
-        .setNullHandlingEnabled(true).setIngestionAggregationConfigs(Collections.emptyList()).build();
-    MutableSegment mutableSegmentImpl = new MutableSegmentImpl(realtimeSegmentConfig, null);
-    int baseValue = index * NUM_RECORDS_PER_SEGMENT / 2;
-    for (int i = 0; i < NUM_RECORDS_PER_SEGMENT; i++) {
-      GenericRow record = new GenericRow();
-      record.putValue(INT_COLUMN, baseValue + i);
-      mutableSegmentImpl.index(record, null);
-    }
-    return mutableSegmentImpl;
   }
 
   private IndexSegment createOfflineSegment(int index)
@@ -180,7 +141,6 @@ public class SelectionCombineOperatorTest {
     assertEquals(combineResult.getNumEntriesScannedInFilter(), 0);
     assertEquals(combineResult.getNumEntriesScannedPostFilter(), numDocsScanned);
     assertEquals(combineResult.getNumSegmentsProcessed(), NUM_SEGMENTS);
-    assertEquals(combineResult.getNumConsumingSegmentsProcessed(), NUM_CONSUMING_SEGMENTS);
     int numSegmentsMatched = combineResult.getNumSegmentsMatched();
     assertTrue(numSegmentsMatched >= 1 && numSegmentsMatched <= QueryMultiThreadingUtils.MAX_NUM_THREADS_PER_QUERY);
     // The check below depends on the order of segment processing. When segments# <= 10 (the value of
@@ -212,8 +172,6 @@ public class SelectionCombineOperatorTest {
     assertEquals(combineResult.getNumEntriesScannedPostFilter(), numDocsScanned);
     assertEquals(combineResult.getNumSegmentsProcessed(), NUM_SEGMENTS);
     assertEquals(combineResult.getNumSegmentsMatched(), NUM_SEGMENTS);
-    assertEquals(combineResult.getNumConsumingSegmentsProcessed(), NUM_CONSUMING_SEGMENTS);
-    assertEquals(combineResult.getNumConsumingSegmentsMatched(), NUM_CONSUMING_SEGMENTS);
     assertEquals(combineResult.getNumTotalDocs(), NUM_SEGMENTS * NUM_RECORDS_PER_SEGMENT);
   }
 
@@ -236,8 +194,6 @@ public class SelectionCombineOperatorTest {
     assertEquals(combineResult.getNumEntriesScannedInFilter(), 0);
     assertEquals(combineResult.getNumEntriesScannedPostFilter(), numDocsScanned);
     assertEquals(combineResult.getNumSegmentsProcessed(), NUM_SEGMENTS);
-    assertEquals(combineResult.getNumConsumingSegmentsProcessed(), NUM_CONSUMING_SEGMENTS);
-    assertEquals(combineResult.getNumConsumingSegmentsMatched(), 0);
     int numSegmentsMatched = combineResult.getNumSegmentsMatched();
     assertTrue(numSegmentsMatched >= 1 && numSegmentsMatched <= QueryMultiThreadingUtils.MAX_NUM_THREADS_PER_QUERY);
     assertEquals(combineResult.getNumTotalDocs(), NUM_SEGMENTS * NUM_RECORDS_PER_SEGMENT);
@@ -260,8 +216,6 @@ public class SelectionCombineOperatorTest {
     assertEquals(combineResult.getNumEntriesScannedInFilter(), 0);
     assertEquals(combineResult.getNumEntriesScannedPostFilter(), numDocsScanned);
     assertEquals(combineResult.getNumSegmentsProcessed(), NUM_SEGMENTS);
-    assertEquals(combineResult.getNumConsumingSegmentsProcessed(), NUM_CONSUMING_SEGMENTS);
-    assertEquals(combineResult.getNumConsumingSegmentsMatched(), NUM_CONSUMING_SEGMENTS);
     numSegmentsMatched = combineResult.getNumSegmentsMatched();
     assertTrue(numSegmentsMatched >= 1 && numSegmentsMatched <= QueryMultiThreadingUtils.MAX_NUM_THREADS_PER_QUERY);
     assertEquals(combineResult.getNumTotalDocs(), NUM_SEGMENTS * NUM_RECORDS_PER_SEGMENT);
@@ -279,8 +233,6 @@ public class SelectionCombineOperatorTest {
     assertEquals(combineResult.getNumEntriesScannedPostFilter(), numDocsScanned);
     assertEquals(combineResult.getNumSegmentsProcessed(), NUM_SEGMENTS);
     assertEquals(combineResult.getNumSegmentsMatched(), NUM_SEGMENTS);
-    assertEquals(combineResult.getNumConsumingSegmentsProcessed(), NUM_CONSUMING_SEGMENTS);
-    assertEquals(combineResult.getNumConsumingSegmentsMatched(), NUM_CONSUMING_SEGMENTS);
     assertEquals(combineResult.getNumTotalDocs(), NUM_SEGMENTS * NUM_RECORDS_PER_SEGMENT);
   }
 


### PR DESCRIPTION
fixing flaky test for SelectionCombineOperatorTest
rollback realtime segment test as it's not sorted, so the segment scanning will always be 100.