### PR TITLE
Expose metric for disabled tables/instances

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -390,6 +390,16 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
   }
 
   /**
+   * Sets the value of an instance gauge.
+   * @param instanceName the instance name
+   * @param gauge the gauge to use
+   * @param value the value to set the gauge to
+   */
+  public void setValueOfInstanceGauge(final String instanceName, final G gauge, final long value) {
+    final String fullGaugeName = gauge.getGaugeName() + "." + instanceName;
+    setValueOfGauge(value, fullGaugeName);
+  }
+  /**
    * Sets the value of a table partition gauge.
    *
    * @param tableName The table name

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -147,7 +147,11 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   FAILED_TO_COPY_SCHEMA_COUNT("failedToCopySchemaCount", true),
 
   // Number of tables that we want to fix but failed to update table config
-  FAILED_TO_UPDATE_TABLE_CONFIG_COUNT("failedToUpdateTableConfigCount", true);
+  FAILED_TO_UPDATE_TABLE_CONFIG_COUNT("failedToUpdateTableConfigCount", true),
+  //indicates if a particular table is disabled
+  TABLE_DISABLED("tableDisabled", false),
+  //indicates if a particular instance is disabled
+  INSTANCE_DISABLED("instanceDisabled", false);
 
   private final String _gaugeName;
   private final String _unit;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -112,6 +112,7 @@ import org.apache.pinot.common.metadata.ZKMetadataProvider;
 import org.apache.pinot.common.metadata.controllerjob.ControllerJobType;
 import org.apache.pinot.common.metadata.instance.InstanceZKMetadata;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.metrics.ControllerGauge;
 import org.apache.pinot.common.metrics.ControllerMetrics;
 import org.apache.pinot.common.minion.MinionTaskMetadataUtils;
 import org.apache.pinot.common.restlet.resources.EndReplaceSegmentsRequest;
@@ -2002,10 +2003,12 @@ public class PinotHelixResourceManager {
         } catch (HelixException e) {
           LOGGER.warn("Caught exception while resetting resource: {}", tableNameWithType, e);
         }
+        _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_DISABLED, 0);
         return PinotResourceManagerResponse.success(
             "Table: " + tableNameWithType + " enabled (reset success = " + resetSuccessful + ")");
       case DISABLE:
         _helixAdmin.enableResource(_helixClusterName, tableNameWithType, false);
+        _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_DISABLED, 1);
         return PinotResourceManagerResponse.success("Table: " + tableNameWithType + " disabled");
       case DROP:
         TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableNameWithType);
@@ -3031,10 +3034,12 @@ public class PinotHelixResourceManager {
   }
 
   public PinotResourceManagerResponse enableInstance(String instanceName) {
+    _controllerMetrics.setValueOfInstanceGauge(instanceName, ControllerGauge.INSTANCE_DISABLED, 0);
     return enableInstance(instanceName, true, 10_000L);
   }
 
   public PinotResourceManagerResponse disableInstance(String instanceName) {
+    _controllerMetrics.setValueOfInstanceGauge(instanceName, ControllerGauge.INSTANCE_DISABLED, 1);
     return enableInstance(instanceName, false, 10_000L);
   }
 


### PR DESCRIPTION
This PR exposes metrics to track disabled tables/instances. Such metrics can be useful in filtering cases where some behaviour is triggered by users. For example, high ingestion lag on tables that are disabled.

Behaviour:
Disabled table: `pinot.controller.tableDisabled.airlineStats_REALTIME` = 1 
Enabled tabled: `pinot.controller.tableDisabled.airlineStats_REALTIME` = 0 OR if this metric is missing.

The caveat here is that these metrics will not be reported when the controller restarts. If it restarts when a table was disabled, the behaviour would flip.