### PR TITLE
Modify distribution pom to include services

### DIFF
--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -164,8 +164,9 @@
               <goal>shade</goal>
             </goals>
             <configuration>
-              <transformers>
+              <transformers combine.self="override">
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
               </transformers>
               <!--
               Usually in hadoop environment, there are multiple jars with different versions.


### PR DESCRIPTION
We have found that there was an issue running quickstarts. Specifically, once the code was compiled with `mvn install -DskipTests -Pbin-dist -Pbuild-shaded-jar`, running `./build/bin/quick-start-batch.sh` produced an error on Lucene indexes.

The reason is well known: While parent pom configures the shading plugin as:
```
          <transformers>
            <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
            <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
              <mainClass>${mainClass}</mainClass>
              <manifestEntries>
                <Multi-Release>true</Multi-Release>
              </manifestEntries>
            </transformer>
          </transformers>
```

Pinot distribution does:
```
              <transformers>
                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
              </transformers>
```

Which implicitly overrides the parent config. It can be seen with `mvn help:effective-pom | grep -A 12 '<artifactId>maven-shade-plugin</artifactId>'`

```
        <artifactId>maven-shade-plugin</artifactId>
        <version>3.2.1</version>
        <executions>
          <execution>
            <goals>
              <goal>shade</goal>
            </goals>
            <configuration>
              <transformers>
                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
              </transformers>
              <relocations>
                <relocation>
```

This PR makes the override explicit (by adding `combine.self="override"`) and copies the `ServicesResourceTransformer` transformer.

The new effective pom is:
```
        <artifactId>maven-shade-plugin</artifactId>
        <version>3.2.1</version>
        <executions>
          <execution>
            <goals>
              <goal>shade</goal>
            </goals>
            <configuration>
              <transformers combine.self="override">
                <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer" />
                <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer" />
              </transformers>
              <relocations>
```

While solving this issue I've found that there is another important transformer that is not being included: the manifest transformer. That means that the distribution *is not* using multi-release jar, which we also detected as problematic.

I'm not fixing that problem here because when I added I found new issues given that multi-release jars slightly change the final URIs. I'll try to open a second PR on Monday to fix that.