### PR TITLE
Fix for #12136 - resolved invalid or missing placeholders in `String.format` calls

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/plugin/PluginManager.java
@@ -188,7 +188,7 @@ public class PluginManager {
 
     for (String pluginsDirectory : directories) {
       if (!new File(pluginsDirectory).exists()) {
-        throw new IllegalArgumentException(String.format("Plugins dir [{}] doesn't exist.", pluginsDirectory));
+        throw new IllegalArgumentException(String.format("Plugins dir [%s] doesn't exist.", pluginsDirectory));
       }
 
       Collection<File> jarFiles = FileUtils.listFiles(

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/JsonUtils.java
@@ -647,7 +647,7 @@ public class JsonUtils {
             fieldTypeMap, timeUnit, fieldsToUnnest, delimiter, collectionNotUnnestedToJson);
       }
     } else {
-      throw new IllegalArgumentException(String.format("Unsupported json node type", jsonNode.getClass()));
+      throw new IllegalArgumentException(String.format("Unsupported json node type for class %s", jsonNode.getClass()));
     }
   }
 


### PR DESCRIPTION
This PR fixes #12136 where calls to `String.format` contained missing or invalid placeholders.  