### PR TITLE
Mark distribution as multi-release

### DIFF
--- a/pinot-distribution/pom.xml
+++ b/pinot-distribution/pom.xml
@@ -167,6 +167,11 @@
               <transformers combine.self="override">
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ApacheLicenseResourceTransformer"/>
                 <transformer implementation="org.apache.maven.plugins.shade.resource.ServicesResourceTransformer"/>
+                <transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
+                  <manifestEntries>
+                    <Multi-Release>true</Multi-Release>
+                  </manifestEntries>
+                </transformer>
               </transformers>
               <!--
               Usually in hadoop environment, there are multiple jars with different versions.


### PR DESCRIPTION
As explained in https://github.com/apache/pinot/pull/12131, we need to distribute Pinot as a multi-release Jar. The reason is that we distribute Pinot as a uber-jar with all dependencies in the same jar and some of our dependencies are multi-release jars.

Not marking the jar as multi-release was incorrect in the past, but it seems to be not problematic until recently, when we updated some libraries that fail if the sources for Java 11/17/21 were not used in these runtimes.

I thought I already marked the jar as multi release, but https://github.com/apache/pinot/pull/12289 proved otherwise. When I actually fix the issue, I've found that our code was failing when multi-release was enabled. The reason is that specifically in Java 11 (AFAIK not in Java 21), when multi-release is enabled, 