### PR TITLE
Add a new MV forward index to only store unique MV values

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -462,7 +462,12 @@ abstract class BaseStarTreeV2Test<R, A> {
    */
   CompressionCodec getCompressionCodec() {
     CompressionCodec[] compressionCodecs = CompressionCodec.values();
-    return compressionCodecs[RANDOM.nextInt(compressionCodecs.length)];
+    while (true) {
+      CompressionCodec compressionCodec = compressionCodecs[RANDOM.nextInt(compressionCodecs.length)];
+      if (compressionCodec.isApplicableToRawIndex()) {
+        return compressionCodec;
+      }
+    }
   }
 
   abstract ValueAggregator<R, A> getValueAggregator();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/FixedBitIntReaderWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/FixedBitIntReaderWriter.java
@@ -50,6 +50,14 @@ public final class FixedBitIntReaderWriter implements Closeable {
     _dataBitSet.writeInt(startIndex, _numBitsPerValue, length, values);
   }
 
+  public int getStartByteOffset(int index) {
+    return (int) (((long) index * _numBitsPerValue) / Byte.SIZE);
+  }
+
+  public int getEndByteOffset(int index) {
+    return (int) (((long) (index + 1) * _numBitsPerValue - 1) / Byte.SIZE) + 1;
+  }
+
   @Override
   public void close() {
     _dataBitSet.close();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/PinotDataBitSet.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/util/PinotDataBitSet.java
@@ -102,6 +102,9 @@ public final class PinotDataBitSet implements Closeable {
   }
 
   public void readInt(int startIndex, int numBitsPerValue, int length, int[] buffer) {
+    if (length == 0) {
+      return;
+    }
     long startBitOffset = (long) startIndex * numBitsPerValue;
     int byteOffset = (int) (startBitOffset / Byte.SIZE);
     int bitOffsetInFirstByte = (int) (startBitOffset % Byte.SIZE);
@@ -167,6 +170,9 @@ public final class PinotDataBitSet implements Closeable {
   }
 
   public void writeInt(int startIndex, int numBitsPerValue, int length, int[] values) {
+    if (length == 0) {
+      return;
+    }
     long startBitOffset = (long) startIndex * numBitsPerValue;
     int byteOffset = (int) (startBitOffset / Byte.SIZE);
     int bitOffsetInFirstByte = (int) (startBitOffset % Byte.SIZE);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/FixedBitMVEntryDictForwardIndexWriter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/writer/impl/FixedBitMVEntryDictForwardIndexWriter.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.io.writer.impl;
+
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import it.unimi.dsi.fastutil.objects.Object2IntMap;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
+import java.io.Closeable;
+import java.io.File;
+import java.io.IOException;
+import java.nio.ByteOrder;
+import org.apache.pinot.segment.local.io.util.FixedBitIntReaderWriter;
+import org.apache.pinot.segment.local.io.util.PinotDataBitSet;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+
+
+/**
+ * Bit-compressed dictionary-encoded forward index writer for multi-value columns, where a second level dictionary
+ * encoding for multi-value entries (instead of individual values within the entry) are maintained within the forward
+ * index.
+ *
+ * Index layout:
+ * - Index header (24 bytes)
+ * - ID buffer (stores the multi-value entry id for each doc id)
+ * - Offset buffer (stores the start offset of each multi-value entry, followed by end offset of the last value)
+ * - Value buffer (stores the individual values)
+ *
+ * Header layout:
+ * - Magic marker (4 bytes)
+ * - Version (2 bytes)
+ * - Bits per value (1 byte)
+ * - Bits per id (1 byte)
+ * - Number of unique MV entries (4 bytes)
+ * - Number of total values (4 bytes)
+ * - Start offset of offset buffer (4 bytes)
+ * - Start offset of value buffer (4 bytes)
+ */
+public class FixedBitMVEntryDictForwardIndexWriter implements Closeable {
+  public static final int MAGIC_MARKER = 0xffabcdef;
+  public static final short VERSION = 1;
+  public static final int HEADER_SIZE = 24;
+
+  private final Object2IntOpenHashMap<IntArrayList> _entryToIdMap = new Object2IntOpenHashMap<>();
+  private final File _file;
+  private final int _numBitsPerValue;
+  private final IntArrayList _ids;
+
+  public FixedBitMVEntryDictForwardIndexWriter(File file, int numDocs, int numBitsPerValue) {
+    _file = file;
+    _numBitsPerValue = numBitsPerValue;
+    _ids = new IntArrayList(numDocs);
+  }
+
+  public void putDictIds(int[] dictIds) {
+    // Lookup the map, and create a new id when the entry is not found.
+    _ids.add(_entryToIdMap.computeIntIfAbsent(IntArrayList.wrap(dictIds), k -> _entryToIdMap.size()));
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    int numUniqueEntries = _entryToIdMap.size();
+    int[][] idToDictIdsMap = new int[numUniqueEntries][];
+    int numTotalValues = 0;
+    for (Object2IntMap.Entry<IntArrayList> entry : _entryToIdMap.object2IntEntrySet()) {
+      int id = entry.getIntValue();
+      int[] dictIds = entry.getKey().elements();
+      idToDictIdsMap[id] = dictIds;
+      numTotalValues += dictIds.length;
+    }
+    int[] ids = _ids.elements();
+    int numBitsPerId = PinotDataBitSet.getNumBitsPerValue(numUniqueEntries - 1);
+    int idBufferSize = (int) (((long) ids.length * numBitsPerId + 7) / 8);
+    int numBitsPerOffset = PinotDataBitSet.getNumBitsPerValue(numTotalValues);
+    int offsetBufferSize = (int) (((long) (numUniqueEntries + 1) * numBitsPerOffset + 7) / 8);
+    int valueBufferSize = (int) (((long) numTotalValues * _numBitsPerValue + 7) / 8);
+    int offsetBufferOffset = HEADER_SIZE + idBufferSize;
+    int valueBufferOffset = offsetBufferOffset + offsetBufferSize;
+    int indexSize = valueBufferOffset + valueBufferSize;
+    try (PinotDataBuffer indexBuffer = PinotDataBuffer.mapFile(_file, false, 0, indexSize, ByteOrder.BIG_ENDIAN,
+        getClass().getSimpleName())) {
+      indexBuffer.putInt(0, MAGIC_MARKER);
+      indexBuffer.putShort(4, VERSION);
+      indexBuffer.putByte(6, (byte) _numBitsPerValue);
+      indexBuffer.putByte(7, (byte) numBitsPerId);
+      indexBuffer.putInt(8, numUniqueEntries);
+      indexBuffer.putInt(12, numTotalValues);
+      indexBuffer.putInt(16, offsetBufferOffset);
+      indexBuffer.putInt(20, valueBufferOffset);
+
+      try (FixedBitIntReaderWriter idWriter = new FixedBitIntReaderWriter(
+          indexBuffer.view(HEADER_SIZE, offsetBufferOffset), ids.length, numBitsPerId)) {
+        idWriter.writeInt(0, ids.length, ids);
+      }
+      try (FixedBitIntReaderWriter offsetWriter = new FixedBitIntReaderWriter(
+          indexBuffer.view(offsetBufferOffset, valueBufferOffset), numUniqueEntries + 1, numBitsPerOffset);
+          FixedBitIntReaderWriter valueWriter = new FixedBitIntReaderWriter(
+              indexBuffer.view(valueBufferOffset, indexSize), numTotalValues, _numBitsPerValue)) {
+        int startOffset = 0;
+        for (int i = 0; i < numUniqueEntries; i++) {
+          offsetWriter.writeInt(i, startOffset);
+          int[] dictIds = idToDictIdsMap[i];
+          valueWriter.writeInt(startOffset, dictIds.length, dictIds);
+          startOffset += dictIds.length;
+        }
+        offsetWriter.writeInt(numUniqueEntries, startOffset);
+      }
+    }
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueEntryDictForwardIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/fwd/MultiValueEntryDictForwardIndexCreator.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.creator.impl.fwd;
+
+import java.io.File;
+import java.io.IOException;
+import org.apache.pinot.segment.local.io.util.PinotDataBitSet;
+import org.apache.pinot.segment.local.io.writer.impl.FixedBitMVEntryDictForwardIndexWriter;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.index.creator.ForwardIndexCreator;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+/**
+ * Forward index creator for dictionary-encoded multi-value column, where multi-value entries are dictionary encoded.
+ */
+public class MultiValueEntryDictForwardIndexCreator implements ForwardIndexCreator {
+  private final FixedBitMVEntryDictForwardIndexWriter _writer;
+
+  public MultiValueEntryDictForwardIndexCreator(File outputDir, String column, int cardinality, int numDocs) {
+    File indexFile = new File(outputDir, column + V1Constants.Indexes.UNSORTED_MV_FORWARD_INDEX_FILE_EXTENSION);
+    int numBitsPerValue = PinotDataBitSet.getNumBitsPerValue(cardinality - 1);
+    _writer = new FixedBitMVEntryDictForwardIndexWriter(indexFile, numDocs, numBitsPerValue);
+  }
+
+  @Override
+  public boolean isDictionaryEncoded() {
+    return true;
+  }
+
+  @Override
+  public boolean isSingleValue() {
+    return false;
+  }
+
+  @Override
+  public DataType getValueType() {
+    return DataType.INT;
+  }
+
+  @Override
+  public void putDictIdMV(int[] dictIds) {
+    _writer.putDictIds(dictIds);
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    _writer.close();
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexCreatorFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexCreatorFactory.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.local.segment.index.forward;
 
 import java.io.File;
 import java.io.IOException;
+import org.apache.pinot.segment.local.segment.creator.impl.fwd.MultiValueEntryDictForwardIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.MultiValueFixedByteRawIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.MultiValueUnsortedForwardIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.MultiValueVarByteRawIndexCreator;
@@ -29,6 +30,7 @@ import org.apache.pinot.segment.local.segment.creator.impl.fwd.SingleValueSorted
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.SingleValueUnsortedForwardIndexCreator;
 import org.apache.pinot.segment.local.segment.creator.impl.fwd.SingleValueVarByteRawIndexCreator;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
+import org.apache.pinot.segment.spi.compression.DictIdCompressionType;
 import org.apache.pinot.segment.spi.creator.IndexCreationContext;
 import org.apache.pinot.segment.spi.index.ForwardIndexConfig;
 import org.apache.pinot.segment.spi.index.creator.ForwardIndexCreator;
@@ -57,8 +59,12 @@ public class ForwardIndexCreatorFactory {
           return new SingleValueUnsortedForwardIndexCreator(indexDir, columnName, cardinality, numTotalDocs);
         }
       } else {
-        return new MultiValueUnsortedForwardIndexCreator(indexDir, columnName, cardinality, numTotalDocs,
-            context.getTotalNumberOfEntries());
+        if (indexConfig.getDictIdCompressionType() == DictIdCompressionType.MV_ENTRY_DICT) {
+          return new MultiValueEntryDictForwardIndexCreator(indexDir, columnName, cardinality, numTotalDocs);
+        } else {
+          return new MultiValueUnsortedForwardIndexCreator(indexDir, columnName, cardinality, numTotalDocs,
+              context.getTotalNumberOfEntries());
+        }
       }
     } else {
       // Dictionary disabled columns

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexReaderFactory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexReaderFactory.java
@@ -20,6 +20,7 @@
 package org.apache.pinot.segment.local.segment.index.forward;
 
 import org.apache.pinot.segment.local.io.writer.impl.VarByteChunkForwardIndexWriterV4;
+import org.apache.pinot.segment.local.segment.index.readers.forward.FixedBitMVEntryDictForwardIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.forward.FixedBitMVForwardIndexReader;
 import org.apache.pinot.segment.local.segment.index.readers.forward.FixedBitSVForwardIndexReaderV2;
 import org.apache.pinot.segment.local.segment.index.readers.forward.FixedByteChunkMVForwardIndexReader;
@@ -72,8 +73,14 @@ public class ForwardIndexReaderFactory extends IndexReaderFactory.Default<Forwar
           return new FixedBitSVForwardIndexReaderV2(dataBuffer, metadata.getTotalDocs(), metadata.getBitsPerElement());
         }
       } else {
-        return new FixedBitMVForwardIndexReader(dataBuffer, metadata.getTotalDocs(), metadata.getTotalNumberOfEntries(),
-            metadata.getBitsPerElement());
+        if (dataBuffer.size() > Integer.BYTES
+            && dataBuffer.getInt(0) == FixedBitMVEntryDictForwardIndexReader.MAGIC_MARKER) {
+          return new FixedBitMVEntryDictForwardIndexReader(dataBuffer, metadata.getTotalDocs(),
+              metadata.getBitsPerElement());
+        } else {
+          return new FixedBitMVForwardIndexReader(dataBuffer, metadata.getTotalDocs(),
+              metadata.getTotalNumberOfEntries(), metadata.getBitsPerElement());
+        }
       }
     } else {
       return createRawIndexReader(dataBuffer, metadata.getDataType().getStoredType(), metadata.isSingleValue());

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/IndexLoadingConfig.java
@@ -35,7 +35,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.config.TableConfigUtils;
 import org.apache.pinot.segment.local.segment.index.column.PhysicalColumnIndexContainer;
 import org.apache.pinot.segment.local.segment.index.loader.columnminmaxvalue.ColumnMinMaxValueGeneratorMode;
-import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.ColumnConfigDeserializer;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
@@ -49,6 +48,7 @@ import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.BloomFilterConfig;
 import org.apache.pinot.spi.config.table.FSTType;
 import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.FieldConfig.CompressionCodec;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.JsonIndexConfig;
@@ -93,7 +93,7 @@ public class IndexLoadingConfig {
   private boolean _enableDynamicStarTreeCreation;
   private List<StarTreeIndexConfig> _starTreeIndexConfigs;
   private boolean _enableDefaultStarTree;
-  private Map<String, ChunkCompressionType> _compressionConfigs = new HashMap<>();
+  private Map<String, CompressionCodec> _compressionConfigs = new HashMap<>();
   private Map<String, FieldIndexConfigs> _indexConfigsByColName = new HashMap<>();
 
   private SegmentVersion _segmentVersion;
@@ -299,8 +299,8 @@ public class IndexLoadingConfig {
             + "indexLoadingConfig for indexType: {}", _schema == null, _tableConfig == null, indexType);
         deserializer = IndexConfigDeserializer.fromMap(table -> fromIndexLoadingConfig);
       } else if (_segmentTier == null) {
-        deserializer = IndexConfigDeserializer.fromMap(table -> fromIndexLoadingConfig)
-            .withFallbackAlternative(stdDeserializer);
+        deserializer =
+            IndexConfigDeserializer.fromMap(table -> fromIndexLoadingConfig).withFallbackAlternative(stdDeserializer);
       } else {
         // No need to fall back to fromIndexLoadingConfig which contains index configs for default tier, when looking
         // for tier specific index configs.
@@ -352,8 +352,7 @@ public class IndexLoadingConfig {
     for (FieldConfig fieldConfig : fieldConfigList) {
       String column = fieldConfig.getName();
       if (fieldConfig.getCompressionCodec() != null) {
-        ChunkCompressionType compressionType = ChunkCompressionType.valueOf(fieldConfig.getCompressionCodec().name());
-        _compressionConfigs.put(column, compressionType);
+        _compressionConfigs.put(column, fieldConfig.getCompressionCodec());
       }
     }
   }
@@ -613,7 +612,7 @@ public class IndexLoadingConfig {
    * Used by segmentPreProcessorTest to set compression configs.
    */
   @VisibleForTesting
-  public void setCompressionConfigs(Map<String, ChunkCompressionType> compressionConfigs) {
+  public void setCompressionConfigs(Map<String, CompressionCodec> compressionConfigs) {
     _compressionConfigs = new HashMap<>(compressionConfigs);
     _dirty = true;
   }
@@ -750,7 +749,7 @@ public class IndexLoadingConfig {
    *
    * @return a map containing column name as key and compressionType as value.
    */
-  public Map<String, ChunkCompressionType> getCompressionConfigs() {
+  public Map<String, CompressionCodec> getCompressionConfigs() {
     return unmodifiable(_compressionConfigs);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitMVEntryDictForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitMVEntryDictForwardIndexReader.java
@@ -1,0 +1,155 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.readers.forward;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import org.apache.pinot.segment.local.io.util.FixedBitIntReaderWriter;
+import org.apache.pinot.segment.local.io.util.PinotDataBitSet;
+import org.apache.pinot.segment.local.io.writer.impl.FixedBitMVEntryDictForwardIndexWriter;
+import org.apache.pinot.segment.spi.compression.DictIdCompressionType;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
+import org.apache.pinot.segment.spi.index.reader.ForwardIndexReaderContext;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+
+
+/**
+ * Bit-compressed dictionary-encoded forward index reader for multi-value columns, where a second level dictionary
+ * encoding for multi-value entries (instead of individual values within the entry) are maintained within the forward
+ * index.
+ * See {@link FixedBitMVEntryDictForwardIndexWriter} for index layout.
+ */
+public final class FixedBitMVEntryDictForwardIndexReader implements ForwardIndexReader<ForwardIndexReaderContext> {
+  public static final int MAGIC_MARKER = FixedBitMVEntryDictForwardIndexWriter.MAGIC_MARKER;
+  public static final short VERSION = FixedBitMVEntryDictForwardIndexWriter.VERSION;
+  private static final int HEADER_SIZE = FixedBitMVEntryDictForwardIndexWriter.HEADER_SIZE;
+
+  private final FixedBitIntReaderWriter _idReader;
+  private final int _offsetBufferOffset;
+  private final FixedBitIntReaderWriter _offsetReader;
+  private final int _valueBufferOffset;
+  private final FixedBitIntReaderWriter _valueReader;
+
+  public FixedBitMVEntryDictForwardIndexReader(PinotDataBuffer dataBuffer, int numDocs, int numBitsPerValue) {
+    int magicMarker = dataBuffer.getInt(0);
+    Preconditions.checkState(magicMarker == MAGIC_MARKER, "Invalid magic marker: %s (expected: %s)", magicMarker,
+        MAGIC_MARKER);
+    short version = dataBuffer.getShort(4);
+    Preconditions.checkState(version == VERSION, "Invalid version: %s (expected: %s)", version, VERSION);
+    int numBitsPerValueInHeader = dataBuffer.getByte(6);
+    Preconditions.checkState(numBitsPerValueInHeader == numBitsPerValue, "Invalid numBitsPerValue: %s (expected: %s)",
+        numBitsPerValueInHeader, numBitsPerValue);
+    int numBitsPerId = dataBuffer.getByte(7);
+    int numUniqueEntries = dataBuffer.getInt(8);
+    int numTotalValues = dataBuffer.getInt(12);
+    _offsetBufferOffset = dataBuffer.getInt(16);
+    _valueBufferOffset = dataBuffer.getInt(20);
+    _idReader = new FixedBitIntReaderWriter(dataBuffer.view(HEADER_SIZE, _offsetBufferOffset), numDocs, numBitsPerId);
+    _offsetReader =
+        new FixedBitIntReaderWriter(dataBuffer.view(_offsetBufferOffset, _valueBufferOffset), numUniqueEntries + 1,
+            PinotDataBitSet.getNumBitsPerValue(numTotalValues));
+    _valueReader = new FixedBitIntReaderWriter(dataBuffer.view(_valueBufferOffset, dataBuffer.size()), numTotalValues,
+        numBitsPerValue);
+  }
+
+  @Override
+  public boolean isDictionaryEncoded() {
+    return true;
+  }
+
+  @Override
+  public boolean isSingleValue() {
+    return false;
+  }
+
+  @Override
+  public DataType getStoredType() {
+    return DataType.INT;
+  }
+
+  @Override
+  public DictIdCompressionType getDictIdCompressionType() {
+    return DictIdCompressionType.MV_ENTRY_DICT;
+  }
+
+  @Override
+  public int getDictIdMV(int docId, int[] dictIdBuffer, ForwardIndexReaderContext context) {
+    int id = _idReader.readInt(docId);
+    int startIndex = _offsetReader.readInt(id);
+    int numValues = _offsetReader.readInt(id + 1) - startIndex;
+    _valueReader.readInt(startIndex, numValues, dictIdBuffer);
+    return numValues;
+  }
+
+  @Override
+  public int[] getDictIdMV(int docId, ForwardIndexReaderContext context) {
+    int id = _idReader.readInt(docId);
+    int startIndex = _offsetReader.readInt(id);
+    int numValues = _offsetReader.readInt(id + 1) - startIndex;
+    int[] dictIdBuffer = new int[numValues];
+    _valueReader.readInt(startIndex, numValues, dictIdBuffer);
+    return dictIdBuffer;
+  }
+
+  @Override
+  public int getNumValuesMV(int docId, ForwardIndexReaderContext context) {
+    int id = _idReader.readInt(docId);
+    return _offsetReader.readInt(id + 1) - _offsetReader.readInt(id);
+  }
+
+  @Override
+  public boolean isBufferByteRangeInfoSupported() {
+    return true;
+  }
+
+  @Override
+  public void recordDocIdByteRanges(int docId, ForwardIndexReaderContext context, List<ByteRange> ranges) {
+    int id = _idReader.readInt(docId);
+    int idReaderStartByteOffset = _idReader.getStartByteOffset(docId);
+    int idReaderEndByteOffset = _idReader.getEndByteOffset(docId);
+    ranges.add(new ByteRange(HEADER_SIZE + idReaderStartByteOffset, idReaderEndByteOffset - idReaderStartByteOffset));
+
+    int startIndex = _offsetReader.readInt(id);
+    int numValues = _offsetReader.readInt(id + 1) - startIndex;
+    int offsetReaderStartByteOffset = _offsetReader.getStartByteOffset(id);
+    int offsetReaderEndByteOffset = _offsetReader.getEndByteOffset(id + 1);
+    ranges.add(new ByteRange(_offsetBufferOffset + offsetReaderStartByteOffset,
+        offsetReaderEndByteOffset - offsetReaderStartByteOffset));
+
+    int valueReaderStartByteOffset = _valueReader.getStartByteOffset(startIndex);
+    int valueReaderEndByteOffset = _valueReader.getEndByteOffset(startIndex + numValues - 1);
+    ranges.add(new ByteRange(_valueBufferOffset + valueReaderStartByteOffset,
+        valueReaderEndByteOffset - valueReaderStartByteOffset));
+  }
+
+  @Override
+  public boolean isFixedOffsetMappingType() {
+    return false;
+  }
+
+  @Override
+  public void close() {
+    // NOTE: DO NOT close the PinotDataBuffer here because it is tracked by the caller and might be reused later. The
+    // caller is responsible of closing the PinotDataBuffer.
+    _idReader.close();
+    _offsetReader.close();
+    _valueReader.close();
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/FixedBitMVEntryDictForwardIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/FixedBitMVEntryDictForwardIndexTest.java
@@ -1,0 +1,123 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.index.forward;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.Random;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.segment.local.io.writer.impl.FixedBitMVEntryDictForwardIndexWriter;
+import org.apache.pinot.segment.local.segment.index.readers.forward.FixedBitMVEntryDictForwardIndexReader;
+import org.apache.pinot.segment.spi.V1Constants;
+import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class FixedBitMVEntryDictForwardIndexTest {
+  private static final File TEMP_DIR = new File(FileUtils.getTempDirectory(), "FixedBitMVEntryDictForwardIndexTest");
+  private static final File INDEX_FILE =
+      new File(TEMP_DIR, "testColumn" + V1Constants.Indexes.UNSORTED_MV_FORWARD_INDEX_FILE_EXTENSION);
+  private static final int NUM_DOCS = 1000;
+  private static final int MAX_NUM_VALUES_PER_MV_ENTRY = 3;
+  private static final Random RANDOM = new Random();
+
+  @BeforeClass
+  public void setUp()
+      throws IOException {
+    FileUtils.forceMkdir(TEMP_DIR);
+  }
+
+  @Test
+  public void testRandomGeneratedValues()
+      throws Exception {
+    for (int numBitsPerValue = 1; numBitsPerValue <= 31; numBitsPerValue++) {
+      // Generate random values
+      int[][] valuesArray = new int[NUM_DOCS][];
+      int maxValue = numBitsPerValue != 31 ? 1 << numBitsPerValue : Integer.MAX_VALUE;
+      for (int i = 0; i < NUM_DOCS; i++) {
+        int numValues = RANDOM.nextInt(MAX_NUM_VALUES_PER_MV_ENTRY + 1);
+        int[] values = new int[numValues];
+        for (int j = 0; j < numValues; j++) {
+          values[j] = RANDOM.nextInt(maxValue);
+        }
+        valuesArray[i] = values;
+      }
+
+      // Create the forward index
+      try (
+          FixedBitMVEntryDictForwardIndexWriter writer = new FixedBitMVEntryDictForwardIndexWriter(INDEX_FILE, NUM_DOCS,
+              numBitsPerValue)) {
+        for (int[] values : valuesArray) {
+          writer.putDictIds(values);
+        }
+      }
+
+      // Read the forward index
+      try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(INDEX_FILE);
+          FixedBitMVEntryDictForwardIndexReader reader = new FixedBitMVEntryDictForwardIndexReader(dataBuffer, NUM_DOCS,
+              numBitsPerValue)) {
+        int[] valueBuffer = new int[MAX_NUM_VALUES_PER_MV_ENTRY];
+        for (int i = 0; i < NUM_DOCS; i++) {
+          int numValues = reader.getDictIdMV(i, valueBuffer, null);
+          assertEquals(numValues, valuesArray[i].length);
+          for (int j = 0; j < numValues; j++) {
+            assertEquals(valueBuffer[j], valuesArray[i][j]);
+          }
+        }
+      }
+
+      FileUtils.forceDelete(INDEX_FILE);
+    }
+  }
+
+  @Test
+  public void testAllEmptyValues()
+      throws Exception {
+    // Create the forward index
+    try (FixedBitMVEntryDictForwardIndexWriter writer = new FixedBitMVEntryDictForwardIndexWriter(INDEX_FILE, NUM_DOCS,
+        1)) {
+      int[] value = new int[0];
+      for (int i = 0; i < NUM_DOCS; i++) {
+        writer.putDictIds(value);
+      }
+    }
+
+    // Read the forward index
+    try (PinotDataBuffer dataBuffer = PinotDataBuffer.mapReadOnlyBigEndianFile(INDEX_FILE);
+        FixedBitMVEntryDictForwardIndexReader reader = new FixedBitMVEntryDictForwardIndexReader(dataBuffer, NUM_DOCS,
+            1)) {
+      int[] valueBuffer = new int[0];
+      for (int i = 0; i < NUM_DOCS; i++) {
+        assertEquals(reader.getDictIdMV(i, valueBuffer, null), 0);
+      }
+    }
+
+    FileUtils.forceDelete(INDEX_FILE);
+  }
+
+  @AfterClass
+  public void tearDown()
+      throws IOException {
+    FileUtils.deleteDirectory(TEMP_DIR);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexTypeTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/forward/ForwardIndexTypeTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.pinot.segment.local.segment.index.AbstractSerdeIndexContract;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
+import org.apache.pinot.segment.spi.compression.DictIdCompressionType;
 import org.apache.pinot.segment.spi.index.ForwardIndexConfig;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.spi.config.table.FieldConfig;
@@ -162,29 +163,17 @@ public class ForwardIndexTypeTest {
     }
 
     @Test
-    public void oldConfEnableDictWithSnappyCompression()
+    public void oldConfEnableDictWithMVEntryDictFormat()
         throws IOException {
       addFieldIndexConfig(""
-          + " {\n"
-          + "    \"name\": \"dimInt\","
-          + "    \"encodingType\": \"DICTIONARY\",\n"
-          + "    \"compressionCodec\": \"SNAPPY\"\n"
-          + " }"
+          + "{"
+          + "  \"name\": \"dimInt\","
+          + "  \"encodingType\": \"DICTIONARY\","
+          + "  \"compressionCodec\": \"MV_ENTRY_DICT\""
+          + "}"
       );
-      assertEquals(ForwardIndexConfig.DEFAULT);
-    }
-
-    @Test
-    public void oldConfEnableDictWithLZ4Compression()
-        throws IOException {
-      addFieldIndexConfig(""
-          + " {\n"
-          + "    \"name\": \"dimInt\","
-          + "    \"encodingType\": \"DICTIONARY\",\n"
-          + "    \"compressionCodec\": \"LZ4\"\n"
-          + " }"
-      );
-      assertEquals(ForwardIndexConfig.DEFAULT);
+      assertEquals(
+          new ForwardIndexConfig.Builder().withDictIdCompressionType(DictIdCompressionType.MV_ENTRY_DICT).build());
     }
 
     @Test
@@ -197,13 +186,7 @@ public class ForwardIndexTypeTest {
                   + " }"
       );
 
-      assertEquals(
-          new ForwardIndexConfig.Builder()
-              .withCompressionType(null)
-              .withDeriveNumDocsPerChunk(false)
-              .withRawIndexWriterVersion(ForwardIndexConfig.DEFAULT_RAW_WRITER_VERSION)
-              .build()
-      );
+      assertEquals(ForwardIndexConfig.DEFAULT);
     }
 
     @Test(dataProvider = "allChunkCompressionType", dataProviderClass = ForwardIndexTypeTest.class)
@@ -269,7 +252,7 @@ public class ForwardIndexTypeTest {
     }
 
     @Test
-    public void newConfigDisabled2()
+    public void newConfigDisabled()
         throws IOException {
       addFieldIndexConfig("{\n"
               + "    \"name\": \"dimInt\",\n"
@@ -294,6 +277,23 @@ public class ForwardIndexTypeTest {
       );
 
       assertEquals(ForwardIndexConfig.DEFAULT);
+    }
+
+    @Test
+    public void newConfigMVEntryDictFormat()
+        throws IOException {
+      addFieldIndexConfig(""
+          + "{"
+          + "  \"name\": \"dimInt\","
+          + "  \"indexes\" : {"
+          + "    \"forward\": {"
+          + "      \"dictIdCompressionType\": \"MV_ENTRY_DICT\""
+          + "    }"
+          + "  }"
+          + "}"
+      );
+      assertEquals(
+          new ForwardIndexConfig.Builder().withDictIdCompressionType(DictIdCompressionType.MV_ENTRY_DICT).build());
     }
 
     @Test(dataProvider = "allChunkCompressionType", dataProviderClass = ForwardIndexTypeTest.class)

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/loader/SegmentPreProcessorTest.java
@@ -62,6 +62,7 @@ import org.apache.pinot.segment.spi.store.SegmentDirectory;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
 import org.apache.pinot.segment.spi.utils.SegmentMetadataUtils;
 import org.apache.pinot.spi.config.table.BloomFilterConfig;
+import org.apache.pinot.spi.config.table.FieldConfig.CompressionCodec;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
 import org.apache.pinot.spi.config.table.StarTreeIndexConfig;
@@ -656,9 +657,8 @@ public class SegmentPreProcessorTest {
   @Test
   public void testForwardIndexHandlerChangeCompression()
       throws Exception {
-    Map<String, ChunkCompressionType> compressionConfigs = new HashMap<>();
-    ChunkCompressionType newCompressionType = ChunkCompressionType.ZSTANDARD;
-    compressionConfigs.put(EXISTING_STRING_COL_RAW, newCompressionType);
+    Map<String, CompressionCodec> compressionConfigs = new HashMap<>();
+    compressionConfigs.put(EXISTING_STRING_COL_RAW, CompressionCodec.ZSTANDARD);
     _indexLoadingConfig.setCompressionConfigs(compressionConfigs);
     _indexLoadingConfig.addNoDictionaryColumns(EXISTING_STRING_COL_RAW);
 
@@ -672,12 +672,11 @@ public class SegmentPreProcessorTest {
     new SegmentV1V2ToV3FormatConverter().convert(_indexDir);
 
     // Test2: Now forward index will be rewritten with ZSTANDARD compressionType.
-    checkForwardIndexCreation(EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0, newCompressionType, true,
-        0, DataType.STRING, 100000);
+    checkForwardIndexCreation(EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0,
+        ChunkCompressionType.ZSTANDARD, true, 0, DataType.STRING, 100000);
 
     // Test3: Change compression on existing raw index column. Also add text index on same column. Check correctness.
-    newCompressionType = ChunkCompressionType.SNAPPY;
-    compressionConfigs.put(EXISTING_STRING_COL_RAW, newCompressionType);
+    compressionConfigs.put(EXISTING_STRING_COL_RAW, CompressionCodec.SNAPPY);
     _indexLoadingConfig.setCompressionConfigs(compressionConfigs);
     Set<String> textIndexColumns = new HashSet<>();
     textIndexColumns.add(EXISTING_STRING_COL_RAW);
@@ -688,12 +687,11 @@ public class SegmentPreProcessorTest {
     ColumnMetadata columnMetadata = segmentMetadata.getColumnMetadataFor(EXISTING_STRING_COL_RAW);
     assertNotNull(columnMetadata);
     checkTextIndexCreation(EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0);
-    validateIndex(StandardIndexes.forward(), EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0, true,
-        0, newCompressionType, false, DataType.STRING, 100000);
+    validateIndex(StandardIndexes.forward(), EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0, true, 0,
+        ChunkCompressionType.SNAPPY, false, DataType.STRING, 100000);
 
     // Test4: Change compression on RAW index column. Change another index on another column. Check correctness.
-    newCompressionType = ChunkCompressionType.ZSTANDARD;
-    compressionConfigs.put(EXISTING_STRING_COL_RAW, newCompressionType);
+    compressionConfigs.put(EXISTING_STRING_COL_RAW, CompressionCodec.ZSTANDARD);
     _indexLoadingConfig.setCompressionConfigs(compressionConfigs);
     Set<String> fstColumns = new HashSet<>();
     fstColumns.add(EXISTING_STRING_COL_DICT);
@@ -706,12 +704,11 @@ public class SegmentPreProcessorTest {
     // Check FST index
     checkFSTIndexCreation(EXISTING_STRING_COL_DICT, 9, 4, _newColumnsSchemaWithFST, false, false, 26);
     // Check forward index.
-    validateIndex(StandardIndexes.forward(), EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0, true,
-        0, newCompressionType, false, DataType.STRING, 100000);
+    validateIndex(StandardIndexes.forward(), EXISTING_STRING_COL_RAW, 5, 3, _schema, false, false, false, 0, true, 0,
+        ChunkCompressionType.ZSTANDARD, false, DataType.STRING, 100000);
 
     // Test5: Change compressionType for an MV column
-    newCompressionType = ChunkCompressionType.ZSTANDARD;
-    compressionConfigs.put(EXISTING_INT_COL_RAW_MV, newCompressionType);
+    compressionConfigs.put(EXISTING_INT_COL_RAW_MV, CompressionCodec.ZSTANDARD);
     _indexLoadingConfig.setCompressionConfigs(compressionConfigs);
     _indexLoadingConfig.addNoDictionaryColumns(EXISTING_INT_COL_RAW_MV);
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -31,6 +31,7 @@ import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.FieldConfig.CompressionCodec;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.ReplicaGroupStrategyConfig;
 import org.apache.pinot.spi.config.table.RoutingConfig;
@@ -706,9 +707,8 @@ public class TableConfigUtilsTest {
     streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_SEGMENT_SIZE, "100m");
     streamConfigs.remove(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS);
     ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(List.of(streamConfigs)));
-    tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
-            .setIngestionConfig(ingestionConfig).build();
+    tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName(TIME_COLUMN)
+        .setIngestionConfig(ingestionConfig).build();
 
     try {
       TableConfigUtils.validate(tableConfig, schema);
@@ -720,9 +720,8 @@ public class TableConfigUtilsTest {
     // When size based threshold is specified, rows has to be set to 0.
     streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "1000");
     ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(List.of(streamConfigs)));
-    tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeColumn")
-            .setIngestionConfig(ingestionConfig).build();
+    tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeColumn")
+        .setIngestionConfig(ingestionConfig).build();
 
     try {
       TableConfigUtils.validate(tableConfig, schema);
@@ -734,9 +733,8 @@ public class TableConfigUtilsTest {
     // When size based threshold is specified, rows has to be set to 0.
     streamConfigs.put(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, "0");
     ingestionConfig.setStreamIngestionConfig(new StreamIngestionConfig(List.of(streamConfigs)));
-    tableConfig =
-        new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeColumn")
-            .setIngestionConfig(ingestionConfig).build();
+    tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setTimeColumnName("timeColumn")
+        .setIngestionConfig(ingestionConfig).build();
 
     try {
       TableConfigUtils.validate(tableConfig, schema);
@@ -1030,7 +1028,9 @@ public class TableConfigUtilsTest {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since FST index is enabled on RAW encoding type");
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "FST Index is only enabled on dictionary encoded columns");
+      Assert.assertEquals(e.getMessage(),
+          "Cannot create FST index on column: myCol1, it can only be applied to dictionary encoded single value "
+              + "string columns");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
@@ -1041,7 +1041,9 @@ public class TableConfigUtilsTest {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since FST index is enabled on multi value column");
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "FST Index is only supported for single value string columns");
+      Assert.assertEquals(e.getMessage(),
+          "Cannot create FST index on column: myCol2, it can only be applied to dictionary encoded single value "
+              + "string columns");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
@@ -1052,7 +1054,9 @@ public class TableConfigUtilsTest {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since FST index is enabled on non String column");
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "FST Index is only supported for single value string columns");
+      Assert.assertEquals(e.getMessage(),
+          "Cannot create FST index on column: intCol, it can only be applied to dictionary encoded single value "
+              + "string columns");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
@@ -1064,7 +1068,8 @@ public class TableConfigUtilsTest {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should fail since TEXT index is enabled on non String column");
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "TEXT Index is only supported for string columns");
+      Assert.assertEquals(e.getMessage(),
+          "Cannot create text index on column: intCol, it can only be applied to string columns");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
@@ -1077,29 +1082,29 @@ public class TableConfigUtilsTest {
       Assert.fail("Should fail since field name is not present in schema");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(),
-          "Column Name myCol21 defined in field config list must be a valid column defined in the schema");
+          "Column: myCol21 defined in field config list must be a valid column defined in the schema");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
       FieldConfig fieldConfig = new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, Collections.emptyList(),
-          FieldConfig.CompressionCodec.SNAPPY, null);
+          CompressionCodec.SNAPPY, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
-      Assert.fail("Should fail since dictionary encoding does not support compression codec snappy");
+      Assert.fail("Should fail since dictionary encoding does not support compression codec SNAPPY");
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "Set compression codec to null for dictionary encoding type");
+      Assert.assertEquals(e.getMessage(), "Compression codec: SNAPPY is not applicable to dictionary encoded index");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
     try {
-      FieldConfig fieldConfig = new FieldConfig("intCol", FieldConfig.EncodingType.DICTIONARY, Collections.emptyList(),
-          FieldConfig.CompressionCodec.ZSTANDARD, null);
+      FieldConfig fieldConfig = new FieldConfig("intCol", FieldConfig.EncodingType.RAW, Collections.emptyList(),
+          CompressionCodec.MV_ENTRY_DICT, null);
       tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
       TableConfigUtils.validate(tableConfig, schema);
-      Assert.fail("Should fail since dictionary encoding does not support compression codec zstandard");
+      Assert.fail("Should fail since raw encoding does not support compression codec MV_ENTRY_DICT");
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "Set compression codec to null for dictionary encoding type");
+      Assert.assertEquals(e.getMessage(), "Compression codec: MV_ENTRY_DICT is not applicable to raw index");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
@@ -1227,7 +1232,7 @@ public class TableConfigUtilsTest {
       Assert.fail("Should not be able to disable dictionary but keep inverted index");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(),
-          "Cannot create an Inverted index on column myCol2 specified in the " + "noDictionaryColumns config");
+          "Cannot create an Inverted index on column myCol2 specified in the noDictionaryColumns config");
     }
 
     // Tests the case when the field-config list marks a column as raw (non-dictionary) and enables
@@ -1242,7 +1247,7 @@ public class TableConfigUtilsTest {
       Assert.fail("Should not be able to disable dictionary but keep inverted index");
     } catch (Exception e) {
       Assert.assertEquals(e.getMessage(),
-          "Cannot create an Inverted Index on column: myCol2, specified as a non dictionary column");
+          "Cannot create inverted index on column: myCol2, it can only be applied to dictionary encoded columns");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
@@ -1258,7 +1263,9 @@ public class TableConfigUtilsTest {
       TableConfigUtils.validate(tableConfig, schema);
       Assert.fail("Should not be able to disable dictionary but keep inverted index");
     } catch (Exception e) {
-      Assert.assertEquals(e.getMessage(), "FST Index is only enabled on dictionary encoded columns");
+      Assert.assertEquals(e.getMessage(),
+          "Cannot create FST index on column: myCol2, it can only be applied to dictionary encoded single value "
+              + "string columns");
     }
 
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
@@ -1433,7 +1440,7 @@ public class TableConfigUtilsTest {
     }
 
     starTreeIndexConfig = new StarTreeIndexConfig(Arrays.asList("myCol"), null, null,
-        Arrays.asList(new StarTreeAggregationConfig("myCol2", "SUM", FieldConfig.CompressionCodec.LZ4)), 1);
+        Arrays.asList(new StarTreeAggregationConfig("myCol2", "SUM", CompressionCodec.LZ4)), 1);
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setStarTreeIndexConfigs(Arrays.asList(starTreeIndexConfig)).build();
     try {
@@ -1798,8 +1805,7 @@ public class TableConfigUtilsTest {
     try {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
     } catch (IllegalStateException e) {
-      Assert.assertEquals(e.getMessage(),
-          "The outOfOrderRecordColumn must be a single-valued BOOLEAN column");
+      Assert.assertEquals(e.getMessage(), "The outOfOrderRecordColumn must be a single-valued BOOLEAN column");
     }
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/compression/DictIdCompressionType.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/compression/DictIdCompressionType.java
@@ -1,0 +1,47 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.compression;
+
+/**
+ * Compression type for dictionary-encoded forward index, where the values stored are dictionary ids.
+ */
+public enum DictIdCompressionType {
+  // Add a second level dictionary encoding for the multi-value entries
+  MV_ENTRY_DICT(false, true);
+
+  private final boolean _applicableToSV;
+  private final boolean _applicableToMV;
+
+  DictIdCompressionType(boolean applicableToSV, boolean applicableToMV) {
+    _applicableToSV = applicableToSV;
+    _applicableToMV = applicableToMV;
+  }
+
+  public boolean isApplicableToSV() {
+    return _applicableToSV;
+  }
+
+  public boolean isApplicableToMV() {
+    return _applicableToMV;
+  }
+
+  public boolean isApplicable(boolean isSingleValue) {
+    return isSingleValue ? isApplicableToSV() : isApplicableToMV();
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
@@ -25,6 +25,7 @@ import lombok.AllArgsConstructor;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import org.apache.pinot.segment.spi.compression.ChunkCompressionType;
+import org.apache.pinot.segment.spi.compression.DictIdCompressionType;
 import org.apache.pinot.segment.spi.index.IndexReader;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.utils.BigDecimalUtils;
@@ -57,9 +58,17 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
   /**
    * Returns the compression type (if valid). Only valid for RAW forward index columns implemented in
    * BaseChunkForwardIndexReader.
-   * @return
    */
+  @Nullable
   default ChunkCompressionType getCompressionType() {
+    return null;
+  }
+
+  /**
+   * Returns the compression type for dictionary encoded forward index.
+   */
+  @Nullable
+  default DictIdCompressionType getDictIdCompressionType() {
     return null;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -119,7 +119,29 @@ public class FieldConfig extends BaseJsonConfig {
   }
 
   public enum CompressionCodec {
-    PASS_THROUGH, SNAPPY, ZSTANDARD, LZ4
+    PASS_THROUGH(true, false),
+    SNAPPY(true, false),
+    ZSTANDARD(true, false),
+    LZ4(true, false),
+
+    // For MV dictionary encoded forward index, add a second level dictionary encoding for the multi-value entries
+    MV_ENTRY_DICT(false, true);
+
+    private final boolean _applicableToRawIndex;
+    private final boolean _applicableToDictEncodedIndex;
+
+    CompressionCodec(boolean applicableToRawIndex, boolean applicableToDictEncodedIndex) {
+      _applicableToRawIndex = applicableToRawIndex;
+      _applicableToDictEncodedIndex = applicableToDictEncodedIndex;
+    }
+
+    public boolean isApplicableToRawIndex() {
+      return _applicableToRawIndex;
+    }
+
+    public boolean isApplicableToDictEncodedIndex() {
+      return _applicableToDictEncodedIndex;
+    }
   }
 
   public String getName() {


### PR DESCRIPTION
Add a new MV dictionary encoded forward index format that only stores the unique MV entries. This new index format can significantly reduce the index size when the MV entries repeat a lot. This is especially useful when user pre-join fact table with dimension table, where the MV values within the dimension table might get repeated a lot after joining with the fact table.

Index layout:
- Header
- Map from doc id to MV entry id (bit compressed)
- Start offsets of each MV entry in the value buffer (bit compressed)
- Value buffer (bit compressed)

To enable the new index format, set the compression codec in the `FieldConfig`:
```
{
  "name": "myCol",
  "encodingType": "DICTIONARY",
  "compressionCodec": "MV_ENTRY_DICT"
}
```

Or use the new index JSON:

```
{
  "name": "myCol",
  "encodingType": "DICTIONARY",
  "indexes": {
    "forward": {
      "dictIdCompressionType": "MV_ENTRY_DICT"
    }
  }
}
```

The new index format can be enabled during index creation, derived column creation, and segment reload.