### PR TITLE
Support Array constructor using literal evaluation

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/FunctionRegistry.java
@@ -52,6 +52,8 @@ public class FunctionRegistry {
   // This FUNCTION_MAP is used by Calcite function catalog to look up function by function signature.
   private static final NameMultimap<Function> FUNCTION_MAP = new NameMultimap<>();
 
+  private static final int VAR_ARG_KEY = -1;
+
   /**
    * Registers the scalar functions via reflection.
    * NOTE: In order to plugin methods using reflection, the methods should be inside a class that includes ".function."
@@ -69,12 +71,14 @@ public class FunctionRegistry {
         // Annotated function names
         String[] scalarFunctionNames = scalarFunction.names();
         boolean nullableParameters = scalarFunction.nullableParameters();
+        boolean isPlaceholder = scalarFunction.isPlaceholder();
+        boolean isVarArg = scalarFunction.isVarArg();
         if (scalarFunctionNames.length > 0) {
           for (String name : scalarFunctionNames) {
-            FunctionRegistry.registerFunction(name, method, nullableParameters, scalarFunction.isPlaceholder());
+            FunctionRegistry.registerFunction(name, method, nullableParameters, isPlaceholder, isVarArg);
           }
         } else {
-          FunctionRegistry.registerFunction(method, nullableParameters, scalarFunction.isPlaceholder());
+          FunctionRegistry.registerFunction(method, nullableParameters, isPlaceholder, isVarArg);
         }
       }
     }
@@ -93,31 +97,40 @@ public class FunctionRegistry {
   /**
    * Registers a method with the name of the method.
    */
-  public static void registerFunction(Method method, boolean nullableParameters, boolean isPlaceholder) {
-    registerFunction(method.getName(), method, nullableParameters, isPlaceholder);
+  public static void registerFunction(Method method, boolean nullableParameters, boolean isPlaceholder,
+      boolean isVarArg) {
+    registerFunction(method.getName(), method, nullableParameters, isPlaceholder, isVarArg);
   }
 
   /**
    * Registers a method with the given function name.
    */
   public static void registerFunction(String functionName, Method method, boolean nullableParameters,
-      boolean isPlaceholder) {
+      boolean isPlaceholder, boolean isVarArg) {
     if (!isPlaceholder) {
-      registerFunctionInfoMap(functionName, method, nullableParameters);
+      registerFunctionInfoMap(functionName, method, nullableParameters, isVarArg);
     }
-    registerCalciteNamedFunctionMap(functionName, method, nullableParameters);
+    registerCalciteNamedFunctionMap(functionName, method, nullableParameters, isVarArg);
   }
 
-  private static void registerFunctionInfoMap(String functionName, Method method, boolean nullableParameters) {
+  private static void registerFunctionInfoMap(String functionName, Method method, boolean nullableParameters,
+      boolean isVarArg) {
     FunctionInfo functionInfo = new FunctionInfo(method, method.getDeclaringClass(), nullableParameters);
     String canonicalName = canonicalize(functionName);
     Map<Integer, FunctionInfo> functionInfoMap = FUNCTION_INFO_MAP.computeIfAbsent(canonicalName, k -> new HashMap<>());
-    FunctionInfo existFunctionInfo = functionInfoMap.put(method.getParameterCount(), functionInfo);
-    Preconditions.checkState(existFunctionInfo == null || existFunctionInfo.getMethod() == functionInfo.getMethod(),
-        "Function: %s with %s parameters is already registered", functionName, method.getParameterCount());
+    if (isVarArg) {
+      FunctionInfo existFunctionInfo = functionInfoMap.put(VAR_ARG_KEY, functionInfo);
+      Preconditions.checkState(existFunctionInfo == null || existFunctionInfo.getMethod() == functionInfo.getMethod(),
+          "Function: %s with variable number of parameters is already registered", functionName);
+    } else {
+      FunctionInfo existFunctionInfo = functionInfoMap.put(method.getParameterCount(), functionInfo);
+      Preconditions.checkState(existFunctionInfo == null || existFunctionInfo.getMethod() == functionInfo.getMethod(),
+          "Function: %s with %s parameters is already registered", functionName, method.getParameterCount());
+    }
   }
 
-  private static void registerCalciteNamedFunctionMap(String functionName, Method method, boolean nullableParameters) {
+  private static void registerCalciteNamedFunctionMap(String functionName, Method method, boolean nullableParameters,
+      boolean isVarArg) {
     if (method.getAnnotation(Deprecated.class) == null) {
       FUNCTION_MAP.put(functionName, ScalarFunctionImpl.create(method));
     }
@@ -146,7 +159,14 @@ public class FunctionRegistry {
   @Nullable
   public static FunctionInfo getFunctionInfo(String functionName, int numParameters) {
     Map<Integer, FunctionInfo> functionInfoMap = FUNCTION_INFO_MAP.get(canonicalize(functionName));
-    return functionInfoMap != null ? functionInfoMap.get(numParameters) : null;
+    if (functionInfoMap != null) {
+      FunctionInfo functionInfo = functionInfoMap.get(numParameters);
+      if (functionInfo != null) {
+        return functionInfo;
+      }
+      return functionInfoMap.get(VAR_ARG_KEY);
+    }
+    return null;
   }
 
   private static String canonicalize(String functionName) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArrayFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/ArrayFunctions.java
@@ -23,6 +23,7 @@ import it.unimi.dsi.fastutil.ints.IntLinkedOpenHashSet;
 import it.unimi.dsi.fastutil.ints.IntSet;
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
+import java.math.BigDecimal;
 import java.util.Arrays;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.pinot.spi.annotations.ScalarFunction;
@@ -225,5 +226,63 @@ public class ArrayFunctions {
   @ScalarFunction
   public static String arrayElementAtString(String[] arr, int idx) {
     return idx > 0 && idx <= arr.length ? arr[idx - 1] : NullValuePlaceHolder.STRING;
+  }
+
+  @ScalarFunction(names = {"array", "arrayValueConstructor"}, isVarArg = true)
+  public static Object arrayValueConstructor(Object... arr) {
+    if (arr.length == 0) {
+      return arr;
+    }
+    Class<?> clazz = arr[0].getClass();
+    if (clazz == Integer.class) {
+      int[] intArr = new int[arr.length];
+      for (int i = 0; i < arr.length; i++) {
+        intArr[i] = (Integer) arr[i];
+      }
+      return intArr;
+    }
+    if (clazz == Long.class) {
+      long[] longArr = new long[arr.length];
+      for (int i = 0; i < arr.length; i++) {
+        longArr[i] = (Long) arr[i];
+      }
+      return longArr;
+    }
+    if (clazz == Float.class) {
+      float[] floatArr = new float[arr.length];
+      for (int i = 0; i < arr.length; i++) {
+        floatArr[i] = (Float) arr[i];
+      }
+      return floatArr;
+    }
+    if (clazz == Double.class) {
+      double[] doubleArr = new double[arr.length];
+      for (int i = 0; i < arr.length; i++) {
+        doubleArr[i] = (Double) arr[i];
+      }
+      return doubleArr;
+    }
+    if (clazz == Boolean.class) {
+      boolean[] boolArr = new boolean[arr.length];
+      for (int i = 0; i < arr.length; i++) {
+        boolArr[i] = (Boolean) arr[i];
+      }
+      return boolArr;
+    }
+    if (clazz == BigDecimal.class) {
+      BigDecimal[] bigDecimalArr = new BigDecimal[arr.length];
+      for (int i = 0; i < arr.length; i++) {
+        bigDecimalArr[i] = (BigDecimal) arr[i];
+      }
+      return bigDecimalArr;
+    }
+    if (clazz == String.class) {
+      String[] strArr = new String[arr.length];
+      for (int i = 0; i < arr.length; i++) {
+        strArr[i] = (String) arr[i];
+      }
+      return strArr;
+    }
+    return arr;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/LiteralContext.java
@@ -102,6 +102,26 @@ public class LiteralContext {
         _type = DataType.BYTES;
         _value = literal.getBinaryValue();
         break;
+      case INT_ARRAY_VALUE:
+        _type = DataType.INT;
+        _value = literal.getIntArrayValue();
+        break;
+      case LONG_ARRAY_VALUE:
+        _type = DataType.LONG;
+        _value = literal.getLongArrayValue();
+        break;
+      case FLOAT_ARRAY_VALUE:
+        _type = DataType.FLOAT;
+        _value = literal.getFloatArrayValue();
+        break;
+      case DOUBLE_ARRAY_VALUE:
+        _type = DataType.DOUBLE;
+        _value = literal.getDoubleArrayValue();
+        break;
+      case STRING_ARRAY_VALUE:
+        _type = DataType.STRING;
+        _value = literal.getStringArrayValue();
+        break;
       case NULL_VALUE:
         _type = DataType.UNKNOWN;
         _value = null;

--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/rewriter/CompileTimeFunctionsInvoker.java
@@ -84,8 +84,13 @@ public class CompileTimeFunctionsInvoker implements QueryRewriter {
         }
         try {
           FunctionInvoker invoker = new FunctionInvoker(functionInfo);
-          invoker.convertTypes(arguments);
-          Object result = invoker.invoke(arguments);
+          Object result;
+          if (invoker.getMethod().isVarArgs()) {
+            result = invoker.invoke(new Object[] {arguments});
+          } else {
+            invoker.convertTypes(arguments);
+            result = invoker.invoke(arguments);
+          }
           return RequestUtils.getLiteralExpression(result);
         } catch (Exception e) {
           throw new SqlCompilationException(

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLiteralTransformFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/ArrayLiteralTransformFunction.java
@@ -24,6 +24,7 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
 import org.apache.pinot.common.request.context.ExpressionContext;
+import org.apache.pinot.common.request.context.LiteralContext;
 import org.apache.pinot.core.operator.ColumnContext;
 import org.apache.pinot.core.operator.blocks.ValueBlock;
 import org.apache.pinot.core.operator.transform.TransformResultMetadata;
@@ -53,6 +54,77 @@ public class ArrayLiteralTransformFunction implements TransformFunction {
   private float[][] _floatArrayResult;
   private double[][] _doubleArrayResult;
   private String[][] _stringArrayResult;
+
+  public ArrayLiteralTransformFunction(LiteralContext literalContext) {
+    List literalArray = (List) literalContext.getValue();
+    Preconditions.checkNotNull(literalArray);
+    if (literalArray.isEmpty()) {
+      _dataType = DataType.UNKNOWN;
+      _intArrayLiteral = new int[0];
+      _longArrayLiteral = new long[0];
+      _floatArrayLiteral = new float[0];
+      _doubleArrayLiteral = new double[0];
+      _stringArrayLiteral = new String[0];
+      return;
+    }
+    _dataType = literalContext.getType();
+    switch (_dataType) {
+      case INT:
+        _intArrayLiteral = new int[literalArray.size()];
+        for (int i = 0; i < _intArrayLiteral.length; i++) {
+          _intArrayLiteral[i] = (int) literalArray.get(i);
+        }
+        _longArrayLiteral = null;
+        _floatArrayLiteral = null;
+        _doubleArrayLiteral = null;
+        _stringArrayLiteral = null;
+        break;
+      case LONG:
+        _longArrayLiteral = new long[literalArray.size()];
+        for (int i = 0; i < _longArrayLiteral.length; i++) {
+          _longArrayLiteral[i] = (long) literalArray.get(i);
+        }
+        _intArrayLiteral = null;
+        _floatArrayLiteral = null;
+        _doubleArrayLiteral = null;
+        _stringArrayLiteral = null;
+        break;
+      case FLOAT:
+        _floatArrayLiteral = new float[literalArray.size()];
+        for (int i = 0; i < _floatArrayLiteral.length; i++) {
+          _floatArrayLiteral[i] = (float) literalArray.get(i);
+        }
+        _intArrayLiteral = null;
+        _longArrayLiteral = null;
+        _doubleArrayLiteral = null;
+        _stringArrayLiteral = null;
+        break;
+      case DOUBLE:
+        _doubleArrayLiteral = new double[literalArray.size()];
+        for (int i = 0; i < _doubleArrayLiteral.length; i++) {
+          _doubleArrayLiteral[i] = (double) literalArray.get(i);
+        }
+        _intArrayLiteral = null;
+        _longArrayLiteral = null;
+        _floatArrayLiteral = null;
+        _stringArrayLiteral = null;
+        break;
+      case STRING:
+        _stringArrayLiteral = new String[literalArray.size()];
+        for (int i = 0; i < _stringArrayLiteral.length; i++) {
+          _stringArrayLiteral[i] = (String) literalArray.get(i);
+        }
+        _intArrayLiteral = null;
+        _longArrayLiteral = null;
+        _floatArrayLiteral = null;
+        _doubleArrayLiteral = null;
+        break;
+      default:
+        throw new IllegalStateException(
+            "Illegal data type for ArrayLiteralTransformFunction: " + _dataType + ", literal contexts: "
+                + Arrays.toString(literalArray.toArray()));
+    }
+  }
 
   public ArrayLiteralTransformFunction(List<ExpressionContext> literalContexts) {
     Preconditions.checkNotNull(literalContexts);

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/transform/function/TransformFunctionFactory.java
@@ -31,6 +31,7 @@ import org.apache.pinot.common.function.FunctionRegistry;
 import org.apache.pinot.common.function.TransformFunctionType;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
+import org.apache.pinot.common.request.context.LiteralContext;
 import org.apache.pinot.common.utils.HashUtil;
 import org.apache.pinot.core.geospatial.transform.function.GeoToH3Function;
 import org.apache.pinot.core.geospatial.transform.function.StAreaFunction;
@@ -335,7 +336,12 @@ public class TransformFunctionFactory {
         String columnName = expression.getIdentifier();
         return new IdentifierTransformFunction(columnName, columnContextMap.get(columnName));
       case LITERAL:
-        return queryContext.getOrComputeSharedValue(LiteralTransformFunction.class, expression.getLiteral(),
+        LiteralContext literal = expression.getLiteral();
+        if (literal.getValue() != null && literal.getValue() instanceof ArrayList) {
+          return queryContext.getOrComputeSharedValue(ArrayLiteralTransformFunction.class, literal,
+              ArrayLiteralTransformFunction::new);
+        }
+        return queryContext.getOrComputeSharedValue(LiteralTransformFunction.class, literal,
             LiteralTransformFunction::new);
       default:
         throw new IllegalStateException();

--- a/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/data/function/InbuiltFunctionEvaluatorTest.java
@@ -131,7 +131,7 @@ public class InbuiltFunctionEvaluatorTest {
       throws Exception {
     MyFunc myFunc = new MyFunc();
     Method method = myFunc.getClass().getDeclaredMethod("appendToStringAndReturn", String.class);
-    FunctionRegistry.registerFunction(method, false, false);
+    FunctionRegistry.registerFunction(method, false, false, false);
     String expression = "appendToStringAndReturn('test ')";
     InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
     assertTrue(evaluator.getArguments().isEmpty());

--- a/pinot-core/src/test/java/org/apache/pinot/queries/HistogramQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/HistogramQueriesTest.java
@@ -312,7 +312,7 @@ public class HistogramQueriesTest extends BaseQueriesTest {
       operator.nextBlock();
     } catch (Exception e) {
       assertEquals(e.getMessage(),
-          "Invalid aggregation function: histogram(intColumn,arrayvalueconstructor('0')); Reason: The number of "
+          "Invalid aggregation function: histogram(intColumn,'[0]'); Reason: The number of "
               + "bin edges must be greater than 1");
     }
 
@@ -333,7 +333,7 @@ public class HistogramQueriesTest extends BaseQueriesTest {
       operator.nextBlock();
     } catch (Exception e) {
       assertEquals(e.getMessage(),
-          "Invalid aggregation function: histogram(intColumn,arrayvalueconstructor('0','0','1','2')); Reason: The "
+          "Invalid aggregation function: histogram(intColumn,'[0, 0, 1, 2]'); Reason: The "
               + "bin edges must be strictly increasing");
     }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ArrayTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/ArrayTest.java
@@ -218,6 +218,22 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
   }
 
   @Test(dataProvider = "useBothQueryEngines")
+  public void testIntArrayLiteralWithoutFrom(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SELECT ARRAY[1,2,3] ";
+    JsonNode jsonNode = postQuery(query);
+    JsonNode rows = jsonNode.get("resultTable").get("rows");
+    Assert.assertEquals(rows.size(), 1);
+    JsonNode row = rows.get(0);
+    Assert.assertEquals(row.size(), 1);
+    Assert.assertEquals(row.get(0).size(), 3);
+    Assert.assertEquals(row.get(0).get(0).asInt(), 1);
+    Assert.assertEquals(row.get(0).get(1).asInt(), 2);
+    Assert.assertEquals(row.get(0).get(2).asInt(), 3);
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
   public void testLongArrayLiteral(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
@@ -225,6 +241,22 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
         String.format("SELECT "
             + "ARRAY[2147483648,2147483649,2147483650] "
             + "FROM %s LIMIT 1", getTableName());
+    JsonNode jsonNode = postQuery(query);
+    JsonNode rows = jsonNode.get("resultTable").get("rows");
+    Assert.assertEquals(rows.size(), 1);
+    JsonNode row = rows.get(0);
+    Assert.assertEquals(row.size(), 1);
+    Assert.assertEquals(row.get(0).size(), 3);
+    Assert.assertEquals(row.get(0).get(0).asLong(), 2147483648L);
+    Assert.assertEquals(row.get(0).get(1).asLong(), 2147483649L);
+    Assert.assertEquals(row.get(0).get(2).asLong(), 2147483650L);
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testLongArrayLiteralWithoutFrom(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SELECT ARRAY[2147483648,2147483649,2147483650]";
     JsonNode jsonNode = postQuery(query);
     JsonNode rows = jsonNode.get("resultTable").get("rows");
     Assert.assertEquals(rows.size(), 1);
@@ -256,6 +288,22 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
   }
 
   @Test(dataProvider = "useBothQueryEngines")
+  public void testFloatArrayLiteralWithoutFrom(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SELECT ARRAY[0.1, 0.2, 0.3]";
+    JsonNode jsonNode = postQuery(query);
+    JsonNode rows = jsonNode.get("resultTable").get("rows");
+    Assert.assertEquals(rows.size(), 1);
+    JsonNode row = rows.get(0);
+    Assert.assertEquals(row.size(), 1);
+    Assert.assertEquals(row.get(0).size(), 3);
+    Assert.assertEquals(row.get(0).get(0).asDouble(), 0.1);
+    Assert.assertEquals(row.get(0).get(1).asDouble(), 0.2);
+    Assert.assertEquals(row.get(0).get(2).asDouble(), 0.3);
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
   public void testDoubleArrayLiteral(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
@@ -275,6 +323,22 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
   }
 
   @Test(dataProvider = "useBothQueryEngines")
+  public void testDoubleArrayLiteralWithoutFrom(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SELECT ARRAY[CAST(0.1 AS DOUBLE), CAST(0.2 AS DOUBLE), CAST(0.3 AS DOUBLE)]";
+    JsonNode jsonNode = postQuery(query);
+    JsonNode rows = jsonNode.get("resultTable").get("rows");
+    Assert.assertEquals(rows.size(), 1);
+    JsonNode row = rows.get(0);
+    Assert.assertEquals(row.size(), 1);
+    Assert.assertEquals(row.get(0).size(), 3);
+    Assert.assertEquals(row.get(0).get(0).asDouble(), 0.1);
+    Assert.assertEquals(row.get(0).get(1).asDouble(), 0.2);
+    Assert.assertEquals(row.get(0).get(2).asDouble(), 0.3);
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
   public void testStringArrayLiteral(boolean useMultiStageQueryEngine)
       throws Exception {
     setUseMultiStageQueryEngine(useMultiStageQueryEngine);
@@ -282,6 +346,22 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
         String.format("SELECT "
             + "ARRAY['a', 'bb', 'ccc'] "
             + "FROM %s LIMIT 1", getTableName());
+    JsonNode jsonNode = postQuery(query);
+    JsonNode rows = jsonNode.get("resultTable").get("rows");
+    Assert.assertEquals(rows.size(), 1);
+    JsonNode row = rows.get(0);
+    Assert.assertEquals(row.size(), 1);
+    Assert.assertEquals(row.get(0).size(), 3);
+    Assert.assertEquals(row.get(0).get(0).asText(), "a");
+    Assert.assertEquals(row.get(0).get(1).asText(), "bb");
+    Assert.assertEquals(row.get(0).get(2).asText(), "ccc");
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testStringArrayLiteralWithoutFrom(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = "SELECT ARRAY['a', 'bb', 'ccc']";
     JsonNode jsonNode = postQuery(query);
     JsonNode rows = jsonNode.get("resultTable").get("rows");
     Assert.assertEquals(rows.size(), 1);
@@ -352,7 +432,7 @@ public class ArrayTest extends CustomDataQueryClusterIntegrationTest {
         fileWriter.append(recordCache.get((int) (i % (getCountStarResult() / 10)), () -> {
               // create avro record
               GenericData.Record record = new GenericData.Record(avroSchema);
-              record.put(BOOLEAN_COLUMN, RANDOM.nextBoolean());
+              record.put(BOOLEAN_COLUMN, finalI % 4 == 0 || finalI % 4 == 1);
               record.put(INT_COLUMN, finalI);
               record.put(LONG_COLUMN, finalI);
               record.put(FLOAT_COLUMN, finalI + RANDOM.nextFloat());

--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotEvaluateLiteralRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/PinotEvaluateLiteralRule.java
@@ -159,8 +159,12 @@ public class PinotEvaluateLiteralRule {
     Object resultValue;
     try {
       FunctionInvoker invoker = new FunctionInvoker(functionInfo);
-      invoker.convertTypes(arguments);
-      resultValue = invoker.invoke(arguments);
+      if (functionInfo.getMethod().isVarArgs()) {
+        resultValue = invoker.invoke(new Object[] {arguments});
+      } else {
+        invoker.convertTypes(arguments);
+        resultValue = invoker.invoke(arguments);
+      }
       if (rexNodeType.getSqlTypeName() == SqlTypeName.ARRAY) {
         RelDataType componentType = rexNodeType.getComponentType();
         if (componentType != null) {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -233,6 +233,9 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
             }
           }
         }
+        if (_functionInvoker.getMethod().isVarArgs()) {
+          return _functionInvoker.invoke(new Object[]{_arguments});
+        }
         _functionInvoker.convertTypes(_arguments);
         return _functionInvoker.invoke(_arguments);
       } catch (Exception e) {
@@ -255,6 +258,9 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
               return null;
             }
           }
+        }
+        if (_functionInvoker.getMethod().isVarArgs()) {
+          return _functionInvoker.invoke(new Object[]{_arguments});
         }
         _functionInvoker.convertTypes(_arguments);
         return _functionInvoker.invoke(_arguments);

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/ScalarFunction.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/annotations/ScalarFunction.java
@@ -59,4 +59,9 @@ public @interface ScalarFunction {
   boolean nullableParameters() default false;
 
   boolean isPlaceholder() default false;
+
+  /**
+   * Whether the scalar function takes various number of arguments.
+   */
+  boolean isVarArg() default false;
 }


### PR DESCRIPTION
Support Array constructor using literal evaluation.

Before this PR, `SELECT ARRAY[1,2]` doesn't work, we need to write it as `SELECT ARRAY[1,2] FROM existTable`, then query is always pushed down to server for processing.