### PR TITLE
add null handling to sketch group-by

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -964,6 +964,14 @@ public class DistinctCountThetaSketchAggregationFunction
   @Override
   public List<ThetaSketchAccumulator> extractGroupByResult(GroupByResultHolder groupByResultHolder, int groupKey) {
     List result = groupByResultHolder.getResult(groupKey);
+    if (result == null) {
+      int numSketches = _filterEvaluators.size() + 1;
+      List<ThetaSketchAccumulator> thetaSketchAccumulators = new ArrayList<>(numSketches);
+      for (int i = 0; i < numSketches; i++) {
+        thetaSketchAccumulators.add(new ThetaSketchAccumulator(_setOperationBuilder, _accumulatorThreshold));
+      }
+      return thetaSketchAccumulators;
+    }
 
     if (result.get(0) instanceof Sketch) {
       int numSketches = result.size();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ThetaSketchTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ThetaSketchTest.java
@@ -442,6 +442,17 @@ public class ThetaSketchTest extends CustomDataQueryClusterIntegrationTest {
       runAndAssert(query, expected);
     }
 
+    // group by sketch with filter
+    {
+      String query = "select dimValue, GET_THETA_SKETCH_ESTIMATE(THETA_SKETCH_INTERSECT( "
+          + "    DISTINCT_COUNT_RAW_THETA_SKETCH(thetaSketchCol, '') FILTER (WHERE dimName = 'gender'),"
+          + "    DISTINCT_COUNT_RAW_THETA_SKETCH(thetaSketchCol, '') FILTER (WHERE dimName != 'gender'))) "
+          + "  FROM " + getTableName() + " GROUP BY dimValue";
+      ImmutableMap<String, Integer> expected =
+          ImmutableMap.of("Female", 0, "Male", 0, "Math", 0, "History", 0, "Biology", 0);
+      runAndAssert(query, expected);
+    }
+
     // group by gender
     {
       String query = "select dimValue, distinctCountThetaSketch(thetaSketchCol) from " + getTableName()


### PR DESCRIPTION
for some reason this was hit when sketch loaded/used directly from binary 

e.g.
```
SELECT 
  groupKey,
  distinctCountThetaSketch(rawSketchBinaryCol) -- this can some times cause group key internal null value 
FROM tbl
GROUP BY 1
```
so we need the null handling code path in extractGroupByResult similar to extractAggregateResult 