### PR TITLE
Fix flaky PinotTenantRestletResourceTest

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTenantRestletResourceTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/api/PinotTenantRestletResourceTest.java
@@ -20,20 +20,26 @@ package org.apache.pinot.controller.api;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import java.io.IOException;
-import org.apache.helix.store.zk.ZkHelixPropertyStore;
-import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import java.util.Collections;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.helix.HelixAdmin;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.controller.helix.ControllerTest;
+import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.utils.SegmentMetadataMockUtils;
-import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.instance.Instance;
+import org.apache.pinot.spi.config.instance.InstanceType;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.spi.utils.builder.ControllerRequestURLBuilder;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
+import org.testng.collections.Sets;
 
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertTrue;
@@ -41,119 +47,100 @@ import static org.testng.Assert.fail;
 
 
 public class PinotTenantRestletResourceTest extends ControllerTest {
-  private static final ControllerTest TEST_INSTANCE = ControllerTest.getInstance();
-  private static final String TABLE_NAME = "restletTable_OFFLINE";
-  private static final String RAW_TABLE_NAME = "toggleTable";
+  private static final String RAW_TABLE_NAME = "testTale";
   private static final String OFFLINE_TABLE_NAME = TableNameBuilder.OFFLINE.tableNameWithType(RAW_TABLE_NAME);
+
+  private ControllerRequestURLBuilder _urlBuilder;
 
   @BeforeClass
   public void setUp()
       throws Exception {
-    TEST_INSTANCE.setupSharedStateAndValidate();
+    DEFAULT_INSTANCE.setupSharedStateAndValidate();
+    _urlBuilder = DEFAULT_INSTANCE.getControllerRequestURLBuilder();
   }
 
   @Test
   public void testTableListForTenant()
       throws Exception {
-    try {
-      // Check that no tables on tenant works
-      String listTablesUrl =
-          TEST_INSTANCE.getControllerRequestURLBuilder().forTablesFromTenant(TagNameUtils.DEFAULT_TENANT_NAME);
-      JsonNode tableList = JsonUtils.stringToJsonNode(ControllerTest.sendGetRequest(listTablesUrl));
-      assertEquals(tableList.get("tables").size(), 0);
+    // Check that there is no existing tables
+    String listTablesUrl = _urlBuilder.forTablesFromTenant(TagNameUtils.DEFAULT_TENANT_NAME);
+    JsonNode listTablesResponse = JsonUtils.stringToJsonNode(ControllerTest.sendGetRequest(listTablesUrl));
+    assertTrue(listTablesResponse.get("tables").isEmpty());
 
-      // Add some non default tag broker instances, UNTAGGED_BROKER_INSTANCE
-      String brokerTag2 = "brokerTag2";
-      TEST_INSTANCE.addFakeBrokerInstanceToAutoJoinHelixCluster("broker_999", false);
-      TEST_INSTANCE.addFakeBrokerInstanceToAutoJoinHelixCluster("broker_1000", false);
-      TEST_INSTANCE.updateBrokerTenant("brokerTag2", 2);
+    // Add 2 brokers with non-default broker tag
+    String createInstanceUrl = _urlBuilder.forInstanceCreate();
+    String brokerTenant = "test";
+    String brokerTag = TagNameUtils.getBrokerTagForTenant(brokerTenant);
+    Instance brokerInstance1 =
+        new Instance("1.2.3.4", 1234, InstanceType.BROKER, Collections.singletonList(brokerTag), null, 0, 0, 0, 0,
+            false);
+    Instance brokerInstance2 =
+        new Instance("2.3.4.5", 2345, InstanceType.BROKER, Collections.singletonList(brokerTag), null, 0, 0, 0, 0,
+            false);
+    sendPostRequest(createInstanceUrl, brokerInstance1.toJsonString());
+    sendPostRequest(createInstanceUrl, brokerInstance2.toJsonString());
 
-      // Add a table
-      ControllerTest.sendPostRequest(TEST_INSTANCE.getControllerRequestURLBuilder().forSchemaCreate(),
-          createDummySchema(TableNameBuilder.extractRawTableName(TABLE_NAME)).toPrettyJsonString());
+    // Add a table to the default tenant
+    String createSchemaUrl = _urlBuilder.forSchemaCreate();
+    ControllerTest.sendPostRequest(createSchemaUrl, createDummySchema(RAW_TABLE_NAME).toSingleLineJsonString());
+    String createTableUrl = _urlBuilder.forTableCreate();
+    ControllerTest.sendPostRequest(createTableUrl,
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build().toJsonString());
 
-      ControllerTest.sendPostRequest(TEST_INSTANCE.getControllerRequestURLBuilder().forTableCreate(),
-          new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build().toJsonString());
+    // Add a second table to the non-default tenant
+    String rawTableName2 = "testTable2";
+    String offlineTableName2 = TableNameBuilder.OFFLINE.tableNameWithType(rawTableName2);
+    ControllerTest.sendPostRequest(createSchemaUrl, createDummySchema(rawTableName2).toSingleLineJsonString());
+    ControllerTest.sendPostRequest(createTableUrl,
+        new TableConfigBuilder(TableType.OFFLINE).setTableName(rawTableName2).setBrokerTenant(brokerTenant).build()
+            .toJsonString());
 
-      // Add a second table with a different broker tag
-      String table2 = "restletTable2_OFFLINE";
-      ControllerTest.sendPostRequest(TEST_INSTANCE.getControllerRequestURLBuilder().forSchemaCreate(),
-          createDummySchema(TableNameBuilder.extractRawTableName(table2)).toPrettyJsonString());
-      ControllerTest.sendPostRequest(TEST_INSTANCE.getControllerRequestURLBuilder().forTableCreate(),
-          new TableConfigBuilder(TableType.OFFLINE).setTableName(table2).setBrokerTenant(
-                  brokerTag2)
-              .build().toJsonString());
+    // There should be 2 tables returned when querying default tenant for servers w/o specifying ?type=server
+    listTablesResponse = JsonUtils.stringToJsonNode(ControllerTest.sendGetRequest(listTablesUrl));
+    JsonNode tables = listTablesResponse.get("tables");
+    assertEquals(tables.size(), 2);
+    Set<String> tableSet = new HashSet<>();
+    tableSet.add(tables.get(0).asText());
+    tableSet.add(tables.get(1).asText());
+    assertEquals(tableSet, Sets.newHashSet(OFFLINE_TABLE_NAME, offlineTableName2));
 
-      // There should be 2 tables on the tenant when querying default Tenant for servers w/o specifying ?type=server
-      tableList = JsonUtils.stringToJsonNode(ControllerTest.sendGetRequest(listTablesUrl));
-      JsonNode tables = tableList.get("tables");
-      assertEquals(tables.size(), 2);
+    // There should be 2 tables returned when specifying ?type=server as that is the default
+    listTablesUrl = _urlBuilder.forTablesFromTenant(TagNameUtils.DEFAULT_TENANT_NAME, "server");
+    listTablesResponse = JsonUtils.stringToJsonNode(ControllerTest.sendGetRequest(listTablesUrl));
+    tables = listTablesResponse.get("tables");
+    assertEquals(tables.size(), 2);
+    tableSet = new HashSet<>();
+    tableSet.add(tables.get(0).asText());
+    tableSet.add(tables.get(1).asText());
+    assertEquals(tableSet, Sets.newHashSet(OFFLINE_TABLE_NAME, offlineTableName2));
 
-      // There should be 2 tables even when specifying ?type=server as that is the default
-      listTablesUrl =
-          TEST_INSTANCE.getControllerRequestURLBuilder().forTablesFromTenant(TagNameUtils.DEFAULT_TENANT_NAME,
-              "server");
-      tableList = JsonUtils.stringToJsonNode(ControllerTest.sendGetRequest(listTablesUrl));
-      tables = tableList.get("tables");
+    // There should be only 1 table returned when specifying ?type=broker for the default tenant
+    listTablesUrl = _urlBuilder.forTablesFromTenant(TagNameUtils.DEFAULT_TENANT_NAME, "broker");
+    listTablesResponse = JsonUtils.stringToJsonNode(ControllerTest.sendGetRequest(listTablesUrl));
+    tables = listTablesResponse.get("tables");
+    assertEquals(tables.size(), 1);
+    assertEquals(tables.get(0).asText(), OFFLINE_TABLE_NAME);
 
-      // Check to make sure that test tables exists.
-      boolean found1 = false;
-      boolean found2 = false;
-      for (int i = 0; i < tables.size(); i++) {
-        found1 = found1 || tables.get(i).asText().equals(TABLE_NAME);
-        found2 = found2 || tables.get(i).asText().equals(table2);
-      }
+    // There should be only 1 table returned when specifying ?type=broker for the non-default tenant
+    listTablesUrl = _urlBuilder.forTablesFromTenant(brokerTenant, "broker");
+    listTablesResponse = JsonUtils.stringToJsonNode(ControllerTest.sendGetRequest(listTablesUrl));
+    tables = listTablesResponse.get("tables");
+    assertEquals(tables.size(), 1);
+    assertEquals(tables.get(0).asText(), offlineTableName2);
 
-      // There should be only 1 table when specifying ?type=broker for the default tenant
-      listTablesUrl =
-          TEST_INSTANCE.getControllerRequestURLBuilder().forTablesFromTenant(TagNameUtils.DEFAULT_TENANT_NAME,
-              "broker");
-      tableList = JsonUtils.stringToJsonNode(ControllerTest.sendGetRequest(listTablesUrl));
-      tables = tableList.get("tables");
-      assertEquals(tables.size(), 1);
-
-      String defaultTenantTable = tables.get(0).asText();
-
-      // There should be only 1 table when specifying ?type=broker for the broker_untagged tenant
-      listTablesUrl =
-          TEST_INSTANCE.getControllerRequestURLBuilder().forTablesFromTenant(brokerTag2,
-              "broker");
-      tableList = JsonUtils.stringToJsonNode(ControllerTest.sendGetRequest(listTablesUrl));
-      tables = tableList.get("tables");
-      assertEquals(tables.size(), 1);
-
-      // This second table should not be the same as the one from the default tenant
-      assertTrue(!defaultTenantTable.equals(tables.get(0).asText()));
-
-      // reset the ZK node to simulate corruption
-      ZkHelixPropertyStore<ZNRecord> propertyStore = TEST_INSTANCE.getPropertyStore();
-      String zkPath = "/CONFIGS/TABLE/" + TABLE_NAME;
-      ZNRecord znRecord = propertyStore.get(zkPath, null, 0);
-      propertyStore.set(zkPath, new ZNRecord(znRecord.getId()), 1);
-
-      // corrupt the other one also
-      zkPath = "/CONFIGS/TABLE/" + table2;
-      znRecord = propertyStore.get(zkPath, null, 0);
-      propertyStore.set(zkPath, new ZNRecord(znRecord.getId()), 1);
-
-      // Now there should be no tables
-      tableList = JsonUtils.stringToJsonNode(ControllerTest.sendGetRequest(listTablesUrl));
-      tables = tableList.get("tables");
-      assertEquals(tables.size(), 0);
-    } finally {
-      // remove the additional, non-default table and broker instances
-      TEST_INSTANCE.dropOfflineTable("restletTable2_OFFLINE");
-      TEST_INSTANCE.stopAndDropFakeInstance("broker_999");
-      TEST_INSTANCE.stopAndDropFakeInstance("broker_1000");
-      TEST_INSTANCE.deleteBrokerTenant("brokerTag2");
-    }
+    // Remove the tables and brokers
+    DEFAULT_INSTANCE.dropOfflineTable(RAW_TABLE_NAME);
+    DEFAULT_INSTANCE.deleteSchema(RAW_TABLE_NAME);
+    DEFAULT_INSTANCE.dropOfflineTable(rawTableName2);
+    DEFAULT_INSTANCE.deleteSchema(rawTableName2);
+    sendDeleteRequest(_urlBuilder.forInstance("Broker_1.2.3.4_1234"));
+    sendDeleteRequest(_urlBuilder.forInstance("Broker_2.3.4.5_2345"));
   }
 
   @Test
   public void testListInstance()
       throws Exception {
-    String listInstancesUrl =
-        TEST_INSTANCE.getControllerRequestURLBuilder().forTenantGet(TagNameUtils.DEFAULT_TENANT_NAME);
+    String listInstancesUrl = _urlBuilder.forTenantGet(TagNameUtils.DEFAULT_TENANT_NAME);
     JsonNode instanceList = JsonUtils.stringToJsonNode(ControllerTest.sendGetRequest(listInstancesUrl));
     assertEquals(instanceList.get("ServerInstances").size(), DEFAULT_NUM_SERVER_INSTANCES);
     assertEquals(instanceList.get("BrokerInstances").size(), DEFAULT_NUM_BROKER_INSTANCES);
@@ -163,74 +150,71 @@ public class PinotTenantRestletResourceTest extends ControllerTest {
   public void testToggleTenantState()
       throws Exception {
     // Create an offline table
-    ControllerTest.sendPostRequest(TEST_INSTANCE.getControllerRequestURLBuilder().forSchemaCreate(),
-        createDummySchema(TableNameBuilder.extractRawTableName(RAW_TABLE_NAME)).toPrettyJsonString());
-    TableConfig tableConfig =
+    String createSchemaUrl = _urlBuilder.forSchemaCreate();
+    ControllerTest.sendPostRequest(createSchemaUrl, createDummySchema(RAW_TABLE_NAME).toSingleLineJsonString());
+    String createTableUrl = _urlBuilder.forTableCreate();
+    sendPostRequest(createTableUrl,
         new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).setNumReplicas(DEFAULT_MIN_NUM_REPLICAS)
-            .build();
-    sendPostRequest(TEST_INSTANCE.getControllerRequestURLBuilder().forTableCreate(), tableConfig.toJsonString());
-    assertEquals(TEST_INSTANCE.getHelixAdmin()
-        .getResourceIdealState(TEST_INSTANCE.getHelixClusterName(), CommonConstants.Helix.BROKER_RESOURCE_INSTANCE)
+            .build().toJsonString());
+
+    // Broker resource should be updated
+    HelixAdmin helixAdmin = DEFAULT_INSTANCE.getHelixAdmin();
+    String clusterName = DEFAULT_INSTANCE.getHelixClusterName();
+    assertEquals(helixAdmin.getResourceIdealState(clusterName, CommonConstants.Helix.BROKER_RESOURCE_INSTANCE)
         .getInstanceSet(OFFLINE_TABLE_NAME).size(), DEFAULT_NUM_BROKER_INSTANCES);
 
     // Add segments
+    PinotHelixResourceManager resourceManager = DEFAULT_INSTANCE.getHelixResourceManager();
     for (int i = 0; i < DEFAULT_NUM_SERVER_INSTANCES; i++) {
-      TEST_INSTANCE.getHelixResourceManager()
-          .addNewSegment(OFFLINE_TABLE_NAME, SegmentMetadataMockUtils.mockSegmentMetadata(RAW_TABLE_NAME),
-              "downloadUrl");
-      assertEquals(TEST_INSTANCE.getHelixAdmin()
-          .getResourceIdealState(TEST_INSTANCE.getHelixClusterName(), OFFLINE_TABLE_NAME).getNumPartitions(), i + 1);
+      resourceManager.addNewSegment(OFFLINE_TABLE_NAME, SegmentMetadataMockUtils.mockSegmentMetadata(RAW_TABLE_NAME),
+          "downloadUrl");
+      assertEquals(helixAdmin.getResourceIdealState(clusterName, OFFLINE_TABLE_NAME).getNumPartitions(), i + 1);
     }
 
     // Disable server instances
     String disableServerInstanceUrl =
-        TEST_INSTANCE.getControllerRequestURLBuilder().forTenantInstancesToggle(TagNameUtils.DEFAULT_TENANT_NAME,
-            "server", "disable");
+        _urlBuilder.forTenantInstancesToggle(TagNameUtils.DEFAULT_TENANT_NAME, "server", "disable");
     JsonUtils.stringToJsonNode(ControllerTest.sendPostRequest(disableServerInstanceUrl));
     checkNumOnlineInstancesFromExternalView(OFFLINE_TABLE_NAME, 0);
 
     // Enable server instances
     String enableServerInstanceUrl =
-        TEST_INSTANCE.getControllerRequestURLBuilder().forTenantInstancesToggle(TagNameUtils.DEFAULT_TENANT_NAME,
-            "server", "enable");
+        _urlBuilder.forTenantInstancesToggle(TagNameUtils.DEFAULT_TENANT_NAME, "server", "enable");
     JsonUtils.stringToJsonNode(ControllerTest.sendPostRequest(enableServerInstanceUrl));
     checkNumOnlineInstancesFromExternalView(OFFLINE_TABLE_NAME, DEFAULT_NUM_SERVER_INSTANCES);
 
     // Disable broker instances
     String disableBrokerInstanceUrl =
-        TEST_INSTANCE.getControllerRequestURLBuilder().forTenantInstancesToggle(TagNameUtils.DEFAULT_TENANT_NAME,
-            "broker", "disable");
+        _urlBuilder.forTenantInstancesToggle(TagNameUtils.DEFAULT_TENANT_NAME, "broker", "disable");
     JsonUtils.stringToJsonNode(ControllerTest.sendPostRequest(disableBrokerInstanceUrl));
     checkNumOnlineInstancesFromExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE, 0);
 
     // Enable broker instances
     String enableBrokerInstanceUrl =
-        TEST_INSTANCE.getControllerRequestURLBuilder().forTenantInstancesToggle(TagNameUtils.DEFAULT_TENANT_NAME,
-            "broker", "enable");
+        _urlBuilder.forTenantInstancesToggle(TagNameUtils.DEFAULT_TENANT_NAME, "broker", "enable");
     JsonUtils.stringToJsonNode(ControllerTest.sendPostRequest(enableBrokerInstanceUrl));
     checkNumOnlineInstancesFromExternalView(CommonConstants.Helix.BROKER_RESOURCE_INSTANCE,
         DEFAULT_NUM_BROKER_INSTANCES);
 
-    // Delete table
-    sendDeleteRequest(TEST_INSTANCE.getControllerRequestURLBuilder().forTableDelete(RAW_TABLE_NAME));
-
     // Check exception in case of enum mismatch of State
     try {
       String mismatchStateBrokerInstanceUrl =
-          TEST_INSTANCE.getControllerRequestURLBuilder().forTenantInstancesToggle(TagNameUtils.DEFAULT_TENANT_NAME,
-              "broker", "random");
+          _urlBuilder.forTenantInstancesToggle(TagNameUtils.DEFAULT_TENANT_NAME, "broker", "random");
       sendPostRequest(mismatchStateBrokerInstanceUrl);
       fail("Passing invalid state to tenant toggle state does not fail.");
     } catch (IOException e) {
       // Expected 500 Bad Request
-      assertTrue(e.getMessage().contains("Error: State mentioned random is wrong. "
-          + "Valid States: Enable, Disable"));
+      assertTrue(e.getMessage().contains("Error: State mentioned random is wrong. Valid States: Enable, Disable"));
     }
+
+    // Delete table and schema
+    DEFAULT_INSTANCE.dropOfflineTable(RAW_TABLE_NAME);
+    DEFAULT_INSTANCE.deleteSchema(RAW_TABLE_NAME);
   }
 
   @AfterClass
   public void tearDown()
       throws IOException {
-    TEST_INSTANCE.cleanup();
+    DEFAULT_INSTANCE.cleanup();
   }
 }


### PR DESCRIPTION
Another attempt of fixing #11329 

Do not add fake instances which connect to the cluster, but only add instance configs. They serve the same way for testing purpose, but fake instances can cause side effect on other tests