### PR TITLE
Add a 'lastUsed' option for resumeConsumption.consumeFrom

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRealtimeTableResource.java
@@ -109,26 +109,26 @@ public class PinotRealtimeTableResource {
   @Produces(MediaType.APPLICATION_JSON)
   @ApiOperation(value = "Resume consumption of a realtime table", notes =
       "Resume the consumption for a realtime table. ConsumeFrom parameter indicates from which offsets "
-          + "consumption should resume. Recommended value is 'lastUsed', which indicates consumption should continue "
-          + "based on the offsets in segment ZK metadata, and in case the offsets are already gone, the first "
+          + "consumption should resume. Recommended value is 'lastConsumed', which indicates consumption should "
+          + "continue based on the offsets in segment ZK metadata, and in case the offsets are already gone, the first "
           + "available offsets are picked to minimize the data loss.")
   public Response resumeConsumption(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(
-          value = "lastUsed (safer) | smallest (repeat rows) | largest (miss rows)",
-          allowableValues = "lastUsed, smallest, largest",
-          defaultValue = "lastUsed"
+          value = "lastConsumed (safer) | smallest (repeat rows) | largest (miss rows)",
+          allowableValues = "lastConsumed, smallest, largest",
+          defaultValue = "lastConsumed"
       )
       @QueryParam("consumeFrom") String consumeFrom) {
     String tableNameWithType = TableNameBuilder.REALTIME.tableNameWithType(tableName);
     validateTable(tableNameWithType);
-    if ("lastUsed".equalsIgnoreCase(consumeFrom)) {
+    if ("lastConsumed".equalsIgnoreCase(consumeFrom)) {
       consumeFrom = null;
     }
     if (consumeFrom != null && !consumeFrom.equalsIgnoreCase("smallest") && !consumeFrom.equalsIgnoreCase("largest")) {
       throw new ControllerApplicationException(LOGGER,
-          String.format("consumeFrom param '%s' is not valid. Valid values are 'lastUsed', 'smallest' and 'largest'.",
-              consumeFrom), Response.Status.BAD_REQUEST);
+          String.format("consumeFrom param '%s' is not valid. Valid values are 'lastConsumed', 'smallest' and "
+                  + "'largest'.", consumeFrom), Response.Status.BAD_REQUEST);
     }
     try {
       return Response.ok(_pinotLLCRealtimeSegmentManager.resumeConsumption(tableNameWithType, consumeFrom)).build();


### PR DESCRIPTION
We recently find issues using the `resumeConsumption` endpoint and we think it would be better to improve the swagger usability. Specifically, in current version the swagger UI is:

![image](https://github.com/apache/pinot/assets/1913993/e97d218f-567c-43f3-add3-91ca59ae6722)

It is important to notice that the expected and safe value for `consumeFrom` is null. That is explained in the description, but a misconfiguration may produce data loss, we think it is important to improve the message and usability. This PR does the following:
1. Adds a new value for `consumeFrom` called `lastUsed`. When that value is provided, Pinot behaves exactly as when null is provided.
2. The UX is improved in such a way that:
   * The list of valid values is codified, so swagger shows a combo box to select them
   * Each value has a small description of its effect

As a result, this is the new UI:
![image](https://github.com/apache/pinot/assets/1913993/4f3ac7c6-896f-414f-9958-9c2970d4bf7f)
