### PR TITLE
[test][multistage] enhance query plan test

### DIFF
--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/QueryCompilationTest.java
@@ -53,12 +53,6 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
     testQueryPlanExplain(query, digest);
   }
 
-  @Test(dataProvider = "testQueryPhysicalPlanDataProvider")
-  public void testQueryPlanExplainPhysical(String query, String digest)
-      throws Exception {
-    testQueryPlanExplain(query, digest);
-  }
-
   private void testQueryPlanExplain(String query, String digest) {
     try {
       long requestId = RANDOM_REQUEST_ID_GEN.nextLong();
@@ -463,51 +457,6 @@ public class QueryCompilationTest extends QueryEnvironmentTestBase {
             + "      LogicalProject(col1=[$0], col3=[$2])\n"
             + "        LogicalTableScan(table=[[b]])\n"
         },
-    };
-    //@formatter:on
-  }
-
-  @DataProvider(name = "testQueryPhysicalPlanDataProvider")
-  private Object[][] provideQueriesWithExplainedPhysicalPlan() {
-    //@formatter:off
-    return new Object[][] {
-new Object[]{"EXPLAIN IMPLEMENTATION PLAN INCLUDING ALL ATTRIBUTES FOR SELECT col1, col3 FROM a",
-  "[0]@localhost:3 MAIL_RECEIVE(BROADCAST_DISTRIBUTED)\n"
-+ "├── [1]@localhost:1 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n"
-+ "│   └── [1]@localhost:1 PROJECT\n"
-+ "│       └── [1]@localhost:1 TABLE SCAN (a) null\n"
-+ "└── [1]@localhost:2 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n"
-+ "    └── [1]@localhost:2 PROJECT\n"
-+ "        └── [1]@localhost:2 TABLE SCAN (a) null\n"},
-new Object[]{"EXPLAIN IMPLEMENTATION PLAN EXCLUDING ATTRIBUTES FOR SELECT col1, COUNT(*) FROM a GROUP BY col1",
-"[0]@localhost:3 MAIL_RECEIVE(BROADCAST_DISTRIBUTED)\n"
-+ "├── [1]@localhost:1 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]} (Subtree Omitted)\n"
-+ "└── [1]@localhost:2 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n"
-+ "    └── [1]@localhost:2 AGGREGATE_FINAL\n"
-+ "        └── [1]@localhost:2 MAIL_RECEIVE(HASH_DISTRIBUTED)\n"
-+ "            ├── [2]@localhost:1 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{1,1}|[1],[1]@localhost@{2,2}|[0]}\n"
-+ "            │   └── [2]@localhost:1 AGGREGATE_LEAF\n"
-+ "            │       └── [2]@localhost:1 TABLE SCAN (a) null\n"
-+ "            └── [2]@localhost:2 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{1,1}|[1],[1]@localhost@{2,2}|[0]}\n"
-+ "                └── [2]@localhost:2 AGGREGATE_LEAF\n"
-+ "                    └── [2]@localhost:2 TABLE SCAN (a) null\n"},
-new Object[]{"EXPLAIN IMPLEMENTATION PLAN FOR SELECT a.col1, b.col3 FROM a JOIN b ON a.col1 = b.col1",
-  "[0]@localhost:3 MAIL_RECEIVE(BROADCAST_DISTRIBUTED)\n"
-+ "├── [1]@localhost:1 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]} (Subtree Omitted)\n"
-+ "└── [1]@localhost:2 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n"
-+ "    └── [1]@localhost:2 PROJECT\n"
-+ "        └── [1]@localhost:2 JOIN\n"
-+ "            ├── [1]@localhost:2 MAIL_RECEIVE(HASH_DISTRIBUTED)\n"
-+ "            │   ├── [2]@localhost:1 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{1,1}|[1],[1]@localhost@{2,2}|[0]}\n"
-+ "            │   │   └── [2]@localhost:1 PROJECT\n"
-+ "            │   │       └── [2]@localhost:1 TABLE SCAN (a) null\n"
-+ "            │   └── [2]@localhost:2 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{1,1}|[1],[1]@localhost@{2,2}|[0]}\n"
-+ "            │       └── [2]@localhost:2 PROJECT\n"
-+ "            │           └── [2]@localhost:2 TABLE SCAN (a) null\n"
-+ "            └── [1]@localhost:2 MAIL_RECEIVE(HASH_DISTRIBUTED)\n"
-+ "                └── [3]@localhost:1 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{1,1}|[1],[1]@localhost@{2,2}|[0]}\n"
-+ "                    └── [3]@localhost:1 PROJECT\n"
-+ "                        └── [3]@localhost:1 TABLE SCAN (b) null\n"}
     };
     //@formatter:on
   }

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/queries/ResourceBasedQueryPlansTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/queries/ResourceBasedQueryPlansTest.java
@@ -41,6 +41,8 @@ import org.testng.annotations.Test;
 
 public class ResourceBasedQueryPlansTest extends QueryEnvironmentTestBase {
   private static final ObjectMapper MAPPER = new ObjectMapper();
+  private static final String EXPLAIN_REGEX =
+      "EXPLAIN (IMPLEMENTATION )*PLAN (INCLUDING |EXCLUDING )*(ALL )*(ATTRIBUTES )*(AS DOT |AS JSON |AS TEXT )*FOR ";
   private static final String QUERY_TEST_RESOURCE_FOLDER = "queries";
   private static final String FILE_FILTER_PROPERTY = "pinot.fileFilter";
 
@@ -51,7 +53,8 @@ public class ResourceBasedQueryPlansTest extends QueryEnvironmentTestBase {
       String explainedPlan = _queryEnvironment.explainQuery(query, requestId);
       Assert.assertEquals(explainedPlan, output,
           String.format("Test case %s for query %s doesn't match expected output: %s", testCaseName, query, output));
-      String queryWithoutExplainPlan = query.replace("EXPLAIN PLAN FOR ", "");
+      // use a regex to exclude the
+      String queryWithoutExplainPlan = query.replaceFirst(EXPLAIN_REGEX, "");
       DispatchableSubPlan dispatchableSubPlan = _queryEnvironment.planQuery(queryWithoutExplainPlan);
       Assert.assertNotNull(dispatchableSubPlan,
           String.format("Test case %s for query %s should not have a null QueryPlan",
@@ -66,7 +69,7 @@ public class ResourceBasedQueryPlansTest extends QueryEnvironmentTestBase {
     try {
       long requestId = RANDOM_REQUEST_ID_GEN.nextLong();
       _queryEnvironment.explainQuery(query, requestId);
-      String queryWithoutExplainPlan = query.replace("EXPLAIN PLAN FOR ", "");
+      String queryWithoutExplainPlan = query.replaceFirst(EXPLAIN_REGEX, "");
       _queryEnvironment.planQuery(queryWithoutExplainPlan);
       Assert.fail("Query compilation should have failed with exception message pattern: " + expectedException);
     } catch (Exception e) {

--- a/pinot-query-planner/src/test/resources/queries/ExplainPhysicalPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/ExplainPhysicalPlans.json
@@ -1,0 +1,80 @@
+{
+  "physical_plan_explain_formats": {
+    "queries": [
+      {
+        "description": "explain plan with attributes",
+        "sql": "EXPLAIN IMPLEMENTATION PLAN INCLUDING ALL ATTRIBUTES FOR SELECT col1, col3 FROM a",
+        "output": [
+          "[0]@localhost:3 MAIL_RECEIVE(BROADCAST_DISTRIBUTED)\n",
+          "├── [1]@localhost:1 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]} (Subtree Omitted)\n",
+          "└── [1]@localhost:2 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n",
+          "    └── [1]@localhost:2 PROJECT\n",
+          "        └── [1]@localhost:2 TABLE SCAN (a) null\n"
+        ]
+      },
+      {
+        "description": "explain plan without attributes",
+        "sql": "EXPLAIN IMPLEMENTATION PLAN EXCLUDING ATTRIBUTES FOR SELECT col1, COUNT(*) FROM a GROUP BY col1",
+        "output": [
+          "[0]@localhost:3 MAIL_RECEIVE(BROADCAST_DISTRIBUTED)\n",
+          "├── [1]@localhost:1 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]} (Subtree Omitted)\n",
+          "└── [1]@localhost:2 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n",
+          "    └── [1]@localhost:2 AGGREGATE_FINAL\n",
+          "        └── [1]@localhost:2 MAIL_RECEIVE(HASH_DISTRIBUTED)\n",
+          "            ├── [2]@localhost:1 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{1,1}|[1],[1]@localhost@{2,2}|[0]} (Subtree Omitted)\n",
+          "            └── [2]@localhost:2 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{1,1}|[1],[1]@localhost@{2,2}|[0]}\n",
+          "                └── [2]@localhost:2 AGGREGATE_LEAF\n",
+          "                    └── [2]@localhost:2 TABLE SCAN (a) null\n"
+        ]
+      },
+      {
+        "description": "explain plan with join",
+        "sql": "EXPLAIN IMPLEMENTATION PLAN FOR SELECT a.col1, b.col3 FROM a JOIN b ON a.col1 = b.col1",
+        "output": [
+          "[0]@localhost:3 MAIL_RECEIVE(BROADCAST_DISTRIBUTED)\n",
+          "├── [1]@localhost:1 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]} (Subtree Omitted)\n",
+          "└── [1]@localhost:2 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n",
+          "    └── [1]@localhost:2 PROJECT\n",
+          "        └── [1]@localhost:2 JOIN\n",
+          "            ├── [1]@localhost:2 MAIL_RECEIVE(HASH_DISTRIBUTED)\n",
+          "            │   ├── [2]@localhost:1 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{1,1}|[1],[1]@localhost@{2,2}|[0]} (Subtree Omitted)\n",
+          "            │   └── [2]@localhost:2 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{1,1}|[1],[1]@localhost@{2,2}|[0]}\n",
+          "            │       └── [2]@localhost:2 PROJECT\n",
+          "            │           └── [2]@localhost:2 TABLE SCAN (a) null\n",
+          "            └── [1]@localhost:2 MAIL_RECEIVE(HASH_DISTRIBUTED)\n",
+          "                └── [3]@localhost:1 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{1,1}|[1],[1]@localhost@{2,2}|[0]}\n",
+          "                    └── [3]@localhost:1 PROJECT\n",
+          "                        └── [3]@localhost:1 TABLE SCAN (b) null\n"
+        ]
+      },
+      {
+        "description": "explain plan with join with colocated tables",
+        "sql": "EXPLAIN IMPLEMENTATION PLAN FOR SELECT a.col2, a.col3, b.col3 FROM a /*+ tableOptions(partition_key='col2', partition_size='4') */ JOIN b /*+ tableOptions(partition_key='col1', partition_size='4') */ ON a.col2 = b.col1 WHERE b.col3 > 0",
+        "output": [
+          "[0]@localhost:3 MAIL_RECEIVE(BROADCAST_DISTRIBUTED)\n",
+          "├── [1]@localhost:2 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]} (Subtree Omitted)\n",
+          "├── [1]@localhost:2 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]} (Subtree Omitted)\n",
+          "├── [1]@localhost:1 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]} (Subtree Omitted)\n",
+          "└── [1]@localhost:1 MAIL_SEND(BROADCAST_DISTRIBUTED)->{[0]@localhost@{3,3}|[0]}\n",
+          "    └── [1]@localhost:1 PROJECT\n",
+          "        └── [1]@localhost:1 JOIN\n",
+          "            ├── [1]@localhost:1 MAIL_RECEIVE(HASH_DISTRIBUTED)\n",
+          "            │   ├── [2]@localhost:2 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{2,2}|[2, 3],[1]@localhost@{1,1}|[0, 1]} (Subtree Omitted)\n",
+          "            │   ├── [2]@localhost:2 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{2,2}|[2, 3],[1]@localhost@{1,1}|[0, 1]} (Subtree Omitted)\n",
+          "            │   ├── [2]@localhost:1 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{2,2}|[2, 3],[1]@localhost@{1,1}|[0, 1]} (Subtree Omitted)\n",
+          "            │   └── [2]@localhost:1 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{2,2}|[2, 3],[1]@localhost@{1,1}|[0, 1]}\n",
+          "            │       └── [2]@localhost:1 PROJECT\n",
+          "            │           └── [2]@localhost:1 TABLE SCAN (a) null\n",
+          "            └── [1]@localhost:1 MAIL_RECEIVE(HASH_DISTRIBUTED)\n",
+          "                ├── [3]@localhost:2 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{2,2}|[2, 3],[1]@localhost@{1,1}|[0, 1]} (Subtree Omitted)\n",
+          "                ├── [3]@localhost:2 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{2,2}|[2, 3],[1]@localhost@{1,1}|[0, 1]} (Subtree Omitted)\n",
+          "                ├── [3]@localhost:1 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{2,2}|[2, 3],[1]@localhost@{1,1}|[0, 1]} (Subtree Omitted)\n",
+          "                └── [3]@localhost:1 MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost@{2,2}|[2, 3],[1]@localhost@{1,1}|[0, 1]}\n",
+          "                    └── [3]@localhost:1 PROJECT\n",
+          "                        └── [3]@localhost:1 FILTER\n",
+          "                            └── [3]@localhost:1 TABLE SCAN (b) null\n"
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
- optimized query physical plan to omit all mailbox 
   - non-leaf will also get omit
   - multiple worker within a server will also get omit
   - all places with contextual info are now 
       - printed as the following format: `<PREFIX>[<FRAGMENT_ID>]@<HOSTNAME>:<PORT>|[<WORKER_ID>]`, 
       - with multiple instances of the context, the format will be wrapped in `{` and `}` in a comma-separated list.
```
...
              └── [1]@localhost:1|[1] PROJECT
                  └── [1]@localhost:1|[1] JOIN
                      ├── [1]@localhost:1|[1] MAIL_RECEIVE(HASH_DISTRIBUTED)
                      │   ├── [2]@localhost:2|[2] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost:2|[2, 3],[1]@localhost:1|[0, 1]} (Subtree Omitted)
                      │   ├── [2]@localhost:2|[3] MAIL_SEND(HASH_DISTRIBUTED)->{[1]@localhost:2|[2, 3],[1]@localhost:1|[0, 1]} (Subtree Omitted)
...
```
- support other plan parsing in `ResourceBasedQueryPlansTest`
    - regex replace supported feature such as `AS ...`, `...ATTRIBUTES`
    - `WITH ...` is not supported as we don't actually have corresponding processing on this variance yet.

This also addresses the verbose issue of subtree omit in #11272 
