### PR TITLE
create new default credential as attempt to fix the conn shutdown issue

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -116,7 +116,7 @@ public class S3PinotFS extends BasePinotFS {
             AwsBasicCredentials.create(s3Config.getAccessKey(), s3Config.getSecretKey());
         awsCredentialsProvider = StaticCredentialsProvider.create(awsBasicCredentials);
       } else {
-        awsCredentialsProvider = DefaultCredentialsProvider.create();
+        awsCredentialsProvider = DefaultCredentialsProvider.builder().build();
       }
 
       // IAM Role based access


### PR DESCRIPTION
Trying to fix [issue](https://github.com/apache/pinot/issues/11761).

Basically, the `DefaultCredentialsProvider.resolveCredentials` failed due to conn pool shutdown. DefaultCredentialsProvider.create() returned a shared instance and it could be closed when the S3PinotFS instance got closed, so here we try to create and return a new instance of default credential for each S3PinotFS instance.