### PR TITLE
Allow instance tag level config override

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java
@@ -38,6 +38,7 @@ import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.model.Message;
 import org.apache.helix.store.zk.ZkHelixPropertyStore;
 import org.apache.helix.zookeeper.datamodel.ZNRecord;
+import org.apache.helix.zookeeper.impl.client.ZkClient;
 import org.apache.pinot.broker.broker.AccessControlFactory;
 import org.apache.pinot.broker.broker.BrokerAdminApiApplication;
 import org.apache.pinot.broker.queryquota.HelixExternalViewBasedQueryQuotaManager;
@@ -135,34 +136,44 @@ public abstract class BaseBrokerStarter implements ServiceStartable {
     // Remove all white-spaces from the list of zkServers (if any).
     _zkServers = brokerConf.getProperty(Helix.CONFIG_OF_ZOOKEEPR_SERVER).replaceAll("\\s+", "");
     _clusterName = brokerConf.getProperty(Helix.CONFIG_OF_CLUSTER_NAME);
-    ServiceStartableUtils.applyClusterConfig(_brokerConf, _zkServers, _clusterName, ServiceRole.BROKER);
+    ZkClient zkClient = ServiceStartableUtils.getZKClient(_brokerConf, _zkServers);
+    try {
+      ServiceStartableUtils.applyClusterConfig(_brokerConf, zkClient, _clusterName, ServiceRole.BROKER);
+      _hostname = brokerConf.getProperty(Broker.CONFIG_OF_BROKER_HOSTNAME);
+      if (_hostname == null) {
+        _hostname =
+            _brokerConf.getProperty(Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtils.getHostnameOrAddress()
+                : NetUtils.getHostAddress();
+      }
 
-    if (_brokerConf.getProperty(MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT,
-        MultiStageQueryRunner.DEFAULT_QUERY_RUNNER_PORT) == 0) {
-      _brokerConf.setProperty(MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT, NetUtils.findOpenPort());
+      if (_brokerConf.getProperty(MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT,
+          MultiStageQueryRunner.DEFAULT_QUERY_RUNNER_PORT) == 0) {
+        _brokerConf.setProperty(MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_PORT, NetUtils.findOpenPort());
+      }
+      _listenerConfigs = ListenerConfigUtil.buildBrokerConfigs(brokerConf);
+
+      // Override multi-stage query runner hostname if not set explicitly
+      if (!_brokerConf.containsKey(MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME)) {
+        _brokerConf.setProperty(MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME, _hostname);
+      }
+      _port = _listenerConfigs.get(0).getPort();
+
+      _instanceId = _brokerConf.getProperty(Broker.CONFIG_OF_BROKER_ID);
+      if (_instanceId == null) {
+        _instanceId = _brokerConf.getProperty(Helix.Instance.INSTANCE_ID_KEY);
+      }
+      if (_instanceId == null) {
+        _instanceId = Helix.PREFIX_OF_BROKER_INSTANCE + _hostname + "_" + _port;
+      }
+
+      ServiceStartableUtils.applyTenantConfigs(_instanceId, zkClient, _clusterName, _brokerConf);
+    } finally {
+      zkClient.close();
     }
+
     setupHelixSystemProperties();
-    _listenerConfigs = ListenerConfigUtil.buildBrokerConfigs(brokerConf);
-    _hostname = brokerConf.getProperty(Broker.CONFIG_OF_BROKER_HOSTNAME);
-    if (_hostname == null) {
-      _hostname =
-          _brokerConf.getProperty(Helix.SET_INSTANCE_ID_TO_HOSTNAME_KEY, false) ? NetUtils.getHostnameOrAddress()
-              : NetUtils.getHostAddress();
-    }
-    // Override multi-stage query runner hostname if not set explicitly
-    if (!_brokerConf.containsKey(MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME)) {
-      _brokerConf.setProperty(MultiStageQueryRunner.KEY_OF_QUERY_RUNNER_HOSTNAME, _hostname);
-    }
-    _port = _listenerConfigs.get(0).getPort();
     _tlsPort = ListenerConfigUtil.findLastTlsPort(_listenerConfigs, -1);
 
-    _instanceId = _brokerConf.getProperty(Broker.CONFIG_OF_BROKER_ID);
-    if (_instanceId == null) {
-      _instanceId = _brokerConf.getProperty(Helix.Instance.INSTANCE_ID_KEY);
-    }
-    if (_instanceId == null) {
-      _instanceId = Helix.PREFIX_OF_BROKER_INSTANCE + _hostname + "_" + _port;
-    }
     // NOTE: Force all instances to have the same prefix in order to derive the instance type based on the instance id
     Preconditions.checkState(InstanceTypeUtils.isBroker(_instanceId), "Instance id must have prefix '%s', got '%s'",
         Helix.PREFIX_OF_BROKER_INSTANCE, _instanceId);

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStartableUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStartableUtils.java
@@ -103,7 +103,7 @@ public class ServiceStartableUtils {
   /**
    * Overrides the instance config with the tenant configs if the tenant is tagged on the instance.
    */
-  public static void overrideTenantConfigs(String instanceId, ZkClient zkClient, String clusterName,
+  public static void applyTenantConfigs(String instanceId, ZkClient zkClient, String clusterName,
       PinotConfiguration instanceConfig) {
     ZNRecord instanceConfigZNRecord =
         zkClient.readData(String.format(INSTANCE_CONFIG_ZK_PATH_TEMPLATE, clusterName, instanceId), true);

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java
@@ -178,7 +178,7 @@ public abstract class BaseServerStarter implements ServiceStartable {
         // NOTE: Need to add the instance id to the config because it is required in HelixInstanceDataManagerConfig
         _serverConf.addProperty(Server.CONFIG_OF_INSTANCE_ID, _instanceId);
       }
-      ServiceStartableUtils.overrideTenantConfigs(_instanceId, zkClient, _helixClusterName, _serverConf);
+      ServiceStartableUtils.applyTenantConfigs(_instanceId, zkClient, _helixClusterName, _serverConf);
     } finally {
       zkClient.close();
     }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/PinotConfiguration.java
@@ -222,7 +222,7 @@ public class PinotConfiguration {
     return relaxPropertyName(propertyEntry.getKey());
   }
 
-  private static String relaxPropertyName(String propertyName) {
+  public static String relaxPropertyName(String propertyName) {
     return propertyName.replace("-", "").replace("_", "").toLowerCase();
   }
 


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Instance initialization applies cluster config, then tenant tag\-based overrides using ZK instance tags, before closing ZK client\.

```mermaid
flowchart TD
  N0["Starter initialization #40;F1#44; F3#41;"]:::stModified
  N1["Get ZK client #40;F2#41;"]:::stModified
  N2["Apply cluster config #40;F2#41;"]:::stModified
  N3["Setup instance #40;F1#44; F3#41;"]:::stModified
  N4["Apply tenant configs #40;F2#41;"]:::stAdded
  N5["Close ZK client #40;F1#44; F3#41;"]:::stModified
  N0 -->|"calls"| N1
  N1 -->|"passes client"| N2
  N2 -->|"followed by"| N3
  N3 -->|"followed by"| N4
  N4 -->|"followed by"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter\.java — [before](https://github.com/apache/pinot/blob/b9ed378355acc5313ebc1031510671f7045f29a9/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java) · [after](https://github.com/apache/pinot/blob/83d60c4789671fd99c5ce59a9945ec67662caa67/pinot-broker/src/main/java/org/apache/pinot/broker/broker/helix/BaseBrokerStarter.java)
- F2: pinot\-common/src/main/java/org/apache/pinot/common/utils/ServiceStartableUtils\.java — [before](https://github.com/apache/pinot/blob/b9ed378355acc5313ebc1031510671f7045f29a9/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStartableUtils.java) · [after](https://github.com/apache/pinot/blob/83d60c4789671fd99c5ce59a9945ec67662caa67/pinot-common/src/main/java/org/apache/pinot/common/utils/ServiceStartableUtils.java)
- F3: pinot\-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter\.java — [before](https://github.com/apache/pinot/blob/b9ed378355acc5313ebc1031510671f7045f29a9/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java) · [after](https://github.com/apache/pinot/blob/83d60c4789671fd99c5ce59a9945ec67662caa67/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/BaseServerStarter.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImI5ZWQzNzgzNTVhY2M1MzEzZWJjMTAzMTUxMDY3MWY3MDQ1ZjI5YTkiLCJjb250ZXh0X2hhc2giOiJlZTYzOTZhMjNkMmY1ZTlhNDMxMTYzMjJlZTU2Nzg1NDIwZDBmMDJjODlhMWEzNTI1MTM5ZmI0MTViMGMxM2VkIiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTMxOTg5LCJoZWFkX3NoYSI6IjgzZDYwYzQ3ODk2NzFmZDk5YzVjZTU5YTk5NDVlYzY3NjYyY2FhNjciLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJiOWVkMzc4MzU1YWNjNTMxM2ViYzEwMzE1MTA2NzFmNzA0NWYyOWE5IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature b0e3be68032d876a0553044b6d6c3d379c38bea59fcff84b5b5d8cfaa8806d26 -->
<!-- pinot-pr-flow:end -->

Allows overriding server configs for a specific tenant by setting tenant prefixed config in /cluster/configs or server.conf file following this convention
```
"pinot.tenant.<serverTenantName>.<ServerConfigKey>": <Value>
```