### PR TITLE
[multistage][cleanup] remove some unused rules

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
@@ -49,10 +49,8 @@ public class PinotQueryRuleSets {
           // push project through set operation
           CoreRules.PROJECT_SET_OP_TRANSPOSE,
 
-          // aggregation and projection rules
-          CoreRules.AGGREGATE_PROJECT_PULL_UP_CONSTANTS,
-          // push a projection past a filter or vice versa
-          CoreRules.PROJECT_FILTER_TRANSPOSE, CoreRules.FILTER_PROJECT_TRANSPOSE,
+          // push a filter past a project
+          CoreRules.FILTER_PROJECT_TRANSPOSE,
           // push a projection to the children of a join
           // push all expressions to handle the time indicator correctly
           CoreRules.JOIN_CONDITION_PUSH,

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotQueryRuleSets.java
@@ -51,8 +51,7 @@ public class PinotQueryRuleSets {
 
           // push a filter past a project
           CoreRules.FILTER_PROJECT_TRANSPOSE,
-          // push a projection to the children of a join
-          // push all expressions to handle the time indicator correctly
+          // push parts of the join condition to its inputs
           CoreRules.JOIN_CONDITION_PUSH,
           // remove identity project
           CoreRules.PROJECT_REMOVE,
@@ -62,14 +61,19 @@ public class PinotQueryRuleSets {
           // push project through WINDOW
           CoreRules.PROJECT_WINDOW_TRANSPOSE,
 
-          // TODO: Revisit and see if they can be replaced with CoreRules.PROJECT_REDUCE_EXPRESSIONS and
-          //       CoreRules.FILTER_REDUCE_EXPRESSIONS
+          // literal rules
+          // TODO: Revisit and see if they can be replaced with
+          //     CoreRules.PROJECT_REDUCE_EXPRESSIONS and
+          //     CoreRules.FILTER_REDUCE_EXPRESSIONS
           PinotEvaluateLiteralRule.Project.INSTANCE, PinotEvaluateLiteralRule.Filter.INSTANCE,
 
+          // sort join rules
           // TODO: evaluate the SORT_JOIN_TRANSPOSE and SORT_JOIN_COPY rules
 
           // join rules
           CoreRules.JOIN_PUSH_EXPRESSIONS,
+
+          // join and semi-join rules
           CoreRules.PROJECT_TO_SEMI_JOIN,
           PinotAggregateToSemiJoinRule.INSTANCE,
 


### PR DESCRIPTION
- project-filter and filter-project basically is a filter-project b/c after https://github.com/apache/pinot/pull/10409  many rules are basically not applied due to the one-rule-per-program 
- literal pull up is not needed anymore b/c of the pinot literal rules
