### PR TITLE
[bugfix] Fix bug with silently ignoring force commit call failures

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -148,8 +148,10 @@ public class PinotRealtimeTableResource {
       response.put("forceCommitStatus", "SUCCESS");
       try {
         String jobId = UUID.randomUUID().toString();
-        _pinotHelixResourceManager.addNewForceCommitJob(tableNameWithType, jobId, startTimeMs,
-            consumingSegmentsForceCommitted);
+        if (!_pinotHelixResourceManager.addNewForceCommitJob(tableNameWithType, jobId, startTimeMs,
+                consumingSegmentsForceCommitted)) {
+          throw new IllegalStateException("Failed to update table jobs ZK metadata");
+        }
         response.put("jobMetaZKWriteStatus", "SUCCESS");
         response.put("forceCommitJobId", jobId);
       } catch (Exception e) {


### PR DESCRIPTION
This fixes `jobMetaZKWriteStatus` returned when adding force commit job to Zookeeper fails.

We see this happening while force committing for large set of tables:
 - Call to force commit would succeed
 - There would be random UUID generated for job
 - Call to the `forceCommitStatus` wouldn't be finding it and there would be no actual commit on the table