### PR TITLE
make all /size users render async

### DIFF
--- a/pinot-controller/src/main/resources/app/components/AsyncInstanceTable.tsx
+++ b/pinot-controller/src/main/resources/app/components/AsyncInstanceTable.tsx
@@ -1,0 +1,122 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { get, lowerCase, mapKeys, startCase } from 'lodash';
+import { InstanceType, TableData } from 'Models';
+import CustomizedTables from './Table';
+import PinotMethodUtils from '../utils/PinotMethodUtils';
+import Utils from '../utils/Utils';
+
+type BaseProps = {
+  instanceType: InstanceType;
+  showInstanceDetails?: boolean;
+};
+
+type ClusterProps = BaseProps & {
+  cluster: string;
+  tenant?: never;
+};
+
+type TenantProps = BaseProps & {
+  tenant: string;
+  cluster?: never;
+};
+
+type Props = ClusterProps | TenantProps;
+
+export const AsyncInstanceTable = ({
+  instanceType,
+  cluster,
+  tenant,
+  showInstanceDetails = false,
+}: Props) => {
+  const instanceColumns = showInstanceDetails
+    ? ['Instance Name', 'Enabled', 'Hostname', 'Port', 'Status']
+    : ['Instance Name'];
+  const [instanceData, setInstanceData] = useState<TableData>(
+    Utils.getLoadingTableData(instanceColumns)
+  );
+
+  const fetchInstances = async (
+    instanceType: InstanceType,
+    tenant?: string
+  ): Promise<string[]> => {
+    if (tenant) {
+      if (instanceType === InstanceType.BROKER) {
+        return PinotMethodUtils.getBrokerOfTenant(tenant).then(
+          (brokersData) => {
+            return Array.isArray(brokersData) ? brokersData : [];
+          }
+        );
+      } else if (instanceType === InstanceType.SERVER) {
+        return PinotMethodUtils.getServerOfTenant(tenant).then(
+          (serversData) => {
+            return Array.isArray(serversData) ? serversData : [];
+          }
+        );
+      }
+    } else {
+      return fetchInstancesOfType(instanceType);
+    }
+  };
+
+  const fetchInstancesOfType = async (instanceType: InstanceType) => {
+    return PinotMethodUtils.getAllInstances().then((instancesData) => {
+      const lowercaseInstanceData = mapKeys(instancesData, (value, key) =>
+        lowerCase(key)
+      );
+      return get(lowercaseInstanceData, lowerCase(instanceType));
+    });
+  };
+
+  useEffect(() => {
+    const instances = fetchInstances(instanceType, tenant);
+    if (showInstanceDetails) {
+      const instanceDetails = instances.then(async (instancesData) => {
+        const liveInstanceArr = await PinotMethodUtils.getLiveInstance(cluster);
+        return PinotMethodUtils.getInstanceData(
+          instancesData,
+          liveInstanceArr.data
+        );
+      });
+      instanceDetails.then((instanceDetailsData) => {
+        setInstanceData(instanceDetailsData);
+      });
+    } else {
+      instances.then((instancesData) => {
+        setInstanceData({
+          columns: instanceColumns,
+          records: instancesData.map((instance) => [instance]),
+        });
+      });
+    }
+  }, [instanceType, cluster, tenant, showInstanceDetails]);
+
+  return (
+    <CustomizedTables
+      title={startCase(instanceType)}
+      data={instanceData}
+      addLinks
+      baseURL="/instance/"
+      showSearchBox={true}
+      inAccordionFormat={true}
+    />
+  );
+};

--- a/pinot-controller/src/main/resources/app/components/AsyncPinotSchemas.tsx
+++ b/pinot-controller/src/main/resources/app/components/AsyncPinotSchemas.tsx
@@ -1,0 +1,76 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { TableData } from 'Models';
+import PinotMethodUtils from '../utils/PinotMethodUtils';
+import Loading from './Loading';
+import CustomizedTables from './Table';
+import { getSchemaList } from '../requests';
+import Utils from '../utils/Utils';
+
+type Props = {
+  onSchemaNamesLoaded?: Function;
+};
+
+export const AsyncPinotSchemas = ({ onSchemaNamesLoaded }: Props) => {
+  const [schemaDetails, setSchemaDetails] = useState<TableData>(
+    Utils.getLoadingTableData(PinotMethodUtils.allSchemaDetailsColumnHeader)
+  );
+
+  const fetchSchemas = async () => {
+    getSchemaList().then((result) => {
+      if (onSchemaNamesLoaded) {
+        onSchemaNamesLoaded(result.data);
+      }
+
+      const schemas = result.data;
+      const records = schemas.map((schema) => [
+        ...[schema],
+        ...Array(PinotMethodUtils.allSchemaDetailsColumnHeader.length - 1)
+          .fill(null)
+          .map((_) => Loading),
+      ]);
+      setSchemaDetails({
+        columns: PinotMethodUtils.allSchemaDetailsColumnHeader,
+        records: records,
+      });
+
+      // Schema details are typically fast to fetch, so we fetch them all at once.
+      PinotMethodUtils.getAllSchemaDetails(schemas).then((result) => {
+        setSchemaDetails(result);
+      });
+    });
+  };
+
+  useEffect(() => {
+    fetchSchemas();
+  }, []);
+
+  return (
+    <CustomizedTables
+      title="Schemas"
+      data={schemaDetails}
+      showSearchBox={true}
+      inAccordionFormat={true}
+      addLinks
+      baseURL="/tenants/schema/"
+    />
+  );
+};

--- a/pinot-controller/src/main/resources/app/components/AsyncPinotTables.tsx
+++ b/pinot-controller/src/main/resources/app/components/AsyncPinotTables.tsx
@@ -1,0 +1,220 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React, { useState, useEffect } from 'react';
+import { flatten, uniq } from 'lodash';
+import CustomizedTables from './Table';
+import { PinotTableDetails, TableData } from 'Models';
+import { getQueryTables, getTenantTable } from '../requests';
+import Utils from '../utils/Utils';
+import PinotMethodUtils from '../utils/PinotMethodUtils';
+
+type BaseProps = {
+  title: string;
+  baseUrl: string;
+  onTableNamesLoaded?: Function;
+};
+
+type InstanceProps = BaseProps & {
+  tenants?: never;
+  instance?: string;
+};
+
+type TenantProps = BaseProps & {
+  tenants?: string[];
+  instance?: never;
+};
+
+type Props = InstanceProps | TenantProps;
+
+const TableTooltipData = [
+  null,
+  'Uncompressed size of all data segments with replication',
+  'Estimated size of all data segments with replication, in case any servers are not reachable for actual size',
+  null,
+  'GOOD if all replicas of all segments are up',
+];
+
+export const AsyncPinotTables = ({
+  title,
+  instance,
+  tenants,
+  baseUrl,
+  onTableNamesLoaded,
+}: Props) => {
+  const columnHeaders = [
+    'Table Name',
+    'Reported Size',
+    'Estimated Size',
+    'Number of Segments',
+    'Status',
+  ];
+  const [tableData, setTableData] = useState<TableData>(
+    Utils.getLoadingTableData(columnHeaders)
+  );
+
+  const fetchTenantData = async (tenants: string[]) => {
+    Promise.all(
+      tenants.map((tenant) => {
+        return getTenantTable(tenant);
+      })
+    ).then((results) => {
+      let allTableDetails = results.map((result) => {
+        return result.data.tables.map((tableName) => {
+          const tableDetails: PinotTableDetails = {
+            name: tableName,
+            estimated_size: null,
+            reported_size: null,
+            segment_status: null,
+            number_of_segments: null,
+          };
+          return tableDetails;
+        });
+      });
+      const allTableDetailsFlattened: PinotTableDetails[] = flatten(
+        allTableDetails
+      );
+
+      const loadingTableData: TableData = {
+        columns: columnHeaders,
+        records: allTableDetailsFlattened.map((td) =>
+          Utils.pinotTableDetailsFormat(td)
+        ),
+      };
+      setTableData(loadingTableData);
+      if (onTableNamesLoaded) {
+        onTableNamesLoaded();
+      }
+
+      results.forEach((result) => {
+        fetchAllTableDetails(result.data.tables);
+      });
+    });
+  };
+
+  const fetchInstanceTenants = async (instance: string): Promise<string[]> => {
+    return PinotMethodUtils.getInstanceDetails(instance).then(
+      (instanceDetails) => {
+        const tenants = instanceDetails.tags
+          .filter((tag) => {
+            return (
+              tag.search('_BROKER') !== -1 ||
+              tag.search('_REALTIME') !== -1 ||
+              tag.search('_OFFLINE') !== -1
+            );
+          })
+          .map((tag) => {
+            return Utils.splitStringByLastUnderscore(tag)[0];
+          });
+        return uniq(tenants);
+      }
+    );
+  };
+
+  const fetchAllTablesData = async () => {
+    Promise.all([getQueryTables('realtime'), getQueryTables('offline')]).then(
+      (results) => {
+        const realtimeTables = results[0].data.tables;
+        const offlineTables = results[1].data.tables;
+        const allTables = realtimeTables.concat(offlineTables);
+        setTableData({
+          columns: columnHeaders,
+          records: allTables.map((tableName) => {
+            const tableDetails: PinotTableDetails = {
+              name: tableName,
+              estimated_size: null,
+              reported_size: null,
+              segment_status: null,
+              number_of_segments: null,
+            };
+            return Utils.pinotTableDetailsFormat(tableDetails);
+          }),
+        });
+        if (onTableNamesLoaded) {
+          onTableNamesLoaded();
+        }
+        fetchAllTableDetails(allTables);
+      }
+    );
+  };
+
+  const fetchAllTableDetails = async (tables: string[]) => {
+    return tables.forEach((tableName) => {
+      PinotMethodUtils.getSegmentCountAndStatus(tableName).then(
+        ({ segment_count, segment_status }) => {
+          setTableData((prevState) => {
+            const newRecords = [...prevState.records];
+            const index = newRecords.findIndex(
+              (record) => record[0] === tableName
+            );
+            newRecords[index] = Utils.pinotTableDetailsFormat({
+              ...Utils.pinotTableDetailsFromArray(newRecords[index]),
+              number_of_segments: segment_count,
+              segment_status: segment_status,
+            });
+            return { ...prevState, records: newRecords };
+          });
+        }
+      );
+
+      PinotMethodUtils.getTableSizes(tableName).then(
+        ({ reported_size, estimated_size }) => {
+          setTableData((prevState) => {
+            const newRecords = [...prevState.records];
+            const index = newRecords.findIndex(
+              (record) => record[0] === tableName
+            );
+            newRecords[index] = Utils.pinotTableDetailsFormat({
+              ...Utils.pinotTableDetailsFromArray(newRecords[index]),
+              estimated_size: estimated_size,
+              reported_size: reported_size,
+            });
+            return { ...prevState, records: newRecords };
+          });
+        }
+      );
+    });
+  };
+
+  useEffect(() => {
+    if (instance) {
+      fetchInstanceTenants(instance).then((tenants) => {
+        fetchTenantData(tenants);
+      });
+    } else if (tenants) {
+      fetchTenantData(tenants);
+    } else {
+      fetchAllTablesData();
+    }
+  }, [instance, tenants]);
+
+  return (
+    <CustomizedTables
+      title={title}
+      data={tableData}
+      tooltipData={TableTooltipData}
+      addLinks
+      baseURL={baseUrl}
+      showSearchBox={true}
+      inAccordionFormat={true}
+    />
+  );
+};
+
+export default AsyncPinotTables;

--- a/pinot-controller/src/main/resources/app/components/Homepage/InstancesTables.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/InstancesTables.tsx
@@ -18,24 +18,34 @@
  */
 
 import React from 'react';
-import get from 'lodash/get';
-import has from 'lodash/has';
-import InstanceTable from './InstanceTable';
+import { startCase } from 'lodash';
+import { AsyncInstanceTable } from '../AsyncInstanceTable';
+import { InstanceType } from 'Models';
 
-const Instances = ({ instances, clusterName }) => {
-  const order = ['Controller', 'Broker', 'Server', 'Minion'];
+type Props = {
+  clusterName: string;
+  instanceType?: InstanceType;
+};
+
+
+const Instances = ({ clusterName, instanceType }: Props) => {
+  const order = [
+    InstanceType.CONTROLLER,
+    InstanceType.BROKER,
+    InstanceType.SERVER,
+    InstanceType.MINION,
+  ];
   return (
     <>
       {order
-        .filter((key) => has(instances, key))
+        .filter((key) => !instanceType || instanceType === key)
         .map((key) => {
-          const value = get(instances, key, []);
           return (
-            <InstanceTable
-              key={key}
-              name={`${key}s`}
-              instances={value}
-              clusterName={clusterName}
+            <AsyncInstanceTable
+              key={startCase(key)}
+              cluster={clusterName}
+              instanceType={key}
+              showInstanceDetails
             />
           );
         })}

--- a/pinot-controller/src/main/resources/app/components/Loading.tsx
+++ b/pinot-controller/src/main/resources/app/components/Loading.tsx
@@ -18,26 +18,8 @@
  */
 
 import React from 'react';
-import { Grid, makeStyles } from '@material-ui/core';
-import TenantsTable from '../components/Homepage/TenantsListing';
+import Skeleton from "@material-ui/lab/Skeleton";
 
-const useStyles = makeStyles(() => ({
-  gridContainer: {
-    padding: 20,
-    backgroundColor: 'white',
-    maxHeight: 'calc(100vh - 70px)',
-    overflowY: 'auto',
-  },
-}));
+const Loading: { customRenderer: JSX.Element } = { customRenderer: <Skeleton animation={'wave'} /> };
 
-const TenantsListingPage = () => {
-  const classes = useStyles();
-
-  return (
-    <Grid item xs className={classes.gridContainer}>
-      <TenantsTable />
-    </Grid>
-  );
-};
-
-export default TenantsListingPage;
+export default Loading;

--- a/pinot-controller/src/main/resources/app/components/NotFound.tsx
+++ b/pinot-controller/src/main/resources/app/components/NotFound.tsx
@@ -1,0 +1,69 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+import React from 'react';
+import TableToolbar from './TableToolbar';
+import { Grid } from '@material-ui/core';
+import { makeStyles } from '@material-ui/core/styles';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    border: '1px #BDCCD9 solid',
+    borderRadius: 4,
+    marginBottom: '20px',
+  },
+  background: {
+    padding: 20,
+    backgroundColor: 'white',
+    maxHeight: 'calc(100vh - 70px)',
+    overflowY: 'auto',
+  },
+  highlightBackground: {
+    border: '1px #4285f4 solid',
+    backgroundColor: 'rgba(66, 133, 244, 0.05)',
+    borderRadius: 4,
+    marginBottom: '20px',
+  },
+  body: {
+    borderTop: '1px solid #BDCCD9',
+    fontSize: '16px',
+    lineHeight: '3rem',
+    paddingLeft: '15px',
+  },
+}));
+
+type Props = {
+  message: String;
+};
+
+export default function NotFound(props: Props) {
+  const classes = useStyles();
+  return (
+    <Grid item xs className={classes.background}>
+      <div className={classes.highlightBackground}>
+        <TableToolbar name="Not found" showSearchBox={false} />
+        <Grid container className={classes.body}>
+          <Grid item>
+            <p>{props.message}</p>
+          </Grid>
+        </Grid>
+      </div>
+    </Grid>
+  );
+}

--- a/pinot-controller/src/main/resources/app/components/Table.tsx
+++ b/pinot-controller/src/main/resources/app/components/Table.tsx
@@ -537,7 +537,7 @@ export default function CustomizedTables({
                           const matches = baseURL.match(regex);
                           url = baseURL.replace(matches[0], row[matches[0].replace(/:/g, '')]);
                         }
-                        return addLinks && !idx ? (
+                        return addLinks && typeof cell === 'string' && !idx ? (
                           <StyledTableCell key={idx}>
                             <Link to={`${encodeURI(`${url}${encodeURIComponent(cell)}`)}`}>{cell}</Link>
                           </StyledTableCell>

--- a/pinot-controller/src/main/resources/app/interfaces/types.d.ts
+++ b/pinot-controller/src/main/resources/app/interfaces/types.d.ts
@@ -18,12 +18,30 @@
  */
 
 declare module 'Models' {
+  export type SegmentStatus = {
+    value: DISPLAY_SEGMENT_STATUS,
+    tooltip: string,
+    component?: JSX.Element
+  }
+
+  export type LoadingRecord = {
+    customRenderer: JSX.Element
+  }
+
   export type TableData = {
-    records: Array<Array<string | number | boolean>>;
+    records: Array<Array<string | number | boolean | SegmentStatus | LoadingRecord>>;
     columns: Array<string>;
     error?: string;
     isLoading? : boolean
   };
+
+  export type PinotTableDetails = {
+    name: string,
+    reported_size: string,
+    estimated_size: string,
+    number_of_segments: string,
+    segment_status: SegmentStatus,
+  }
 
   type SchemaDetails = {
     schemaName: string,
@@ -79,6 +97,12 @@ declare module 'Models' {
     segments: Object;
   };
 
+  type SegmentMetadata = {
+    indexes?: any;
+    columns: Array<any>;
+    code?: number;
+  };
+
   export type IdealState = {
     OFFLINE: Object | null;
     REALTIME: Object | null;
@@ -97,6 +121,7 @@ declare module 'Models' {
     metricFieldSpecs?: Array<schema>;
     dateTimeFieldSpecs?: Array<schema>;
     error?: string;
+    code?: number;
   };
 
   type schema = {
@@ -145,7 +170,8 @@ declare module 'Models' {
 
   export type ZKConfig = {
     ctime: any,
-    mtime: any
+    mtime: any,
+    code?: number
   };
   export type OperationResponse = any;
 
@@ -251,6 +277,13 @@ declare module 'Models' {
   export const enum InstanceState {
     ENABLE = "enable",
     DISABLE = "disable"
+  }
+
+  export const enum InstanceType {
+    BROKER = "broker",
+    CONTROLLER = "controller",
+    MINION = "minion",
+    SERVER = "server"
   }
 
   export const enum TableType {

--- a/pinot-controller/src/main/resources/app/pages/InstanceDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/InstanceDetails.tsx
@@ -17,31 +17,32 @@
  * under the License.
  */
 
-import React, { useState, useEffect } from 'react';
-import { Button, FormControlLabel, Grid, makeStyles, Switch, Tooltip } from '@material-ui/core';
+import React, { useEffect, useState } from 'react';
+import {
+  FormControlLabel,
+  Grid,
+  makeStyles,
+  Switch,
+  Tooltip,
+} from '@material-ui/core';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/material.css';
 import 'codemirror/mode/javascript/javascript';
-import { InstanceState, TableData } from 'Models';
+import { InstanceState, InstanceType } from 'Models';
 import { RouteComponentProps } from 'react-router-dom';
 import PinotMethodUtils from '../utils/PinotMethodUtils';
 import AppLoader from '../components/AppLoader';
-import CustomizedTables from '../components/Table';
 import SimpleAccordion from '../components/SimpleAccordion';
 import CustomButton from '../components/CustomButton';
 import EditTagsOp from '../components/Homepage/Operations/EditTagsOp';
 import EditConfigOp from '../components/Homepage/Operations/EditConfigOp';
 import { NotificationContext } from '../components/Notification/NotificationContext';
-import { uniq, startCase } from 'lodash';
+import { startCase } from 'lodash';
 import Confirm from '../components/Confirm';
-import Utils from "../utils/Utils";
-
-const instanceTypes = {
-  broker: 'BROKER',
-  minion: 'MINION',
-  server: 'SERVER',
-}
+import { getInstanceTypeFromInstanceName } from '../utils/Utils';
+import AsyncPinotTables from '../components/AsyncPinotTables';
+import NotFound from '../components/NotFound';
 
 const useStyles = makeStyles((theme) => ({
   codeMirrorDiv: {
@@ -56,7 +57,7 @@ const useStyles = makeStyles((theme) => ({
     border: '1px #BDCCD9 solid',
     borderRadius: 4,
     marginBottom: 20,
-  }
+  },
 }));
 
 const jsonoptions = {
@@ -65,38 +66,31 @@ const jsonoptions = {
   styleActiveLine: true,
   gutters: ['CodeMirror-lint-markers'],
   theme: 'default',
-  readOnly: true
+  readOnly: true,
 };
 
 type Props = {
-  instanceName: string
+  instanceName: string;
 };
 
 const InstanceDetails = ({ match }: RouteComponentProps<Props>) => {
   const classes = useStyles();
-  const {instanceName} = match.params;
-  let instanceType;
-  if (instanceName.toLowerCase().startsWith(instanceTypes.broker.toLowerCase())) {
-    instanceType = instanceTypes.broker;
-  } else if (instanceName.toLowerCase().startsWith(instanceTypes.minion.toLowerCase())) {
-    instanceType = instanceTypes.minion;
-  } else {
-    instanceType = instanceTypes.server;
-  }
-  const clutserName = localStorage.getItem('pinot_ui:clusterName');
+  const { instanceName } = match.params;
+  const instanceType = getInstanceTypeFromInstanceName(instanceName);
+  const clusterName = localStorage.getItem('pinot_ui:clusterName');
   const [fetching, setFetching] = useState(true);
+  const [instanceNotFound, setInstanceNotFound] = useState(false);
   const [confirmDialog, setConfirmDialog] = React.useState(false);
   const [dialogDetails, setDialogDetails] = React.useState(null);
 
   const [instanceConfig, setInstanceConfig] = useState(null);
   const [liveConfig, setLiveConfig] = useState(null);
   const [instanceDetails, setInstanceDetails] = useState(null);
-  const [tableData, setTableData] = useState<TableData>({
-    columns: [],
-    records: []
-  });
   const [tagsList, setTagsList] = useState([]);
-  const [tagsErrorObj, setTagsErrorObj] = useState({isError: false, errorMessage: null})
+  const [tagsErrorObj, setTagsErrorObj] = useState({
+    isError: false,
+    errorMessage: null,
+  });
   const [config, setConfig] = useState('{}');
 
   const [state, setState] = React.useState({
@@ -105,123 +99,102 @@ const InstanceDetails = ({ match }: RouteComponentProps<Props>) => {
 
   const [showEditTag, setShowEditTag] = useState(false);
   const [showEditConfig, setShowEditConfig] = useState(false);
-  const {dispatch} = React.useContext(NotificationContext);
+  const { dispatch } = React.useContext(NotificationContext);
 
   const fetchData = async () => {
-    const configResponse = await PinotMethodUtils.getInstanceConfig(clutserName, instanceName);
-    const liveConfigResponse = await PinotMethodUtils.getLiveInstanceConfig(clutserName, instanceName);
-    const instanceDetails = await PinotMethodUtils.getInstanceDetails(instanceName);
-    const tenantListResponse = getTenants(instanceDetails);
-    setInstanceConfig(JSON.stringify(configResponse, null, 2));
-    const instanceHost = instanceDetails.hostName.replace(`${startCase(instanceType.toLowerCase())}_`, '');
-    const instancePutObj = {
-      host: instanceHost,
-      port: instanceDetails.port,
-      type: instanceType,
-      tags: instanceDetails.tags,
-      pools: instanceDetails.pools,
-      grpcPort: instanceDetails.grpcPort,
-      adminPort: instanceDetails.adminPort,
-      queryServicePort: instanceDetails.queryServicePort,
-      queryMailboxPort: instanceDetails.queryMailboxPort,
-      queriesDisabled: instanceDetails.queriesDisabled,
-    };
-    setState({enabled: instanceDetails.enabled});
-    setInstanceDetails(JSON.stringify(instancePutObj, null, 2));
-    setLiveConfig(JSON.stringify(liveConfigResponse, null, 2));
-    if(tenantListResponse){
-      fetchTableDetails(tenantListResponse);
+    const configResponse = await PinotMethodUtils.getInstanceConfig(
+      clusterName,
+      instanceName
+    );
+
+    if (configResponse?.code === 404) {
+      setInstanceNotFound(true);
     } else {
-      setFetching(false);
+      const liveConfigResponse = await PinotMethodUtils.getLiveInstanceConfig(
+        clusterName,
+        instanceName
+      );
+      const instanceDetails = await PinotMethodUtils.getInstanceDetails(
+        instanceName
+      );
+      setInstanceConfig(JSON.stringify(configResponse, null, 2));
+      const instanceHost = instanceDetails.hostName.replace(
+        `${startCase(instanceType.toLowerCase())}_`,
+        ''
+      );
+      const instancePutObj = {
+        host: instanceHost,
+        port: instanceDetails.port,
+        type: instanceType,
+        tags: instanceDetails.tags,
+        pools: instanceDetails.pools,
+        grpcPort: instanceDetails.grpcPort,
+        adminPort: instanceDetails.adminPort,
+        queryServicePort: instanceDetails.queryServicePort,
+        queryMailboxPort: instanceDetails.queryMailboxPort,
+        queriesDisabled: instanceDetails.queriesDisabled,
+      };
+      setState({ enabled: instanceDetails.enabled });
+      setInstanceDetails(JSON.stringify(instancePutObj, null, 2));
+      setLiveConfig(JSON.stringify(liveConfigResponse, null, 2));
     }
+    setFetching(false);
   };
 
   useEffect(() => {
     fetchData();
   }, []);
 
-  const fetchTableDetails = (tenantList) => {
-    const promiseArr = [];
-    tenantList.map((tenantName) => {
-      promiseArr.push(PinotMethodUtils.getTenantTableData(tenantName));
-    });
-    const tenantTableData = {
-      columns: [],
-      records: []
-    };
-    Promise.all(promiseArr).then((results)=>{
-      results.map((result)=>{
-        tenantTableData.columns = result.columns;
-        tenantTableData.records.push(...result.records);
-      });
-      setTableData(tenantTableData);
-      setFetching(false);
-    });
-  };
-
-  const getTenants = (instanceDetails) => {
-    const tenantsList = [];
-    instanceDetails.tags.forEach((tag) => {
-      if(tag.search('_BROKER') !== -1 ||
-        tag.search('_REALTIME') !== -1 ||
-        tag.search('_OFFLINE') !== -1
-      ){
-        let [baseTag, ] = Utils.splitStringByLastUnderscore(tag);
-        tenantsList.push(baseTag);
-      }
-    });
-    return uniq(tenantsList);
-  };
-
-  const handleTagsChange = (e: React.ChangeEvent<HTMLInputElement>, tags: Array<string>|null) => {
+  const handleTagsChange = (
+    e: React.ChangeEvent<HTMLInputElement>,
+    tags: Array<string> | null
+  ) => {
     isTagsValid(tags);
     setTagsList(tags);
   };
 
   const isTagsValid = (_tagsList) => {
     let isValid = true;
-    setTagsErrorObj({isError: false, errorMessage: null});
-    _tagsList.map((tag)=>{
-      if(!isValid){
+    setTagsErrorObj({ isError: false, errorMessage: null });
+    _tagsList.map((tag) => {
+      if (!isValid) {
         return;
       }
-      if(instanceType === 'BROKER'){
-        if(!tag.endsWith('_BROKER')){
+      if (instanceType === InstanceType.BROKER) {
+        if (!tag.endsWith('_BROKER')) {
           isValid = false;
           setTagsErrorObj({
             isError: true,
-            errorMessage: "Tags should end with _BROKER."
+            errorMessage: 'Tags should end with _BROKER.',
           });
         }
-      } else if(instanceType === 'SERVER'){
-        if(!tag.endsWith('_REALTIME') &&
-          !tag.endsWith('_OFFLINE')
-        ){
+      } else if (instanceType === InstanceType.SERVER) {
+        if (!tag.endsWith('_REALTIME') && !tag.endsWith('_OFFLINE')) {
           isValid = false;
           setTagsErrorObj({
             isError: true,
-            errorMessage: "Tags should end with _OFFLINE or _REALTIME."
+            errorMessage: 'Tags should end with _OFFLINE or _REALTIME.',
           });
         }
       }
     });
     return isValid;
-  }
+  };
 
   const saveTagsAction = async (event, typedTag) => {
     let newTagsList = [...tagsList];
-    if(typedTag.length > 0){
+    if (typedTag.length > 0) {
       newTagsList.push(typedTag);
     }
-    if(!isTagsValid(newTagsList)){
+    if (!isTagsValid(newTagsList)) {
       return;
     }
     const result = await PinotMethodUtils.updateTags(instanceName, newTagsList);
-    if(result.status){
-      dispatch({type: 'success', message: result.status, show: true});
+    if (result.status) {
+      dispatch({ type: 'success', message: result.status, show: true });
       fetchData();
     } else {
-      dispatch({type: 'error', message: result.error, show: true});
+      dispatch({ type: 'error', message: result.error, show: true });
     }
     setShowEditTag(false);
   };
@@ -230,18 +203,18 @@ const InstanceDetails = ({ match }: RouteComponentProps<Props>) => {
     setDialogDetails({
       title: 'Drop Instance',
       content: 'Are you sure want to drop this instance?',
-      successCb: () => dropInstance()
+      successCb: () => dropInstance(),
     });
     setConfirmDialog(true);
   };
 
   const dropInstance = async () => {
     const result = await PinotMethodUtils.deleteInstance(instanceName);
-    if(result.status){
-      dispatch({type: 'success', message: result.status, show: true});
+    if (result.status) {
+      dispatch({ type: 'success', message: result.status, show: true });
       fetchData();
     } else {
-      dispatch({type: 'error', message: result.error, show: true});
+      dispatch({ type: 'error', message: result.error, show: true });
     }
     closeDialog();
   };
@@ -249,19 +222,24 @@ const InstanceDetails = ({ match }: RouteComponentProps<Props>) => {
   const handleSwitchChange = (event) => {
     setDialogDetails({
       title: state.enabled ? 'Disable Instance' : 'Enable Instance',
-      content: `Are you sure want to ${state.enabled ? 'disable' : 'enable'} this instance?`,
-      successCb: () => toggleInstanceState()
+      content: `Are you sure want to ${
+        state.enabled ? 'disable' : 'enable'
+      } this instance?`,
+      successCb: () => toggleInstanceState(),
     });
     setConfirmDialog(true);
   };
 
   const toggleInstanceState = async () => {
-    const result = await PinotMethodUtils.toggleInstanceState(instanceName, state.enabled ? InstanceState.DISABLE : InstanceState.ENABLE);
-    if(result.status){
-      dispatch({type: 'success', message: result.status, show: true});
+    const result = await PinotMethodUtils.toggleInstanceState(
+      instanceName,
+      state.enabled ? InstanceState.DISABLE : InstanceState.ENABLE
+    );
+    if (result.status) {
+      dispatch({ type: 'success', message: result.status, show: true });
       fetchData();
     } else {
-      dispatch({type: 'error', message: result.error, show: true});
+      dispatch({ type: 'error', message: result.error, show: true });
     }
     setState({ enabled: !state.enabled });
     closeDialog();
@@ -272,13 +250,16 @@ const InstanceDetails = ({ match }: RouteComponentProps<Props>) => {
   };
 
   const saveConfigAction = async () => {
-    if(JSON.parse(config)){
-      const result = await PinotMethodUtils.updateInstanceDetails(instanceName, config);
-      if(result.status){
-        dispatch({type: 'success', message: result.status, show: true});
+    if (JSON.parse(config)) {
+      const result = await PinotMethodUtils.updateInstanceDetails(
+        instanceName,
+        config
+      );
+      if (result.status) {
+        dispatch({ type: 'success', message: result.status, show: true });
         fetchData();
       } else {
-        dispatch({type: 'error', message: result.error, show: true});
+        dispatch({ type: 'error', message: result.error, show: true });
       }
       setShowEditConfig(false);
     }
@@ -289,137 +270,154 @@ const InstanceDetails = ({ match }: RouteComponentProps<Props>) => {
     setDialogDetails(null);
   };
 
-  return (
-    fetching ? <AppLoader /> :
-    <Grid
-      item
-      xs
-      style={{
-        padding: 20,
-        backgroundColor: 'white',
-        maxHeight: 'calc(100vh - 70px)',
-        overflowY: 'auto',
-      }}
-    >
-      {!instanceName.toLowerCase().startsWith('controller') &&
-        <div className={classes.operationDiv}>
-          <SimpleAccordion
-            headerTitle="Operations"
-            showSearchBox={false}
-          >
-            <div>
-              <CustomButton
-                onClick={()=>{
-                  setTagsList(JSON.parse(instanceConfig)?.listFields?.TAG_LIST || []);
-                  setShowEditTag(true);
-                }}
-                tooltipTitle="Add/remove tags from this node"
-                enableTooltip={true}
-              >
-                Edit Tags
-              </CustomButton>
-              <CustomButton
-                onClick={()=>{
-                  setConfig(instanceDetails);
-                  setShowEditConfig(true);
-                }}
-                enableTooltip={true}
-              >
-                Edit Config
-              </CustomButton>
-              <CustomButton
-                onClick={handleDropAction}
-                tooltipTitle={instanceType !== instanceTypes.minion ? "Removes the node from the cluster. Untag and rebalance (to ensure the node is not being used by any table) and shutdown the instance before dropping." : ""}
-                enableTooltip={true}
-              >
-                Drop
-              </CustomButton>
-              <Tooltip title="Disabling will disable the node for queries." arrow placement="top-start" >
-              <FormControlLabel
-                control={
-                  <Switch
-                    checked={state.enabled}
-                    onChange={handleSwitchChange}
-                    name="enabled"
-                    color="primary"
+  if (fetching) {
+    return <AppLoader />;
+  } else if (instanceNotFound) {
+    return <NotFound message={`Instance ${instanceName} not found`} />;
+  } else {
+    return (
+      <Grid
+        item
+        xs
+        style={{
+          padding: 20,
+          backgroundColor: 'white',
+          maxHeight: 'calc(100vh - 70px)',
+          overflowY: 'auto',
+        }}
+      >
+        {!instanceName.toLowerCase().startsWith('controller') && (
+          <div className={classes.operationDiv}>
+            <SimpleAccordion headerTitle="Operations" showSearchBox={false}>
+              <div>
+                <CustomButton
+                  onClick={() => {
+                    setTagsList(
+                      JSON.parse(instanceConfig)?.listFields?.TAG_LIST || []
+                    );
+                    setShowEditTag(true);
+                  }}
+                  tooltipTitle="Add/remove tags from this node"
+                  enableTooltip={true}
+                >
+                  Edit Tags
+                </CustomButton>
+                <CustomButton
+                  onClick={() => {
+                    setConfig(instanceDetails);
+                    setShowEditConfig(true);
+                  }}
+                  enableTooltip={true}
+                >
+                  Edit Config
+                </CustomButton>
+                <CustomButton
+                  onClick={handleDropAction}
+                  tooltipTitle={
+                    instanceType !== InstanceType.MINION
+                      ? 'Removes the node from the cluster. Untag and rebalance (to ensure the node is not being used by any table) and shutdown the instance before dropping.'
+                      : ''
+                  }
+                  enableTooltip={true}
+                >
+                  Drop
+                </CustomButton>
+                <Tooltip
+                  title="Disabling will disable the node for queries."
+                  arrow
+                  placement="top-start"
+                >
+                  <FormControlLabel
+                    control={
+                      <Switch
+                        checked={state.enabled}
+                        onChange={handleSwitchChange}
+                        name="enabled"
+                        color="primary"
+                      />
+                    }
+                    label="Enable"
                   />
-                }
-                label="Enable"
-              />
-              </Tooltip>
-            </div>
-          </SimpleAccordion>
-        </div>}
-      <Grid container spacing={2}>
-        <Grid item xs={liveConfig ? 6 : 12}>
-          <div className={classes.codeMirrorDiv}>
-            <SimpleAccordion
-              headerTitle="Instance Config"
-              showSearchBox={false}
-            >
-              <CodeMirror
-                options={jsonoptions}
-                value={instanceConfig}
-                className={classes.codeMirror}
-                autoCursor={false}
-              />
+                </Tooltip>
+              </div>
             </SimpleAccordion>
           </div>
-        </Grid>
-        {liveConfig ?
-          <Grid item xs={6}>
+        )}
+        <Grid container spacing={2}>
+          <Grid item xs={liveConfig ? 6 : 12}>
             <div className={classes.codeMirrorDiv}>
               <SimpleAccordion
-                headerTitle="LiveInstance Config"
+                headerTitle="Instance Config"
                 showSearchBox={false}
               >
                 <CodeMirror
                   options={jsonoptions}
-                  value={liveConfig}
+                  value={instanceConfig}
                   className={classes.codeMirror}
                   autoCursor={false}
                 />
               </SimpleAccordion>
             </div>
           </Grid>
-          : null}
-      </Grid>
-      {tableData.columns.length ?
-        <CustomizedTables
-          title="Tables"
-          data={tableData}
-          addLinks
-          baseURL={`/instance/${instanceName}/table/`}
-          showSearchBox={true}
-          inAccordionFormat={true}
+          {liveConfig ? (
+            <Grid item xs={6}>
+              <div className={classes.codeMirrorDiv}>
+                <SimpleAccordion
+                  headerTitle="LiveInstance Config"
+                  showSearchBox={false}
+                >
+                  <CodeMirror
+                    options={jsonoptions}
+                    value={liveConfig}
+                    className={classes.codeMirror}
+                    autoCursor={false}
+                  />
+                </SimpleAccordion>
+              </div>
+            </Grid>
+          ) : null}
+        </Grid>
+        {instanceType == InstanceType.BROKER ||
+        instanceType == InstanceType.SERVER ? (
+          <AsyncPinotTables
+            title="Tables"
+            baseUrl={`/instance/${instanceName}/table/`}
+            instance={instanceName}
+          />
+        ) : null}
+        <EditTagsOp
+          showModal={showEditTag}
+          hideModal={() => {
+            setShowEditTag(false);
+          }}
+          saveTags={saveTagsAction}
+          tags={tagsList}
+          handleTagsChange={handleTagsChange}
+          error={tagsErrorObj}
         />
-        : null}
-      <EditTagsOp
-        showModal={showEditTag}
-        hideModal={()=>{setShowEditTag(false);}}
-        saveTags={saveTagsAction}
-        tags={tagsList}
-        handleTagsChange={handleTagsChange}
-        error={tagsErrorObj}
-      />
-      <EditConfigOp
-        showModal={showEditConfig}
-        hideModal={()=>{setShowEditConfig(false);}}
-        saveConfig={saveConfigAction}
-        config={config}
-        handleConfigChange={handleConfigChange}
-      />
-      {confirmDialog && dialogDetails && <Confirm
-        openDialog={confirmDialog}
-        dialogTitle={dialogDetails.title}
-        dialogContent={dialogDetails.content}
-        successCallback={dialogDetails.successCb}
-        closeDialog={closeDialog}
-        dialogYesLabel='Yes'
-        dialogNoLabel='No'
-      />}
-    </Grid>
-  );
+        <EditConfigOp
+          showModal={showEditConfig}
+          hideModal={() => {
+            setShowEditConfig(false);
+          }}
+          saveConfig={saveConfigAction}
+          config={config}
+          handleConfigChange={handleConfigChange}
+        />
+        {confirmDialog && dialogDetails && (
+          <Confirm
+            openDialog={confirmDialog}
+            dialogTitle={dialogDetails.title}
+            dialogContent={dialogDetails.content}
+            successCallback={dialogDetails.successCb}
+            closeDialog={closeDialog}
+            dialogYesLabel="Yes"
+            dialogNoLabel="No"
+          />
+        )}
+      </Grid>
+    );
+  }
 };
 
 export default InstanceDetails;

--- a/pinot-controller/src/main/resources/app/pages/InstanceListingPage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/InstanceListingPage.tsx
@@ -20,10 +20,11 @@
 import React, {useState, useEffect} from 'react';
 import { Grid, makeStyles } from '@material-ui/core';
 import { startCase, pick } from 'lodash';
-import { DataTable } from 'Models';
+import { DataTable, InstanceType } from 'Models';
 import AppLoader from '../components/AppLoader';
 import PinotMethodUtils from '../utils/PinotMethodUtils';
 import Instances from '../components/Homepage/InstancesTables';
+import { getInstanceTypeFromString } from '../utils/Utils';
 
 const useStyles = makeStyles(() => ({
   gridContainer: {
@@ -38,13 +39,12 @@ const InstanceListingPage = () => {
   const classes = useStyles();
 
   const [fetching, setFetching] = useState(true);
-  const [instances, setInstances] = useState<DataTable>();
+  // const [instances, setInstances] = useState<DataTable>();
   const [clusterName, setClusterName] = useState('');
 
   const fetchData = async () => {
-    const instanceResponse = await PinotMethodUtils.getAllInstances();
-    const instanceType = startCase(window.location.hash.split('/')[1].slice(0, -1));
-    setInstances(pick(instanceResponse, instanceType));
+    // const instanceResponse = await PinotMethodUtils.getAllInstances();
+    // setInstances(pick(instanceResponse, instanceType));
     let clusterNameRes = localStorage.getItem('pinot_ui:clusterName');
     if(!clusterNameRes){
       clusterNameRes = await PinotMethodUtils.getClusterName();
@@ -57,11 +57,13 @@ const InstanceListingPage = () => {
     fetchData();
   }, []);
 
+  const instanceType = getInstanceTypeFromString(window.location.hash.split('/')[1].slice(0, -1));
+
   return fetching ? (
     <AppLoader />
   ) : (
     <Grid item xs className={classes.gridContainer}>
-      <Instances instances={instances} clusterName={clusterName} />
+      <Instances clusterName={clusterName} instanceType={instanceType} />
     </Grid>
   );
 };

--- a/pinot-controller/src/main/resources/app/pages/InstanceListingPage.tsx
+++ b/pinot-controller/src/main/resources/app/pages/InstanceListingPage.tsx
@@ -39,12 +39,9 @@ const InstanceListingPage = () => {
   const classes = useStyles();
 
   const [fetching, setFetching] = useState(true);
-  // const [instances, setInstances] = useState<DataTable>();
   const [clusterName, setClusterName] = useState('');
 
   const fetchData = async () => {
-    // const instanceResponse = await PinotMethodUtils.getAllInstances();
-    // setInstances(pick(instanceResponse, instanceType));
     let clusterNameRes = localStorage.getItem('pinot_ui:clusterName');
     if(!clusterNameRes){
       clusterNameRes = await PinotMethodUtils.getClusterName();

--- a/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/SegmentDetails.tsx
@@ -18,11 +18,12 @@
  */
 
 import React, { useState, useEffect } from 'react';
+import moment from 'moment';
+import { keys } from 'lodash';
 import { makeStyles } from '@material-ui/core/styles';
 import { Grid } from '@material-ui/core';
 import { RouteComponentProps, useHistory, useLocation } from 'react-router-dom';
 import { UnControlled as CodeMirror } from 'react-codemirror2';
-import AppLoader from '../components/AppLoader';
 import TableToolbar from '../components/TableToolbar';
 import 'codemirror/lib/codemirror.css';
 import 'codemirror/theme/material.css';
@@ -35,6 +36,15 @@ import CustomButton from '../components/CustomButton';
 import Confirm from '../components/Confirm';
 import { NotificationContext } from '../components/Notification/NotificationContext';
 import Utils from '../utils/Utils';
+import {
+  getExternalView,
+  getSegmentDebugInfo,
+  getSegmentMetadata,
+} from '../requests';
+import { SegmentMetadata } from 'Models';
+import Skeleton from '@material-ui/lab/Skeleton';
+import NotFound from '../components/NotFound';
+import AppLoader from '../components/AppLoader';
 
 const useStyles = makeStyles((theme) => ({
   root: {
@@ -66,8 +76,8 @@ const useStyles = makeStyles((theme) => ({
   operationDiv: {
     border: '1px #BDCCD9 solid',
     borderRadius: 4,
-    marginBottom: 20
-  }
+    marginBottom: 20,
+  },
 }));
 
 const jsonoptions = {
@@ -76,7 +86,7 @@ const jsonoptions = {
   styleActiveLine: true,
   gutters: ['CodeMirror-lint-markers'],
   theme: 'default',
-  readOnly: true
+  readOnly: true,
 };
 
 type Props = {
@@ -95,38 +105,181 @@ const SegmentDetails = ({ match }: RouteComponentProps<Props>) => {
   const classes = useStyles();
   const history = useHistory();
   const location = useLocation();
-  const { tableName, segmentName: encodedSegmentName} = match.params;
+  const { tableName, segmentName: encodedSegmentName } = match.params;
   const segmentName = Utils.encodeString(encodedSegmentName);
 
-  const [fetching, setFetching] = useState(true);
   const [confirmDialog, setConfirmDialog] = React.useState(false);
   const [dialogDetails, setDialogDetails] = React.useState(null);
-  const {dispatch} = React.useContext(NotificationContext);
+  const { dispatch } = React.useContext(NotificationContext);
 
-  const [segmentSummary, setSegmentSummary] = useState<Summary>({
+  const [initialLoad, setInitialLoad] = useState(true);
+  const [segmentNotFound, setSegmentNotFound] = useState(false);
+
+  const initialSummary = {
     segmentName,
-    totalDocs: '',
-    createTime: '',
-  });
-
-  const [replica, setReplica] = useState({
-    columns: [],
-    records: []
-  });
-
-  const [indexes, setIndexes] = useState({
-      columns: [],
-      records: []
-  });
-  const [value, setValue] = useState('');
-  const fetchData = async () => {
-    const result = await PinotMethodUtils.getSegmentDetails(tableName, segmentName);
-    setSegmentSummary(result.summary);
-    setIndexes(result.indexes);
-    setReplica(result.replicaSet);
-    setValue(JSON.stringify(result.JSON, null, 2));
-    setFetching(false);
+    totalDocs: null,
+    createTime: null,
   };
+  const [segmentSummary, setSegmentSummary] = useState<Summary>(initialSummary);
+
+  const replicaColumns = ['Server Name', 'Status'];
+  const initialReplica = Utils.getLoadingTableData(replicaColumns);
+  const [replica, setReplica] = useState(initialReplica);
+
+  const indexColumns = [
+    'Field Name',
+    'Bloom Filter',
+    'Dictionary',
+    'Forward Index',
+    'Sorted',
+    'Inverted Index',
+    'JSON Index',
+    'Null Value Vector Reader',
+    'Range Index',
+  ];
+  const initialIndexes = Utils.getLoadingTableData(indexColumns);
+  const [indexes, setIndexes] = useState(initialIndexes);
+  const initialSegmentMetadataJson = 'Loading...';
+  const [segmentMetadataJson, setSegmentMetadataJson] = useState(
+    initialSegmentMetadataJson
+  );
+
+  const fetchData = async () => {
+    // reset all state in case the segment was reloaded or deleted.
+    setInitialData();
+
+    getSegmentMetadata(tableName, segmentName).then((result) => {
+      if (result.data?.code === 404) {
+        setSegmentNotFound(true);
+        setInitialLoad(false);
+      } else {
+        setInitialLoad(false);
+        setSummary(result.data);
+        setSegmentMetadata(result.data);
+        setSegmentIndexes(result.data);
+      }
+    });
+    setSegmentReplicas();
+  };
+
+  const setInitialData = () => {
+    setInitialLoad(true);
+    setSegmentSummary(initialSummary);
+    setReplica(initialReplica);
+    setIndexes(initialIndexes);
+    setSegmentMetadataJson(initialSegmentMetadataJson);
+  };
+
+  const setSummary = (segmentMetadata: SegmentMetadata) => {
+    const segmentMetaDataJson = { ...segmentMetadata };
+    setSegmentSummary({
+      segmentName,
+      totalDocs: segmentMetaDataJson['segment.total.docs'] || 0,
+      createTime: moment(+segmentMetaDataJson['segment.creation.time']).format(
+        'MMMM Do YYYY, h:mm:ss'
+      ),
+    });
+  };
+
+  const setSegmentMetadata = (segmentMetadata: SegmentMetadata) => {
+    const segmentMetaDataJson = { ...segmentMetadata };
+    delete segmentMetaDataJson.indexes;
+    delete segmentMetaDataJson.columns;
+    setSegmentMetadataJson(JSON.stringify(segmentMetaDataJson, null, 2));
+  };
+
+  const setSegmentIndexes = (segmentMetadata: SegmentMetadata) => {
+    setIndexes({
+      columns: indexColumns,
+      records: Object.keys(segmentMetadata.indexes).map((fieldName) => [
+        fieldName,
+        segmentMetadata.indexes?.[fieldName]?.['bloom-filter'] === 'YES',
+        segmentMetadata.indexes?.[fieldName]?.['dictionary'] === 'YES',
+        segmentMetadata.indexes?.[fieldName]?.['forward-index'] === 'YES',
+        (
+          (segmentMetadata.columns || []).filter(
+            (row) => row.columnName === fieldName
+          )[0] || { sorted: false }
+        ).sorted,
+        segmentMetadata.indexes?.[fieldName]?.['inverted-index'] === 'YES',
+        segmentMetadata.indexes?.[fieldName]?.['json-index'] === 'YES',
+        segmentMetadata.indexes?.[fieldName]?.['null-value-vector-reader'] ===
+          'YES',
+        segmentMetadata.indexes?.[fieldName]?.['range-index'] === 'YES',
+      ]),
+    });
+  };
+
+  const setSegmentReplicas = () => {
+    let [baseTableName, tableType] = Utils.splitStringByLastUnderscore(
+      tableName
+    );
+
+    getExternalView(tableName).then((results) => {
+      const externalView = results.data.OFFLINE || results.data.REALTIME;
+
+      const records = keys(externalView?.[segmentName] || {}).map((prop) => {
+        const status = externalView?.[segmentName]?.[prop];
+        return [
+          prop,
+          { value: status, tooltip: `Segment is ${status.toLowerCase()}` },
+        ];
+      });
+
+      setReplica({
+        columns: replicaColumns,
+        records: records,
+      });
+
+      getSegmentDebugInfo(baseTableName, tableType.toLowerCase()).then(
+        (debugInfo) => {
+          const segmentDebugInfo = debugInfo.data;
+
+          let debugInfoObj = {};
+          if (segmentDebugInfo && segmentDebugInfo[0]) {
+            const debugInfosObj = segmentDebugInfo[0].segmentDebugInfos?.find(
+              (o) => {
+                return o.segmentName === segmentName;
+              }
+            );
+            if (debugInfosObj) {
+              const serverNames = keys(debugInfosObj?.serverState || {});
+              serverNames?.map((serverName) => {
+                debugInfoObj[serverName] =
+                  debugInfosObj.serverState[
+                    serverName
+                  ]?.errorInfo?.errorMessage;
+              });
+            }
+          }
+
+          const records = keys(externalView?.[segmentName] || {}).map(
+            (prop) => {
+              const status = externalView?.[segmentName]?.[prop];
+              return [
+                prop,
+                status === 'ERROR'
+                  ? {
+                      value: status,
+                      tooltip: debugInfoObj?.[prop] || 'testing',
+                    }
+                  : {
+                      value: status,
+                      tooltip: `Segment is ${status.toLowerCase()}`,
+                    },
+              ];
+            }
+          );
+
+          setReplica({
+            columns: replicaColumns,
+            records: records,
+          });
+        }
+      );
+    });
+  };
+
   useEffect(() => {
     fetchData();
   }, []);
@@ -139,22 +292,26 @@ const SegmentDetails = ({ match }: RouteComponentProps<Props>) => {
   const handleDeleteSegmentClick = () => {
     setDialogDetails({
       title: 'Delete Segment',
-      content: 'Are you sure want to delete this instance? Data from this segment will be permanently deleted.',
-      successCb: () => handleDeleteSegment()
+      content:
+        'Are you sure want to delete this instance? Data from this segment will be permanently deleted.',
+      successCb: () => handleDeleteSegment(),
     });
     setConfirmDialog(true);
   };
 
   const handleDeleteSegment = async () => {
-    const result = await PinotMethodUtils.deleteSegmentOp(tableName, segmentName);
-    if(result && result.status){
-      dispatch({type: 'success', message: result.status, show: true});
+    const result = await PinotMethodUtils.deleteSegmentOp(
+      tableName,
+      segmentName
+    );
+    if (result && result.status) {
+      dispatch({ type: 'success', message: result.status, show: true });
       fetchData();
     } else {
-      dispatch({type: 'error', message: result.error, show: true});
+      dispatch({ type: 'error', message: result.error, show: true });
     }
     closeDialog();
-    setTimeout(()=>{
+    setTimeout(() => {
       history.push(Utils.navigateToPreviousPage(location, false));
     }, 1000);
   };
@@ -163,122 +320,147 @@ const SegmentDetails = ({ match }: RouteComponentProps<Props>) => {
     setDialogDetails({
       title: 'Reload Segment',
       content: 'Are you sure want to reload this segment?',
-      successCb: () => handleReloadOp()
+      successCb: () => handleReloadOp(),
     });
     setConfirmDialog(true);
   };
 
   const handleReloadOp = async () => {
-    const result = await PinotMethodUtils.reloadSegmentOp(tableName, segmentName);
-    if(result.status){
-      dispatch({type: 'success', message: result.status, show: true});
+    const result = await PinotMethodUtils.reloadSegmentOp(
+      tableName,
+      segmentName
+    );
+    if (result.status) {
+      dispatch({ type: 'success', message: result.status, show: true });
       fetchData();
     } else {
-      dispatch({type: 'error', message: result.error, show: true});
+      dispatch({ type: 'error', message: result.error, show: true });
     }
     closeDialog();
-  }
+  };
 
-  return fetching ? (
-    <AppLoader />
-  ) : (
-    <Grid
-      item
-      xs
-      style={{
-        padding: 20,
-        backgroundColor: 'white',
-        maxHeight: 'calc(100vh - 70px)',
-        overflowY: 'auto',
-      }}
-    >
-      <div className={classes.operationDiv}>
-        <SimpleAccordion
-          headerTitle="Operations"
-          showSearchBox={false}
-        >
-          <div>
-            <CustomButton
-              onClick={()=>{handleDeleteSegmentClick()}}
-              tooltipTitle="Delete Segment"
-              enableTooltip={true}
-            >
-              Delete Segment
-            </CustomButton>
-            <CustomButton
-              onClick={()=>{handleReloadSegmentClick()}}
-              tooltipTitle="Reload the segment to apply changes such as indexing, column default values, etc"
-              enableTooltip={true}
-            >
-              Reload Segment
-            </CustomButton>
-          </div>
-        </SimpleAccordion>
-      </div>
-      <div className={classes.highlightBackground}>
-        <TableToolbar name="Summary" showSearchBox={false} />
-        <Grid container className={classes.body}>
+  if (initialLoad) {
+    return <AppLoader />;
+  } else if (segmentNotFound) {
+    return <NotFound message={`Segment ${segmentName} not found`} />;
+  } else {
+    return (
+      <Grid
+        item
+        xs
+        style={{
+          padding: 20,
+          backgroundColor: 'white',
+          maxHeight: 'calc(100vh - 70px)',
+          overflowY: 'auto',
+        }}
+      >
+        <div className={classes.operationDiv}>
+          <SimpleAccordion headerTitle="Operations" showSearchBox={false}>
+            <div>
+              <CustomButton
+                onClick={() => {
+                  handleDeleteSegmentClick();
+                }}
+                tooltipTitle="Delete Segment"
+                enableTooltip={true}
+              >
+                Delete Segment
+              </CustomButton>
+              <CustomButton
+                onClick={() => {
+                  handleReloadSegmentClick();
+                }}
+                tooltipTitle="Reload the segment to apply changes such as indexing, column default values, etc"
+                enableTooltip={true}
+              >
+                Reload Segment
+              </CustomButton>
+            </div>
+          </SimpleAccordion>
+        </div>
+        <div className={classes.highlightBackground}>
+          <TableToolbar name="Summary" showSearchBox={false} />
+          <Grid container className={classes.body}>
+            <Grid item xs={6}>
+              <strong>Segment Name:</strong>{' '}
+              {unescape(segmentSummary.segmentName)}
+            </Grid>
+            <Grid item container xs={2} wrap="nowrap" spacing={1}>
+              <Grid item>
+                <strong>Total Docs:</strong>
+              </Grid>
+              <Grid item>
+                {segmentSummary.totalDocs ? (
+                  segmentSummary.totalDocs
+                ) : (
+                  <Skeleton variant="text" animation="wave" width={50} />
+                )}
+              </Grid>
+            </Grid>
+            <Grid item container xs={4} wrap="nowrap" spacing={1}>
+              <Grid item>
+                <strong>Create Time:</strong>
+              </Grid>
+              <Grid item>
+                {segmentSummary.createTime ? (
+                  segmentSummary.createTime
+                ) : (
+                  <Skeleton variant="text" animation="wave" width={200} />
+                )}
+              </Grid>
+            </Grid>
+          </Grid>
+        </div>
+
+        <Grid container spacing={2}>
           <Grid item xs={6}>
-            <strong>Segment Name:</strong> {unescape(segmentSummary.segmentName)}
+            <CustomizedTables
+              title="Replica Set"
+              data={replica}
+              showSearchBox={true}
+              inAccordionFormat={true}
+              addLinks
+              baseURL="/instance/"
+            />
           </Grid>
-          <Grid item xs={3}>
-            <strong>Total Docs:</strong> {segmentSummary.totalDocs}
-          </Grid>
-          <Grid item xs={3}>
-            <strong>Create Time:</strong>  {segmentSummary.createTime}
+          <Grid item xs={6}>
+            <div className={classes.sqlDiv}>
+              <SimpleAccordion headerTitle="Metadata" showSearchBox={false}>
+                <CodeMirror
+                  options={jsonoptions}
+                  value={segmentMetadataJson}
+                  className={classes.queryOutput}
+                  autoCursor={false}
+                />
+              </SimpleAccordion>
+            </div>
           </Grid>
         </Grid>
-      </div>
 
-      <Grid container spacing={2}>
-        <Grid item xs={6}>
+        <Grid item xs={12}>
           <CustomizedTables
-            title="Replica Set"
-            data={replica}
-            addLinks
-            baseURL="/instance/"
+            title="Indexes"
+            data={indexes}
             showSearchBox={true}
             inAccordionFormat={true}
           />
         </Grid>
-        <Grid item xs={6}>
-          <div className={classes.sqlDiv}>
-            <SimpleAccordion
-              headerTitle="Metadata"
-              showSearchBox={false}
-            >
-              <CodeMirror
-                options={jsonoptions}
-                value={value}
-                className={classes.queryOutput}
-                autoCursor={false}
-              />
-            </SimpleAccordion>
-          </div>
-        </Grid>
 
+        {confirmDialog && dialogDetails && (
+          <Confirm
+            openDialog={confirmDialog}
+            dialogTitle={dialogDetails.title}
+            dialogContent={dialogDetails.content}
+            successCallback={dialogDetails.successCb}
+            closeDialog={closeDialog}
+            dialogYesLabel="Yes"
+            dialogNoLabel="No"
+          />
+        )}
       </Grid>
-
-              <Grid item xs={12}>
-                <CustomizedTables
-                  title="Indexes"
-                  data={indexes}
-                  showSearchBox={true}
-                  inAccordionFormat={true}
-                />
-              </Grid>
-
-      {confirmDialog && dialogDetails && <Confirm
-        openDialog={confirmDialog}
-        dialogTitle={dialogDetails.title}
-        dialogContent={dialogDetails.content}
-        successCallback={dialogDetails.successCb}
-        closeDialog={closeDialog}
-        dialogYesLabel='Yes'
-        dialogNoLabel='No'
-      />}
-    </Grid>
-  );
+    );
+  }
 };
 
 export default SegmentDetails;

--- a/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TenantDetails.tsx
@@ -500,9 +500,9 @@ const TenantPageDetails = ({ match }: RouteComponentProps<Props>) => {
                 Delete Schema
               </CustomButton>
               <CustomButton
-                isDisabled={true} onClick={()=>{console.log('truncate table');}}
-                // tooltipTitle="Truncate Table"
-                // enableTooltip={true}
+                isDisabled={true} onClick={()=>{}}
+                tooltipTitle="Truncate Table"
+                enableTooltip={true}
               >
                 Truncate Table
               </CustomButton>

--- a/pinot-controller/src/main/resources/app/pages/Tenants.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Tenants.tsx
@@ -17,76 +17,49 @@
  * under the License.
  */
 
-import React, { useState, useEffect } from 'react';
+import React from 'react';
 import { Grid, makeStyles } from '@material-ui/core';
-import { TableData } from 'Models';
+import { InstanceType } from 'Models';
 import { RouteComponentProps } from 'react-router-dom';
-import CustomizedTables from '../components/Table';
-import AppLoader from '../components/AppLoader';
-import PinotMethodUtils from '../utils/PinotMethodUtils';
 import SimpleAccordion from '../components/SimpleAccordion';
+import AsyncPinotTables from '../components/AsyncPinotTables';
 import CustomButton from '../components/CustomButton';
+import { AsyncInstanceTable } from '../components/AsyncInstanceTable';
 
 const useStyles = makeStyles((theme) => ({
   operationDiv: {
     border: '1px #BDCCD9 solid',
     borderRadius: 4,
-    marginBottom: 20
-  }
+    marginBottom: 20,
+  },
 }));
 
 type Props = {
-  tenantName: string
+  tenantName: string;
 };
 
-const TableTooltipData = [
-  null,
-  "Uncompressed size of all data segments with replication",
-  "Estimated size of all data segments with replication, in case any servers are not reachable for actual size",
-  null,
-  "GOOD if all replicas of all segments are up"
-];
-
 const TenantPage = ({ match }: RouteComponentProps<Props>) => {
-
-  const {tenantName} = match.params;
-  const columnHeaders = ['Table Name', 'Reported Size', 'Estimated Size', 'Number of Segments', 'Status'];
-  const [fetching, setFetching] = useState(true);
-  const [tableData, setTableData] = useState<TableData>({
-    columns: columnHeaders,
-    records: []
-  });
-  const [brokerData, setBrokerData] = useState(null);
-  const [serverData, setServerData] = useState([]);
-
-  const fetchData = async () => {
-    const tenantData = await PinotMethodUtils.getTenantTableData(tenantName);
-    const brokersData = await PinotMethodUtils.getBrokerOfTenant(tenantName);
-    const serversData = await PinotMethodUtils.getServerOfTenant(tenantName);
-    setTableData(tenantData);
-    const separatedBrokers = Array.isArray(brokersData) ? brokersData.map((elm) => [elm]) : [];
-    setBrokerData(separatedBrokers || []);
-    const separatedServers = Array.isArray(serversData) ? serversData.map((elm) => [elm]) : [];
-    setServerData(separatedServers || []);
-    setFetching(false);
-  };
-  useEffect(() => {
-    fetchData();
-  }, []);
-
+  const { tenantName } = match.params;
   const classes = useStyles();
 
   return (
-    fetching ? <AppLoader /> :
-    <Grid item xs style={{ padding: 20, backgroundColor: 'white', maxHeight: 'calc(100vh - 70px)', overflowY: 'auto' }}>
+    <Grid
+      item
+      xs
+      style={{
+        padding: 20,
+        backgroundColor: 'white',
+        maxHeight: 'calc(100vh - 70px)',
+        overflowY: 'auto',
+      }}
+    >
       <div className={classes.operationDiv}>
-        <SimpleAccordion
-          headerTitle="Operations"
-          showSearchBox={false}
-        >
+        <SimpleAccordion headerTitle="Operations" showSearchBox={false}>
           <div>
             <CustomButton
-              onClick={()=>{console.log('rebalance');}}
+              onClick={() => {
+                console.log('rebalance');
+              }}
               tooltipTitle="Recalculates the segment to server mapping for all tables in this tenant"
               enableTooltip={true}
               isDisabled={true}
@@ -94,7 +67,9 @@ const TenantPage = ({ match }: RouteComponentProps<Props>) => {
               Rebalance Server Tenant
             </CustomButton>
             <CustomButton
-              onClick={()=>{console.log('rebuild');}}
+              onClick={() => {
+                console.log('rebuild');
+              }}
               tooltipTitle="Rebuilds brokerResource mappings for all tables in this tenant"
               enableTooltip={true}
               isDisabled={true}
@@ -104,40 +79,22 @@ const TenantPage = ({ match }: RouteComponentProps<Props>) => {
           </div>
         </SimpleAccordion>
       </div>
-      <CustomizedTables
+      <AsyncPinotTables
         title={tenantName}
-        data={tableData}
-        tooltipData={TableTooltipData}
-        addLinks
-        baseURL={`/tenants/${tenantName}/table/`}
-        showSearchBox={true}
-        inAccordionFormat={true}
+        tenants={[tenantName]}
+        baseUrl={`/tenants/${tenantName}/table/`}
       />
       <Grid container spacing={2}>
         <Grid item xs={6}>
-          <CustomizedTables
-            title="Brokers"
-            data={{
-              columns: ['Instance Name'],
-              records: brokerData.length > 0 ? brokerData : []
-            }}
-            addLinks
-            baseURL="/instance/"
-            showSearchBox={true}
-            inAccordionFormat={true}
+          <AsyncInstanceTable
+            instanceType={InstanceType.BROKER}
+            tenant={tenantName}
           />
         </Grid>
         <Grid item xs={6}>
-          <CustomizedTables
-            title="Servers"
-            data={{
-              columns: ['Instance Name'],
-              records: serverData.length > 0 ? serverData : []
-            }}
-            addLinks
-            baseURL="/instance/"
-            showSearchBox={true}
-            inAccordionFormat={true}
+          <AsyncInstanceTable
+            instanceType={InstanceType.SERVER}
+            tenant={tenantName}
           />
         </Grid>
       </Grid>

--- a/pinot-controller/src/main/resources/app/pages/Tenants.tsx
+++ b/pinot-controller/src/main/resources/app/pages/Tenants.tsx
@@ -57,9 +57,7 @@ const TenantPage = ({ match }: RouteComponentProps<Props>) => {
         <SimpleAccordion headerTitle="Operations" showSearchBox={false}>
           <div>
             <CustomButton
-              onClick={() => {
-                console.log('rebalance');
-              }}
+              onClick={() => {}}
               tooltipTitle="Recalculates the segment to server mapping for all tables in this tenant"
               enableTooltip={true}
               isDisabled={true}
@@ -67,9 +65,7 @@ const TenantPage = ({ match }: RouteComponentProps<Props>) => {
               Rebalance Server Tenant
             </CustomButton>
             <CustomButton
-              onClick={() => {
-                console.log('rebuild');
-              }}
+              onClick={() => {}}
               tooltipTitle="Rebuilds brokerResource mappings for all tables in this tenant"
               enableTooltip={true}
               isDisabled={true}

--- a/pinot-controller/src/main/resources/app/requests/index.ts
+++ b/pinot-controller/src/main/resources/app/requests/index.ts
@@ -18,10 +18,34 @@
  */
 
 import { AxiosResponse } from 'axios';
-import { TableData, Instances, Instance, Tenants, ClusterConfig, TableName, TableSize,
-  IdealState, QueryTables, TableSchema, SQLResult, ClusterName, ZKGetList, ZKConfig, OperationResponse,
-  BrokerList, ServerList, UserList, TableList, UserObject, TaskProgressResponse, TableSegmentJobs, TaskRuntimeConfig,
-  SegmentDebugDetails, QuerySchemas, TableType, InstanceState
+import {
+  TableData,
+  Instances,
+  Instance,
+  Tenants,
+  ClusterConfig,
+  TableName,
+  TableSize,
+  IdealState,
+  QueryTables,
+  TableSchema,
+  SQLResult,
+  ClusterName,
+  ZKGetList,
+  ZKConfig,
+  OperationResponse,
+  BrokerList,
+  ServerList,
+  UserList,
+  TableList,
+  UserObject,
+  TaskProgressResponse,
+  TableSegmentJobs,
+  TaskRuntimeConfig,
+  SegmentDebugDetails,
+  QuerySchemas,
+  TableType,
+  InstanceState, SegmentMetadata,
 } from 'Models';
 
 const headers = {
@@ -62,7 +86,7 @@ export const putSchema = (name: string, params: string, reload?: boolean): Promi
   return baseApi.put(`/schemas/${name}`, params, { headers, params: queryParams });
 }
 
-export const getSegmentMetadata = (tableName: string, segmentName: string): Promise<AxiosResponse<IdealState>> =>
+export const getSegmentMetadata = (tableName: string, segmentName: string): Promise<AxiosResponse<SegmentMetadata>> =>
   baseApi.get(`/segments/${tableName}/${segmentName}/metadata?columns=*`);
 
 export const getTableSize = (name: string): Promise<AxiosResponse<TableSize>> =>

--- a/pinot-controller/src/main/resources/app/router.tsx
+++ b/pinot-controller/src/main/resources/app/router.tsx
@@ -37,6 +37,7 @@ import LoginPage from './pages/LoginPage';
 import UserPage from "./pages/UserPage";
 
 export default [
+  // TODO: make async
   { path: '/', Component: HomePage },
   { path: '/query', Component: QueryPage },
   { path: '/tenants', Component: TenantsListingPage },

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -141,10 +141,6 @@ const getTenantsData = () => {
   });
 };
 
-const getTenantData = (tenant: string) => {
-
-}
-
 // This method is used to fetch all instances on cluster manager home page
 // API: /instances
 // Expected Output: {Controller: ['Controller1', 'Controller2'], Broker: ['Broker1', 'Broker2']}

--- a/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
+++ b/pinot-controller/src/main/resources/app/utils/PinotMethodUtils.ts
@@ -19,7 +19,7 @@
 
 import jwtDecode from "jwt-decode";
 import { get, map, each, isEqual, isArray, keys, union } from 'lodash';
-import { DataTable, SqlException, SQLResult } from 'Models';
+import { DataTable, SegmentMetadata, SqlException, SQLResult, TableSize } from 'Models';
 import moment from 'moment';
 import {
   getTenants,
@@ -140,6 +140,10 @@ const getTenantsData = () => {
     });
   });
 };
+
+const getTenantData = (tenant: string) => {
+
+}
 
 // This method is used to fetch all instances on cluster manager home page
 // API: /instances
@@ -352,7 +356,6 @@ const getTenantTableData = (tenantName) => {
 const getSchemaObject = async (schemaName) =>{
   let schemaObj:Array<any> = [];
     let {data} = await getSchema(schemaName);
-    console.log(data);
       schemaObj.push(data.schemaName);
       schemaObj.push(data.dimensionFieldSpecs ? data.dimensionFieldSpecs.length : 0);
       schemaObj.push(data.dateTimeFieldSpecs ? data.dateTimeFieldSpecs.length : 0);
@@ -409,6 +412,30 @@ const allTableDetailsColumnHeader = [
   'Status',
 ];
 
+const getTableSizes = (tableName: string) => {
+  return getTableSize(tableName).then(result => {
+    return {
+      reported_size: Utils.formatBytes(result.data.reportedSizeInBytes),
+      estimated_size: Utils.formatBytes(result.data.estimatedSizeInBytes),
+    };
+  })
+}
+
+const getSegmentCountAndStatus = (tableName: string) => {
+  return getIdealState(tableName).then(result => {
+    const idealState = result.data.OFFLINE || result.data.REALTIME || {};
+    return getExternalView(tableName).then(result => {
+      const externalView = result.data.OFFLINE || result.data.REALTIME || {};
+      const externalSegmentCount = Object.keys(externalView).length;
+      const idealSegmentCount = Object.keys(idealState).length;
+      return {
+        segment_count: `${externalSegmentCount} / ${idealSegmentCount}`,
+        segment_status: Utils.getSegmentStatus(idealState, externalView)
+      };
+    });
+  });
+}
+
 const getAllTableDetails = (tablesList) => {
   if (tablesList.length) {
     const promiseArr = [];
@@ -464,10 +491,10 @@ const getAllTableDetails = (tablesList) => {
       };
     });
   }
-  return {
+  return Promise.resolve({
     columns: allTableDetailsColumnHeader,
     records: []
-  };
+  });
 };
 
 // This method is used to display summary of a particular tenant table
@@ -556,7 +583,7 @@ const getSegmentDetails = (tableName, segmentName) => {
 
   return Promise.all(promiseArr).then((results) => {
     const obj = results[0].data.OFFLINE || results[0].data.REALTIME;
-    const segmentMetaData = results[1].data;
+    const segmentMetaData: SegmentMetadata = results[1].data;
     const debugObj = results[2].data;
     let debugInfoObj = {};
 
@@ -569,7 +596,6 @@ const getSegmentDetails = (tableName, segmentName) => {
         });
       }
     }
-    console.log(debugInfoObj);
 
     const result = [];
     for (const prop in obj[segmentName]) {
@@ -719,13 +745,13 @@ const deleteNode = (path) => {
   });
 };
 
-const getBrokerOfTenant = (tenantName) => {
+const getBrokerOfTenant = (tenantName: string) => {
   return getBrokerListOfTenant(tenantName).then((response)=>{
     return !response.data.error ? response.data : [];
   });
 };
 
-const getServerOfTenant = (tenantName) => {
+const getServerOfTenant = (tenantName: string) => {
   return getServerListOfTenant(tenantName).then((response)=>{
     return !response.data.error ? response.data.ServerInstances : [];
   });
@@ -1227,6 +1253,7 @@ export default {
   getSegmentStatus,
   getTableDetails,
   getSegmentDetails,
+  getSegmentCountAndStatus,
   getClusterName,
   getLiveInstance,
   getLiveInstanceConfig,
@@ -1249,6 +1276,7 @@ export default {
   fetchSegmentReloadStatus,
   getTaskTypeDebugData,
   getTableData,
+  getTableSizes,
   getTaskRuntimeConfigData,
   getTaskInfo,
   stopAllTasks,

--- a/pinot-controller/src/main/resources/app/utils/Utils.tsx
+++ b/pinot-controller/src/main/resources/app/utils/Utils.tsx
@@ -22,7 +22,14 @@ import React from 'react';
 import ReactDiffViewer, {DiffMethod} from 'react-diff-viewer';
 import { map, isEqual, findIndex, findLast } from 'lodash';
 import app_state from '../app_state';
-import {DISPLAY_SEGMENT_STATUS, SEGMENT_STATUS, TableData} from 'Models';
+import {
+  DISPLAY_SEGMENT_STATUS, InstanceType,
+  PinotTableDetails,
+  SEGMENT_STATUS,
+  SegmentStatus,
+  TableData,
+} from 'Models';
+import Loading from '../components/Loading';
 
 const sortArray = function (sortingArr, keyName, ascendingFlag) {
   if (ascendingFlag) {
@@ -46,6 +53,26 @@ const sortArray = function (sortingArr, keyName, ascendingFlag) {
     return 0;
   });
 };
+
+const pinotTableDetailsFormat = (tableDetails: PinotTableDetails): Array<string | number | boolean | SegmentStatus | { customRenderer: JSX.Element }> => {
+  return [
+    tableDetails.name,
+    tableDetails.estimated_size || Loading,
+    tableDetails.reported_size || Loading,
+    tableDetails.number_of_segments || Loading,
+    tableDetails.segment_status || Loading
+  ];
+}
+
+const pinotTableDetailsFromArray = (tableDetails: Array<string | number | boolean | SegmentStatus | { customRenderer: JSX.Element }>): PinotTableDetails => {
+  return {
+    name: tableDetails[0] as string,
+    estimated_size: tableDetails[1] as string,
+    reported_size: tableDetails[2] as string,
+    number_of_segments: tableDetails[3] as string,
+    segment_status: tableDetails[4] as any
+  };
+}
 
 const tableFormat = (data: TableData): Array<{ [key: string]: any }> => {
   const rows = data.records;
@@ -321,7 +348,7 @@ const encodeString = (str: string) => {
   return str;
 }
 
-const formatBytes = (bytes, decimals = 2) => {
+const formatBytes = (bytes: number, decimals = 2) => {
   if (bytes === 0) return '0 Bytes';
 
   const k = 1024;
@@ -385,6 +412,43 @@ export const getDisplaySegmentStatus = (idealState, externalView): DISPLAY_SEGME
   return DISPLAY_SEGMENT_STATUS.UPDATING;
 }
 
+export const getInstanceTypeFromInstanceName = (instanceName: string): InstanceType => {
+  if (instanceName.toLowerCase().startsWith(InstanceType.BROKER.toLowerCase())) {
+    return InstanceType.BROKER;
+  } else if (instanceName.toLowerCase().startsWith(InstanceType.CONTROLLER.toLowerCase())) {
+    return InstanceType.CONTROLLER;
+  } else if (instanceName.toLowerCase().startsWith(InstanceType.MINION.toLowerCase())) {
+    return InstanceType.MINION;
+  } else if (instanceName.toLowerCase().startsWith(InstanceType.SERVER.toLowerCase())) {
+    return InstanceType.SERVER;
+  }  else {
+    return null;
+  }
+}
+
+export const getInstanceTypeFromString = (instanceType: string): InstanceType => {
+  if (instanceType.toLowerCase() === InstanceType.BROKER.toLowerCase()) {
+    return InstanceType.BROKER;
+  } else if (instanceType.toLowerCase() === InstanceType.CONTROLLER.toLowerCase()) {
+    return InstanceType.CONTROLLER;
+  } else if (instanceType.toLowerCase() === InstanceType.MINION.toLowerCase()) {
+    return InstanceType.MINION;
+  } else if (instanceType.toLowerCase() === InstanceType.SERVER.toLowerCase()) {
+    return InstanceType.SERVER;
+  }  else {
+    return null;
+  }
+}
+
+const getLoadingTableData = (columns: string[]): TableData => {
+  return {
+    columns: columns,
+    records: [
+      columns.map((_) => Loading),
+    ],
+  };
+}
+
 export default {
   sortArray,
   tableFormat,
@@ -396,5 +460,8 @@ export default {
   syncTableSchemaData,
   encodeString,
   formatBytes,
-  splitStringByLastUnderscore
+  splitStringByLastUnderscore,
+  pinotTableDetailsFormat,
+  pinotTableDetailsFromArray,
+  getLoadingTableData
 };

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableSizeResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableSizeResource.java
@@ -29,6 +29,7 @@ import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Random;
 import javax.inject.Inject;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableSizeResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TableSizeResource.java
@@ -29,7 +29,6 @@ import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Random;
 import javax.inject.Inject;
 import javax.ws.rs.DefaultValue;
 import javax.ws.rs.GET;


### PR DESCRIPTION
This is a UI feature change addressing #10504. Apologies for the humungous PR, but I figured it would be best to knock this out in 1 go. There's a couple of things happening here:
- added a small "NotFound" page if you navigate to tables/schemas/instances/segments that don't exist. It doesn't happen often, but previous the UI just broke if you did this
- as much as I could, all UI elements should now load async. Meaning the UI will immediately render with "loading" indicators, and then the data will populate the page
  - for a small cluster, this change is likely imperceptible
  - for a large cluster, everything will feel a lot snappier. Table sizes, table status, and instance counts are the slowest things to load. Before this, they would hold up rendering the entire page
  - restarting a server would also previously induce a lot of slowness in the UI. The UI wouldn't load until the /size endpoint from controller->server timed out. Now it just shows that it's "loading" but the rest of the data is on the page
- I ran prettier (with the Pinot config) over each file I touched. This was mostly because writing JS without a linter is hard, and it was simpler to just reformat the whole file rather than try to get my changes correct.

Here is a recording of me clicking around RealtimeQuickstart
https://github.com/apache/pinot/assets/4760722/3f87c467-4d00-46d4-bb0b-4d0cc7c12d63

Here is a recording where I added a random 0-3 second sleep in the server's /size endpoint
https://github.com/apache/pinot/assets/4760722/c5d79abe-195c-4bfa-bdc3-f107b38e39f2

