### PR TITLE
Add support for murmur3 as a partition function

### DIFF
--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/Murmur3PartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/Murmur3PartitionFunction.java
@@ -49,8 +49,12 @@ public class Murmur3PartitionFunction implements PartitionFunction {
                 "x64_32")),
         "Murmur3 variant must be either x86_32 or x64_32");
     _numPartitions = numPartitions;
+
+    // default value of the hash seed is 0.
     _hashSeed = (functionConfig == null || functionConfig.get(SEED_KEY) == null) ? 0
         : Integer.parseInt(functionConfig.get(SEED_KEY));
+
+    // default value of the murmur3 variant is x86_32.
     _variant = (functionConfig == null || functionConfig.get(MURMUR3_VARIANT) == null) ? "x86_32"
         : functionConfig.get(MURMUR3_VARIANT);
   }
@@ -149,7 +153,6 @@ public class Murmur3PartitionFunction implements PartitionFunction {
    * @return 64 bit hashed key
    */
   private long murmurHash364bitsX64(final byte[] key, final int seed) {
-    // Exactly the same as MurmurHash3_x64_128, except it only returns state.h1
     State state = new State();
 
     state._h1 = 0x9368e53c2f6af274L ^ seed;

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/Murmur3PartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/Murmur3PartitionFunction.java
@@ -298,9 +298,10 @@ public class Murmur3PartitionFunction implements PartitionFunction {
     } else {
       // Differing from the source implementation here. The default case in the source implementation is to apply the
       // hash on the hashcode of the object. The hashcode of an object is not guaranteed to be consistent across JVMs
-      // (except for String values), so we cannot guarantee the same value as the data source. Instead, we will apply
-      // the hash on the string representation of the object, which aligns with rest of our codebase.
-      return murmurHash332BitsX64(o.toString().getBytes(UTF_8), seed);
+      // (except for String values), so we cannot guarantee the same value as the data source. Since we cannot
+      // guarantee similar values, we will instead apply the hash on the string representation of the object, which
+      // aligns with the rest of our code base.
+      return murmurHash332BitsX64(o.toString(), seed);
     }
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/Murmur3PartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/Murmur3PartitionFunction.java
@@ -65,9 +65,9 @@ public class Murmur3PartitionFunction implements PartitionFunction {
   @Override
   public int getPartition(Object value) {
     if (_variant.equals("x86_32")) {
-      return (murmurHash332BitsX86(value.toString().getBytes(UTF_8), _hashSeed) & Integer.MAX_VALUE) % _numPartitions;
+      return (murmur3Hash32BitsX86(value.toString().getBytes(UTF_8), _hashSeed) & Integer.MAX_VALUE) % _numPartitions;
     }
-    return (murmurHash332BitsX64(value, _hashSeed) & Integer.MAX_VALUE) % _numPartitions;
+    return (murmur3Hash32BitsX64(value, _hashSeed) & Integer.MAX_VALUE) % _numPartitions;
   }
 
   @Override
@@ -87,7 +87,7 @@ public class Murmur3PartitionFunction implements PartitionFunction {
   }
 
   @VisibleForTesting
-  int murmurHash332BitsX86(byte[] data, int hashSeed) {
+  int murmur3Hash32BitsX86(byte[] data, int hashSeed) {
     return Hashing.murmur3_32_fixed(hashSeed).hashBytes(data).asInt();
   }
 
@@ -156,7 +156,7 @@ public class Murmur3PartitionFunction implements PartitionFunction {
    * @param seed random value
    * @return 64 bit hashed key
    */
-  private long murmurHash364BitsX64(final byte[] key, final int seed) {
+  private long murmur3Hash64BitsX64(final byte[] key, final int seed) {
     State state = new State();
 
     state._h1 = 0x9368e53c2f6af274L ^ seed;
@@ -234,11 +234,11 @@ public class Murmur3PartitionFunction implements PartitionFunction {
    * @param seed random value
    * @return 32 bit hashed key
    */
-  private int murmurHash332BitsX64(final byte[] key, final int seed) {
-    return (int) (murmurHash364BitsX64(key, seed) >>> 32);
+  private int murmur3Hash32BitsX64(final byte[] key, final int seed) {
+    return (int) (murmur3Hash64BitsX64(key, seed) >>> 32);
   }
 
-  private long murmurHash364BitsX64(final long[] key, final int seed) {
+  private long murmur3Hash64BitsX64(final long[] key, final int seed) {
     // Exactly the same as MurmurHash3_x64_128, except it only returns state.h1
     State state = new State();
 
@@ -283,33 +283,33 @@ public class Murmur3PartitionFunction implements PartitionFunction {
    * @param seed random value
    * @return 32 bit hashed key
    */
-  private int murmurHash332BitsX64(final long[] key, final int seed) {
-    return (int) (murmurHash364BitsX64(key, seed) >>> 32);
+  private int murmur3Hash32BitsX64(final long[] key, final int seed) {
+    return (int) (murmur3Hash64BitsX64(key, seed) >>> 32);
   }
 
   @VisibleForTesting
-  int murmurHash332BitsX64(Object o, int seed) {
+  int murmur3Hash32BitsX64(Object o, int seed) {
     if (o instanceof byte[]) {
-      return murmurHash332BitsX64((byte[]) o, seed);
+      return murmur3Hash32BitsX64((byte[]) o, seed);
     } else if (o instanceof long[]) {
-      return murmurHash332BitsX64((long[]) o, seed);
+      return murmur3Hash32BitsX64((long[]) o, seed);
     } else if (o instanceof String) {
-      return murmurHash332BitsX64((String) o, seed);
+      return murmur3Hash32BitsX64((String) o, seed);
     } else {
       // Differing from the source implementation here. The default case in the source implementation is to apply the
       // hash on the hashcode of the object. The hashcode of an object is not guaranteed to be consistent across JVMs
       // (except for String values), so we cannot guarantee the same value as the data source. Since we cannot
       // guarantee similar values, we will instead apply the hash on the string representation of the object, which
       // aligns with the rest of our code base.
-      return murmurHash332BitsX64(o.toString(), seed);
+      return murmur3Hash32BitsX64(o.toString(), seed);
     }
   }
 
-  private int murmurHash332BitsX64(String s, int seed) {
-    return (int) (murmurHash364BitsX64String(s, seed) >> 32);
+  private int murmur3Hash32BitsX64(String s, int seed) {
+    return (int) (murmur3Hash32BitsX64String(s, seed) >> 32);
   }
 
-  private long murmurHash364BitsX64String(String s, long seed) {
+  private long murmur3Hash32BitsX64String(String s, long seed) {
     // Exactly the same as MurmurHash3_x64_64, except it works directly on a String's chars
     State state = new State();
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/Murmur3PartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/Murmur3PartitionFunction.java
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi.partition;
+
+import com.google.common.base.Preconditions;
+import com.google.common.hash.Hashing;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+
+
+/**
+ * Implementation of {@link PartitionFunction} which partitions based on 32 bit murmur3 hash
+ */
+public class Murmur3PartitionFunction implements PartitionFunction {
+  private static final String NAME = "Murmur3";
+  private final int _numPartitions;
+  private final int _hashSeed;
+
+  /**
+   * Constructor for the class.
+   * @param numPartitions Number of partitions.
+   * @param functionConfig to extract configurations for the partition function.
+   */
+  public Murmur3PartitionFunction(int numPartitions, Map<String, String> functionConfig) {
+    Preconditions.checkArgument(numPartitions > 0, "Number of partitions must be > 0");
+    _numPartitions = numPartitions;
+    _hashSeed = (functionConfig == null || functionConfig.get("seed") == null) ? 0
+        : Integer.parseInt(functionConfig.get("seed"));
+  }
+
+  @Override
+  public int getPartition(Object value) {
+    return (Hashing.murmur3_32_fixed(_hashSeed).hashBytes(value.toString().getBytes(UTF_8)).asInt() & Integer.MAX_VALUE)
+        % _numPartitions;
+  }
+
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  @Override
+  public int getNumPartitions() {
+    return _numPartitions;
+  }
+
+  // Keep it for backward-compatibility, use getName() instead
+  @Override
+  public String toString() {
+    return NAME;
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/Murmur3PartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/Murmur3PartitionFunction.java
@@ -56,8 +56,9 @@ public class Murmur3PartitionFunction implements PartitionFunction {
             : Integer.parseInt(functionConfig.get(SEED_KEY));
 
     // default value of the murmur3 variant is x86_32.
-    _variant = (functionConfig == null || functionConfig.get(MURMUR3_VARIANT) == null || functionConfig.get(MURMUR3_VARIANT).isEmpty()) ? "x86_32"
-        : functionConfig.get(MURMUR3_VARIANT);
+    _variant =
+        (functionConfig == null || functionConfig.get(MURMUR3_VARIANT) == null || functionConfig.get(MURMUR3_VARIANT)
+            .isEmpty()) ? "x86_32" : functionConfig.get(MURMUR3_VARIANT);
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/Murmur3PartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/Murmur3PartitionFunction.java
@@ -30,6 +30,7 @@ import static java.nio.charset.StandardCharsets.UTF_8;
  * Implementation of {@link PartitionFunction} which partitions based on 32 bit murmur3 hash
  */
 public class Murmur3PartitionFunction implements PartitionFunction {
+  public static final byte INVALID_CHAR = (byte) '?';
   private static final String NAME = "Murmur3";
   private static final String SEED_KEY = "seed";
   private static final String MURMUR3_VARIANT = "variant";
@@ -64,9 +65,9 @@ public class Murmur3PartitionFunction implements PartitionFunction {
   @Override
   public int getPartition(Object value) {
     if (_variant.equals("x86_32")) {
-      return (murmurHash332bitsX86(value.toString().getBytes(UTF_8), _hashSeed) & Integer.MAX_VALUE) % _numPartitions;
+      return (murmurHash332BitsX86(value.toString().getBytes(UTF_8), _hashSeed) & Integer.MAX_VALUE) % _numPartitions;
     }
-    return (murmurHash332bitsX64(value.toString().getBytes(UTF_8), _hashSeed) & Integer.MAX_VALUE) % _numPartitions;
+    return (murmurHash332BitsX64(value, _hashSeed) & Integer.MAX_VALUE) % _numPartitions;
   }
 
   @Override
@@ -84,8 +85,9 @@ public class Murmur3PartitionFunction implements PartitionFunction {
   public String toString() {
     return NAME;
   }
+
   @VisibleForTesting
-  int murmurHash332bitsX86(byte[] data, int hashSeed) {
+  int murmurHash332BitsX86(byte[] data, int hashSeed) {
     return Hashing.murmur3_32_fixed(hashSeed).hashBytes(data).asInt();
   }
 
@@ -154,7 +156,7 @@ public class Murmur3PartitionFunction implements PartitionFunction {
    * @param seed random value
    * @return 64 bit hashed key
    */
-  private long murmurHash364bitsX64(final byte[] key, final int seed) {
+  private long murmurHash364BitsX64(final byte[] key, final int seed) {
     State state = new State();
 
     state._h1 = 0x9368e53c2f6af274L ^ seed;
@@ -232,9 +234,209 @@ public class Murmur3PartitionFunction implements PartitionFunction {
    * @param seed random value
    * @return 32 bit hashed key
    */
+  private int murmurHash332BitsX64(final byte[] key, final int seed) {
+    return (int) (murmurHash364BitsX64(key, seed) >>> 32);
+  }
+
+  private long murmurHash364BitsX64(final long[] key, final int seed) {
+    // Exactly the same as MurmurHash3_x64_128, except it only returns state.h1
+    State state = new State();
+
+    state._h1 = 0x9368e53c2f6af274L ^ seed;
+    state._h2 = 0x586dcd208f7cd3fdL ^ seed;
+
+    state._c1 = 0x87c37b91114253d5L;
+    state._c2 = 0x4cf5ad432745937fL;
+
+    for (int i = 0; i < key.length / 2; i++) {
+      state._k1 = key[i * 2];
+      state._k2 = key[i * 2 + 1];
+
+      bmix(state);
+    }
+
+    long tail = key[key.length - 1];
+
+    if (key.length % 2 != 0) {
+      state._k1 ^= tail;
+      bmix(state);
+    }
+
+    state._h2 ^= key.length * 8;
+
+    state._h1 += state._h2;
+    state._h2 += state._h1;
+
+    state._h1 = fmix(state._h1);
+    state._h2 = fmix(state._h2);
+
+    state._h1 += state._h2;
+    state._h2 += state._h1;
+
+    return state._h1;
+  }
+
+  /**
+   * Hash a value using the x64 32 bit variant of MurmurHash3
+   *
+   * @param key value to hash
+   * @param seed random value
+   * @return 32 bit hashed key
+   */
+  private int murmurHash332BitsX64(final long[] key, final int seed) {
+    return (int) (murmurHash364BitsX64(key, seed) >>> 32);
+  }
+
   @VisibleForTesting
-  int murmurHash332bitsX64(final byte[] key, final int seed) {
-    return (int) (murmurHash364bitsX64(key, seed) >>> 32);
+  int murmurHash332BitsX64(Object o, int seed) {
+    if (o instanceof byte[]) {
+      return murmurHash332BitsX64((byte[]) o, seed);
+    } else if (o instanceof long[]) {
+      return murmurHash332BitsX64((long[]) o, seed);
+    } else if (o instanceof String) {
+      return murmurHash332BitsX64((String) o, seed);
+    } else {
+      // Differing from the source implementation here. The default case in the source implementation is to apply the
+      // hash on the hashcode of the object. The hashcode of an object is not guaranteed to be consistent across JVMs
+      // (except for String values), so we cannot guarantee the same value as the data source. Instead, we will apply
+      // the hash on the string representation of the object, which aligns with rest of our codebase.
+      return murmurHash332BitsX64(o.toString().getBytes(UTF_8), seed);
+    }
+  }
+
+  private int murmurHash332BitsX64(String s, int seed) {
+    return (int) (murmurHash364BitsX64String(s, seed) >> 32);
+  }
+
+  private long murmurHash364BitsX64String(String s, long seed) {
+    // Exactly the same as MurmurHash3_x64_64, except it works directly on a String's chars
+    State state = new State();
+
+    state._h1 = 0x9368e53c2f6af274L ^ seed;
+    state._h2 = 0x586dcd208f7cd3fdL ^ seed;
+
+    state._c1 = 0x87c37b91114253d5L;
+    state._c2 = 0x4cf5ad432745937fL;
+
+    int byteLen = 0;
+    int stringLen = s.length();
+
+    // CHECKSTYLE:OFF
+    for (int i = 0; i < stringLen; i++) {
+      char c1 = s.charAt(i);
+      int cp;
+      if (!Character.isSurrogate(c1)) {
+        cp = c1;
+      } else if (Character.isHighSurrogate(c1)) {
+        if (i + 1 < stringLen) {
+          char c2 = s.charAt(i + 1);
+          if (Character.isLowSurrogate(c2)) {
+            i++;
+            cp = Character.toCodePoint(c1, c2);
+          } else {
+            cp = INVALID_CHAR;
+          }
+        } else {
+          cp = INVALID_CHAR;
+        }
+      } else {
+        cp = INVALID_CHAR;
+      }
+
+      if (cp <= 0x7f) {
+        addByte(state, (byte) cp, byteLen++);
+      } else if (cp <= 0x07ff) {
+        byte b1 = (byte) (0xc0 | (0x1f & (cp >> 6)));
+        byte b2 = (byte) (0x80 | (0x3f & cp));
+        addByte(state, b1, byteLen++);
+        addByte(state, b2, byteLen++);
+      } else if (cp <= 0xffff) {
+        byte b1 = (byte) (0xe0 | (0x0f & (cp >> 12)));
+        byte b2 = (byte) (0x80 | (0x3f & (cp >> 6)));
+        byte b3 = (byte) (0x80 | (0x3f & cp));
+        addByte(state, b1, byteLen++);
+        addByte(state, b2, byteLen++);
+        addByte(state, b3, byteLen++);
+      } else {
+        byte b1 = (byte) (0xf0 | (0x07 & (cp >> 18)));
+        byte b2 = (byte) (0x80 | (0x3f & (cp >> 12)));
+        byte b3 = (byte) (0x80 | (0x3f & (cp >> 6)));
+        byte b4 = (byte) (0x80 | (0x3f & cp));
+        addByte(state, b1, byteLen++);
+        addByte(state, b2, byteLen++);
+        addByte(state, b3, byteLen++);
+        addByte(state, b4, byteLen++);
+      }
+    }
+
+    // CHECKSTYLE:ON
+    long savedK1 = state._k1;
+    long savedK2 = state._k2;
+    state._k1 = 0;
+    state._k2 = 0;
+
+    // CHECKSTYLE:OFF
+    switch (byteLen & 15) {
+      case 15:
+        state._k2 ^= (long) ((byte) (savedK2 >> 48)) << 48;
+      case 14:
+        state._k2 ^= (long) ((byte) (savedK2 >> 40)) << 40;
+      case 13:
+        state._k2 ^= (long) ((byte) (savedK2 >> 32)) << 32;
+      case 12:
+        state._k2 ^= (long) ((byte) (savedK2 >> 24)) << 24;
+      case 11:
+        state._k2 ^= (long) ((byte) (savedK2 >> 16)) << 16;
+      case 10:
+        state._k2 ^= (long) ((byte) (savedK2 >> 8)) << 8;
+      case 9:
+        state._k2 ^= ((byte) savedK2);
+      case 8:
+        state._k1 ^= (long) ((byte) (savedK1 >> 56)) << 56;
+      case 7:
+        state._k1 ^= (long) ((byte) (savedK1 >> 48)) << 48;
+      case 6:
+        state._k1 ^= (long) ((byte) (savedK1 >> 40)) << 40;
+      case 5:
+        state._k1 ^= (long) ((byte) (savedK1 >> 32)) << 32;
+      case 4:
+        state._k1 ^= (long) ((byte) (savedK1 >> 24)) << 24;
+      case 3:
+        state._k1 ^= (long) ((byte) (savedK1 >> 16)) << 16;
+      case 2:
+        state._k1 ^= (long) ((byte) (savedK1 >> 8)) << 8;
+      case 1:
+        state._k1 ^= ((byte) savedK1);
+        bmix(state);
+    }
+    // CHECKSTYLE:ON
+    state._h2 ^= byteLen;
+
+    state._h1 += state._h2;
+    state._h2 += state._h1;
+
+    state._h1 = fmix(state._h1);
+    state._h2 = fmix(state._h2);
+
+    state._h1 += state._h2;
+    state._h2 += state._h1;
+
+    return state._h1;
+  }
+
+  private void addByte(State state, byte b, int len) {
+    int shift = (len & 0x7) * 8;
+    long bb = (b & 0xffL) << shift;
+    if ((len & 0x8) == 0) {
+      state._k1 |= bb;
+    } else {
+      state._k2 |= bb;
+      if ((len & 0xf) == 0xf) {
+        bmix(state);
+        state._k1 = 0;
+        state._k2 = 0;
+      }
+    }
   }
 
   static class State {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/Murmur3PartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/Murmur3PartitionFunction.java
@@ -44,18 +44,19 @@ public class Murmur3PartitionFunction implements PartitionFunction {
    */
   public Murmur3PartitionFunction(int numPartitions, Map<String, String> functionConfig) {
     Preconditions.checkArgument(numPartitions > 0, "Number of partitions must be > 0");
-    Preconditions.checkArgument(functionConfig == null || functionConfig.get(MURMUR3_VARIANT) == null || (
-            functionConfig.get(MURMUR3_VARIANT).equals("x86_32") || functionConfig.get(MURMUR3_VARIANT).equals(
-                "x64_32")),
-        "Murmur3 variant must be either x86_32 or x64_32");
+    Preconditions.checkArgument(
+        functionConfig == null || functionConfig.get(MURMUR3_VARIANT) == null || functionConfig.get(MURMUR3_VARIANT)
+            .isEmpty() || functionConfig.get(MURMUR3_VARIANT).equals("x86_32") || functionConfig.get(MURMUR3_VARIANT)
+            .equals("x64_32"), "Murmur3 variant must be either x86_32 or x64_32");
     _numPartitions = numPartitions;
 
     // default value of the hash seed is 0.
-    _hashSeed = (functionConfig == null || functionConfig.get(SEED_KEY) == null) ? 0
-        : Integer.parseInt(functionConfig.get(SEED_KEY));
+    _hashSeed =
+        (functionConfig == null || functionConfig.get(SEED_KEY) == null || functionConfig.get(SEED_KEY).isEmpty()) ? 0
+            : Integer.parseInt(functionConfig.get(SEED_KEY));
 
     // default value of the murmur3 variant is x86_32.
-    _variant = (functionConfig == null || functionConfig.get(MURMUR3_VARIANT) == null) ? "x86_32"
+    _variant = (functionConfig == null || functionConfig.get(MURMUR3_VARIANT) == null || functionConfig.get(MURMUR3_VARIANT).isEmpty()) ? "x86_32"
         : functionConfig.get(MURMUR3_VARIANT);
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunctionFactory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunctionFactory.java
@@ -28,7 +28,7 @@ import java.util.Map;
 public class PartitionFunctionFactory {
   // Enum for various partition functions to be added.
   public enum PartitionFunctionType {
-    Modulo, Murmur, ByteArray, HashCode, BoundedColumnValue;
+    Modulo, Murmur, Murmur3, ByteArray, HashCode, BoundedColumnValue;
     // Add more functions here.
 
     private static final Map<String, PartitionFunctionType> VALUE_MAP = new HashMap<>();
@@ -76,6 +76,9 @@ public class PartitionFunctionFactory {
 
       case Murmur:
         return new MurmurPartitionFunction(numPartitions);
+
+      case Murmur3:
+        return new Murmur3PartitionFunction(numPartitions, functionConfig);
 
       case ByteArray:
         return new ByteArrayPartitionFunction(numPartitions);

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
@@ -19,7 +19,9 @@
 package org.apache.pinot.segment.spi.partition;
 
 import com.fasterxml.jackson.databind.JsonNode;
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Random;
 import org.apache.pinot.spi.utils.JsonUtils;
@@ -244,86 +246,102 @@ public class PartitionFunctionTest {
 
   @Test
   public void testMurmur3Equivalence() {
-    long seed = 100;
-    int numberOfPartitions = 5;
-    Random random = new Random(seed);
-
-    Murmur3PartitionFunction murmur3PartitionFunction = new Murmur3PartitionFunction(numberOfPartitions, null);
 
     // 10 values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
     // Applied org.infinispan.commons.hash.MurmurHash3::MurmurHash3_x64_32 with seed = 0 to those values and stored in
-    // expectedMurmurValuesFor32BitX64WithZeroSeed.
-
-    int[] expectedMurmurValuesFor32BitX64WithZeroSeed = new int[]{
+    // expectedMurmurValuesFor32BitX64WithZeroSeedForByteArray.
+    int[] expectedMurmurValuesFor32BitX64WithZeroSeedForByteArray = new int[]{
         -1569442405, -921191038, 16439113, -881572510, 2111401876, 655879980, 1409856380, -1348364123, -1770645361,
         1277101955
     };
 
-    // Generate the same values as above - 10 random values of size 7, using {@link Random::nextBytes} with seed 100
-    // Apply {@link Murmur3PartitionFunction::murmurHash332bitsX64}. Here seed = 0.
-    // compare with stored results.
-    byte[] array = new byte[7];
-    for (int expectedMurmur3Value : expectedMurmurValuesFor32BitX64WithZeroSeed) {
-      random.nextBytes(array);
-      int actualMurmurValue = murmur3PartitionFunction.murmurHash332bitsX64(array, 0);
-      assertEquals(actualMurmurValue, expectedMurmur3Value);
-    }
-
     // 10 values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
     // Applied org.infinispan.commons.hash.MurmurHash3::MurmurHash3_x64_32 with seed = 9001 to those values and
-    // stored in expectedMurmurValuesFor32BitX64WithNonZeroSeed.
-
-    int[] expectedMurmurValuesFor32BitX64WithNonZeroSeed = new int[]{
+    // stored in expectedMurmurValuesFor32BitX64WithNonZeroSeedForByteArray.
+    int[] expectedMurmurValuesFor32BitX64WithNonZeroSeedForByteArray = new int[]{
         698083240, 174075836, -938825597, 155806634, -831733828, 319389887, -939822329, -1785781936, -1796939240,
         757512622
     };
 
-    // Generate the same values as above - 10 random values of size 7, using {@link Random::nextBytes} with seed 100
-    // Apply {@link Murmur3PartitionFunction::murmurHash332bitsX64}. Here seed = 9001.
-    // compare with stored results.
-    random = new Random(seed);
-    array = new byte[7];
-    for (int expectedMurmur3Value : expectedMurmurValuesFor32BitX64WithNonZeroSeed) {
-      random.nextBytes(array);
-      int actualMurmurValue = murmur3PartitionFunction.murmurHash332bitsX64(array, 9001);
-      assertEquals(actualMurmurValue, expectedMurmur3Value);
-    }
+    // 10 values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
+    // Applied org.infinispan.commons.hash.MurmurHash3::MurmurHash3_x64_32 with seed = 0 to those values and stored in
+    // expectedMurmurValuesFor32BitX64WithZeroSeedForLongArray.
+    int[] expectedMurmurValuesFor32BitX64WithZeroSeedForLongArray = new int[]{
+        -621156783, -1341356662, 1615513844, 1608247599, -1339558745, -1782606270, 1204009437, 8939246, -42073819,
+        1268621125
+    };
 
     // 10 values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
-    // Applied com.google.common.hash.hashing::murmur3_32_fixed to those values with seed = 0 and stored in
+    // Applied org.infinispan.commons.hash.MurmurHash3::MurmurHash3_x64_32 with seed = 9001 to those values and
+    // stored in expectedMurmurValuesFor32BitX64WithNonZeroSeedForLongArray.
+    int[] expectedMurmurValuesFor32BitX64WithNonZeroSeedForLongArray = new int[]{
+        -159780599, 1266925141, -2039451704, 237323842, -1373894107, -1718192521, 314068498, 1377198162, 1239340429,
+        -1643307044
+    };
+
+    // 10 String values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
+    // Applied org.infinispan.commons.hash.MurmurHash3::MurmurHash3_x64_64_String with seed = 0, applied right shift
+    // on 32 bits to those values and stored in expectedMurmurValuesFor32BitX64WithZeroSeedForString.
+    int[] expectedMurmurValuesFor32BitX64WithZeroSeedForString = new int[]{
+        -930531654, 1010637996, -1251084035, -1551293561, 1591443335, 181872103, 1308755538, -432310401, -701537488,
+        674867586
+    };
+
+    // 10 String values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
+    // Applied org.infinispan.commons.hash.MurmurHash3::MurmurHash3_x64_64_String with seed = 0, applied right shift
+    // on 32 bits those values and stored in expectedMurmurValuesFor32BitX64WithNonZeroSeedForString.
+    int[] expectedMurmurValuesFor32BitX64WithNonZeroSeedForString = new int[]{
+        1558697417, 933581816, 1071120824, 1964512897, 1629803052, 2037246152, -1867319466, -1003065762, -275998120,
+        1386652858
+    };
+
+    // 10 values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
+    // Applied org.infinispan.commons.hash.MurmurHash3::MurmurHash3_x86_32 with seed = 0 to those values and stored in
     // expectedMurmurValuesFor32BitX86WithZeroSeed.
     int[] expectedMurmurValuesFor32BitX86WithZeroSeed = new int[]{
         1255034832, -395463542, 659973067, 1070436837, -1193041642, -1412829846, -483463488, -1385092001, 568671606,
-        -807299446,
+        -807299446
     };
-
-    // Generate the same values as above - 10 random values of size 7, using {@link Random::nextBytes} with seed 100
-    // Apply {@link Murmur3PartitionFunction::murmurHash332bitsX86}. Here seed = 0.
-    // compare with stored results.
-    random = new Random(seed);
-    for (int expectedMurmur3Value : expectedMurmurValuesFor32BitX86WithZeroSeed) {
-      random.nextBytes(array);
-      int actualMurmurValue = murmur3PartitionFunction.murmurHash332bitsX86(array, 0);
-      assertEquals(actualMurmurValue, expectedMurmur3Value);
-    }
 
     // 10 values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
-    // Applied com.google.common.hash.hashing::murmur3_32_fixed to those values with seed = 9001 and stored in
-    // expectedMurmurValuesFor32BitX86WithNonZeroSeed.
+    // Applied org.infinispan.commons.hash.MurmurHash3::MurmurHash3_x86_32 with seed = 9001 to those values and
+    // stored in expectedMurmurValuesFor32BitX86WithNonZeroSeed.
     int[] expectedMurmurValuesFor32BitX86WithNonZeroSeed = new int[]{
         -590969347, -315366997, 1642137565, -1732240651, -597560989, -1430018124, -448506674, 410998174, -1912106487,
-        -19253806,
+        -19253806
     };
 
-    // Generate the same values as above - 10 random values of size 7, using {@link Random::nextBytes} with seed 100
-    // Apply {@link Murmur3PartitionFunction::murmurHash332bitsX86}. Here seed = 9001.
-    // compare with stored results
-    random = new Random(seed);
-    for (int expectedMurmur3Value : expectedMurmurValuesFor32BitX86WithNonZeroSeed) {
-      random.nextBytes(array);
-      int actualMurmurValue = murmur3PartitionFunction.murmurHash332bitsX86(array, 9001);
-      assertEquals(actualMurmurValue, expectedMurmur3Value);
-    }
+    // Test for 32 bit murmur3 hash with x64_64 variant and seed = 0 for byte array.
+    testMurmur3HashEquivalenceForDifferentDataTypes(0, expectedMurmurValuesFor32BitX64WithZeroSeedForByteArray,
+        "byteArray", "x64_32");
+
+    // Test for 32 bit murmur3 hash with x64_64 variant and seed = 9001 for byte array.
+    testMurmur3HashEquivalenceForDifferentDataTypes(9001, expectedMurmurValuesFor32BitX64WithNonZeroSeedForByteArray,
+        "byteArray", "x64_32");
+
+    // Test for 32 bit murmur3 hash with x64_64 variant and seed = 0 for long array.
+    testMurmur3HashEquivalenceForDifferentDataTypes(0, expectedMurmurValuesFor32BitX64WithZeroSeedForLongArray,
+        "longArray", "x64_32");
+
+    // Test for 32 bit murmur3 hash with x64_64 variant and seed = 9001 for long array.
+    testMurmur3HashEquivalenceForDifferentDataTypes(9001, expectedMurmurValuesFor32BitX64WithNonZeroSeedForLongArray,
+        "longArray", "x64_32");
+
+    // Test for 64 bit murmur3 hash with x64_64 variant and seed = 0 for String.
+    testMurmur3HashEquivalenceForDifferentDataTypes(0, expectedMurmurValuesFor32BitX64WithZeroSeedForString, "String",
+        "x64_32");
+
+    // Test for 64 bit murmur3 hash with x64_64 variant and seed = 9001 for String.
+    testMurmur3HashEquivalenceForDifferentDataTypes(9001, expectedMurmurValuesFor32BitX64WithNonZeroSeedForString,
+        "String", "x64_32");
+
+    // Test for 32 bit murmur3 hash with x86_32 variant and seed = 0 for byte array.
+    testMurmur3HashEquivalenceForDifferentDataTypes(0, expectedMurmurValuesFor32BitX86WithZeroSeed, "byteArray",
+        "x86_32");
+
+    // Test for 32 bit murmur3 hash with x86_32 variant and seed = 9001 for byte array.
+    testMurmur3HashEquivalenceForDifferentDataTypes(9001, expectedMurmurValuesFor32BitX86WithNonZeroSeed, "byteArray",
+        "x86_32");
   }
 
   /**
@@ -492,23 +510,34 @@ public class PartitionFunctionTest {
     // 10 String values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
     // Applied org.infinispan.commons.hash.MurmurHash3::MurmurHash3_x64_32 with seed = 0 to those values and stored in
     // expectedMurmurValuesFor32BitX64WithZeroSeed.
-    // stored the results in expectedPartitions32BitsX64WithZeroSeed.
-    int[] expectedPartitions32BitsX64WithZeroSeed = new int[]{
+    int[] expectedPartitions32BitsX64WithZeroSeedForByteArrayAndString = new int[]{
         4, 1, 3, 2, 0, 3, 3, 2, 0, 1
     };
 
     // 10 String values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
     // Applied org.infinispan.commons.hash.MurmurHash3::MurmurHash3_x64_32 with seed = 9001 to those values and
     // stored in expectedMurmurValuesFor32BitX64WithZeroSeed.
-    // stored the results in expectedPartitions32BitsX64WithZeroSeed.
-    int[] expectedPartitions32BitsX64WithNonZeroSeed = new int[]{
+    int[] expectedPartitions32BitsX64WithNonZeroSeedForByteArrayAndString = new int[]{
         2, 1, 4, 2, 2, 2, 2, 1, 3, 3
+    };
+
+    // 10 long[] values of size 10, were randomly generated, using {@link Random::nextLong} with seed 100
+    // Applied org.infinispan.commons.hash.MurmurHash3::MurmurHash3_x64_32 with seed = 0 to those values and stored in
+    // expectedPartitions32BitsX64WithZeroSeedForLongArray.
+    int[] expectedPartitions32BitsX64WithZeroSeedForLongArray = new int[]{
+        0, 1, 4, 4, 3, 3, 2, 1, 4, 0
+    };
+
+    // 10 long[] values of size 10, were randomly generated, using {@link Random::nextLong} with seed 100
+    // Applied org.infinispan.commons.hash.MurmurHash3::MurmurHash3_x64_32 with seed = 0 to those values and stored in
+    // expectedPartitions32BitsX64WithNonZeroSeedForLongArray.
+    int[] expectedPartitions32BitsX64WithNonZeroSeedForLongArray = new int[]{
+        4, 1, 4, 2, 1, 2, 3, 2, 4, 4
     };
 
     // 10 String values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
     // Applied com.google.common.hash.hashing::murmur3_32_fixed with seed = 0 to those values and stored in
     // expectedMurmurValuesFor32BitX64WithZeroSeed.
-    // stored the results in expectedPartitions32BitsX86WithZeroSeed.
     int[] expectedPartitions32BitsX86WithZeroSeed = new int[]{
         4, 3, 3, 2, 3, 4, 0, 3, 1, 4
     };
@@ -516,7 +545,6 @@ public class PartitionFunctionTest {
     // 10 String values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
     // Applied com.google.common.hash.hashing::murmur3_32_fixed with seed = 9001 to those values and stored in
     // expectedMurmurValuesFor32BitX64WithZeroSeed.
-    // stored the results in expectedPartitions32BitsX64WithZeroSeed.
     int[] expectedPartitions32BitsX86WithNonZeroSeed = new int[]{
         2, 1, 3, 2, 2, 1, 1, 4, 4, 2
     };
@@ -544,10 +572,22 @@ public class PartitionFunctionTest {
     // x86_32 bit variant with seed = 9001.
     Murmur3PartitionFunction murmur3PartitionFunction4 = new Murmur3PartitionFunction(numPartitions, functionConfig);
 
-    // generate the same 10 String values.
-    // Apply the partition function and compare with stored results.
-    testPartitionFunctionEquivalence(murmur3PartitionFunction1, expectedPartitions32BitsX64WithZeroSeed);
-    testPartitionFunctionEquivalence(murmur3PartitionFunction2, expectedPartitions32BitsX64WithNonZeroSeed);
+    // Generate the same 10 String values. Test if the calculated values are equal for both String and byte[] and if the
+    // values are equal to the expected values for the x64_32 variant with seed = 0 and x64_32 variant with seed = 9001.
+    testPartitionFunctionEquivalenceWithStringAndByteArray(murmur3PartitionFunction1,
+        expectedPartitions32BitsX64WithZeroSeedForByteArrayAndString);
+    testPartitionFunctionEquivalenceWithStringAndByteArray(murmur3PartitionFunction2,
+        expectedPartitions32BitsX64WithNonZeroSeedForByteArrayAndString);
+
+    // Generate the same 10 long[] values. Test if the calculated values are equal to the expected values for the x64_32
+    // variant with seed = 0 and x64_32 variant with seed = 9001.
+    testPartitionFunctionEquivalenceWithLongArray(murmur3PartitionFunction1,
+        expectedPartitions32BitsX64WithZeroSeedForLongArray);
+    testPartitionFunctionEquivalenceWithLongArray(murmur3PartitionFunction2,
+        expectedPartitions32BitsX64WithNonZeroSeedForLongArray);
+
+    // Generate the same 10 String values. Test if the calculated values are equal to the expected values for the x86_32
+    // variant with seed = 0 and x86_32 variant with seed = 9001.
     testPartitionFunctionEquivalence(murmur3PartitionFunction3, expectedPartitions32BitsX86WithZeroSeed);
     testPartitionFunctionEquivalence(murmur3PartitionFunction4, expectedPartitions32BitsX86WithNonZeroSeed);
   }
@@ -587,6 +627,108 @@ public class PartitionFunctionTest {
     }
   }
 
+  private void testPartitionFunctionEquivalenceWithStringAndByteArray(PartitionFunction partitionFunction,
+      int[] expectedPartitions) {
+    long seed = 100;
+    Random random = new Random(seed);
+
+    // Generate 10 random String values of size 7, using {@link Random::nextBytes} with seed 100
+    // Apply given partition function
+    // compare with expectedPartitions
+    byte[] array = new byte[7];
+    for (int expectedPartitionNumber : expectedPartitions) {
+      random.nextBytes(array);
+      String nextString = new String(array, UTF_8);
+      int actualPartitionNumberFromString = partitionFunction.getPartition(nextString);
+      int actualPartitionNumberFromByteArray = partitionFunction.getPartition(nextString.getBytes(UTF_8));
+      assertEquals(actualPartitionNumberFromString, actualPartitionNumberFromByteArray);
+      assertEquals(actualPartitionNumberFromString, expectedPartitionNumber);
+    }
+  }
+
+  private void testPartitionFunctionEquivalenceWithLongArray(PartitionFunction partitionFunction,
+      int[] expectedPartitions) {
+    int seed = 100;
+    Random random = new Random(seed);
+
+    // Create a list of 10 long[] values using ArrayList, each of size 10.
+    List<long[]> longList = new ArrayList<>();
+
+    for (int i = 0; i < 10; i++) {
+      long[] longArray = new long[10];
+      for (int j = 0; j < 10; j++) {
+        longArray[j] = random.nextLong();
+      }
+      longList.add(longArray);
+    }
+
+    // Apply the partition function and compare with expected values.
+    for (int i = 0; i < 10; i++) {
+      int actualPartitionNumberFromLongArray = partitionFunction.getPartition(longList.get(i));
+      assertEquals(actualPartitionNumberFromLongArray, expectedPartitions[i]);
+    }
+  }
+
+  private void testMurmur3HashEquivalenceForDifferentDataTypes(int hashSeed, int[] expectedHashValues, String dataType,
+      String variant) {
+    long seed = 100;
+    Random random;
+    int numPartitions = 5;
+    Murmur3PartitionFunction murmur3PartitionFunction = new Murmur3PartitionFunction(numPartitions, null);
+
+    switch (dataType.toLowerCase()) {
+      case "string":
+        // Generate 10 random String values of size 7, using {@link Random::nextBytes} with seed 100
+        // Apply given partition function
+        // compare with expectedPartitions
+        random = new Random(seed);
+        byte[] array1 = new byte[7];
+        for (int expectedHashValue : expectedHashValues) {
+          random.nextBytes(array1);
+          String nextString = new String(array1, UTF_8);
+          int actualHashValueFromString = murmur3PartitionFunction.murmurHash332BitsX64(nextString, hashSeed);
+          assertEquals(actualHashValueFromString, expectedHashValue);
+        }
+        break;
+      case "bytearray":
+        // Generate 10 random String values of size 7, using {@link Random::nextBytes} with seed 100
+        // Apply given partition function
+        // compare with expectedPartitions
+        random = new Random(seed);
+        int actualHashValueFromByteArray;
+        byte[] array2 = new byte[7];
+        for (int expectedHashValue : expectedHashValues) {
+          random.nextBytes(array2);
+          if (variant.equals("x64_32")) {
+            actualHashValueFromByteArray = murmur3PartitionFunction.murmurHash332BitsX64(array2, hashSeed);
+          } else {
+            actualHashValueFromByteArray = murmur3PartitionFunction.murmurHash332BitsX86(array2, hashSeed);
+          }
+          assertEquals(actualHashValueFromByteArray, expectedHashValue);
+        }
+        break;
+      case "longarray":
+        random = new Random(seed);
+        // Create a list of 10 long[] values using ArrayList, each of size 10.
+        List<long[]> longList = new ArrayList<>();
+
+        for (int i = 0; i < 10; i++) {
+          long[] longArray = new long[10];
+          for (int j = 0; j < 10; j++) {
+            longArray[j] = random.nextLong();
+          }
+          longList.add(longArray);
+        }
+
+        // Apply the partition function and compare with expected values.
+        for (int i = 0; i < 10; i++) {
+          int actualHashValueFromLongArray = murmur3PartitionFunction.murmurHash332BitsX64(longList.get(i), hashSeed);
+          assertEquals(actualHashValueFromLongArray, expectedHashValues[i]);
+        }
+        break;
+        default:
+    }
+  }
   private void testToStringAndPartitionNumber(PartitionFunction partitionFunction, int testValueForGetPartition,
       int numPartitions) {
     int partition1 = partitionFunction.getPartition(testValueForGetPartition);

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
@@ -204,6 +204,90 @@ public class PartitionFunctionTest {
     }
   }
 
+  @Test
+  public void testMurmur3Equivalence() {
+    long seed = 100;
+    int numberOfPartitions = 5;
+    Random random = new Random(seed);
+
+    Murmur3PartitionFunction murmur3PartitionFunction = new Murmur3PartitionFunction(numberOfPartitions, null);
+
+    // 10 values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
+    // Applied org.infinispan.commons.hash.MurmurHash3::MurmurHash3_x64_32 with seed = 0 to those values and stored in
+    // expectedMurmurValuesFor32BitX64WithZeroSeed.
+
+    int[] expectedMurmurValuesFor32BitX64WithZeroSeed = new int[]{
+        -1569442405, -921191038, 16439113, -881572510, 2111401876, 655879980, 1409856380, -1348364123, -1770645361,
+        1277101955
+    };
+
+    // Generate the same values as above - 10 random values of size 7, using {@link Random::nextBytes} with seed 100
+    // Apply {@link Murmur3PartitionFunction::murmurHash332bitsX64}. Here seed = 0.
+    // compare with stored results.
+    byte[] array = new byte[7];
+    for (int expectedMurmur3Value : expectedMurmurValuesFor32BitX64WithZeroSeed) {
+      random.nextBytes(array);
+      int actualMurmurValue = murmur3PartitionFunction.murmurHash332bitsX64(array, 0);
+      assertEquals(actualMurmurValue, expectedMurmur3Value);
+    }
+
+    // 10 values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
+    // Applied org.infinispan.commons.hash.MurmurHash3::MurmurHash3_x64_32 with seed = 9001 to those values and
+    // stored in expectedMurmurValuesFor32BitX64WithNonZeroSeed.
+
+    int[] expectedMurmurValuesFor32BitX64WithNonZeroSeed = new int[]{
+        698083240, 174075836, -938825597, 155806634, -831733828, 319389887, -939822329, -1785781936, -1796939240,
+        757512622
+    };
+
+    // Generate the same values as above - 10 random values of size 7, using {@link Random::nextBytes} with seed 100
+    // Apply {@link Murmur3PartitionFunction::murmurHash332bitsX64}. Here seed = 9001.
+    // compare with stored results.
+    random = new Random(seed);
+    array = new byte[7];
+    for (int expectedMurmur3Value : expectedMurmurValuesFor32BitX64WithNonZeroSeed) {
+      random.nextBytes(array);
+      int actualMurmurValue = murmur3PartitionFunction.murmurHash332bitsX64(array, 9001);
+      assertEquals(actualMurmurValue, expectedMurmur3Value);
+    }
+
+    // 10 values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
+    // Applied com.google.common.hash.hashing::murmur3_32_fixed to those values with seed = 0 and stored in
+    // expectedMurmurValuesFor32BitX86WithZeroSeed.
+    int[] expectedMurmurValuesFor32BitX86WithZeroSeed = new int[]{
+        1255034832, -395463542, 659973067, 1070436837, -1193041642, -1412829846, -483463488, -1385092001, 568671606,
+        -807299446,
+    };
+
+    // Generate the same values as above - 10 random values of size 7, using {@link Random::nextBytes} with seed 100
+    // Apply {@link Murmur3PartitionFunction::murmurHash332bitsX86}. Here seed = 0.
+    // compare with stored results.
+    random = new Random(seed);
+    for (int expectedMurmur3Value : expectedMurmurValuesFor32BitX86WithZeroSeed) {
+      random.nextBytes(array);
+      int actualMurmurValue = murmur3PartitionFunction.murmurHash332bitsX86(array, 0);
+      assertEquals(actualMurmurValue, expectedMurmur3Value);
+    }
+
+    // 10 values of size 7, were randomly generated, using {@link Random::nextBytes} with seed 100
+    // Applied com.google.common.hash.hashing::murmur3_32_fixed to those values with seed = 9001 and stored in
+    // expectedMurmurValuesFor32BitX86WithNonZeroSeed.
+    int[] expectedMurmurValuesFor32BitX86WithNonZeroSeed = new int[]{
+        -590969347, -315366997, 1642137565, -1732240651, -597560989, -1430018124, -448506674, 410998174, -1912106487,
+        -19253806,
+    };
+
+    // Generate the same values as above - 10 random values of size 7, using {@link Random::nextBytes} with seed 100
+    // Apply {@link Murmur3PartitionFunction::murmurHash332bitsX86}. Here seed = 9001.
+    // compare with stored results
+    random = new Random(seed);
+    for (int expectedMurmur3Value : expectedMurmurValuesFor32BitX86WithNonZeroSeed) {
+      random.nextBytes(array);
+      int actualMurmurValue = murmur3PartitionFunction.murmurHash332bitsX86(array, 9001);
+      assertEquals(actualMurmurValue, expectedMurmur3Value);
+    }
+  }
+
   /**
    * Unit test for {@link MurmurPartitionFunction}.
    * <ul>

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
@@ -170,10 +170,25 @@ public class PartitionFunctionTest {
       PartitionFunction partitionFunction4 =
           PartitionFunctionFactory.getPartitionFunction(functionName, numPartitions, functionConfig);
 
+      // Put variant value as "x86_32" in function config.
+      functionConfig.put("variant", "x86_32");
+
+      // Put seed value as 0 in function config.
+      functionConfig.put("seed", "0");
+
+      // Create partition function with function config present with variant provided as "x86_32" in function config.
+      PartitionFunction partitionFunction5 =
+          PartitionFunctionFactory.getPartitionFunction(functionName, numPartitions, functionConfig);
+
+      // Partition number should be equal as partitionNumWithNullConfig and partitionNumWithNoSeedValue as this is
+      // default behavior.
+      assertEquals(partitionFunction5.getPartition(valueTobeHashed), partitionNumWithNullConfig);
+
       testBasicProperties(partitionFunction1, functionName, numPartitions);
-      testBasicProperties(partitionFunction2, functionName, numPartitions);
-      testBasicProperties(partitionFunction3, functionName, numPartitions);
-      testBasicProperties(partitionFunction4, functionName, numPartitions);
+      testBasicProperties(partitionFunction2, functionName, numPartitions, functionConfig);
+      testBasicProperties(partitionFunction3, functionName, numPartitions, functionConfig);
+      testBasicProperties(partitionFunction4, functionName, numPartitions, functionConfig);
+      testBasicProperties(partitionFunction5, functionName, numPartitions, functionConfig);
 
       for (int j = 0; j < NUM_ROUNDS; j++) {
         int value = j == 0 ? Integer.MIN_VALUE : random.nextInt();
@@ -199,6 +214,12 @@ public class PartitionFunctionTest {
         // check for the partition function with non-null function config and with seed value and variant.
         partition1 = partitionFunction4.getPartition(value);
         partition2 = partitionFunction4.getPartition(Integer.toString(value));
+        assertEquals(partition1, partition2);
+        assertTrue(partition1 >= 0 && partition1 < numPartitions);
+
+        // check for the partition function with non-null function config and with seed value and variant.
+        partition1 = partitionFunction5.getPartition(value);
+        partition2 = partitionFunction5.getPartition(Integer.toString(value));
         assertEquals(partition1, partition2);
         assertTrue(partition1 >= 0 && partition1 < numPartitions);
       }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.segment.spi.partition;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.hash.Hashing;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
@@ -687,7 +687,7 @@ public class PartitionFunctionTest {
         for (int expectedHashValue : expectedHashValues) {
           random.nextBytes(array1);
           String nextString = new String(array1, UTF_8);
-          int actualHashValueFromString = murmur3PartitionFunction.murmurHash332BitsX64(nextString, hashSeed);
+          int actualHashValueFromString = murmur3PartitionFunction.murmur3Hash32BitsX64(nextString, hashSeed);
           assertEquals(actualHashValueFromString, expectedHashValue);
         }
         break;
@@ -701,9 +701,9 @@ public class PartitionFunctionTest {
         for (int expectedHashValue : expectedHashValues) {
           random.nextBytes(array2);
           if (variant.equals("x64_32")) {
-            actualHashValueFromByteArray = murmur3PartitionFunction.murmurHash332BitsX64(array2, hashSeed);
+            actualHashValueFromByteArray = murmur3PartitionFunction.murmur3Hash32BitsX64(array2, hashSeed);
           } else {
-            actualHashValueFromByteArray = murmur3PartitionFunction.murmurHash332BitsX86(array2, hashSeed);
+            actualHashValueFromByteArray = murmur3PartitionFunction.murmur3Hash32BitsX86(array2, hashSeed);
           }
           assertEquals(actualHashValueFromByteArray, expectedHashValue);
         }
@@ -723,7 +723,7 @@ public class PartitionFunctionTest {
 
         // Apply the partition function and compare with expected values.
         for (int i = 0; i < 10; i++) {
-          int actualHashValueFromLongArray = murmur3PartitionFunction.murmurHash332BitsX64(longList.get(i), hashSeed);
+          int actualHashValueFromLongArray = murmur3PartitionFunction.murmur3Hash32BitsX64(longList.get(i), hashSeed);
           assertEquals(actualHashValueFromLongArray, expectedHashValues[i]);
         }
         break;

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
@@ -163,9 +163,16 @@ public class PartitionFunctionTest {
       PartitionFunction partitionFunction3 =
           PartitionFunctionFactory.getPartitionFunction(functionName, numPartitions, functionConfig);
 
+      // Create partition function with function config present with random seed value
+      // and with variant provided as "x64_32" in function config.
+      functionConfig.put("variant", "x64_32");
+      PartitionFunction partitionFunction4 =
+          PartitionFunctionFactory.getPartitionFunction(functionName, numPartitions, functionConfig);
+
       testBasicProperties(partitionFunction1, functionName, numPartitions);
       testBasicProperties(partitionFunction2, functionName, numPartitions);
       testBasicProperties(partitionFunction3, functionName, numPartitions);
+      testBasicProperties(partitionFunction4, functionName, numPartitions);
 
       for (int j = 0; j < NUM_ROUNDS; j++) {
         int value = j == 0 ? Integer.MIN_VALUE : random.nextInt();
@@ -185,6 +192,12 @@ public class PartitionFunctionTest {
         // check for the partition function with non-null function config and with seed value.
         partition1 = partitionFunction3.getPartition(value);
         partition2 = partitionFunction3.getPartition(Integer.toString(value));
+        assertEquals(partition1, partition2);
+        assertTrue(partition1 >= 0 && partition1 < numPartitions);
+
+        // check for the partition function with non-null function config and with seed value and variant.
+        partition1 = partitionFunction4.getPartition(value);
+        partition2 = partitionFunction4.getPartition(Integer.toString(value));
         assertEquals(partition1, partition2);
         assertTrue(partition1 >= 0 && partition1 < numPartitions);
       }

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
@@ -572,8 +572,9 @@ public class PartitionFunctionTest {
     // x86_32 bit variant with seed = 9001.
     Murmur3PartitionFunction murmur3PartitionFunction4 = new Murmur3PartitionFunction(numPartitions, functionConfig);
 
-    // Generate the same 10 String values. Test if the calculated values are equal for both String and byte[] and if the
-    // values are equal to the expected values for the x64_32 variant with seed = 0 and x64_32 variant with seed = 9001.
+    // Generate the same 10 String values. Test if the calculated values are equal for both String and byte[] (they
+    // should be equal when String is converted to byte[]) and if the values are equal to the expected values for the
+    // x64_32 variant with seed = 0 and x64_32 variant with seed = 9001.
     testPartitionFunctionEquivalenceWithStringAndByteArray(murmur3PartitionFunction1,
         expectedPartitions32BitsX64WithZeroSeedForByteArrayAndString);
     testPartitionFunctionEquivalenceWithStringAndByteArray(murmur3PartitionFunction2,


### PR DESCRIPTION
Currently pinot supports murmur2 as a partition function. This PR adds support for murmur3 as a partition function.

# Release Notes
* Added support for Murmur3 as a partition function.
* Added support for adding optional field `seed` and `variant` for the hash in `functionConfig` field of `columnPartitionMap` for Murmur3.
* default value for `seed` is 0.
* Added support for 2 variants of `Murmur3`: `x86_32` and `x64_32` configurable using the `variant` field in `functionConfig`
    * `x86_32` is Guava's version of the original implementation of Murmur3 32 bit hash for x86 architecture.
    * `x64_32` was not part of the original implementation but is a variant which reduces the bits from `x64_128` variant of the implementation. I have taken this implementation from `Infinispan` which is also used by `Debezium`. 
    * If no variant is provided we choose to keep the `x86_32` variant as it was part of the original implementation.
* Examples of `functionConfig`;
    ```   
    "tableIndexConfig": {
          ..
          "segmentPartitionConfig": {
            "columnPartitionMap": {
              "memberId": {
                "functionName": "Murmur3",
                "numPartitions": 3 
              },
              ..
            }
          }
    ```
Here there is no functionConfig configured, so the `seed` value will be `0` and variant will be `x86_32`.

    ```   
    "tableIndexConfig": {
          ..
          "segmentPartitionConfig": {
            "columnPartitionMap": {
              "memberId": {
                "functionName": "Murmur3",
                "numPartitions": 3,
                "functionConfig": {
                   "seed": "9001"
                 },
              },
              ..
            }
          }
    ```
Here the `seed` is configured as `9001` but as no variant is provided, `x86_32` will be picked up.  

    ```   
    "tableIndexConfig": {
          ..
          "segmentPartitionConfig": {
            "columnPartitionMap": {
              "memberId": {
                "functionName": "Murmur3",
                "numPartitions": 3,
                "functionConfig" :{
                   "seed": "9001"
                   "variant": "x64_32"
                 },
              },
              ..
            }
          }
    ```
Here the `variant` is mentioned so Murmur3 will use the `x64_32` variant with `9001` as seed. 

* Note on users using `Debezium` and `Murmur3` as partitioning function : 
    * The partitioning key should be set up on either of `byte[]`, `String` or `long[]` columns.  
    * On pinot `variant` should be set as `x64_32` and `seed` should be set as `9001`.


