### PR TITLE
Prevent inverted index on a non dictionary column in table config

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -1156,6 +1156,11 @@ public final class TableConfigUtils {
                       && fieldConfigColSpec.getDataType().getStoredType() == DataType.STRING,
                   "FST Index is only supported for single value string columns");
               break;
+            case INVERTED:
+              Preconditions.checkArgument(fieldConfig.getEncodingType() == FieldConfig.EncodingType.DICTIONARY,
+                  "Cannot create an Inverted Index on column: " + fieldConfig.getName() + ", specified as "
+                      + "a non dictionary column");
+              break;
             case TEXT:
               Preconditions.checkState(fieldConfigColSpec.getDataType().getStoredType() == DataType.STRING,
                   "TEXT Index is only supported for string columns");

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1230,6 +1230,21 @@ public class TableConfigUtilsTest {
           "Cannot create an Inverted index on column myCol2 specified in the " + "noDictionaryColumns config");
     }
 
+    // Tests the case when the field-config list marks a column as raw (non-dictionary) and enables
+    // inverted index on it
+    tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME).build();
+    try {
+      FieldConfig fieldConfig = new FieldConfig.Builder("myCol2")
+          .withIndexTypes(Arrays.asList(FieldConfig.IndexType.INVERTED))
+          .withEncodingType(FieldConfig.EncodingType.RAW).build();
+      tableConfig.setFieldConfigList(Arrays.asList(fieldConfig));
+      TableConfigUtils.validate(tableConfig, schema);
+      Assert.fail("Should not be able to disable dictionary but keep inverted index");
+    } catch (Exception e) {
+      Assert.assertEquals(e.getMessage(),
+          "Cannot create an Inverted Index on column: myCol2, specified as a non dictionary column");
+    }
+
     tableConfig = new TableConfigBuilder(TableType.OFFLINE).setTableName(TABLE_NAME)
         .setNoDictionaryColumns(Arrays.asList("myCol2")).build();
     try {


### PR DESCRIPTION
A column should be of Dictionary type for it to have an inverted index. 

Current Scenario:
Config will be flagged as **invalid** during the upsert of table config if the column is marked as **noDictionaryColumn** and has inverted index enabled. e.g. 
[invalid_table_config.json](https://github.com/apache/pinot/files/13442766/invalid_table_config.json)

Issues:
Field Config List can also be used to mark the column's encoding type as RAW (or no dictionary) and enable an inverted index on it. 

Resolution:
This PR aims to put similar checks for columns in the Field Config List as well e.g. 
[invalidConfig_field_config_list.json](https://github.com/apache/pinot/files/13442802/invalidConfig_field_config_list.json)

The response of current and new code on a table config upsert (
[invalidConfig_field_config_list.json](https://github.com/apache/pinot/files/13442845/invalidConfig_field_config_list.json)
) will be the following:
Current code: config gets inserted 
[prev_resultant_config.json](https://github.com/apache/pinot/files/13442849/prev_resultant_config.json)
New Code: Throws an error: {"code":400,"error":"Invalid TableConfigs. Invalid TableConfigs: transcript2. Cannot create an Inverted Index on column: lastName, specified as a non dictionary column"}