### PR TITLE
[multistage][bugfix] canonicalize SqlKind.OTHERS as well as SqlKind.OTHER_FUNCTIONS

### DIFF
--- a/pinot-query-runtime/src/test/resources/queries/StringFunctions.json
+++ b/pinot-query-runtime/src/test/resources/queries/StringFunctions.json
@@ -30,6 +30,8 @@
         "comment": "standard sql concat is vararg, while we treat the third input as a separator",
         "sql": "SELECT concat(strCol, strCol, ',') FROM {stringTbl}"
       },
+      { "sql": "SELECT strCol || strCol FROM {stringTbl}" },
+      { "sql": "SELECT strCol || strCol || ',' FROM {stringTbl}"},
       { "sql": "SELECT trim(strCol) FROM {stringTbl}" },
       { "sql": "SELECT lower(strCol), regexp_Replace(strCol, 'e.*o', 'le') FROM {stringTbl}" },
       {


### PR DESCRIPTION
Fix the following issues:

When compiling the RexExpression
- SqlKind.OTHERS should extract actual function name inside obj instead of getting the toString functionName "others" 
- SqlKind.OTHERS/OTHER_FUNCTIONS should canonicalized function name during parsing instead of rely on downstream operator to parse and interpret them.
- Support `concat` as `||` operator

