### PR TITLE
11761 - fix for connection pool error

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
+++ b/pinot-plugins/pinot-file-system/pinot-s3/src/main/java/org/apache/pinot/plugin/filesystem/S3PinotFS.java
@@ -116,7 +116,7 @@ public class S3PinotFS extends BasePinotFS {
             AwsBasicCredentials.create(s3Config.getAccessKey(), s3Config.getSecretKey());
         awsCredentialsProvider = StaticCredentialsProvider.create(awsBasicCredentials);
       } else {
-        awsCredentialsProvider = DefaultCredentialsProvider.create();
+        awsCredentialsProvider = DefaultCredentialsProvider.builder().build();
       }
 
       // IAM Role based access

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConnectionHandler.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConnectionHandler.java
@@ -96,7 +96,7 @@ public class KinesisConnectionHandler {
         AwsBasicCredentials awsBasicCredentials = AwsBasicCredentials.create(_accessKey, _secretKey);
         awsCredentialsProvider = StaticCredentialsProvider.create(awsBasicCredentials);
       } else {
-        awsCredentialsProvider = DefaultCredentialsProvider.create();
+        awsCredentialsProvider = DefaultCredentialsProvider.builder().build();
       }
 
       if (_kinesisConfig.isIamRoleBasedAccess()) {

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataProducer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/server/KinesisDataProducer.java
@@ -87,7 +87,7 @@ public class KinesisDataProducer implements StreamDataProducer {
               .httpClientBuilder(new ApacheSdkHttpService().createHttpClientBuilder());
         } else {
           kinesisClientBuilder = KinesisClient.builder().region(Region.of(props.getProperty(REGION)))
-              .credentialsProvider(DefaultCredentialsProvider.create())
+              .credentialsProvider(DefaultCredentialsProvider.builder().build())
               .httpClientBuilder(new ApacheSdkHttpService().createHttpClientBuilder());
         }
 


### PR DESCRIPTION
This PR includes a fix for https://github.com/apache/pinot/issues/11761 . This is based on https://github.com/apache/pinot/pull/12063/files fix proposed by @klsince 
-  I have tested that connection pool is fixed for KinesisConsumer and the S3 files are also flushed periodically for Realtime table

These labels need to be added
- `bugfix`
- `testing` incase additional testing is needed for other users who faced this issue

