### PR TITLE
Add column name to JSONParsing exception message during index build

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonMalformedIndexTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonMalformedIndexTest.java
@@ -18,6 +18,11 @@
  */
 package org.apache.pinot.queries;
 
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
@@ -37,12 +42,6 @@ import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
-
-import java.io.File;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.HashSet;
-import java.util.List;
 
 public class JsonMalformedIndexTest extends BaseQueriesTest {
     private static final String RAW_TABLE_NAME = "testTable";

--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonMalformedIndexTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonMalformedIndexTest.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.queries;
 
 import org.apache.commons.io.FileUtils;
@@ -45,13 +63,13 @@ public class JsonMalformedIndexTest extends BaseQueriesTest {
 
     protected IndexSegment _indexSegment;
     protected List<IndexSegment> _indexSegments;
-    List<GenericRow> records = new ArrayList<>();
+    List<GenericRow> _records = new ArrayList<>();
 
     @BeforeClass
     public void setUp() throws Exception {
-        records.add(createRecord("ludwik von drake",
-                "{\"name\": {\"first\": \"ludwik\", \"last\": \"von drake\"}, \"id\": 181, \"data\": [\"l\", \"b\", \"c\", "
-                        + "\"d\"]"));
+        _records.add(createRecord("ludwik von drake",
+                "{\"name\": {\"first\": \"ludwik\", \"last\": \"von drake\"}, \"id\": 181, "
+                        + "\"data\": [\"l\", \"b\", \"c\", \"d\"]"));
     }
 
     protected void checkResult(String query, Object[][] expectedResults) {
@@ -87,7 +105,7 @@ public class JsonMalformedIndexTest extends BaseQueriesTest {
         segmentGeneratorConfig.setOutDir(indexDir.getPath());
 
         SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
-        driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+        driver.init(segmentGeneratorConfig, new GenericRowRecordReader(_records));
         driver.build();
 
         IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
@@ -118,5 +136,4 @@ public class JsonMalformedIndexTest extends BaseQueriesTest {
     protected List<IndexSegment> getIndexSegments() {
         return _indexSegments;
     }
-
 }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonMalformedIndexTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonMalformedIndexTest.java
@@ -1,17 +1,15 @@
 package org.apache.pinot.queries;
 
-import com.google.common.collect.ImmutableList;
-import com.google.common.collect.ImmutableMap;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.response.broker.BrokerResponseNative;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.ColumnJsonParserException;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
-import org.apache.pinot.spi.config.table.FieldConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -20,7 +18,6 @@ import org.apache.pinot.spi.data.readers.GenericRow;
 import org.apache.pinot.spi.utils.ReadMode;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.testng.annotations.BeforeClass;
-import org.testng.annotations.DataProvider;
 import org.testng.annotations.Test;
 
 import java.io.File;
@@ -29,7 +26,7 @@ import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
 
-public class JsonMalformedTest extends BaseQueriesTest {
+public class JsonMalformedIndexTest extends BaseQueriesTest {
 
 
     static final String RAW_TABLE_NAME = "testTable";
@@ -51,8 +48,7 @@ public class JsonMalformedTest extends BaseQueriesTest {
     List<GenericRow> records = new ArrayList<>();
 
     @BeforeClass
-    public void setUp()
-            throws Exception {
+    public void setUp() throws Exception {
         records.add(createRecord("ludwik von drake",
                 "{\"name\": {\"first\": \"ludwik\", \"last\": \"von drake\"}, \"id\": 181, \"data\": [\"l\", \"b\", \"c\", "
                         + "\"d\"]"));
@@ -74,7 +70,10 @@ public class JsonMalformedTest extends BaseQueriesTest {
         return record;
     }
 
-    @Test
+    @Test(
+            expectedExceptions = ColumnJsonParserException.class,
+            expectedExceptionsMessageRegExp = "Column: jsonColumn.*"
+    )
     public void testJsonIndexBuild() throws Exception {
         File indexDir = indexDir();
         FileUtils.deleteDirectory(indexDir);

--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonMalformedIndexTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonMalformedIndexTest.java
@@ -45,28 +45,22 @@ import java.util.HashSet;
 import java.util.List;
 
 public class JsonMalformedIndexTest extends BaseQueriesTest {
-
-
-    static final String RAW_TABLE_NAME = "testTable";
-    static final String SEGMENT_NAME = "testSegment";
-
-    static final String STRING_COLUMN = "stringColumn";
-    static final String JSON_COLUMN = "jsonColumn";
-
+    private static final String RAW_TABLE_NAME = "testTable";
+    private static final String SEGMENT_NAME = "testSegment";
+    private static final String STRING_COLUMN = "stringColumn";
+    private static final String JSON_COLUMN = "jsonColumn";
     private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
             .addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
             .addSingleValueDimension(JSON_COLUMN, FieldSpec.DataType.STRING).build();
-
     private static final TableConfig TABLE_CONFIG =
-            new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
-                    .build();
-
-    protected IndexSegment _indexSegment;
-    protected List<IndexSegment> _indexSegments;
-    List<GenericRow> _records = new ArrayList<>();
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME).build();
+    private IndexSegment _indexSegment;
+    private List<IndexSegment> _indexSegments;
+    private final List<GenericRow> _records = new ArrayList<>();
 
     @BeforeClass
-    public void setUp() throws Exception {
+    public void setUp()
+            throws Exception {
         _records.add(createRecord("ludwik von drake",
                 "{\"name\": {\"first\": \"ludwik\", \"last\": \"von drake\"}, \"id\": 181, "
                         + "\"data\": [\"l\", \"b\", \"c\", \"d\"]"));
@@ -88,11 +82,10 @@ public class JsonMalformedIndexTest extends BaseQueriesTest {
         return record;
     }
 
-    @Test(
-            expectedExceptions = ColumnJsonParserException.class,
-            expectedExceptionsMessageRegExp = "Column: jsonColumn.*"
-    )
-    public void testJsonIndexBuild() throws Exception {
+    @Test(expectedExceptions = ColumnJsonParserException.class,
+          expectedExceptionsMessageRegExp = "Column: jsonColumn.*")
+    public void testJsonIndexBuild()
+            throws Exception {
         File indexDir = indexDir();
         FileUtils.deleteDirectory(indexDir);
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/JsonMalformedTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/JsonMalformedTest.java
@@ -1,0 +1,123 @@
+package org.apache.pinot.queries;
+
+import com.google.common.collect.ImmutableList;
+import com.google.common.collect.ImmutableMap;
+import org.apache.commons.io.FileUtils;
+import org.apache.pinot.common.response.broker.BrokerResponseNative;
+import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoader;
+import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
+import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
+import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
+import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.utils.ReadMode;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+
+public class JsonMalformedTest extends BaseQueriesTest {
+
+
+    static final String RAW_TABLE_NAME = "testTable";
+    static final String SEGMENT_NAME = "testSegment";
+
+    static final String STRING_COLUMN = "stringColumn";
+    static final String JSON_COLUMN = "jsonColumn";
+
+    private static final Schema SCHEMA = new Schema.SchemaBuilder().setSchemaName(RAW_TABLE_NAME)
+            .addSingleValueDimension(STRING_COLUMN, FieldSpec.DataType.STRING)
+            .addSingleValueDimension(JSON_COLUMN, FieldSpec.DataType.STRING).build();
+
+    private static final TableConfig TABLE_CONFIG =
+            new TableConfigBuilder(TableType.OFFLINE).setTableName(RAW_TABLE_NAME)
+                    .build();
+
+    protected IndexSegment _indexSegment;
+    protected List<IndexSegment> _indexSegments;
+    List<GenericRow> records = new ArrayList<>();
+
+    @BeforeClass
+    public void setUp()
+            throws Exception {
+        records.add(createRecord("ludwik von drake",
+                "{\"name\": {\"first\": \"ludwik\", \"last\": \"von drake\"}, \"id\": 181, \"data\": [\"l\", \"b\", \"c\", "
+                        + "\"d\"]"));
+    }
+
+    protected void checkResult(String query, Object[][] expectedResults) {
+        BrokerResponseNative brokerResponse = getBrokerResponseForOptimizedQuery(query, TABLE_CONFIG, SCHEMA);
+        QueriesTestUtils.testInterSegmentsResult(brokerResponse, Arrays.asList(expectedResults));
+    }
+
+    File indexDir() {
+        return new File(FileUtils.getTempDirectory(), getClass().getSimpleName());
+    }
+
+    GenericRow createRecord(String stringValue, String jsonValue) {
+        GenericRow record = new GenericRow();
+        record.putValue(STRING_COLUMN, stringValue);
+        record.putValue(JSON_COLUMN, jsonValue);
+        return record;
+    }
+
+    @Test
+    public void testJsonIndexBuild() throws Exception {
+        File indexDir = indexDir();
+        FileUtils.deleteDirectory(indexDir);
+
+        List<String> jsonIndexColumns = new ArrayList<>();
+        jsonIndexColumns.add("jsonColumn");
+        TABLE_CONFIG.getIndexingConfig().setJsonIndexColumns(jsonIndexColumns);
+        SegmentGeneratorConfig segmentGeneratorConfig = new SegmentGeneratorConfig(TABLE_CONFIG, SCHEMA);
+        segmentGeneratorConfig.setTableName(RAW_TABLE_NAME);
+        segmentGeneratorConfig.setSegmentName(SEGMENT_NAME);
+        segmentGeneratorConfig.setOutDir(indexDir.getPath());
+
+        SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
+        driver.init(segmentGeneratorConfig, new GenericRowRecordReader(records));
+        driver.build();
+
+        IndexLoadingConfig indexLoadingConfig = new IndexLoadingConfig();
+        indexLoadingConfig.setTableConfig(TABLE_CONFIG);
+        indexLoadingConfig.setJsonIndexColumns(new HashSet<>(jsonIndexColumns));
+        indexLoadingConfig.setReadMode(ReadMode.mmap);
+
+        ImmutableSegment immutableSegment =
+                ImmutableSegmentLoader.load(new File(indexDir, SEGMENT_NAME), indexLoadingConfig);
+        _indexSegment = immutableSegment;
+        _indexSegments = Arrays.asList(immutableSegment, immutableSegment);
+
+        Object[][] expecteds1 = {{"von drake"}, {"von drake"}, {"von drake"}, {"von drake"}};
+        checkResult("SELECT jsonextractscalar(jsonColumn, '$.name.last', 'STRING') FROM testTable", expecteds1);
+    }
+
+    @Override
+    protected String getFilter() {
+        return "";
+    }
+
+    @Override
+    protected IndexSegment getIndexSegment() {
+        return _indexSegment;
+    }
+
+    @Override
+    protected List<IndexSegment> getIndexSegments() {
+        return _indexSegments;
+    }
+
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnJsonParserException.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnJsonParserException.java
@@ -26,7 +26,6 @@ public class ColumnJsonParserException extends JsonParseException {
      * processing JSON content in a column
      * Sub-class of {@link com.fasterxml.jackson.core.JsonParseException}.
      */
-
     private final String _columnName;
 
     public ColumnJsonParserException(String columnName, JsonParseException jpe) {
@@ -39,10 +38,7 @@ public class ColumnJsonParserException extends JsonParseException {
      */
     @Override
     public String getMessage() {
-        return "Column: "
-                + _columnName
-                + "\n"
-                + super.getMessage();
+        return "Column: " + _columnName + "\n" + super.getMessage();
     }
 
     @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnJsonParserException.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnJsonParserException.java
@@ -27,9 +27,9 @@ public class ColumnJsonParserException extends JsonParseException {
      * Sub-class of {@link com.fasterxml.jackson.core.JsonParseException}.
      */
 
-    final String _columnName;
+    private final String _columnName;
 
-    protected ColumnJsonParserException(String columnName, JsonParseException jpe) {
+    public ColumnJsonParserException(String columnName, JsonParseException jpe) {
         super(jpe.getProcessor(), jpe.getOriginalMessage(), jpe.getCause());
         _columnName = columnName;
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnJsonParserException.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnJsonParserException.java
@@ -1,0 +1,44 @@
+package org.apache.pinot.segment.local.segment.creator.impl;
+
+import com.fasterxml.jackson.core.JsonLocation;
+import com.fasterxml.jackson.core.JsonParseException;
+
+public class ColumnJsonParserException extends JsonParseException {
+    /**
+     * Exception type for parsing problems when
+     * processing JSON content in a column
+     * Sub-class of {@link com.fasterxml.jackson.core.JsonParseException}.
+     */
+    final static long serialVersionUID = 123; // Stupid eclipse...
+
+    final String columnName;
+
+    protected ColumnJsonParserException(String columnName, String msg, JsonLocation loc, Throwable rootCause)
+    {
+        /* Argh. IOException(Throwable,String) is only available starting
+         * with JDK 1.6...
+         */
+        super(msg, loc, rootCause);
+        this.columnName = columnName;
+    }
+
+    /**
+     * Default method overridden so that we can add location information
+     */
+    @Override
+    public String getMessage()
+    {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Column: ");
+        sb.append(this.columnName);
+        sb.append("\n");
+        sb.append(super.getMessage());
+        return sb.toString();
+    }
+
+    @Override
+    public String toString() {
+        return getClass().getName()+": "+getMessage();
+    }
+
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnJsonParserException.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnJsonParserException.java
@@ -1,3 +1,21 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
 package org.apache.pinot.segment.local.segment.creator.impl;
 
 import com.fasterxml.jackson.core.JsonLocation;
@@ -11,26 +29,24 @@ public class ColumnJsonParserException extends JsonParseException {
      */
     final static long serialVersionUID = 123; // Stupid eclipse...
 
-    final String columnName;
+    final String _columnName;
 
-    protected ColumnJsonParserException(String columnName, String msg, JsonLocation loc, Throwable rootCause)
-    {
+    protected ColumnJsonParserException(String columnName, String msg, JsonLocation loc, Throwable rootCause) {
         /* Argh. IOException(Throwable,String) is only available starting
          * with JDK 1.6...
          */
         super(msg, loc, rootCause);
-        this.columnName = columnName;
+        _columnName = columnName;
     }
 
     /**
      * Default method overridden so that we can add location information
      */
     @Override
-    public String getMessage()
-    {
+    public String getMessage() {
         StringBuilder sb = new StringBuilder();
         sb.append("Column: ");
-        sb.append(this.columnName);
+        sb.append(_columnName);
         sb.append("\n");
         sb.append(super.getMessage());
         return sb.toString();
@@ -38,7 +54,6 @@ public class ColumnJsonParserException extends JsonParseException {
 
     @Override
     public String toString() {
-        return getClass().getName()+": "+getMessage();
+        return getClass().getName() + ": " + getMessage();
     }
-
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnJsonParserException.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnJsonParserException.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.segment.local.segment.creator.impl;
 
-import com.fasterxml.jackson.core.JsonLocation;
 import com.fasterxml.jackson.core.JsonParseException;
 
 public class ColumnJsonParserException extends JsonParseException {
@@ -40,10 +39,10 @@ public class ColumnJsonParserException extends JsonParseException {
      */
     @Override
     public String getMessage() {
-        return "Column: " +
-                _columnName +
-                "\n" +
-                super.getMessage();
+        return "Column: "
+                + _columnName
+                + "\n"
+                + super.getMessage();
     }
 
     @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnJsonParserException.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnJsonParserException.java
@@ -40,12 +40,10 @@ public class ColumnJsonParserException extends JsonParseException {
      */
     @Override
     public String getMessage() {
-        StringBuilder sb = new StringBuilder();
-        sb.append("Column: ");
-        sb.append(_columnName);
-        sb.append("\n");
-        sb.append(super.getMessage());
-        return sb.toString();
+        return "Column: " +
+                _columnName +
+                "\n" +
+                super.getMessage();
     }
 
     @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnJsonParserException.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/ColumnJsonParserException.java
@@ -27,20 +27,16 @@ public class ColumnJsonParserException extends JsonParseException {
      * processing JSON content in a column
      * Sub-class of {@link com.fasterxml.jackson.core.JsonParseException}.
      */
-    final static long serialVersionUID = 123; // Stupid eclipse...
 
     final String _columnName;
 
-    protected ColumnJsonParserException(String columnName, String msg, JsonLocation loc, Throwable rootCause) {
-        /* Argh. IOException(Throwable,String) is only available starting
-         * with JDK 1.6...
-         */
-        super(msg, loc, rootCause);
+    protected ColumnJsonParserException(String columnName, JsonParseException jpe) {
+        super(jpe.getProcessor(), jpe.getOriginalMessage(), jpe.getCause());
         _columnName = columnName;
     }
 
     /**
-     * Default method overridden so that we can add location information
+     * Default method overridden so that we can add column and location information
      */
     @Override
     public String getMessage() {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -323,7 +323,7 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
           indexMultiValueRow(dictionaryCreator, (Object[]) columnValueToIndex, creatorsByIndex);
         }
       } catch (JsonParseException jpe) {
-        throw new ColumnJsonParserException(columnName, jpe.getOriginalMessage(), jpe.getLocation(), jpe.getCause());
+        throw new ColumnJsonParserException(columnName, jpe);
       }
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/creator/impl/SegmentColumnarIndexCreator.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.local.segment.creator.impl;
 
+import com.fasterxml.jackson.core.JsonParseException;
 import com.google.common.annotations.VisibleForTesting;
 import com.google.common.base.Preconditions;
 import com.google.common.collect.Maps;
@@ -315,11 +316,14 @@ public class SegmentColumnarIndexCreator implements SegmentCreator {
 
       FieldSpec fieldSpec = _schema.getFieldSpecFor(columnName);
       SegmentDictionaryCreator dictionaryCreator = _dictionaryCreatorMap.get(columnName);
-
-      if (fieldSpec.isSingleValueField()) {
-        indexSingleValueRow(dictionaryCreator, columnValueToIndex, creatorsByIndex);
-      } else {
-        indexMultiValueRow(dictionaryCreator, (Object[]) columnValueToIndex, creatorsByIndex);
+      try {
+        if (fieldSpec.isSingleValueField()) {
+          indexSingleValueRow(dictionaryCreator, columnValueToIndex, creatorsByIndex);
+        } else {
+          indexMultiValueRow(dictionaryCreator, (Object[]) columnValueToIndex, creatorsByIndex);
+        }
+      } catch (JsonParseException jpe) {
+        throw new ColumnJsonParserException(columnName, jpe.getOriginalMessage(), jpe.getLocation(), jpe.getCause());
       }
     }
 


### PR DESCRIPTION
JSON Index build may fail due to errors in JSON content. When there are multiple JSON indices or when the schema is not immediately available, the column for which index build broke is not clear. 

Add column name to the JSONParsing Exception message to help debug JSON index builds.

Previously, a JSON Parse Exception emitted the following message:

```
Unexpected end-of-input: expected close marker for Object (start marker at [Source: (String)"<json content>"; line: 1, column: 91]
``` 

With this change, the above error message is prepended with `Column: <column name>`