### PR TITLE
Support table suffix in ZkBasicAuthAccessControlFactory

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/ZkBasicAuthAccessControlFactory.java
@@ -39,6 +39,7 @@ import org.apache.pinot.core.auth.BasicAuthPrincipal;
 import org.apache.pinot.core.auth.BasicAuthUtils;
 import org.apache.pinot.core.auth.ZkBasicAuthPrincipal;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 
 /**
@@ -108,7 +109,7 @@ public class ZkBasicAuthAccessControlFactory extends AccessControlFactory {
 
       ZkBasicAuthPrincipal principal = principalOpt.get();
       for (String table : tables) {
-        if (!principal.hasTable(table)) {
+        if (!principal.hasTable(TableNameBuilder.extractRawTableName(table))) {
           return false;
         }
       }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/ZkBasicAuthAccessControlFactory.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/access/ZkBasicAuthAccessControlFactory.java
@@ -32,6 +32,7 @@ import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.core.auth.BasicAuthUtils;
 import org.apache.pinot.core.auth.ZkBasicAuthPrincipal;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 
 /**
@@ -85,7 +86,8 @@ public class ZkBasicAuthAccessControlFactory implements AccessControlFactory {
     @Override
     public boolean hasAccess(String tableName, AccessType accessType, HttpHeaders httpHeaders, String endpointUrl) {
       return getPrincipal(httpHeaders).filter(
-          p -> p.hasTable(tableName) && p.hasPermission(Objects.toString(accessType))).isPresent();
+          p -> p.hasTable(TableNameBuilder.extractRawTableName(tableName))
+              && p.hasPermission(Objects.toString(accessType))).isPresent();
     }
 
     @Override


### PR DESCRIPTION
This is to support `_OFFLINE` and `_REALTIME` suffix for querying table.

<img width="1470" alt="image" src="https://github.com/apache/pinot/assets/1202120/74ee2f68-f361-426f-855c-ceef12e1fbda">
