### PR TITLE
Bug Fix: Ensure thread-safety while consuming pulsar messages

### DIFF
--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/src/main/java/org/apache/pinot/plugin/stream/pulsar/PulsarPartitionLevelConsumer.java
@@ -21,6 +21,7 @@ package org.apache.pinot.plugin.stream.pulsar;
 import com.google.common.collect.Iterables;
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -75,7 +76,7 @@ public class PulsarPartitionLevelConsumer extends PulsarPartitionLevelConnection
     final MessageId endMessageId =
         endMsgOffset == null ? MessageId.latest : ((MessageIdStreamOffset) endMsgOffset).getMessageId();
 
-    List<PulsarStreamMessage> messagesList = new ArrayList<>();
+    List<PulsarStreamMessage> messagesList = Collections.synchronizedList(new ArrayList<>());
     Future<PulsarMessageBatch> pulsarResultFuture =
         _executorService.submit(() -> fetchMessages(startMessageId, endMessageId, messagesList));
 


### PR DESCRIPTION
Whenever we reach a fetchTimeout In PulsarConsumer, we can run into an issue whereby we use `forEach` on the messages list to read the data while also simultaneously adding data to the list. 

This happens irregularly because there can be a small delay when we send the `cancel` signal to the executor vs when the task is actually cancelled.  The end result is a `ConcurrentModificationException`


The solution is to use a synchronisedList in place of vanilla array list to ensure thread safe execution.

Another solution can be to ensure the executor gets shutdown completely before triggering `forEach`. However there's no hard time limit on how long can executor take to stop which is why I didn't take this approach