### PR TITLE
Avoid unnecessary transformer for CompositeTransformer

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
@@ -24,6 +24,7 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import javax.annotation.Nullable;
+import org.apache.pinot.segment.local.utils.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
@@ -116,6 +117,9 @@ public class CompositeTransformer implements RecordTransformer {
   @Override
   public GenericRow transform(GenericRow record) {
     for (RecordTransformer transformer : _transformers) {
+      if (!IngestionUtils.shouldIngestRow(record)) {
+        return record;
+      }
       record = transformer.transform(record);
       if (record == null) {
         return null;


### PR DESCRIPTION
The Cisco WAP Storage Team, we found a step that needs optimization. One of Pinot Clusters is unstable in a period of time. We firstly tried to find the error log in pinot server log. We identified numerous error logs from transformers, but upon investigation, we determined that they are not the root cause. These extensive and unnecessary logs are significantly impeding our ability to pinpoint the actual cause of the error. During troubleshooting, we found the root cause:
1. Some table share the same kafka topic. Each table use filter config to ingest data. Such as below config:
`"filterConfig": {
                "filterFunction": "Groovy({featureName !=  \"wap_unified_monitor\"},featureName)"
            },` 
2. CompositeTransformer contains Transformers. Some records is already marked as Skipped records. But those records still need to be transformed by remaining transformers. I think this will bring **misleading error log** and **unnecessary compute**.  `Stream.of(new ExpressionTransformer(tableConfig, schema), new FilterTransformer(tableConfig),
            new SchemaConformingTransformer(tableConfig, schema), new DataTypeTransformer(tableConfig, schema),
            new TimeValidationTransformer(tableConfig, schema), new SpecialValueTransformer(schema),
            new NullValueTransformer(tableConfig, schema), new SanitizationTransformer(schema)).filter(t -> !t.isNoOp())
        .collect(Collectors.toList())`
        
 So we add a patch to CompositeTransformer. We haven't find potential risk. So please pinot maintainers help us to review this PR. Thanks in advance!