### PR TITLE
Reduce logging volume to log the conversions per record instead of per conversion for SpecialValueTransformer 

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
@@ -113,10 +113,12 @@ public class SpecialValueTransformer implements RecordTransformer {
     LOGGER.info("Converted {} -0.0s to 0.0 and {} NaNs to null", _negativeZeroConversionCount, _nanConversionCount);
     return record;
   }
+
   @VisibleForTesting
   int getNegativeZeroConversionCount() {
     return _negativeZeroConversionCount;
   }
+
   @VisibleForTesting
   int getNanConversionCount() {
     return _nanConversionCount;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
@@ -110,7 +110,9 @@ public class SpecialValueTransformer implements RecordTransformer {
         }
       }
     }
-    LOGGER.info("Converted {} -0.0s to 0.0 and {} NaNs to null", _negativeZeroConversionCount, _nanConversionCount);
+    if (_negativeZeroConversionCount > 0 || _nanConversionCount > 0) {
+      LOGGER.info("Converted {} -0.0s to 0.0 and {} NaNs to null", _negativeZeroConversionCount, _nanConversionCount);
+    }
     return record;
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
@@ -277,7 +277,7 @@ public class RecordTransformerTest {
 
   @Test
   public void testSpecialValueTransformer() {
-    RecordTransformer transformer = new SpecialValueTransformer(SCHEMA);
+    SpecialValueTransformer transformer = new SpecialValueTransformer(SCHEMA);
     GenericRow record = getRecord();
     for (int i = 0; i < NUM_ROUNDS; i++) {
       record = transformer.transform(record);
@@ -294,6 +294,8 @@ public class RecordTransformerTest {
           new Float[]{0.0f, 2.0f});
       assertEquals(record.getValue("mvDoubleNaN"),
           new Double[]{0.0d, 2.0d});
+      assertEquals(transformer.getNegativeZeroConversionCount(),6);
+      assertEquals(transformer.getNanConversionCount(), 4);
     }
   }
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformerTest.java
@@ -290,11 +290,9 @@ public class RecordTransformerTest {
       assertEquals(record.getValue("mvDoubleNegativeZero"), new Double[]{0.0d, 1.0d, 0.0d, 3.0d});
       assertNull(record.getValue("svFloatNaN"));
       assertNull(record.getValue("svDoubleNaN"));
-      assertEquals(record.getValue("mvFloatNaN"),
-          new Float[]{0.0f, 2.0f});
-      assertEquals(record.getValue("mvDoubleNaN"),
-          new Double[]{0.0d, 2.0d});
-      assertEquals(transformer.getNegativeZeroConversionCount(),6);
+      assertEquals(record.getValue("mvFloatNaN"), new Float[]{0.0f, 2.0f});
+      assertEquals(record.getValue("mvDoubleNaN"), new Double[]{0.0d, 2.0d});
+      assertEquals(transformer.getNegativeZeroConversionCount(), 6);
       assertEquals(transformer.getNanConversionCount(), 4);
     }
   }


### PR DESCRIPTION
Reduced the logging volume for SpecialValueTransformer to per record.