### PR TITLE
Bug fix: Do not ignore scheme property in Java client

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportFactory.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/JsonAsyncHttpPinotClientTransportFactory.java
@@ -85,8 +85,9 @@ public class JsonAsyncHttpPinotClientTransportFactory implements PinotClientTran
       _headers = ConnectionUtils.getHeadersFromProperties(properties);
     }
 
-    if (_scheme == null) {
-      _scheme = properties.getProperty("scheme", CommonConstants.HTTP_PROTOCOL);
+    String scheme = properties.getProperty("scheme", CommonConstants.HTTP_PROTOCOL);
+    if (_scheme == null || !_scheme.contentEquals(scheme)) {
+      _scheme = scheme;
     }
 
     if (_sslContext == null && _scheme.contentEquals(CommonConstants.HTTPS_PROTOCOL)) {


### PR DESCRIPTION
Scheme property already has a default value of `http` when initialised. This leads to a bug where we always ignore when a scheme is set using properties.