### PR TITLE
Fix derived column from MV column

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -581,7 +581,7 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
         outputValues[i] = outputValue;
         if (outputValueType == null) {
           Class<?> outputValueClass = outputValue.getClass();
-          outputValueType = FunctionUtils.getParameterType(outputValueClass);
+          outputValueType = FunctionUtils.getArgumentType(outputValueClass);
           Preconditions.checkState(outputValueType != null, "Unsupported output value class: %s", outputValueClass);
         }
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/StringDictionary.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/StringDictionary.java
@@ -88,7 +88,23 @@ public class StringDictionary extends BaseImmutableDictionary {
   }
 
   @Override
+  public void readIntValues(int[] dictIds, int length, Integer[] outValues) {
+    byte[] buffer = getBuffer();
+    for (int i = 0; i < length; i++) {
+      outValues[i] = Integer.parseInt(getUnpaddedString(dictIds[i], buffer));
+    }
+  }
+
+  @Override
   public void readLongValues(int[] dictIds, int length, long[] outValues) {
+    byte[] buffer = getBuffer();
+    for (int i = 0; i < length; i++) {
+      outValues[i] = Long.parseLong(getUnpaddedString(dictIds[i], buffer));
+    }
+  }
+
+  @Override
+  public void readLongValues(int[] dictIds, int length, Long[] outValues) {
     byte[] buffer = getBuffer();
     for (int i = 0; i < length; i++) {
       outValues[i] = Long.parseLong(getUnpaddedString(dictIds[i], buffer));
@@ -104,7 +120,23 @@ public class StringDictionary extends BaseImmutableDictionary {
   }
 
   @Override
+  public void readFloatValues(int[] dictIds, int length, Float[] outValues) {
+    byte[] buffer = getBuffer();
+    for (int i = 0; i < length; i++) {
+      outValues[i] = Float.parseFloat(getUnpaddedString(dictIds[i], buffer));
+    }
+  }
+
+  @Override
   public void readDoubleValues(int[] dictIds, int length, double[] outValues) {
+    byte[] buffer = getBuffer();
+    for (int i = 0; i < length; i++) {
+      outValues[i] = Double.parseDouble(getUnpaddedString(dictIds[i], buffer));
+    }
+  }
+
+  @Override
+  public void readDoubleValues(int[] dictIds, int length, Double[] outValues) {
     byte[] buffer = getBuffer();
     for (int i = 0; i < length; i++) {
       outValues[i] = Double.parseDouble(getUnpaddedString(dictIds[i], buffer));

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/PinotSegmentColumnReader.java
@@ -96,11 +96,41 @@ public class PinotSegmentColumnReader implements Closeable {
         return _dictionary.get(_forwardIndexReader.getDictId(docId, _forwardIndexReaderContext));
       } else {
         int numValues = _forwardIndexReader.getDictIdMV(docId, _dictIdBuffer, _forwardIndexReaderContext);
-        Object[] values = new Object[numValues];
-        for (int i = 0; i < numValues; i++) {
-          values[i] = _dictionary.get(_dictIdBuffer[i]);
+        DataType storedType = _dictionary.getValueType();
+        switch (storedType) {
+          case INT: {
+            Integer[] values = new Integer[numValues];
+            _dictionary.readIntValues(_dictIdBuffer, numValues, values);
+            return values;
+          }
+          case LONG: {
+            Long[] values = new Long[numValues];
+            _dictionary.readLongValues(_dictIdBuffer, numValues, values);
+            return values;
+          }
+          case FLOAT: {
+            Float[] values = new Float[numValues];
+            _dictionary.readFloatValues(_dictIdBuffer, numValues, values);
+            return values;
+          }
+          case DOUBLE: {
+            Double[] values = new Double[numValues];
+            _dictionary.readDoubleValues(_dictIdBuffer, numValues, values);
+            return values;
+          }
+          case STRING: {
+            String[] values = new String[numValues];
+            _dictionary.readStringValues(_dictIdBuffer, numValues, values);
+            return values;
+          }
+          case BYTES: {
+            byte[][] values = new byte[numValues][];
+            _dictionary.readBytesValues(_dictIdBuffer, numValues, values);
+            return values;
+          }
+          default:
+            throw new IllegalStateException("Unsupported MV type: " + storedType);
         }
-        return values;
       }
     } else {
       // Raw index based

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/Dictionary.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/Dictionary.java
@@ -208,7 +208,19 @@ public interface Dictionary extends IndexReader {
     }
   }
 
+  default void readIntValues(int[] dictIds, int length, Integer[] outValues) {
+    for (int i = 0; i < length; i++) {
+      outValues[i] = getIntValue(dictIds[i]);
+    }
+  }
+
   default void readLongValues(int[] dictIds, int length, long[] outValues) {
+    for (int i = 0; i < length; i++) {
+      outValues[i] = getLongValue(dictIds[i]);
+    }
+  }
+
+  default void readLongValues(int[] dictIds, int length, Long[] outValues) {
     for (int i = 0; i < length; i++) {
       outValues[i] = getLongValue(dictIds[i]);
     }
@@ -220,7 +232,19 @@ public interface Dictionary extends IndexReader {
     }
   }
 
+  default void readFloatValues(int[] dictIds, int length, Float[] outValues) {
+    for (int i = 0; i < length; i++) {
+      outValues[i] = getFloatValue(dictIds[i]);
+    }
+  }
+
   default void readDoubleValues(int[] dictIds, int length, double[] outValues) {
+    for (int i = 0; i < length; i++) {
+      outValues[i] = getDoubleValue(dictIds[i]);
+    }
+  }
+
+  default void readDoubleValues(int[] dictIds, int length, Double[] outValues) {
     for (int i = 0; i < length; i++) {
       outValues[i] = getDoubleValue(dictIds[i]);
     }


### PR DESCRIPTION
Fix 2 bugs:
- Exception when using an existing MV column to derive a new MV column (e.g. change data type)
- Exception when using `CAST` with `RANGE`