### PR TITLE
[multistage][bugfix] relax sort copy rule to always push limit if no collation

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotSortExchangeCopyRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotSortExchangeCopyRule.java
@@ -89,7 +89,8 @@ public class PinotSortExchangeCopyRule extends RelRule<RelRule.Config> {
       fetch = REX_BUILDER.makeLiteral(total, TYPE_FACTORY.createSqlType(SqlTypeName.INTEGER));
     }
     // do not transform sort-exchange copy when there's no fetch limit, or fetch amount is larger than threshold
-    if (fetch == null || RexExpressionUtils.getValueAsInt(fetch) > DEFAULT_SORT_EXCHANGE_COPY_THRESHOLD) {
+    if (!collation.getFieldCollations().isEmpty()
+        && (fetch == null || RexExpressionUtils.getValueAsInt(fetch) > DEFAULT_SORT_EXCHANGE_COPY_THRESHOLD)) {
       return;
     }
 

--- a/pinot-query-planner/src/test/resources/queries/OrderByPlans.json
+++ b/pinot-query-planner/src/test/resources/queries/OrderByPlans.json
@@ -50,6 +50,18 @@
         ]
       },
       {
+        "description": "Select * with super large limit",
+        "sql": "EXPLAIN PLAN FOR SELECT * FROM b LIMIT 10000000",
+        "output": [
+          "Execution Plan",
+          "\nLogicalSort(offset=[0], fetch=[10000000])",
+          "\n  PinotLogicalSortExchange(distribution=[hash], collation=[[]], isSortOnSender=[false], isSortOnReceiver=[false])",
+          "\n    LogicalSort(fetch=[10000000])",
+          "\n      LogicalTableScan(table=[[b]])",
+          "\n"
+        ]
+      },
+      {
         "description": "Select * order by on 2 columns with super large limit",
         "sql": "EXPLAIN PLAN FOR SELECT * FROM b ORDER BY col1, col2 DESC LIMIT 10000000",
         "output": [


### PR DESCRIPTION
further improve on #12228 
in addition to #12237, this change relaxes to always pushdown when non-collation limit exists. therefore the configuration of pushdown limit no longer needs to be configurable until long-term impl is in place.