### PR TITLE
[multistage][hotfix] table name not escaped during route finding dummy query

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/routing/WorkerManager.java
@@ -344,7 +344,7 @@ public class WorkerManager {
     String tableNameWithType =
         TableNameBuilder.forType(tableType).tableNameWithType(TableNameBuilder.extractRawTableName(tableName));
     return _routingManager.getRoutingTable(
-        CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM " + tableNameWithType), requestId);
+        CalciteSqlCompiler.compileToBrokerRequest("SELECT * FROM \"" + tableNameWithType + "\""), requestId);
   }
 
   // --------------------------------------------------------------------------


### PR DESCRIPTION
table name is not escaped during routing entry discovery. 
this adds double quote around the table name for dummy query