### PR TITLE
Fix for 11974... exclude `module-info.class` during shade operations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2101,6 +2101,7 @@
             <filter>
               <artifact>*:*</artifact>
               <excludes>
+                <exclude>module-info.class</exclude>
                 <exclude>META-INF/*.SF</exclude>
                 <exclude>META-INF/*.DSA</exclude>
                 <exclude>META-INF/*.RSA</exclude>


### PR DESCRIPTION
the existence of `module-info.class` in shaded jars causes maven to log numerous warnings like `[WARNING] Discovered module-info.class. Shading will break its strong encapsulation.`.  This pull request updates the base `maven-shade-plugin` configuration to exclude these files. This PR fixes #11974. 