### PR TITLE
fix for #11996 which corrects property name typo in main pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1185,7 +1185,7 @@
       <dependency>
         <groupId>org.apache.maven.surefire</groupId>
         <artifactId>surefire-testng</artifactId>
-        <version>${surefire.versino}</version>
+        <version>${surefire.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>


### PR DESCRIPTION
this PR fixes a typo on the main pom.xml which corrects `${surefire.versino}` to `${surefire.version}`.  Fixes #11996.