### PR TITLE
bugfix: use PropertiesWriter to escape index_map keys properly

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectory.java
@@ -446,24 +446,25 @@ class SingleFileIndexDirectory extends ColumnIndexDirectory {
   }
 
   @VisibleForTesting
-  static void persistIndexMaps(List<IndexEntry> entries, PrintWriter writer) {
+  static void persistIndexMaps(List<IndexEntry> entries, PrintWriter writer)
+      throws IOException {
     for (IndexEntry entry : entries) {
       persistIndexMap(entry, writer);
     }
   }
 
-  private static void persistIndexMap(IndexEntry entry, PrintWriter writer) {
+  private static void persistIndexMap(IndexEntry entry, PrintWriter writer)
+      throws IOException {
     String colName = entry._key._name;
     String idxType = entry._key._type.getId();
 
-    String startKey = getKey(colName, idxType, true);
-    StringBuilder sb = new StringBuilder();
-    sb.append(startKey).append(" = ").append(entry._startOffset);
-    writer.println(sb);
+    PropertiesConfiguration.PropertiesWriter propertiesWriter =
+        CommonsConfigurationUtils.getPropertiesWriterFromWriter(writer);
 
+    String startKey = getKey(colName, idxType, true);
+    propertiesWriter.writeProperty(startKey, entry._startOffset);
     String endKey = getKey(colName, idxType, false);
-    sb = new StringBuilder();
-    sb.append(endKey).append(" = ").append(entry._size);
-    writer.println(sb);
+    propertiesWriter.writeProperty(endKey, entry._size);
+    propertiesWriter.flush();
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
@@ -325,18 +325,23 @@ public class SingleFileIndexDirectoryTest {
   }
 
   @Test
-  public void testPersistIndexMaps() {
+  public void testPersistIndexMaps()
+      throws IOException {
     ByteArrayOutputStream output = new ByteArrayOutputStream(1024 * 1024);
     try (PrintWriter pw = new PrintWriter(output)) {
       List<IndexEntry> entries = Arrays
           .asList(new IndexEntry(new IndexKey("foo", StandardIndexes.inverted()), 0, 1024),
               new IndexEntry(new IndexKey("bar", StandardIndexes.inverted()), 1024, 100),
-              new IndexEntry(new IndexKey("baz", StandardIndexes.inverted()), 1124, 200));
+              new IndexEntry(new IndexKey("baz", StandardIndexes.inverted()), 1124, 200),
+              new IndexEntry(new IndexKey("=special", StandardIndexes.inverted()), 1324, 200),
+              new IndexEntry(new IndexKey("period.:colon", StandardIndexes.inverted()), 1524, 200));
       SingleFileIndexDirectory.persistIndexMaps(entries, pw);
     }
     assertEquals(output.toString(), "foo.inverted_index.startOffset = 0\nfoo.inverted_index.size = 1024\n"
         + "bar.inverted_index.startOffset = 1024\nbar.inverted_index.size = 100\n"
-        + "baz.inverted_index.startOffset = 1124\nbaz.inverted_index.size = 200\n");
+        + "baz.inverted_index.startOffset = 1124\nbaz.inverted_index.size = 200\n"
+        + "\\=special.inverted_index.startOffset = 1324\n\\=special.inverted_index.size = 200\n"
+        + "period.\\:colon.inverted_index.startOffset = 1524\nperiod.\\:colon.inverted_index.size = 200\n");
   }
 
   @Test

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -50,7 +50,7 @@ public class CommonsConfigurationUtils {
   // the value is same of PropertiesConfiguration `DEFAULT_SEPARATOR` constant.
   public static final String VERSIONED_CONFIG_SEPARATOR = " = ";
   private static final Character DEFAULT_LIST_DELIMITER = ',';
-  public static final ListDelimiterHandler DEFAULT_LIST_DELIMITER_HANDLER =
+  private static final ListDelimiterHandler DEFAULT_LIST_DELIMITER_HANDLER =
       new LegacyListDelimiterHandler(DEFAULT_LIST_DELIMITER);
   public static final String VERSION_HEADER_IDENTIFIER = "version";
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.Writer;
 import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
@@ -35,6 +36,7 @@ import javax.annotation.Nullable;
 import org.apache.commons.configuration2.Configuration;
 import org.apache.commons.configuration2.PropertiesConfiguration;
 import org.apache.commons.configuration2.convert.LegacyListDelimiterHandler;
+import org.apache.commons.configuration2.convert.ListDelimiterHandler;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.configuration2.io.FileHandler;
 import org.apache.commons.lang3.StringUtils;
@@ -48,6 +50,8 @@ public class CommonsConfigurationUtils {
   // the value is same of PropertiesConfiguration `DEFAULT_SEPARATOR` constant.
   public static final String VERSIONED_CONFIG_SEPARATOR = " = ";
   private static final Character DEFAULT_LIST_DELIMITER = ',';
+  public static final ListDelimiterHandler DEFAULT_LIST_DELIMITER_HANDLER =
+      new LegacyListDelimiterHandler(DEFAULT_LIST_DELIMITER);
   public static final String VERSION_HEADER_IDENTIFIER = "version";
 
   // usage: default header version of all configurations.
@@ -392,5 +396,19 @@ public class CommonsConfigurationUtils {
   // The return statement follow the pattern 'version = <value>'
   static String getVersionHeaderString(String versionHeaderValue) {
     return VERSION_HEADER_IDENTIFIER + VERSIONED_CONFIG_SEPARATOR + versionHeaderValue;
+  }
+
+  /**
+   * Get the {@link PropertiesConfiguration.PropertiesWriter} from the provided generic writer. PropertiesWriter
+   * ensures properties are written correctly with default delimiter/separators.
+   * <p>
+   * This method is useful when writing is done incrementally and modifying a PropertiesConfiguration instance
+   * is not ideal.
+   */
+  public static PropertiesConfiguration.PropertiesWriter getPropertiesWriterFromWriter(Writer writer) {
+    PropertiesConfiguration.PropertiesWriter propertiesWriter =
+        new PropertiesConfiguration.PropertiesWriter(writer, DEFAULT_LIST_DELIMITER_HANDLER);
+    propertiesWriter.setGlobalSeparator(VERSIONED_CONFIG_SEPARATOR);
+    return propertiesWriter;
   }
 }


### PR DESCRIPTION
Previously segment build failed if a column name contained `:` or `=`, since these characters have special meaning in `Properties` files. For example, an exception produced for a column like `headers.:auth` is: 

```
j.lang.IllegalStateException: Index separator not found: headers. , segment: /data/pinot-server/dataDir/table_REALTIME/table__127__0__20231020T1604Z/v3 at c.g.common.base.Preconditions.checkState(Preconditions.java:504) at o.a.p.s.s.s.ColumnIndexUtils.parseIndexMapKeys(ColumnIndexUtils.java:43) at o.a.p.s.l.s.s.SingleFileIndexDirectory.loadMap(SingleFileIndexDirectory.java:220) at o.a.p.s.l.s.s.SingleFileIndexDirectory.load(SingleFileIndexDirectory.java:209) at o.a.p.s.l.s.s.SingleFileIndexDirectory.<init>(SingleFileIndexDirectory.java:121) at o.a.p.s.l.s.s.SegmentLocalFSDirectory.loadData(SegmentLocalFSDirectory.java:262) at o.a.p.s.l.s.s.SegmentLocalFSDirectory.load(SegmentLocalFSDirectory.java:247) at o.a.p.s.l.s.s.SegmentLocalFSDirectory.<init>(SegmentLocalFSDirectory.java:98) at o.a.p.s.l.s.s.SegmentLocalFSDirectory.<init>(SegmentLocalFSDirectory.java:81) at o.a.p.s.l.l...
``` 

This changes the writing to be done via PropertiesWriter instead of building the string explicitly. 

Testing: unit tests + deployed in a cluster and verified segments were sealed properly 