### PR TITLE
Make FunctionRegistry use Calcite NamedMultiMap

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -19,11 +19,13 @@
 package org.apache.pinot.common.function;
 
 import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
@@ -42,15 +44,16 @@ import org.slf4j.LoggerFactory;
 
 /**
  * Registry for scalar functions.
- * <p>TODO: Merge FunctionRegistry and FunctionDefinitionRegistry to provide one single registry for all functions.
  */
 public class FunctionRegistry {
+  private static final Logger LOGGER = LoggerFactory.getLogger(FunctionRegistry.class);
+  // TODO: remove both when FunctionOperatorTable is in used.
+  private static final Map<String, Map<Integer, FunctionInfo>> FUNCTION_INFO_MAP = new HashMap<>();
+  private static final NameMultimap<PinotScalarFunction> FUNCTION_MAP = new NameMultimap<>();
+
   private FunctionRegistry() {
   }
 
-  private static final Logger LOGGER = LoggerFactory.getLogger(FunctionRegistry.class);
-
-  private static final NameMultimap<PinotScalarFunction> FUNCTION_MAP = new NameMultimap<>();
 
   /**
    * Registers the scalar functions via reflection.
@@ -68,7 +71,9 @@ public class FunctionRegistry {
       if (scalarFunction.enabled()) {
         // Parse annotated function names and alias
         Set<String> scalarFunctionNames = Arrays.stream(scalarFunction.names()).collect(Collectors.toSet());
-        scalarFunctionNames.add(method.getName());
+        if (scalarFunctionNames.size() == 0) {
+          scalarFunctionNames.add(method.getName());
+        }
         boolean nullableParameters = scalarFunction.nullableParameters();
         FunctionRegistry.registerFunction(method, scalarFunctionNames, nullableParameters);
       }
@@ -95,11 +100,24 @@ public class FunctionRegistry {
 
   private static void registerFunction(Method method, Set<String> alias, boolean nullableParameters) {
     if (method.getAnnotation(Deprecated.class) == null) {
-//      String name = canonicalize(method.getName());
       for (String name : alias) {
-        FUNCTION_MAP.put(name, new PinotScalarFunction(name, alias, method, nullableParameters));
+        registerFunctionInfoMap(name, method, nullableParameters);
+        registerCalciteNamedFunctionMap(name, method, nullableParameters);
       }
     }
+  }
+
+  private static void registerFunctionInfoMap(String functionName, Method method, boolean nullableParameters) {
+    FunctionInfo functionInfo = new FunctionInfo(method, method.getDeclaringClass(), nullableParameters);
+    String canonicalName = canonicalize(functionName);
+    Map<Integer, FunctionInfo> functionInfoMap = FUNCTION_INFO_MAP.computeIfAbsent(canonicalName, k -> new HashMap<>());
+    FunctionInfo existFunctionInfo = functionInfoMap.put(method.getParameterCount(), functionInfo);
+    Preconditions.checkState(existFunctionInfo == null || existFunctionInfo.getMethod() == functionInfo.getMethod(),
+        "Function: %s with %s parameters is already registered", functionName, method.getParameterCount());
+  }
+
+  private static void registerCalciteNamedFunctionMap(String name, Method method, boolean nullableParameters) {
+    FUNCTION_MAP.put(name, new PinotScalarFunction(name, method, nullableParameters));
   }
 
   public static Map<String, List<PinotScalarFunction>> getRegisteredCalciteFunctionMap() {
@@ -114,7 +132,9 @@ public class FunctionRegistry {
    * Returns {@code true} if the given function name is registered, {@code false} otherwise.
    */
   public static boolean containsFunction(String functionName) {
-    return FUNCTION_MAP.containsKey(canonicalize(functionName), false);
+    // TODO: remove fallback to FUNCTION_INFO_MAP
+    return FUNCTION_MAP.containsKey(canonicalize(functionName), false)
+        || FUNCTION_INFO_MAP.containsKey(canonicalize(functionName));
   }
 
   /**
@@ -124,6 +144,22 @@ public class FunctionRegistry {
    */
   @Nullable
   public static FunctionInfo getFunctionInfo(String functionName, int numParameters) {
+    // TODO: remove fallback to FUNCTION_INFO_MAP
+    try {
+      return getFunctionInfoFromCalciteNamedMap(functionName, numParameters);
+    } catch (IllegalArgumentException iae) {
+      return getFunctionInfoFromFunctionInfoMap(functionName, numParameters);
+    }
+  }
+
+  @Nullable
+  private static FunctionInfo getFunctionInfoFromFunctionInfoMap(String functionName, int numParameters) {
+    Map<Integer, FunctionInfo> functionInfoMap = FUNCTION_INFO_MAP.get(canonicalize(functionName));
+    return functionInfoMap != null ? functionInfoMap.get(numParameters) : null;
+  }
+
+  @Nullable
+  private static FunctionInfo getFunctionInfoFromCalciteNamedMap(String functionName, int numParameters) {
     List<PinotScalarFunction> candidates = findByNumParameters(FUNCTION_MAP.range(functionName, false), numParameters);
     if (candidates.size() <= 1) {
       return candidates.size() == 1 ? candidates.get(0).getFunctionInfo() : null;
@@ -181,15 +217,13 @@ public class FunctionRegistry {
       implements org.apache.calcite.schema.ScalarFunction {
     private final FunctionInfo _functionInfo;
     private final String _name;
-    private final Set<String> _alias;
     private final Method _method;
 
-    public PinotScalarFunction(String name, Set<String> alias, Method method, boolean isNullableParameter) {
+    public PinotScalarFunction(String name, Method method, boolean isNullableParameter) {
       super(method);
       _name = name;
-      _alias = alias;
       _method = method;
-      _functionInfo = new FunctionInfo(method, method.getClass(), isNullableParameter);
+      _functionInfo = new FunctionInfo(method, method.getDeclaringClass(), isNullableParameter);
     }
 
     @Override
@@ -199,10 +233,6 @@ public class FunctionRegistry {
 
     public String getName() {
       return _name;
-    }
-
-    public Set<String> getAlias() {
-      return _alias;
     }
 
     public Method getMethod() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -140,7 +140,7 @@ public class StringFunctions {
    * @param seperator
    * @return The two input strings joined by the seperator
    */
-  @ScalarFunction(names = "concat_ws")
+  @ScalarFunction(names = {"concatWS", "concat_ws"})
   public static String concatws(String seperator, String input1, String input2) {
     return concat(input1, input2, seperator);
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
@@ -131,7 +131,7 @@ public class InbuiltFunctionEvaluatorTest {
       throws Exception {
     MyFunc myFunc = new MyFunc();
     Method method = myFunc.getClass().getDeclaredMethod("appendToStringAndReturn", String.class);
-    FunctionRegistry.registerFunction(method, false, false);
+    FunctionRegistry.registerFunction(method, false);
     String expression = "appendToStringAndReturn('test ')";
     InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
     assertTrue(evaluator.getArguments().isEmpty());

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
@@ -30,7 +30,6 @@ import org.testng.annotations.Test;
 import static org.testng.Assert.assertEquals;
 import static org.testng.Assert.assertNull;
 import static org.testng.Assert.assertTrue;
-import static org.testng.Assert.fail;
 
 
 public class InbuiltFunctionEvaluatorTest {
@@ -155,21 +154,6 @@ public class InbuiltFunctionEvaluatorTest {
       InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
       GenericRow row = new GenericRow();
       assertNull(evaluator.evaluate(row));
-    }
-  }
-
-  @Test
-  public void testPlaceholderFunctionShouldNotBeRegistered()
-      throws Exception {
-    GenericRow row = new GenericRow();
-    row.putValue("testColumn", "testValue");
-    String expression = "text_match(testColumn, 'pattern')";
-    try {
-      InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
-      evaluator.evaluate(row);
-      fail();
-    } catch (Throwable t) {
-      assertTrue(t.getMessage().contains("text_match"));
     }
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunctionTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/postaggregation/PostAggregationFunctionTest.java
@@ -56,7 +56,7 @@ public class PostAggregationFunctionTest {
     assertEquals(function.invoke(new Object[]{"1234567890"}), "0987654321");
 
     // ST_AsText
-    function = new PostAggregationFunction("ST_AsText", new ColumnDataType[]{ColumnDataType.BYTES});
+    function = new PostAggregationFunction("ST_As_Text", new ColumnDataType[]{ColumnDataType.BYTES});
     assertEquals(function.getResultType(), ColumnDataType.STRING);
     assertEquals(function.invoke(
         new Object[]{GeometrySerializer.serialize(GeometryUtils.GEOMETRY_FACTORY.createPoint(new Coordinate(10, 20)))}),

--- a/pinot-query-planner/src/main/java/org/apache/calcite/jdbc/CalciteSchemaBuilder.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/jdbc/CalciteSchemaBuilder.java
@@ -54,7 +54,8 @@ public class CalciteSchemaBuilder {
   public static CalciteSchema asRootSchema(Schema root) {
     CalciteSchema rootSchema = CalciteSchema.createRootSchema(false, false, "", root);
     SchemaPlus schemaPlus = rootSchema.plus();
-    for (Map.Entry<String, List<Function>> e : FunctionRegistry.getRegisteredCalciteFunctionMap().entrySet()) {
+    for (Map.Entry<String, List<FunctionRegistry.PinotScalarFunction>> e
+        : FunctionRegistry.getRegisteredCalciteFunctionMap().entrySet()) {
       for (Function f : e.getValue()) {
         schemaPlus.add(e.getKey(), f);
       }


### PR DESCRIPTION
Changelist
----

- consolidate FunctionRegistry into CalciteNamedMultiMap
- allows multiple function with same num-of-args
- ready the FunctionRegistry for polymorphism in the future
- ready the CalciteSchema to allow polymorphism and consolidate Transform/Scalar in the future

Unaddressed problem
----

- backward incompatible, all canonicalize function names are not auto canonicalized