### PR TITLE
making nonLeaderForTables exhaustive

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -77,8 +77,6 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
 
   private TableSizeReader _tableSizeReader;
 
-  private Set<String> _cachedTableNamesWithType = new HashSet<>();
-
   /**
    * Constructs the segment status checker.
    * @param pinotHelixResourceManager The resource checker used to interact with Helix
@@ -152,12 +150,6 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
         _controllerMetrics.setValueOfTableGauge(tableNameWithType, ControllerGauge.TABLE_DISABLED, 0);
       }
     });
-
-    // Remove metrics for tables that are no longer in the cluster
-    _cachedTableNamesWithType.removeAll(context._processedTables);
-    _cachedTableNamesWithType.forEach(this::removeMetricsForTable);
-    _cachedTableNamesWithType.clear();
-    _cachedTableNamesWithType.addAll(context._processedTables);
   }
 
   /**
@@ -350,6 +342,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
   }
 
   private void removeMetricsForTable(String tableNameWithType) {
+    LOGGER.info("Removing metrics from {} given it is not a table known by Helix", tableNameWithType);
     _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.NUMBER_OF_REPLICAS);
     _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.PERCENT_OF_REPLICAS);
     _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/periodictask/ControllerPeriodicTask.java
@@ -97,9 +97,12 @@ public abstract class ControllerPeriodicTask<C> extends BasePeriodicTask {
   }
 
   /**
-   * Processes the given list of tables, and returns the number of tables processed.
+   * Processes the given list of tables lead by the current controller, and returns the number of tables processed.
    * <p>
    * Override one of this method, {@link #processTable(String)} or {@link #processTable(String, C)}.
+   * <p/>
+   * Note: This method is called each time the task is executed <b>if and only if</b> the current controller is the
+   * leader of at least one table. A corollary is that it won't be called every time the task is executed.
    */
   protected void processTables(List<String> tableNamesWithType, Properties periodicTaskProperties) {
     int numTables = tableNamesWithType.size();
@@ -127,14 +130,14 @@ public abstract class ControllerPeriodicTask<C> extends BasePeriodicTask {
   }
 
   /**
-   * Can be overridden to provide context before processing the tables.
+   * Can be overridden to provide context before processing the tables lead by the current controller.
    */
   protected C preprocess(Properties periodicTaskProperties) {
     return null;
   }
 
   /**
-   * Processes the given table.
+   * Processes the given table lead by the current controller.
    * <p>
    * Override one of this method, {@link #processTable(String)} or {@link #processTables(List, Properties)}.
    */
@@ -143,7 +146,7 @@ public abstract class ControllerPeriodicTask<C> extends BasePeriodicTask {
   }
 
   /**
-   * Processes the given table.
+   * Processes the given table lead by the current controller.
    * <p>
    * Override one of this method, {@link #processTable(String, C)} or {@link #processTables(List, Properties)}.
    */
@@ -151,20 +154,23 @@ public abstract class ControllerPeriodicTask<C> extends BasePeriodicTask {
   }
 
   /**
-   * Can be overridden to perform cleanups after processing the tables.
+   * Can be overridden to perform cleanups after processing the tables lead by the current controller.
    */
   protected void postprocess(C context) {
     postprocess();
   }
 
   /**
-   * Can be overridden to perform cleanups after processing the tables.
+   * Can be overridden to perform cleanups after processing the tables lead by the current controller.
    */
   protected void postprocess() {
   }
 
   /**
-   * Can be overridden to perform cleanups for tables that the current controller isn't the leader.
+   * Can be overridden to perform cleanups for tables the current controller lost the leadership.
+   * <p/>
+   * Note: This method is only being called when there is at least one table in the given list. A corollary is that it
+   * won't be called every time the task is executed.
    *
    * @param tableNamesWithType the table names that the current controller isn't the leader for
    */


### PR DESCRIPTION
Labels:
* `bugfix`
* `observability`

This PR removes a bunch of metrics that should be removed when segments are deleted.

See #12344 