### PR TITLE
Bug fix: reset primary key count to 0 when table is deleted

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -772,6 +772,11 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       }
     }
     doClose();
+    // We don't remove the segment from the metadata manager when
+    // it's closed. This was done to make table deletion faster. Since we don't remove the segment, we never decrease
+    // the primary key count. So, we set the primary key count to 0 here.
+    _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId, ServerGauge.UPSERT_PRIMARY_KEYS_COUNT,
+        0L);
     _logger.info("Closed the metadata manager");
   }
 


### PR DESCRIPTION
We made change in the Table deletion flow to not remove segments from the upsert metadata manager and directly close it to save time.

However, due to this change, we run into a metric mismatch issue, where the primary key count still shows up as the last updated one instead of 0 or NULL in dashboards.

The fix is to set this metric to 0 explicitly when the metadata manager is closed. 

This can be verified in the following way:

1. Download prometheus javagent https://repo.maven.apache.org/maven2/io/prometheus/jmx/jmx_prometheus_javaagent/0.20.0/jmx_prometheus_javaagent-0.20.0.jar

2. Run UpsertQuickstart with the following VM options `-ea -javaagent:jmx_prometheus_javaagent-0.20.0.jar=9021:$PINOT_GIT_DIR/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml`

3. Run jconsole and connect to quickstart VM

4. Check the metric `"org.apache.pinot.common.metrics":type="ServerMetrics",name="pinot.server.upsertPrimaryKeysCount.upsertMeetupRsvp_REALTIME.0"` 

5. Delete the table and check the metric again.

