### PR TITLE
Fix for #12133 - add context and proper logging framework to OsCheck output

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/util/OsCheck.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/OsCheck.java
@@ -19,12 +19,14 @@
 package org.apache.pinot.core.util;
 
 import java.util.Locale;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 
 public final class OsCheck {
 
   // cached result of OS detection
-  protected static final OSType _detectedOS;
+  private static final OSType _detectedOS;
 
   private OsCheck() {
   }
@@ -46,9 +48,11 @@ public final class OsCheck {
     Windows, MacOS, Linux, Other
   }
 
+  private static final Logger log = LoggerFactory.getLogger(OsCheck.class);
+
   static {
     String os = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
-    System.out.println(os);
+    log.info("System property \"os.name\" is [{}]", os);
     if ((os.contains("mac")) || (os.contains("darwin"))) {
       _detectedOS = OSType.MacOS;
     } else if (os.contains("win")) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/OsCheck.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/OsCheck.java
@@ -52,7 +52,7 @@ public final class OsCheck {
 
   static {
     String os = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
-    log.info("System property \"os.name\" is [{}]", os);
+    log.info("System property \"os.name\" is: {}", os);
     if ((os.contains("mac")) || (os.contains("darwin"))) {
       _detectedOS = OSType.MacOS;
     } else if (os.contains("win")) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/OsCheck.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/OsCheck.java
@@ -48,7 +48,7 @@ public final class OsCheck {
     Windows, MacOS, Linux, Other
   }
 
-  private static final Logger log = LoggerFactory.getLogger(OsCheck.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(OsCheck.class);
 
   static {
     String os = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);

--- a/pinot-core/src/main/java/org/apache/pinot/core/util/OsCheck.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/util/OsCheck.java
@@ -26,7 +26,7 @@ import org.slf4j.LoggerFactory;
 public final class OsCheck {
 
   // cached result of OS detection
-  private static final OSType _detectedOS;
+  private static final OSType DETECTED_OS;
 
   private OsCheck() {
   }
@@ -38,7 +38,7 @@ public final class OsCheck {
    * @return - the operating system detected
    */
   public static OSType getOperatingSystemType() {
-    return _detectedOS;
+    return DETECTED_OS;
   }
 
   /**
@@ -52,15 +52,15 @@ public final class OsCheck {
 
   static {
     String os = System.getProperty("os.name", "generic").toLowerCase(Locale.ENGLISH);
-    log.info("System property \"os.name\" is: {}", os);
+    LOGGER.info("System property \"os.name\" is: {}", os);
     if ((os.contains("mac")) || (os.contains("darwin"))) {
-      _detectedOS = OSType.MacOS;
+      DETECTED_OS = OSType.MacOS;
     } else if (os.contains("win")) {
-      _detectedOS = OSType.Windows;
+      DETECTED_OS = OSType.Windows;
     } else if (os.contains("linux")) {
-      _detectedOS = OSType.Linux;
+      DETECTED_OS = OSType.Linux;
     } else {
-      _detectedOS = OSType.Other;
+      DETECTED_OS = OSType.Other;
     }
   }
 }


### PR DESCRIPTION
The visibility of the 'detectedOS' field in the OsCheck class has been changed from protected to private. Moreover, the system output was replaced with a logger for error debugging and tracking.  Instead of simply printing the 'os.name' value to the System.out, additional context has been added to the logging statement.  Fixes #12133 