### PR TITLE
Upgrading Flink dep to 1.17.1

### DIFF
--- a/pinot-connectors/pinot-flink-connector/pom.xml
+++ b/pinot-connectors/pinot-flink-connector/pom.xml
@@ -51,7 +51,15 @@
     </dependency>
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-streaming-java_${scala.compat.version}</artifactId>
+      <artifactId>flink-streaming-java</artifactId>
+      <version>${flink.version}</version>
+      <exclusions>
+        <exclusion>
+          <!-- Causes unnecessary dependency convergence errors -->
+          <groupId>com.twitter</groupId>
+          <artifactId>chill-java</artifactId>
+        </exclusion>
+      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.apache.pinot</groupId>
@@ -82,7 +90,8 @@
     </dependency>
     <dependency>
       <groupId>org.apache.flink</groupId>
-      <artifactId>flink-clients_${scala.compat.version}</artifactId>
+      <artifactId>flink-clients</artifactId>
+      <version>${flink.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -188,7 +188,7 @@
     <scala.version>2.12.18</scala.version>
     <scala.compat.version>2.12</scala.compat.version>
 
-    <flink.version>1.12.0</flink.version>
+    <flink.version>1.17.1</flink.version>
     <commons-configuration2.version>2.9.0</commons-configuration2.version>
 
     <proto.google.common.protos.version>2.9.6</proto.google.common.protos.version>


### PR DESCRIPTION
In testing the Flink-Pinot sink connector, the version of the Kafka source connector was getting a NPE. By upgrading the Flink version to `1.17.1`, I was able to deploy a Flink job with Kafka source and Pinot sink.

`dependencies`
