### PR TITLE
Fix partition handling by always using string values

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/MultiPartitionColumnsSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/MultiPartitionColumnsSegmentPruner.java
@@ -34,6 +34,7 @@ import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
+import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.sql.FilterKind;
 
 
@@ -140,7 +141,7 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
         if (identifier != null) {
           SegmentPartitionInfo partitionInfo = columnPartitionInfoMap.get(identifier.getName());
           return partitionInfo == null || partitionInfo.getPartitions().contains(
-              partitionInfo.getPartitionFunction().getPartition(operands.get(1).getLiteral().getFieldValue()));
+              partitionInfo.getPartitionFunction().getPartition(RequestContextUtils.getStringValue(operands.get(1))));
         } else {
           return true;
         }
@@ -155,7 +156,7 @@ public class MultiPartitionColumnsSegmentPruner implements SegmentPruner {
           int numOperands = operands.size();
           for (int i = 1; i < numOperands; i++) {
             if (partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction()
-                .getPartition(operands.get(i).getLiteral().getFieldValue().toString()))) {
+                .getPartition(RequestContextUtils.getStringValue(operands.get(i))))) {
               return true;
             }
           }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SinglePartitionColumnSegmentPruner.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/routing/segmentpruner/SinglePartitionColumnSegmentPruner.java
@@ -33,6 +33,7 @@ import org.apache.pinot.common.request.BrokerRequest;
 import org.apache.pinot.common.request.Expression;
 import org.apache.pinot.common.request.Function;
 import org.apache.pinot.common.request.Identifier;
+import org.apache.pinot.common.request.context.RequestContextUtils;
 import org.apache.pinot.sql.FilterKind;
 
 
@@ -129,7 +130,7 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
         Identifier identifier = operands.get(0).getIdentifier();
         if (identifier != null && identifier.getName().equals(_partitionColumn)) {
           return partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction()
-              .getPartition(operands.get(1).getLiteral().getFieldValue().toString()));
+              .getPartition(RequestContextUtils.getStringValue(operands.get(1))));
         } else {
           return true;
         }
@@ -140,7 +141,7 @@ public class SinglePartitionColumnSegmentPruner implements SegmentPruner {
           int numOperands = operands.size();
           for (int i = 1; i < numOperands; i++) {
             if (partitionInfo.getPartitions().contains(partitionInfo.getPartitionFunction()
-                .getPartition(operands.get(i).getLiteral().getFieldValue().toString()))) {
+                .getPartition(RequestContextUtils.getStringValue(operands.get(i))))) {
               return true;
             }
           }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ColumnValueSegmentPruner.java
@@ -107,9 +107,8 @@ public class ColumnValueSegmentPruner extends ValueBasedSegmentPruner {
     assert dataSource != null;
     DataSourceMetadata dataSourceMetadata = dataSource.getDataSourceMetadata();
     ValueCache.CachedValue cachedValue = valueCache.get(eqPredicate, dataSourceMetadata.getDataType());
-    Comparable value = cachedValue.getComparableValue();
     // Check min/max value
-    if (!checkMinMaxRange(dataSourceMetadata, value)) {
+    if (!checkMinMaxRange(dataSourceMetadata, cachedValue.getComparableValue())) {
       return true;
     }
     // Check column partition
@@ -117,7 +116,7 @@ public class ColumnValueSegmentPruner extends ValueBasedSegmentPruner {
     if (partitionFunction != null) {
       Set<Integer> partitions = dataSourceMetadata.getPartitions();
       assert partitions != null;
-      if (!partitions.contains(partitionFunction.getPartition(value))) {
+      if (!partitions.contains(partitionFunction.getPartition(cachedValue.getValue()))) {
         return true;
       }
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ValueBasedSegmentPruner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/pruner/ValueBasedSegmentPruner.java
@@ -200,15 +200,19 @@ abstract public class ValueBasedSegmentPruner implements SegmentPruner {
     }
 
     public static class CachedValue {
-      private final Object _value;
+      private final String _value;
       private boolean _hashed = false;
       private long _hash1;
       private long _hash2;
       private DataType _dt;
       private Comparable _comparableValue;
 
-      private CachedValue(Object value) {
+      private CachedValue(String value) {
         _value = value;
+      }
+
+      public String getValue() {
+        return _value;
       }
 
       public Comparable getComparableValue() {
@@ -218,9 +222,8 @@ abstract public class ValueBasedSegmentPruner implements SegmentPruner {
 
       public void ensureDataType(DataType dt) {
         if (dt != _dt) {
-          String strValue = _value.toString();
           _dt = dt;
-          _comparableValue = convertValue(strValue, dt);
+          _comparableValue = convertValue(_value, dt);
           _hashed = false;
         }
       }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TableConfigPartitioner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TableConfigPartitioner.java
@@ -18,10 +18,12 @@
  */
 package org.apache.pinot.core.segment.processing.partitioner;
 
+import java.math.BigDecimal;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
 import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.BytesUtils;
 
 
 /**
@@ -41,6 +43,16 @@ public class TableConfigPartitioner implements Partitioner {
 
   @Override
   public String getPartition(GenericRow genericRow) {
-    return String.valueOf(_partitionFunction.getPartition(genericRow.getValue(_column)));
+    return String.valueOf(_partitionFunction.getPartition(convertToString(genericRow.getValue(_column))));
+  }
+
+  private static String convertToString(Object value) {
+    if (value instanceof BigDecimal) {
+      return ((BigDecimal) value).toPlainString();
+    }
+    if (value instanceof byte[]) {
+      return BytesUtils.toHexString((byte[]) value);
+    }
+    return value.toString();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TableConfigPartitioner.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/partitioner/TableConfigPartitioner.java
@@ -18,12 +18,11 @@
  */
 package org.apache.pinot.core.segment.processing.partitioner;
 
-import java.math.BigDecimal;
 import org.apache.pinot.segment.spi.partition.PartitionFunction;
 import org.apache.pinot.segment.spi.partition.PartitionFunctionFactory;
 import org.apache.pinot.spi.config.table.ColumnPartitionConfig;
+import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.utils.BytesUtils;
 
 
 /**
@@ -43,16 +42,6 @@ public class TableConfigPartitioner implements Partitioner {
 
   @Override
   public String getPartition(GenericRow genericRow) {
-    return String.valueOf(_partitionFunction.getPartition(convertToString(genericRow.getValue(_column))));
-  }
-
-  private static String convertToString(Object value) {
-    if (value instanceof BigDecimal) {
-      return ((BigDecimal) value).toPlainString();
-    }
-    if (value instanceof byte[]) {
-      return BytesUtils.toHexString((byte[]) value);
-    }
-    return value.toString();
+    return String.valueOf(_partitionFunction.getPartition(FieldSpec.getStringValue(genericRow.getValue(_column))));
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -24,6 +24,7 @@ import it.unimi.dsi.fastutil.ints.IntArrays;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -103,6 +104,7 @@ import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.stream.RowMetadata;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
+import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.FixedIntArray;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.roaringbitmap.BatchIterator;
@@ -111,6 +113,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.pinot.spi.data.FieldSpec.DataType.BIG_DECIMAL;
 import static org.apache.pinot.spi.data.FieldSpec.DataType.BYTES;
 import static org.apache.pinot.spi.data.FieldSpec.DataType.STRING;
 
@@ -680,13 +683,20 @@ public class MutableSegmentImpl implements MutableSegment {
       if (fieldSpec.isSingleValueField()) {
         // Check partitions
         if (column.equals(_partitionColumn)) {
-          Object valueToPartition = (dataType == BYTES) ? new ByteArray((byte[]) value) : value;
-          int partition = _partitionFunction.getPartition(valueToPartition);
+          String stringValue;
+          if (dataType == BIG_DECIMAL) {
+            stringValue = ((BigDecimal) value).toPlainString();
+          } else if (dataType == BYTES) {
+            stringValue = BytesUtils.toHexString((byte[]) value);
+          } else {
+            stringValue = value.toString();
+          }
+          int partition = _partitionFunction.getPartition(stringValue);
           if (partition != _mainPartitionId) {
             if (indexContainer._partitions.add(partition)) {
               // for every partition other than mainPartitionId, log a warning once
               _logger.warn("Found new partition: {} from partition column: {}, value: {}", partition, column,
-                  valueToPartition);
+                  stringValue);
             }
             // always emit a metric when a partition other than mainPartitionId is detected
             if (_serverMetrics != null) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java
@@ -24,7 +24,6 @@ import it.unimi.dsi.fastutil.ints.IntArrays;
 import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
-import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -104,7 +103,6 @@ import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.stream.RowMetadata;
 import org.apache.pinot.spi.utils.BooleanUtils;
 import org.apache.pinot.spi.utils.ByteArray;
-import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.FixedIntArray;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 import org.roaringbitmap.BatchIterator;
@@ -113,7 +111,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
-import static org.apache.pinot.spi.data.FieldSpec.DataType.BIG_DECIMAL;
 import static org.apache.pinot.spi.data.FieldSpec.DataType.BYTES;
 import static org.apache.pinot.spi.data.FieldSpec.DataType.STRING;
 
@@ -683,14 +680,7 @@ public class MutableSegmentImpl implements MutableSegment {
       if (fieldSpec.isSingleValueField()) {
         // Check partitions
         if (column.equals(_partitionColumn)) {
-          String stringValue;
-          if (dataType == BIG_DECIMAL) {
-            stringValue = ((BigDecimal) value).toPlainString();
-          } else if (dataType == BYTES) {
-            stringValue = BytesUtils.toHexString((byte[]) value);
-          } else {
-            stringValue = value.toString();
-          }
+          String stringValue = dataType.toString(value);
           int partition = _partitionFunction.getPartition(stringValue);
           if (partition != _mainPartitionId) {
             if (indexContainer._partitions.add(partition)) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/AbstractColumnStatisticsCollector.java
@@ -110,6 +110,7 @@ public abstract class AbstractColumnStatisticsCollector implements ColumnStatist
    * Returns the {@link PartitionFunction} for the column.
    * @return Partition function for the column.
    */
+  @Nullable
   public PartitionFunction getPartitionFunction() {
     return _partitionFunction;
   }
@@ -143,18 +144,20 @@ public abstract class AbstractColumnStatisticsCollector implements ColumnStatist
     return _partitions;
   }
 
+  protected boolean isPartitionEnabled() {
+    return _partitionFunction != null;
+  }
+
   /**
    * Updates the partition range based on the partition of the given value.
    *
    * @param value Column value.
    */
-  protected void updatePartition(Object value) {
-    if (_partitionFunction != null) {
-      _partitions.add(_partitionFunction.getPartition(value));
-    }
+  protected void updatePartition(String value) {
+    _partitions.add(_partitionFunction.getPartition(value));
   }
 
-  void updateTotalNumberOfEntries(Object[] entries) {
+  protected void updateTotalNumberOfEntries(Object[] entries) {
     _totalNumberOfEntries += entries.length;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BigDecimalColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BigDecimalColumnPreIndexStatsCollector.java
@@ -51,7 +51,9 @@ public class BigDecimalColumnPreIndexStatsCollector extends AbstractColumnStatis
       int length = BigDecimalUtils.byteSize(value);
       addressSorted(value);
       if (_values.add(value)) {
-        updatePartition(value);
+        if (isPartitionEnabled()) {
+          updatePartition(value.toPlainString());
+        }
         _minLength = Math.min(_minLength, length);
         _maxLength = Math.max(_maxLength, length);
         _maxRowLength = _maxLength;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BytesColumnPredIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/BytesColumnPredIndexStatsCollector.java
@@ -62,7 +62,9 @@ public class BytesColumnPredIndexStatsCollector extends AbstractColumnStatistics
       ByteArray value = new ByteArray((byte[]) entry);
       addressSorted(value);
       if (_values.add(value)) {
-        updatePartition(value);
+        if (isPartitionEnabled()) {
+          updatePartition(value.toString());
+        }
         int length = value.length();
         _minLength = Math.min(_minLength, length);
         _maxLength = Math.max(_maxLength, length);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/DoubleColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/DoubleColumnPreIndexStatsCollector.java
@@ -51,7 +51,9 @@ public class DoubleColumnPreIndexStatsCollector extends AbstractColumnStatistics
       double value = (double) entry;
       addressSorted(value);
       if (_values.add(value)) {
-        updatePartition(value);
+        if (isPartitionEnabled()) {
+          updatePartition(Double.toString(value));
+        }
       }
 
       _totalNumberOfEntries++;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/FloatColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/FloatColumnPreIndexStatsCollector.java
@@ -51,7 +51,9 @@ public class FloatColumnPreIndexStatsCollector extends AbstractColumnStatisticsC
       float value = (float) entry;
       addressSorted(value);
       if (_values.add(value)) {
-        updatePartition(value);
+        if (isPartitionEnabled()) {
+          updatePartition(Float.toString(value));
+        }
       }
 
       _totalNumberOfEntries++;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/IntColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/IntColumnPreIndexStatsCollector.java
@@ -51,7 +51,9 @@ public class IntColumnPreIndexStatsCollector extends AbstractColumnStatisticsCol
       int value = (int) entry;
       addressSorted(value);
       if (_values.add(value)) {
-        updatePartition(value);
+        if (isPartitionEnabled()) {
+          updatePartition(Integer.toString(value));
+        }
       }
 
       _totalNumberOfEntries++;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/LongColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/LongColumnPreIndexStatsCollector.java
@@ -51,7 +51,9 @@ public class LongColumnPreIndexStatsCollector extends AbstractColumnStatisticsCo
       long value = (long) entry;
       addressSorted(value);
       if (_values.add(value)) {
-        updatePartition(value);
+        if (isPartitionEnabled()) {
+          updatePartition(Long.toString(value));
+        }
       }
 
       _totalNumberOfEntries++;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StringColumnPreIndexStatsCollector.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/stats/StringColumnPreIndexStatsCollector.java
@@ -62,7 +62,9 @@ public class StringColumnPreIndexStatsCollector extends AbstractColumnStatistics
       String value = (String) entry;
       addressSorted(value);
       if (_values.add(value)) {
-        updatePartition(value);
+        if (isPartitionEnabled()) {
+          updatePartition(value);
+        }
         int valueLength = value.getBytes(UTF_8).length;
         _minLength = Math.min(_minLength, valueLength);
         _maxLength = Math.max(_maxLength, valueLength);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/BoundedColumnValuePartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/BoundedColumnValuePartitionFunction.java
@@ -62,9 +62,9 @@ public class BoundedColumnValuePartitionFunction implements PartitionFunction {
   }
 
   @Override
-  public int getPartition(Object value) {
+  public int getPartition(String value) {
     for (int i = 0; i < _numPartitions - 1; i++) {
-      if (_values[i].equalsIgnoreCase(value.toString())) {
+      if (_values[i].equalsIgnoreCase(value)) {
         return i + 1;
       }
     }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ByteArrayPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ByteArrayPartitionFunction.java
@@ -42,8 +42,8 @@ public class ByteArrayPartitionFunction implements PartitionFunction {
   }
 
   @Override
-  public int getPartition(Object value) {
-    return abs(Arrays.hashCode(value.toString().getBytes(UTF_8))) % _numPartitions;
+  public int getPartition(String value) {
+    return abs(Arrays.hashCode(value.getBytes(UTF_8))) % _numPartitions;
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/HashCodePartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/HashCodePartitionFunction.java
@@ -37,8 +37,8 @@ public class HashCodePartitionFunction implements PartitionFunction {
   }
 
   @Override
-  public int getPartition(Object value) {
-    return abs(value.toString().hashCode()) % _numPartitions;
+  public int getPartition(String value) {
+    return abs(value.hashCode()) % _numPartitions;
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ModuloPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/ModuloPartitionFunction.java
@@ -49,19 +49,8 @@ public class ModuloPartitionFunction implements PartitionFunction {
    * @return Partition id for the given value.
    */
   @Override
-  public int getPartition(Object value) {
-    if (value instanceof Integer) {
-      return toNonNegative((Integer) value % _numPartitions);
-    } else if (value instanceof Long) {
-      // Since _numPartitions is int, the modulo should also be int.
-      return toNonNegative((int) ((Long) value % _numPartitions));
-    } else if (value instanceof String) {
-      // Parse String as Long, to support both Integer and Long.
-      return toNonNegative((int) (Long.parseLong((String) value) % _numPartitions));
-    } else {
-      throw new IllegalArgumentException(
-          "Illegal argument for partitioning, expected Integer, got: " + value.getClass().getSimpleName());
-    }
+  public int getPartition(String value) {
+    return toNonNegative((int) (Long.parseLong(value) % _numPartitions));
   }
 
   @Override

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/MurmurPartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/MurmurPartitionFunction.java
@@ -41,8 +41,8 @@ public class MurmurPartitionFunction implements PartitionFunction {
   }
 
   @Override
-  public int getPartition(Object value) {
-    return (murmur2(value.toString().getBytes(UTF_8)) & Integer.MAX_VALUE) % _numPartitions;
+  public int getPartition(String value) {
+    return (murmur2(value.getBytes(UTF_8)) & Integer.MAX_VALUE) % _numPartitions;
   }
 
   @Override
@@ -69,7 +69,7 @@ public class MurmurPartitionFunction implements PartitionFunction {
    * @return 32 bit hash of the given array
    */
   @VisibleForTesting
-  int murmur2(final byte[] data) {
+  static int murmur2(final byte[] data) {
     int length = data.length;
     int seed = 0x9747b28c;
     // 'm' and 'r' are mixing constants generated offline.

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunction.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunction.java
@@ -34,11 +34,12 @@ public interface PartitionFunction extends Serializable {
 
   /**
    * Method to compute and return partition id for the given value.
+   * NOTE: The value is expected to be a string representation of the actual value.
    *
    * @param value Value for which to determine the partition id.
    * @return partition id for the value.
    */
-  int getPartition(Object value);
+  int getPartition(String value);
 
   /**
    * Returns the name of the partition function.

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunctionFactory.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/partition/PartitionFunctionFactory.java
@@ -20,6 +20,7 @@ package org.apache.pinot.segment.spi.partition;
 
 import java.util.HashMap;
 import java.util.Map;
+import javax.annotation.Nullable;
 
 
 /**
@@ -68,7 +69,7 @@ public class PartitionFunctionFactory {
   // The PartitionFunctionFactory should be able to support these default implementations, as well as instantiate
   // based on config
   public static PartitionFunction getPartitionFunction(String functionName, int numPartitions,
-      Map<String, String> functionConfig) {
+      @Nullable Map<String, String> functionConfig) {
     PartitionFunctionType function = PartitionFunctionType.fromString(functionName);
     switch (function) {
       case Modulo:

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/FieldSpec.java
@@ -207,12 +207,14 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
    * @param value Value for which String value needs to be returned
    * @return String value for the object.
    */
-  protected static String getStringValue(Object value) {
+  public static String getStringValue(Object value) {
+    if (value instanceof BigDecimal) {
+      return ((BigDecimal) value).toPlainString();
+    }
     if (value instanceof byte[]) {
       return BytesUtils.toHexString((byte[]) value);
-    } else {
-      return value.toString();
     }
+    return value.toString();
   }
 
   // Required by JSON de-serializer. DO NOT REMOVE.
@@ -560,6 +562,19 @@ public abstract class FieldSpec implements Comparable<FieldSpec>, Serializable {
       } catch (Exception e) {
         throw new IllegalArgumentException(String.format("Cannot convert value: '%s' to type: %s", value, this));
       }
+    }
+
+    /**
+     * Converts the given value of the data type to string.The input value for BYTES type should be byte[].
+     */
+    public String toString(Object value) {
+      if (this == BIG_DECIMAL) {
+        return ((BigDecimal) value).toPlainString();
+      }
+      if (this == BYTES) {
+        return BytesUtils.toHexString((byte[]) value);
+      }
+      return value.toString();
     }
 
     /**


### PR DESCRIPTION
Always use string representation of the value to compute the partition so that the value from query can always match the value from the segment.
Fix the wrong handling of `BYTES` and `BIG_DECIMAL` type as partition column