### PR TITLE
(WIP) Fixing partitioning function for byte array

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/MultiPartitionColumnsSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/MultiPartitionColumnsSegmentPruner.java
@@ -140,7 +140,7 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
         if (identifier != null) {
           SegmentPartitionInfo partitionInfo = columnPartitionInfoMap.get(identifier.getName());
           return partitionInfo == null || partitionInfo.getPartitions().contains(
-              partitionInfo.getPartitionFunction().getPartition(operands.get(1).getLiteral().getFieldValue()));
+              partitionInfo.getPartitionFunction().getValueToPartition(operands.get(1).getLiteral().getFieldValue()));
         } else {
           return true;
         }
@@ -155,7 +155,7 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
           int numOperands = operands.size();
           for (int i = 1; i < numOperands; i++) {
             if (partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction()
-                .getPartition(operands.get(i).getLiteral().getFieldValue().toString()))) {
+                .getValueToPartition(operands.get(i).getLiteral().getFieldValue().toString()))) {
               return true;
             }
           }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SinglePartitionColumnSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SinglePartitionColumnSegmentPruner.java
@@ -129,7 +129,7 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
         Identifier identifier = operands.get(0).getIdentifier();
         if (identifier != null && identifier.getName().equals(_partitionColumn)) {
           return partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction()
-              .getPartition(operands.get(1).getLiteral().getFieldValue().toString()));
+              .getValueToPartition(operands.get(1).getLiteral().getFieldValue().toString()));
         } else {
           return true;
         }
@@ -140,7 +140,7 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
           int numOperands = operands.size();
           for (int i = 1; i < numOperands; i++) {
             if (partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction()
-                .getPartition(operands.get(i).getLiteral().getFieldValue().toString()))) {
+                .getValueToPartition(operands.get(i).getLiteral().getFieldValue().toString()))) {
               return true;
             }
           }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -117,7 +117,7 @@ public class ColumnValueSegmentPruner extends ValueBasedSegmentPruner {
     if (partitionFunction != null) {
       Set<Integer> partitions = dataSourceMetadata.getPartitions();
       assert partitions != null;
-      if (!partitions.contains(partitionFunction.getPartition(value))) {
+      if (!partitions.contains(partitionFunction.getValueToPartition(value))) {
         return true;
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TableConfigPartitioner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TableConfigPartitioner.java
@@ -41,6 +41,6 @@ public class TableConfigPartitioner implements Partitioner {
 
   @Override
   public String getPartition(GenericRow genericRow) {
-    return String.valueOf(_partitionFunction.getPartition(genericRow.getValue(_column)));
+    return String.valueOf(_partitionFunction.getValueToPartition(genericRow.getValue(_column)));
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -680,13 +680,12 @@ public class MutableSegmentImpl implements MutableSegment {
       if (fieldSpec.isSingleValueField()) {
         // Check partitions
         if (column.equals(_partitionColumn)) {
-          Object valueToPartition = (dataType == BYTES) ? new ByteArray((byte[]) value) : value;
-          int partition = _partitionFunction.getPartition(valueToPartition);
+          int partition = _partitionFunction.getValueToPartition(value);
           if (partition != _mainPartitionId) {
             if (indexContainer._partitions.add(partition)) {
               // for every partition other than mainPartitionId, log a warning once
               _logger.warn("Found new partition: {} from partition column: {}, value: {}", partition, column,
-                  valueToPartition);
+                  value);
             }
             // always emit a metric when a partition other than mainPartitionId is detected
             if (_serverMetrics != null) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
@@ -150,7 +150,7 @@ public abstract class AbstractColumnStatisticsCollector implements ColumnStatist
    */
   protected void updatePartition(Object value) {
     if (_partitionFunction != null) {
-      _partitions.add(_partitionFunction.getPartition(value));
+      _partitions.add(_partitionFunction.getValueToPartition(value));
     }
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunction.java
@@ -21,6 +21,7 @@ package org.apache.pinot.segment.spi.partition;
 import java.io.Serializable;
 import java.util.Map;
 import javax.annotation.Nullable;
+import org.apache.pinot.spi.utils.ByteArray;
 
 
 /**
@@ -32,6 +33,18 @@ import javax.annotation.Nullable;
  */
 public interface PartitionFunction extends Serializable {
 
+  /**
+   * Translates value to the correct instance type before invoking partitioning function
+   * @param value
+   * @return
+   */
+  default int getValueToPartition(Object value) {
+    Object valueForType = value;
+    if (value instanceof byte[]) {
+      valueForType = new ByteArray((byte[]) value);
+    }
+    return getPartition(valueForType);
+  }
   /**
    * Method to compute and return partition id for the given value.
    *

--- a/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
+++ b/pinot-segment-spi/src/test/java/org/apache/pinot/segment/spi/partition/PartitionFunctionTest.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Random;
 import org.apache.pinot.spi.utils.JsonUtils;
+import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
@@ -82,6 +83,17 @@ public class PartitionFunctionTest {
         assertEquals(partitionFunction.getPartition(Long.toString(value)), expectedPartition);
       }
     }
+  }
+
+  @Test
+  public void testPartioningOnByteArray() {
+    byte[] arr1 = new byte[] {5, 1, 9, 2, 6};
+    byte[] arr2 = new byte[] {5, 1, 9, 2, 6};
+    byte[] arr3 = new byte[] {10, 1, 9, 2, 6};
+    String functionName = "mUrmur";
+    PartitionFunction partitionFunction = PartitionFunctionFactory.getPartitionFunction(functionName, 5, null);
+    Assert.assertTrue(partitionFunction.getValueToPartition(arr1) == partitionFunction.getValueToPartition(arr2));
+    Assert.assertTrue(partitionFunction.getValueToPartition(arr1) != partitionFunction.getValueToPartition(arr3));
   }
 
   /**


### PR DESCRIPTION
##Description
Our partitioning functions invokes the toString() on an Object prior to computing the partition. For native byte array, toString() translates to an address. Hence two byte arrays that have the same content, will differ, which is incorrect. [This PR ](https://github.com/apache/pinot/pull/10110) addresses issue for the realtime path. Attempting to move the logic to a common/base method to make this change available across all partitioning functions and modes (realtime/offline)

 
