### PR TITLE
correct errmsg format for Preconditions.check...

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/tier/FixedTierSegmentSelector.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/tier/FixedTierSegmentSelector.java
@@ -61,7 +61,7 @@ public class FixedTierSegmentSelector implements TierSegmentSelector {
       SegmentZKMetadata segmentZKMetadata =
           ZKMetadataProvider.getSegmentZKMetadata(_helixManager.getHelixPropertyStore(), tableNameWithType,
               segmentName);
-      Preconditions.checkNotNull(segmentZKMetadata, "Could not find zk metadata for segment: {} of table: {}",
+      Preconditions.checkNotNull(segmentZKMetadata, "Could not find zk metadata for segment: %s of table: %s",
           segmentName, tableNameWithType);
       return segmentZKMetadata.getStatus().isCompleted();
     }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -2765,7 +2765,7 @@ public class PinotHelixResourceManager {
       throw new IllegalStateException("Ideal state does not exist for table: " + tableNameWithType);
     }
     Map<String, String> instanceStateMap = idealState.getInstanceStateMap(segmentName);
-    Preconditions.checkState(instanceStateMap != null, "Segment: {} does not exist in the ideal state of table: {}",
+    Preconditions.checkState(instanceStateMap != null, "Segment: %s does not exist in the ideal state of table: %s",
         segmentName, tableNameWithType);
     Set<String> servers = new TreeSet<>();
     for (Map.Entry<String, String> entry : instanceStateMap.entrySet()) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/rebalance/RebalanceChecker.java
@@ -151,7 +151,7 @@ public class RebalanceChecker extends ControllerPeriodicTask<Void> {
     // Get tableConfig only when the table needs to retry rebalance, and get it before submitting rebalance to another
     // thread, in order to avoid unnecessary ZK reads and making too many ZK reads in a short time.
     TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
-    Preconditions.checkState(tableConfig != null, "Failed to find table config for table: {}", tableNameWithType);
+    Preconditions.checkState(tableConfig != null, "Failed to find table config for table: %s", tableNameWithType);
     _executorService.submit(() -> {
       // Retry rebalance in another thread as rebalance can take time.
       try {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/relocation/SegmentRelocator.java
@@ -146,7 +146,7 @@ public class SegmentRelocator extends ControllerPeriodicTask<Void> {
 
   private void rebalanceTable(String tableNameWithType) {
     TableConfig tableConfig = _pinotHelixResourceManager.getTableConfig(tableNameWithType);
-    Preconditions.checkState(tableConfig != null, "Failed to find table config for table: {}", tableNameWithType);
+    Preconditions.checkState(tableConfig != null, "Failed to find table config for table: %s", tableNameWithType);
 
     boolean relocate = false;
     if (TierConfigUtils.shouldRelocateToTiers(tableConfig)) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -170,7 +170,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     File consumerDir = new File(consumerDirPath);
     if (consumerDir.exists()) {
       File[] segmentFiles = consumerDir.listFiles((dir, name) -> !name.equals(STATS_FILE_NAME));
-      Preconditions.checkState(segmentFiles != null, "Failed to list segment files from consumer dir: {} for table: {}",
+      Preconditions.checkState(segmentFiles != null, "Failed to list segment files from consumer dir: %s for table: %s",
           consumerDirPath, _tableNameWithType);
       for (File file : segmentFiles) {
         if (file.delete()) {
@@ -680,7 +680,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     File indexDir = new File(_indexDir, segmentName);
     // Use the latest table config and schema to load the segment
     TableConfig tableConfig = ZKMetadataProvider.getTableConfig(_propertyStore, _tableNameWithType);
-    Preconditions.checkState(tableConfig != null, "Failed to get table config for table: {}", _tableNameWithType);
+    Preconditions.checkState(tableConfig != null, "Failed to get table config for table: %s", _tableNameWithType);
     Schema schema = ZKMetadataProvider.getTableSchema(_propertyStore, tableConfig);
 
     // Construct a new indexLoadingConfig with the updated tableConfig and schema.

--- a/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
+++ b/pinot-plugins/pinot-batch-ingestion/pinot-batch-ingestion-hadoop/src/main/java/org/apache/pinot/plugin/ingestion/batch/hadoop/HadoopSegmentCreationMapper.java
@@ -108,7 +108,7 @@ public class HadoopSegmentCreationMapper extends Mapper<LongWritable, Text, Long
   protected void map(LongWritable key, Text value, Context context) {
     try {
       String[] splits = StringUtils.split(value.toString(), ' ');
-      Preconditions.checkState(splits.length == 2, "Illegal input value: {}", value);
+      Preconditions.checkState(splits.length == 2, "Illegal input value: %s", value);
 
       String path = splits[0];
       int idx = Integer.valueOf(splits[1]);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/purge/PurgeTaskGenerator.java
@@ -67,7 +67,7 @@ public class PurgeTaskGenerator extends BaseTaskGenerator {
         continue;
       }
       taskConfigs = tableTaskConfig.getConfigsForTaskType(MinionConstants.PurgeTask.TASK_TYPE);
-      Preconditions.checkNotNull(taskConfigs, "Task config shouldn't be null for Table: {}", tableName);
+      Preconditions.checkNotNull(taskConfigs, "Task config shouldn't be null for Table: %s", tableName);
 
       String deltaTimePeriod =
           taskConfigs.getOrDefault(MinionConstants.PurgeTask.LAST_PURGE_TIME_THREESOLD_PERIOD,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -132,7 +132,7 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
       TableTaskConfig tableTaskConfig = tableConfig.getTaskConfig();
       Preconditions.checkState(tableTaskConfig != null);
       Map<String, String> taskConfigs = tableTaskConfig.getConfigsForTaskType(taskType);
-      Preconditions.checkState(taskConfigs != null, "Task config shouldn't be null for table: {}", realtimeTableName);
+      Preconditions.checkState(taskConfigs != null, "Task config shouldn't be null for table: %s", realtimeTableName);
 
       // Get the bucket size and buffer
       String bucketTimePeriod =

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/segmentgenerationandpush/SegmentGenerationAndPushTaskGenerator.java
@@ -109,7 +109,7 @@ public class SegmentGenerationAndPushTaskGenerator extends BaseTaskGenerator {
       Preconditions.checkNotNull(tableTaskConfig);
       Map<String, String> taskConfigs =
           tableTaskConfig.getConfigsForTaskType(MinionConstants.SegmentGenerationAndPushTask.TASK_TYPE);
-      Preconditions.checkNotNull(taskConfigs, "Task config shouldn't be null for Table: {}", tableNameWithType);
+      Preconditions.checkNotNull(taskConfigs, "Task config shouldn't be null for Table: %s", tableNameWithType);
 
       // Get max number of tasks for this table
       int tableMaxNumTasks;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/AggregateNode.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/plannode/AggregateNode.java
@@ -50,7 +50,7 @@ public class AggregateNode extends AbstractPlanNode {
   public AggregateNode(int planFragmentId, DataSchema dataSchema, List<AggregateCall> aggCalls,
       List<RexExpression> groupSet, List<RelHint> relHints) {
     super(planFragmentId, dataSchema);
-    Preconditions.checkState(areHintsValid(relHints), "invalid sql hint for agg node: {}", relHints);
+    Preconditions.checkState(areHintsValid(relHints), "invalid sql hint for agg node: %s", relHints);
     _aggCalls = aggCalls.stream().map(RexExpressionUtils::fromAggregateCall).collect(Collectors.toList());
     _filterArgIndices = aggCalls.stream().map(c -> c.filterArg).collect(Collectors.toList());
     _groupSet = groupSet;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/converter/SegmentV1V2ToV3FormatConverter.java
@@ -76,11 +76,11 @@ public class SegmentV1V2ToV3FormatConverter implements SegmentFormatConverter {
     // check existing segment version
     SegmentMetadataImpl v2Metadata = new SegmentMetadataImpl(v2SegmentDirectory);
     SegmentVersion oldVersion = v2Metadata.getVersion();
-    Preconditions.checkState(oldVersion != SegmentVersion.v3, "Segment {} is already in v3 format but at wrong path",
+    Preconditions.checkState(oldVersion != SegmentVersion.v3, "Segment %s is already in v3 format but at wrong path",
         v2Metadata.getName());
 
     Preconditions.checkArgument(oldVersion == SegmentVersion.v1 || oldVersion == SegmentVersion.v2,
-        "Can not convert segment version: {} at path: {} ", oldVersion, v2SegmentDirectory);
+        "Can not convert segment version: %s at path: %s ", oldVersion, v2SegmentDirectory);
 
     deleteStaleConversionDirectories(v2SegmentDirectory);
 
@@ -303,8 +303,8 @@ public class SegmentV1V2ToV3FormatConverter implements SegmentFormatConverter {
       System.exit(1);
     }
     File tableDirectory = new File(args[0]);
-    Preconditions.checkState(tableDirectory.exists(), "Directory: {} does not exist", tableDirectory);
-    Preconditions.checkState(tableDirectory.isDirectory(), "Path: {} is not a directory", tableDirectory);
+    Preconditions.checkState(tableDirectory.exists(), "Directory: %s does not exist", tableDirectory);
+    Preconditions.checkState(tableDirectory.isDirectory(), "Path: %s is not a directory", tableDirectory);
     File[] files = tableDirectory.listFiles();
     SegmentFormatConverter converter = new SegmentV1V2ToV3FormatConverter();
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -265,7 +265,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
   @Override
   public void preloadSegment(ImmutableSegment segment) {
     String segmentName = segment.getSegmentName();
-    Preconditions.checkArgument(_enableSnapshot, "Snapshot must be enabled to preload segment: {}, table: {}",
+    Preconditions.checkArgument(_enableSnapshot, "Snapshot must be enabled to preload segment: %s, table: %s",
         segmentName, _tableNameWithType);
     // Note that EmptyIndexSegment should not reach here either, as it doesn't have validDocIds snapshot.
     Preconditions.checkArgument(segment instanceof ImmutableSegmentImpl,
@@ -292,7 +292,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
 
     MutableRoaringBitmap validDocIds = segment.loadValidDocIdsFromSnapshot();
     Preconditions.checkState(validDocIds != null,
-        "Snapshot of validDocIds is required to preload segment: {}, table: {}", segmentName, _tableNameWithType);
+        "Snapshot of validDocIds is required to preload segment: %s, table: %s", segmentName, _tableNameWithType);
     if (validDocIds.isEmpty()) {
       _logger.info("Skip preloading segment: {} without valid doc, current primary key count: {}",
           segment.getSegmentName(), getNumPrimaryKeys());

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/creator/SegmentGeneratorConfig.java
@@ -373,7 +373,7 @@ public class SegmentGeneratorConfig implements Serializable {
   public void setInputFilePath(String inputFilePath) {
     Preconditions.checkNotNull(inputFilePath);
     File inputFile = new File(inputFilePath);
-    Preconditions.checkState(inputFile.exists(), "Input path {} does not exist.", inputFilePath);
+    Preconditions.checkState(inputFile.exists(), "Input path %s does not exist.", inputFilePath);
     _inputFilePath = inputFile.getAbsolutePath();
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatSpec.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/DateTimeFormatSpec.java
@@ -215,7 +215,7 @@ public class DateTimeFormatSpec {
   }
 
   public static DateTimeFormatSpec forEpoch(int size, String timeUnit) {
-    Preconditions.checkArgument(size > 0, "Invalid size: {}, must be positive", size);
+    Preconditions.checkArgument(size > 0, "Invalid size: %s, must be positive", size);
     Preconditions.checkArgument(timeUnit != null, "Must provide time unit");
     return new DateTimeFormatSpec(size, new DateTimeFormatUnitSpec(timeUnit), DateTimeFormatPatternSpec.EPOCH);
   }


### PR DESCRIPTION
Preconditions.check... errmsg uses `%s` to format instead of {}, otherwise, we'd see errmsg like below

```
java.lang.IllegalStateException: Snapshot of validDocIds is required to preload segment: {}, table: {} [upsertMeetupRsvpLLC__0__6__20240123T1930Z, upsertMeetupRsvpLLC_REALTIME]
        at org.apache.pinot.shaded.com.google.common.base.Preconditions.checkState(Preconditions.java:835)
        at org.apache.pinot.segment.local.upsert.BasePartitionUpsertMetadataManager.doPreloadSegment(BasePartitionUpsertMetadataManager.java:284)
...
```

Found those places with cmd `git grep 'Preconditions' | grep '{}'` 