### PR TITLE
Fix helm chart server probe endpoint backward incompatible

### DIFF
--- a/helm/pinot/templates/server/statefulset.yaml
+++ b/helm/pinot/templates/server/statefulset.yaml
@@ -88,7 +88,7 @@ spec:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
           httpGet:
-            {{- if .Values.server.probes.livenessProbe.endpoint }}
+            {{- if and .Values.server.probes.livenessProbe .Values.server.probes.livenessProbe.endpoint}}
             path: {{ .Values.server.probes.livenessProbe.endpoint }}
             {{- else }}
             path: {{ .Values.server.probes.endpoint }}
@@ -100,7 +100,7 @@ spec:
           initialDelaySeconds: {{ .Values.probes.initialDelaySeconds }}
           periodSeconds: {{ .Values.probes.periodSeconds }}
           httpGet:
-            {{- if .Values.server.probes.readinessProbe.endpoint }}
+            {{- if and .Values.server.probes.readinessProbe .Values.server.probes.readinessProbe.endpoint}}
             path: {{ .Values.server.probes.readinessProbe.endpoint }}
             {{- else }}
             path: {{ .Values.server.probes.endpoint }}


### PR DESCRIPTION
### Change
Fix helm chart server probe endpoint backward incompatible

### Issue
https://github.com/apache/pinot/issues/12113

### Problem
Made this change previously https://github.com/apache/pinot/pull/11800
But it is not backward compatible, if someone uses the following in their helm template:
```
probes:
      livenessEnabled: true
      readinessEnabled: true
```
It will throw error:

Error: INSTALLATION FAILED: template: pinot-v2/charts/pinot/templates/server/statefulset.yaml:93:26: executing "pinot-v2/charts/pinot/templates/server/statefulset.yaml" at <.Values.server.probes.livenessProbe.endpoint>: nil pointer evaluating interface {}.endpoint

It is because the previous commit  uses `{{- if .Values.server.probes.readinessProbe.endpoint }}` but never checked the existence of `.Values.server.probes.readinessProbe`

The above template setting should fall back to use `.Values.server.probes.endpoint` instead of throwing error.

### Proposal
Change to if AND to ensure the existence of `.Values.server.probes.readinessProbe`

### Testing
* `helm dependency update`
* `helm install -f ./values.yaml pinot . -n pinot`. It can spin up the k8s pods locally.
* Edit values.yaml Test for separate liveness and readiness probe endpoint for server.
  * With only `server: probes: livenessEnabled: true` AND `server: probes: readinessEnabled: true`
    * It won't throw error
    * Liveness:   http-get http://:7443/health delay=120s timeout=1s period=20s #success=1 #failure=3
    * Readiness:  http-get http://:7443/health delay=120s timeout=1s period=20s #success=1 #failure=3
  * Adding `livenessProbe: endpoint: "/health?checkType=liveness"`, `readinessProbe: endpoint:"/health?checkType=readiness"`
     * Liveness:   http-get http://:7443/health%3FcheckType=liveness delay=120s timeout=1s period=20s #success=1 #failure=3
     * Readiness:  http-get http://:7443/health%3FcheckType=readiness delay=120s timeout=1s period=20s #success=1 #failure=3

