### PR TITLE
Introduce UpsertContext to simplify the upsert metadata manager constructor

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -207,8 +207,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       // NOTE: Set _tableUpsertMetadataManager before initializing it because when preloading is enabled, we need to
       //       load segments into it
       _tableUpsertMetadataManager = TableUpsertMetadataManagerFactory.create(tableConfig);
-      _tableUpsertMetadataManager.init(tableConfig, schema, this, _serverMetrics, _helixManager,
-          _segmentPreloadExecutor);
+      _tableUpsertMetadataManager.init(tableConfig, schema, this, _helixManager, _segmentPreloadExecutor);
     }
 
     // For dedup and partial-upsert, need to wait for all segments loaded before starting consuming data

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -38,12 +38,12 @@ import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImp
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.upsert.ConcurrentMapPartitionUpsertMetadataManager;
+import org.apache.pinot.segment.local.upsert.UpsertContext;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
-import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.IndexConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -54,7 +54,6 @@ import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.TimeGranularitySpec;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
-import org.mockito.Mockito;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.AfterTest;
 import org.testng.annotations.BeforeClass;
@@ -62,6 +61,7 @@ import org.testng.annotations.BeforeTest;
 import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
+import static org.mockito.Mockito.mock;
 import static org.testng.Assert.assertNotNull;
 import static org.testng.Assert.assertTrue;
 
@@ -126,13 +126,17 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
   @BeforeClass
   public void loadSegment()
       throws Exception {
+    ServerMetrics.register(mock(ServerMetrics.class));
     _indexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
-    ServerMetrics serverMetrics = Mockito.mock(ServerMetrics.class);
     _upsertIndexSegment = ImmutableSegmentLoader.load(new File(INDEX_DIR, SEGMENT_NAME), ReadMode.heap);
-    ((ImmutableSegmentImpl) _upsertIndexSegment).enableUpsert(
-        new ConcurrentMapPartitionUpsertMetadataManager("testTable_REALTIME", 0, Collections.singletonList("column6"),
-            Collections.singletonList("daysSinceEpoch"), null, HashFunction.NONE, null,
-            false, 0, 0, INDEX_DIR, serverMetrics), new ThreadSafeMutableRoaringBitmap(), null);
+    UpsertContext upsertContext =
+        new UpsertContext.Builder().setTableConfig(mock(TableConfig.class)).setSchema(mock(Schema.class))
+            .setPrimaryKeyColumns(Collections.singletonList("column6"))
+            .setComparisonColumns(Collections.singletonList("daysSinceEpoch")).setTableIndexDir(INDEX_DIR).build();
+    ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
+        new ConcurrentMapPartitionUpsertMetadataManager("testTable_REALTIME", 0, upsertContext);
+    ((ImmutableSegmentImpl) _upsertIndexSegment).enableUpsert(upsertMetadataManager,
+        new ThreadSafeMutableRoaringBitmap(), null);
   }
 
   @AfterClass

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -19,9 +19,7 @@
 package org.apache.pinot.segment.local.upsert;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.io.File;
 import java.util.Iterator;
-import java.util.List;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -30,7 +28,6 @@ import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMeter;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.segment.local.segment.readers.LazyRow;
@@ -38,7 +35,6 @@ import org.apache.pinot.segment.local.utils.HashUtils;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
-import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.roaringbitmap.PeekableIntIterator;
@@ -58,12 +54,8 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
   @VisibleForTesting
   final ConcurrentHashMap<Object, RecordLocation> _primaryKeyToRecordLocationMap = new ConcurrentHashMap<>();
 
-  public ConcurrentMapPartitionUpsertMetadataManager(String tableNameWithType, int partitionId,
-      List<String> primaryKeyColumns, List<String> comparisonColumns, @Nullable String deleteRecordColumn,
-      HashFunction hashFunction, @Nullable PartialUpsertHandler partialUpsertHandler, boolean enableSnapshot,
-      double metadataTTL, double deletedKeysTTL, File tableIndexDir, ServerMetrics serverMetrics) {
-    super(tableNameWithType, partitionId, primaryKeyColumns, comparisonColumns, deleteRecordColumn,
-        hashFunction, partialUpsertHandler, enableSnapshot, metadataTTL, deletedKeysTTL, tableIndexDir, serverMetrics);
+  public ConcurrentMapPartitionUpsertMetadataManager(String tableNameWithType, int partitionId, UpsertContext context) {
+    super(tableNameWithType, partitionId, context);
   }
 
   @Override
@@ -268,15 +260,15 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
 
     int numDeletedTTLKeys = numDeletedTTLKeysRemoved.get();
     if (numDeletedTTLKeys > 0) {
-      _logger.info("Deleted {} primary keys based on deletedKeysTTL in the table {}",
-          numDeletedTTLKeys, _tableNameWithType);
+      _logger.info("Deleted {} primary keys based on deletedKeysTTL in the table {}", numDeletedTTLKeys,
+          _tableNameWithType);
       _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.DELETED_KEYS_TTL_PRIMARY_KEYS_REMOVED,
           numDeletedTTLKeys);
     }
     int numMetadataTTLKeys = numMetadataTTLKeysRemoved.get();
     if (numMetadataTTLKeys > 0) {
-      _logger.info("Deleted {} primary keys based on metadataTTL in the table {}",
-          numMetadataTTLKeys, _tableNameWithType);
+      _logger.info("Deleted {} primary keys based on metadataTTL in the table {}", numMetadataTTLKeys,
+          _tableNameWithType);
       _serverMetrics.addMeteredTableValue(_tableNameWithType, ServerMeter.METADATA_TTL_PRIMARY_KEYS_REMOVED,
           numMetadataTTLKeys);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -35,9 +35,7 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   @Override
   public ConcurrentMapPartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId) {
     return _partitionMetadataManagerMap.computeIfAbsent(partitionId,
-        k -> new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _primaryKeyColumns,
-            _comparisonColumns, _deleteRecordColumn, _hashFunction, _partialUpsertHandler,
-            _enableSnapshot, _metadataTTL, _deletedKeysTTL, _tableIndexDir, _serverMetrics));
+        k -> new ConcurrentMapPartitionUpsertMetadataManager(_tableNameWithType, k, _context));
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -23,7 +23,6 @@ import java.util.concurrent.ExecutorService;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.helix.HelixManager;
-import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
@@ -35,8 +34,9 @@ import org.apache.pinot.spi.data.Schema;
  */
 @ThreadSafe
 public interface TableUpsertMetadataManager extends Closeable {
-  void init(TableConfig tableConfig, Schema schema, TableDataManager tableDataManager, ServerMetrics serverMetrics,
-      HelixManager helixManager, @Nullable ExecutorService segmentPreloadExecutor);
+
+  void init(TableConfig tableConfig, Schema schema, TableDataManager tableDataManager, HelixManager helixManager,
+      @Nullable ExecutorService segmentPreloadExecutor);
 
   PartitionUpsertMetadataManager getOrCreatePartitionManager(int partitionId);
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
@@ -1,0 +1,197 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.upsert;
+
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.commons.collections.CollectionUtils;
+import org.apache.pinot.spi.config.table.HashFunction;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.data.Schema;
+
+
+public class UpsertContext {
+  private final TableConfig _tableConfig;
+  private final Schema _schema;
+  private final List<String> _primaryKeyColumns;
+  private final List<String> _comparisonColumns;
+  private final String _deleteRecordColumn;
+  private final HashFunction _hashFunction;
+  private final PartialUpsertHandler _partialUpsertHandler;
+  private final boolean _enableSnapshot;
+  private final boolean _enablePreload;
+  private final double _metadataTTL;
+  private final double _deletedKeysTTL;
+  private final File _tableIndexDir;
+
+  private UpsertContext(TableConfig tableConfig, Schema schema, List<String> primaryKeyColumns,
+      List<String> comparisonColumns, @Nullable String deleteRecordColumn, HashFunction hashFunction,
+      @Nullable PartialUpsertHandler partialUpsertHandler, boolean enableSnapshot, boolean enablePreload,
+      double metadataTTL, double deletedKeysTTL, File tableIndexDir) {
+    _tableConfig = tableConfig;
+    _schema = schema;
+    _primaryKeyColumns = primaryKeyColumns;
+    _comparisonColumns = comparisonColumns;
+    _deleteRecordColumn = deleteRecordColumn;
+    _hashFunction = hashFunction;
+    _partialUpsertHandler = partialUpsertHandler;
+    _enableSnapshot = enableSnapshot;
+    _enablePreload = enablePreload;
+    _metadataTTL = metadataTTL;
+    _deletedKeysTTL = deletedKeysTTL;
+    _tableIndexDir = tableIndexDir;
+  }
+
+  public TableConfig getTableConfig() {
+    return _tableConfig;
+  }
+
+  public Schema getSchema() {
+    return _schema;
+  }
+
+  public List<String> getPrimaryKeyColumns() {
+    return _primaryKeyColumns;
+  }
+
+  public List<String> getComparisonColumns() {
+    return _comparisonColumns;
+  }
+
+  public String getDeleteRecordColumn() {
+    return _deleteRecordColumn;
+  }
+
+  public HashFunction getHashFunction() {
+    return _hashFunction;
+  }
+
+  public PartialUpsertHandler getPartialUpsertHandler() {
+    return _partialUpsertHandler;
+  }
+
+  public boolean isSnapshotEnabled() {
+    return _enableSnapshot;
+  }
+
+  public boolean isPreloadEnabled() {
+    return _enablePreload;
+  }
+
+  public double getMetadataTTL() {
+    return _metadataTTL;
+  }
+
+  public double getDeletedKeysTTL() {
+    return _deletedKeysTTL;
+  }
+
+  public File getTableIndexDir() {
+    return _tableIndexDir;
+  }
+
+  public static class Builder {
+    private TableConfig _tableConfig;
+    private Schema _schema;
+    private List<String> _primaryKeyColumns;
+    private List<String> _comparisonColumns;
+    private String _deleteRecordColumn;
+    private HashFunction _hashFunction = HashFunction.NONE;
+    private PartialUpsertHandler _partialUpsertHandler;
+    private boolean _enableSnapshot;
+    private boolean _enablePreload;
+    private double _metadataTTL;
+    private double _deletedKeysTTL;
+    private File _tableIndexDir;
+
+    public Builder setTableConfig(TableConfig tableConfig) {
+      _tableConfig = tableConfig;
+      return this;
+    }
+
+    public Builder setSchema(Schema schema) {
+      _schema = schema;
+      return this;
+    }
+
+    public Builder setPrimaryKeyColumns(List<String> primaryKeyColumns) {
+      _primaryKeyColumns = primaryKeyColumns;
+      return this;
+    }
+
+    public Builder setComparisonColumns(List<String> comparisonColumns) {
+      _comparisonColumns = comparisonColumns;
+      return this;
+    }
+
+    public Builder setDeleteRecordColumn(String deleteRecordColumn) {
+      _deleteRecordColumn = deleteRecordColumn;
+      return this;
+    }
+
+    public Builder setHashFunction(HashFunction hashFunction) {
+      _hashFunction = hashFunction;
+      return this;
+    }
+
+    public Builder setPartialUpsertHandler(PartialUpsertHandler partialUpsertHandler) {
+      _partialUpsertHandler = partialUpsertHandler;
+      return this;
+    }
+
+    public Builder setEnableSnapshot(boolean enableSnapshot) {
+      _enableSnapshot = enableSnapshot;
+      return this;
+    }
+
+    public Builder setEnablePreload(boolean enablePreload) {
+      _enablePreload = enablePreload;
+      return this;
+    }
+
+    public Builder setMetadataTTL(double metadataTTL) {
+      _metadataTTL = metadataTTL;
+      return this;
+    }
+
+    public Builder setDeletedKeysTTL(double deletedKeysTTL) {
+      _deletedKeysTTL = deletedKeysTTL;
+      return this;
+    }
+
+    public Builder setTableIndexDir(File tableIndexDir) {
+      _tableIndexDir = tableIndexDir;
+      return this;
+    }
+
+    public UpsertContext build() {
+      Preconditions.checkState(_tableConfig != null, "Table config must be set");
+      Preconditions.checkState(_schema != null, "Schema must be set");
+      Preconditions.checkState(CollectionUtils.isNotEmpty(_primaryKeyColumns), "Primary key columns must be set");
+      Preconditions.checkState(CollectionUtils.isNotEmpty(_comparisonColumns), "Comparison columns must be set");
+      Preconditions.checkState(_hashFunction != null, "Hash function must be set");
+      Preconditions.checkState(_tableIndexDir != null, "Table index directory must be set");
+      return new UpsertContext(_tableConfig, _schema, _primaryKeyColumns, _comparisonColumns, _deleteRecordColumn,
+          _hashFunction, _partialUpsertHandler, _enableSnapshot, _enablePreload, _metadataTTL, _deletedKeysTTL,
+          _tableIndexDir);
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -48,7 +48,9 @@ import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.index.reader.ForwardIndexReader;
 import org.apache.pinot.spi.config.table.HashFunction;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.FieldSpec.DataType;
+import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
@@ -58,6 +60,7 @@ import org.mockito.MockedConstruction;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
+import org.testng.annotations.BeforeMethod;
 import org.testng.annotations.Test;
 
 import static org.mockito.ArgumentMatchers.any;
@@ -72,13 +75,25 @@ import static org.testng.Assert.*;
 public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   private static final String RAW_TABLE_NAME = "testTable";
   private static final String REALTIME_TABLE_NAME = TableNameBuilder.REALTIME.tableNameWithType(RAW_TABLE_NAME);
+  private static final List<String> PRIMARY_KEY_COLUMNS = Collections.singletonList("pk");
+  private static final List<String> COMPARISON_COLUMNS = Collections.singletonList("timeCol");
+  private static final String DELETE_RECORD_COLUMN = "deleteCol";
   private static final File INDEX_DIR =
       new File(FileUtils.getTempDirectory(), "ConcurrentMapPartitionUpsertMetadataManagerTest");
+
+  private UpsertContext.Builder _contextBuilder;
 
   @BeforeClass
   public void setUp()
       throws IOException {
     FileUtils.forceMkdir(INDEX_DIR);
+    ServerMetrics.register(mock(ServerMetrics.class));
+  }
+
+  @BeforeMethod
+  public void setUpContextBuilder() {
+    _contextBuilder = new UpsertContext.Builder().setTableConfig(mock(TableConfig.class)).setSchema(mock(Schema.class))
+        .setPrimaryKeyColumns(PRIMARY_KEY_COLUMNS).setComparisonColumns(COMPARISON_COLUMNS).setTableIndexDir(INDEX_DIR);
   }
 
   @AfterClass
@@ -90,9 +105,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   @Test
   public void testStartFinishOperation() {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList("timeCol"), null, HashFunction.NONE, null, false, 0, 0, INDEX_DIR,
-            mock(ServerMetrics.class));
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
 
     // Start 2 operations
     assertTrue(upsertMetadataManager.startOperation());
@@ -150,6 +163,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   @Test
   public void testUpsertMetadataCleanupWithTTLConfig()
       throws IOException {
+    _contextBuilder.setEnableSnapshot(true).setMetadataTTL(30);
     verifyRemoveExpiredPrimaryKeys(new Integer(80), new Integer(120));
     verifyRemoveExpiredPrimaryKeys(new Float(80), new Float(120));
     verifyRemoveExpiredPrimaryKeys(new Double(80), new Double(120));
@@ -165,6 +179,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
   @Test
   public void testGetQueryableDocIds() {
+    _contextBuilder.setDeleteRecordColumn(DELETE_RECORD_COLUMN);
+
     boolean[] deleteFlags1 = new boolean[]{false, false, false, true, true, false};
     int[] docIds1 = new int[]{2, 4, 5};
     MutableRoaringBitmap validDocIdsSnapshot1 = new MutableRoaringBitmap();
@@ -202,11 +218,9 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
   private void verifyAddReplaceRemoveSegment(HashFunction hashFunction, boolean enableSnapshot)
       throws IOException {
-    String comparisonColumn = "timeCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, 0, 0, INDEX_DIR,
-            mock(ServerMetrics.class));
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0,
+            _contextBuilder.setHashFunction(hashFunction).build());
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
     Set<IndexSegment> trackedSegments = upsertMetadataManager._trackedSegments;
 
@@ -354,6 +368,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   @Test
   public void testAddReplaceRemoveSegmentWithRecordDelete()
       throws IOException {
+    _contextBuilder.setDeleteRecordColumn(DELETE_RECORD_COLUMN);
     verifyAddReplaceRemoveSegmentWithRecordDelete(HashFunction.NONE, false);
     verifyAddReplaceRemoveSegmentWithRecordDelete(HashFunction.MD5, false);
     verifyAddReplaceRemoveSegmentWithRecordDelete(HashFunction.MURMUR3, false);
@@ -364,12 +379,9 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
   private void verifyAddReplaceRemoveSegmentWithRecordDelete(HashFunction hashFunction, boolean enableSnapshot)
       throws IOException {
-    String comparisonColumn = "timeCol";
-    String deleteRecordColumn = "deleteCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), deleteRecordColumn, hashFunction, null, false, 0,
-            0, INDEX_DIR, mock(ServerMetrics.class));
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0,
+            _contextBuilder.setHashFunction(hashFunction).setEnableSnapshot(enableSnapshot).build());
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
     Set<IndexSegment> trackedSegments = upsertMetadataManager._trackedSegments;
 
@@ -548,11 +560,11 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   }
 
   private List<RecordInfo> getRecordInfoListForTTL(int numRecords, int[] primaryKeys, int[] timestamps,
-                                             @Nullable boolean[] deleteRecordFlags) {
+      @Nullable boolean[] deleteRecordFlags) {
     List<RecordInfo> recordInfoList = new ArrayList<>();
     for (int i = 0; i < numRecords; i++) {
       recordInfoList.add(new RecordInfo(makePrimaryKey(primaryKeys[i]), i, new Integer(timestamps[i]),
-              deleteRecordFlags != null && deleteRecordFlags[i]));
+          deleteRecordFlags != null && deleteRecordFlags[i]));
     }
     return recordInfoList;
   }
@@ -667,11 +679,9 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
   private void verifyAddRecord(HashFunction hashFunction)
       throws IOException {
-    String comparisonColumn = "timeCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, 0, 0, INDEX_DIR,
-            mock(ServerMetrics.class));
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0,
+            _contextBuilder.setHashFunction(hashFunction).build());
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add the first segment
@@ -760,11 +770,9 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
   private void verifyAddOutOfOrderRecord(HashFunction hashFunction)
       throws IOException {
-    String comparisonColumn = "timeCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, 0, 0, INDEX_DIR,
-            mock(ServerMetrics.class));
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0,
+            _contextBuilder.setHashFunction(hashFunction).build());
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add the first segment
@@ -828,11 +836,9 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   }
 
   private void verifyPreloadSegment(HashFunction hashFunction) {
-    String comparisonColumn = "timeCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), null, hashFunction, null, false, 0, 0, INDEX_DIR,
-            mock(ServerMetrics.class));
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0,
+            _contextBuilder.setHashFunction(hashFunction).build());
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add the first segment
@@ -876,6 +882,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   @Test
   public void testAddRecordWithDeleteColumn()
       throws IOException {
+    _contextBuilder.setDeleteRecordColumn(DELETE_RECORD_COLUMN);
     verifyAddRecordWithDeleteColumn(HashFunction.NONE);
     verifyAddRecordWithDeleteColumn(HashFunction.MD5);
     verifyAddRecordWithDeleteColumn(HashFunction.MURMUR3);
@@ -883,12 +890,9 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
   private void verifyAddRecordWithDeleteColumn(HashFunction hashFunction)
       throws IOException {
-    String comparisonColumn = "timeCol";
-    String deleteColumn = "deleteCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), deleteColumn, hashFunction, null,
-            false, 0, 0, INDEX_DIR, mock(ServerMetrics.class));
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0,
+            _contextBuilder.setHashFunction(hashFunction).build());
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // queryableDocIds is same as validDocIds in the absence of delete markers
@@ -985,21 +989,18 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
   @Test
   public void testRemoveExpiredDeletedKeys()
-          throws IOException {
+      throws IOException {
+    _contextBuilder.setDeleteRecordColumn(DELETE_RECORD_COLUMN).setDeletedKeysTTL(20);
     verifyRemoveExpiredDeletedKeys(HashFunction.NONE);
     verifyRemoveExpiredDeletedKeys(HashFunction.MD5);
     verifyRemoveExpiredDeletedKeys(HashFunction.MURMUR3);
   }
 
   private void verifyRemoveExpiredDeletedKeys(HashFunction hashFunction)
-          throws IOException {
-
-    String comparisonColumn = "timeCol";
-    String deleteColumn = "deleteCol";
+      throws IOException {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-            new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-                    Collections.singletonList(comparisonColumn), deleteColumn, hashFunction, null,
-                    false, 0, 20, INDEX_DIR, mock(ServerMetrics.class));
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0,
+            _contextBuilder.setHashFunction(hashFunction).build());
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
 
     // Add the first segment
@@ -1010,9 +1011,9 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     ThreadSafeMutableRoaringBitmap validDocIds1 = new ThreadSafeMutableRoaringBitmap();
     ThreadSafeMutableRoaringBitmap queryableDocIds1 = new ThreadSafeMutableRoaringBitmap();
     ImmutableSegmentImpl segment1 =
-            mockImmutableSegment(1, validDocIds1, queryableDocIds1, getPrimaryKeyList(numRecords, primaryKeys));
+        mockImmutableSegment(1, validDocIds1, queryableDocIds1, getPrimaryKeyList(numRecords, primaryKeys));
     upsertMetadataManager.addSegment(segment1, validDocIds1, queryableDocIds1,
-            getRecordInfoListForTTL(numRecords, primaryKeys, timestamps, null).iterator());
+        getRecordInfoListForTTL(numRecords, primaryKeys, timestamps, null).iterator());
 
     // Update records from the second segment
     ThreadSafeMutableRoaringBitmap validDocIds2 = new ThreadSafeMutableRoaringBitmap();
@@ -1069,16 +1070,18 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     assertEquals(validDocIds2.getMutableRoaringBitmap().toArray(), new int[]{2});
     assertEquals(queryableDocIds1.getMutableRoaringBitmap().toArray(), new int[]{0, 1});
     assertEquals(queryableDocIds2.getMutableRoaringBitmap().toArray(), new int[]{});
+
+    // Stop the metadata manager
+    upsertMetadataManager.stop();
+
+    // Close the metadata manager
+    upsertMetadataManager.close();
   }
 
   private void verifyRemoveExpiredPrimaryKeys(Comparable earlierComparisonValue, Comparable largerComparisonValue)
       throws IOException {
-    File tableDir = new File(INDEX_DIR, REALTIME_TABLE_NAME);
-
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList("timeCol"), null, HashFunction.NONE, null, false, 30, 0, tableDir,
-            mock(ServerMetrics.class));
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
     Map<Object, ConcurrentMapPartitionUpsertMetadataManager.RecordLocation> recordLocationMap =
         upsertMetadataManager._primaryKeyToRecordLocationMap;
 
@@ -1095,8 +1098,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     ThreadSafeMutableRoaringBitmap validDocIds1 = new ThreadSafeMutableRoaringBitmap();
     List<PrimaryKey> primaryKeys1 = getPrimaryKeyList(numRecords, primaryKeys);
     ImmutableSegmentImpl segment1 =
-        mockImmutableSegmentWithEndTime(1, validDocIds1, null, primaryKeys1, Collections.singletonList("timeCol"),
-            earlierComparisonValue, null);
+        mockImmutableSegmentWithEndTime(1, validDocIds1, null, primaryKeys1, COMPARISON_COLUMNS, earlierComparisonValue,
+            null);
 
     int[] docIds1 = new int[]{0, 1, 2, 3};
     MutableRoaringBitmap validDocIdsSnapshot1 = new MutableRoaringBitmap();
@@ -1141,12 +1144,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
   private void verifyAddOutOfTTLSegment()
       throws IOException {
-    File tableDir = new File(INDEX_DIR, REALTIME_TABLE_NAME);
-
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList("timeCol"), null, HashFunction.NONE, null, true, 30, 0, tableDir,
-            mock(ServerMetrics.class));
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
     Map<Object, ConcurrentMapPartitionUpsertMetadataManager.RecordLocation> recordLocationMap =
         upsertMetadataManager._primaryKeyToRecordLocationMap;
 
@@ -1163,8 +1162,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     ThreadSafeMutableRoaringBitmap validDocIds1 = new ThreadSafeMutableRoaringBitmap();
     List<PrimaryKey> primaryKeys1 = getPrimaryKeyList(numRecords, primaryKeys);
     ImmutableSegmentImpl segment1 =
-        mockImmutableSegmentWithEndTime(1, validDocIds1, null, primaryKeys1, Collections.singletonList("timeCol"),
-            new Double(80), null);
+        mockImmutableSegmentWithEndTime(1, validDocIds1, null, primaryKeys1, COMPARISON_COLUMNS, new Double(80), null);
 
     int[] docIds1 = new int[]{0, 1, 2, 3};
     MutableRoaringBitmap validDocIdsSnapshot1 = new MutableRoaringBitmap();
@@ -1199,8 +1197,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     validDocIdsSnapshot2.add(docIds2);
     ThreadSafeMutableRoaringBitmap validDocIds2 = new ThreadSafeMutableRoaringBitmap();
     ImmutableSegmentImpl segment2 =
-        mockImmutableSegmentWithEndTime(1, validDocIds2, null, primaryKeys2, Collections.singletonList("timeCol"),
-            new Double(80), validDocIdsSnapshot2);
+        mockImmutableSegmentWithEndTime(1, validDocIds2, null, primaryKeys2, COMPARISON_COLUMNS, new Double(80),
+            validDocIdsSnapshot2);
     upsertMetadataManager.addSegment(segment2);
     // out of ttl segment should not be added to recordLocationMap
     assertEquals(recordLocationMap.size(), 5);
@@ -1214,12 +1212,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
   private void verifyAddOutOfTTLSegmentWithRecordDelete()
       throws IOException {
-    String comparisonColumn = "timeCol";
-    String deleteRecordColumn = "deleteCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), deleteRecordColumn, HashFunction.NONE, null, true, 30,
-            0, INDEX_DIR, mock(ServerMetrics.class));
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
     Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
     Set<IndexSegment> trackedSegments = upsertMetadataManager._trackedSegments;
 
@@ -1235,8 +1229,9 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     int[] docIds1 = new int[]{2, 4, 5};
     MutableRoaringBitmap validDocIdsSnapshot1 = new MutableRoaringBitmap();
     validDocIdsSnapshot1.add(docIds1);
-    ImmutableSegmentImpl segment1 = mockImmutableSegmentWithEndTime(1, validDocIds1, queryableDocIds1, primaryKeys1,
-        Collections.singletonList(comparisonColumn), new Double(120), validDocIdsSnapshot1);
+    ImmutableSegmentImpl segment1 =
+        mockImmutableSegmentWithEndTime(1, validDocIds1, queryableDocIds1, primaryKeys1, COMPARISON_COLUMNS,
+            new Double(120), validDocIdsSnapshot1);
 
     // get recordInfo from validDocIdSnapshot.
     // segment1 snapshot: 0 -> {5, 100}, 1 -> {4, 120}, 2 -> {2, 100}
@@ -1266,7 +1261,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     validDocIdsSnapshot2.add(docIds2);
     ImmutableSegmentImpl segment2 =
         mockImmutableSegmentWithEndTime(2, validDocIds2, queryableDocIds2, getPrimaryKeyList(numRecords, primaryKeys),
-            Collections.singletonList(comparisonColumn), new Double(40), validDocIdsSnapshot2);
+            COMPARISON_COLUMNS, new Double(40), validDocIdsSnapshot2);
 
     // get recordInfo from validDocIdSnapshot.
     // segment2 snapshot: 3 -> {3, 40}, 4 -> {4, 40}
@@ -1299,12 +1294,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
   public void verifyGetQueryableDocIds(boolean isDeleteColumnNull, boolean[] deleteFlags,
       MutableRoaringBitmap validDocIdsSnapshot, MutableRoaringBitmap queryableDocIds) {
-    String comparisonColumn = "timeCol";
-    String deleteRecordColumn = "deleteCol";
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList(comparisonColumn), deleteRecordColumn, HashFunction.NONE, null, true, 30,
-            0, INDEX_DIR, mock(ServerMetrics.class));
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
 
     try (MockedConstruction<PinotSegmentColumnReader> deleteColReader = mockConstruction(PinotSegmentColumnReader.class,
         (mockReader, context) -> {
@@ -1318,9 +1309,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
       ColumnMetadata columnMetadata = mock(ColumnMetadata.class);
       when(segmentMetadata.getTotalDocs()).thenReturn(deleteFlags.length);
       when(segmentMetadata.getColumnMetadataMap()).thenReturn(new TreeMap() {{
-        this.put(comparisonColumn, columnMetadata);
+        this.put(COMPARISON_COLUMNS.get(0), columnMetadata);
       }});
-      when(columnMetadata.getMaxValue()).thenReturn(null);
 
       ImmutableSegmentImpl segment =
           mockImmutableSegmentWithSegmentMetadata(1, new ThreadSafeMutableRoaringBitmap(), null, null, segmentMetadata,
@@ -1331,12 +1321,8 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
 
   private void verifyAddSegmentForTTL(Comparable comparisonValue)
       throws IOException {
-    File tableDir = new File(INDEX_DIR, REALTIME_TABLE_NAME);
-
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList("timeCol"), null, HashFunction.NONE, null, true, 30, 0, tableDir,
-            mock(ServerMetrics.class));
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
     Map<Object, ConcurrentMapPartitionUpsertMetadataManager.RecordLocation> recordLocationMap =
         upsertMetadataManager._primaryKeyToRecordLocationMap;
 
@@ -1352,8 +1338,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     ThreadSafeMutableRoaringBitmap validDocIds1 = new ThreadSafeMutableRoaringBitmap();
     List<PrimaryKey> primaryKeys1 = getPrimaryKeyList(numRecords, primaryKeys);
     ImmutableSegmentImpl segment1 =
-        mockImmutableSegmentWithEndTime(1, validDocIds1, null, primaryKeys1, Collections.singletonList("timeCol"), -1,
-            null);
+        mockImmutableSegmentWithEndTime(1, validDocIds1, null, primaryKeys1, COMPARISON_COLUMNS, -1, null);
 
     int[] docIds1 = new int[]{0, 1, 2, 3};
     MutableRoaringBitmap validDocIdsSnapshot1 = new MutableRoaringBitmap();
@@ -1395,9 +1380,7 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
   private void verifyPersistAndLoadWatermark()
       throws IOException {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, Collections.singletonList("pk"),
-            Collections.singletonList("timeCol"), null, HashFunction.NONE, null, true, 10, 0, INDEX_DIR,
-            mock(ServerMetrics.class));
+        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0, _contextBuilder.build());
 
     double currentTimeMs = System.currentTimeMillis();
     upsertMetadataManager.persistWatermark(currentTimeMs);


### PR DESCRIPTION
The argument list for `BasePartitionUpsertMetadataManager` has become too long. Introducing `UpsertContext` so that we don't need to change the signature for every new feature added to upsert.