### PR TITLE
UI: fix table link issue in task detail page

### DIFF
--- a/pinot-controller/src/main/resources/app/pages/TaskQueue.tsx
+++ b/pinot-controller/src/main/resources/app/pages/TaskQueue.tsx
@@ -68,7 +68,7 @@ const TaskQueue = (props) => {
     const tablesResponse:any = await PinotMethodUtils.getTableData({ taskType });
     setTaskInfo(taskInfoRes);
     setTables((prevState): TableData => {
-      const _records = map(get(tablesResponse, 'tables', []), table => [[table]]);
+      const _records = map(get(tablesResponse, 'tables', []), table => [table]);
       return { ...prevState, records: _records };
     });
     setFetching(false);


### PR DESCRIPTION
Table link was not clickable in task details page 

Before
<img width="1728" alt="image" src="https://github.com/apache/pinot/assets/41536903/48d69dd1-dcf7-405e-8038-93cabf5307fb">

After
<img width="1728" alt="image" src="https://github.com/apache/pinot/assets/41536903/552797a6-67c2-4a83-a2a4-522d1c6b69c6">
