### PR TITLE
Fix incorrect handling of consumer creation errors

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestClient.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/ControllerRequestClient.java
@@ -325,6 +325,16 @@ public class ControllerRequestClient {
     }
   }
 
+  public void runPeriodicTask(String taskName)
+      throws IOException {
+    try {
+      HttpClient.wrapAndThrowHttpException(_httpClient.sendGetRequest(new URL(
+          _controllerRequestURLBuilder.forPeriodTaskRun(taskName)).toURI()));
+    } catch (HttpErrorStatusException | URISyntaxException e) {
+      throw new IOException(e);
+    }
+  }
+
   protected String getBrokerTenantRequestPayload(String tenantName, int numBrokers) {
     return new Tenant(TenantRole.BROKER, tenantName, numBrokers, 0, 0).toJsonString();
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -828,7 +828,8 @@ public class PinotLLCRealtimeSegmentManager {
     // Helix throws an exception if we try to reset state of a partition that is NOT in ERROR state in EV,
     // So, if any exceptions are thrown, ignore it here.
     try {
-      _helixAdmin.resetPartition(_helixManager.getClusterName(), instanceName, TableNameBuilder.REALTIME.tableNameWithType(llcSegmentName.getTableName()),
+      _helixAdmin.resetPartition(_helixManager.getClusterName(), instanceName,
+          TableNameBuilder.REALTIME.tableNameWithType(llcSegmentName.getTableName()),
           Collections.singletonList(segmentName));
     } catch (Exception e) {
       // Ignore

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -827,10 +827,13 @@ public class PinotLLCRealtimeSegmentManager {
     // in the server when it receives the ERROR to OFFLINE state transition.
     // Helix throws an exception if we try to reset state of a partition that is NOT in ERROR state in EV,
     // So, if any exceptions are thrown, ignore it here.
+    // TODO: https://github.com/apache/pinot/issues/12055
+    // If we have reaosn codes, then the server can indicate to us the reason (in this case, consumer was never
+    // created, OR consumer was created but could not consume the segment compeltely), and we can call reset()
+    // in one of the cases and not the other.
     try {
       _helixAdmin.resetPartition(_helixManager.getClusterName(), instanceName,
-          TableNameBuilder.REALTIME.tableNameWithType(llcSegmentName.getTableName()),
-          Collections.singletonList(segmentName));
+          realtimeTableName, Collections.singletonList(segmentName));
     } catch (Exception e) {
       // Ignore
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -825,9 +825,14 @@ public class PinotLLCRealtimeSegmentManager {
     // We can now do a best effort to reset the externalview to be OFFLINE if it is in ERROR state.
     // If the externalview is not in error state, then this reset will be ignored by the helix participant
     // in the server when it receives the ERROR to OFFLINE state transition.
-    _helixAdmin.resetPartition(_helixManager.getClusterName(), instanceName,
-        TableNameBuilder.REALTIME.tableNameWithType(llcSegmentName.getTableName()),
-        Collections.singletonList(segmentName));
+    // Helix throws an exception if we try to reset state of a partition that is NOT in ERROR state in EV,
+    // So, if any exceptions are thrown, ignore it here.
+    try {
+      _helixAdmin.resetPartition(_helixManager.getClusterName(), instanceName, TableNameBuilder.REALTIME.tableNameWithType(llcSegmentName.getTableName()),
+          Collections.singletonList(segmentName));
+    } catch (Exception e) {
+      // Ignore
+    }
   }
 
   /**

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -821,6 +821,13 @@ public class PinotLLCRealtimeSegmentManager {
       _controllerMetrics.addMeteredTableValue(realtimeTableName, ControllerMeter.LLC_ZOOKEEPER_UPDATE_FAILURES, 1L);
       throw e;
     }
+    // We know that we have successfully set the idealstate to be OFFLINE.
+    // We can now do a best effort to reset the externalview to be OFFLINE if it is in ERROR state.
+    // If the externalview is not in error state, then this reset will be ignored by the helix participant
+    // in the server when it receives the ERROR to OFFLINE state transition.
+    _helixAdmin.resetPartition(_helixManager.getClusterName(), instanceName,
+        TableNameBuilder.REALTIME.tableNameWithType(llcSegmentName.getTableName()),
+        Collections.singletonList(segmentName));
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1516,7 +1516,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           "Failed to initialize segment data manager", e));
       _segmentLogger.warn(
           "Scheduling task to call controller to mark the segment as OFFLINE in Ideal State due"
-           + "to initialization error: '{}'",
+           + " to initialization error: '{}'",
           e.getMessage());
       // Since we are going to throw exception from this thread (helix execution thread), the externalview
       // entry for this segment will be ERROR. We allow time for Helix to make this transition, and then

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseRealtimeClusterIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseRealtimeClusterIntegrationTest.java
@@ -74,8 +74,14 @@ public abstract class BaseRealtimeClusterIntegrationTest extends BaseClusterInte
     // Initialize the query generator
     setUpQueryGenerator(avroFiles);
 
+    runValidationJob(600_000);
+
     // Wait for all documents loaded
     waitForAllDocsLoaded(600_000L);
+  }
+
+  protected void runValidationJob(long timeoutMs)
+      throws Exception {
   }
 
   protected void createSegmentsAndUpload(List<File> avroFile, Schema schema, TableConfig tableConfig)

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/builder/ControllerRequestURLBuilder.java
@@ -109,6 +109,10 @@ public class ControllerRequestURLBuilder {
     return StringUtil.join("/", _baseUrl, "users", username, params.toString());
   }
 
+  public String forPeriodTaskRun(String taskName) {
+    return StringUtil.join("/", _baseUrl, "periodictask", "run?taskname=" + taskName);
+  }
+
   public String forUpdateUserConfig(String username, String componentTypeStr, boolean passwordChanged) {
     StringBuilder params = new StringBuilder();
     if (StringUtils.isNotBlank(username)) {


### PR DESCRIPTION
The current handling of exceptions during creation of a consumer is incorrect, since the ExternalView for the segment remains in ERROR state while we specify the IdealState to be OFFLINE. This happens for one replica, while other replicas may consume fine and reach ONLINE state eventually. At that time, however, the particular segment that had problem consuming is not able to transition to ONLINE since a transition from ERROR to ONLINE is not suppored by Helix.

A partition state of ERROR is a special state in Helix. Helix does not work the same way moving from ERROR to other states. Instead, Helix provides an admin API to reset the state of a partition from ERROR to its starting state (which in our case is OFFLINE). When this reset API is invoked, a state transition message of ERROR to StartingState is sent to the specific instance that hosts the partition in question. If the participant's currentstate is not ERROR, then this message is discarded automatically (and Pinot will never see it). Otherwise, it is passed on to Pinot and we have a transition from ERROR to OFFLINE.

Tested by manually inserting an exception in the consumer creation code ad observing that externalview changes to ERROR, and then later onto OFFLINE.

Added integration tests to make sure that the two types of auto-correction happen correctly in RealtimeSegmentValidationManager:
- Exception thrown during consumer creation
- Exception thrown during event consumption