### PR TITLE
Add partition level Force Commit

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -141,8 +141,10 @@ public class PinotRealtimeTableResource {
           + "only those partitions or consuming segments will be force committed.")
   public Map<String, String> forceCommit(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
-      @ApiParam(value = "Comma separated list of partitions to be committed") @QueryParam("partitions") String partitions,
-      @ApiParam(value = "Comma separated list of consuming segments to be committed") @QueryParam("segments") String consumingSegments) {
+      @ApiParam(value = "Comma separated list of partitions to be committed") @QueryParam("partitions")
+      String partitions,
+      @ApiParam(value = "Comma separated list of consuming segments to be committed") @QueryParam("segments")
+      String consumingSegments) {
     long startTimeMs = System.currentTimeMillis();
     String tableNameWithType = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     validate(tableNameWithType);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -141,8 +141,8 @@ public class PinotRealtimeTableResource {
           + "only those partitions or consuming segments will be force committed.")
   public Map<String, String> forceCommit(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
-      @ApiParam(value = "Comma separated list of partitions to be committed") @QueryParam("partitions")
-      String partitions,
+      @ApiParam(value = "Comma separated list of partition group IDs to be committed") @QueryParam("partitions")
+      String partitionGroupIds,
       @ApiParam(value = "Comma separated list of consuming segments to be committed") @QueryParam("segments")
       String consumingSegments) {
     long startTimeMs = System.currentTimeMillis();
@@ -151,7 +151,7 @@ public class PinotRealtimeTableResource {
     Map<String, String> response = new HashMap<>();
     try {
       Set<String> consumingSegmentsForceCommitted =
-          _pinotLLCRealtimeSegmentManager.forceCommit(tableNameWithType, partitions, consumingSegments);
+          _pinotLLCRealtimeSegmentManager.forceCommit(tableNameWithType, partitionGroupIds, consumingSegments);
       response.put("forceCommitStatus", "SUCCESS");
       try {
         String jobId = UUID.randomUUID().toString();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.controller.api.resources;
 
 import com.fasterxml.jackson.databind.JsonNode;
-import com.google.common.base.Preconditions;
 import io.swagger.annotations.Api;
 import io.swagger.annotations.ApiKeyAuthDefinition;
 import io.swagger.annotations.ApiOperation;

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -136,15 +136,20 @@ public class PinotRealtimeTableResource {
       notes = "Force commit the current segments in consuming state and restart consumption. "
           + "This should be used after schema/table config changes. "
           + "Please note that this is an asynchronous operation, "
-          + "and 200 response does not mean it has actually been done already")
+          + "and 200 response does not mean it has actually been done already."
+          + "If specific partitions or consuming segments are provided, "
+          + "only those partitions or consuming segments will be force committed.")
   public Map<String, String> forceCommit(
-      @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName) {
+      @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "Comma separated list of partitions to be committed") @QueryParam("partitions") String partitions,
+      @ApiParam(value = "Comma separated list of consuming segments to be committed") @QueryParam("segments") String consumingSegments) {
     long startTimeMs = System.currentTimeMillis();
     String tableNameWithType = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     validate(tableNameWithType);
     Map<String, String> response = new HashMap<>();
     try {
-      Set<String> consumingSegmentsForceCommitted = _pinotLLCRealtimeSegmentManager.forceCommit(tableNameWithType);
+      Set<String> consumingSegmentsForceCommitted =
+          _pinotLLCRealtimeSegmentManager.forceCommit(tableNameWithType, partitions, consumingSegments);
       response.put("forceCommitStatus", "SUCCESS");
       try {
         String jobId = UUID.randomUUID().toString();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1569,6 +1569,8 @@ public class PinotLLCRealtimeSegmentManager {
    */
   public Set<String> forceCommit(String tableNameWithType, @Nullable String partitionGroupIdsToCommit,
       @Nullable String segmentsToCommit) {
+    Preconditions.checkArgument(partitionGroupIdsToCommit == null || segmentsToCommit == null,
+        "Cannot specify both partitions and segments to commit");
     IdealState idealState = getIdealState(tableNameWithType);
     Set<String> allConsumingSegments = findConsumingSegments(idealState);
     Set<String> targetConsumingSegments = filterSegmentsToCommit(allConsumingSegments, partitionGroupIdsToCommit,
@@ -1585,15 +1587,15 @@ public class PinotLLCRealtimeSegmentManager {
     if (partitionGroupIdsToCommitStr == null && segmentsToCommitStr == null) {
       return allConsumingSegments;
     }
-    Preconditions.checkState(partitionGroupIdsToCommitStr == null || segmentsToCommitStr == null,
-        "Cannot specify both partitions and segments to commit");
 
     if (segmentsToCommitStr != null) {
       Set<String> segmentsToCommit = Arrays.stream(segmentsToCommitStr.split(","))
           .map(String::trim)
           .collect(Collectors.toSet());
       Preconditions.checkState(allConsumingSegments.containsAll(segmentsToCommit),
-          "Cannot commit segments that are not in CONSUMING state");
+          "Cannot commit segments that are not in CONSUMING state. "
+              + "All consuming segments: %s, provided segments to commit: %s", allConsumingSegments,
+          segmentsToCommitStr);
       return segmentsToCommit;
     }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/PinotLLCRealtimeSegmentManager.java
@@ -1569,8 +1569,6 @@ public class PinotLLCRealtimeSegmentManager {
    */
   public Set<String> forceCommit(String tableNameWithType, @Nullable String partitionGroupIdsToCommit,
       @Nullable String segmentsToCommit) {
-    Preconditions.checkArgument(partitionGroupIdsToCommit == null || segmentsToCommit == null,
-        "Cannot specify both partitions and segments to commit");
     IdealState idealState = getIdealState(tableNameWithType);
     Set<String> allConsumingSegments = findConsumingSegments(idealState);
     Set<String> targetConsumingSegments = filterSegmentsToCommit(allConsumingSegments, partitionGroupIdsToCommit,


### PR DESCRIPTION
Currently, the force-commit operation is applied to all partitions within a table. However, in certain instances, problems may arise in only a specific subset of consuming segments. Addressing these issues requires force-committing the problematic partitions, but applying force-commit to the entire table affects all partitions. This is undesirable for tables with a large number of partitions. This PR introduces partition-level force-commit functionality, expanding the endpoint to accept a comma-separated list of partitions or consuming segment names.