### PR TITLE
[UI] Adds support for CTRL key as a modifier for Query shortcuts

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/Query.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Query.tsx
@@ -214,12 +214,14 @@ const QueryPage = () => {
   };
 
   const handleQueryInterfaceKeyDown = (editor, event) => {
-    // Map Cmd + Enter KeyPress to executing the query
-    if (event.metaKey == true && event.keyCode == 13) {
+    const modifiedEnabled = event.metaKey == true || event.ctrlKey == true;
+
+    // Map (Cmd/Ctrl) + Enter KeyPress to executing the query
+    if (modifiedEnabled && event.keyCode == 13) {
       handleRunNow(editor.getValue());
     }
-    // Map Cmd + / KeyPress to toggle commenting the query
-    if (event.metaKey == true && event.keyCode == 191) {
+    // Map (Cmd/Ctrl) + / KeyPress to toggle commenting the query
+    if (modifiedEnabled && event.keyCode == 191) {
       handleComment(editor);
     }
   }


### PR DESCRIPTION
This PR includes a simple UI enhancement, adding support for the CTRL key as a modifier on the Query page (for Windows and Linux users).

The feature was originally added on https://github.com/apache/pinot/pull/7359, but only included support for the `event.metaKey` modifier, which maps to the ⌘ key on MacOS, but really can't be used as a modifier for Windows/Linux users.

https://github.com/apache/pinot/blob/949083d8b4903cd187660aaba5d0dd55bf7c85d0/pinot-controller/src/main/resources/app/pages/Query.tsx#L216-L225

With the implementation on this PR, MacOS users could use either the Cmd (⌘) or Control (^) as modifiers.

Closes https://github.com/apache/pinot/issues/12086