### PR TITLE
Enabling SegmentGenerationAndPushTask to push segment to realtime table

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -65,6 +65,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.StringUtil;
 import org.apache.pinot.spi.utils.builder.ControllerRequestURLBuilder;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -1227,8 +1228,9 @@ public class FileUploadDownloadClient implements AutoCloseable {
    * @return param list
    */
   public static List<NameValuePair> makeTableParam(String tableName) {
-    return Collections.singletonList(
-        new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME, tableName));
+    return List.of(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME, tableName),
+        new BasicNameValuePair(QueryParameters.TABLE_TYPE,
+            TableNameBuilder.getTableTypeFromTableName(tableName).name()));
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -1228,9 +1228,13 @@ public class FileUploadDownloadClient implements AutoCloseable {
    * @return param list
    */
   public static List<NameValuePair> makeTableParam(String tableName) {
-    return List.of(new BasicNameValuePair(QueryParameters.TABLE_NAME, tableName),
-        new BasicNameValuePair(QueryParameters.TABLE_TYPE,
-            TableNameBuilder.getTableTypeFromTableName(tableName).name()));
+    List<NameValuePair> tableParams = new ArrayList<>();
+    tableParams.add(new BasicNameValuePair(QueryParameters.TABLE_NAME, tableName));
+    TableType tableType = TableNameBuilder.getTableTypeFromTableName(tableName);
+    if (tableType != null) {
+      tableParams.add(new BasicNameValuePair(QueryParameters.TABLE_TYPE, tableType.name()));
+    }
+    return tableParams;
   }
 
   @Override

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/FileUploadDownloadClient.java
@@ -1228,7 +1228,7 @@ public class FileUploadDownloadClient implements AutoCloseable {
    * @return param list
    */
   public static List<NameValuePair> makeTableParam(String tableName) {
-    return List.of(new BasicNameValuePair(FileUploadDownloadClient.QueryParameters.TABLE_NAME, tableName),
+    return List.of(new BasicNameValuePair(QueryParameters.TABLE_NAME, tableName),
         new BasicNameValuePair(QueryParameters.TABLE_TYPE,
             TableNameBuilder.getTableTypeFromTableName(tableName).name()));
   }

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentGenerationMinionRealtimeIngestionTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentGenerationMinionRealtimeIngestionTest.java
@@ -1,0 +1,126 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.io.File;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.task.AdhocTaskConfig;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
+import org.apache.pinot.spi.utils.JsonUtils;
+import org.apache.pinot.util.TestUtils;
+import org.testng.annotations.AfterTest;
+import org.testng.annotations.BeforeTest;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+public class SegmentGenerationMinionRealtimeIngestionTest extends BaseClusterIntegrationTest {
+  private TableConfig _realtimeTableConfig;
+  private static final String REALTIME_TABLE_NAME = "mytable";
+  private static final String REALTIME_SCHEMA_NAME = "mytable";
+
+  @BeforeTest
+  public void setUp()
+      throws Exception {
+    TestUtils.ensureDirectoriesExistAndEmpty(_tempDir, _segmentDir, _tarDir);
+
+    // Start the Pinot cluster
+    startZk();
+    startController();
+    startBroker();
+    startServer();
+    startKafka();
+    startMinion();
+
+    Schema realtimeTableSchema = createSchema();
+    addSchemaWithCustomSchemaName(realtimeTableSchema, REALTIME_SCHEMA_NAME);
+    // Unpack the Avro files
+    List<File> avroFiles = unpackAvroData(_tempDir);
+
+    // Create the realtime table
+    _realtimeTableConfig = createRealtimeTableConfig(avroFiles.get(0));
+    addTableConfig(_realtimeTableConfig);
+  }
+
+  @AfterTest
+  public void tearDown() {
+    try {
+      stopMinion();
+      stopKafka();
+      stopServer();
+      stopBroker();
+      stopController();
+      stopZk();
+    } finally {
+      FileUtils.deleteQuietly(_tempDir);
+    }
+  }
+
+  private void addSchemaWithCustomSchemaName(Schema schema, String schemaName)
+      throws IOException {
+    schema.setSchemaName(schemaName);
+    getControllerRequestClient().addSchema(schema);
+  }
+
+  /**
+   * This test validates if we are able to ingest segments into realtime table.
+   * @throws Exception
+   */
+  @Test
+  public void testIngestionIntoRealtimeTable()
+      throws Exception {
+    Map<String, String> taskConfigs = new HashMap<>();
+
+    taskConfigs.put(BatchConfigProperties.INPUT_DIR_URI, _tempDir.getAbsolutePath());
+    taskConfigs.put(BatchConfigProperties.INPUT_FORMAT, "avro");
+
+    AdhocTaskConfig adhocTaskConfig =
+        new AdhocTaskConfig("SegmentGenerationAndPushTask", REALTIME_TABLE_NAME, null, taskConfigs);
+
+    String url = getControllerBaseApiUrl() + "/tasks/execute";
+    sendPostRequest(url, JsonUtils.objectToString(adhocTaskConfig),
+        Collections.singletonMap("accept", "application/json"));
+    TestUtils.waitForCondition(aVoid -> {
+      try {
+        int totalDocs = getTotalDocs(REALTIME_TABLE_NAME);
+        return totalDocs == DEFAULT_COUNT_STAR_RESULT;
+      } catch (Exception e) {
+        return false;
+      }
+    }, 5000L, 600_000L, "Failed to load " + DEFAULT_COUNT_STAR_RESULT + " documents", true);
+    JsonNode result = postQuery("SELECT COUNT(*) FROM " + REALTIME_TABLE_NAME);
+    assertEquals(result.get("numSegmentsQueried").asInt(), 14);
+  }
+
+  private int getTotalDocs(String tableName)
+      throws Exception {
+    String query = "SELECT COUNT(*) FROM " + tableName;
+    JsonNode response = postQuery(query);
+    JsonNode resTbl = response.get("resultTable");
+    return (resTbl == null) ? 0 : resTbl.get("rows").get(0).get(0).asInt();
+  }
+}

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
@@ -48,8 +48,10 @@ import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
+import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 
@@ -59,6 +61,7 @@ import org.testng.annotations.Test;
  * todo: add test for URI push
  */
 public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
+  private String TABLE_NAME_WITH_TYPE = DEFAULT_TABLE_NAME + "_" + "OFFLINE";
 
   @Override
   protected Map<String, String> getStreamConfigs() {
@@ -136,8 +139,8 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     jobSpec.setPinotFSSpecs(Lists.newArrayList(fsSpec));
     jobSpec.setOutputDirURI(_tarDir.getAbsolutePath());
     TableSpec tableSpec = new TableSpec();
-    tableSpec.setTableName(DEFAULT_TABLE_NAME);
-    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(DEFAULT_TABLE_NAME));
+    tableSpec.setTableName(TABLE_NAME_WITH_TYPE);
+    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(TABLE_NAME_WITH_TYPE));
     jobSpec.setTableSpec(tableSpec);
     PinotClusterSpec clusterSpec = new PinotClusterSpec();
     clusterSpec.setControllerURI(getControllerBaseApiUrl());
@@ -215,7 +218,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     Schema schema = createSchema();
     addSchema(schema);
     TableConfig offlineTableConfig = createOfflineTableConfigWithConsistentPush();
-    waitForEVToDisappear(offlineTableConfig.getTableName());
+    // waitForEVToDisappear(offlineTableConfig.getTableName());
     addTableConfig(offlineTableConfig);
 
     List<File> avroFiles = getAllAvroFiles();
@@ -237,8 +240,8 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     jobSpec.setPinotFSSpecs(Lists.newArrayList(fsSpec));
     jobSpec.setOutputDirURI(_tarDir.getAbsolutePath());
     TableSpec tableSpec = new TableSpec();
-    tableSpec.setTableName(DEFAULT_TABLE_NAME);
-    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(DEFAULT_TABLE_NAME));
+    tableSpec.setTableName(TABLE_NAME_WITH_TYPE);
+    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(TABLE_NAME_WITH_TYPE));
     jobSpec.setTableSpec(tableSpec);
     PinotClusterSpec clusterSpec = new PinotClusterSpec();
     clusterSpec.setControllerURI(getControllerBaseApiUrl());

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
@@ -48,10 +48,8 @@ import org.apache.pinot.util.TestUtils;
 import org.testng.Assert;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterMethod;
-import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.BeforeMethod;
-import org.testng.annotations.BeforeTest;
 import org.testng.annotations.Test;
 
 
@@ -61,7 +59,7 @@ import org.testng.annotations.Test;
  * todo: add test for URI push
  */
 public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
-  private String TABLE_NAME_WITH_TYPE = DEFAULT_TABLE_NAME + "_" + "OFFLINE";
+  private static final String TABLE_NAME_WITH_TYPE = DEFAULT_TABLE_NAME + "_" + "OFFLINE";
 
   @Override
   protected Map<String, String> getStreamConfigs() {
@@ -218,7 +216,7 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     Schema schema = createSchema();
     addSchema(schema);
     TableConfig offlineTableConfig = createOfflineTableConfigWithConsistentPush();
-    // waitForEVToDisappear(offlineTableConfig.getTableName());
+    waitForEVToDisappear(offlineTableConfig.getTableName());
     addTableConfig(offlineTableConfig);
 
     List<File> avroFiles = getAllAvroFiles();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/SegmentUploadIntegrationTest.java
@@ -59,7 +59,6 @@ import org.testng.annotations.Test;
  * todo: add test for URI push
  */
 public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
-  private static final String TABLE_NAME_WITH_TYPE = DEFAULT_TABLE_NAME + "_" + "OFFLINE";
 
   @Override
   protected Map<String, String> getStreamConfigs() {
@@ -137,8 +136,8 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     jobSpec.setPinotFSSpecs(Lists.newArrayList(fsSpec));
     jobSpec.setOutputDirURI(_tarDir.getAbsolutePath());
     TableSpec tableSpec = new TableSpec();
-    tableSpec.setTableName(TABLE_NAME_WITH_TYPE);
-    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(TABLE_NAME_WITH_TYPE));
+    tableSpec.setTableName(DEFAULT_TABLE_NAME);
+    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(DEFAULT_TABLE_NAME));
     jobSpec.setTableSpec(tableSpec);
     PinotClusterSpec clusterSpec = new PinotClusterSpec();
     clusterSpec.setControllerURI(getControllerBaseApiUrl());
@@ -238,8 +237,8 @@ public class SegmentUploadIntegrationTest extends BaseClusterIntegrationTest {
     jobSpec.setPinotFSSpecs(Lists.newArrayList(fsSpec));
     jobSpec.setOutputDirURI(_tarDir.getAbsolutePath());
     TableSpec tableSpec = new TableSpec();
-    tableSpec.setTableName(TABLE_NAME_WITH_TYPE);
-    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(TABLE_NAME_WITH_TYPE));
+    tableSpec.setTableName(DEFAULT_TABLE_NAME);
+    tableSpec.setTableConfigURI(_controllerRequestURLBuilder.forUpdateTableConfig(DEFAULT_TABLE_NAME));
     jobSpec.setTableSpec(tableSpec);
     PinotClusterSpec clusterSpec = new PinotClusterSpec();
     clusterSpec.setControllerURI(getControllerBaseApiUrl());

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
@@ -45,13 +45,11 @@ import org.apache.pinot.plugin.minion.tasks.MinionTaskUtils;
 import org.apache.pinot.spi.annotations.minion.TaskGenerator;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableTaskConfig;
-import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.config.table.ingestion.BatchIngestionConfig;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
-import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -106,18 +104,12 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
     List<PinotTaskConfig> pinotTaskConfigs = new ArrayList<>();
 
     for (TableConfig tableConfig : tableConfigs) {
-      // Only generate tasks for OFFLINE tables
-      String offlineTableName = tableConfig.getTableName();
-      if (tableConfig.getTableType() != TableType.OFFLINE) {
-        LOGGER.warn("Skip generating SegmentGenerationAndPushTask for non-OFFLINE table: {}", offlineTableName);
-        continue;
-      }
-
+      String tableName = tableConfig.getTableName();
       TableTaskConfig tableTaskConfig = tableConfig.getTaskConfig();
       Preconditions.checkNotNull(tableTaskConfig);
       Map<String, String> taskConfigs =
           tableTaskConfig.getConfigsForTaskType(MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE);
-      Preconditions.checkNotNull(taskConfigs, "Task config shouldn't be null for Table: {}", offlineTableName);
+      Preconditions.checkNotNull(taskConfigs, "Task config shouldn't be null for Table: {}", tableName);
 
       // Get max number of tasks for this table
       int tableMaxNumTasks;
@@ -149,10 +141,10 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
           List<SegmentZKMetadata> segmentsZKMetadata = Collections.emptyList();
           // For append mode, we don't create segments for input file URIs already created.
           if (BatchConfigProperties.SegmentIngestionType.APPEND.name().equalsIgnoreCase(batchSegmentIngestionType)) {
-            segmentsZKMetadata = getSegmentsZKMetadataForTable(offlineTableName);
+            segmentsZKMetadata = getSegmentsZKMetadataForTable(tableName);
           }
           Set<String> existingSegmentInputFiles = getExistingSegmentInputFiles(segmentsZKMetadata);
-          Set<String> inputFilesFromRunningTasks = getInputFilesFromRunningTasks(offlineTableName);
+          Set<String> inputFilesFromRunningTasks = getInputFilesFromRunningTasks(tableName);
           existingSegmentInputFiles.addAll(inputFilesFromRunningTasks);
           LOGGER.info("Trying to extract input files from path: {}, "
                   + "and exclude input files from existing segments metadata: {}, "
@@ -166,7 +158,7 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
           }
           for (URI inputFileURI : inputFileURIs) {
             Map<String, String> singleFileGenerationTaskConfig =
-                getSingleFileGenerationTaskConfig(offlineTableName, tableNumTasks, batchConfigMap, inputFileURI, null);
+                getSingleFileGenerationTaskConfig(tableName, tableNumTasks, batchConfigMap, inputFileURI, null);
             pinotTaskConfigs.add(new PinotTaskConfig(MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE,
                 singleFileGenerationTaskConfig));
             tableNumTasks++;
@@ -189,12 +181,7 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
   public List<PinotTaskConfig> generateTasks(TableConfig tableConfig, Map<String, String> taskConfigs)
       throws Exception {
     String taskUUID = UUID.randomUUID().toString();
-    // Only generate tasks for OFFLINE tables
-    String offlineTableName = tableConfig.getTableName();
-    if (tableConfig.getTableType() != TableType.OFFLINE) {
-      LOGGER.warn("Skip generating SegmentGenerationAndPushTask for non-OFFLINE table: {}", offlineTableName);
-      return ImmutableList.of();
-    }
+    String tableName = tableConfig.getTableName();
 
     // Override task configs from table with adhoc task configs.
     Map<String, String> batchConfigMap = new HashMap<>();
@@ -224,8 +211,8 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
       LOGGER.info("Final input files for task config generation: {}", inputFileURIs);
       for (URI inputFileURI : inputFileURIs) {
         Map<String, String> singleFileGenerationTaskConfig =
-            getSingleFileGenerationTaskConfig(offlineTableName, tableNumTasks, batchConfigMap, inputFileURI,
-                generateFixedSegmentName(offlineTableName, taskUUID, tableNumTasks));
+            getSingleFileGenerationTaskConfig(tableName, tableNumTasks, batchConfigMap, inputFileURI,
+                generateFixedSegmentName(tableName, taskUUID, tableNumTasks));
         pinotTaskConfigs.add(new PinotTaskConfig(MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE,
             singleFileGenerationTaskConfig));
         tableNumTasks++;
@@ -243,8 +230,8 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
     }
   }
 
-  private String generateFixedSegmentName(String offlineTableName, String taskUUID, int tableNumTasks) {
-    return String.format("%s_%s_%d", offlineTableName, taskUUID, tableNumTasks);
+  private String generateFixedSegmentName(String tableName, String taskUUID, int tableNumTasks) {
+    return String.format("%s_%s_%d", tableName, taskUUID, tableNumTasks);
   }
 
   private String extractFormatFromFileSuffix(String path) {
@@ -255,10 +242,10 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
     return path.substring(lastDotPosition + 1);
   }
 
-  private Set<String> getInputFilesFromRunningTasks(String offlineTableName) {
+  private Set<String> getInputFilesFromRunningTasks(String tableName) {
     Set<String> inputFilesFromRunningTasks = new HashSet<>();
     TaskGeneratorUtils
-        .forRunningTasks(offlineTableName, MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE, _clusterInfoAccessor,
+        .forRunningTasks(tableName, MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE, _clusterInfoAccessor,
             taskConfig -> {
               String inputFileURI = taskConfig.get(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY);
               if (inputFileURI != null) {
@@ -268,7 +255,7 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
     return inputFilesFromRunningTasks;
   }
 
-  private Map<String, String> getSingleFileGenerationTaskConfig(String offlineTableName, int sequenceID,
+  private Map<String, String> getSingleFileGenerationTaskConfig(String tableName, int sequenceID,
       Map<String, String> batchConfigMap, URI inputFileURI, @Nullable String segmentName)
       throws URISyntaxException {
 
@@ -281,7 +268,7 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
 
     Map<String, String> singleFileGenerationTaskConfig = new HashMap<>(batchConfigMap);
     singleFileGenerationTaskConfig
-        .put(BatchConfigProperties.TABLE_NAME, TableNameBuilder.OFFLINE.tableNameWithType(offlineTableName));
+        .put(BatchConfigProperties.TABLE_NAME, tableName);
     singleFileGenerationTaskConfig.put(BatchConfigProperties.INPUT_DATA_FILE_URI_KEY, inputFileURI.toString());
     if (outputDirURI != null) {
       URI outputSegmentDirURI = SegmentGenerationUtils.getRelativeOutputPath(inputDirURI, inputFileURI, outputDirURI);


### PR DESCRIPTION
### Description:

Following are the changes . [Segment upload to realtime was already in this PR](SegmentGenerationAndPushTask)
1. Updated segment push utilities to pass in tableType parameter in order to push segments to realtime tables. The tableType parameter has to be passed, without which default of OFFLINE gets used by the controller API that pushes segments to tables. **makeTableParam** is the method called by push utilities
**pushSegments
sendSegmentUris
sendSegmentUriAndMetadata**
2. Minor changes in SegmentGenerationAndPushTask to allow segments to be pushed to realtime table. 

### Testing:
Integration tests for SegmentGenerationAndPushTask that validates ingestion into realtime table.


