### PR TITLE
Proper computation of realtime "segment.flush.threshold.size" in case of force-commit

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/protocols/SegmentCompletionProtocol.java
@@ -255,6 +255,7 @@ public class SegmentCompletionProtocol {
         _memoryUsedBytes = MEMORY_USED_BYTES_DEFAULT;
         _segmentSizeBytes = SEGMENT_SIZE_BYTES_DEFAULT;
         _streamPartitionMsgOffset = null;
+        _reason = null;
       }
 
       public Params(Params params) {
@@ -269,6 +270,7 @@ public class SegmentCompletionProtocol {
         _memoryUsedBytes = params.getMemoryUsedBytes();
         _segmentSizeBytes = params.getSegmentSizeBytes();
         _streamPartitionMsgOffset = params.getStreamPartitionMsgOffset();
+        _reason = params.getReason();
       }
 
       @Deprecated

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/LLCSegmentCompletionHandlers.java
@@ -363,6 +363,7 @@ public class LLCSegmentCompletionHandlers {
       @QueryParam(SegmentCompletionProtocol.PARAM_WAIT_TIME_MILLIS) long waitTimeMillis,
       @QueryParam(SegmentCompletionProtocol.PARAM_ROW_COUNT) int numRows,
       @QueryParam(SegmentCompletionProtocol.PARAM_SEGMENT_SIZE_BYTES) long segmentSizeBytes,
+      @QueryParam(SegmentCompletionProtocol.PARAM_REASON) String stopReason,
       FormDataMultiPart metadataFiles) {
     if (instanceId == null || segmentName == null || segmentLocation == null || metadataFiles == null || (offset == -1
         && streamPartitionMsgOffset == null)) {
@@ -376,7 +377,7 @@ public class LLCSegmentCompletionHandlers {
     SegmentCompletionProtocol.Request.Params requestParams = new SegmentCompletionProtocol.Request.Params();
     requestParams.withInstanceId(instanceId).withSegmentName(segmentName).withSegmentLocation(segmentLocation)
         .withSegmentSizeBytes(segmentSizeBytes).withBuildTimeMillis(buildTimeMillis).withWaitTimeMillis(waitTimeMillis)
-        .withNumRows(numRows).withMemoryUsedBytes(memoryUsedBytes);
+        .withNumRows(numRows).withMemoryUsedBytes(memoryUsedBytes).withReason(stopReason);
     extractOffsetFromParams(requestParams, streamPartitionMsgOffset, offset);
     LOGGER.info("Processing segmentCommitEndWithMetadata:{}", requestParams.toString());
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/CommittingSegmentDescriptor.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/CommittingSegmentDescriptor.java
@@ -31,6 +31,7 @@ public class CommittingSegmentDescriptor {
   private String _segmentLocation;
   private String _nextOffset;
   private SegmentMetadataImpl _segmentMetadata;
+  private String _stopReason;
 
   public static CommittingSegmentDescriptor fromSegmentCompletionReqParams(
       SegmentCompletionProtocol.Request.Params reqParams) {
@@ -38,6 +39,7 @@ public class CommittingSegmentDescriptor {
         new CommittingSegmentDescriptor(reqParams.getSegmentName(), reqParams.getStreamPartitionMsgOffset(),
             reqParams.getSegmentSizeBytes());
     committingSegmentDescriptor.setSegmentLocation(reqParams.getSegmentLocation());
+    committingSegmentDescriptor.setStopReason(reqParams.getReason());
     return committingSegmentDescriptor;
   }
 
@@ -94,5 +96,13 @@ public class CommittingSegmentDescriptor {
 
   public void setSegmentMetadata(SegmentMetadataImpl segmentMetadata) {
     _segmentMetadata = segmentMetadata;
+  }
+
+  public String getStopReason() {
+    return _stopReason;
+  }
+
+  public void setStopReason(String stopReason) {
+    _stopReason = stopReason;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentFlushThresholdComputer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentFlushThresholdComputer.java
@@ -22,10 +22,9 @@ import com.google.common.annotations.VisibleForTesting;
 import java.time.Clock;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.common.protocols.SegmentCompletionProtocol;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.utils.TimeUtils;
-
-import static org.apache.pinot.common.protocols.SegmentCompletionProtocol.REASON_FORCE_COMMIT_MESSAGE_RECEIVED;
 
 
 class SegmentFlushThresholdComputer {
@@ -82,7 +81,8 @@ class SegmentFlushThresholdComputer {
 
     final long committingSegmentSizeBytes = committingSegmentDescriptor.getSegmentSizeBytes();
     if (committingSegmentSizeBytes <= 0 // repair segment case
-        || REASON_FORCE_COMMIT_MESSAGE_RECEIVED.equals(committingSegmentDescriptor.getStopReason())) {
+        || SegmentCompletionProtocol.REASON_FORCE_COMMIT_MESSAGE_RECEIVED.equals(
+        committingSegmentDescriptor.getStopReason())) {
       String reason = committingSegmentSizeBytes <= 0 //
           ? "Committing segment size is not available" //
           : "Committing segment is due to force-commit";

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentFlushThresholdComputerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentFlushThresholdComputerTest.java
@@ -120,7 +120,7 @@ public class SegmentFlushThresholdComputerTest {
     when(committingSegmentZKMetadata.getSizeThresholdToFlushSegment()).thenReturn(committingSegmentSizeThreshold);
 
     StreamConfig streamConfig = mock(StreamConfig.class);
-    
+
     int newSegmentSizeThreshold =
         computer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
             "newSegmentName");

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentFlushThresholdComputerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentFlushThresholdComputerTest.java
@@ -26,6 +26,7 @@ import org.apache.pinot.spi.stream.StreamConfig;
 import org.testng.annotations.Test;
 
 import static java.util.concurrent.TimeUnit.MILLISECONDS;
+import static org.apache.pinot.common.protocols.SegmentCompletionProtocol.*;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 import static org.testng.Assert.assertEquals;
@@ -103,6 +104,28 @@ public class SegmentFlushThresholdComputerTest {
         "newSegmentName");
 
     assertEquals(threshold, segmentSizeThreshold);
+  }
+
+  @Test
+  public void testUseLastSegmentsThresholdIfSegmentIsCommittingDueToForceCommit() {
+    long committingSegmentSizeBytes = 500_000L;
+    int committingSegmentSizeThreshold = 25_000;
+    SegmentFlushThresholdComputer computer = new SegmentFlushThresholdComputer();
+
+    CommittingSegmentDescriptor committingSegmentDescriptor = mock(CommittingSegmentDescriptor.class);
+    when(committingSegmentDescriptor.getSegmentSizeBytes()).thenReturn(committingSegmentSizeBytes);
+    when(committingSegmentDescriptor.getStopReason()).thenReturn(REASON_FORCE_COMMIT_MESSAGE_RECEIVED);
+
+    SegmentZKMetadata committingSegmentZKMetadata = mock(SegmentZKMetadata.class);
+    when(committingSegmentZKMetadata.getSizeThresholdToFlushSegment()).thenReturn(committingSegmentSizeThreshold);
+
+    StreamConfig streamConfig = mock(StreamConfig.class);
+    
+    int newSegmentSizeThreshold =
+        computer.computeThreshold(streamConfig, committingSegmentDescriptor, committingSegmentZKMetadata,
+            "newSegmentName");
+
+    assertEquals(newSegmentSizeThreshold, committingSegmentSizeThreshold);
   }
 
   @Test

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1060,7 +1060,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     SegmentCompletionProtocol.Request.Params params = new SegmentCompletionProtocol.Request.Params();
 
     params.withSegmentName(_segmentNameStr).withStreamPartitionMsgOffset(_currentOffset.toString())
-        .withNumRows(_numRowsConsumed).withInstanceId(_instanceId)
+        .withNumRows(_numRowsConsumed).withInstanceId(_instanceId).withReason(_stopReason)
         .withBuildTimeMillis(_segmentBuildDescriptor.getBuildTimeMillis())
         .withSegmentSizeBytes(_segmentBuildDescriptor.getSegmentSizeBytes())
         .withWaitTimeMillis(_segmentBuildDescriptor.getWaitTimeMillis());


### PR DESCRIPTION
The `SegmentFlushThresholdComputer` does not appropriately manage situations where segments are committing as a result of force-commit requests. In this PR, the size threshold of the committing segment is selected as the value for the new consuming segment.