### PR TITLE
Refactoring the upsert compaction related code

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -209,9 +209,9 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     // TODO: Use different global query id for OFFLINE and REALTIME table after releasing 0.12.0. See QueryIdUtils for
     //       details
     String globalQueryId = getGlobalQueryId(requestId);
-    List<String> serverUrls = new ArrayList<>();
+    List<Pair<String, String>> serverUrls = new ArrayList<>();
     for (ServerInstance serverInstance : queryServers._servers) {
-      serverUrls.add(String.format("%s/query/%s", serverInstance.getAdminEndpoint(), globalQueryId));
+      serverUrls.add(Pair.of(String.format("%s/query/%s", serverInstance.getAdminEndpoint(), globalQueryId), null));
     }
     LOGGER.debug("Cancelling the query: {} via server urls: {}", queryServers._query, serverUrls);
     CompletionService<MultiHttpRequestResponse> completionService =

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdMetadataInfo.java
@@ -1,0 +1,56 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.restlet.resources;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.annotation.JsonProperty;
+
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ValidDocIdMetadataInfo {
+  private final String _segmentName;
+  private final long _totalValidDocs;
+  private final long _totalInvalidDocs;
+  private final long _totalDocs;
+
+  public ValidDocIdMetadataInfo(@JsonProperty("segmentName") String segmentName,
+      @JsonProperty("totalValidDocs") long totalValidDocs, @JsonProperty("totalInvalidDocs") long totalInvalidDocs,
+      @JsonProperty("totalDocs") long totalDocs) {
+    _segmentName = segmentName;
+    _totalValidDocs = totalValidDocs;
+    _totalInvalidDocs = totalInvalidDocs;
+    _totalDocs = totalDocs;
+  }
+
+  public String getSegmentName() {
+    return _segmentName;
+  }
+
+  public long getTotalValidDocs() {
+    return _totalValidDocs;
+  }
+
+  public long getTotalInvalidDocs() {
+    return _totalInvalidDocs;
+  }
+
+  public long getTotalDocs() {
+    return _totalDocs;
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/http/MultiHttpRequestTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/http/MultiHttpRequestTest.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Executors;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.impl.conn.PoolingHttpClientConnectionManager;
 import org.apache.http.util.EntityUtils;
 import org.slf4j.Logger;
@@ -43,6 +44,30 @@ import org.testng.annotations.Test;
 
 
 public class MultiHttpRequestTest {
+  class TestResult {
+    private final int _success;
+    private final int _errors;
+    private final int _timeouts;
+
+    public TestResult(int success, int errors, int timeouts) {
+      _success = success;
+      _errors = errors;
+      _timeouts = timeouts;
+    }
+
+    public int getSuccess() {
+      return _success;
+    }
+
+    public int getErrors() {
+      return _errors;
+    }
+
+    public int getTimeouts() {
+      return _timeouts;
+    }
+  }
+
   private static final Logger LOGGER = LoggerFactory.getLogger(MultiHttpRequest.class);
   private static final String SUCCESS_MSG = "success";
   private static final String ERROR_MSG = "error";
@@ -61,6 +86,7 @@ public class MultiHttpRequestTest {
     startServer(_portStart, createHandler(SUCCESS_CODE, SUCCESS_MSG, 0));
     startServer(_portStart + 1, createHandler(ERROR_CODE, ERROR_MSG, 0));
     startServer(_portStart + 2, createHandler(SUCCESS_CODE, TIMEOUT_MSG, TIMEOUT_MS));
+    startServer(_portStart + 3, createPostHandler(SUCCESS_CODE, SUCCESS_MSG, 0));
   }
 
   @AfterTest
@@ -90,6 +116,33 @@ public class MultiHttpRequestTest {
     };
   }
 
+  private HttpHandler createPostHandler(final int status, final String msg, final int sleepTimeMs) {
+    return new HttpHandler() {
+      @Override
+      public void handle(HttpExchange httpExchange)
+          throws IOException {
+        if (sleepTimeMs > 0) {
+          try {
+            Thread.sleep(sleepTimeMs);
+          } catch (InterruptedException e) {
+            LOGGER.info("Handler interrupted during sleep");
+          }
+        }
+        if (httpExchange.getRequestMethod().equals("POST")) {
+          httpExchange.sendResponseHeaders(status, msg.length());
+          OutputStream responseBody = httpExchange.getResponseBody();
+          responseBody.write(msg.getBytes());
+          responseBody.close();
+        } else {
+          httpExchange.sendResponseHeaders(ERROR_CODE, ERROR_MSG.length());
+          OutputStream responseBody = httpExchange.getResponseBody();
+          responseBody.write(ERROR_MSG.getBytes());
+          responseBody.close();
+        }
+      }
+    };
+  }
+
   private void startServer(int port, HttpHandler handler)
       throws IOException {
     final HttpServer server = HttpServer.create(new InetSocketAddress(port), 0);
@@ -104,22 +157,58 @@ public class MultiHttpRequestTest {
   }
 
   @Test
-  public void testMultiGet() throws Exception {
-    MultiHttpRequest mget =
-        new MultiHttpRequest(Executors.newCachedThreadPool(), new PoolingHttpClientConnectionManager());
+  public void testMultiGet() {
     List<String> urls = Arrays.asList("http://localhost:" + String.valueOf(_portStart) + URI_PATH,
         "http://localhost:" + String.valueOf(_portStart + 1) + URI_PATH,
         "http://localhost:" + String.valueOf(_portStart + 2) + URI_PATH,
         // 2nd request to the same server
-        "http://localhost:" + String.valueOf(_portStart) + URI_PATH);
+        "http://localhost:" + String.valueOf(_portStart) + URI_PATH,
+        "http://localhost:" + String.valueOf(_portStart + 3) + URI_PATH);
+
+    MultiHttpRequest mget =
+        new MultiHttpRequest(Executors.newCachedThreadPool(), new PoolingHttpClientConnectionManager());
+
     // timeout value needs to be less than 5000ms set above for
     // third server
     final int requestTimeoutMs = 1000;
-    CompletionService<MultiHttpRequestResponse> completionService = mget.execute(urls, null, requestTimeoutMs);
+    CompletionService<MultiHttpRequestResponse> completionService = mget.executeGet(urls, null, requestTimeoutMs);
+
+    TestResult result = collectResult(completionService, urls.size());
+    Assert.assertEquals(result.getSuccess(), 2);
+    Assert.assertEquals(result.getErrors(), 2);
+    Assert.assertEquals(result.getTimeouts(), 1);
+  }
+
+  @Test
+  public void testMultiPost() {
+    List<Pair<String, String>> urlsAndRequestBodies =
+        List.of(Pair.of("http://localhost:" + String.valueOf(_portStart) + URI_PATH, "b0"),
+            Pair.of("http://localhost:" + String.valueOf(_portStart + 1) + URI_PATH, "b1"),
+            Pair.of("http://localhost:" + String.valueOf(_portStart + 2) + URI_PATH, "b2"),
+            // 2nd request to the same server
+            Pair.of("http://localhost:" + String.valueOf(_portStart) + URI_PATH, "b3"),
+            Pair.of("http://localhost:" + String.valueOf(_portStart + 3) + URI_PATH, "b4"));
+
+    MultiHttpRequest mpost =
+        new MultiHttpRequest(Executors.newCachedThreadPool(), new PoolingHttpClientConnectionManager());
+
+    // timeout value needs to be less than 5000ms set above for
+    // third server
+    final int requestTimeoutMs = 1000;
+    CompletionService<MultiHttpRequestResponse> completionService =
+        mpost.executePost(urlsAndRequestBodies, null, requestTimeoutMs);
+
+    TestResult result = collectResult(completionService, urlsAndRequestBodies.size());
+    Assert.assertEquals(result.getSuccess(), 3);
+    Assert.assertEquals(result.getErrors(), 1);
+    Assert.assertEquals(result.getTimeouts(), 1);
+  }
+
+  private TestResult collectResult(CompletionService<MultiHttpRequestResponse> completionService, int size) {
     int success = 0;
     int errors = 0;
     int timeouts = 0;
-    for (int i = 0; i < urls.size(); i++) {
+    for (int i = 0; i < size; i++) {
       try (MultiHttpRequestResponse httpRequestResponse = completionService.take().get()) {
         if (httpRequestResponse.getResponse().getStatusLine().getStatusCode() >= 300) {
           errors++;
@@ -143,9 +232,6 @@ public class MultiHttpRequestTest {
         errors++;
       }
     }
-
-    Assert.assertEquals(success, 2);
-    Assert.assertEquals(errors, 1);
-    Assert.assertEquals(timeouts, 1);
+    return new TestResult(success, errors, timeouts);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRunningQueryResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotRunningQueryResource.java
@@ -187,7 +187,7 @@ public class PinotRunningQueryResource {
     }
     LOGGER.debug("Getting running queries via broker urls: {}", brokerUrls);
     CompletionService<MultiHttpRequestResponse> completionService =
-        new MultiHttpRequest(_executor, _httpConnMgr).execute(brokerUrls, requestHeaders, timeoutMs);
+        new MultiHttpRequest(_executor, _httpConnMgr).executeGet(brokerUrls, requestHeaders, timeoutMs);
     Map<String, Map<String, String>> queriesByBroker = new HashMap<>();
     List<String> errMsgs = new ArrayList<>(brokerUrls.size());
     for (int i = 0; i < brokerUrls.size(); i++) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -958,7 +958,9 @@ public class PinotTableRestletResource {
       + "aggregate valid doc id metadata of all segments for a table")
   public String getTableAggregateValidDocIdMetadata(
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
-      @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr) {
+      @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
+      @ApiParam(value = "A list of segments", allowMultiple = true) @QueryParam("segmentNames")
+      List<String> segmentNames) {
     LOGGER.info("Received a request to fetch aggregate valid doc id metadata for a table {}", tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);
     if (tableType == TableType.OFFLINE) {
@@ -972,8 +974,9 @@ public class PinotTableRestletResource {
     try {
       TableMetadataReader tableMetadataReader =
           new TableMetadataReader(_executor, _connectionManager, _pinotHelixResourceManager);
-      JsonNode segmentsMetadataJson = tableMetadataReader.getAggregateValidDocIdMetadata(tableNameWithType,
-          _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
+      JsonNode segmentsMetadataJson =
+          tableMetadataReader.getAggregateValidDocIdMetadata(tableNameWithType, segmentNames,
+              _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
       validDocIdMetadata = JsonUtils.objectToPrettyString(segmentsMetadataJson);
     } catch (InvalidConfigException e) {
       throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -951,6 +951,40 @@ public class PinotTableRestletResource {
   }
 
   @GET
+  @Path("tables/{tableName}/validDocIdMetadata")
+  @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "Get the aggregate valid doc id metadata of all segments for a table", notes = "Get the "
+      + "aggregate valid doc id metadata of all segments for a table")
+  public String getTableAggregateValidDocIdMetadata(
+      @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
+      @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr) {
+    LOGGER.info("Received a request to fetch aggregate valid doc id metadata for a table {}", tableName);
+    TableType tableType = Constants.validateTableType(tableTypeStr);
+    if (tableType == TableType.OFFLINE) {
+      throw new ControllerApplicationException(LOGGER, "Table type : " + tableTypeStr + " not yet supported.",
+          Response.Status.NOT_IMPLEMENTED);
+    }
+    String tableNameWithType =
+        ResourceUtils.getExistingTableNamesWithType(_pinotHelixResourceManager, tableName, tableType, LOGGER).get(0);
+
+    String validDocIdMetadata;
+    try {
+      TableMetadataReader tableMetadataReader =
+          new TableMetadataReader(_executor, _connectionManager, _pinotHelixResourceManager);
+      JsonNode segmentsMetadataJson = tableMetadataReader.getAggregateValidDocIdMetadata(tableNameWithType,
+          _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
+      validDocIdMetadata = JsonUtils.objectToPrettyString(segmentsMetadataJson);
+    } catch (InvalidConfigException e) {
+      throw new ControllerApplicationException(LOGGER, e.getMessage(), Response.Status.BAD_REQUEST);
+    } catch (IOException ioe) {
+      throw new ControllerApplicationException(LOGGER, "Error parsing Pinot server response: " + ioe.getMessage(),
+          Response.Status.INTERNAL_SERVER_ERROR, ioe);
+    }
+    return validDocIdMetadata;
+  }
+
+  @GET
   @Path("tables/{tableName}/indexes")
   @Authorize(targetType = TargetType.TABLE, paramName = "tableName", action = Actions.Table.GET_METADATA)
   @Produces(MediaType.APPLICATION_JSON)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/CompletionServiceHelper.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/CompletionServiceHelper.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.Executor;
 import javax.annotation.Nullable;
+import org.apache.commons.lang3.tuple.Pair;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.http.util.EntityUtils;
 import org.apache.pinot.common.http.MultiHttpRequest;
@@ -79,12 +80,46 @@ public class CompletionServiceHelper {
   public CompletionServiceResponse doMultiGetRequest(List<String> serverURLs, String tableNameWithType,
       boolean multiRequestPerServer, @Nullable Map<String, String> requestHeaders, int timeoutMs,
       @Nullable String useCase) {
-    CompletionServiceResponse completionServiceResponse = new CompletionServiceResponse();
-
     // TODO: use some service other than completion service so that we know which server encounters the error
     CompletionService<MultiHttpRequestResponse> completionService =
-        new MultiHttpRequest(_executor, _httpConnectionManager).execute(serverURLs, requestHeaders, timeoutMs);
-    for (int i = 0; i < serverURLs.size(); i++) {
+        new MultiHttpRequest(_executor, _httpConnectionManager).executeGet(serverURLs, requestHeaders, timeoutMs);
+
+    return collectResponse(tableNameWithType, serverURLs.size(), completionService, multiRequestPerServer, useCase);
+  }
+
+  /**
+   * This method makes a MultiPost call to all given URLs and its corresponding bodies.
+   * @param serverURLsAndRequestBodies server urls to send GET request.
+   * @param tableNameWithType table name with type suffix
+   * @param multiRequestPerServer it's possible that need to send multiple requests to a same server.
+   *                              If multiRequestPerServer is set as false, return as long as one of the requests get
+   *                              response; If multiRequestPerServer is set as true, wait until all requests
+   *                              get response.
+   * @param requestHeaders Headers to be set when making the http calls.
+   * @param timeoutMs timeout in milliseconds to wait per request.
+   * @param useCase the use case initiating the multi-get request. If not null and an exception is thrown, only the
+   *                error message and the use case are logged instead of the full stack trace.
+   * @return CompletionServiceResponse Map of the endpoint(server instance, or full request path if
+   * multiRequestPerServer is true) to the response from that endpoint.
+   */
+  public CompletionServiceResponse doMultiPostRequest(List<Pair<String, String>> serverURLsAndRequestBodies,
+      String tableNameWithType, boolean multiRequestPerServer, @Nullable Map<String, String> requestHeaders,
+      int timeoutMs, @Nullable String useCase) {
+
+    CompletionService<MultiHttpRequestResponse> completionService =
+        new MultiHttpRequest(_executor, _httpConnectionManager).executePost(serverURLsAndRequestBodies, requestHeaders,
+            timeoutMs);
+
+    return collectResponse(tableNameWithType, serverURLsAndRequestBodies.size(), completionService,
+        multiRequestPerServer, useCase);
+  }
+
+  private CompletionServiceResponse collectResponse(String tableNameWithType, int size,
+      CompletionService<MultiHttpRequestResponse> completionService, boolean multiRequestPerServer,
+      @Nullable String useCase) {
+    CompletionServiceResponse completionServiceResponse = new CompletionServiceResponse();
+
+    for (int i = 0; i < size; i++) {
       MultiHttpRequestResponse multiHttpRequestResponse = null;
       try {
         multiHttpRequestResponse = completionService.take().get();
@@ -93,7 +128,8 @@ public class CompletionServiceHelper {
             _endpointsToServers.get(String.format("%s://%s:%d", uri.getScheme(), uri.getHost(), uri.getPort()));
         int statusCode = multiHttpRequestResponse.getResponse().getStatusLine().getStatusCode();
         if (statusCode >= 300) {
-          LOGGER.error("Server: {} returned error: {}", instance, statusCode);
+          String reason = multiHttpRequestResponse.getResponse().getStatusLine().getReasonPhrase();
+          LOGGER.error("Server: {} returned error: {}, reason: {}", instance, statusCode, reason);
           completionServiceResponse._failedResponseCount++;
           continue;
         }
@@ -102,7 +138,7 @@ public class CompletionServiceHelper {
             .put(multiRequestPerServer ? uri.toString() : instance, responseString);
       } catch (Exception e) {
         String reason = useCase == null ? "" : String.format(" in '%s'", useCase);
-        LOGGER.error("Connection error{}. Details: {}", reason, e.getMessage());
+        LOGGER.error("Connection error {}. Details: {}", reason, e.getMessage());
         completionServiceResponse._failedResponseCount++;
       } finally {
         if (multiHttpRequestResponse != null) {
@@ -116,9 +152,9 @@ public class CompletionServiceHelper {
     }
 
     int numServersResponded = completionServiceResponse._httpResponses.size();
-    if (numServersResponded != serverURLs.size()) {
+    if (numServersResponded != size) {
       LOGGER.warn("Finished reading information for table: {} with {}/{} server responses", tableNameWithType,
-          numServersResponded, serverURLs.size());
+          numServersResponded, size);
     } else {
       LOGGER.info("Finished reading information for table: {}", tableNameWithType);
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -31,6 +31,7 @@ import java.util.stream.Collectors;
 import org.apache.http.conn.HttpClientConnectionManager;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.restlet.resources.TableMetadataInfo;
+import org.apache.pinot.common.restlet.resources.ValidDocIdMetadataInfo;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.spi.utils.JsonUtils;
 
@@ -81,8 +82,9 @@ public class TableMetadataReader {
       }
     }
 
-    List<String> segmentsMetadata = serverSegmentMetadataReader
-        .getSegmentMetadataFromServer(tableNameWithType, serverToSegmentsMap, endpoints, columns, timeoutMs);
+    List<String> segmentsMetadata =
+        serverSegmentMetadataReader.getSegmentMetadataFromServer(tableNameWithType, serverToSegmentsMap, endpoints,
+            columns, timeoutMs);
     Map<String, JsonNode> response = new HashMap<>();
     for (String segmentMetadata : segmentsMetadata) {
       JsonNode responseJson = JsonUtils.stringToJsonNode(segmentMetadata);
@@ -146,8 +148,29 @@ public class TableMetadataReader {
     ServerSegmentMetadataReader serverSegmentMetadataReader =
         new ServerSegmentMetadataReader(_executor, _connectionManager);
 
-    TableMetadataInfo aggregateTableMetadataInfo = serverSegmentMetadataReader
-        .getAggregatedTableMetadataFromServer(tableNameWithType, endpoints, columns, numReplica, timeoutMs);
+    TableMetadataInfo aggregateTableMetadataInfo =
+        serverSegmentMetadataReader.getAggregatedTableMetadataFromServer(tableNameWithType, endpoints, columns,
+            numReplica, timeoutMs);
+    return JsonUtils.objectToJsonNode(aggregateTableMetadataInfo);
+  }
+
+  /**
+   * This method retrieves the aggregated valid doc id metadata for a given table.
+   * @return a list of ValidDocIdMetadataInfo
+   */
+  public JsonNode getAggregateValidDocIdMetadata(String tableNameWithType, int timeoutMs)
+      throws InvalidConfigException {
+    final Map<String, List<String>> serverToSegments =
+        _pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType);
+    BiMap<String, String> endpoints =
+        _pinotHelixResourceManager.getDataInstanceAdminEndpoints(serverToSegments.keySet());
+    ServerSegmentMetadataReader serverSegmentMetadataReader =
+        new ServerSegmentMetadataReader(_executor, _connectionManager);
+
+    List<ValidDocIdMetadataInfo> aggregateTableMetadataInfo =
+        serverSegmentMetadataReader.getValidDocIdMetadataFromServer(tableNameWithType, serverToSegments, endpoints,
+            null, timeoutMs);
+
     return JsonUtils.objectToJsonNode(aggregateTableMetadataInfo);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -158,7 +158,7 @@ public class TableMetadataReader {
    * This method retrieves the aggregated valid doc id metadata for a given table.
    * @return a list of ValidDocIdMetadataInfo
    */
-  public JsonNode getAggregateValidDocIdMetadata(String tableNameWithType, int timeoutMs)
+  public JsonNode getAggregateValidDocIdMetadata(String tableNameWithType, List<String> segmentNames, int timeoutMs)
       throws InvalidConfigException {
     final Map<String, List<String>> serverToSegments =
         _pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType);
@@ -169,8 +169,7 @@ public class TableMetadataReader {
 
     List<ValidDocIdMetadataInfo> aggregateTableMetadataInfo =
         serverSegmentMetadataReader.getValidDocIdMetadataFromServer(tableNameWithType, serverToSegments, endpoints,
-            null, timeoutMs);
-
+            segmentNames, timeoutMs);
     return JsonUtils.objectToJsonNode(aggregateTableMetadataInfo);
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -21,15 +21,23 @@ package org.apache.pinot.plugin.minion.tasks;
 import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.helix.HelixAdmin;
+import org.apache.helix.model.ExternalView;
+import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.utils.config.InstanceUtils;
 import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
+import org.apache.pinot.controller.util.ServerSegmentMetadataReader;
+import org.apache.pinot.minion.MinionContext;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.spi.filesystem.PinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
 import org.apache.pinot.spi.ingestion.batch.BatchConfigProperties;
 import org.apache.pinot.spi.plugin.PluginManager;
+import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -129,5 +137,38 @@ public class MinionTaskUtils {
       return dirInStr + DEFAULT_DIR_PATH_TERMINATOR;
     }
     return dirInStr;
+  }
+
+  public static RoaringBitmap getValidDocIds(String tableNameWithType, String segmentName, Map<String, String> configs,
+      MinionContext minionContext) {
+    HelixAdmin helixAdmin = minionContext.getHelixManager().getClusterManagmentTool();
+    String clusterName = minionContext.getHelixManager().getClusterName();
+
+    String server = getServer(segmentName, tableNameWithType, helixAdmin, clusterName);
+    InstanceConfig instanceConfig = helixAdmin.getInstanceConfig(clusterName, server);
+    String endpoint = InstanceUtils.getServerAdminEndpoint(instanceConfig);
+
+    // We only need aggregated table size and the total number of docs/rows. Skipping column related stats, by
+    // passing an empty list.
+    ServerSegmentMetadataReader serverSegmentMetadataReader = new ServerSegmentMetadataReader();
+    return serverSegmentMetadataReader.getValidDocIdsFromServer(tableNameWithType, segmentName, endpoint, 60_000);
+  }
+
+  public static String getServer(String segmentName, String tableNameWithType, HelixAdmin helixAdmin,
+      String clusterName) {
+    ExternalView externalView = helixAdmin.getResourceExternalView(clusterName, tableNameWithType);
+    if (externalView == null) {
+      throw new IllegalStateException("External view does not exist for table: " + tableNameWithType);
+    }
+    Map<String, String> instanceStateMap = externalView.getStateMap(segmentName);
+    if (instanceStateMap == null) {
+      throw new IllegalStateException("Failed to find segment: " + segmentName);
+    }
+    for (Map.Entry<String, String> entry : instanceStateMap.entrySet()) {
+      if (entry.getValue().equals(CommonConstants.Helix.StateModel.SegmentStateModel.ONLINE)) {
+        return entry.getKey();
+      }
+    }
+    throw new IllegalStateException("Failed to find ONLINE server for segment: " + segmentName);
   }
 }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -19,40 +19,28 @@
 package org.apache.pinot.plugin.minion.tasks.upsertcompaction;
 
 import com.google.common.annotations.VisibleForTesting;
-import com.google.common.base.Preconditions;
 import java.io.File;
-import java.io.IOException;
-import java.net.URISyntaxException;
-import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.Map;
-import java.util.Set;
-import javax.annotation.Nullable;
-import javax.ws.rs.client.ClientBuilder;
-import javax.ws.rs.core.Response;
 import org.apache.commons.io.FileUtils;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
-import org.apache.http.client.utils.URIBuilder;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.common.utils.config.InstanceUtils;
+import org.apache.pinot.controller.util.ServerSegmentMetadataReader;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.plugin.minion.tasks.BaseSingleSegmentConversionExecutor;
 import org.apache.pinot.plugin.minion.tasks.SegmentConversionResult;
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
-import org.apache.pinot.segment.local.segment.readers.PinotSegmentRecordReader;
+import org.apache.pinot.segment.local.segment.readers.CompactedPinotSegmentRecordReader;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.spi.config.table.TableConfig;
-import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.data.readers.RecordReader;
-import org.apache.pinot.spi.data.readers.RecordReaderConfig;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
-import org.roaringbitmap.PeekableIntIterator;
-import org.roaringbitmap.buffer.ImmutableRoaringBitmap;
+import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -62,74 +50,6 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
   private static HelixManager _helixManager = MINION_CONTEXT.getHelixManager();
   private static HelixAdmin _clusterManagementTool = _helixManager.getClusterManagmentTool();
   private static String _clusterName = _helixManager.getClusterName();
-
-  private class CompactedRecordReader implements RecordReader {
-    private final PinotSegmentRecordReader _pinotSegmentRecordReader;
-    private final PeekableIntIterator _validDocIdsIterator;
-    // Reusable generic row to store the next row to return
-    GenericRow _nextRow = new GenericRow();
-    // Flag to mark whether we need to fetch another row
-    boolean _nextRowReturned = true;
-
-    CompactedRecordReader(File indexDir, ImmutableRoaringBitmap validDocIds) {
-      _pinotSegmentRecordReader = new PinotSegmentRecordReader();
-      _pinotSegmentRecordReader.init(indexDir, null, null);
-      _validDocIdsIterator = validDocIds.getIntIterator();
-    }
-
-    @Override
-    public void init(File dataFile, Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig) {
-    }
-
-    @Override
-    public boolean hasNext() {
-      if (!_validDocIdsIterator.hasNext() && _nextRowReturned) {
-        return false;
-      }
-
-      // If next row has not been returned, return true
-      if (!_nextRowReturned) {
-        return true;
-      }
-
-      // Try to get the next row to return
-      if (_validDocIdsIterator.hasNext()) {
-        int docId = _validDocIdsIterator.next();
-        _nextRow.clear();
-        _pinotSegmentRecordReader.getRecord(docId, _nextRow);
-        _nextRowReturned = false;
-        return true;
-      }
-
-      // Cannot find next row to return, return false
-      return false;
-    }
-
-    @Override
-    public GenericRow next() {
-      return next(new GenericRow());
-    }
-
-    @Override
-    public GenericRow next(GenericRow reuse) {
-      Preconditions.checkState(!_nextRowReturned);
-      reuse.init(_nextRow);
-      _nextRowReturned = true;
-      return reuse;
-    }
-
-    @Override
-    public void rewind() {
-      _pinotSegmentRecordReader.rewind();
-      _nextRowReturned = true;
-    }
-
-    @Override
-    public void close()
-        throws IOException {
-      _pinotSegmentRecordReader.close();
-    }
-  }
 
   @Override
   protected SegmentConversionResult convert(PinotTaskConfig pinotTaskConfig, File indexDir, File workingDir)
@@ -143,7 +63,7 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
 
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
     TableConfig tableConfig = getTableConfig(tableNameWithType);
-    ImmutableRoaringBitmap validDocIds = getValidDocIds(tableNameWithType, configs);
+    RoaringBitmap validDocIds = getValidDocIds(tableNameWithType, configs);
 
     if (validDocIds.isEmpty()) {
       // prevents empty segment generation
@@ -159,7 +79,8 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
     }
 
     SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
-    try (CompactedRecordReader compactedRecordReader = new CompactedRecordReader(indexDir, validDocIds)) {
+    try (CompactedPinotSegmentRecordReader compactedRecordReader = new CompactedPinotSegmentRecordReader(indexDir,
+        validDocIds)) {
       SegmentGeneratorConfig config = getSegmentGeneratorConfig(workingDir, tableConfig, segmentMetadata, segmentName);
       SegmentIndexCreationDriverImpl driver = new SegmentIndexCreationDriverImpl();
       driver.init(config, compactedRecordReader);
@@ -198,26 +119,17 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
     return config;
   }
 
-  // TODO: Consider moving this method to a more appropriate class (eg ServerSegmentMetadataReader)
-  private static ImmutableRoaringBitmap getValidDocIds(String tableNameWithType, Map<String, String> configs)
-      throws URISyntaxException {
+  private static RoaringBitmap getValidDocIds(String tableNameWithType, Map<String, String> configs) {
     String segmentName = configs.get(MinionConstants.SEGMENT_NAME_KEY);
     String server = getServer(segmentName, tableNameWithType);
-
-    // get the url for the validDocIds for the server
     InstanceConfig instanceConfig = _clusterManagementTool.getInstanceConfig(_clusterName, server);
     String endpoint = InstanceUtils.getServerAdminEndpoint(instanceConfig);
-    String url =
-        new URIBuilder(endpoint).setPath(String.format("/segments/%s/%s/validDocIds", tableNameWithType, segmentName))
-            .toString();
 
-    // get the validDocIds from that server
-    Response response = ClientBuilder.newClient().target(url).request().get(Response.class);
-    Preconditions.checkState(response.getStatus() == Response.Status.OK.getStatusCode(),
-        "Unable to retrieve validDocIds from %s", url);
-    byte[] snapshot = response.readEntity(byte[].class);
-    ImmutableRoaringBitmap validDocIds = new ImmutableRoaringBitmap(ByteBuffer.wrap(snapshot));
-    return validDocIds;
+    // We only need aggregated table size and the total number of docs/rows. Skipping column related stats, by
+    // passing an empty list.
+    ServerSegmentMetadataReader serverSegmentMetadataReader = new ServerSegmentMetadataReader();
+    return serverSegmentMetadataReader.getValidDocIdsFromServer(tableNameWithType, segmentName, endpoint,
+        60_000);
   }
 
   @VisibleForTesting

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutorTest.java
@@ -24,6 +24,7 @@ import org.apache.helix.HelixAdmin;
 import org.apache.helix.HelixManager;
 import org.apache.helix.model.ExternalView;
 import org.apache.pinot.minion.MinionContext;
+import org.apache.pinot.plugin.minion.tasks.MinionTaskUtils;
 import org.apache.pinot.spi.utils.CommonConstants.Helix.StateModel.SegmentStateModel;
 import org.mockito.Mockito;
 import org.testng.Assert;
@@ -51,13 +52,15 @@ public class UpsertCompactionTaskExecutorTest {
     Mockito.when(helixManager.getClusterManagmentTool()).thenReturn(clusterManagementTool);
     minionContext.setHelixManager(helixManager);
 
-    String server = UpsertCompactionTaskExecutor.getServer(SEGMENT_NAME, REALTIME_TABLE_NAME);
+    String server = MinionTaskUtils.getServer(SEGMENT_NAME, REALTIME_TABLE_NAME, helixManager.getClusterManagmentTool(),
+        helixManager.getClusterName());
 
     Assert.assertEquals(server, "server1");
 
     // verify exception thrown with OFFLINE server
     map.put("server1", SegmentStateModel.OFFLINE);
     Assert.assertThrows(IllegalStateException.class,
-        () -> UpsertCompactionTaskExecutor.getServer(SEGMENT_NAME, REALTIME_TABLE_NAME));
+        () -> MinionTaskUtils.getServer(SEGMENT_NAME, REALTIME_TABLE_NAME,
+            helixManager.getClusterManagmentTool(), helixManager.getClusterName()));
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/CompactedPinotSegmentRecordReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/CompactedPinotSegmentRecordReader.java
@@ -41,8 +41,7 @@ public class CompactedPinotSegmentRecordReader implements RecordReader {
   // Flag to mark whether we need to fetch another row
   boolean _nextRowReturned = true;
 
-  public CompactedPinotSegmentRecordReader(File indexDir, RoaringBitmap validDocIds)
-      throws Exception {
+  public CompactedPinotSegmentRecordReader(File indexDir, RoaringBitmap validDocIds) {
     _pinotSegmentRecordReader = new PinotSegmentRecordReader();
     _pinotSegmentRecordReader.init(indexDir, null, null);
     _validDocIdsIterator = validDocIds.getIntIterator();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/CompactedPinotSegmentRecordReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/readers/CompactedPinotSegmentRecordReader.java
@@ -1,0 +1,107 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.segment.readers;
+
+import com.google.common.base.Preconditions;
+import java.io.File;
+import java.io.IOException;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.apache.pinot.spi.data.readers.RecordReader;
+import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+import org.roaringbitmap.PeekableIntIterator;
+import org.roaringbitmap.RoaringBitmap;
+
+
+/**
+ * Compacted Pinot Segment Record Reader used for upsert compaction
+ */
+public class CompactedPinotSegmentRecordReader implements RecordReader {
+  private final PinotSegmentRecordReader _pinotSegmentRecordReader;
+  private final PeekableIntIterator _validDocIdsIterator;
+  // Reusable generic row to store the next row to return
+  GenericRow _nextRow = new GenericRow();
+  // Flag to mark whether we need to fetch another row
+  boolean _nextRowReturned = true;
+
+  public CompactedPinotSegmentRecordReader(File indexDir, RoaringBitmap validDocIds)
+      throws Exception {
+    _pinotSegmentRecordReader = new PinotSegmentRecordReader();
+    _pinotSegmentRecordReader.init(indexDir, null, null);
+    _validDocIdsIterator = validDocIds.getIntIterator();
+  }
+
+  @Override
+  public void init(File dataFile, @Nullable Set<String> fieldsToRead, @Nullable RecordReaderConfig recordReaderConfig)
+      throws IOException {
+  }
+
+  @Override
+  public boolean hasNext() {
+    if (!_validDocIdsIterator.hasNext() && _nextRowReturned) {
+      return false;
+    }
+
+    // If next row has not been returned, return true
+    if (!_nextRowReturned) {
+      return true;
+    }
+
+    // Try to get the next row to return
+    if (_validDocIdsIterator.hasNext()) {
+      int docId = _validDocIdsIterator.next();
+      _nextRow.clear();
+      _pinotSegmentRecordReader.getRecord(docId, _nextRow);
+      _nextRowReturned = false;
+      return true;
+    }
+
+    // Cannot find next row to return, return false
+    return false;
+  }
+
+  @Override
+  public GenericRow next()
+      throws IOException {
+    return next(new GenericRow());
+  }
+
+  @Override
+  public GenericRow next(GenericRow reuse)
+      throws IOException {
+    Preconditions.checkState(!_nextRowReturned);
+    reuse.init(_nextRow);
+    _nextRowReturned = true;
+    return reuse;
+  }
+
+  @Override
+  public void rewind()
+      throws IOException {
+    _pinotSegmentRecordReader.rewind();
+    _nextRowReturned = true;
+  }
+
+  @Override
+  public void close()
+      throws IOException {
+    _pinotSegmentRecordReader.close();
+  }
+}

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -555,7 +555,7 @@ public class TablesResource {
         ServerResourceUtils.checkGetTableDataManager(_serverInstance, tableNameWithType);
     List<String> missingSegments = new ArrayList<>();
     List<SegmentDataManager> segmentDataManagers;
-    if (segments == null || segments.isEmpty()) {
+    if (segments == null) {
       segmentDataManagers = tableDataManager.acquireAllSegments();
     } else {
       segmentDataManagers = tableDataManager.acquireSegments(segments, missingSegments);

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import javax.ws.rs.client.Entity;
 import javax.ws.rs.core.Response;
 import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
@@ -305,6 +306,27 @@ public class TablesResourceTest extends BaseResourceTest {
         _webTarget.path(validDocIdMetadataPath).queryParam("segmentNames", segment.getSegmentName()).request()
             .get(String.class);
     JsonNode validDocIdMetadata = JsonUtils.stringToJsonNode(metadataResponse).get(0);
+
+    Assert.assertEquals(validDocIdMetadata.get("totalDocs").asInt(), 100000);
+    Assert.assertEquals(validDocIdMetadata.get("totalValidDocs").asInt(), 8);
+    Assert.assertEquals(validDocIdMetadata.get("totalInvalidDocs").asInt(), 99992);
+  }
+
+  @Test
+  public void testValidDocIdMetadataPost()
+      throws IOException {
+    IndexSegment segment = _realtimeIndexSegments.get(0);
+    // Verify the content of the downloaded snapshot from a realtime table.
+    downLoadAndVerifyValidDocIdsSnapshot(TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME),
+        (ImmutableSegmentImpl) segment);
+    List<String> segments = List.of(segment.getSegmentName());
+    TableSegments tableSegments = new TableSegments(segments);
+    String validDocIdMetadataPath =
+        "/tables/" + TableNameBuilder.REALTIME.tableNameWithType(TABLE_NAME) + "/validDocIdMetadata";
+    String response =
+        _webTarget.path(validDocIdMetadataPath).queryParam("segmentNames", segment.getSegmentName()).request()
+            .post(Entity.json(tableSegments), String.class);
+    JsonNode validDocIdMetadata = JsonUtils.stringToJsonNode(response).get(0);
 
     Assert.assertEquals(validDocIdMetadata.get("totalDocs").asInt(), 100000);
     Assert.assertEquals(validDocIdMetadata.get("totalValidDocs").asInt(), 8);


### PR DESCRIPTION
1. Fix the issue with fetching validDocId metadata for table with a large number of segments. (Added POST API with list of segments to be part of the request body)
2. Added POST support for MultiHttpRequest to cover 1.
3. Added GET /tables/<tableName>/validDocIdMetadata API on the controller for improving debuggability.
```
e.g. sample response

GET tables/{tableName}/validDocIdMetadata
[
  {
    "segmentName": "gameScores__1__0__20240117T0931Z",
    "totalValidDocs": 0,
    "totalInvalidDocs": 100,
    "totalDocs": 100
  },
  {
    "segmentName": "gameScores__1__10__20240117T0931Z",
    "totalValidDocs": 0,
    "totalInvalidDocs": 100,
    "totalDocs": 100
  }
]
```