### PR TITLE
refine how to take validDocIds snapshot: more atomic and by certain order

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/immutable/ImmutableSegmentLoader.java
@@ -20,7 +20,6 @@ package org.apache.pinot.segment.local.indexsegment.immutable;
 
 import com.google.common.base.Preconditions;
 import java.io.File;
-import java.net.URI;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -180,13 +179,6 @@ public class ImmutableSegmentLoader {
       }
     } else {
       indexLoadingConfig.addKnownColumns(columnMetadataMap.keySet());
-    }
-
-    URI indexDirURI = segmentDirectory.getIndexDir();
-    String scheme = indexDirURI.getScheme();
-    File localIndexDir = null;
-    if (scheme != null && scheme.equalsIgnoreCase("file")) {
-      localIndexDir = new File(indexDirURI);
     }
 
     SegmentDirectory.Reader segmentReader = segmentDirectory.createReader();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -26,6 +26,7 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
@@ -627,12 +628,27 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     long startTimeMs = System.currentTimeMillis();
 
     int numImmutableSegments = 0;
+    // The segments without validDocIds snapshots should take their snapshots at last. So that when there is failure
+    // to take snapshots, the validDocIds snapshot on disk still keep track of an exclusive set of valid docs across
+    // segments. Because the valid docs as tracked by the existing validDocIds snapshots can only get less. That no
+    // overlap of valid docs among segments with snapshots is required by the preloading to work correctly.
+    Set<ImmutableSegmentImpl> segmentsWithoutSnapshot = new HashSet<>();
     for (IndexSegment segment : _trackedSegments) {
-      if (segment instanceof ImmutableSegmentImpl) {
-        ((ImmutableSegmentImpl) segment).persistValidDocIdsSnapshot();
-        numImmutableSegments++;
-        numPrimaryKeysInSnapshot += segment.getValidDocIds().getMutableRoaringBitmap().getCardinality();
+      if (!(segment instanceof ImmutableSegmentImpl)) {
+        continue;
       }
+      ImmutableSegmentImpl immutableSegment = (ImmutableSegmentImpl) segment;
+      if (!immutableSegment.hasValidDocIdsSnapshotFile()) {
+        segmentsWithoutSnapshot.add(immutableSegment);
+      }
+      immutableSegment.persistValidDocIdsSnapshot();
+      numImmutableSegments++;
+      numPrimaryKeysInSnapshot += immutableSegment.getValidDocIds().getMutableRoaringBitmap().getCardinality();
+    }
+    for (ImmutableSegmentImpl segment : segmentsWithoutSnapshot) {
+      segment.persistValidDocIdsSnapshot();
+      numImmutableSegments++;
+      numPrimaryKeysInSnapshot += segment.getValidDocIds().getMutableRoaringBitmap().getCardinality();
     }
 
     _serverMetrics.setValueOfPartitionGauge(_tableNameWithType, _partitionId,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -157,7 +157,9 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
   private void preloadSegments()
       throws Exception {
     LOGGER.info("Preload segments from table: {} for fast upsert metadata recovery", _tableNameWithType);
-    onPreloadStart();
+    if (!onPreloadStart()) {
+      return;
+    }
     ZkHelixPropertyStore<ZNRecord> propertyStore = _helixManager.getHelixPropertyStore();
     String instanceId = getInstanceId();
     IndexLoadingConfig indexLoadingConfig = createIndexLoadingConfig();
@@ -196,8 +198,11 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
 
   /**
    * Can be overridden to perform operations before preload starts.
+   *
+   * @return whether to continue the preloading logic.
    */
-  protected void onPreloadStart() {
+  protected boolean onPreloadStart() {
+    return true;
   }
 
   /**


### PR DESCRIPTION
This PR refines the way to take snapshot for validDocIds of upsert table:

1. make it more atomic when to take snapshot, by writing to a tmp file and then rename to snapshot file, instead of writing directly to snapshot file
2. take snapshots for segments with existing snapshots first, so that upon failure to take all snapshots, the snapshots left on disk still track an 'exclusive' set of valid docs among segments. The set of valid docs tracked by those snapshots might be incomplete due to failure, but that can be handled correctly when server loads the segments again.
3. misc: remove dead code found along the way; and allow to change the control flow of preloadSegment()

