### PR TITLE
fix multiple instances where the number of placeholders did not match the number of arguments to logging methods

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -154,7 +154,7 @@ public class SegmentDeletionManager {
         }
       }
     } catch (Exception e) {
-      LOGGER.warn(String.format("Caught exception while checking helix states for table [%s]", tableName), e);
+      LOGGER.warn("Caught exception while checking helix states for table: {}", tableName, e);
       segmentsToDelete.clear();
       segmentsToDelete.addAll(segmentIds);
       segmentsToRetryLater.clear();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/SegmentDeletionManager.java
@@ -154,7 +154,7 @@ public class SegmentDeletionManager {
         }
       }
     } catch (Exception e) {
-      LOGGER.warn("Caught exception while checking helix states for table {} " + tableName, e);
+      LOGGER.warn(String.format("Caught exception while checking helix states for table [%s]", tableName), e);
       segmentsToDelete.clear();
       segmentsToDelete.addAll(segmentIds);
       segmentsToRetryLater.clear();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -379,7 +379,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         }
         return false;
       default:
-        _segmentLogger.error("Illegal state {}" + _state.toString());
+        _segmentLogger.error("Illegal state [{}]", _state.toString());
         throw new RuntimeException("Illegal state to consume");
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -379,7 +379,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         }
         return false;
       default:
-        _segmentLogger.error("Illegal state [{}]", _state.toString());
+        _segmentLogger.error("Illegal state: {}", _state);
         throw new RuntimeException("Illegal state to consume");
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildTimeLeaseExtender.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildTimeLeaseExtender.java
@@ -102,7 +102,7 @@ public class SegmentBuildTimeLeaseExtender {
       Future future = entry.getValue();
       boolean cancelled = future.cancel(true);
       if (!cancelled) {
-        LOGGER.warn("Task could not be cancelled for [{}]", entry.getKey());
+        LOGGER.warn("Task could not be cancelled for {}", entry.getKey());
       }
     }
     _segmentToFutureMap.clear();

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildTimeLeaseExtender.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/SegmentBuildTimeLeaseExtender.java
@@ -102,7 +102,7 @@ public class SegmentBuildTimeLeaseExtender {
       Future future = entry.getValue();
       boolean cancelled = future.cancel(true);
       if (!cancelled) {
-        LOGGER.warn("Task could not be cancelled for {}" + entry.getKey());
+        LOGGER.warn("Task could not be cancelled for [{}]", entry.getKey());
       }
     }
     _segmentToFutureMap.clear();
@@ -133,7 +133,7 @@ public class SegmentBuildTimeLeaseExtender {
     if (future != null) {
       boolean cancelled = future.cancel(true);
       if (!cancelled) {
-        LOGGER.warn("Task could not be cancelled for {}" + segmentId);
+        LOGGER.warn("Task could not be cancelled for {}", segmentId);
       }
     }
     _segmentToFutureMap.remove(segmentId);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -859,8 +859,8 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
       if (v == null) {
         LOGGER.info(
             "Creating the gauge metric for tracking the merge/roll-up number buckets to process for table: {} "
-                + "and mergeLevel: {}.(bufferTimeMs={}, bucketTimeMs={}, numTimeBucketsToProcess={})"
-                + tableNameWithType, mergeLevel, bufferTimeMs, bucketTimeMs, finalCount);
+                + "and mergeLevel: {}.(bufferTimeMs={}, bucketTimeMs={}, numTimeBucketsToProcess={})",
+                tableNameWithType, mergeLevel, bufferTimeMs, bucketTimeMs, finalCount);
         controllerMetrics.setOrUpdateGauge(getMetricNameForNumBucketsToProcess(tableNameWithType, mergeLevel),
             () -> _tableNumberBucketsToProcess.get(tableNameWithType).getOrDefault(mergeLevel, finalCount));
       }


### PR DESCRIPTION
This PR fixes #12132.  Found a number of instances where the number of logging placeholders did not match the number of arguments to the logging method.  This would result in unexpected and possibly unhelpful logging messages.

