### PR TITLE
Handle case when the Buffer array passed as arg is less than the size of MV column

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
@@ -246,7 +246,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
     int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
     int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = _dataReaders.get(bufferIndex);
-    length = Math.min(length,dictIdBuffer.length);
+    length = Math.min(length, dictIdBuffer.length);
     for (int i = 0; i < length; i++) {
       dictIdBuffer[i] = dataReader.getInt(startIndex + i, 0);
     }
@@ -286,7 +286,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
     int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
     int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = _dataReaders.get(bufferIndex);
-    length = Math.min(length,valueBuffer.length);
+    length = Math.min(length, valueBuffer.length);
     for (int i = 0; i < length; i++) {
       valueBuffer[i] = dataReader.getLong(startIndex + i, 0);
     }
@@ -316,7 +316,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
     int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
     int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = _dataReaders.get(bufferIndex);
-    length = Math.min(length,valueBuffer.length);
+    length = Math.min(length, valueBuffer.length);
     for (int i = 0; i < length; i++) {
       valueBuffer[i] = dataReader.getFloat(startIndex + i, 0);
     }
@@ -346,7 +346,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
     int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
     int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = _dataReaders.get(bufferIndex);
-    length = Math.min(length,valueBuffer.length);
+    length = Math.min(length, valueBuffer.length);
     for (int i = 0; i < length; i++) {
       valueBuffer[i] = dataReader.getDouble(startIndex + i, 0);
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java
@@ -246,6 +246,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
     int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
     int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = _dataReaders.get(bufferIndex);
+    length = Math.min(length,dictIdBuffer.length);
     for (int i = 0; i < length; i++) {
       dictIdBuffer[i] = dataReader.getInt(startIndex + i, 0);
     }
@@ -285,6 +286,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
     int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
     int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = _dataReaders.get(bufferIndex);
+    length = Math.min(length,valueBuffer.length);
     for (int i = 0; i < length; i++) {
       valueBuffer[i] = dataReader.getLong(startIndex + i, 0);
     }
@@ -314,6 +316,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
     int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
     int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = _dataReaders.get(bufferIndex);
+    length = Math.min(length,valueBuffer.length);
     for (int i = 0; i < length; i++) {
       valueBuffer[i] = dataReader.getFloat(startIndex + i, 0);
     }
@@ -343,6 +346,7 @@ public class FixedByteMVMutableForwardIndex implements MutableForwardIndex {
     int startIndex = headerReader.getInt(rowInCurrentHeader, 1);
     int length = headerReader.getInt(rowInCurrentHeader, 2);
     FixedByteSingleValueMultiColReader dataReader = _dataReaders.get(bufferIndex);
+    length = Math.min(length,valueBuffer.length);
     for (int i = 0; i < length; i++) {
       valueBuffer[i] = dataReader.getDouble(startIndex + i, 0);
     }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Clamp MV length to buffer size before copying values in four accessor methods\.

```mermaid
flowchart TD
  N0["getDictIdMV#58; read header #40;F1#41;"]:::stAdded
  N1["getDictIdMV#58; clamp length #40;F1#41;"]:::stAdded
  N2["getDictIdMV#58; copy dictId buffer #40;F1#41;"]:::stAdded
  N3["getLongMV#58; read header #40;F1#41;"]:::stAdded
  N4["getLongMV#58; clamp length #40;F1#41;"]:::stAdded
  N5["getLongMV#58; copy long buffer #40;F1#41;"]:::stAdded
  N6["getFloatMV#58; read header #40;F1#41;"]:::stAdded
  N7["getFloatMV#58; clamp length #40;F1#41;"]:::stAdded
  N8["getFloatMV#58; copy float buffer #40;F1#41;"]:::stAdded
  N9["getDoubleMV#58; read header #40;F1#41;"]:::stAdded
  N10["getDoubleMV#58; clamp length #40;F1#41;"]:::stAdded
  N11["getDoubleMV#58; copy double buffer #40;F1#41;"]:::stAdded
  N0 -->|"seq after reading header before clamping"| N1
  N1 -->|"seq after clamping before copy"| N2
  N3 -->|"seq after reading header before clamping"| N4
  N4 -->|"seq after clamping before copy"| N5
  N6 -->|"seq after reading header before clamping"| N7
  N7 -->|"seq after clamping before copy"| N8
  N9 -->|"seq after reading header before clamping"| N10
  N10 -->|"seq after clamping before copy"| N11
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex\.java — [before](https://github.com/apache/pinot/blob/9947bc59164cb99264a3e163622361bc06e81813/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java) · [after](https://github.com/apache/pinot/blob/ca414e505a5d32334b779e9d47dbcbc29ebf651a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/forward/FixedByteMVMutableForwardIndex.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6Ijk5NDdiYzU5MTY0Y2I5OTI2NGEzZTE2MzYyMjM2MWJjMDZlODE4MTMiLCJjb250ZXh0X2hhc2giOiJkNmM2ZjI0ODYxMWI2MGY4MGY0YjE0NTc0MWRhZmJlMzI0NGY0NDQzZjllODc5YTczNGJjNTdlZjQ3ZmZiZjA4IiwiZ2VuZXJhdGVkX2F0IjoxNzg4OTk4NTY0LCJoZWFkX3NoYSI6ImNhNDE0ZTUwNWE1ZDMyMzM0Yjc3OWU5ZDQ3ZGJjYmMyOWViZjY1MWEiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI5OTQ3YmM1OTE2NGNiOTkyNjRhM2UxNjM2MjIzNjFiYzA2ZTgxODEzIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature e64550417f2e5ae86eed78b2488efdf58c982282d235c11ee5910f0ce4ba2756 -->
<!-- pinot-pr-flow:end -->

[bugfix] 

we recently encountered an error :
```
java.lang.ArrayIndexOutOfBoundsException:  Index  349  out  of  bounds  for  length  349
  at  org.apache.pinot.segment.local.realtime.impl.forward.FixedByteMVMutableForwardIndex.getLongMV(FixedByteMVMutableForwardIndex.java:294)
  at  org.apache.pinot.segment.spi.index.mutable.MutableForwardIndex.getLongMV(MutableForwardIndex.java:492)
  at  org.apache.pinot.core.operator.dociditerators.MVScanDocIdIterator$LongMatcher.doesValueMatch(MVScanDocIdIterator.java:201)
  at  org.apache.pinot.core.operator.dociditerators.MVScanDocIdIterator.applyAnd(MVScanDocIdIterator.java:104)
  at  org.apache.pinot.core.operator.dociditerators.ScanBasedDocIdIterator.applyAnd(ScanBasedDocIdIterator.java:48)
  at  org.apache.pinot.core.operator.docidsets.AndDocIdSet.iterator(AndDocIdSet.java:151)
  at  org.apache.pinot.core.operator.docidsets.AndDocIdSet.iterator(AndDocIdSet.java:78)
  at  org.apache.pinot.core.operator.docidsets.NotDocIdSet.iterator(NotDocIdSet.java:37)
  at  org.apache.pinot.core.operator.docidsets.AndDocIdSet.iterator(AndDocIdSet.java:78)
  at  org.apache.pinot.core.operator.DocIdSetOperator.getNextBlock(DocIdSetOperator.java:67)
  at  org.apache.pinot.core.operator.DocIdSetOperator.getNextBlock(DocIdSetOperator.java:39)
  at  org.apache.pinot.core.operator.BaseOperator.nextBlock(BaseOperator.java:43)
  at  org.apache.pinot.core.operator.ProjectionOperator.getNextBlock(ProjectionOperator.java:70)
  at  org.apache.pinot.core.operator.ProjectionOperator.getNextBlock(ProjectionOperator.java:37)
  at  org.apache.pinot.core.operator.BaseOperator.nextBlock(BaseOperator.java:43)
  at  org.apache.pinot.core.operator.query.GroupByOperator.getNextBlock(GroupByOperator.java:105)
  at  org.apache.pinot.core.operator.query.GroupByOperator.getNextBlock(GroupByOperator.java:46)
  at  org.apache.pinot.core.operator.BaseOperator.nextBlock(BaseOperator.java:43)
  at  org.apache.pinot.core.operator.combine.GroupByCombineOperator.processSegments(GroupByCombineOperator.java:133)
  at  org.apache.pinot.core.operator.combine.BaseCombineOperator$1.runJob(BaseCombineOperator.java:121)
  at  org.apache.pinot.core.util.trace.TraceRunnable.run(TraceRunnable.java:40)
  at  java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
  at  java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
  at  java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:515)
  at  com.google.common.util.concurrent.TrustedListenableFutureTask$TrustedFutureInterruptibleTask.runInterruptibly(TrustedListenableFutureTask.java:125)
  at  com.google.common.util.concurrent.InterruptibleTask.run(InterruptibleTask.java:57)
  at  com.google.common.util.concurrent.TrustedListenableFutureTask.run(TrustedListenableFutureTask.java:78)
  at  java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
  at  java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
  at  java.base/java.lang.Thread.run(Thread.java:829)
```
This patch fixes it by reading only till the available size in the passed buffer array . 

I think the cause can be MutubaleDataSource._maxNumValuesPerMVEntry ( which is used to intialize the size of buffer array ) value updation may not be Atomic 