### PR TITLE
Cleaning replication delay metrics on cleanupMetrics

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1127,6 +1127,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
    */
   private void cleanupMetrics() {
     _serverMetrics.removeTableGauge(_clientId, ServerGauge.LLC_PARTITION_CONSUMING);
+    _realtimeTableDataManager.onConsumingToDropped(_segmentNameStr);
   }
 
   protected void hold() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1127,7 +1127,6 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
    */
   private void cleanupMetrics() {
     _serverMetrics.removeTableGauge(_clientId, ServerGauge.LLC_PARTITION_CONSUMING);
-    _realtimeTableDataManager.onConsumingToDropped(_segmentNameStr);
   }
 
   protected void hold() {

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentOnlineOfflineStateModelFactory.java
@@ -139,6 +139,11 @@ public class SegmentOnlineOfflineStateModelFactory extends StateModelFactory<Sta
       String segmentName = message.getPartitionName();
       try {
         _instanceDataManager.offloadSegment(realtimeTableName, segmentName);
+        // At this point ingestion thread should be stopped, we notify tableManager so it can remove its resources
+        // safely
+        TableDataManager tableDataManager = _instanceDataManager.getTableDataManager(realtimeTableName);
+        Preconditions.checkState(tableDataManager != null, "Failed to find table: %s", realtimeTableName);
+        tableDataManager.onConsumingToDropped(segmentName);
       } catch (Exception e) {
         _logger.error("Caught exception in state transition CONSUMING -> OFFLINE for table: {}, segment: {}",
             realtimeTableName, segmentName, e);


### PR DESCRIPTION
Labels:
* `bugfix`
* `observability`

Metric `realtimeIngestionDelayMs` were not deleted on rebalance. For example imagine a cluster with two servers where 5 partitions are in server 0 and 5 in server 1. After changing the tenants, all partitions are moved to server 0. Before this patch nobody notified `RealtimeTableDataManager` about that, so `realtimeIngestionDelayMs` increased continuously.

Requesting reviews from @suddendust @zhtaoxiang @jugomezv @Jackie-Jiang @klsince, who are the people that recently touched the related classes.

This bug is related to #12344. Although in this case the problem was not when a table was deleted but when a rebalance was executed.

EDIT: Initially this PR added a call to `RealtimeTableDataManager.onConsumingToDropped()` in `RealtimeDataManager.cleanupMetrics()`. During the PR we decided to move the call to `SegmentOnlineOfflineStateModelFactory.onBecomeOfflineFromConsuming`