### PR TITLE
Specify Multi-Release property in manifest

### DIFF
--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -559,9 +559,6 @@
                 <manifest>
                   <mainClass>org.apache.pinot.tools.PinotToolLauncher</mainClass>
                 </manifest>
-                <manifestEntries>
-                  <Multi-Release>true</Multi-Release>
-                </manifestEntries>
               </archive>
               <finalName>pinot-tool-launcher</finalName>
             </configuration>

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -559,6 +559,9 @@
                 <manifest>
                   <mainClass>org.apache.pinot.tools.PinotToolLauncher</mainClass>
                 </manifest>
+                <manifestEntries>
+                  <Multi-Release>true</Multi-Release>
+                </manifestEntries>
               </archive>
               <finalName>pinot-tool-launcher</finalName>
             </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1551,7 +1551,6 @@
                 <Implementation-Version>${project.version}-${buildNumber}</Implementation-Version>
                 <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
                 <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
-                <Multi-Release>true</Multi-Release>
               </manifestEntries>
             </archive>
           </configuration>

--- a/pom.xml
+++ b/pom.xml
@@ -1551,6 +1551,7 @@
                 <Implementation-Version>${project.version}-${buildNumber}</Implementation-Version>
                 <Implementation-Vendor-Id>${project.groupId}</Implementation-Vendor-Id>
                 <Implementation-Vendor>${project.organization.name}</Implementation-Vendor>
+                <Multi-Release>true</Multi-Release>
               </manifestEntries>
             </archive>
           </configuration>
@@ -2081,6 +2082,9 @@
             <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
             <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
               <mainClass>${mainClass}</mainClass>
+              <manifestEntries>
+                <Multi-Release>true</Multi-Release>
+              </manifestEntries>
             </transformer>
           </transformers>
           <!-- exclude signed Manifests -->


### PR DESCRIPTION
Tag: bugfix

This is a very simple PR that modifies Pinot to include the standard tag `Multi-Release` in the shaded manifest.

This tag is defined in [JEP-238](https://openjdk.org/jeps/238). When specified, Java runtime 9 and newer consider the jar as a multi-release jar. You can read the JEP to have more context, but the TL;DR is that multi release jars may include more than one .class file for each Java class. Each .class can be optionally be associated with a given Java version and the JVM will load the correct class depending on their version. 

For example, for a given class X, the jar may include a standard X and a custom version of X to be used in Java 11. In this case when running with Java 8, 9 or 10, the standard X will be used but the runtime is Java 11 or higher, it will use the Java 11 version.

It is important to note that we do not provide custom classes for any runtime, but our dependencies do include them. Given that by default we distribute Pinot in a fat-jar, we need to enable Multi-Release in our uber-jar to inform Java that it should use the newest classes.

For example, Lucene or Roaring Bitmap provide their own classes and even we include them in our uber-jar, Java does not load them right now because the Manifest doesn't say so. In the case of Lucene that is a problem because the standard org.apache.lucene.store.MemorySegmentIndexInput class doesn't work in Java 21.

In order to try this PR I've just did the following:
- execute `mvn clean`
- execute `mvn install package -DskipTests -Pbin-dist -Pbuild-shaded-jar -Djdk.version=11 -T1C` (which is what Dockerbuild does)
- unzip `build/lib/pinot-all-1.1.0-SNAPSHOT-jar-with-dependencies.jar`
- verify that `META-INF/MANIFES.MF` contains Multi-Release: true
- verify that `META-INF/versions/...` is not empty (this is not necessary given these classes were already there, but just to verify that).

