### PR TITLE
PR to address Issue #12127 - Refactor foreign logger initialization in multiple classes

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotConnection.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/PinotConnection.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.client;
 
-import java.sql.Connection;
 import java.sql.DatabaseMetaData;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
@@ -33,13 +32,10 @@ import org.apache.pinot.client.controller.PinotControllerTransport;
 import org.apache.pinot.client.controller.PinotControllerTransportFactory;
 import org.apache.pinot.client.controller.response.ControllerTenantBrokerResponse;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 public class PinotConnection extends AbstractBaseConnection {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(Connection.class);
   protected static final String[] POSSIBLE_QUERY_OPTIONS = {
     QueryOptionKey.ENABLE_NULL_HANDLING,
     QueryOptionKey.USE_MULTISTAGE_ENGINE

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/JsonIndexRule.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/rules/impl/JsonIndexRule.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
 
 /** JSON columns must be NoDictionary columns with JsonIndex. */
 public class JsonIndexRule extends AbstractRule {
-  private static final Logger LOGGER = LoggerFactory.getLogger(RangeIndexRule.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(JsonIndexRule.class);
 
   public JsonIndexRule(InputManager input, ConfigManager output) {
     super(input, output);

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/DirectOOMHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/DirectOOMHandler.java
@@ -35,7 +35,7 @@ import org.slf4j.LoggerFactory;
  * no one will reach channelRead0.
  */
 public class DirectOOMHandler extends ChannelInboundHandlerAdapter {
-  private static final Logger LOGGER = LoggerFactory.getLogger(DataTableHandler.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(DirectOOMHandler.class);
   private static final AtomicBoolean DIRECT_OOM_SHUTTING_DOWN = new AtomicBoolean(false);
   private final QueryRouter _queryRouter;
   private final ServerRoutingInstance _serverRoutingInstance;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/mailbox/InMemorySendingMailbox.java
@@ -27,7 +27,7 @@ import org.slf4j.LoggerFactory;
 
 
 public class InMemorySendingMailbox implements SendingMailbox {
-  private static final Logger LOGGER = LoggerFactory.getLogger(GrpcSendingMailbox.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(InMemorySendingMailbox.class);
 
   private final String _id;
   private final MailboxService _mailboxService;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -47,7 +47,7 @@ import org.slf4j.LoggerFactory;
  * {@link QueryServer} is the GRPC server that accepts query plan requests sent from {@link QueryDispatcher}.
  */
 public class QueryServer extends PinotQueryWorkerGrpc.PinotQueryWorkerImplBase {
-  private static final Logger LOGGER = LoggerFactory.getLogger(GrpcQueryServer.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(QueryServer.class);
   // TODO: Inbound messages can get quite large because we send the entire stage metadata map in each call.
   // See https://github.com/apache/pinot/issues/10331
   private static final int MAX_INBOUND_MESSAGE_SIZE = 64 * 1024 * 1024;

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/server/QueryServer.java
@@ -33,7 +33,6 @@ import org.apache.pinot.common.exception.QueryException;
 import org.apache.pinot.common.proto.PinotQueryWorkerGrpc;
 import org.apache.pinot.common.proto.Worker;
 import org.apache.pinot.common.utils.NamedThreadFactory;
-import org.apache.pinot.core.transport.grpc.GrpcQueryServer;
 import org.apache.pinot.query.runtime.QueryRunner;
 import org.apache.pinot.query.runtime.plan.DistributedStagePlan;
 import org.apache.pinot.query.runtime.plan.serde.QueryPlanSerDeUtils;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/SpecialValueTransformer.java
@@ -41,7 +41,7 @@ import org.slf4j.LoggerFactory;
  */
 public class SpecialValueTransformer implements RecordTransformer {
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(NullValueTransformer.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(SpecialValueTransformer.class);
   private final HashSet<String> _specialValuesKeySet = new HashSet<>();
 
   public SpecialValueTransformer(Schema schema) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/text/LuceneFSTIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/text/LuceneFSTIndexCreator.java
@@ -23,7 +23,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import org.apache.lucene.store.OutputStreamDataOutput;
 import org.apache.lucene.util.fst.FST;
-import org.apache.pinot.segment.local.segment.creator.impl.SegmentColumnarIndexCreator;
 import org.apache.pinot.segment.local.utils.fst.FSTBuilder;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.creator.IndexCreationContext;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/text/LuceneFSTIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/text/LuceneFSTIndexCreator.java
@@ -39,7 +39,7 @@ import org.slf4j.LoggerFactory;
  *
  */
 public class LuceneFSTIndexCreator implements FSTIndexCreator {
-  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentColumnarIndexCreator.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(LuceneFSTIndexCreator.class);
   private final File _fstIndexFile;
   private final FSTBuilder _fstBuilder;
   Integer _dictId;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/vector/HnswVectorIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/vector/HnswVectorIndexReader.java
@@ -33,7 +33,6 @@ import org.apache.lucene.store.Directory;
 import org.apache.lucene.store.FSDirectory;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
 import org.apache.pinot.segment.local.segment.creator.impl.vector.HnswVectorIndexCreator;
-import org.apache.pinot.segment.local.segment.index.readers.text.LuceneTextIndexReader;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.creator.VectorIndexConfig;
 import org.apache.pinot.segment.spi.index.reader.VectorIndexReader;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/vector/HnswVectorIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/vector/HnswVectorIndexReader.java
@@ -45,7 +45,7 @@ import org.slf4j.LoggerFactory;
 
 public class HnswVectorIndexReader implements VectorIndexReader {
 
-  private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(LuceneTextIndexReader.class);
+  private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(HnswVectorIndexReader.class);
 
   private final IndexReader _indexReader;
   private final Directory _indexDirectory;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/ConsistentDataPushUtils.java
@@ -50,7 +50,7 @@ public class ConsistentDataPushUtils {
   private ConsistentDataPushUtils() {
   }
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(SegmentPushUtils.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ConsistentDataPushUtils.class);
   private static final FileUploadDownloadClient FILE_UPLOAD_DOWNLOAD_CLIENT = new FileUploadDownloadClient();
   private static final RetryPolicy DEFAULT_RETRY_POLICY = RetryPolicies.exponentialBackoffRetryPolicy(5, 10_000L, 2.0);
   public static final String SEGMENT_NAME_POSTFIX = "segment.name.postfix";

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/fst/RegexpMatcher.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/fst/RegexpMatcher.java
@@ -29,8 +29,6 @@ import org.apache.lucene.util.automaton.RegExp;
 import org.apache.lucene.util.automaton.Transition;
 import org.apache.lucene.util.fst.FST;
 import org.apache.lucene.util.fst.Util;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -42,7 +40,6 @@ import org.slf4j.LoggerFactory;
  *   match(input) Function builds the automaton and matches given input.
  */
 public class RegexpMatcher {
-  public static final Logger LOGGER = LoggerFactory.getLogger(FSTBuilder.class);
 
   private final String _regexQuery;
   private final FST<Long> _fst;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ChangeNumReplicasCommand.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/admin/command/ChangeNumReplicasCommand.java
@@ -27,7 +27,7 @@ import picocli.CommandLine;
 
 @CommandLine.Command(name = "ChangeNumReplicas")
 public class ChangeNumReplicasCommand extends AbstractBaseAdminCommand implements Command {
-  private static final Logger LOGGER = LoggerFactory.getLogger(StartBrokerCommand.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(ChangeNumReplicasCommand.class);
 
   @CommandLine.Option(names = {"-zkAddress"}, required = false, description = "HTTP address of Zookeeper.")
   private String _zkAddress = DEFAULT_ZK_ADDRESS;

--- a/pinot-tools/src/main/java/org/apache/pinot/tools/streams/AvroFileSourceGenerator.java
+++ b/pinot-tools/src/main/java/org/apache/pinot/tools/streams/AvroFileSourceGenerator.java
@@ -48,7 +48,7 @@ import org.slf4j.LoggerFactory;
  * time index based on row number.
  */
 public class AvroFileSourceGenerator implements PinotSourceDataGenerator {
-  private static final Logger LOGGER = LoggerFactory.getLogger(PinotRealtimeSource.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(AvroFileSourceGenerator.class);
   private DataFileStream<GenericRecord> _avroDataStream;
   private final Schema _pinotSchema;
   private long _rowsProduced;


### PR DESCRIPTION
This PR addresses a widespread issue of Logger instances being incorrectly initialized in multiple classes. The Logger instances were mostly being created with the wrong class as argument to the LoggerFactory.getLogger() method. This issue has now been fixed by replacing the incorrect class names with the corresponding class in which the Logger instance is initialized.   

In some instances the guilty logger was not used and therefore removed entirely from the class.

This PR fixes #12127 
