### PR TITLE
Enhancing metadata API to return upsert partition to primary key count map for both controller and server APIs

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableMetadataInfo.java
@@ -43,7 +43,7 @@ public class TableMetadataInfo {
   private final Map<String, Double> _columnCardinalityMap;
   private final Map<String, Double> _maxNumMultiValuesMap;
   private final Map<String, Map<String, Double>> _columnIndexSizeMap;
-  private final Map<Integer, Long> _upsertPartitionToPrimaryKeyCountMap;
+  private final Map<Integer, Map<String, Long>> _upsertPartitionToServerPrimaryKeyCountMap;
 
   @JsonCreator
   public TableMetadataInfo(@JsonProperty("tableName") String tableName,
@@ -52,7 +52,8 @@ public class TableMetadataInfo {
       @JsonProperty("columnCardinalityMap") Map<String, Double> columnCardinalityMap,
       @JsonProperty("maxNumMultiValuesMap") Map<String, Double> maxNumMultiValuesMap,
       @JsonProperty("columnIndexSizeMap") Map<String, Map<String, Double>> columnIndexSizeMap,
-      @JsonProperty("upsertPartitionToPrimaryKeyCountMap") Map<Integer, Long> upsertPartitionToPrimaryKeyCountMap) {
+      @JsonProperty("upsertPartitionToServerPrimaryKeyCountMap")
+      Map<Integer, Map<String, Long>> upsertPartitionToServerPrimaryKeyCountMap) {
     _tableName = tableName;
     _diskSizeInBytes = sizeInBytes;
     _numSegments = numSegments;
@@ -61,7 +62,7 @@ public class TableMetadataInfo {
     _columnCardinalityMap = columnCardinalityMap;
     _maxNumMultiValuesMap = maxNumMultiValuesMap;
     _columnIndexSizeMap = columnIndexSizeMap;
-    _upsertPartitionToPrimaryKeyCountMap = upsertPartitionToPrimaryKeyCountMap;
+    _upsertPartitionToServerPrimaryKeyCountMap = upsertPartitionToServerPrimaryKeyCountMap;
   }
 
   public String getTableName() {
@@ -96,7 +97,7 @@ public class TableMetadataInfo {
     return _columnIndexSizeMap;
   }
 
-  public Map<Integer, Long> getUpsertPartitionToPrimaryKeyCountMap() {
-    return _upsertPartitionToPrimaryKeyCountMap;
+  public Map<Integer, Map<String, Long>> getUpsertPartitionToServerPrimaryKeyCountMap() {
+    return _upsertPartitionToServerPrimaryKeyCountMap;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/TableMetadataInfo.java
@@ -43,6 +43,7 @@ public class TableMetadataInfo {
   private final Map<String, Double> _columnCardinalityMap;
   private final Map<String, Double> _maxNumMultiValuesMap;
   private final Map<String, Map<String, Double>> _columnIndexSizeMap;
+  private final Map<Integer, Long> _upsertPartitionToPrimaryKeyCountMap;
 
   @JsonCreator
   public TableMetadataInfo(@JsonProperty("tableName") String tableName,
@@ -50,7 +51,8 @@ public class TableMetadataInfo {
       @JsonProperty("numRows") long numRows, @JsonProperty("columnLengthMap") Map<String, Double> columnLengthMap,
       @JsonProperty("columnCardinalityMap") Map<String, Double> columnCardinalityMap,
       @JsonProperty("maxNumMultiValuesMap") Map<String, Double> maxNumMultiValuesMap,
-      @JsonProperty("columnIndexSizeMap") Map<String, Map<String, Double>> columnIndexSizeMap) {
+      @JsonProperty("columnIndexSizeMap") Map<String, Map<String, Double>> columnIndexSizeMap,
+      @JsonProperty("upsertPartitionToPrimaryKeyCountMap") Map<Integer, Long> upsertPartitionToPrimaryKeyCountMap) {
     _tableName = tableName;
     _diskSizeInBytes = sizeInBytes;
     _numSegments = numSegments;
@@ -59,6 +61,7 @@ public class TableMetadataInfo {
     _columnCardinalityMap = columnCardinalityMap;
     _maxNumMultiValuesMap = maxNumMultiValuesMap;
     _columnIndexSizeMap = columnIndexSizeMap;
+    _upsertPartitionToPrimaryKeyCountMap = upsertPartitionToPrimaryKeyCountMap;
   }
 
   public String getTableName() {
@@ -91,5 +94,9 @@ public class TableMetadataInfo {
 
   public Map<String, Map<String, Double>> getColumnIndexSizeMap() {
     return _columnIndexSizeMap;
+  }
+
+  public Map<Integer, Long> getUpsertPartitionToPrimaryKeyCountMap() {
+    return _upsertPartitionToPrimaryKeyCountMap;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -149,9 +149,9 @@ public class ServerSegmentMetadataReader {
       return v;
     });
 
-    // Since table segments may have multiple replicas, divide diskSizeInBytes, numRows, numSegments and primary key
-    // count by numReplica to avoid double counting, for columnAvgLengthMap, columnAvgCardinalityMap and
-    // maxNumMultiValuesMap, dividing by numReplica is not needed since totalNumSegments already contains replicas.
+    // Since table segments may have multiple replicas, divide diskSizeInBytes, numRows and numSegments by numReplica
+    // to avoid double counting, for columnAvgLengthMap, columnAvgCardinalityMap and maxNumMultiValuesMap, dividing by
+    // numReplica is not needed since totalNumSegments already contains replicas.
     totalDiskSizeInBytes /= numReplica;
     totalNumSegments /= numReplica;
     totalNumRows /= numReplica;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -701,6 +702,18 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   @VisibleForTesting
   public TableUpsertMetadataManager getTableUpsertMetadataManager() {
     return _tableUpsertMetadataManager;
+  }
+
+  /**
+   * Retrieves a mapping of partition id to the primary key count for the partition.
+   *
+   * @return A {@code Map} where keys are partition id and values are count of primary keys for that specific partition.
+   */
+  public Map<Integer, Long> getUpsertPartitionToPrimaryKeyCount() {
+    if (isUpsertEnabled()) {
+      return _tableUpsertMetadataManager.getPartitionToPrimaryKeyCount();
+    }
+    return new HashMap<>();
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -23,7 +23,7 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
-import java.util.HashMap;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -713,7 +713,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
     if (isUpsertEnabled()) {
       return _tableUpsertMetadataManager.getPartitionToPrimaryKeyCount();
     }
-    return new HashMap<>();
+    return Collections.emptyMap();
   }
 
   /**

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/models/DummyTableUpsertMetadataManager.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/models/DummyTableUpsertMetadataManager.java
@@ -75,7 +75,7 @@ public class DummyTableUpsertMetadataManager extends BaseTableUpsertMetadataMana
 
   @Override
   public Map<Integer, Long> getPartitionToPrimaryKeyCount() {
-    return null;
+    return Collections.emptyMap();
   }
 
   @Override

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/models/DummyTableUpsertMetadataManager.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/models/DummyTableUpsertMetadataManager.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.Iterator;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import org.apache.helix.HelixManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
@@ -70,6 +71,11 @@ public class DummyTableUpsertMetadataManager extends BaseTableUpsertMetadataMana
 
   @Override
   public void stop() {
+  }
+
+  @Override
+  public Map<Integer, Long> getPartitionToPrimaryKeyCount() {
+    return null;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.upsert;
 
 import java.io.IOException;
+import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.ThreadSafe;
@@ -43,6 +44,15 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
     for (ConcurrentMapPartitionUpsertMetadataManager metadataManager : _partitionMetadataManagerMap.values()) {
       metadataManager.stop();
     }
+  }
+
+  @Override
+  public Map<Integer, Long> getPartitionToPrimaryKeyCount() {
+    Map<Integer, Long> partitionToPrimaryKeyCount = new HashMap<>();
+    for (Integer partitionID : _partitionMetadataManagerMap.keySet()) {
+      partitionToPrimaryKeyCount.put(partitionID, _partitionMetadataManagerMap.get(partitionID).getNumPrimaryKeys());
+    }
+    return partitionToPrimaryKeyCount;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -49,9 +49,9 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   @Override
   public Map<Integer, Long> getPartitionToPrimaryKeyCount() {
     Map<Integer, Long> partitionToPrimaryKeyCount = new HashMap<>();
-    for (Integer partitionID : _partitionMetadataManagerMap.keySet()) {
-      partitionToPrimaryKeyCount.put(partitionID, _partitionMetadataManagerMap.get(partitionID).getNumPrimaryKeys());
-    }
+    _partitionMetadataManagerMap.forEach(
+        (partitionID, upsertMetadataManager) -> partitionToPrimaryKeyCount.put(partitionID,
+            upsertMetadataManager.getNumPrimaryKeys()));
     return partitionToPrimaryKeyCount;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.upsert;
 
 import java.io.Closeable;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.ThreadSafe;
@@ -46,6 +47,13 @@ public interface TableUpsertMetadataManager extends Closeable {
    * Stops the metadata manager. After invoking this method, no access to the metadata will be accepted.
    */
   void stop();
+
+  /**
+   * Retrieves a mapping of partition id to the primary key count for the partition.
+   *
+   * @return A {@code Map} where keys are partition id and values are count of primary keys for that specific partition
+   */
+  Map<Integer, Long> getPartitionToPrimaryKeyCount();
 
   boolean isPreloading();
 }

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -291,10 +291,16 @@ public class TablesResource {
       upsertPartitionToPrimaryKeyCountMap = realtimeTableDataManager.getUpsertPartitionToPrimaryKeyCount();
     }
 
+    // construct upsertPartitionToServerPrimaryKeyCountMap to populate in TableMetadataInfo
+    Map<Integer, Map<String, Long>> upsertPartitionToServerPrimaryKeyCountMap = new HashMap<>();
+    upsertPartitionToPrimaryKeyCountMap.forEach(
+        (partition, primaryKeyCount) -> upsertPartitionToServerPrimaryKeyCountMap.put(partition,
+            Map.of(instanceDataManager.getInstanceId(), primaryKeyCount)));
+
     TableMetadataInfo tableMetadataInfo =
         new TableMetadataInfo(tableDataManager.getTableName(), totalSegmentSizeBytes, segmentDataManagers.size(),
             totalNumRows, columnLengthMap, columnCardinalityMap, maxNumMultiValuesMap, columnIndexSizesMap,
-            upsertPartitionToPrimaryKeyCountMap);
+            upsertPartitionToServerPrimaryKeyCountMap);
     return ResourceUtils.convertToJsonString(tableMetadataInfo);
   }
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -77,6 +77,7 @@ import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.core.data.manager.InstanceDataManager;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
 import org.apache.pinot.core.data.manager.realtime.RealtimeSegmentDataManager;
+import org.apache.pinot.core.data.manager.realtime.RealtimeTableDataManager;
 import org.apache.pinot.core.data.manager.realtime.SegmentUploader;
 import org.apache.pinot.segment.local.data.manager.SegmentDataManager;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
@@ -283,9 +284,17 @@ public class TablesResource {
       }
     }
 
+    // fetch partition to primary key count for realtime tables that have upsert enabled
+    Map<Integer, Long> upsertPartitionToPrimaryKeyCountMap = new HashMap<>();
+    if (tableDataManager instanceof RealtimeTableDataManager) {
+      RealtimeTableDataManager realtimeTableDataManager = (RealtimeTableDataManager) tableDataManager;
+      upsertPartitionToPrimaryKeyCountMap = realtimeTableDataManager.getUpsertPartitionToPrimaryKeyCount();
+    }
+
     TableMetadataInfo tableMetadataInfo =
         new TableMetadataInfo(tableDataManager.getTableName(), totalSegmentSizeBytes, segmentDataManagers.size(),
-            totalNumRows, columnLengthMap, columnCardinalityMap, maxNumMultiValuesMap, columnIndexSizesMap);
+            totalNumRows, columnLengthMap, columnCardinalityMap, maxNumMultiValuesMap, columnIndexSizesMap,
+            upsertPartitionToPrimaryKeyCountMap);
     return ResourceUtils.convertToJsonString(tableMetadataInfo);
   }
 


### PR DESCRIPTION
## Scope of the PR
Enhance **server and controller API** to return **partition to primary key count** for realtime tables that have **upsert** enabled:
1. Server API: returns the map for all the partitions hosted by the instance.
2. Controller API: returns the map for the table.

## Testing
The changes were tested locally by invoking the **server endpoint** followed by **controller endpoint** to test that there is no duplication in counting PK's. The replication of segments across servers could be a potential reason for duplication, but the controller API has taken care of it.

- Server responses: 
```
{
    "tableName": "upsertMeetupRsvp_REALTIME",
    "diskSizeInBytes": 0,
    "numSegments": 1,
    "numRows": 0,
    "columnLengthMap": {},
    "columnCardinalityMap": {},
    "maxNumMultiValuesMap": {},
    "columnIndexSizeMap": {},
    "upsertPartitionToPrimaryKeyCountMap": {
        "0": 48
    }
},


{
    "tableName": "upsertMeetupRsvp_REALTIME",
    "diskSizeInBytes": 0,
    "numSegments": 1,
    "numRows": 0,
    "columnLengthMap": {},
    "columnCardinalityMap": {},
    "maxNumMultiValuesMap": {},
    "columnIndexSizeMap": {},
    "upsertPartitionToPrimaryKeyCountMap": {
        "1": 45
    }
}
```

- Controller response

```
{
        "tableName": "upsertMeetupRsvp_REALTIME",
        "diskSizeInBytes": 0,
        "numSegments": 2,
        "numRows": 0,
        "columnLengthMap": {},
        "columnCardinalityMap": {},
        "maxNumMultiValuesMap": {},
        "columnIndexSizeMap": {},
        "upsertPartitionToPrimaryKeyCountMap": {
          "0": 48,
          "1": 45
        }
}

```


## Edited Response:

```
{
  "tableName": "upsertJsonMeetupRsvp_REALTIME",
  "diskSizeInBytes": 83788,
  "numSegments": 1,
  "numRows": 72,
  "columnLengthMap": {},
  "columnCardinalityMap": {},
  "maxNumMultiValuesMap": {},
  "columnIndexSizeMap": {},
  "upsertPartitionToServerPrimaryKeyCountMap": {
    "0": {
      "Server_100.84.215.146_7052": 95
    },
    "1": {
      "Server_100.84.215.146_7053": 90
    }
  }
}
```

![image](https://github.com/apache/pinot/assets/35227405/fe2b50b3-22a1-4f33-b768-132e52272cc0)
