### PR TITLE
[bugfix] Add new Transformer to transform -0.0 and NaN

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
@@ -68,13 +68,18 @@ public class CompositeTransformer implements RecordTransformer {
    *     Optional {@link SanitizationTransformer} after {@link NullValueTransformer} so that before sanitation, all
    *     values are non-null and follow the data types defined in the schema
    *   </li>
+   *   <li>
+   *     {@link SpecialValueTransformer} after {@link DataTypeTransformer} so that we already have the values complying
+   *      with the schema before handling special values
+   *   </li>
    * </ul>
    */
   public static List<RecordTransformer> getDefaultTransformers(TableConfig tableConfig, Schema schema) {
     return Stream.of(new ExpressionTransformer(tableConfig, schema), new FilterTransformer(tableConfig),
-        new SchemaConformingTransformer(tableConfig, schema), new DataTypeTransformer(tableConfig, schema),
-        new TimeValidationTransformer(tableConfig, schema), new NullValueTransformer(tableConfig, schema),
-        new SanitizationTransformer(schema)).filter(t -> !t.isNoOp()).collect(Collectors.toList());
+            new SchemaConformingTransformer(tableConfig, schema), new DataTypeTransformer(tableConfig, schema),
+            new TimeValidationTransformer(tableConfig, schema), new NullValueTransformer(tableConfig, schema),
+            new SpecialValueTransformer(schema), new SanitizationTransformer(schema)).filter(t -> !t.isNoOp())
+        .collect(Collectors.toList());
   }
 
   public static CompositeTransformer getDefaultTransformer(TableConfig tableConfig, Schema schema) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
@@ -70,15 +70,16 @@ public class CompositeTransformer implements RecordTransformer {
    *   </li>
    *   <li>
    *     {@link SpecialValueTransformer} after {@link DataTypeTransformer} so that we already have the values complying
-   *      with the schema before handling special values
+   *      with the schema before handling special values and before {@link NullValueTransformer} so that it transforms
+   *      all the null values properly
    *   </li>
    * </ul>
    */
   public static List<RecordTransformer> getDefaultTransformers(TableConfig tableConfig, Schema schema) {
     return Stream.of(new ExpressionTransformer(tableConfig, schema), new FilterTransformer(tableConfig),
             new SchemaConformingTransformer(tableConfig, schema), new DataTypeTransformer(tableConfig, schema),
-            new TimeValidationTransformer(tableConfig, schema), new NullValueTransformer(tableConfig, schema),
-            new SpecialValueTransformer(schema), new SanitizationTransformer(schema)).filter(t -> !t.isNoOp())
+            new TimeValidationTransformer(tableConfig, schema), new SpecialValueTransformer(schema),
+            new NullValueTransformer(tableConfig, schema), new SanitizationTransformer(schema)).filter(t -> !t.isNoOp())
         .collect(Collectors.toList());
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
@@ -23,6 +23,8 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 /**
@@ -35,6 +37,8 @@ import org.apache.pinot.spi.data.readers.GenericRow;
  * {@link FieldSpec}.
  */
 public class SpecialValueTransformer implements RecordTransformer {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(NullValueTransformer.class);
   private final HashSet<String> _specialValuesKeySet = new HashSet<>();
 
   public SpecialValueTransformer(Schema schema) {
@@ -48,9 +52,11 @@ public class SpecialValueTransformer implements RecordTransformer {
 
   private Object transformNegativeZero(Object value) {
     if ((value instanceof Float) && (Float.floatToRawIntBits((float) value) == Float.floatToRawIntBits(-0.0f))) {
+      LOGGER.info("-0.0f value detected, converting to 0.0.");
       value = 0.0f;
     } else if ((value instanceof Double) && (Double.doubleToLongBits((double) value) == Double.doubleToLongBits(
         -0.0d))) {
+      LOGGER.info("-0.0d value detected, converting to 0.0.");
       value = 0.0d;
     }
     return value;
@@ -58,8 +64,10 @@ public class SpecialValueTransformer implements RecordTransformer {
 
   private Object transformNaN(Object value) {
     if ((value instanceof Float) && ((Float) value).isNaN()) {
+      LOGGER.info("Float.NaN detected, converting to default null.");
       value = FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_FLOAT;
     } else if ((value instanceof Double) && ((Double) value).isNaN()) {
+      LOGGER.info("Double.NaN detected, converting to default null.");
       value = FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_DOUBLE;
     }
     return value;
@@ -74,20 +82,22 @@ public class SpecialValueTransformer implements RecordTransformer {
   public GenericRow transform(GenericRow record) {
     for (String element : _specialValuesKeySet) {
       Object value = record.getValue(element);
-      if (value instanceof Float || value instanceof Double) {
+      if (value instanceof Object[]) {
+        // Multi-valued column.
+        Object[] values = (Object[]) value;
+        int numValues = values.length;
+        for (int i = 0; i < numValues; i++) {
+          if (values[i] != null) {
+            values[i] = transformNegativeZero(values[i]);
+            values[i] = transformNaN(values[i]);
+          }
+        }
+      } else {
         // Single-valued column.
         Object zeroTransformedValue = transformNegativeZero(value);
         Object nanTransformedValue = transformNaN(zeroTransformedValue);
         if (nanTransformedValue != value) {
           record.putValue(element, nanTransformedValue);
-        }
-      } else if (value instanceof Object[]) {
-        // Multi-valued column.
-        Object[] values = (Object[]) value;
-        int numValues = values.length;
-        for (int i = 0; i < numValues; i++) {
-          values[i] = transformNegativeZero(values[i]);
-          values[i] = transformNaN(values[i]);
         }
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.recordtransformer;
+
+import java.util.HashSet;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+
+
+/**
+ * The {@code SpecialValueTransformer} class will transform special values the values to follow certain rules including:
+ * <ul>
+ *   <li>Negative zero (-0.0) should be converted to 0.0</li>
+ *   <li>NaN should be converted to default null</li>
+ * </ul>
+ * <p>NOTE: should put this after the {@link DataTypeTransformer} so that all values follow the data types in
+ * {@link FieldSpec}.
+ */
+public class SpecialValueTransformer implements RecordTransformer {
+  private final HashSet<String> _specialValuesKeySet = new HashSet<>();
+
+  public SpecialValueTransformer(Schema schema) {
+    for (FieldSpec fieldSpec : schema.getAllFieldSpecs()) {
+      if (!fieldSpec.isVirtualColumn() && (fieldSpec.getDataType() == DataType.FLOAT
+          || fieldSpec.getDataType() == DataType.DOUBLE)) {
+        _specialValuesKeySet.add(fieldSpec.getName());
+      }
+    }
+  }
+
+  private Object transformNegativeZero(Object value) {
+    if ((value instanceof Float) && (Float.floatToRawIntBits((float) value) == Float.floatToRawIntBits(-0.0f))) {
+      value = 0.0f;
+    } else if ((value instanceof Double) && (Double.doubleToLongBits((double) value) == Double.doubleToLongBits(
+        -0.0d))) {
+      value = 0.0d;
+    }
+    return value;
+  }
+
+  private Object transformNaN(Object value) {
+    if ((value instanceof Float) && ((Float) value).isNaN()) {
+      value = FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_FLOAT;
+    } else if ((value instanceof Double) && ((Double) value).isNaN()) {
+      value = FieldSpec.DEFAULT_DIMENSION_NULL_VALUE_OF_DOUBLE;
+    }
+    return value;
+  }
+
+  @Override
+  public boolean isNoOp() {
+    return _specialValuesKeySet.isEmpty();
+  }
+
+  @Override
+  public GenericRow transform(GenericRow record) {
+    for (String element : _specialValuesKeySet) {
+      Object value = record.getValue(element);
+      if (value instanceof Float || value instanceof Double) {
+        // Single-valued column.
+        Object zeroTransformedValue = transformNegativeZero(value);
+        Object nanTransformedValue = transformNaN(zeroTransformedValue);
+        if (nanTransformedValue != value) {
+          record.putValue(element, nanTransformedValue);
+        }
+      } else if (value instanceof Object[]) {
+        // Multi-valued column.
+        Object[] values = (Object[]) value;
+        int numValues = values.length;
+        for (int i = 0; i < numValues; i++) {
+          values[i] = transformNegativeZero(values[i]);
+          values[i] = transformNaN(values[i]);
+        }
+      }
+    }
+    return record;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
@@ -26,7 +26,7 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 
 
 /**
- * The {@code SpecialValueTransformer} class will transform special values the values to follow certain rules including:
+ * The {@code SpecialValueTransformer} class will transform special values according to the following rules:
  * <ul>
  *   <li>Negative zero (-0.0) should be converted to 0.0</li>
  *   <li>NaN should be converted to default null</li>

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
@@ -97,7 +97,7 @@ public class SpecialValueTransformer implements RecordTransformer {
             negativeZeroNanSanitizedValues.add(nanTransformedValue);
           }
         }
-        record.putValue(element,negativeZeroNanSanitizedValues.toArray());
+        record.putValue(element, negativeZeroNanSanitizedValues.toArray());
       } else {
         // Single-valued column.
         Object zeroTransformedValue = transformNegativeZero(value);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
@@ -35,8 +35,9 @@ import org.slf4j.LoggerFactory;
  *   <li>Negative zero (-0.0) should be converted to 0.0</li>
  *   <li>NaN should be converted to default null</li>
  * </ul>
- * <p>NOTE: should put this after the {@link DataTypeTransformer} so that all values follow the data types in
- * {@link FieldSpec}.
+ * <p>NOTE: should put this after the {@link DataTypeTransformer} so that we already have the values complying
+ * with the schema before handling special values and before {@link NullValueTransformer} so that it transforms
+ * all the null values properly.
  */
 public class SpecialValueTransformer implements RecordTransformer {
 


### PR DESCRIPTION
This PR transforms the values of `-0.0` to `0.0` and `NaN` to default null during data ingestion. Allowing `-0.0` and `NaN` messes up the binary search/sorting in certain cases. Further discussion [here](https://github.com/apache/pinot/issues/10697).

# Release Notes
- `-0.0` and `NaN` as column values was causing issues for Binary search and sorted indexes for certain cases. 
- Added change to modify `-0.0` to `0.0`.
- Added change to modify `NaN` in single-valued columns to default null.
- Added change to remove `NaN` in multi-valued columns.