### PR TITLE
Configurable Lucene analyzer

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/text/LuceneTextIndexCreator.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
@@ -99,7 +98,7 @@ public class LuceneTextIndexCreator extends AbstractTextIndexCreator {
    */
   public LuceneTextIndexCreator(String column, File segmentIndexDir, boolean commit,
       @Nullable List<String> stopWordsInclude, @Nullable List<String> stopWordsExclude, boolean useCompoundFile,
-      int maxBufferSizeMB, @Nonnull String luceneAnalyzerFQCN) {
+      int maxBufferSizeMB, @Nullable String luceneAnalyzerFQCN) {
     _textColumn = column;
     try {
       // segment generation is always in V1 and later we convert (as part of post creation processing)
@@ -108,7 +107,8 @@ public class LuceneTextIndexCreator extends AbstractTextIndexCreator {
       _indexDirectory = FSDirectory.open(indexFile.toPath());
 
       Analyzer luceneAnalyzer;
-      if (luceneAnalyzerFQCN.isEmpty() || luceneAnalyzerFQCN.equals(StandardAnalyzer.class.getName())) {
+      if (null == luceneAnalyzerFQCN || luceneAnalyzerFQCN.isEmpty()
+              || luceneAnalyzerFQCN.equals(StandardAnalyzer.class.getName())) {
         luceneAnalyzer = TextIndexUtils.getStandardAnalyzerWithCustomizedStopWords(stopWordsInclude, stopWordsExclude);
       } else {
         luceneAnalyzer = TextIndexUtils.getAnalyzerFromFQCN(luceneAnalyzerFQCN);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.nio.ByteOrder;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.lucene.document.Document;
 import org.apache.lucene.index.DirectoryReader;
@@ -63,7 +64,7 @@ public class LuceneTextIndexReader implements TextIndexReader {
   private final IndexSearcher _indexSearcher;
   private final String _column;
   private final DocIdTranslator _docIdTranslator;
-  private final StandardAnalyzer _standardAnalyzer;
+  private final Analyzer _analyzer;
   private boolean _useANDForMultiTermQueries = false;
 
   public LuceneTextIndexReader(String column, File indexDir, int numDocs, TextIndexConfig config) {
@@ -84,8 +85,11 @@ public class LuceneTextIndexReader implements TextIndexReader {
       // TODO: consider using a threshold of num docs per segment to decide between building
       // mapping file upfront on segment load v/s on-the-fly during query processing
       _docIdTranslator = new DocIdTranslator(indexDir, _column, numDocs, _indexSearcher);
-      _standardAnalyzer = TextIndexUtils.getStandardAnalyzerWithCustomizedStopWords(config.getStopWordsInclude(),
-          config.getStopWordsExclude());
+      String luceneAnalyzerFQCN = config.getLuceneAnalyzerFQCN();
+      _analyzer = luceneAnalyzerFQCN.equals(StandardAnalyzer.class.getName())
+              ? TextIndexUtils.getStandardAnalyzerWithCustomizedStopWords(
+              config.getStopWordsInclude(), config.getStopWordsExclude())
+              : TextIndexUtils.getAnalyzerFromFQCN(luceneAnalyzerFQCN);
       LOGGER.info("Successfully read lucene index for {} from {}", _column, indexDir);
     } catch (Exception e) {
       LOGGER.error("Failed to instantiate Lucene text index reader for column {}, exception {}", column,
@@ -146,7 +150,7 @@ public class LuceneTextIndexReader implements TextIndexReader {
       // Lucene Query Parser is JavaCC based. It is stateful and should
       // be instantiated per query. Analyzer on the other hand is stateless
       // and can be created upfront.
-      QueryParser parser = new QueryParser(_column, _standardAnalyzer);
+      QueryParser parser = new QueryParser(_column, _analyzer);
       if (_useANDForMultiTermQueries) {
         parser.setDefaultOperator(QueryParser.Operator.AND);
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
@@ -85,11 +85,11 @@ public class LuceneTextIndexReader implements TextIndexReader {
       // TODO: consider using a threshold of num docs per segment to decide between building
       // mapping file upfront on segment load v/s on-the-fly during query processing
       _docIdTranslator = new DocIdTranslator(indexDir, _column, numDocs, _indexSearcher);
-      String luceneAnalyzerFQCN = config.getLuceneAnalyzerFQCN();
-      _analyzer = luceneAnalyzerFQCN.equals(StandardAnalyzer.class.getName())
+      String luceneAnalyzerClass = config.getLuceneAnalyzerClass();
+      _analyzer = luceneAnalyzerClass.equals(StandardAnalyzer.class.getName())
               ? TextIndexUtils.getStandardAnalyzerWithCustomizedStopWords(
               config.getStopWordsInclude(), config.getStopWordsExclude())
-              : TextIndexUtils.getAnalyzerFromFQCN(luceneAnalyzerFQCN);
+              : TextIndexUtils.getAnalyzerFromFQCN(luceneAnalyzerClass);
       LOGGER.info("Successfully read lucene index for {} from {}", _column, indexDir);
     } catch (Exception e) {
       LOGGER.error("Failed to instantiate Lucene text index reader for column {}, exception {}", column,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexConfigBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexConfigBuilder.java
@@ -61,6 +61,9 @@ public class TextIndexConfigBuilder extends TextIndexConfig.AbstractBuilder {
             Integer.parseInt(textIndexProperties.get(FieldConfig.TEXT_INDEX_LUCENE_MAX_BUFFER_SIZE_MB));
       }
 
+      if (textIndexProperties.get(FieldConfig.TEXT_INDEX_LUCENE_ANALYZER_FQCN) != null) {
+        _luceneAnalyzerFQCN = textIndexProperties.get(FieldConfig.TEXT_INDEX_LUCENE_ANALYZER_FQCN);
+      }
 
       for (Map.Entry<String, String> entry : textIndexProperties.entrySet()) {
         if (entry.getKey().equalsIgnoreCase(FieldConfig.TEXT_FST_TYPE)) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexConfigBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexConfigBuilder.java
@@ -61,8 +61,8 @@ public class TextIndexConfigBuilder extends TextIndexConfig.AbstractBuilder {
             Integer.parseInt(textIndexProperties.get(FieldConfig.TEXT_INDEX_LUCENE_MAX_BUFFER_SIZE_MB));
       }
 
-      if (textIndexProperties.get(FieldConfig.TEXT_INDEX_LUCENE_ANALYZER_FQCN) != null) {
-        _luceneAnalyzerFQCN = textIndexProperties.get(FieldConfig.TEXT_INDEX_LUCENE_ANALYZER_FQCN);
+      if (textIndexProperties.get(FieldConfig.TEXT_INDEX_LUCENE_ANALYZER_CLASS) != null) {
+        _luceneAnalyzerClass = textIndexProperties.get(FieldConfig.TEXT_INDEX_LUCENE_ANALYZER_CLASS);
       }
 
       for (Map.Entry<String, String> entry : textIndexProperties.entrySet()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
@@ -197,7 +197,6 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
       throw new IllegalArgumentException("A consumer directory is required");
     }
     return new RealtimeLuceneTextIndex(context.getFieldSpec().getName(), context.getConsumerDir(),
-        context.getSegmentName(), config.getStopWordsInclude(), config.getStopWordsExclude(),
-        config.isLuceneUseCompoundFile(), config.getLuceneMaxBufferSizeMB(), config.getLuceneAnalyzerFQCN());
+        context.getSegmentName(), config);
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexType.java
@@ -198,6 +198,6 @@ public class TextIndexType extends AbstractIndexType<TextIndexConfig, TextIndexR
     }
     return new RealtimeLuceneTextIndex(context.getFieldSpec().getName(), context.getConsumerDir(),
         context.getSegmentName(), config.getStopWordsInclude(), config.getStopWordsExclude(),
-        config.isLuceneUseCompoundFile(), config.getLuceneMaxBufferSizeMB());
+        config.isLuceneUseCompoundFile(), config.getLuceneMaxBufferSizeMB(), config.getLuceneAnalyzerFQCN());
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
@@ -28,6 +28,7 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.io.FileUtils;
+import org.apache.lucene.analysis.Analyzer;
 import org.apache.lucene.analysis.CharArraySet;
 import org.apache.lucene.analysis.standard.StandardAnalyzer;
 import org.apache.pinot.segment.local.segment.creator.impl.text.LuceneTextIndexCreator;
@@ -110,6 +111,12 @@ public class TextIndexUtils {
     String includeWords = columnProperties.getOrDefault(stopWordKey, "");
     return Arrays.stream(includeWords.split(FieldConfig.TEXT_INDEX_STOP_WORD_SEPERATOR))
         .map(String::trim).collect(Collectors.toList());
+  }
+
+  public static Analyzer getAnalyzerFromFQCN(@Nonnull String luceneAnalyzerFQCN) throws
+      ReflectiveOperationException {
+    // Support instantiation with default constructor for now unless customized
+    return (Analyzer) Class.forName(luceneAnalyzerFQCN).getConstructor().newInstance();
   }
 
   public static StandardAnalyzer getStandardAnalyzerWithCustomizedStopWords(@Nullable List<String> stopWordsInclude,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/store/TextIndexUtils.java
@@ -113,7 +113,7 @@ public class TextIndexUtils {
         .map(String::trim).collect(Collectors.toList());
   }
 
-  public static Analyzer getAnalyzerFromFQCN(@Nonnull String luceneAnalyzerFQCN) throws
+  public static Analyzer getAnalyzerFromClassName(String luceneAnalyzerClass) throws
       ReflectiveOperationException {
     // Support instantiation with default constructor for now unless customized
     return (Analyzer) Class.forName(luceneAnalyzerFQCN).getConstructor().newInstance();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -25,6 +25,7 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.search.SearcherManager;
+import org.apache.pinot.segment.spi.index.TextIndexConfig;
 import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.AfterClass;
@@ -57,8 +58,10 @@ public class LuceneMutableTextIndexTest {
   @BeforeClass
   public void setUp()
       throws Exception {
+    TextIndexConfig config =
+            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null);
     _realtimeLuceneTextIndex =
-        new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500, null);
+        new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", config);
     String[][] documents = getTextData();
     String[][] repeatedDocuments = getRepeatedData();
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -58,7 +58,7 @@ public class LuceneMutableTextIndexTest {
   public void setUp()
       throws Exception {
     _realtimeLuceneTextIndex =
-        new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500);
+        new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500, null);
     String[][] documents = getTextData();
     String[][] repeatedDocuments = getRepeatedData();
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.lucene.search.SearcherManager;
+import org.apache.pinot.segment.spi.index.TextIndexConfig;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
@@ -70,12 +71,14 @@ public class NativeAndLuceneMutableTextIndexTest {
   @BeforeClass
   public void setUp()
       throws Exception {
+    TextIndexConfig config =
+        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null);
     _realtimeLuceneTextIndex =
-        new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500, null);
+        new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", config);
     _nativeMutableTextIndex = new NativeMutableTextIndex(TEXT_COLUMN_NAME);
 
     _realtimeLuceneMVTextIndex =
-        new RealtimeLuceneTextIndex(MV_TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500, null);
+        new RealtimeLuceneTextIndex(MV_TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", config);
     _nativeMutableMVTextIndex = new NativeMutableTextIndex(MV_TEXT_COLUMN_NAME);
 
     String[] documents = getTextData();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
@@ -71,11 +71,11 @@ public class NativeAndLuceneMutableTextIndexTest {
   public void setUp()
       throws Exception {
     _realtimeLuceneTextIndex =
-        new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500);
+        new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500, null);
     _nativeMutableTextIndex = new NativeMutableTextIndex(TEXT_COLUMN_NAME);
 
     _realtimeLuceneMVTextIndex =
-        new RealtimeLuceneTextIndex(MV_TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500);
+        new RealtimeLuceneTextIndex(MV_TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", null, null, true, 500, null);
     _nativeMutableMVTextIndex = new NativeMutableTextIndex(MV_TEXT_COLUMN_NAME);
 
     String[] documents = getTextData();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.segment.local.segment.index.readers.text.LuceneTextIndex
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.index.TextIndexConfig;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.ColumnIndexDirectory;
@@ -200,11 +201,11 @@ public class FilePerIndexDirectoryTest {
   @Test
   public void testRemoveTextIndices()
       throws IOException {
+    TextIndexConfig config =
+            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null);
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
-        LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true,
-            null, null, true, 500, null);
-        LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true,
-            null, null, true, 500, null)) {
+         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, config);
+        LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true, config)) {
       PinotDataBuffer buf = fpi.newBuffer("col1", StandardIndexes.forward(), 1024);
       buf.putInt(0, 1);
 
@@ -263,12 +264,12 @@ public class FilePerIndexDirectoryTest {
   @Test
   public void testGetColumnIndices()
       throws IOException {
+    TextIndexConfig config =
+            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null);
     // Write sth to buffers and flush them to index files on disk
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
-        LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true,
-            null, null, true, 500, null);
-        LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true,
-            null, null, true, 500, null)) {
+        LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, config);
+        LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true, config)) {
       PinotDataBuffer buf = fpi.newBuffer("col1", StandardIndexes.forward(), 1024);
       buf.putInt(0, 111);
       buf = fpi.newBuffer("col2", StandardIndexes.dictionary(), 1024);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
@@ -202,9 +202,9 @@ public class FilePerIndexDirectoryTest {
       throws IOException {
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true,
-            null, null, true, 500);
+            null, null, true, 500, null);
         LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true,
-            null, null, true, 500)) {
+            null, null, true, 500, null)) {
       PinotDataBuffer buf = fpi.newBuffer("col1", StandardIndexes.forward(), 1024);
       buf.putInt(0, 1);
 
@@ -266,9 +266,9 @@ public class FilePerIndexDirectoryTest {
     // Write sth to buffers and flush them to index files on disk
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true,
-            null, null, true, 500);
+            null, null, true, 500, null);
         LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true,
-            null, null, true, 500)) {
+            null, null, true, 500, null)) {
       PinotDataBuffer buf = fpi.newBuffer("col1", StandardIndexes.forward(), 1024);
       buf.putInt(0, 111);
       buf = fpi.newBuffer("col2", StandardIndexes.dictionary(), 1024);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
@@ -39,6 +39,7 @@ import org.apache.pinot.segment.local.segment.index.readers.text.LuceneTextIndex
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.creator.SegmentVersion;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
+import org.apache.pinot.segment.spi.index.TextIndexConfig;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.memory.PinotDataBuffer;
 import org.apache.pinot.segment.spi.store.ColumnIndexDirectory;
@@ -233,11 +234,11 @@ public class SingleFileIndexDirectoryTest {
   @Test
   public void testRemoveTextIndices()
       throws IOException, ConfigurationException {
+    TextIndexConfig config =
+            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null);
     try (SingleFileIndexDirectory sfd = new SingleFileIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
-        LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true,
-            null, null, true, 500, null);
-        LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true,
-            null, null, true, 500, null)) {
+        LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, config);
+        LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true, config)) {
       PinotDataBuffer buf = sfd.newBuffer("col1", StandardIndexes.forward(), 1024);
       buf.putInt(0, 1);
 
@@ -339,11 +340,11 @@ public class SingleFileIndexDirectoryTest {
   @Test
   public void testGetColumnIndices()
       throws Exception {
+    TextIndexConfig config =
+            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null);
     try (SingleFileIndexDirectory sfd = new SingleFileIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
-        LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true,
-            null, null, true, 500, null);
-        LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true,
-            null, null, true, 500, null)) {
+        LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, config);
+        LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true, config)) {
       PinotDataBuffer buf = sfd.newBuffer("col1", StandardIndexes.forward(), 1024);
       buf.putInt(0, 111);
       buf = sfd.newBuffer("col2", StandardIndexes.dictionary(), 1024);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
@@ -235,9 +235,9 @@ public class SingleFileIndexDirectoryTest {
       throws IOException, ConfigurationException {
     try (SingleFileIndexDirectory sfd = new SingleFileIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true,
-            null, null, true, 500);
+            null, null, true, 500, null);
         LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true,
-            null, null, true, 500)) {
+            null, null, true, 500, null)) {
       PinotDataBuffer buf = sfd.newBuffer("col1", StandardIndexes.forward(), 1024);
       buf.putInt(0, 1);
 
@@ -341,9 +341,9 @@ public class SingleFileIndexDirectoryTest {
       throws Exception {
     try (SingleFileIndexDirectory sfd = new SingleFileIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true,
-            null, null, true, 500);
+            null, null, true, 500, null);
         LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true,
-            null, null, true, 500)) {
+            null, null, true, 500, null)) {
       PinotDataBuffer buf = sfd.newBuffer("col1", StandardIndexes.forward(), 1024);
       buf.putInt(0, 111);
       buf = sfd.newBuffer("col2", StandardIndexes.dictionary(), 1024);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Objects;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.config.table.FSTType;
+import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.IndexConfig;
 
 
@@ -36,7 +37,7 @@ public class TextIndexConfig extends IndexConfig {
   private static final boolean LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE = true;
   public static final TextIndexConfig DISABLED =
       new TextIndexConfig(true, null, null, false, false, Collections.emptyList(), Collections.emptyList(), false,
-          LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB);
+          LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB, null);
   private final FSTType _fstType;
   @Nullable
   private final Object _rawValueForTextIndex;
@@ -46,6 +47,7 @@ public class TextIndexConfig extends IndexConfig {
   private final List<String> _stopWordsExclude;
   private final boolean _luceneUseCompoundFile;
   private final int _luceneMaxBufferSizeMB;
+  private final String _luceneAnalyzerFQCN;
 
   @JsonCreator
   public TextIndexConfig(
@@ -57,7 +59,9 @@ public class TextIndexConfig extends IndexConfig {
       @JsonProperty("stopWordsInclude") List<String> stopWordsInclude,
       @JsonProperty("stopWordsExclude") List<String> stopWordsExclude,
       @JsonProperty("luceneUseCompoundFile") Boolean luceneUseCompoundFile,
-      @JsonProperty("luceneMaxBufferSizeMB") Integer luceneMaxBufferSizeMB) {
+      @JsonProperty("luceneMaxBufferSizeMB") Integer luceneMaxBufferSizeMB,
+      @JsonProperty("luceneAnalyzerFQCN") String luceneAnalyzerFQCN
+      ) {
     super(disabled);
     _fstType = fstType;
     _rawValueForTextIndex = rawValueForTextIndex;
@@ -69,6 +73,8 @@ public class TextIndexConfig extends IndexConfig {
         luceneUseCompoundFile == null ? LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE : luceneUseCompoundFile;
     _luceneMaxBufferSizeMB =
         luceneMaxBufferSizeMB == null ? LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB : luceneMaxBufferSizeMB;
+    _luceneAnalyzerFQCN = (luceneAnalyzerFQCN == null || luceneAnalyzerFQCN.isEmpty())
+            ? FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_FQCN : luceneAnalyzerFQCN;
   }
 
   public FSTType getFstType() {
@@ -115,6 +121,13 @@ public class TextIndexConfig extends IndexConfig {
     return _luceneMaxBufferSizeMB;
   }
 
+  /**
+   * Lucene analyzer FQCN specifying which analyzer class to use for indexing
+   */
+  public String getLuceneAnalyzerFQCN() {
+    return _luceneAnalyzerFQCN;
+  }
+
   public static abstract class AbstractBuilder {
     @Nullable
     protected FSTType _fstType;
@@ -126,6 +139,7 @@ public class TextIndexConfig extends IndexConfig {
     protected List<String> _stopWordsExclude = new ArrayList<>();
     protected boolean _luceneUseCompoundFile = LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE;
     protected int _luceneMaxBufferSizeMB = LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB;
+    protected String _luceneAnalyzerFQCN = FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_FQCN;
 
     public AbstractBuilder(@Nullable FSTType fstType) {
       _fstType = fstType;
@@ -139,11 +153,12 @@ public class TextIndexConfig extends IndexConfig {
       _stopWordsExclude = new ArrayList<>(other._stopWordsExclude);
       _luceneUseCompoundFile = other._luceneUseCompoundFile;
       _luceneMaxBufferSizeMB = other._luceneMaxBufferSizeMB;
+      _luceneAnalyzerFQCN = other._luceneAnalyzerFQCN;
     }
 
     public TextIndexConfig build() {
       return new TextIndexConfig(false, _fstType, _rawValueForTextIndex, _enableQueryCache, _useANDForMultiTermQueries,
-          _stopWordsInclude, _stopWordsExclude, _luceneUseCompoundFile, _luceneMaxBufferSizeMB);
+          _stopWordsInclude, _stopWordsExclude, _luceneUseCompoundFile, _luceneMaxBufferSizeMB, _luceneAnalyzerFQCN);
     }
 
     public abstract AbstractBuilder withProperties(@Nullable Map<String, String> textIndexProperties);
@@ -172,6 +187,11 @@ public class TextIndexConfig extends IndexConfig {
       _luceneMaxBufferSizeMB = maxBufferSizeMB;
       return this;
     }
+
+    public AbstractBuilder withLuceneAnalyzerFQCN(String luceneAnalyzerFQCN) {
+      _luceneAnalyzerFQCN = luceneAnalyzerFQCN;
+      return this;
+    }
   }
 
   @Override
@@ -197,6 +217,6 @@ public class TextIndexConfig extends IndexConfig {
   public int hashCode() {
     return Objects.hash(super.hashCode(), _fstType, _rawValueForTextIndex, _enableQueryCache,
         _useANDForMultiTermQueries, _stopWordsInclude, _stopWordsExclude, _luceneUseCompoundFile,
-        _luceneMaxBufferSizeMB);
+        _luceneMaxBufferSizeMB, _luceneAnalyzerFQCN);
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -47,7 +47,7 @@ public class TextIndexConfig extends IndexConfig {
   private final List<String> _stopWordsExclude;
   private final boolean _luceneUseCompoundFile;
   private final int _luceneMaxBufferSizeMB;
-  private final String _luceneAnalyzerFQCN;
+  private final String _luceneAnalyzerClass;
 
   @JsonCreator
   public TextIndexConfig(
@@ -60,7 +60,7 @@ public class TextIndexConfig extends IndexConfig {
       @JsonProperty("stopWordsExclude") List<String> stopWordsExclude,
       @JsonProperty("luceneUseCompoundFile") Boolean luceneUseCompoundFile,
       @JsonProperty("luceneMaxBufferSizeMB") Integer luceneMaxBufferSizeMB,
-      @JsonProperty("luceneAnalyzerFQCN") String luceneAnalyzerFQCN
+      @JsonProperty("luceneAnalyzerClass") String luceneAnalyzerClass
       ) {
     super(disabled);
     _fstType = fstType;
@@ -73,8 +73,8 @@ public class TextIndexConfig extends IndexConfig {
         luceneUseCompoundFile == null ? LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE : luceneUseCompoundFile;
     _luceneMaxBufferSizeMB =
         luceneMaxBufferSizeMB == null ? LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB : luceneMaxBufferSizeMB;
-    _luceneAnalyzerFQCN = (luceneAnalyzerFQCN == null || luceneAnalyzerFQCN.isEmpty())
-            ? FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_FQCN : luceneAnalyzerFQCN;
+    _luceneAnalyzerClass = (luceneAnalyzerClass == null || luceneAnalyzerClass.isEmpty())
+            ? FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_CLASS : luceneAnalyzerClass;
   }
 
   public FSTType getFstType() {
@@ -122,10 +122,10 @@ public class TextIndexConfig extends IndexConfig {
   }
 
   /**
-   * Lucene analyzer FQCN specifying which analyzer class to use for indexing
+   * Lucene analyzer fully qualified class name specifying which analyzer class to use for indexing
    */
-  public String getLuceneAnalyzerFQCN() {
-    return _luceneAnalyzerFQCN;
+  public String getLuceneAnalyzerClass() {
+    return _luceneAnalyzerClass;
   }
 
   public static abstract class AbstractBuilder {
@@ -139,7 +139,7 @@ public class TextIndexConfig extends IndexConfig {
     protected List<String> _stopWordsExclude = new ArrayList<>();
     protected boolean _luceneUseCompoundFile = LUCENE_INDEX_DEFAULT_USE_COMPOUND_FILE;
     protected int _luceneMaxBufferSizeMB = LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB;
-    protected String _luceneAnalyzerFQCN = FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_FQCN;
+    protected String _luceneAnalyzerClass = FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_CLASS;
 
     public AbstractBuilder(@Nullable FSTType fstType) {
       _fstType = fstType;
@@ -153,12 +153,12 @@ public class TextIndexConfig extends IndexConfig {
       _stopWordsExclude = new ArrayList<>(other._stopWordsExclude);
       _luceneUseCompoundFile = other._luceneUseCompoundFile;
       _luceneMaxBufferSizeMB = other._luceneMaxBufferSizeMB;
-      _luceneAnalyzerFQCN = other._luceneAnalyzerFQCN;
+      _luceneAnalyzerClass = other._luceneAnalyzerClass;
     }
 
     public TextIndexConfig build() {
       return new TextIndexConfig(false, _fstType, _rawValueForTextIndex, _enableQueryCache, _useANDForMultiTermQueries,
-          _stopWordsInclude, _stopWordsExclude, _luceneUseCompoundFile, _luceneMaxBufferSizeMB, _luceneAnalyzerFQCN);
+          _stopWordsInclude, _stopWordsExclude, _luceneUseCompoundFile, _luceneMaxBufferSizeMB, _luceneAnalyzerClass);
     }
 
     public abstract AbstractBuilder withProperties(@Nullable Map<String, String> textIndexProperties);
@@ -189,7 +189,7 @@ public class TextIndexConfig extends IndexConfig {
     }
 
     public AbstractBuilder withLuceneAnalyzerFQCN(String luceneAnalyzerFQCN) {
-      _luceneAnalyzerFQCN = luceneAnalyzerFQCN;
+      _luceneAnalyzerClass = luceneAnalyzerFQCN;
       return this;
     }
   }
@@ -217,6 +217,6 @@ public class TextIndexConfig extends IndexConfig {
   public int hashCode() {
     return Objects.hash(super.hashCode(), _fstType, _rawValueForTextIndex, _enableQueryCache,
         _useANDForMultiTermQueries, _stopWordsInclude, _stopWordsExclude, _luceneUseCompoundFile,
-        _luceneMaxBufferSizeMB, _luceneAnalyzerFQCN);
+        _luceneMaxBufferSizeMB, _luceneAnalyzerClass);
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -188,7 +188,7 @@ public class TextIndexConfig extends IndexConfig {
       return this;
     }
 
-    public AbstractBuilder withLuceneAnalyzerFQCN(String luceneAnalyzerFQCN) {
+    public AbstractBuilder withLuceneAnalyzerClass(String luceneAnalyzerClass) {
       _luceneAnalyzerClass = luceneAnalyzerFQCN;
       return this;
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -51,8 +51,8 @@ public class FieldConfig extends BaseJsonConfig {
   public static final String TEXT_INDEX_STOP_WORD_EXCLUDE_KEY = "stopWordExclude";
   public static final String TEXT_INDEX_LUCENE_USE_COMPOUND_FILE = "luceneUseCompoundFile";
   public static final String TEXT_INDEX_LUCENE_MAX_BUFFER_SIZE_MB = "luceneMaxBufferSizeMB";
-  public static final String TEXT_INDEX_LUCENE_ANALYZER_FQCN = "luceneAnalyzerFQCN";
-  public static final String TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_FQCN
+  public static final String TEXT_INDEX_LUCENE_ANALYZER_CLASS = "luceneAnalyzerClass";
+  public static final String TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_CLASS
           = "org.apache.lucene.analysis.standard.StandardAnalyzer";
   public static final String TEXT_INDEX_STOP_WORD_SEPERATOR = ",";
   // "native" for native, default is Lucene

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -51,6 +51,9 @@ public class FieldConfig extends BaseJsonConfig {
   public static final String TEXT_INDEX_STOP_WORD_EXCLUDE_KEY = "stopWordExclude";
   public static final String TEXT_INDEX_LUCENE_USE_COMPOUND_FILE = "luceneUseCompoundFile";
   public static final String TEXT_INDEX_LUCENE_MAX_BUFFER_SIZE_MB = "luceneMaxBufferSizeMB";
+  public static final String TEXT_INDEX_LUCENE_ANALYZER_FQCN = "luceneAnalyzerFQCN";
+  public static final String TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_FQCN
+          = "org.apache.lucene.analysis.standard.StandardAnalyzer";
   public static final String TEXT_INDEX_STOP_WORD_SEPERATOR = ",";
   // "native" for native, default is Lucene
   public static final String TEXT_FST_TYPE = "fstType";


### PR DESCRIPTION
Currently, Pinot hard-coded the Lucene analyzer (`standardAnalyzer`) to tokenize strings for indexing and search. In various scenarios, it is extremely useful to customize the analyzer. There are at least two other users who have requested this feature in https://github.com/apache/pinot/issues/9154. 

This PR introduces the capability to specify a custom Lucene analyzer used by text index for indexing and search on an individual column basis. Specifically, this PR allows user to specify the class name (fully qualified) of the Lucene analyzer to use in the text index:

```
fieldConfigList: [
   {
        "name": "columnName",
        "indexType": "TEXT",
        "indexTypes": [
          "TEXT"
        ],
        "properties": {
          "luceneAnalyzerClass": "org.apache.lucene.analysis.core.KeywordAnalyzer"
        },
      }
  ]
  ```    

**Default Behavior**
If user did not specify the `luceneAnalyzerClass` property, the behavior is exactly the same as before which is to use the StandardAnalyzer with couple configuration properties.

**User Specified Behavior 1**
When user specifies the `luceneAnalyzerClass` and the class name is `org.apache.lucene.analysis.standard.StandardAnalyzer`, the behavior is exactly the same as before which is to use the StandardAnalyzer with couple configuration properties.

**User Specified Behavior 2**
When user specifies the `luceneAnalyzerClass` and the class name is not  `org.apache.lucene.analysis.standard.StandardAnalyzer`, the default constructor of the specified Lucene analyzer class is invoked via reflection to create a Lucene analyzer. If user-specified analyzer class does not exist, the ReflectionOperationException is caught and a runtime exception with a more meaningful exception message is thrown.

**Testing**
This configurable Lucene analyzer feature is currently used in production to index and search large amount of text data on multi-variable text columns using `KeywordAnalyzer`. All existing unit tests with the default behavior are passing.

tags: `release-notes`, `enhancement`