### PR TITLE
Allow String / numeric data type for deleteRecordColumn config

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -729,11 +729,14 @@ public final class TableConfigUtils {
       if (deleteRecordColumn != null) {
         FieldSpec fieldSpec = schema.getFieldSpecFor(deleteRecordColumn);
         Preconditions.checkState(
-            fieldSpec != null && fieldSpec.isSingleValueField(),
+            fieldSpec != null,
+            "Invalid delete record column found");
+        Preconditions.checkState(
+            fieldSpec.isSingleValueField(),
             "The delete record column must be a single-valued column");
         DataType dataType = fieldSpec.getDataType();
         Preconditions.checkState(dataType == DataType.BOOLEAN || dataType == DataType.STRING
-                || dataType.isNumeric(), "The delete record column must be of type: STRING / Boolean / numeric");
+                || dataType.isNumeric(), "The delete record column must be of type: String / Boolean / Numeric");
       }
 
       String outOfOrderRecordColumn = upsertConfig.getOutOfOrderRecordColumn();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -731,6 +731,9 @@ public final class TableConfigUtils {
         Preconditions.checkState(
             fieldSpec != null && fieldSpec.isSingleValueField(),
             "The delete record column must be a single-valued column");
+        DataType dataType = fieldSpec.getDataType();
+        Preconditions.checkState(dataType == DataType.BOOLEAN || dataType == DataType.STRING
+                || dataType.isNumeric(), "The delete record column must be of type: STRING / Boolean / numeric");
       }
 
       String outOfOrderRecordColumn = upsertConfig.getOutOfOrderRecordColumn();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -728,15 +728,15 @@ public final class TableConfigUtils {
       String deleteRecordColumn = upsertConfig.getDeleteRecordColumn();
       if (deleteRecordColumn != null) {
         FieldSpec fieldSpec = schema.getFieldSpecFor(deleteRecordColumn);
-        Preconditions.checkState(
-            fieldSpec != null,
-            "Invalid delete record column found");
-        Preconditions.checkState(
-            fieldSpec.isSingleValueField(),
-            "The delete record column must be a single-valued column");
+        Preconditions.checkState(fieldSpec != null,
+            String.format("Column %s specified in deleteRecordColumn does not exist", deleteRecordColumn));
+        Preconditions.checkState(fieldSpec.isSingleValueField(),
+            String.format("The deleteRecordColumn - %s must be a single-valued column", deleteRecordColumn));
         DataType dataType = fieldSpec.getDataType();
-        Preconditions.checkState(dataType == DataType.BOOLEAN || dataType == DataType.STRING
-                || dataType.isNumeric(), "The delete record column must be of type: String / Boolean / Numeric");
+        Preconditions.checkState(
+            dataType == DataType.BOOLEAN || dataType == DataType.STRING || dataType.isNumeric(),
+            String.format("The deleteRecordColumn - %s must be of type: String / Boolean / Numeric",
+                deleteRecordColumn));
       }
 
       String outOfOrderRecordColumn = upsertConfig.getOutOfOrderRecordColumn();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -729,8 +729,8 @@ public final class TableConfigUtils {
       if (deleteRecordColumn != null) {
         FieldSpec fieldSpec = schema.getFieldSpecFor(deleteRecordColumn);
         Preconditions.checkState(
-            fieldSpec != null && fieldSpec.isSingleValueField() && fieldSpec.getDataType() == DataType.BOOLEAN,
-            "The delete record column must be a single-valued BOOLEAN column");
+            fieldSpec != null && fieldSpec.isSingleValueField(),
+            "The delete record column must be a single-valued column");
       }
 
       String outOfOrderRecordColumn = upsertConfig.getOutOfOrderRecordColumn();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1736,6 +1736,7 @@ public class TableConfigUtilsTest {
     String delCol = "myDelCol";
     String mvCol = "mvCol";
     String timestampCol = "timestampCol";
+    String invalidCol = "invalidCol";
     schema = new Schema.SchemaBuilder().setSchemaName(TABLE_NAME).setPrimaryKeyColumns(Lists.newArrayList("myPkCol"))
         .addSingleValueDimension("myCol", FieldSpec.DataType.STRING)
         .addSingleValueDimension(stringTypeDelCol, FieldSpec.DataType.STRING)
@@ -1779,7 +1780,20 @@ public class TableConfigUtilsTest {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail("Should have failed table creation when delete column type is timestamp.");
     } catch (IllegalStateException e) {
-      Assert.assertEquals(e.getMessage(), "The delete record column must be of type: STRING / Boolean / numeric");
+      Assert.assertEquals(e.getMessage(), "The delete record column must be of type: String / Boolean / Numeric");
+    }
+
+    upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
+    upsertConfig.setDeleteRecordColumn(invalidCol);
+    tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME).setStreamConfigs(streamConfigs)
+        .setUpsertConfig(upsertConfig)
+        .setRoutingConfig(new RoutingConfig(null, null, RoutingConfig.STRICT_REPLICA_GROUP_INSTANCE_SELECTOR_TYPE))
+        .build();
+    try {
+      TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
+      Assert.fail("Should have failed table creation when invalid delete column entered.");
+    } catch (IllegalStateException e) {
+      Assert.assertEquals(e.getMessage(), "Invalid delete record column found");
     }
 
     upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -1780,7 +1780,8 @@ public class TableConfigUtilsTest {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail("Should have failed table creation when delete column type is timestamp.");
     } catch (IllegalStateException e) {
-      Assert.assertEquals(e.getMessage(), "The delete record column must be of type: String / Boolean / Numeric");
+      Assert.assertEquals(e.getMessage(),
+          "The deleteRecordColumn - timestampCol must be of type: String / Boolean / Numeric");
     }
 
     upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
@@ -1793,7 +1794,7 @@ public class TableConfigUtilsTest {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail("Should have failed table creation when invalid delete column entered.");
     } catch (IllegalStateException e) {
-      Assert.assertEquals(e.getMessage(), "Invalid delete record column found");
+      Assert.assertEquals(e.getMessage(), "Column invalidCol specified in deleteRecordColumn does not exist");
     }
 
     upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
@@ -1806,7 +1807,7 @@ public class TableConfigUtilsTest {
       TableConfigUtils.validateUpsertAndDedupConfig(tableConfig, schema);
       Assert.fail("Should have failed table creation when delete column type is multi-valued.");
     } catch (IllegalStateException e) {
-      Assert.assertEquals(e.getMessage(), "The delete record column must be a single-valued column");
+      Assert.assertEquals(e.getMessage(), "The deleteRecordColumn - mvCol must be a single-valued column");
     }
 
     // upsert deleted-keys-ttl configs with no deleted column


### PR DESCRIPTION
Relates to #12217.

This patch add the criteria that `deleteRecordColumn` field can be of String / numeric data type thus allowing String based "true"/"false"/"0"/"1" to work or int based 0/1 as well based on BooleanUtils class.

Tested in one of our clusters using String based field for deleted column and worked as expected.