### PR TITLE
Making taskManager resources protected for derived classes to override

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
@@ -84,8 +84,8 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
   private static final String PRIMARY_KEY_COL = "playerId";
   private static final String DELETE_COL = "deleted";
 
-  private PinotTaskManager _taskManager;
-  private PinotHelixTaskResourceManager _helixTaskResourceManager;
+  protected PinotTaskManager _taskManager;
+  protected PinotHelixTaskResourceManager _helixTaskResourceManager;
 
   @BeforeClass
   public void setUp()


### PR DESCRIPTION
**What's in the PR:**
UpsertTableIntegrationTest is a public class which has been extended to implement custom tests with its own setUp() methods. (outside OSS). Making minion resource handles protected for subclasses to override.

**Why its needed:**
Since derived classes that extend UpsertTableIntegrationTest can override setUp() methods, we want the ability to instantiate minion resource handles as well (pinotTaskManager, PinotHelixTaskResourceManager)
