### PR TITLE
Remove parameters from ThetaSketchAggregation function

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawThetaSketchAggregationFunction.java
@@ -54,7 +54,6 @@ public class DistinctCountRawThetaSketchAggregationFunction extends DistinctCoun
     List<Sketch> mergedSketches = new ArrayList<>(numAccumulators);
 
     for (ThetaSketchAccumulator accumulator : accumulators) {
-      accumulator.setOrdered(_intermediateOrdering);
       accumulator.setThreshold(_accumulatorThreshold);
       accumulator.setSetOperationBuilder(_setOperationBuilder);
       mergedSketches.add(accumulator.getResult());

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -87,8 +87,6 @@ public class DistinctCountThetaSketchAggregationFunction
   private static final String SET_DIFF = "setdiff";
   private static final String DEFAULT_SKETCH_IDENTIFIER = "$0";
   private static final int DEFAULT_ACCUMULATOR_THRESHOLD = 2;
-  private static final boolean DEFAULT_INTERMEDIATE_ORDERING = false;
-
   private final List<ExpressionContext> _inputExpressions;
   private final boolean _includeDefaultSketch;
   private final List<FilterEvaluator> _filterEvaluators;

--- a/pinot-core/src/test/java/org/apache/pinot/core/common/ObjectSerDeUtilsTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/common/ObjectSerDeUtilsTest.java
@@ -504,15 +504,14 @@ public class ObjectSerDeUtilsTest {
     for (int i = 0; i < NUM_ITERATIONS; i++) {
       UpdateSketch input = Sketches.updateSketchBuilder().build();
       int size = RANDOM.nextInt(100) + 10;
-      boolean shouldOrder = RANDOM.nextBoolean();
 
       for (int j = 0; j < size; j++) {
         input.update(j);
       }
 
       SetOperationBuilder setOperationBuilder = new SetOperationBuilder();
-      ThetaSketchAccumulator accumulator = new ThetaSketchAccumulator(setOperationBuilder, shouldOrder, 2);
-      Sketch sketch = input.compact(shouldOrder, null);
+      ThetaSketchAccumulator accumulator = new ThetaSketchAccumulator(setOperationBuilder, 2);
+      Sketch sketch = input.compact(false, null);
       accumulator.apply(sketch);
 
       byte[] bytes = ObjectSerDeUtils.serialize(accumulator);
@@ -521,7 +520,6 @@ public class ObjectSerDeUtilsTest {
 
       assertEquals(actual.getResult().getEstimate(), sketch.getEstimate(), ERROR_MESSAGE);
       assertEquals(actual.getResult().toByteArray(), sketch.toByteArray(), ERROR_MESSAGE);
-      assertEquals(actual.getResult().isOrdered(), shouldOrder, ERROR_MESSAGE);
     }
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/ThetaSketchAccumulator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/ThetaSketchAccumulator.java
@@ -38,7 +38,6 @@ import org.apache.datasketches.theta.Union;
  */
 public class ThetaSketchAccumulator {
   private ArrayList<Sketch> _accumulator;
-  private boolean _ordered = false;
   private SetOperationBuilder _setOperationBuilder = new SetOperationBuilder();
   private Union _union;
   private int _threshold;
@@ -51,14 +50,9 @@ public class ThetaSketchAccumulator {
   // happens on serialization. Therefore, when deserialized, the values may be null and will
   // require re-initialisation. Since the primary use case is at query time for the Broker
   // and Server, these properties are already in memory and are re-set.
-  public ThetaSketchAccumulator(SetOperationBuilder setOperationBuilder, boolean ordered, int threshold) {
+  public ThetaSketchAccumulator(SetOperationBuilder setOperationBuilder, int threshold) {
     _setOperationBuilder = setOperationBuilder;
-    _ordered = ordered;
     _threshold = threshold;
-  }
-
-  public void setOrdered(boolean ordered) {
-    _ordered = ordered;
   }
 
   public void setSetOperationBuilder(SetOperationBuilder setOperationBuilder) {
@@ -111,12 +105,12 @@ public class ThetaSketchAccumulator {
     }
     // Return the default update "gadget" sketch as a compact sketch
     if (isEmpty()) {
-      return _union.getResult(_ordered, null);
+      return _union.getResult(false, null);
     }
     // Corner-case: the parameters are not strictly respected when there is a single sketch.
     // This single sketch might have been the result of a previously accumulated union and
     // would already have the parameters set.  The sketch is returned as-is without adjusting
-    // ordering and nominal entries which requires an additional union operation.
+    // nominal entries which requires an additional union operation.
     if (_numInputs == 1) {
       return _accumulator.get(0);
     }
@@ -136,6 +130,6 @@ public class ThetaSketchAccumulator {
     }
     _accumulator.clear();
 
-    return _union.getResult(_ordered, null);
+    return _union.getResult(false, null);
   }
 }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/customobject/ThetaSketchAccumulatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/customobject/ThetaSketchAccumulatorTest.java
@@ -39,7 +39,7 @@ public class ThetaSketchAccumulatorTest {
 
   @Test
   public void testEmptyAccumulator() {
-    ThetaSketchAccumulator accumulator = new ThetaSketchAccumulator(_setOperationBuilder, false, 2);
+    ThetaSketchAccumulator accumulator = new ThetaSketchAccumulator(_setOperationBuilder, 2);
     Assert.assertTrue(accumulator.isEmpty());
     Assert.assertEquals(accumulator.getResult().getEstimate(), 0.0);
   }
@@ -50,7 +50,7 @@ public class ThetaSketchAccumulatorTest {
     IntStream.range(0, 1000).forEach(input::update);
     Sketch sketch = input.compact();
 
-    ThetaSketchAccumulator accumulator = new ThetaSketchAccumulator(_setOperationBuilder, false, 2);
+    ThetaSketchAccumulator accumulator = new ThetaSketchAccumulator(_setOperationBuilder, 2);
     accumulator.apply(sketch);
 
     Assert.assertFalse(accumulator.isEmpty());
@@ -66,9 +66,9 @@ public class ThetaSketchAccumulatorTest {
     IntStream.range(1000, 2000).forEach(input2::update);
     Sketch sketch2 = input2.compact();
 
-    ThetaSketchAccumulator accumulator1 = new ThetaSketchAccumulator(_setOperationBuilder, true, 3);
+    ThetaSketchAccumulator accumulator1 = new ThetaSketchAccumulator(_setOperationBuilder, 3);
     accumulator1.apply(sketch1);
-    ThetaSketchAccumulator accumulator2 = new ThetaSketchAccumulator(_setOperationBuilder, true, 3);
+    ThetaSketchAccumulator accumulator2 = new ThetaSketchAccumulator(_setOperationBuilder, 3);
     accumulator2.apply(sketch2);
     accumulator1.merge(accumulator2);
 
@@ -84,7 +84,7 @@ public class ThetaSketchAccumulatorTest {
     IntStream.range(1000, 2000).forEach(input2::update);
     Sketch sketch2 = input2.compact();
 
-    ThetaSketchAccumulator accumulator = new ThetaSketchAccumulator(_setOperationBuilder, true, 3);
+    ThetaSketchAccumulator accumulator = new ThetaSketchAccumulator(_setOperationBuilder, 3);
     accumulator.apply(sketch1);
     accumulator.apply(sketch2);
 
@@ -93,8 +93,8 @@ public class ThetaSketchAccumulatorTest {
 
   @Test
   public void testUnionWithEmptyInput() {
-    ThetaSketchAccumulator accumulator = new ThetaSketchAccumulator(_setOperationBuilder, true, 3);
-    ThetaSketchAccumulator emptyAccumulator = new ThetaSketchAccumulator(_setOperationBuilder, true, 3);
+    ThetaSketchAccumulator accumulator = new ThetaSketchAccumulator(_setOperationBuilder, 3);
+    ThetaSketchAccumulator emptyAccumulator = new ThetaSketchAccumulator(_setOperationBuilder, 3);
 
     accumulator.merge(emptyAccumulator);
 


### PR DESCRIPTION
These additional parameters did not improve performance of the aggregation function when tested in a production environment at scale.  They are therefore removed to simplify the implementation.

Instead, the parameters default to the previous values.  They are removed before the next OSS release to ensure that no end users depend on these unreleased params that have only existed in master to this point.
