### PR TITLE
fix by repalcing HashSet with TreeSet

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/ExprMinMaxRewriter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/ExprMinMaxRewriter.java
@@ -25,6 +25,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
@@ -107,7 +108,8 @@ public class ExprMinMaxRewriter implements QueryRewriter {
       operands.add(RequestUtils.getLiteralExpression((int) exprMinMaxFunctionIDMap.get(measuringColumns)));
       operands.add(RequestUtils.getLiteralExpression(measuringColumns.size()));
       operands.addAll(measuringColumns);
-      operands.addAll(projectionColumns);
+      Set<Expression> sortedProjectionColumns = new TreeSet<>(projectionColumns);
+      operands.addAll(sortedProjectionColumns);
       functionExpression.getFunctionCall().setOperands(operands);
       selectList.add(functionExpression);
     }

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/ExprMinMaxRewriterTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/rewriter/ExprMinMaxRewriterTest.java
@@ -43,7 +43,7 @@ public class ExprMinMaxRewriterTest {
         "SELECT CHILD_EXPR_MIN(0,col5,col5,col1,col2), "
             + "CHILD_EXPR_MIN(0,col6,col6,col1,col2), "
             + "CHILD_EXPR_MAX(0,col6,col6,col1,col2),"
-            + "PARENT_EXPR_MIN(0,2,col1,col2,col6,col5),"
+            + "PARENT_EXPR_MIN(0,2,col1,col2,col5,col6),"
             + "PARENT_EXPR_MAX(0,2,col1,col2,col6) FROM myTable");
   }
 


### PR DESCRIPTION
## Setup:
Java version: openjdk 11.0.20.1
Maven version: Apache Maven 3.8.1

## Fixed Test:
org.apache.pinot.sql.parsers.rewriter.ExprMinMaxRewriterTest#testQueryRewrite

## Test Failure:
The test's `PARENT_EXPR_MIN` field's order shows nondeterminism when applying the `NonDex` tool. When asserting the created query's `PROJECT` field, the column names's order could be random, which `PARENT_EXPR_MIN(0,2,col1,col2,col5,col6)
` could randomly be `PARENT_EXPR_MIN(0,2,col1,col2,col6,col5)`. 

## Root Cause:
The root cause is in [`appendParentExprMinMaxFunctions()` in ExprMinMaxRewriter.java](https://github.com/apache/pinot/blob/f79b618141e07c140663791959d96956ad91d811/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/ExprMinMaxRewriter.java#L99), which it uses `List.addAll()` function to add a `HashSet` `projectionColumns` into a `List`. This `List.addAll()` function will random iterate through the element in the `HashSet` and add them into the `List`, which cause the non-deternimism.

## Fix:
The Fix here is to first sort the fields by constructing a `TreeSet`, and use `List.addAll()` function to put the contruted `TreeSet` into the `List`. This can completely eleminite the non-deternimism inside of it.