### PR TITLE
Fix the race condition of concurrent modification to segment data managers

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -28,7 +28,6 @@ import java.io.IOException;
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -206,10 +205,12 @@ public abstract class BaseTableDataManager implements TableDataManager {
    * Releases and removes all segments tracked by the table data manager.
    */
   protected void releaseAndRemoveAllSegments() {
-    Iterator<SegmentDataManager> iterator = _segmentDataManagerMap.values().iterator();
-    while (iterator.hasNext()) {
-      SegmentDataManager segmentDataManager = iterator.next();
-      iterator.remove();
+    List<SegmentDataManager> segmentDataManagers;
+    synchronized (_segmentDataManagerMap) {
+      segmentDataManagers = new ArrayList<>(_segmentDataManagerMap.values());
+      _segmentDataManagerMap.clear();
+    }
+    for (SegmentDataManager segmentDataManager : segmentDataManagers) {
       releaseSegment(segmentDataManager);
     }
   }
@@ -522,7 +523,10 @@ public abstract class BaseTableDataManager implements TableDataManager {
    */
   @Nullable
   protected SegmentDataManager registerSegment(String segmentName, SegmentDataManager segmentDataManager) {
-    SegmentDataManager oldSegmentDataManager = _segmentDataManagerMap.put(segmentName, segmentDataManager);
+    SegmentDataManager oldSegmentDataManager;
+    synchronized (_segmentDataManagerMap) {
+      oldSegmentDataManager = _segmentDataManagerMap.put(segmentName, segmentDataManager);
+    }
     _recentlyDeletedSegments.invalidate(segmentName);
     return oldSegmentDataManager;
   }
@@ -537,7 +541,9 @@ public abstract class BaseTableDataManager implements TableDataManager {
   @Nullable
   protected SegmentDataManager unregisterSegment(String segmentName) {
     _recentlyDeletedSegments.put(segmentName, segmentName);
-    return _segmentDataManagerMap.remove(segmentName);
+    synchronized (_segmentDataManagerMap) {
+      return _segmentDataManagerMap.remove(segmentName);
+    }
   }
 
   protected boolean allowDownload(String segmentName, SegmentZKMetadata zkMetadata) {


### PR DESCRIPTION
In `BaseTableDataManager`, do not allow concurrent modification to `_segmentDataManagerMap`.
There is a race condition where `releaseAndRemoveAllSegments()` and `unregisterSegment()` can happen at the same time, and cause the same `SegmentDataManager` to be released twice. If there is another thread reading the segment, it can cause server crash.