### PR TITLE
Fix rebalance on upsert table

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignment.java
@@ -58,7 +58,14 @@ import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateM
  */
 public class StrictRealtimeSegmentAssignment extends RealtimeSegmentAssignment {
 
-  // Cache segment partition id to avoid ZK reads
+  // Cache segment partition id to avoid ZK reads.
+  // NOTE:
+  // 1. This cache is used for table rebalance only, but not segment assignment. During rebalance, rebalanceTable() can
+  //    be invoked multiple times when the ideal state changes during the rebalance process.
+  // 2. The cache won't be refreshed when an existing segment is replaced with a segment from a different partition.
+  //    Replacing a segment with a segment from a different partition should not be allowed for upsert table because it
+  //    will cause the segment being served by the wrong servers. If this happens during the table rebalance, another
+  //    rebalance might be needed to fix the assignment.
   private final Object2IntOpenHashMap<String> _segmentPartitionIdMap = new Object2IntOpenHashMap<>();
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignment.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/assignment/segment/StrictRealtimeSegmentAssignment.java
@@ -19,15 +19,21 @@
 package org.apache.pinot.controller.helix.core.assignment.segment;
 
 import com.google.common.base.Preconditions;
+import it.unimi.dsi.fastutil.objects.Object2IntOpenHashMap;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.TreeMap;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.assignment.InstancePartitions;
 import org.apache.pinot.common.metrics.ControllerMeter;
+import org.apache.pinot.common.tier.Tier;
 import org.apache.pinot.common.utils.LLCSegmentName;
+import org.apache.pinot.common.utils.SegmentUtils;
+import org.apache.pinot.controller.helix.core.rebalance.RebalanceConfig;
 import org.apache.pinot.spi.config.table.assignment.InstancePartitionsType;
-import org.apache.pinot.spi.utils.CommonConstants;
+import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 
 
 /**
@@ -52,70 +58,29 @@ import org.apache.pinot.spi.utils.CommonConstants;
  */
 public class StrictRealtimeSegmentAssignment extends RealtimeSegmentAssignment {
 
+  // Cache segment partition id to avoid ZK reads
+  private final Object2IntOpenHashMap<String> _segmentPartitionIdMap = new Object2IntOpenHashMap<>();
+
   @Override
   public List<String> assignSegment(String segmentName, Map<String, Map<String, String>> currentAssignment,
       Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap) {
     Preconditions.checkState(instancePartitionsMap.size() == 1, "One instance partition type should be provided");
-    Map.Entry<InstancePartitionsType, InstancePartitions> typeToInstancePartitions =
-        instancePartitionsMap.entrySet().iterator().next();
-    InstancePartitionsType instancePartitionsType = typeToInstancePartitions.getKey();
-    InstancePartitions instancePartitions = typeToInstancePartitions.getValue();
-    Preconditions.checkState(instancePartitionsType == InstancePartitionsType.CONSUMING,
-        "Only CONSUMING instance partition type is allowed for table using upsert but got: " + instancePartitionsType);
+    InstancePartitions instancePartitions = instancePartitionsMap.get(InstancePartitionsType.CONSUMING);
+    Preconditions.checkState(instancePartitions != null, "Failed to find CONSUMING instance partitions for table: %s",
+        _tableNameWithType);
     _logger.info("Assigning segment: {} with instance partitions: {} for table: {}", segmentName, instancePartitions,
         _tableNameWithType);
-    int segmentPartitionId =
-        SegmentAssignmentUtils.getRealtimeSegmentPartitionId(segmentName, _tableNameWithType, _helixManager,
-            _partitionColumn);
-    List<String> instancesAssigned = assignConsumingSegment(segmentPartitionId, instancePartitions);
-    // Iterate the idealState to find the first segment that's in the same table partition with the new segment, and
-    // check if their assignments are same. We try to derive the partition id from segment name to avoid ZK reads.
-    Set<String> idealAssignment = null;
-    List<String> nonStandardSegments = new ArrayList<>();
-    for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
-      // Skip OFFLINE segments as they are not rebalanced, so their assignment in idealState can be stale.
-      if (isOfflineSegment(entry.getValue())) {
-        continue;
-      }
-      LLCSegmentName llcSegmentName = LLCSegmentName.of(entry.getKey());
-      if (llcSegmentName == null) {
-        nonStandardSegments.add(entry.getKey());
-        continue;
-      }
-      if (llcSegmentName.getPartitionGroupId() == segmentPartitionId) {
-        idealAssignment = entry.getValue().keySet();
-        break;
-      }
-    }
-    if (idealAssignment == null && !nonStandardSegments.isEmpty()) {
-      if (_logger.isDebugEnabled()) {
-        int segmentCnt = nonStandardSegments.size();
-        if (segmentCnt <= 10) {
-          _logger.debug("Check ZK metadata of {} segments: {} for any one also from partition: {}", segmentCnt,
-              nonStandardSegments, segmentPartitionId);
-        } else {
-          _logger.debug("Check ZK metadata of {} segments: {}... for any one also from partition: {}", segmentCnt,
-              nonStandardSegments.subList(0, 10), segmentPartitionId);
-        }
-      }
-      // Check ZK metadata for segments with non-standard LLC segment names to look for a segment that's in the same
-      // table partition with the new segment.
-      for (String nonStandardSegment : nonStandardSegments) {
-        if (SegmentAssignmentUtils.getRealtimeSegmentPartitionId(nonStandardSegment, _tableNameWithType, _helixManager,
-            _partitionColumn) == segmentPartitionId) {
-          idealAssignment = currentAssignment.get(nonStandardSegment).keySet();
-          break;
-        }
-      }
-    }
-    // Check if the candidate assignment is consistent with idealState. Use idealState if not.
-    if (idealAssignment == null) {
+
+    int partitionId = getPartitionId(segmentName);
+    List<String> instancesAssigned = assignConsumingSegment(partitionId, instancePartitions);
+    Set<String> existingAssignment = getExistingAssignment(partitionId, currentAssignment);
+    // Check if the candidate assignment is consistent with existing assignment. Use existing assignment if not.
+    if (existingAssignment == null) {
       _logger.info("No existing assignment from idealState, using the one decided by instancePartitions");
-    } else if (!isSameAssignment(idealAssignment, instancesAssigned)) {
+    } else if (!isSameAssignment(existingAssignment, instancesAssigned)) {
       _logger.warn("Assignment: {} is inconsistent with idealState: {}, using the one from idealState",
-          instancesAssigned, idealAssignment);
-      instancesAssigned.clear();
-      instancesAssigned.addAll(idealAssignment);
+          instancesAssigned, existingAssignment);
+      instancesAssigned = new ArrayList<>(existingAssignment);
       if (_controllerMetrics != null) {
         _controllerMetrics.addMeteredTableValue(_tableNameWithType,
             ControllerMeter.CONTROLLER_REALTIME_TABLE_SEGMENT_ASSIGNMENT_MISMATCH, 1L);
@@ -126,12 +91,100 @@ public class StrictRealtimeSegmentAssignment extends RealtimeSegmentAssignment {
     return instancesAssigned;
   }
 
+  /**
+   * Returns the existing assignment for the given partition id, or {@code null} if there is no existing segment for the
+   * partition. We try to derive the partition id from segment name to avoid ZK reads.
+   */
+  @Nullable
+  private Set<String> getExistingAssignment(int partitionId, Map<String, Map<String, String>> currentAssignment) {
+    List<String> uploadedSegments = new ArrayList<>();
+    for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
+      // Skip OFFLINE segments as they are not rebalanced, so their assignment in idealState can be stale.
+      if (isOfflineSegment(entry.getValue())) {
+        continue;
+      }
+      LLCSegmentName llcSegmentName = LLCSegmentName.of(entry.getKey());
+      if (llcSegmentName == null) {
+        uploadedSegments.add(entry.getKey());
+        continue;
+      }
+      if (llcSegmentName.getPartitionGroupId() == partitionId) {
+        return entry.getValue().keySet();
+      }
+    }
+    // Check ZK metadata for uploaded segments to look for a segment that's in the same partition
+    for (String uploadedSegment : uploadedSegments) {
+      if (getPartitionId(uploadedSegment) == partitionId) {
+        return currentAssignment.get(uploadedSegment).keySet();
+      }
+    }
+    return null;
+  }
+
+  /**
+   * Returns {@code true} if all instances are OFFLINE (neither ONLINE nor CONSUMING), {@code false} otherwise.
+   */
+  private boolean isOfflineSegment(Map<String, String> instanceStateMap) {
+    return !instanceStateMap.containsValue(SegmentStateModel.ONLINE) && !instanceStateMap.containsValue(
+        SegmentStateModel.CONSUMING);
+  }
+
+  /**
+   * Returns the partition id of the given segment.
+   */
+  private int getPartitionId(String segmentName) {
+    Integer partitionId =
+        SegmentUtils.getRealtimeSegmentPartitionId(segmentName, _tableNameWithType, _helixManager, _partitionColumn);
+    Preconditions.checkState(partitionId != null, "Failed to find partition id for segment: %s of table: %s",
+        segmentName, _tableNameWithType);
+    return partitionId;
+  }
+
+  /**
+   * Returns {@code true} if the ideal assignment and the actual assignment are the same, {@code false} otherwise.
+   */
   private boolean isSameAssignment(Set<String> idealAssignment, List<String> instancesAssigned) {
     return idealAssignment.size() == instancesAssigned.size() && idealAssignment.containsAll(instancesAssigned);
   }
 
-  private boolean isOfflineSegment(Map<String, String> instanceStateMap) {
-    return !instanceStateMap.containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE)
-        && !instanceStateMap.containsValue(CommonConstants.Helix.StateModel.SegmentStateModel.CONSUMING);
+  @Override
+  public Map<String, Map<String, String>> rebalanceTable(Map<String, Map<String, String>> currentAssignment,
+      Map<InstancePartitionsType, InstancePartitions> instancePartitionsMap, @Nullable List<Tier> sortedTiers,
+      @Nullable Map<String, InstancePartitions> tierInstancePartitionsMap, RebalanceConfig config) {
+    Preconditions.checkState(instancePartitionsMap.size() == 1, "One instance partition type should be provided");
+    InstancePartitions instancePartitions = instancePartitionsMap.get(InstancePartitionsType.CONSUMING);
+    Preconditions.checkState(instancePartitions != null, "Failed to find CONSUMING instance partitions for table: %s",
+        _tableNameWithType);
+    Preconditions.checkArgument(config.isIncludeConsuming(),
+        "Consuming segment must be included when rebalancing upsert table: %s", _tableNameWithType);
+    Preconditions.checkState(sortedTiers == null, "Tiers must not be specified for upsert table: %s",
+        _tableNameWithType);
+    _logger.info("Rebalancing table: {} with instance partitions: {}", _tableNameWithType, instancePartitions);
+
+    Map<String, Map<String, String>> newAssignment = new TreeMap<>();
+    for (Map.Entry<String, Map<String, String>> entry : currentAssignment.entrySet()) {
+      String segmentName = entry.getKey();
+      Map<String, String> instanceStateMap = entry.getValue();
+      if (isOfflineSegment(instanceStateMap)) {
+        // Keep the OFFLINE segments not moved, and RealtimeSegmentValidationManager will periodically detect the
+        // OFFLINE segments and re-assign them
+        newAssignment.put(segmentName, instanceStateMap);
+      } else {
+        // Reassign CONSUMING and COMPLETED segments
+        List<String> instancesAssigned =
+            assignConsumingSegment(getPartitionIdUsingCache(segmentName), instancePartitions);
+        String state = instanceStateMap.containsValue(SegmentStateModel.CONSUMING) ? SegmentStateModel.CONSUMING
+            : SegmentStateModel.ONLINE;
+        newAssignment.put(segmentName, SegmentAssignmentUtils.getInstanceStateMap(instancesAssigned, state));
+      }
+    }
+    return newAssignment;
+  }
+
+  /**
+   * Returns the partition id of the given segment, using cached partition id if exists.
+   */
+  private int getPartitionIdUsingCache(String segmentName) {
+    return _segmentPartitionIdMap.computeIntIfAbsent(segmentName, this::getPartitionId);
   }
 }


### PR DESCRIPTION
#11628 introduced the feature to assign segments for upsert table based on the existing segment assignment. It can potentially cause new segment mis-assigned during rebalance when rebalancer tries to reuse the target assignment.

This PR fixes the issue by always re-calculate target assignment for `StrictRealtimeSegmentAssignment`, and enhances `StrictRealtimeSegmentAssignment` to cache the segment partition id to reduce the cost of rebalance.