### PR TITLE
[multistage][bugfix] fix operator eos pull

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -131,19 +131,15 @@ public class AggregateOperator extends MultiStageOperator {
 
   @Override
   protected TransferableBlock getNextBlock() {
-    try {
-      if (_hasConstructedAggregateBlock) {
-        return TransferableBlockUtils.getEndOfStreamTransferableBlock();
-      }
-      TransferableBlock finalBlock = _aggregationExecutor != null ? consumeAggregation() : consumeGroupBy();
-      // returning upstream error block if finalBlock contains error.
-      if (finalBlock.isErrorBlock()) {
-        return finalBlock;
-      }
-      return produceAggregatedBlock();
-    } catch (Exception e) {
-      return TransferableBlockUtils.getErrorTransferableBlock(e);
+    if (_hasConstructedAggregateBlock) {
+      return TransferableBlockUtils.getEndOfStreamTransferableBlock();
     }
+    TransferableBlock finalBlock = _aggregationExecutor != null ? consumeAggregation() : consumeGroupBy();
+    // returning upstream error block if finalBlock contains error.
+    if (finalBlock.isErrorBlock()) {
+      return finalBlock;
+    }
+    return produceAggregatedBlock();
   }
 
   private TransferableBlock produceAggregatedBlock() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/AggregateOperator.java
@@ -70,7 +70,7 @@ public class AggregateOperator extends MultiStageOperator {
   private final MultistageAggregationExecutor _aggregationExecutor;
   private final MultistageGroupByExecutor _groupByExecutor;
 
-  private boolean _hasReturnedAggregateBlock;
+  private boolean _hasConstructedAggregateBlock;
 
   public AggregateOperator(OpChainExecutionContext context, MultiStageOperator inputOperator, DataSchema resultSchema,
       List<RexExpression> aggCalls, List<RexExpression> groupSet, AggType aggType, List<Integer> filterArgIndices,
@@ -132,25 +132,22 @@ public class AggregateOperator extends MultiStageOperator {
   @Override
   protected TransferableBlock getNextBlock() {
     try {
+      if (_hasConstructedAggregateBlock) {
+        return TransferableBlockUtils.getEndOfStreamTransferableBlock();
+      }
       TransferableBlock finalBlock = _aggregationExecutor != null ? consumeAggregation() : consumeGroupBy();
-
-      // setting upstream error block
+      // returning upstream error block if finalBlock contains error.
       if (finalBlock.isErrorBlock()) {
         return finalBlock;
       }
-
-      if (!_hasReturnedAggregateBlock) {
-        return produceAggregatedBlock();
-      } else {
-        return TransferableBlockUtils.getEndOfStreamTransferableBlock();
-      }
+      return produceAggregatedBlock();
     } catch (Exception e) {
       return TransferableBlockUtils.getErrorTransferableBlock(e);
     }
   }
 
   private TransferableBlock produceAggregatedBlock() {
-    _hasReturnedAggregateBlock = true;
+    _hasConstructedAggregateBlock = true;
     if (_aggregationExecutor != null) {
       return new TransferableBlock(_aggregationExecutor.getResult(), _resultSchema, DataBlock.Type.ROW);
     } else {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -28,6 +28,7 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
+import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
@@ -77,7 +78,15 @@ public class FilterOperator extends MultiStageOperator {
 
   @Override
   protected TransferableBlock getNextBlock() {
-    TransferableBlock block = _upstreamOperator.nextBlock();
+    try {
+      TransferableBlock block = _upstreamOperator.nextBlock();
+      return filter(block);
+    } catch (RuntimeException e) {
+      return TransferableBlockUtils.getErrorTransferableBlock(e);
+    }
+  }
+
+  private TransferableBlock filter(TransferableBlock block) {
     if (block.isEndOfStreamBlock()) {
       return block;
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/FilterOperator.java
@@ -28,7 +28,6 @@ import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
-import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
@@ -78,15 +77,7 @@ public class FilterOperator extends MultiStageOperator {
 
   @Override
   protected TransferableBlock getNextBlock() {
-    try {
-      TransferableBlock block = _upstreamOperator.nextBlock();
-      return filter(block);
-    } catch (RuntimeException e) {
-      return TransferableBlockUtils.getErrorTransferableBlock(e);
-    }
-  }
-
-  private TransferableBlock filter(TransferableBlock block) {
+    TransferableBlock block = _upstreamOperator.nextBlock();
     if (block.isEndOfStreamBlock()) {
       return block;
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -201,7 +201,7 @@ public class HashJoinOperator extends MultiStageOperator {
         return _upstreamErrorBlock;
       }
       TransferableBlock leftBlock = _leftTableOperator.nextBlock();
-      // JOIN each left block with the right block.
+      // JOIN each left block with the constructed right hash table.
       return buildJoinedDataBlock(leftBlock);
     } catch (Exception e) {
       return TransferableBlockUtils.getErrorTransferableBlock(e);

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/HashJoinOperator.java
@@ -188,24 +188,21 @@ public class HashJoinOperator extends MultiStageOperator {
   }
 
   @Override
-  protected TransferableBlock getNextBlock() {
-    try {
-      if (_isTerminated) {
-        return TransferableBlockUtils.getEndOfStreamTransferableBlock();
-      }
-      if (!_isHashTableBuilt) {
-        // Build JOIN hash table
-        buildBroadcastHashTable();
-      }
-      if (_upstreamErrorBlock != null) {
-        return _upstreamErrorBlock;
-      }
-      TransferableBlock leftBlock = _leftTableOperator.nextBlock();
-      // JOIN each left block with the constructed right hash table.
-      return buildJoinedDataBlock(leftBlock);
-    } catch (Exception e) {
-      return TransferableBlockUtils.getErrorTransferableBlock(e);
+  protected TransferableBlock getNextBlock()
+      throws ProcessingException {
+    if (_isTerminated) {
+      return TransferableBlockUtils.getEndOfStreamTransferableBlock();
     }
+    if (!_isHashTableBuilt) {
+      // Build JOIN hash table
+      buildBroadcastHashTable();
+    }
+    if (_upstreamErrorBlock != null) {
+      return _upstreamErrorBlock;
+    }
+    TransferableBlock leftBlock = _leftTableOperator.nextBlock();
+    // JOIN each left block with the constructed right hash table.
+    return buildJoinedDataBlock(leftBlock);
   }
 
   private void buildBroadcastHashTable()

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/MultiStageOperator.java
@@ -79,7 +79,8 @@ public abstract class MultiStageOperator implements Operator<TransferableBlock>,
   }
 
   // Make it protected because we should always call nextBlock()
-  protected abstract TransferableBlock getNextBlock() throws Exception;
+  protected abstract TransferableBlock getNextBlock()
+      throws Exception;
 
   protected void earlyTerminate() {
     _isEarlyTerminated = true;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/OperatorStats.java
@@ -43,7 +43,6 @@ public class OperatorStats {
   private long _startTimeMs = -1;
   private long _endTimeMs = -1;
   private final Map<String, String> _executionStats;
-  private boolean _processingStarted = false;
 
   public OperatorStats(OpChainExecutionContext context) {
     this(context.getRequestId(), context.getStageId(), context.getServer());
@@ -69,7 +68,6 @@ public class OperatorStats {
       _executeStopwatch.stop();
       _endTimeMs = System.currentTimeMillis();
     }
-    _processingStarted = true;
   }
 
   public void recordRow(int numBlock, int numRows) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/SortOperator.java
@@ -108,19 +108,15 @@ public class SortOperator extends MultiStageOperator {
 
   @Override
   protected TransferableBlock getNextBlock() {
-    try {
-      if (_hasConstructedSortedBlock) {
-        return TransferableBlockUtils.getEndOfStreamTransferableBlock();
-      }
-      TransferableBlock finalBlock = consumeInputBlocks();
-      // returning upstream error block if finalBlock contains error.
-      if (finalBlock.isErrorBlock()) {
-        return finalBlock;
-      }
-      return produceSortedBlock();
-    } catch (Exception e) {
-      return TransferableBlockUtils.getErrorTransferableBlock(e);
+    if (_hasConstructedSortedBlock) {
+      return TransferableBlockUtils.getEndOfStreamTransferableBlock();
     }
+    TransferableBlock finalBlock = consumeInputBlocks();
+    // returning upstream error block if finalBlock contains error.
+    if (finalBlock.isErrorBlock()) {
+      return finalBlock;
+    }
+    return produceSortedBlock();
   }
 
   private TransferableBlock produceSortedBlock() {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -51,7 +51,6 @@ public class TransformOperator extends MultiStageOperator {
   private final int _resultColumnSize;
   // TODO: Check type matching between resultSchema and the actual result.
   private final DataSchema _resultSchema;
-  private TransferableBlock _upstreamErrorBlock;
 
   public TransformOperator(OpChainExecutionContext context, MultiStageOperator upstreamOperator,
       DataSchema resultSchema, List<RexExpression> transforms, DataSchema upstreamDataSchema) {
@@ -90,19 +89,9 @@ public class TransformOperator extends MultiStageOperator {
   }
 
   private TransferableBlock transform(TransferableBlock block) {
-    // TODO: Other operators keep the first erroneous block, while this keep the last.
-    //  We should decide what is what we want to do and be consistent with that.
-    if (block.isErrorBlock()) {
-      _upstreamErrorBlock = block;
-    }
-    if (_upstreamErrorBlock != null) {
-      return _upstreamErrorBlock;
-    }
-
-    if (TransferableBlockUtils.isEndOfStream(block)) {
+    if (block.isEndOfStreamBlock()) {
       return block;
     }
-
     List<Object[]> container = block.getContainer();
     List<Object[]> resultRows = new ArrayList<>(container.size());
     for (Object[] row : container) {

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/TransformOperator.java
@@ -27,7 +27,6 @@ import org.apache.pinot.common.datablock.DataBlock;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.query.planner.logical.RexExpression;
 import org.apache.pinot.query.runtime.blocks.TransferableBlock;
-import org.apache.pinot.query.runtime.blocks.TransferableBlockUtils;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperand;
 import org.apache.pinot.query.runtime.operator.operands.TransformOperandFactory;
 import org.apache.pinot.query.runtime.plan.OpChainExecutionContext;
@@ -80,15 +79,7 @@ public class TransformOperator extends MultiStageOperator {
 
   @Override
   protected TransferableBlock getNextBlock() {
-    try {
-      TransferableBlock block = _upstreamOperator.nextBlock();
-      return transform(block);
-    } catch (RuntimeException e) {
-      return TransferableBlockUtils.getErrorTransferableBlock(e);
-    }
-  }
-
-  private TransferableBlock transform(TransferableBlock block) {
+    TransferableBlock block = _upstreamOperator.nextBlock();
     if (block.isEndOfStreamBlock()) {
       return block;
     }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
@@ -163,18 +163,14 @@ public class WindowAggregateOperator extends MultiStageOperator {
 
   @Override
   protected TransferableBlock getNextBlock() {
-    try {
-      if (_hasReturnedWindowAggregateBlock) {
-        return TransferableBlockUtils.getEndOfStreamTransferableBlock();
-      }
-      TransferableBlock finalBlock = consumeInputBlocks();
-      if (finalBlock.isErrorBlock()) {
-        return finalBlock;
-      }
-      return produceWindowAggregatedBlock();
-    } catch (Exception e) {
-      return TransferableBlockUtils.getErrorTransferableBlock(e);
+    if (_hasReturnedWindowAggregateBlock) {
+      return TransferableBlockUtils.getEndOfStreamTransferableBlock();
     }
+    TransferableBlock finalBlock = consumeInputBlocks();
+    if (finalBlock.isErrorBlock()) {
+      return finalBlock;
+    }
+    return produceWindowAggregatedBlock();
   }
 
   private void validateAggregationCalls(String functionName,

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/WindowAggregateOperator.java
@@ -164,18 +164,15 @@ public class WindowAggregateOperator extends MultiStageOperator {
   @Override
   protected TransferableBlock getNextBlock() {
     try {
+      if (_hasReturnedWindowAggregateBlock) {
+        return TransferableBlockUtils.getEndOfStreamTransferableBlock();
+      }
       TransferableBlock finalBlock = consumeInputBlocks();
       if (finalBlock.isErrorBlock()) {
         return finalBlock;
       }
-
-      if (!_hasReturnedWindowAggregateBlock) {
-        return produceWindowAggregatedBlock();
-      } else {
-        return TransferableBlockUtils.getEndOfStreamTransferableBlock();
-      }
+      return produceWindowAggregatedBlock();
     } catch (Exception e) {
-      LOGGER.error("Caught exception while executing WindowAggregationOperator, returning an error block", e);
       return TransferableBlockUtils.getErrorTransferableBlock(e);
     }
   }


### PR DESCRIPTION
currently agg, window, transform, fitler operator can potentially pull more than once against input for EOS.

This PR changes the behavior.
- single-input stop-the-world operator (agg, window, sort) only pull once and check for produced block first
- streaming operator (filter, transform) keeps the behavior
- dual-input, right-sided stop-the-world & left-sided stream operator (join, set) will only pull EOS on each input at most once 
    - when right side error out first, left side will not be pulled

this guarantees that no more than one EOS block will be pulled; tests are covered by existing resource queries tests