### PR TITLE
Use higher fetch timeout for Kinesis

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/stream/StreamConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/stream/StreamConfigTest.java
@@ -403,4 +403,31 @@ public class StreamConfigTest {
       // expected
     }
   }
+
+  @Test
+  public void testKinesisFetchTimeout() {
+    String streamType = "fakeStream";
+    String topic = "fakeTopic";
+    String tableName = "fakeTable_REALTIME";
+    String consumerFactoryClass = "KinesisConsumerFactory";
+    String decoderClass = FakeStreamMessageDecoder.class.getName();
+
+    Map<String, String> streamConfigMap = new HashMap<>();
+    streamConfigMap.put(StreamConfigProperties.STREAM_TYPE, streamType);
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME), topic);
+    streamConfigMap.put(StreamConfigProperties.constructStreamProperty(streamType,
+        StreamConfigProperties.STREAM_CONSUMER_FACTORY_CLASS), consumerFactoryClass);
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_DECODER_CLASS),
+        decoderClass);
+
+    String consumerType = "simple";
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_TYPES),
+        consumerType);
+    StreamConfig streamConfig = new StreamConfig(tableName, streamConfigMap);
+
+    assertEquals(streamConfig.getFetchTimeoutMillis(), StreamConfig.DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS_KINESIS);
+  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -48,6 +48,7 @@ public class StreamConfig {
 
   public static final long DEFAULT_STREAM_CONNECTION_TIMEOUT_MILLIS = 30_000;
   public static final int DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS = 5_000;
+  public static final int DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS_KINESIS = 600_000;
   public static final int DEFAULT_IDLE_TIMEOUT_MILLIS = 3 * 60 * 1000;
 
   private static final double CONSUMPTION_RATE_LIMIT_NOT_SPECIFIED = -1;
@@ -142,7 +143,10 @@ public class StreamConfig {
     }
     _connectionTimeoutMillis = connectionTimeoutMillis;
 
-    int fetchTimeoutMillis = DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS;
+    // For Kinesis, we need to set a higher fetch timeout to avoid getting stuck in empty records loop
+    int fetchTimeoutMillis =
+        !_consumerFactoryClassName.contains("KinesisConsumerFactory") ? DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS_KINESIS
+            : DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS;
     String fetchTimeoutKey =
         StreamConfigProperties.constructStreamProperty(_type, StreamConfigProperties.STREAM_FETCH_TIMEOUT_MILLIS);
     String fetchTimeoutValue = streamConfigMap.get(fetchTimeoutKey);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -144,6 +144,7 @@ public class StreamConfig {
     _connectionTimeoutMillis = connectionTimeoutMillis;
 
     // For Kinesis, we need to set a higher fetch timeout to avoid getting stuck in empty records loop
+    // TODO: Remove this once we have a better way to handle empty records in Kinesis
     int fetchTimeoutMillis =
         !_consumerFactoryClassName.contains("KinesisConsumerFactory") ? DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS_KINESIS
             : DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -146,7 +146,7 @@ public class StreamConfig {
     // For Kinesis, we need to set a higher fetch timeout to avoid getting stuck in empty records loop
     // TODO: Remove this once we have a better way to handle empty records in Kinesis
     int fetchTimeoutMillis =
-        !_consumerFactoryClassName.contains("KinesisConsumerFactory") ? DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS_KINESIS
+        _consumerFactoryClassName.contains("KinesisConsumerFactory") ? DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS_KINESIS
             : DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS;
     String fetchTimeoutKey =
         StreamConfigProperties.constructStreamProperty(_type, StreamConfigProperties.STREAM_FETCH_TIMEOUT_MILLIS);


### PR DESCRIPTION
Currently, we run into a scenario where KinesisConsumer gets stuck due to timeouts.

The scenario is explained in the attached diagram

![Getting Started_ Boards (1) (1)](https://github.com/apache/pinot/assets/5559703/470a74c8-bef2-40d8-8dc9-b3b88930bc67)


The temporary solution is to increase the timeout of kinesis. A more permanent solution would be to modify the fetchRecords method to accept a `emitter` function that can be called from a forever running while loop to push the data.
