### PR TITLE
Make server resource classes configurable

### DIFF
--- a/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
@@ -53,17 +53,21 @@ import org.slf4j.LoggerFactory;
 public class AdminApiApplication extends ResourceConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(AdminApiApplication.class);
   public static final String PINOT_CONFIGURATION = "pinotConfiguration";
-  public static final String RESOURCE_PACKAGE = "org.apache.pinot.server.api.resources";
   public static final String SERVER_INSTANCE_ID = "serverInstanceId";
 
   private final AtomicBoolean _shutDownInProgress = new AtomicBoolean();
   private final ServerInstance _serverInstance;
   private HttpServer _httpServer;
+  private final String _adminApiResourcePackages;
+
 
   public AdminApiApplication(ServerInstance instance, AccessControlFactory accessControlFactory,
       PinotConfiguration serverConf) {
     _serverInstance = instance;
-    packages(RESOURCE_PACKAGE);
+
+    _adminApiResourcePackages = serverConf.getProperty(CommonConstants.Server.CONFIG_OF_ADMIN_API_RESOURCE_PACKAGES,
+        CommonConstants.Server.DEFAULT_ADMIN_API_RESOURCE_PACKAGES);
+    packages(_adminApiResourcePackages);
     property(PINOT_CONFIGURATION, serverConf);
 
     register(new AbstractBinder() {
@@ -132,7 +136,7 @@ public class AdminApiApplication extends ResourceConfig {
       beanConfig.setSchemes(new String[]{CommonConstants.HTTP_PROTOCOL, CommonConstants.HTTPS_PROTOCOL});
     }
     beanConfig.setBasePath("/");
-    beanConfig.setResourcePackage(RESOURCE_PACKAGE);
+    beanConfig.setResourcePackage(_adminApiResourcePackages);
     beanConfig.setScan(true);
     try {
       beanConfig.setHost(InetAddress.getLocalHost().getHostName());

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
@@ -65,8 +65,8 @@ public class AdminApiApplication extends ResourceConfig {
       PinotConfiguration serverConf) {
     _serverInstance = instance;
 
-    _adminApiResourcePackages = serverConf.getProperty(CommonConstants.Server.CONFIG_OF_ADMIN_API_RESOURCE_PACKAGES,
-        CommonConstants.Server.DEFAULT_ADMIN_API_RESOURCE_PACKAGES);
+    _adminApiResourcePackages = serverConf.getProperty(CommonConstants.Server.CONFIG_OF_SERVER_RESOURCE_PACKAGES,
+        CommonConstants.Server.DEFAULT_SERVER_RESOURCE_PACKAGES);
     packages(_adminApiResourcePackages);
     property(PINOT_CONFIGURATION, serverConf);
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -568,7 +568,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_SWAGGER_USE_HTTPS = "pinot.server.swagger.use.https";
     public static final String CONFIG_OF_ADMIN_API_PORT = "pinot.server.adminapi.port";
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
-    public static final String CONFIG_OF_ADMIN_API_RESOURCE_PACKAGES = "pinot.server.adminapi.resource.packages";
+    public static final String CONFIG_OF_SERVER_RESOURCE_PACKAGES = "pinot.server.restlet.api.resource.packages";
     public static final String DEFAULT_ADMIN_API_RESOURCE_PACKAGES = "org.apache.pinot.server.api.resources";
 
     public static final String CONFIG_OF_SEGMENT_FORMAT_VERSION = "pinot.server.instance.segment.format.version";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -568,7 +568,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_SWAGGER_USE_HTTPS = "pinot.server.swagger.use.https";
     public static final String CONFIG_OF_ADMIN_API_PORT = "pinot.server.adminapi.port";
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
-    public static final String CONFIG_OF_SERVER_RESOURCE_PACKAGES = "pinot.server.restlet.api.resource.packages";
+    public static final String CONFIG_OF_SERVER_RESOURCE_PACKAGES = "server.restlet.api.resource.packages";
     public static final String DEFAULT_ADMIN_API_RESOURCE_PACKAGES = "org.apache.pinot.server.api.resources";
 
     public static final String CONFIG_OF_SEGMENT_FORMAT_VERSION = "pinot.server.instance.segment.format.version";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -568,6 +568,8 @@ public class CommonConstants {
     public static final String CONFIG_OF_SWAGGER_USE_HTTPS = "pinot.server.swagger.use.https";
     public static final String CONFIG_OF_ADMIN_API_PORT = "pinot.server.adminapi.port";
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
+    public static final String CONFIG_OF_ADMIN_API_RESOURCE_PACKAGES = "pinot.server.adminapi.resource.packages";
+    public static final String DEFAULT_ADMIN_API_RESOURCE_PACKAGES = "org.apache.pinot.server.api.resources";
 
     public static final String CONFIG_OF_SEGMENT_FORMAT_VERSION = "pinot.server.instance.segment.format.version";
     public static final String CONFIG_OF_REALTIME_OFFHEAP_ALLOCATION = "pinot.server.instance.realtime.alloc.offheap";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -569,7 +569,7 @@ public class CommonConstants {
     public static final String CONFIG_OF_ADMIN_API_PORT = "pinot.server.adminapi.port";
     public static final int DEFAULT_ADMIN_API_PORT = 8097;
     public static final String CONFIG_OF_SERVER_RESOURCE_PACKAGES = "server.restlet.api.resource.packages";
-    public static final String DEFAULT_ADMIN_API_RESOURCE_PACKAGES = "org.apache.pinot.server.api.resources";
+    public static final String DEFAULT_SERVER_RESOURCE_PACKAGES = "org.apache.pinot.server.api.resources";
 
     public static final String CONFIG_OF_SEGMENT_FORMAT_VERSION = "pinot.server.instance.segment.format.version";
     public static final String CONFIG_OF_REALTIME_OFFHEAP_ALLOCATION = "pinot.server.instance.realtime.alloc.offheap";


### PR DESCRIPTION
Controller API resource locations are already configurable but Server Admin API one's are hardcoded. 

The PR fixes that by allowing users to change the resource path using `pinot.server.adminapi.resource.packages` config