### PR TITLE
Catch-all Regex for JXM -> Prom Exporter

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
@@ -172,9 +172,16 @@ rules:
     table: "$3"
     tableType: "$4"
     partition: "$5"
+  #when there is no partition in the metric
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\\"?><>(\\w+)"
+  name: "pinot_$1_$2_$5"
+  cache: true
+  labels:
+    table: "$3"
+    tableType: "$4"
   #This is a catch-all pattern for pinot table metrics with offline/realtime suffix that also contain kafka topic
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"?><>(\\w+)"
-  name: "pinot_$1_$2_$6"
+  name: "pinot_$1_$2_$7"
   cache: true
   labels:
     table: "$3"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
@@ -159,6 +159,12 @@ rules:
   ## In case a metric does not fit the catch-all patterns, add them before this comment
   # This is a catch-all pattern for pinot table metrics with offline/realtime suffix without kafka topic
   # Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$4_$5"
+  cache: true
+  labels:
+    table: "$2"
+    tableType: "$3"
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_$2_$6"
   cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/broker.yml
@@ -157,15 +157,24 @@ rules:
 
   ## Metrics that fit the catch-all patterns above should not be added to this file.
   ## In case a metric does not fit the catch-all patterns, add them before this comment
-
-  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix.
+  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix without kafka topic
   # Patterns after this line may be skipped.
-- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
-  name: "pinot_$1_$4_$5"
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$2_$6"
   cache: true
   labels:
-    table: "$2"
-    tableType: "$3"
+    table: "$3"
+    tableType: "$4"
+    partition: "$5"
+  #This is a catch-all pattern for pinot table metrics with offline/realtime suffix that also contain kafka topic
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$2_$6"
+  cache: true
+  labels:
+    table: "$3"
+    tableType: "$4"
+    topic: "$5"
+    partition: "$6"
   # This is a catch-all pattern for pinot table metrics. Patterns after this line may be skipped.
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_$3_$4"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -224,13 +224,20 @@ rules:
     partition: "$5"
   #This is a catch-all pattern for pinot table metrics with offline/realtime suffix that also contain kafka topic
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"?><>(\\w+)"
-  name: "pinot_$1_$2_$6"
+  name: "pinot_$1_$2_$7"
   cache: true
   labels:
     table: "$3"
     tableType: "$4"
     topic: "$5"
     partition: "$6"
+  #when there is no partition in the metric
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\\"?><>(\\w+)"
+  name: "pinot_$1_$2_$5"
+  cache: true
+  labels:
+    table: "$3"
+    tableType: "$4"
   # This is a catch-all pattern for pinot table metrics. Patterns after this line may be skipped.
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_$3_$4"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -207,15 +207,24 @@ rules:
 
   ## Metrics that fit the catch-all patterns above should not be added to this file.
   ## In case a metric does not fit the catch-all patterns, add them before this comment
-
-  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix.
+  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix without kafka topic
   # Patterns after this line may be skipped.
-- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
-  name: "pinot_$1_$4_$5"
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$2_$6"
   cache: true
   labels:
-    table: "$2"
-    tableType: "$3"
+    table: "$3"
+    tableType: "$4"
+    partition: "$5"
+  #This is a catch-all pattern for pinot table metrics with offline/realtime suffix that also contain kafka topic
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$2_$6"
+  cache: true
+  labels:
+    table: "$3"
+    tableType: "$4"
+    topic: "$5"
+    partition: "$6"
   # This is a catch-all pattern for pinot table metrics. Patterns after this line may be skipped.
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_$3_$4"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/controller.yml
@@ -209,6 +209,12 @@ rules:
   ## In case a metric does not fit the catch-all patterns, add them before this comment
   # This is a catch-all pattern for pinot table metrics with offline/realtime suffix without kafka topic
   # Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$4_$5"
+  cache: true
+  labels:
+    table: "$2"
+    tableType: "$3"
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_$2_$6"
   cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/pinot.yml
@@ -503,7 +503,7 @@ rules:
   ## Metrics that fit the catch-all patterns above should not be added to this file.
   ## In case a metric does not fit the catch-all patterns, add them before this comment
 
-  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix.
+  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix without topic or partition info
   # Patterns after this line may be skipped.
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_$4_$5"
@@ -511,6 +511,31 @@ rules:
   labels:
     table: "$2"
     tableType: "$3"
+  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix without topic but containing partition
+  # Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$2_$6"
+  cache: true
+  labels:
+    table: "$3"
+    tableType: "$4"
+    partition: "$5"
+  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix with topic and partition
+  # Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$2_$7"
+  cache: true
+  labels:
+    table: "$3"
+    tableType: "$4"
+    topic: "$5"
+    partition: "$6"
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\\"?><>(\\w+)"
+  name: "pinot_$1_$2_$5"
+  cache: true
+  labels:
+    table: "$3"
+    tableType: "$4"
   # This is a catch-all pattern for pinot table metrics. Patterns after this line may be skipped.
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_$3_$4"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -31,14 +31,14 @@ rules:
     tableType: "$2"
     topic: "$3"
     partition: "$4"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.highestStreamOffsetConsumed.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"><>(\\w+)"
-  name: "pinot_server_highestStreamOffsetConsumed_$5"
-  cache: true
-  labels:
-    table: "$1"
-    tableType: "$2"
-    topic: "$3"
-    partition: "$4"
+#- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.highestStreamOffsetConsumed.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"><>(\\w+)"
+#  name: "pinot_server_highestStreamOffsetConsumed_$5"
+#  cache: true
+#  labels:
+#    table: "$1"
+#    tableType: "$2"
+#    topic: "$3"
+#    partition: "$4"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.lastRealtimeSegment(\\w+)Seconds.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"><>(\\w+)"
   name: "pinot_server_lastRealtimeSegment$1Seconds_$6"
   cache: true
@@ -50,21 +50,21 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.llcControllerResponse(\\w+)\"><>(\\w+)"
   name: "pinot_server_llcControllerResponse_$1_$2"
   cache: true
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.llcPartitionConsuming.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"><>(\\w+)"
-  name: "pinot_server_llcPartitionConsuming_$5"
-  cache: true
-  labels:
-    table: "$1"
-    tableType: "$2"
-    topic: "$3"
-    partition: "$4"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeIngestionDelayMs.([^\\.]*?)_(OFFLINE|REALTIME)\\.(\\w+)\"><>(\\w+)"
-  name: "pinot_server_realtimeIngestionDelayMs_$4"
-  cache: true
-  labels:
-    table: "$1"
-    tableType: "$2"
-    partition: "$3"
+#- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.llcPartitionConsuming.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"><>(\\w+)"
+#  name: "pinot_server_llcPartitionConsuming_$5"
+#  cache: true
+#  labels:
+#    table: "$1"
+#    tableType: "$2"
+#    topic: "$3"
+#    partition: "$4"
+#- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeIngestionDelayMs.([^\\.]*?)_(OFFLINE|REALTIME)\\.(\\w+)\"><>(\\w+)"
+#  name: "pinot_server_realtimeIngestionDelayMs_$4"
+#  cache: true
+#  labels:
+#    table: "$1"
+#    tableType: "$2"
+#    partition: "$3"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.llcSimultaneousSegmentBuilds\"><>(\\w+)"
   name: "pinot_server_llcSimultaneousSegmentBuilds_$1"
   cache: true
@@ -112,44 +112,44 @@ rules:
   cache: true
   labels:
     table: "$1"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.numResizes.([^\\.]*?)_(OFFLINE|REALTIME)\"><>(\\w+)"
-  name: "pinot_server_numResizes_$3"
-  cache: true
-  labels:
-    table: "$1"
-    tableType: "$2"
+#- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.numResizes.([^\\.]*?)_(OFFLINE|REALTIME)\"><>(\\w+)"
+#  name: "pinot_server_numResizes_$3"
+#  cache: true
+#  labels:
+#    table: "$1"
+#    tableType: "$2"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.resizeTimeMs.([^\\.]*?)_(OFFLINE|REALTIME)\"><>(\\w+)"
   name: "pinot_server_resizeTimeMs_$3"
   cache: true
   labels:
     table: "$1"
     tableType: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.upsertPrimaryKeysCount.([^\\.]*?)_(OFFLINE|REALTIME).(\\w+)\"><>(\\w+)"
-  name: "pinot_server_upsertPrimaryKeysCount_$4"
-  cache: true
-  labels:
-    table: "$1"
-    tableType: "$2"
-    partition: "$3"
+#- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.upsertPrimaryKeysCount.([^\\.]*?)_(OFFLINE|REALTIME).(\\w+)\"><>(\\w+)"
+#  name: "pinot_server_upsertPrimaryKeysCount_$4"
+#  cache: true
+#  labels:
+#    table: "$1"
+#    tableType: "$2"
+#    partition: "$3"
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.version\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_version"
   cache: true
   labels:
     version: "$2"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.upsertValidDocSnapshotCount.([^\\.]*?)_(OFFLINE|REALTIME).(\\w+)\"><>(\\w+)"
-  name: "pinot_server_upsertValidDocSnapshotCount_$4"
-  cache: true
-  labels:
-    table: "$1"
-    tableType: "$2"
-    partition: "$3"
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.upsertPrimaryKeysInSnapshotCount.([^\\.]*?)_(OFFLINE|REALTIME).(\\w+)\"><>(\\w+)"
-  name: "pinot_server_upsertPrimaryKeysInSnapshotCount_$4"
-  cache: true
-  labels:
-    table: "$1"
-    tableType: "$2"
-    partition: "$3"
+#- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.upsertValidDocIdSnapshotCount.([^\\.]*?)_(OFFLINE|REALTIME).(\\w+)\"><>(\\w+)"
+#  name: "pinot_server_upsertValidDocIdSnapshotCount_$4"
+#  cache: true
+#  labels:
+#    table: "$1"
+#    tableType: "$2"
+#    partition: "$3"
+#- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.upsertPrimaryKeysInSnapshotCount.([^\\.]*?)_(OFFLINE|REALTIME).(\\w+)\"><>(\\w+)"
+#  name: "pinot_server_upsertPrimaryKeysInSnapshotCount_$4"
+#  cache: true
+#  labels:
+#    table: "$1"
+#    tableType: "$2"
+#    partition: "$3"
 #grpc related metrics
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.grpc(.+)\"><>(\\w+)"
   name: "pinot_server_grpc$1_$2"
@@ -157,15 +157,24 @@ rules:
 
   ## Metrics that fit the catch-all patterns above should not be added to this file.
   ## In case a metric does not fit the catch-all patterns, add them before this comment
-
-  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix.
+  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix without kafka topic
   # Patterns after this line may be skipped.
-- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
-  name: "pinot_$1_$4_$5"
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$2_$6"
   cache: true
   labels:
-    table: "$2"
-    tableType: "$3"
+    table: "$3"
+    tableType: "$4"
+    partition: "$5"
+#This is a catch-all pattern for pinot table metrics with offline/realtime suffix that also contain kafka topic
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$2_$6"
+  cache: true
+  labels:
+    table: "$3"
+    tableType: "$4"
+    topic: "$5"
+    partition: "$6"
   # This is a catch-all pattern for pinot table metrics. Patterns after this line may be skipped.
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_$3_$4"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -165,6 +165,7 @@ rules:
   labels:
     table: "$2"
     tableType: "$3"
+#when there is partition but no topic in the metric
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_$2_$6"
   cache: true
@@ -172,15 +173,22 @@ rules:
     table: "$3"
     tableType: "$4"
     partition: "$5"
-#This is a catch-all pattern for pinot table metrics with offline/realtime suffix that also contains the topic
+#when there is partition and topic in the metric
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"?><>(\\w+)"
-  name: "pinot_$1_$2_$6"
+  name: "pinot_$1_$2_$7"
   cache: true
   labels:
     table: "$3"
     tableType: "$4"
     topic: "$5"
     partition: "$6"
+#when there is no partition in the metric
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\\"?><>(\\w+)"
+  name: "pinot_$1_$2_$5"
+  cache: true
+  labels:
+    table: "$3"
+    tableType: "$4"
   # This is a catch-all pattern for pinot table metrics. Patterns after this line may be skipped.
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_$3_$4"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -31,14 +31,6 @@ rules:
     tableType: "$2"
     topic: "$3"
     partition: "$4"
-#- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.highestStreamOffsetConsumed.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"><>(\\w+)"
-#  name: "pinot_server_highestStreamOffsetConsumed_$5"
-#  cache: true
-#  labels:
-#    table: "$1"
-#    tableType: "$2"
-#    topic: "$3"
-#    partition: "$4"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.lastRealtimeSegment(\\w+)Seconds.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"><>(\\w+)"
   name: "pinot_server_lastRealtimeSegment$1Seconds_$6"
   cache: true
@@ -50,21 +42,6 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.llcControllerResponse(\\w+)\"><>(\\w+)"
   name: "pinot_server_llcControllerResponse_$1_$2"
   cache: true
-#- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.llcPartitionConsuming.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"><>(\\w+)"
-#  name: "pinot_server_llcPartitionConsuming_$5"
-#  cache: true
-#  labels:
-#    table: "$1"
-#    tableType: "$2"
-#    topic: "$3"
-#    partition: "$4"
-#- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeIngestionDelayMs.([^\\.]*?)_(OFFLINE|REALTIME)\\.(\\w+)\"><>(\\w+)"
-#  name: "pinot_server_realtimeIngestionDelayMs_$4"
-#  cache: true
-#  labels:
-#    table: "$1"
-#    tableType: "$2"
-#    partition: "$3"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.llcSimultaneousSegmentBuilds\"><>(\\w+)"
   name: "pinot_server_llcSimultaneousSegmentBuilds_$1"
   cache: true
@@ -112,44 +89,17 @@ rules:
   cache: true
   labels:
     table: "$1"
-#- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.numResizes.([^\\.]*?)_(OFFLINE|REALTIME)\"><>(\\w+)"
-#  name: "pinot_server_numResizes_$3"
-#  cache: true
-#  labels:
-#    table: "$1"
-#    tableType: "$2"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.resizeTimeMs.([^\\.]*?)_(OFFLINE|REALTIME)\"><>(\\w+)"
   name: "pinot_server_resizeTimeMs_$3"
   cache: true
   labels:
     table: "$1"
     tableType: "$2"
-#- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.upsertPrimaryKeysCount.([^\\.]*?)_(OFFLINE|REALTIME).(\\w+)\"><>(\\w+)"
-#  name: "pinot_server_upsertPrimaryKeysCount_$4"
-#  cache: true
-#  labels:
-#    table: "$1"
-#    tableType: "$2"
-#    partition: "$3"
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.version\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_version"
   cache: true
   labels:
     version: "$2"
-#- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.upsertValidDocIdSnapshotCount.([^\\.]*?)_(OFFLINE|REALTIME).(\\w+)\"><>(\\w+)"
-#  name: "pinot_server_upsertValidDocIdSnapshotCount_$4"
-#  cache: true
-#  labels:
-#    table: "$1"
-#    tableType: "$2"
-#    partition: "$3"
-#- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.upsertPrimaryKeysInSnapshotCount.([^\\.]*?)_(OFFLINE|REALTIME).(\\w+)\"><>(\\w+)"
-#  name: "pinot_server_upsertPrimaryKeysInSnapshotCount_$4"
-#  cache: true
-#  labels:
-#    table: "$1"
-#    tableType: "$2"
-#    partition: "$3"
 #grpc related metrics
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.grpc(.+)\"><>(\\w+)"
   name: "pinot_server_grpc$1_$2"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -157,8 +157,14 @@ rules:
 
   ## Metrics that fit the catch-all patterns above should not be added to this file.
   ## In case a metric does not fit the catch-all patterns, add them before this comment
-  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix without kafka topic
+  # This is a catch-all pattern for pinot table metrics with offline/realtime suffix without the topic
   # Patterns after this line may be skipped.
+- pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
+  name: "pinot_$1_$4_$5"
+  cache: true
+  labels:
+    table: "$2"
+    tableType: "$3"
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\.(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_$2_$6"
   cache: true
@@ -166,7 +172,7 @@ rules:
     table: "$3"
     tableType: "$4"
     partition: "$5"
-#This is a catch-all pattern for pinot table metrics with offline/realtime suffix that also contain kafka topic
+#This is a catch-all pattern for pinot table metrics with offline/realtime suffix that also contains the topic
 - pattern: "\"?org\\.apache\\.pinot\\.common\\.metrics\"?<type=\"?\\w+\"?, name=\"?pinot\\.(\\w+)\\.(\\w+)\\.(\\w+)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+)\"?><>(\\w+)"
   name: "pinot_$1_$2_$6"
   cache: true


### PR DESCRIPTION
Recently, we detected that the catch-all label was incorrect - It failed to capture a metric for which a specific regex had not been added. It also does not capture metrics that contain the kafka topic in the name. This PR fixes these problems. Commented regexes are captured with catch-all, I have kept them as they can come in handy later.

Commented metrics are exported successfully:

<img width="1294" alt="Screenshot 2023-11-30 at 12 37 27 PM" src="https://github.com/apache/pinot/assets/84911643/c367107a-dc9e-4e18-ae52-3823ed237186">

<img width="1220" alt="Screenshot 2023-11-30 at 12 38 46 PM" src="https://github.com/apache/pinot/assets/84911643/e13c6471-7c90-444b-9034-e5b5fc9a53e5">

<img width="1300" alt="Screenshot 2023-11-30 at 12 39 44 PM" src="https://github.com/apache/pinot/assets/84911643/f3e0d740-a59e-48bc-a4f5-cf3ffb8303f3">
<img width="1660" alt="Screenshot 2023-11-30 at 12 40 03 PM" src="https://github.com/apache/pinot/assets/84911643/9b16fda9-1324-42e5-92bc-9107e2b7eec4">


<img width="1153" alt="Screenshot 2023-11-30 at 12 40 19 PM" src="https://github.com/apache/pinot/assets/84911643/2928fc82-5a7a-4856-a616-bf4c8bc917b2">

<img width="1660" alt="Screenshot 2023-11-30 at 12 40 32 PM" src="https://github.com/apache/pinot/assets/84911643/4d18883f-dbb3-48db-9bd5-7d2b06fea846">

<img width="1383" alt="Screenshot 2023-11-30 at 12 40 47 PM" src="https://github.com/apache/pinot/assets/84911643/ac388342-57ed-411b-8cb6-041c7c0d966f">
