### PR TITLE
PR for issue #12129 - insuring opened `Channel` instances are properly closed

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RangeIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/inv/RangeIndexCreator.java
@@ -30,6 +30,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.nio.channels.FileChannel;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.io.FileUtils;
@@ -321,6 +322,7 @@ public final class RangeIndexCreator implements CombinedInvertedIndexCreator {
     try (BufferedOutputStream bos = new BufferedOutputStream(new FileOutputStream(_rangeIndexFile));
         DataOutputStream header = new DataOutputStream(bos);
         FileOutputStream fos = new FileOutputStream(_rangeIndexFile);
+        FileChannel channel = fos.getChannel();
         DataOutputStream dataOutputStream = new DataOutputStream(new BufferedOutputStream(fos))) {
 
       //VERSION
@@ -358,7 +360,8 @@ public final class RangeIndexCreator implements CombinedInvertedIndexCreator {
       long bitmapOffset = bytesWritten + bitmapOffsetHeaderSize;
       header.writeLong(bitmapOffset);
       bytesWritten += Long.BYTES;
-      fos.getChannel().position(bitmapOffset);
+
+      channel.position(bitmapOffset);
 
       for (int i = 0; i < ranges.size(); i++) {
         Pair<Integer, Integer> range = ranges.get(i);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PinotByteBuffer.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/memory/PinotByteBuffer.java
@@ -276,12 +276,14 @@ public class PinotByteBuffer extends PinotDataBuffer {
       throws IOException {
     assert offset <= Integer.MAX_VALUE;
     assert size <= Integer.MAX_VALUE;
-    try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r")) {
+    try (RandomAccessFile randomAccessFile = new RandomAccessFile(file, "r");
+        FileChannel channel = randomAccessFile.getChannel()) {
+
       ByteBuffer duplicate = _buffer.duplicate();
       int start = (int) offset;
       int end = start + (int) size;
       ((Buffer) duplicate).position(start).limit(end);
-      randomAccessFile.getChannel().read(duplicate, srcOffset);
+      channel.read(duplicate, srcOffset);
     }
   }
 


### PR DESCRIPTION
This commit modifies several classes to use a try-with-resource block for file operations, conforming with best practices for Java resource management. Previously, file resources such as RandomAccessFile and FileOutputStream were not included in a try-with-resource statement, which could lead to resource leaks if exceptions occurred. The changes ensure these resources are properly closed after usage.  Fixes #12129 .