### PR TITLE
Add HttpHeaders in broker event listener requestContext

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -92,6 +92,7 @@ import org.apache.pinot.spi.data.DimensionFieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.eventlistener.query.BrokerQueryEventListener;
+import org.apache.pinot.spi.eventlistener.query.PinotBrokerQueryEventListenerFactory;
 import org.apache.pinot.spi.exception.BadQueryRequestException;
 import org.apache.pinot.spi.trace.RequestContext;
 import org.apache.pinot.spi.trace.Tracing;
@@ -261,7 +262,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     requestContext.setRequestId(requestId);
     if (httpHeaders != null) {
       requestContext.setRequestHttpHeaders(httpHeaders.getRequestHeaders().entrySet().stream()
-          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+          .filter(entry -> PinotBrokerQueryEventListenerFactory.getAllowlistQueryRequestHeaders()
+              .contains(entry.getKey())).collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
     }
 
     // First-stage access control to prevent unauthenticated requests from using up resources. Secondary table-level

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -259,6 +259,10 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     long requestId = _brokerIdGenerator.get();
     requestContext.setRequestId(requestId);
+    if (httpHeaders != null) {
+      requestContext.setRequestHttpHeaders(httpHeaders.getRequestHeaders().entrySet().stream()
+          .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
 
     // First-stage access control to prevent unauthenticated requests from using up resources. Secondary table-level
     // check comes later.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/eventlistener/query/PinotBrokerQueryEventListenerFactory.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/eventlistener/query/PinotBrokerQueryEventListenerFactory.java
@@ -30,8 +30,8 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import static org.apache.pinot.spi.utils.CommonConstants.CONFIG_OF_ALLOWLIST_QUERY_REQUEST_HEADERS;
 import static org.apache.pinot.spi.utils.CommonConstants.CONFIG_OF_BROKER_EVENT_LISTENER_CLASS_NAME;
+import static org.apache.pinot.spi.utils.CommonConstants.CONFIG_OF_REQUEST_CONTEXT_TRACKED_HEADER_KEYS;
 import static org.apache.pinot.spi.utils.CommonConstants.DEFAULT_BROKER_EVENT_LISTENER_CLASS_NAME;
 
 
@@ -93,7 +93,7 @@ public class PinotBrokerQueryEventListenerFactory {
   private static void initializeAllowlistQueryRequestHeaders(PinotConfiguration eventListenerConfiguration) {
     List<String> allowlistQueryRequestHeaders =
         Splitter.on(",").omitEmptyStrings().trimResults()
-            .splitToList(eventListenerConfiguration.getProperty(CONFIG_OF_ALLOWLIST_QUERY_REQUEST_HEADERS, ""));
+            .splitToList(eventListenerConfiguration.getProperty(CONFIG_OF_REQUEST_CONTEXT_TRACKED_HEADER_KEYS, ""));
 
     LOGGER.info("{}: allowlist headers will be used for PinotBrokerQueryEventListener", allowlistQueryRequestHeaders);
     registerAllowlistQueryRequestHeaders(allowlistQueryRequestHeaders);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/DefaultRequestContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/DefaultRequestContext.java
@@ -80,6 +80,7 @@ public class DefaultRequestContext implements RequestScope {
   private long _explainPlanNumMatchAllFilterSegments;
   private Map<String, String> _traceInfo = new HashMap<>();
   private List<String> _processingExceptions = new ArrayList<>();
+  private Map<String, List<String>> _requestHttpHeaders = new HashMap<>();
 
   public DefaultRequestContext() {
   }
@@ -560,6 +561,16 @@ public class DefaultRequestContext implements RequestScope {
   @Override
   public void setProcessingExceptions(List<String> processingExceptions) {
     _processingExceptions.addAll(processingExceptions);
+  }
+
+  @Override
+  public Map<String, List<String>> getRequestHttpHeaders() {
+    return _requestHttpHeaders;
+  }
+
+  @Override
+  public void setRequestHttpHeaders(Map<String, List<String>> requestHttpHeaders) {
+    _requestHttpHeaders.putAll(requestHttpHeaders);
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/trace/RequestContext.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/trace/RequestContext.java
@@ -217,6 +217,10 @@ public interface RequestContext {
 
   void setProcessingExceptions(List<String> processingExceptions);
 
+  Map<String, List<String>> getRequestHttpHeaders();
+
+  void setRequestHttpHeaders(Map<String, List<String>> requestHttpHeaders);
+
   enum FanoutType {
     OFFLINE, REALTIME, HYBRID
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -44,6 +44,7 @@ public class CommonConstants {
   public static final String UNKNOWN = "unknown";
   public static final String CONFIG_OF_METRICS_FACTORY_CLASS_NAME = "factory.className";
   public static final String CONFIG_OF_BROKER_EVENT_LISTENER_CLASS_NAME = "factory.className";
+  public static final String CONFIG_OF_ALLOWLIST_QUERY_REQUEST_HEADERS = "allowlist.request.headers";
   public static final String DEFAULT_METRICS_FACTORY_CLASS_NAME =
       "org.apache.pinot.plugin.metrics.yammer.YammerMetricsFactory";
   public static final String DEFAULT_BROKER_EVENT_LISTENER_CLASS_NAME =

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -44,7 +44,7 @@ public class CommonConstants {
   public static final String UNKNOWN = "unknown";
   public static final String CONFIG_OF_METRICS_FACTORY_CLASS_NAME = "factory.className";
   public static final String CONFIG_OF_BROKER_EVENT_LISTENER_CLASS_NAME = "factory.className";
-  public static final String CONFIG_OF_ALLOWLIST_QUERY_REQUEST_HEADERS = "allowlist.request.headers";
+  public static final String CONFIG_OF_REQUEST_CONTEXT_TRACKED_HEADER_KEYS = "request.context.tracked.header.keys";
   public static final String DEFAULT_METRICS_FACTORY_CLASS_NAME =
       "org.apache.pinot.plugin.metrics.yammer.YammerMetricsFactory";
   public static final String DEFAULT_BROKER_EVENT_LISTENER_CLASS_NAME =


### PR DESCRIPTION
A small patch to add httpHeaders we get in query-request to the event-listener requestContext class. 
We plan to send caller and additional metadata as http headers and want to emit them along with the query metrics.

I am working on an integration test for the event-listener functionality and will raise a follow-up PR.

cc @ankitsultana @walterddr 