### PR TITLE
Implement IN and NOT_IN filters in FilterOperand class (#12285 fix)

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/TransformOperandFactory.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/runtime/operator/operands/TransformOperandFactory.java
@@ -46,6 +46,12 @@ public class TransformOperandFactory {
     int numOperands = operands.size();
     String canonicalName = OperatorUtils.canonicalizeFunctionName(functionCall.getFunctionName());
     switch (canonicalName) {
+      case "IN":
+        Preconditions.checkState(numOperands >= 2, "IN takes >=2 arguments, got: %s", numOperands);
+        return new FilterOperand.In(operands, dataSchema, false);
+      case "NOT_IN":
+        Preconditions.checkState(numOperands >= 2, "NOT_IN takes >=2 arguments, got: %s", numOperands);
+        return new FilterOperand.In(operands, dataSchema, true);
       case "AND":
         Preconditions.checkState(numOperands >= 2, "AND takes >=2 arguments, got: %s", numOperands);
         return new FilterOperand.And(operands, dataSchema);


### PR DESCRIPTION
[bugfix]

Added IN and NOT_IN cases to the FilterOperand class and TransformOperandFactory classes. The PR is related to the 12285 bug:  using of the IN expression in the CASE statement within the projection part of the SELECT multistage query. When this expression is used, the query execution fails with an IllegalStateException error, indicating that the function IN cannot be found.
