### PR TITLE
FileWriter bug fixes

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/writer/CsvWriter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/writer/CsvWriter.java
@@ -25,6 +25,14 @@ import org.apache.pinot.controller.recommender.data.generator.DataGenerator;
 
 
 public class CsvWriter extends FileWriter {
+  private String _headers;
+
+  @Override
+  public void init(WriterSpec spec) {
+    super.init(spec);
+    _headers = StringUtils.join(_spec.getGenerator().nextRow().keySet(), ",");
+  }
+
   @Override
   protected String generateRow(DataGenerator generator) {
     Map<String, Object> row = generator.nextRow();
@@ -41,8 +49,7 @@ public class CsvWriter extends FileWriter {
   @Override
   protected void preprocess(java.io.FileWriter writer)
       throws Exception {
-    final String headers = StringUtils.join(_spec.getGenerator().nextRow().keySet(), ",");
-    writer.append(headers).append('\n');
+    writer.append(_headers).append('\n');
   }
 
   private Object serializeIfMultiValue(Object obj) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/writer/CsvWriter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/writer/CsvWriter.java
@@ -18,12 +18,8 @@
  */
 package org.apache.pinot.controller.recommender.data.writer;
 
-import com.google.common.base.Preconditions;
-import java.io.File;
-import java.io.FileReader;
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.controller.recommender.data.generator.DataGenerator;
 
@@ -43,21 +39,10 @@ public class CsvWriter extends FileWriter {
   }
 
   @Override
-  public void write()
+  protected void preprocess(java.io.FileWriter writer)
       throws Exception {
-    super.write();
     final String headers = StringUtils.join(_spec.getGenerator().nextRow().keySet(), ",");
-    for (File file : Objects.requireNonNull(_spec.getBaseDir().listFiles())) {
-      File tempFile = new File(_spec.getBaseDir(), String.format("temp_%s", file.getName()));
-      try (java.io.FileWriter writer = new java.io.FileWriter(tempFile)) {
-        writer.append(headers).append('\n');
-        try (FileReader reader = new FileReader(file)) {
-          reader.transferTo(writer);
-        }
-      }
-      Preconditions.checkState(file.delete());
-      Preconditions.checkState(tempFile.renameTo(file));
-    }
+    writer.append(headers).append('\n');
   }
 
   private Object serializeIfMultiValue(Object obj) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/writer/FileWriter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/writer/FileWriter.java
@@ -20,7 +20,6 @@ package org.apache.pinot.controller.recommender.data.writer;
 
 import java.io.File;
 import java.util.Objects;
-import org.apache.commons.lang.StringUtils;
 import org.apache.pinot.controller.recommender.data.generator.DataGenerator;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -29,7 +28,7 @@ import org.slf4j.LoggerFactory;
 public abstract class FileWriter implements Writer {
   private static final Logger LOGGER = LoggerFactory.getLogger(FileWriter.class);
 
-  private FileWriterSpec _spec;
+  protected FileWriterSpec _spec;
   @Override
   public void init(WriterSpec spec) {
     _spec = (FileWriterSpec) spec;
@@ -39,12 +38,10 @@ public abstract class FileWriter implements Writer {
   public void write()
       throws Exception {
     final int numPerFiles = (int) (_spec.getTotalDocs() / _spec.getNumFiles());
-    final String headers = StringUtils.join(_spec.getGenerator().nextRow().keySet(), ",");
     final String extension = getExtension() == null ? "" : String.format(".%s", getExtension());
     for (int i = 0; i < _spec.getNumFiles(); i++) {
       try (java.io.FileWriter writer =
           new java.io.FileWriter(new File(_spec.getBaseDir(), String.format("output_%d%s", i, extension)))) {
-        writer.append(headers).append('\n');
         for (int j = 0; j < numPerFiles; j++) {
           String appendString = generateRow(_spec.getGenerator());
           writer.append(appendString).append('\n');

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/writer/FileWriter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/writer/FileWriter.java
@@ -45,6 +45,7 @@ public abstract class FileWriter implements Writer {
     while (ingestedDocs < totalDocs) {
       try (java.io.FileWriter writer =
           new java.io.FileWriter(new File(_spec.getBaseDir(), String.format("output_%d%s", fileIndex, extension)))) {
+        preprocess(writer);
         for (int j = 0; j < docsPerFile && ingestedDocs < totalDocs; j++) {
           String appendString = generateRow(_spec.getGenerator());
           writer.append(appendString).append('\n');
@@ -53,6 +54,10 @@ public abstract class FileWriter implements Writer {
       }
       fileIndex++;
     }
+  }
+
+  protected void preprocess(java.io.FileWriter writer)
+      throws Exception {
   }
 
   protected String getExtension() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/writer/FileWriter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/recommender/data/writer/FileWriter.java
@@ -37,16 +37,21 @@ public abstract class FileWriter implements Writer {
   @Override
   public void write()
       throws Exception {
-    final int numPerFiles = (int) (_spec.getTotalDocs() / _spec.getNumFiles());
+    long totalDocs = _spec.getTotalDocs();
+    final long docsPerFile = (long) Math.ceil((double) totalDocs / _spec.getNumFiles());
     final String extension = getExtension() == null ? "" : String.format(".%s", getExtension());
-    for (int i = 0; i < _spec.getNumFiles(); i++) {
+    long ingestedDocs = 0;
+    int fileIndex = 0;
+    while (ingestedDocs < totalDocs) {
       try (java.io.FileWriter writer =
-          new java.io.FileWriter(new File(_spec.getBaseDir(), String.format("output_%d%s", i, extension)))) {
-        for (int j = 0; j < numPerFiles; j++) {
+          new java.io.FileWriter(new File(_spec.getBaseDir(), String.format("output_%d%s", fileIndex, extension)))) {
+        for (int j = 0; j < docsPerFile && ingestedDocs < totalDocs; j++) {
           String appendString = generateRow(_spec.getGenerator());
           writer.append(appendString).append('\n');
+          ingestedDocs++;
         }
       }
+      fileIndex++;
     }
   }
 


### PR DESCRIPTION
This PR includes 2 bug fixes

1. `FileWriter` was appending header line by default. Pushed this down to `CsvWriter` where its required.
2. Ensure that the number of rows written to the files is equal to the value provided in the spec.