### PR TITLE
Create DateTimeGenerator and add it to data generator

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/DataGeneratorSpec.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/DataGeneratorSpec.java
@@ -41,6 +41,8 @@ public class DataGeneratorSpec {
   private final Map<String, DataType> _dataTypeMap;
   private final Map<String, FieldType> _fieldTypeMap;
   private final Map<String, TimeUnit> _timeUnitMap;
+  private final Map<String, String> _dateTimeFormatMap;
+  private final Map<String, String> _dateTimeGranularityMap;
 
   @Deprecated
   private FileFormat _outputFileFormat;
@@ -74,11 +76,15 @@ public class DataGeneratorSpec {
     _dataTypeMap = dataTypesMap;
     _fieldTypeMap = fieldTypesMap;
     _timeUnitMap = timeUnitMap;
+
+    _dateTimeFormatMap = new HashMap<>();
+    _dateTimeGranularityMap = new HashMap<>();
   }
 
   public DataGeneratorSpec(List<String> columns, Map<String, Integer> cardinalityMap, Map<String, IntRange> rangeMap,
       Map<String, Map<String, Object>> patternMap, Map<String, Double> mvCountMap, Map<String, Integer> lengthMap,
-      Map<String, DataType> dataTypesMap, Map<String, FieldType> fieldTypesMap, Map<String, TimeUnit> timeUnitMap) {
+      Map<String, DataType> dataTypesMap, Map<String, FieldType> fieldTypesMap, Map<String, TimeUnit> timeUnitMap,
+      Map<String, String> dateTimeFormatMap, Map<String, String> dateTimeGranularityMap) {
     _columns = columns;
     _cardinalityMap = cardinalityMap;
     _rangeMap = rangeMap;
@@ -89,6 +95,8 @@ public class DataGeneratorSpec {
     _dataTypeMap = dataTypesMap;
     _fieldTypeMap = fieldTypesMap;
     _timeUnitMap = timeUnitMap;
+    _dateTimeGranularityMap = dateTimeGranularityMap;
+    _dateTimeFormatMap = dateTimeFormatMap;
   }
 
   public Map<String, DataType> getDataTypeMap() {
@@ -139,6 +147,14 @@ public class DataGeneratorSpec {
     return _outputDir;
   }
 
+  public Map<String, String> getDateTimeFormatMap() {
+    return _dateTimeFormatMap;
+  }
+
+  public Map<String, String> getDateTimeGranularityMap() {
+    return _dateTimeGranularityMap;
+  }
+
   @Override
   public String toString() {
     final StringBuilder builder = new StringBuilder();
@@ -155,5 +171,79 @@ public class DataGeneratorSpec {
     builder.append("output file format : " + _outputFileFormat);
     builder.append(", output dir : " + _outputDir);
     return builder.toString();
+  }
+
+  public static class Builder {
+    private List<String> _columns = new ArrayList<>();
+    private Map<String, Integer> _cardinalityMap = new HashMap<>();
+    private Map<String, IntRange> _rangeMap = new HashMap<>();
+    private Map<String, Map<String, Object>> _patternMap = new HashMap<>();
+    private Map<String, Double> _mvCountMap = new HashMap<>();
+    private Map<String, Integer> _lengthMap = new HashMap<>();
+    private Map<String, DataType> _dataTypeMap = new HashMap<>();
+    private Map<String, FieldType> _fieldTypeMap = new HashMap<>();
+    private Map<String, TimeUnit> _timeUnitMap = new HashMap<>();
+    private Map<String, String> _dateTimeFormatMap = new HashMap<>();
+    private Map<String, String> _dateTimeGranularityMap = new HashMap<>();
+
+    public DataGeneratorSpec build() {
+      return new DataGeneratorSpec(_columns, _cardinalityMap, _rangeMap, _patternMap, _mvCountMap, _lengthMap,
+          _dataTypeMap, _fieldTypeMap, _timeUnitMap, _dateTimeFormatMap, _dateTimeGranularityMap);
+    }
+
+    public Builder setColumns(List<String> columns) {
+      _columns = columns;
+      return this;
+    }
+
+    public Builder setCardinalityMap(Map<String, Integer> cardinalityMap) {
+      _cardinalityMap = cardinalityMap;
+      return this;
+    }
+
+    public Builder setRangeMap(Map<String, IntRange> rangeMap) {
+      _rangeMap = rangeMap;
+      return this;
+    }
+
+    public Builder setPatternMap(Map<String, Map<String, Object>> patternMap) {
+      _patternMap = patternMap;
+      return this;
+    }
+
+    public Builder setMvCountMap(Map<String, Double> mvCountMap) {
+      _mvCountMap = mvCountMap;
+      return this;
+    }
+
+    public Builder setLengthMap(Map<String, Integer> lengthMap) {
+      _lengthMap = lengthMap;
+      return this;
+    }
+
+    public Builder setDataTypeMap(Map<String, DataType> dataTypeMap) {
+      _dataTypeMap = dataTypeMap;
+      return this;
+    }
+
+    public Builder setFieldTypeMap(Map<String, FieldType> fieldTypeMap) {
+      _fieldTypeMap = fieldTypeMap;
+      return this;
+    }
+
+    public Builder setTimeUnitMap(Map<String, TimeUnit> timeUnitMap) {
+      _timeUnitMap = timeUnitMap;
+      return this;
+    }
+
+    public Builder setDateTimeFormatMap(Map<String, String> dateTimeFormatMap) {
+      _dateTimeFormatMap = dateTimeFormatMap;
+      return this;
+    }
+
+    public Builder setDateTimeGranularityMap(Map<String, String> dateTimeGranularityMap) {
+      _dateTimeGranularityMap = dateTimeGranularityMap;
+      return this;
+    }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/DateTimeGenerator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/generator/DateTimeGenerator.java
@@ -1,0 +1,51 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.controller.recommender.data.generator;
+
+import java.util.Date;
+import java.util.Random;
+import org.apache.pinot.spi.data.DateTimeFormatSpec;
+import org.apache.pinot.spi.data.DateTimeGranularitySpec;
+
+
+public class DateTimeGenerator implements Generator {
+
+  private static final int MULTIPLIER_CARDINALITY = 5;
+  private final DateTimeFormatSpec _formatSpec;
+  private final DateTimeGranularitySpec _granularitySpec;
+  private long _currentValue;
+  private Random _multiplier = new Random();
+
+  public DateTimeGenerator(String format, String granularity) {
+    _formatSpec = new DateTimeFormatSpec(format);
+    _granularitySpec = new DateTimeGranularitySpec(granularity);
+  }
+
+  @Override
+  public void init() {
+    _currentValue = new Date().getTime();
+  }
+
+  @Override
+  public Object next() {
+    _currentValue += _granularitySpec.granularityToMillis() * _multiplier.nextInt(MULTIPLIER_CARDINALITY);
+    return _formatSpec.fromMillisToFormat(_currentValue);
+  }
+}

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/realtime/provisioning/MemoryEstimator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/realtime/provisioning/MemoryEstimator.java
@@ -526,9 +526,15 @@ public class MemoryEstimator {
 
       // generate data
       String outputDir = new File(_workingDir, "csv").getAbsolutePath();
-      DataGeneratorSpec spec =
-          new DataGeneratorSpec(colNames, cardinalities, new HashMap<>(), new HashMap<>(), mvCounts, lengths, dataTypes,
-              fieldTypes, timeUnits);
+      DataGeneratorSpec spec = new DataGeneratorSpec.Builder()
+          .setColumns(colNames)
+          .setCardinalityMap(cardinalities)
+          .setMvCountMap(mvCounts)
+          .setLengthMap(lengths)
+          .setDataTypeMap(dataTypes)
+          .setFieldTypeMap(fieldTypes)
+          .setTimeUnitMap(timeUnits)
+          .build();
       DataGenerator dataGenerator = new DataGenerator();
       try {
         dataGenerator.init(spec);


### PR DESCRIPTION
This PR adds 2 new fields to `DataGeneratorSpec`
- `_dateTimeFormatMap`
- `_dateTimeGranularityMap`

which allows us to create the `DateTimeGenerator ` for  `DATE_TIME` field type columns.