### PR TITLE
Bump up the parquet version to 1.13.1

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -34,7 +34,7 @@
   <properties>
     <pinot.root>${basedir}/..</pinot.root>
     <spark.version>3.2.1</spark.version>
-    <airlift.version>0.16</airlift.version>
+    <airlift.version>0.21</airlift.version>
   </properties>
   <dependencies>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -122,7 +122,7 @@
     <SKIP_INTEGRATION_TESTS>true</SKIP_INTEGRATION_TESTS>
     <!-- Configuration for unit/integration tests section 1 of 3 (properties) ENDS HERE.-->
     <avro.version>1.10.2</avro.version>
-    <parquet.version>1.12.3</parquet.version>
+    <parquet.version>1.13.1</parquet.version>
     <helix.version>1.3.1</helix.version>
     <zkclient.version>0.7</zkclient.version>
     <jackson.version>2.12.7.20221012</jackson.version>


### PR DESCRIPTION
- Bumping up the parquet version to 1.13.1
- e.g `LZ4_RAW` codec has been added in the newer version of parquet lib.