### PR TITLE
Adding byte functions for UUIDs

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -21,9 +21,11 @@ package org.apache.pinot.common.function.scalar;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
+import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.text.Normalizer;
 import java.util.Base64;
+import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
@@ -491,6 +493,37 @@ public class StringFunctions {
   @ScalarFunction
   public static byte[] toAscii(String input) {
     return input.getBytes(StandardCharsets.US_ASCII);
+  }
+
+  /**
+   * @param input UUID as string
+   * @return bytearray
+   * returns bytes and null on exception
+   */
+  @ScalarFunction
+  public static byte[] toUuidBytes(String input) {
+    try {
+      UUID uuid = UUID.fromString(input);
+      ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
+      bb.putLong(uuid.getMostSignificantBits());
+      bb.putLong(uuid.getLeastSignificantBits());
+      return bb.array();
+    } catch (IllegalArgumentException e) {
+      return null;
+    }
+  }
+
+  /**
+   * @param input UUID serialized to bytes
+   * @return String representation of UUID
+   * returns bytes and null on exception
+   */
+  @ScalarFunction
+  public static String fromUuidBytes(byte[] input) {
+    ByteBuffer bb = ByteBuffer.wrap(input);
+    long firstLong = bb.getLong();
+    long secondLong = bb.getLong();
+    return new UUID(firstLong, secondLong).toString();
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -501,7 +501,7 @@ public class StringFunctions {
    * returns bytes and null on exception
    */
   @ScalarFunction
-  public static byte[] toUuidBytes(String input) {
+  public static byte[] toUUIDBytes(String input) {
     try {
       UUID uuid = UUID.fromString(input);
       ByteBuffer bb = ByteBuffer.wrap(new byte[16]);
@@ -519,7 +519,7 @@ public class StringFunctions {
    * returns bytes and null on exception
    */
   @ScalarFunction
-  public static String fromUuidBytes(byte[] input) {
+  public static String fromUUIDBytes(byte[] input) {
     ByteBuffer bb = ByteBuffer.wrap(input);
     long firstLong = bb.getLong();
     long secondLong = bb.getLong();


### PR DESCRIPTION
We use UUIDs as identifiers in our data that we ingest into Pinot and we noticed that these take up quite a lot of space because they can't easily be compressed in their String representation. Converting them to bytes, however, results in about 30% storage savings.

This adds two new scalar functions for dealing with UUIDs:
- `toUUIDBytes`: turns a String representation of a UUID to bytes
- `fromUUIDBytes`: turns a byte representation of a UUID back to a String

Thanks for the help of @kishoreg for investigating this