### PR TITLE
Skip removing segments from upsert metadata manager when table is disabled

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -38,6 +38,10 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.io.FileUtils;
+import org.apache.helix.HelixDataAccessor;
+import org.apache.helix.HelixManager;
+import org.apache.helix.PropertyKey;
+import org.apache.helix.model.IdealState;
 import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.metrics.ServerMeter;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -99,6 +103,8 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   private int _numPendingOperations = 1;
   private boolean _closed;
 
+  private HelixManager _helixManager;
+
   protected BasePartitionUpsertMetadataManager(String tableNameWithType, int partitionId, UpsertContext context) {
     _tableNameWithType = tableNameWithType;
     _partitionId = partitionId;
@@ -114,6 +120,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     _deletedKeysTTL = context.getDeletedKeysTTL();
     _tableIndexDir = context.getTableIndexDir();
     _serverMetrics = ServerMetrics.get();
+    _helixManager = context.getHelixManager();
     _logger = LoggerFactory.getLogger(tableNameWithType + "-" + partitionId + "-" + getClass().getSimpleName());
     if (_metadataTTL > 0) {
       _largestSeenComparisonValue = loadWatermark();
@@ -514,6 +521,16 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
         return;
       }
     }
+
+    HelixDataAccessor dataAccessor = _helixManager.getHelixDataAccessor();
+    PropertyKey propertyKey = dataAccessor.keyBuilder().idealStates(_tableNameWithType);
+    IdealState idealState = dataAccessor.getProperty(propertyKey);
+    if (!idealState.isEnabled()) {
+      _logger.info("Skip removing segment: {} because the ideal state for the table {} is disabled", segmentName,
+          _tableNameWithType);
+      return;
+    }
+
     if (!startOperation()) {
       _logger.info("Skip removing segment: {} because metadata manager is already stopped", segmentName);
       return;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -522,13 +522,15 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       }
     }
 
-    HelixDataAccessor dataAccessor = _helixManager.getHelixDataAccessor();
-    PropertyKey propertyKey = dataAccessor.keyBuilder().idealStates(_tableNameWithType);
-    IdealState idealState = dataAccessor.getProperty(propertyKey);
-    if (!idealState.isEnabled()) {
-      _logger.info("Skip removing segment: {} because the ideal state for the table {} is disabled", segmentName,
-          _tableNameWithType);
-      return;
+    if (_helixManager != null) {
+      HelixDataAccessor dataAccessor = _helixManager.getHelixDataAccessor();
+      PropertyKey propertyKey = dataAccessor.keyBuilder().idealStates(_tableNameWithType);
+      IdealState idealState = dataAccessor.getProperty(propertyKey);
+      if (!idealState.isEnabled()) {
+        _logger.info("Skip removing segment: {} because the ideal state for the table {} is disabled", segmentName,
+            _tableNameWithType);
+        return;
+      }
     }
 
     if (!startOperation()) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -523,13 +523,19 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     }
 
     if (_helixManager != null) {
-      HelixDataAccessor dataAccessor = _helixManager.getHelixDataAccessor();
-      PropertyKey propertyKey = dataAccessor.keyBuilder().idealStates(_tableNameWithType);
-      IdealState idealState = dataAccessor.getProperty(propertyKey);
-      if (!idealState.isEnabled()) {
-        _logger.info("Skip removing segment: {} because the ideal state for the table {} is disabled", segmentName,
-            _tableNameWithType);
-        return;
+      try {
+        HelixDataAccessor dataAccessor = _helixManager.getHelixDataAccessor();
+        PropertyKey propertyKey = dataAccessor.keyBuilder().idealStates(_tableNameWithType);
+        IdealState idealState = dataAccessor.getProperty(propertyKey);
+        if (!idealState.isEnabled()) {
+          _logger.info("Skip removing segment: {} because the ideal state for the table {} is disabled", segmentName,
+              _tableNameWithType);
+          return;
+        }
+      } catch (Exception e) {
+        _logger.warn(
+            "Caught exception while checking if the ideal state for the table {} is disabled during remove segment",
+            _tableNameWithType, e);
       }
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -105,7 +105,8 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
         .setPrimaryKeyColumns(primaryKeyColumns).setComparisonColumns(comparisonColumns)
         .setDeleteRecordColumn(deleteRecordColumn).setHashFunction(hashFunction)
         .setPartialUpsertHandler(partialUpsertHandler).setEnableSnapshot(enableSnapshot).setEnablePreload(enablePreload)
-        .setMetadataTTL(metadataTTL).setDeletedKeysTTL(deletedKeysTTL).setTableIndexDir(tableIndexDir).build();
+        .setMetadataTTL(metadataTTL).setDeletedKeysTTL(deletedKeysTTL).setTableIndexDir(tableIndexDir)
+        .setHelixManager(_helixManager).build();
     LOGGER.info(
         "Initialized {} for table: {} with primary key columns: {}, comparison columns: {}, delete record column: {},"
             + " hash function: {}, upsert mode: {}, enable snapshot: {}, enable preload: {}, metadata TTL: {},"

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/UpsertContext.java
@@ -23,6 +23,7 @@ import java.io.File;
 import java.util.List;
 import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
+import org.apache.helix.HelixManager;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
@@ -41,11 +42,12 @@ public class UpsertContext {
   private final double _metadataTTL;
   private final double _deletedKeysTTL;
   private final File _tableIndexDir;
+  private final HelixManager _helixManager;
 
   private UpsertContext(TableConfig tableConfig, Schema schema, List<String> primaryKeyColumns,
       List<String> comparisonColumns, @Nullable String deleteRecordColumn, HashFunction hashFunction,
       @Nullable PartialUpsertHandler partialUpsertHandler, boolean enableSnapshot, boolean enablePreload,
-      double metadataTTL, double deletedKeysTTL, File tableIndexDir) {
+      double metadataTTL, double deletedKeysTTL, File tableIndexDir, HelixManager helixManager) {
     _tableConfig = tableConfig;
     _schema = schema;
     _primaryKeyColumns = primaryKeyColumns;
@@ -58,6 +60,7 @@ public class UpsertContext {
     _metadataTTL = metadataTTL;
     _deletedKeysTTL = deletedKeysTTL;
     _tableIndexDir = tableIndexDir;
+    _helixManager = helixManager;
   }
 
   public TableConfig getTableConfig() {
@@ -108,6 +111,10 @@ public class UpsertContext {
     return _tableIndexDir;
   }
 
+  public HelixManager getHelixManager() {
+    return _helixManager;
+  }
+
   public static class Builder {
     private TableConfig _tableConfig;
     private Schema _schema;
@@ -121,6 +128,7 @@ public class UpsertContext {
     private double _metadataTTL;
     private double _deletedKeysTTL;
     private File _tableIndexDir;
+    private HelixManager _helixManager;
 
     public Builder setTableConfig(TableConfig tableConfig) {
       _tableConfig = tableConfig;
@@ -182,6 +190,11 @@ public class UpsertContext {
       return this;
     }
 
+    public Builder setHelixManager(HelixManager helixManager) {
+      _helixManager = helixManager;
+      return this;
+    }
+
     public UpsertContext build() {
       Preconditions.checkState(_tableConfig != null, "Table config must be set");
       Preconditions.checkState(_schema != null, "Schema must be set");
@@ -191,7 +204,7 @@ public class UpsertContext {
       Preconditions.checkState(_tableIndexDir != null, "Table index directory must be set");
       return new UpsertContext(_tableConfig, _schema, _primaryKeyColumns, _comparisonColumns, _deleteRecordColumn,
           _hashFunction, _partialUpsertHandler, _enableSnapshot, _enablePreload, _metadataTTL, _deletedKeysTTL,
-          _tableIndexDir);
+          _tableIndexDir, _helixManager);
     }
   }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Skip segment removal when table's ideal state is disabled\.

```mermaid
flowchart TD
  N0["removeSegment start #40;F1#41;"]:::stAdded
  N1["segment #61;#61; null#63; #40;F1#41;"]:::stUnchanged
  N2["#95;helixManager #33;#61; null#63; #40;F1#41;"]:::stAdded
  N3["get IdealState from Helix #40;F1#41;"]:::stAdded
  N4["idealState#46;isEnabled#40;#41;#63; #40;F1#41;"]:::stAdded
  N5["startOperation#40;#41;#63; #40;F1#41;"]:::stUnchanged
  N6["proceed to remove segment #40;F1#41;"]:::stUnchanged
  N7["End #40;F1#41;"]:::stUnchanged
  N0 --> N1
  N1 -->|"segment not null"| N2
  N1 -->|"segment null"| N7
  N2 --> N3
  N3 --> N4
  N4 -->|"ideal state disabled"| N7
  N4 -->|"ideal state enabled"| N5
  N5 -->|"#33;startOperation"| N7
  N5 -->|"startOperation"| N6
  N6 --> N7
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager\.java — [before](https://github.com/apache/pinot/blob/8c86ad465232efa4ab1a1eb5a1f19598b2628166/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java) · [after](https://github.com/apache/pinot/blob/b9e7c2c042175798da332b04f90395b99e665612/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjhjODZhZDQ2NTIzMmVmYTRhYjFhMWViNWExZjE5NTk4YjI2MjgxNjYiLCJjb250ZXh0X2hhc2giOiJhNDg4MmEzNWI1N2Y1NDI4MmZiNWNkYjM0ZGU1NjAwZmRhZTllMWYzMGE4OGU3MjFjYjA1ZDY5MjQ2MmFiOTI1IiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDAzNDM0LCJoZWFkX3NoYSI6ImI5ZTdjMmMwNDIxNzU3OThkYTMzMmIwNGY5MDM5NWI5OWU2NjU2MTIiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIyZTM2N2EyMDJlOGY1ZTRlMDhiOGIyY2JlZjU5NzE0YjlmMmQyNjUzIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature a2def66e6e5db3dff38a898be0ff7c6676e247bee12368c7c25d744b55031bc8 -->
<!-- pinot-pr-flow:end -->

Currently, we remove segments from upsert metadata manager when table is disabled. This leads to high resource usage unnecessarily. 