### PR TITLE
need to synchronize replacing upsert segment

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -543,6 +543,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     // consuming thread can't commit the segment in time. Adding segment should be done by a single HelixTaskExecutor
     // thread but do it with segmentLock as well for simplicity.
     Lock segmentLock = SegmentLocks.getSegmentLock(_tableNameWithType, segmentName);
+    segmentLock.lock();
     try {
       SegmentDataManager oldSegmentManager = _segmentDataManagerMap.get(segmentName);
       if (oldSegmentManager == null) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -31,6 +31,7 @@ import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.locks.Lock;
 import java.util.function.BooleanSupplier;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.ThreadSafe;
@@ -61,6 +62,7 @@ import org.apache.pinot.segment.local.upsert.PartitionUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.TableUpsertMetadataManagerFactory;
 import org.apache.pinot.segment.local.utils.SchemaUtils;
+import org.apache.pinot.segment.local.utils.SegmentLocks;
 import org.apache.pinot.segment.local.utils.tablestate.TableStateUtils;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
@@ -528,22 +530,35 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     ImmutableSegmentDataManager newSegmentManager = new ImmutableSegmentDataManager(immutableSegment);
     // Register the new segment after it is fully initialized by partitionUpsertMetadataManager, e.g. to fill up its
     // validDocId bitmap. Otherwise, the query can return wrong results, if accessing the premature segment.
-    SegmentDataManager oldSegmentManager = _segmentDataManagerMap.get(segmentName);
-    if (oldSegmentManager == null) {
-      if (_tableUpsertMetadataManager.isPreloading()) {
-        partitionUpsertMetadataManager.preloadSegment(immutableSegment);
-      } else {
+    if (_tableUpsertMetadataManager.isPreloading()) {
+      // Preloading segment happens when creating table manager when server restarts, and segment is ensured to be
+      // preloaded by a single thread, so no need for segmentLock.
+      partitionUpsertMetadataManager.preloadSegment(immutableSegment);
+      registerSegment(segmentName, newSegmentManager);
+      _logger.info("Preloaded immutable segment: {} to upsert-enabled table: {}", segmentName, _tableNameWithType);
+      return;
+    }
+    // Replacing segment may happen in two threads, i.e. the consuming thread that's committing the mutable segment
+    // and a HelixTaskExecutor thread that's bringing segment from ONLINE to CONSUMING when the server finds
+    // consuming thread can't commit the segment in time. Adding segment should be done by a single HelixTaskExecutor
+    // thread but do it with segmentLock as well for simplicity.
+    Lock segmentLock = SegmentLocks.getSegmentLock(_tableNameWithType, segmentName);
+    try {
+      SegmentDataManager oldSegmentManager = _segmentDataManagerMap.get(segmentName);
+      if (oldSegmentManager == null) {
         partitionUpsertMetadataManager.addSegment(immutableSegment);
+        registerSegment(segmentName, newSegmentManager);
+        _logger.info("Added new immutable segment: {} to upsert-enabled table: {}", segmentName, _tableNameWithType);
+      } else {
+        IndexSegment oldSegment = oldSegmentManager.getSegment();
+        partitionUpsertMetadataManager.replaceSegment(immutableSegment, oldSegment);
+        registerSegment(segmentName, newSegmentManager);
+        _logger.info("Replaced {} segment: {} of upsert-enabled table: {}",
+            oldSegment instanceof ImmutableSegment ? "immutable" : "mutable", segmentName, _tableNameWithType);
+        releaseSegment(oldSegmentManager);
       }
-      registerSegment(segmentName, newSegmentManager);
-      _logger.info("Added new immutable segment: {} to upsert-enabled table: {}", segmentName, _tableNameWithType);
-    } else {
-      IndexSegment oldSegment = oldSegmentManager.getSegment();
-      partitionUpsertMetadataManager.replaceSegment(immutableSegment, oldSegment);
-      registerSegment(segmentName, newSegmentManager);
-      _logger.info("Replaced {} segment: {} of upsert-enabled table: {}",
-          oldSegment instanceof ImmutableSegment ? "immutable" : "mutable", segmentName, _tableNameWithType);
-      releaseSegment(oldSegmentManager);
+    } finally {
+      segmentLock.unlock();
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -844,8 +844,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     ImmutableSegmentImpl segment1 =
         mockImmutableSegment(1, validDocIds1, null, getPrimaryKeyList(numRecords, primaryKeys));
     // Preloading segment adds the segment without checking for upsert.
-    upsertMetadataManager.addSegmentUnsafe(segment1, validDocIds1, null,
-        getRecordInfoList(numRecords, primaryKeys, timestamps, null).iterator(), true);
+    upsertMetadataManager.doPreloadSegment(segment1, validDocIds1, null,
+        getRecordInfoList(numRecords, primaryKeys, timestamps, null).iterator());
 
     // segment1: 0 -> {0, 100}, 1 -> {1, 120}, 2 -> {2, 100}
     checkRecordLocation(recordLocationMap, 0, segment1, 0, 100, hashFunction);
@@ -861,8 +861,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     ThreadSafeMutableRoaringBitmap validDocIds2 = new ThreadSafeMutableRoaringBitmap();
     ImmutableSegmentImpl segment2 =
         mockImmutableSegment(2, validDocIds2, null, getPrimaryKeyList(numRecords, primaryKeys));
-    upsertMetadataManager.addSegmentUnsafe(segment2, validDocIds2, null,
-        getRecordInfoList(numRecords, primaryKeys, timestamps, null).iterator(), true);
+    upsertMetadataManager.doPreloadSegment(segment2, validDocIds2, null,
+        getRecordInfoList(numRecords, primaryKeys, timestamps, null).iterator());
 
     // segment1: 0 -> {0, 100}, 1 -> {1, 120}, 2 -> {2, 100}
     // segment2: 0 -> {0, 1}, 1 -> {1, 2}


### PR DESCRIPTION
For upsert table, replacing segment could happen in two threads concurrently, but there are multiple steps to replace upsert segments and not thread safe. This PR changes to do them with segmentLock to be thread safe. In fact, the partitionUpsertMetadataManager.addSegment/replaceSegment takes segmentLock inside anyway.

For upsert table, when consuming thread commits a newly built immutable segment, it needs to replace the old mutable segment, in order to update the upsert states to point to the new immutable segment. But committing segment can take longer than expected. When committing takes long to complete, server decides to download the segment as a way to help catch up ingestion quicker. The HelixTaskExecutor thread, to download and replace segment, tries to stop the consuming thread by setting a _shouldStop flag, but consuming thread doesn't check the flag once in the middle of replacing the segment. The HelixTaskExecutor thread waits up to 10min and then continues to replace the segment. Now we would get two threads replacing the same upsert segment concurrently.

In comparison, for non-upsert RT tables, it's thread safe to add or replace segments as the operation is made atomic; for OFFLINE tables, the segmentLock is taken to add or replace segment.