### PR TITLE
Fix the misuse of star-tree when all predicates are always false under OR

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
@@ -78,7 +78,8 @@ public class GroupByPlanNode implements PlanNode {
 
     // Use star-tree to solve the query if possible
     List<StarTreeV2> starTrees = _indexSegment.getStarTrees();
-    if (starTrees != null && !_queryContext.isSkipStarTree()) {
+    if (!_queryContext.isNullHandlingEnabled() && !filterOperator.isResultEmpty() && starTrees != null
+        && !_queryContext.isSkipStarTree()) {
       AggregationFunctionColumnPair[] aggregationFunctionColumnPairs =
           StarTreeUtils.extractAggregationFunctionPairs(aggregationFunctions);
       if (aggregationFunctionColumnPairs != null) {
@@ -99,6 +100,7 @@ public class GroupByPlanNode implements PlanNode {
       }
     }
 
+    // TODO: Do not create ProjectOperator when filter result is empty
     Set<ExpressionContext> expressionsToTransform =
         AggregationFunctionUtils.collectExpressionsToTransform(aggregationFunctions, groupByExpressionsList);
     BaseProjectOperator<?> projectOperator =

--- a/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/startree/StarTreeUtils.java
@@ -117,8 +117,8 @@ public class StarTreeUtils {
           Predicate predicate = filterNode.getPredicate();
           PredicateEvaluator predicateEvaluator = getPredicateEvaluator(indexSegment, predicate,
               predicateEvaluatorMapping);
-          if (predicateEvaluator == null) {
-            // The predicate cannot be solved with star-tree
+          // Do not use star-tree when the predicate cannot be solved with star-tree or is always false
+          if (predicateEvaluator == null || predicateEvaluator.isAlwaysFalse()) {
             return null;
           }
           if (!predicateEvaluator.isAlwaysTrue()) {
@@ -210,6 +210,10 @@ public class StarTreeUtils {
         predicateEvaluators.add(predicateEvaluator);
       }
     }
+    // When all predicates are always false, do not use star-tree
+    if (predicateEvaluators.isEmpty()) {
+      return null;
+    }
     return Pair.of(identifier, predicateEvaluators);
   }
 
@@ -230,7 +234,6 @@ public class StarTreeUtils {
           if (!extractOrClausePredicates(child, predicates)) {
             return false;
           }
-          predicates.add(child.getPredicate());
           break;
         case PREDICATE:
           predicates.add(child.getPredicate());

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -111,6 +111,9 @@ abstract class BaseStarTreeV2Test<R, A> {
   private static final String QUERY_FILTER_OR_MULTIPLE_DIMENSIONS = " WHERE d1 > 10 OR d2 < 50";
   private static final String QUERY_FILTER_OR_ON_AND = " WHERE (d1 > 10 AND d1 < 50) OR d1 < 50";
   private static final String QUERY_FILTER_OR_ON_NOT = " WHERE (NOT d1 > 10) OR d1 < 50";
+  // Always false filters
+  private static final String QUERY_FILTER_ALWAYS_FALSE = " WHERE d1 > 100";
+  private static final String QUERY_FILTER_OR_ALWAYS_FALSE = " WHERE d1 > 100 OR d1 < 0";
 
   private static final String QUERY_GROUP_BY = " GROUP BY d2";
   private static final String FILTER_AGG_CLAUSE = " FILTER(WHERE d1 > 10)";
@@ -188,6 +191,8 @@ abstract class BaseStarTreeV2Test<R, A> {
     testUnsupportedFilter(query + QUERY_FILTER_OR_MULTIPLE_DIMENSIONS);
     testUnsupportedFilter(query + QUERY_FILTER_OR_ON_AND);
     testUnsupportedFilter(query + QUERY_FILTER_OR_ON_NOT);
+    testUnsupportedFilter(query + QUERY_FILTER_ALWAYS_FALSE);
+    testUnsupportedFilter(query + QUERY_FILTER_OR_ALWAYS_FALSE);
   }
 
   @Test


### PR DESCRIPTION
Fix #11718 

Fixes 2 scenarios where star-tree shouldn't be used:
- When the filter is empty (no matching doc). There is a bug when all predicates under OR are always false, it is mis-identified as always true
- When null handling is enabled for GROUP BY queries

