### PR TITLE
Consolidate two for loops when poll data Block from multi stream consumers 

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java
@@ -204,16 +204,8 @@ public abstract class BlockingMultiStreamConsumer<E> implements AutoCloseable {
    */
   @Nullable
   private E readBlockOrNull() {
-    // in case _lastRead is _mailboxes.size() - 1, we just skip this loop.
-    for (int i = _lastRead + 1; i < _mailboxes.size(); i++) {
-      AsyncStream<E> mailbox = _mailboxes.get(i);
-      E block = mailbox.poll();
-      if (block != null) {
-        _lastRead = i;
-        return block;
-      }
-    }
-    for (int i = 0; i <= _lastRead; i++) {
+    int len = _mailboxes.size();
+    for (int count = len, i = (_lastRead + 1) % len; count > 0; count--, i = (i + 1) % len) {
       AsyncStream<E> mailbox = _mailboxes.get(i);
       E block = mailbox.poll();
       if (block != null) {


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Consolidated two loops into single modular loop that polls all mailboxes once without early return\.

```mermaid
flowchart TD
  N0["Compute len #61; #95;mailboxes#46;size#40;#41; #40;F1#41;"]:::stModified
  N1["Init count #61; len#44; i #61; #40;#95;lastRead #43; 1#41; #37; len #40;F1#41;"]:::stModified
  N2["Check loop condition count #62; 0 #40;F1#41;"]:::stModified
  N3["Get mailbox #61; #95;mailboxes#46;get#40;i#41; #40;F1#41;"]:::stModified
  N4["Poll block #61; mailbox#46;poll#40;#41; #40;F1#41;"]:::stModified
  N5["Check if block #33;#61; null #40;F1#41;"]:::stModified
  N6["Update count#45;#45;#44; i #61; #40;i #43; 1#41; #37; len #40;F1#41;"]:::stModified
  N0 -->|"value transfer#58; len used to initialise count and i"| N1
  N1 -->|"control flow#58; init to condition"| N2
  N2 -->|"control flow#58; condition true #45;#62; loop body"| N3
  N3 -->|"sequential#58; get mailbox then poll"| N4
  N4 -->|"sequential#58; poll result used in null check"| N5
  N5 -->|"control flow#58; after if block #40;empty#41; proceeds to loop update"| N6
  N6 -->|"control flow#58; loop update re#8209;evaluates condition"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-query\-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer\.java — [before](https://github.com/apache/pinot/blob/b9ed378355acc5313ebc1031510671f7045f29a9/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java) · [after](https://github.com/apache/pinot/blob/b05a2e17af6fc79ffcfb1ac3eb45ac44b2bd6dbd/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/utils/BlockingMultiStreamConsumer.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImI5ZWQzNzgzNTVhY2M1MzEzZWJjMTAzMTUxMDY3MWY3MDQ1ZjI5YTkiLCJjb250ZXh0X2hhc2giOiI3OGQzODk0NTNkMTI3OGMwM2VlMDM1M2U3N2I0NDk5NGY3YjJkMTczYTU1YTA0NWFhNTcyZjQ1OTg4MjkxMWEwIiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTkzOTkwLCJoZWFkX3NoYSI6ImIwNWEyZTE3YWY2ZmM3OWZmY2ZiMWFjM2ViNDVhYzQ0YjJiZDZkYmQiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJiOWVkMzc4MzU1YWNjNTMxM2ViYzEwMzE1MTA2NzFmNzA0NWYyOWE5IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature a70025acb61c98d30ec983fb70ded7d0d914e7973fd204c8262c60ff8ba201db -->
<!-- pinot-pr-flow:end -->

Leverage the modular arithmetic to avoid code duplication.