### PR TITLE
Cover the race condition for upsert compaction

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdMetadataInfo.java
@@ -29,18 +29,18 @@ public class ValidDocIdMetadataInfo {
   private final long _totalInvalidDocs;
   private final long _totalDocs;
   private final String _segmentCrc;
-  private final String _validDocIdType;
+  private final String _validDocIdsType;
 
   public ValidDocIdMetadataInfo(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("totalValidDocs") long totalValidDocs, @JsonProperty("totalInvalidDocs") long totalInvalidDocs,
       @JsonProperty("totalDocs") long totalDocs, @JsonProperty("segmentCrc") String segmentCrc,
-      @JsonProperty("validDocIdType") String validDocIdType) {
+      @JsonProperty("validDocIdsType") String validDocIdsType) {
     _segmentName = segmentName;
     _totalValidDocs = totalValidDocs;
     _totalInvalidDocs = totalInvalidDocs;
     _totalDocs = totalDocs;
     _segmentCrc = segmentCrc;
-    _validDocIdType = validDocIdType;
+    _validDocIdsType = validDocIdsType;
   }
 
   public String getSegmentName() {
@@ -63,7 +63,7 @@ public class ValidDocIdMetadataInfo {
     return _segmentCrc;
   }
 
-  public String getValidDocIdType() {
-    return _validDocIdType;
+  public String getValidDocIdsType() {
+    return _validDocIdsType;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdMetadataInfo.java
@@ -29,12 +29,12 @@ public class ValidDocIdMetadataInfo {
   private final long _totalInvalidDocs;
   private final long _totalDocs;
   private final String _segmentCrc;
-  private final String _validDocIdsType;
+  private final ValidDocIdsType _validDocIdsType;
 
   public ValidDocIdMetadataInfo(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("totalValidDocs") long totalValidDocs, @JsonProperty("totalInvalidDocs") long totalInvalidDocs,
       @JsonProperty("totalDocs") long totalDocs, @JsonProperty("segmentCrc") String segmentCrc,
-      @JsonProperty("validDocIdsType") String validDocIdsType) {
+      @JsonProperty("validDocIdsType") ValidDocIdsType validDocIdsType) {
     _segmentName = segmentName;
     _totalValidDocs = totalValidDocs;
     _totalInvalidDocs = totalInvalidDocs;
@@ -63,7 +63,7 @@ public class ValidDocIdMetadataInfo {
     return _segmentCrc;
   }
 
-  public String getValidDocIdsType() {
+  public ValidDocIdsType getValidDocIdsType() {
     return _validDocIdsType;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdMetadataInfo.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdMetadataInfo.java
@@ -28,16 +28,19 @@ public class ValidDocIdMetadataInfo {
   private final long _totalValidDocs;
   private final long _totalInvalidDocs;
   private final long _totalDocs;
-  private final String _crc;
+  private final String _segmentCrc;
+  private final String _validDocIdType;
 
   public ValidDocIdMetadataInfo(@JsonProperty("segmentName") String segmentName,
       @JsonProperty("totalValidDocs") long totalValidDocs, @JsonProperty("totalInvalidDocs") long totalInvalidDocs,
-      @JsonProperty("totalDocs") long totalDocs, @JsonProperty("crc") String crc) {
+      @JsonProperty("totalDocs") long totalDocs, @JsonProperty("segmentCrc") String segmentCrc,
+      @JsonProperty("validDocIdType") String validDocIdType) {
     _segmentName = segmentName;
     _totalValidDocs = totalValidDocs;
     _totalInvalidDocs = totalInvalidDocs;
     _totalDocs = totalDocs;
-    _crc = crc;
+    _segmentCrc = segmentCrc;
+    _validDocIdType = validDocIdType;
   }
 
   public String getSegmentName() {
@@ -56,7 +59,11 @@ public class ValidDocIdMetadataInfo {
     return _totalDocs;
   }
 
-  public String getCrc() {
-    return _crc;
+  public String getSegmentCrc() {
+    return _segmentCrc;
+  }
+
+  public String getValidDocIdType() {
+    return _validDocIdType;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
@@ -24,15 +24,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ValidDocIdsBitmapResponse {
   private final String _segmentName;
   private final String _segmentCrc;
-  private final String _validDocIdType;
+  private final String _validDocIdsType;
   private final byte[] _bitmap;
 
   public ValidDocIdsBitmapResponse(@JsonProperty("segmentName") String segmentName,
-      @JsonProperty("segmentCrc") String crc, @JsonProperty("validDocIdType") String validDocIdType,
+      @JsonProperty("segmentCrc") String crc, @JsonProperty("validDocIdsType") String validDocIdsType,
       @JsonProperty("bitmap") byte[] bitmap) {
     _segmentName = segmentName;
     _segmentCrc = crc;
-    _validDocIdType = validDocIdType;
+    _validDocIdsType = validDocIdsType;
     _bitmap = bitmap;
   }
 
@@ -44,8 +44,8 @@ public class ValidDocIdsBitmapResponse {
     return _segmentCrc;
   }
 
-  public String getValidDocIdType() {
-    return _validDocIdType;
+  public String getValidDocIdsType() {
+    return _validDocIdsType;
   }
 
   public byte[] getBitmap() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
@@ -23,13 +23,16 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 public class ValidDocIdsBitmapResponse {
   private final String _segmentName;
-  private final String _crc;
+  private final String _segmentCrc;
+  private final String _validDocIdType;
   private final byte[] _bitmap;
 
-  public ValidDocIdsBitmapResponse(@JsonProperty("segmentName") String segmentName, @JsonProperty("crc") String crc,
+  public ValidDocIdsBitmapResponse(@JsonProperty("segmentName") String segmentName,
+      @JsonProperty("segmentCrc") String crc, @JsonProperty("validDocIdType") String validDocIdType,
       @JsonProperty("bitmap") byte[] bitmap) {
     _segmentName = segmentName;
-    _crc = crc;
+    _segmentCrc = crc;
+    _validDocIdType = validDocIdType;
     _bitmap = bitmap;
   }
 
@@ -37,8 +40,12 @@ public class ValidDocIdsBitmapResponse {
     return _segmentName;
   }
 
-  public String getCrc() {
-    return _crc;
+  public String getSegmentCrc() {
+    return _segmentCrc;
+  }
+
+  public String getValidDocIdType() {
+    return _validDocIdType;
   }
 
   public byte[] getBitmap() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
@@ -18,45 +18,30 @@
  */
 package org.apache.pinot.common.restlet.resources;
 
-import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 
-@JsonIgnoreProperties(ignoreUnknown = true)
-public class ValidDocIdMetadataInfo {
+public class ValidDocIdsBitmapResponse {
   private final String _segmentName;
-  private final long _totalValidDocs;
-  private final long _totalInvalidDocs;
-  private final long _totalDocs;
   private final String _crc;
+  private final byte[] _bitmap;
 
-  public ValidDocIdMetadataInfo(@JsonProperty("segmentName") String segmentName,
-      @JsonProperty("totalValidDocs") long totalValidDocs, @JsonProperty("totalInvalidDocs") long totalInvalidDocs,
-      @JsonProperty("totalDocs") long totalDocs, @JsonProperty("crc") String crc) {
+  public ValidDocIdsBitmapResponse(@JsonProperty("segmentName") String segmentName, @JsonProperty("crc") String crc,
+      @JsonProperty("bitmap") byte[] bitmap) {
     _segmentName = segmentName;
-    _totalValidDocs = totalValidDocs;
-    _totalInvalidDocs = totalInvalidDocs;
-    _totalDocs = totalDocs;
     _crc = crc;
+    _bitmap = bitmap;
   }
 
   public String getSegmentName() {
     return _segmentName;
   }
 
-  public long getTotalValidDocs() {
-    return _totalValidDocs;
-  }
-
-  public long getTotalInvalidDocs() {
-    return _totalInvalidDocs;
-  }
-
-  public long getTotalDocs() {
-    return _totalDocs;
-  }
-
   public String getCrc() {
     return _crc;
+  }
+
+  public byte[] getBitmap() {
+    return _bitmap;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsBitmapResponse.java
@@ -24,11 +24,11 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 public class ValidDocIdsBitmapResponse {
   private final String _segmentName;
   private final String _segmentCrc;
-  private final String _validDocIdsType;
+  private final ValidDocIdsType _validDocIdsType;
   private final byte[] _bitmap;
 
   public ValidDocIdsBitmapResponse(@JsonProperty("segmentName") String segmentName,
-      @JsonProperty("segmentCrc") String crc, @JsonProperty("validDocIdsType") String validDocIdsType,
+      @JsonProperty("segmentCrc") String crc, @JsonProperty("validDocIdsType") ValidDocIdsType validDocIdsType,
       @JsonProperty("bitmap") byte[] bitmap) {
     _segmentName = segmentName;
     _segmentCrc = crc;
@@ -44,7 +44,7 @@ public class ValidDocIdsBitmapResponse {
     return _segmentCrc;
   }
 
-  public String getValidDocIdsType() {
+  public ValidDocIdsType getValidDocIdsType() {
     return _validDocIdsType;
   }
 

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsType.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.restlet.resources;
+
+public enum ValidDocIdsType {
+  // Default validDocIds type. This indicates that the validDocIds bitmap is loaded from the snapshot from the
+  // Pinot segment. UpsertConfig's 'enableSnapshot' must be enabled for this type.
+  SNAPSHOT("snapshot"),
+  // This indicates that the validDocIds bitmap is loaded from the real-time server.
+  ON_HEAP("onHeap"),
+  // This indicates that the validDocIds bitmap is read from the real-time server. The valid document ids here does
+  // take account into the deleted records. UpsertConfig's 'deleteRecordColumn' must be provided for this type.
+  ON_HEAP_WITH_DELETE("onHeapWithDelete");
+
+  private final String _type;
+
+  ValidDocIdsType(String type) {
+    _type = type;
+  }
+
+  @Override
+  public String toString() {
+    return _type;
+  }
+
+  public static ValidDocIdsType fromString(String type) {
+    for (ValidDocIdsType validDocIdsType : ValidDocIdsType.values()) {
+      if (validDocIdsType.toString().equalsIgnoreCase(type)) {
+        return validDocIdsType;
+      }
+    }
+    throw new IllegalArgumentException("Invalid validDocIds type: " + type);
+  }
+}

--- a/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsType.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/restlet/resources/ValidDocIdsType.java
@@ -21,30 +21,19 @@ package org.apache.pinot.common.restlet.resources;
 public enum ValidDocIdsType {
   // Default validDocIds type. This indicates that the validDocIds bitmap is loaded from the snapshot from the
   // Pinot segment. UpsertConfig's 'enableSnapshot' must be enabled for this type.
-  SNAPSHOT("snapshot"),
-  // This indicates that the validDocIds bitmap is loaded from the real-time server.
-  ON_HEAP("onHeap"),
-  // This indicates that the validDocIds bitmap is read from the real-time server. The valid document ids here does
-  // take account into the deleted records. UpsertConfig's 'deleteRecordColumn' must be provided for this type.
-  ON_HEAP_WITH_DELETE("onHeapWithDelete");
+  SNAPSHOT,
 
-  private final String _type;
+  // This indicates that the validDocIds bitmap is loaded from the real-time server's in-memory.
+  //
+  // NOTE: Using in-memory based validDocids bitmap is a bit dangerous as it will not give us the consistency in some
+  // cases (e.g. fetching validDocIds bitmap while the server is restarting & updating validDocIds).
+  IN_MEMORY,
 
-  ValidDocIdsType(String type) {
-    _type = type;
-  }
-
-  @Override
-  public String toString() {
-    return _type;
-  }
-
-  public static ValidDocIdsType fromString(String type) {
-    for (ValidDocIdsType validDocIdsType : ValidDocIdsType.values()) {
-      if (validDocIdsType.toString().equalsIgnoreCase(type)) {
-        return validDocIdsType;
-      }
-    }
-    throw new IllegalArgumentException("Invalid validDocIds type: " + type);
-  }
+  // This indicates that the validDocIds bitmap is read from the real-time server's in-memory. The valid document ids
+  // here does take account into the deleted records. UpsertConfig's 'deleteRecordColumn' must be provided for this
+  // type.
+  //
+  // NOTE: Using in-memory based validDocids bitmap is a bit dangerous as it will not give us the consistency in some
+  // cases (e.g. fetching validDocIds bitmap while the server is restarting & updating validDocIds).
+  IN_MEMORY_WITH_DELETE;
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -961,7 +961,7 @@ public class PinotTableRestletResource {
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
       @ApiParam(value = "A list of segments", allowMultiple = true) @QueryParam("segmentNames")
       List<String> segmentNames,
-      @ApiParam(value = "Valid doc id type", example = "validDocIdsSnapshot|validDocIds|queryableDocIds")
+      @ApiParam(value = "Valid doc id type", example = "snapshot|onHeap|onHeapWithDelete")
       @QueryParam("validDocIdsType") String validDocIdsType) {
     LOGGER.info("Received a request to fetch aggregate valid doc id metadata for a table {}", tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -961,7 +961,7 @@ public class PinotTableRestletResource {
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
       @ApiParam(value = "A list of segments", allowMultiple = true) @QueryParam("segmentNames")
       List<String> segmentNames,
-      @ApiParam(value = "Valid doc id type", example = "snapshot|onHeap|onHeapWithDelete")
+      @ApiParam(value = "Valid doc id type", example = "SNAPSHOT|IN_MEMORY|IN_MEMORY_WITH_DELETE")
       @QueryParam("validDocIdsType") String validDocIdsType) {
     LOGGER.info("Received a request to fetch aggregate valid doc id metadata for a table {}", tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -962,7 +962,7 @@ public class PinotTableRestletResource {
       @ApiParam(value = "A list of segments", allowMultiple = true) @QueryParam("segmentNames")
       List<String> segmentNames,
       @ApiParam(value = "Valid doc id type", example = "validDocIdsSnapshot|validDocIds|queryableDocIds")
-      @QueryParam("validDocIdType") String validDocIdType) {
+      @QueryParam("validDocIdsType") String validDocIdsType) {
     LOGGER.info("Received a request to fetch aggregate valid doc id metadata for a table {}", tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);
     if (tableType == TableType.OFFLINE) {
@@ -977,7 +977,7 @@ public class PinotTableRestletResource {
       TableMetadataReader tableMetadataReader =
           new TableMetadataReader(_executor, _connectionManager, _pinotHelixResourceManager);
       JsonNode segmentsMetadataJson =
-          tableMetadataReader.getAggregateValidDocIdMetadata(tableNameWithType, segmentNames, validDocIdType,
+          tableMetadataReader.getAggregateValidDocIdMetadata(tableNameWithType, segmentNames, validDocIdsType,
               _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
       validDocIdMetadata = JsonUtils.objectToPrettyString(segmentsMetadataJson);
     } catch (InvalidConfigException e) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotTableRestletResource.java
@@ -960,7 +960,9 @@ public class PinotTableRestletResource {
       @ApiParam(value = "Name of the table", required = true) @PathParam("tableName") String tableName,
       @ApiParam(value = "OFFLINE|REALTIME") @QueryParam("type") String tableTypeStr,
       @ApiParam(value = "A list of segments", allowMultiple = true) @QueryParam("segmentNames")
-      List<String> segmentNames) {
+      List<String> segmentNames,
+      @ApiParam(value = "Valid doc id type", example = "validDocIdsSnapshot|validDocIds|queryableDocIds")
+      @QueryParam("validDocIdType") String validDocIdType) {
     LOGGER.info("Received a request to fetch aggregate valid doc id metadata for a table {}", tableName);
     TableType tableType = Constants.validateTableType(tableTypeStr);
     if (tableType == TableType.OFFLINE) {
@@ -975,7 +977,7 @@ public class PinotTableRestletResource {
       TableMetadataReader tableMetadataReader =
           new TableMetadataReader(_executor, _connectionManager, _pinotHelixResourceManager);
       JsonNode segmentsMetadataJson =
-          tableMetadataReader.getAggregateValidDocIdMetadata(tableNameWithType, segmentNames,
+          tableMetadataReader.getAggregateValidDocIdMetadata(tableNameWithType, segmentNames, validDocIdType,
               _controllerConf.getServerAdminRequestTimeoutSeconds() * 1000);
       validDocIdMetadata = JsonUtils.objectToPrettyString(segmentsMetadataJson);
     } catch (InvalidConfigException e) {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ServerSegmentMetadataReader.java
@@ -211,7 +211,7 @@ public class ServerSegmentMetadataReader {
    */
   public List<ValidDocIdMetadataInfo> getValidDocIdMetadataFromServer(String tableNameWithType,
       Map<String, List<String>> serverToSegmentsMap, BiMap<String, String> serverToEndpoints,
-      @Nullable List<String> segmentNames, int timeoutMs, String validDocIdType) {
+      @Nullable List<String> segmentNames, int timeoutMs, String validDocIdsType) {
     List<Pair<String, String>> serverURLsAndBodies = new ArrayList<>();
     for (Map.Entry<String, List<String>> serverToSegments : serverToSegmentsMap.entrySet()) {
       List<String> segmentsForServer = serverToSegments.getValue();
@@ -226,7 +226,7 @@ public class ServerSegmentMetadataReader {
           }
         }
       }
-      serverURLsAndBodies.add(generateValidDocIdMetadataURL(tableNameWithType, segmentsToQuery, validDocIdType,
+      serverURLsAndBodies.add(generateValidDocIdMetadataURL(tableNameWithType, segmentsToQuery, validDocIdsType,
           serverToEndpoints.get(serverToSegments.getKey())));
     }
 
@@ -276,10 +276,10 @@ public class ServerSegmentMetadataReader {
    * @return a bitmap of validDocIds
    */
   @Deprecated
-  public RoaringBitmap getValidDocIdsFromServer(String tableNameWithType, String segmentName, String validDocIdType,
+  public RoaringBitmap getValidDocIdsFromServer(String tableNameWithType, String segmentName, String validDocIdsType,
       String endpoint, int timeoutMs) {
     // Build the endpoint url
-    String url = generateValidDocIdsURL(tableNameWithType, segmentName, validDocIdType, endpoint);
+    String url = generateValidDocIdsURL(tableNameWithType, segmentName, validDocIdsType, endpoint);
 
     // Set timeout
     ClientConfig clientConfig = new ClientConfig();
@@ -300,9 +300,9 @@ public class ServerSegmentMetadataReader {
    * @return a bitmap of validDocIds
    */
   public ValidDocIdsBitmapResponse getValidDocIdsBitmapFromServer(String tableNameWithType, String segmentName,
-      String endpoint, String validDocIdType, int timeoutMs) {
+      String endpoint, String validDocIdsType, int timeoutMs) {
     // Build the endpoint url
-    String url = generateValidDocIdsBitmapURL(tableNameWithType, segmentName, validDocIdType, endpoint);
+    String url = generateValidDocIdsBitmapURL(tableNameWithType, segmentName, validDocIdsType, endpoint);
 
     // Set timeout
     ClientConfig clientConfig = new ClientConfig();
@@ -332,30 +332,30 @@ public class ServerSegmentMetadataReader {
   }
 
   @Deprecated
-  private String generateValidDocIdsURL(String tableNameWithType, String segmentName, String validDocIdType,
+  private String generateValidDocIdsURL(String tableNameWithType, String segmentName, String validDocIdsType,
       String endpoint) {
     tableNameWithType = URLEncoder.encode(tableNameWithType, StandardCharsets.UTF_8);
     segmentName = URLEncoder.encode(segmentName, StandardCharsets.UTF_8);
     String url = String.format("%s/segments/%s/%s/validDocIds", endpoint, tableNameWithType, segmentName);
-    if (validDocIdType != null) {
-      url = url + "?validDocIdType=" + validDocIdType;
+    if (validDocIdsType != null) {
+      url = url + "?validDocIdsType=" + validDocIdsType;
     }
     return url;
   }
 
-  private String generateValidDocIdsBitmapURL(String tableNameWithType, String segmentName, String validDocIdType,
+  private String generateValidDocIdsBitmapURL(String tableNameWithType, String segmentName, String validDocIdsType,
       String endpoint) {
     tableNameWithType = URLEncoder.encode(tableNameWithType, StandardCharsets.UTF_8);
     segmentName = URLEncoder.encode(segmentName, StandardCharsets.UTF_8);
     String url = String.format("%s/segments/%s/%s/validDocIdsBitmap", endpoint, tableNameWithType, segmentName);
-    if (validDocIdType != null) {
-      url = url + "?validDocIdType=" + validDocIdType;
+    if (validDocIdsType != null) {
+      url = url + "?validDocIdsType=" + validDocIdsType;
     }
     return url;
   }
 
   private Pair<String, String> generateValidDocIdMetadataURL(String tableNameWithType, List<String> segmentNames,
-      String validDocIdType, String endpoint) {
+      String validDocIdsType, String endpoint) {
     tableNameWithType = URLEncoder.encode(tableNameWithType, StandardCharsets.UTF_8);
     TableSegments tableSegments = new TableSegments(segmentNames);
     String jsonTableSegments;
@@ -366,8 +366,8 @@ public class ServerSegmentMetadataReader {
       throw new RuntimeException(e);
     }
     String url = String.format("%s/tables/%s/validDocIdMetadata", endpoint, tableNameWithType);
-    if (validDocIdType != null) {
-      url = url + "?validDocIdType=" + validDocIdType;
+    if (validDocIdsType != null) {
+      url = url + "?validDocIdsType=" + validDocIdsType;
     }
     return Pair.of(url, jsonTableSegments);
   }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -140,7 +140,7 @@ public class TableMetadataReader {
    */
   public JsonNode getAggregateTableMetadata(String tableNameWithType, List<String> columns, int numReplica,
       int timeoutMs)
-      throws InvalidConfigException, IOException {
+      throws InvalidConfigException {
     final Map<String, List<String>> serverToSegments =
         _pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType);
     BiMap<String, String> endpoints =
@@ -158,7 +158,8 @@ public class TableMetadataReader {
    * This method retrieves the aggregated valid doc id metadata for a given table.
    * @return a list of ValidDocIdMetadataInfo
    */
-  public JsonNode getAggregateValidDocIdMetadata(String tableNameWithType, List<String> segmentNames, int timeoutMs)
+  public JsonNode getAggregateValidDocIdMetadata(String tableNameWithType, List<String> segmentNames,
+      String validDocIdType, int timeoutMs)
       throws InvalidConfigException {
     final Map<String, List<String>> serverToSegments =
         _pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType);
@@ -169,7 +170,7 @@ public class TableMetadataReader {
 
     List<ValidDocIdMetadataInfo> aggregateTableMetadataInfo =
         serverSegmentMetadataReader.getValidDocIdMetadataFromServer(tableNameWithType, serverToSegments, endpoints,
-            segmentNames, timeoutMs);
+            segmentNames, timeoutMs, validDocIdType);
     return JsonUtils.objectToJsonNode(aggregateTableMetadataInfo);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/TableMetadataReader.java
@@ -159,7 +159,7 @@ public class TableMetadataReader {
    * @return a list of ValidDocIdMetadataInfo
    */
   public JsonNode getAggregateValidDocIdMetadata(String tableNameWithType, List<String> segmentNames,
-      String validDocIdType, int timeoutMs)
+      String validDocIdsType, int timeoutMs)
       throws InvalidConfigException {
     final Map<String, List<String>> serverToSegments =
         _pinotHelixResourceManager.getServerToSegmentsMap(tableNameWithType);
@@ -170,7 +170,7 @@ public class TableMetadataReader {
 
     List<ValidDocIdMetadataInfo> aggregateTableMetadataInfo =
         serverSegmentMetadataReader.getValidDocIdMetadataFromServer(tableNameWithType, serverToSegments, endpoints,
-            segmentNames, timeoutMs, validDocIdType);
+            segmentNames, timeoutMs, validDocIdsType);
     return JsonUtils.objectToJsonNode(aggregateTableMetadataInfo);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -166,8 +166,7 @@ public class MinionConstants {
     public static final String INVALID_RECORDS_THRESHOLD_COUNT = "invalidRecordsThresholdCount";
 
     /**
-     * Valid doc id type ('validDocIdsSnapshot', `validDocIds`, `queryableDocIds`). If not set, 'validDocIdsSnapshot'
-     * is used.
+     * Valid doc id type
      */
     public static final String VALID_DOC_IDS_TYPE = "validDocIdsType";
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -169,6 +169,6 @@ public class MinionConstants {
      * Valid doc id type ('validDocIdsSnapshot', `validDocIds`, `queryableDocIds`). If not set, 'validDocIdsSnapshot'
      * is used.
      */
-    public static final String VALID_DOC_ID_TYPE = "validDocIdType";
+    public static final String VALID_DOC_IDS_TYPE = "validDocIdsType";
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -164,5 +164,11 @@ public class MinionConstants {
      * e.g. if the count surpasses 100k, then the segment may be compacted
      */
     public static final String INVALID_RECORDS_THRESHOLD_COUNT = "invalidRecordsThresholdCount";
+
+    /**
+     * Valid doc id type ('validDocIdsSnapshot', `validDocIds`, `queryableDocIds`). If not set, 'validDocIdsSnapshot'
+     * is used.
+     */
+    public static final String VALID_DOC_ID_TYPE = "validDocIdType";
   }
 }

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTest.java
@@ -405,6 +405,7 @@ public abstract class BaseClusterIntegrationTest extends ClusterTest {
 
     if (upsertConfig == null) {
       upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
+      upsertConfig.setEnableSnapshot(true);
     }
     if (kafkaTopicName == null) {
       kafkaTopicName = getKafkaTopic();

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
@@ -520,7 +520,7 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
     TableTaskConfig taskConfig = getCompactionTaskConfig();
     Map<String, String> compactionTaskConfig =
         taskConfig.getConfigsForTaskType(MinionConstants.UpsertCompactionTask.TASK_TYPE);
-    compactionTaskConfig.put("validDocIdType", "queryableDocIds");
+    compactionTaskConfig.put("validDocIdsType", "queryableDocIds");
     taskConfig = new TableTaskConfig(
         Collections.singletonMap(MinionConstants.UpsertCompactionTask.TASK_TYPE, compactionTaskConfig));
     tableConfig.setTaskConfig(taskConfig);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
@@ -458,11 +458,13 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
       throws Exception {
     final UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
     upsertConfig.setDeleteRecordColumn(DELETE_COL);
+    upsertConfig.setEnableSnapshot(true);
     String tableName = "gameScoresWithCompaction";
     TableConfig tableConfig =
         setupTable(tableName, getKafkaTopic() + "-with-compaction", INPUT_DATA_LARGE_TAR_FILE, upsertConfig);
     tableConfig.setTaskConfig(getCompactionTaskConfig());
     updateTableConfig(tableConfig);
+
     waitForAllDocsLoaded(tableName, 600_000L, 1000);
     assertEquals(getScore(tableName), 3692);
     waitForNumQueriedSegmentsToConverge(tableName, 10_000L, 3);
@@ -483,6 +485,7 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
       throws Exception {
     final UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
     upsertConfig.setDeleteRecordColumn(DELETE_COL);
+    upsertConfig.setEnableSnapshot(true);
     String tableName = "gameScoresWithCompactionDeleteSegments";
     String kafkaTopicName = getKafkaTopic() + "-with-compaction-segment-delete";
     TableConfig tableConfig = setupTable(tableName, kafkaTopicName, INPUT_DATA_LARGE_TAR_FILE, upsertConfig);
@@ -514,7 +517,13 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
     String tableName = "gameScoresWithCompactionWithSoftDelete";
     String kafkaTopicName = getKafkaTopic() + "-with-compaction-delete";
     TableConfig tableConfig = setupTable(tableName, kafkaTopicName, INPUT_DATA_LARGE_TAR_FILE, upsertConfig);
-    tableConfig.setTaskConfig(getCompactionTaskConfig());
+    TableTaskConfig taskConfig = getCompactionTaskConfig();
+    Map<String, String> compactionTaskConfig =
+        taskConfig.getConfigsForTaskType(MinionConstants.UpsertCompactionTask.TASK_TYPE);
+    compactionTaskConfig.put("validDocIdType", "queryableDocIds");
+    taskConfig = new TableTaskConfig(
+        Collections.singletonMap(MinionConstants.UpsertCompactionTask.TASK_TYPE, compactionTaskConfig));
+    tableConfig.setTaskConfig(taskConfig);
     updateTableConfig(tableConfig);
 
     // Push data one more time

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
@@ -521,7 +521,7 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
     TableTaskConfig taskConfig = getCompactionTaskConfig();
     Map<String, String> compactionTaskConfig =
         taskConfig.getConfigsForTaskType(MinionConstants.UpsertCompactionTask.TASK_TYPE);
-    compactionTaskConfig.put("validDocIdsType", ValidDocIdsType.ON_HEAP_WITH_DELETE.toString());
+    compactionTaskConfig.put("validDocIdsType", ValidDocIdsType.IN_MEMORY_WITH_DELETE.toString());
     taskConfig = new TableTaskConfig(
         Collections.singletonMap(MinionConstants.UpsertCompactionTask.TASK_TYPE, compactionTaskConfig));
     tableConfig.setTaskConfig(taskConfig);

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/UpsertTableIntegrationTest.java
@@ -35,6 +35,7 @@ import org.apache.helix.HelixManager;
 import org.apache.helix.model.InstanceConfig;
 import org.apache.helix.task.TaskState;
 import org.apache.pinot.client.ResultSet;
+import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.common.utils.helix.HelixHelper;
 import org.apache.pinot.controller.helix.core.minion.PinotHelixTaskResourceManager;
@@ -520,7 +521,7 @@ public class UpsertTableIntegrationTest extends BaseClusterIntegrationTestSet {
     TableTaskConfig taskConfig = getCompactionTaskConfig();
     Map<String, String> compactionTaskConfig =
         taskConfig.getConfigsForTaskType(MinionConstants.UpsertCompactionTask.TASK_TYPE);
-    compactionTaskConfig.put("validDocIdsType", "queryableDocIds");
+    compactionTaskConfig.put("validDocIdsType", ValidDocIdsType.ON_HEAP_WITH_DELETE.toString());
     taskConfig = new TableTaskConfig(
         Collections.singletonMap(MinionConstants.UpsertCompactionTask.TASK_TYPE, compactionTaskConfig));
     tableConfig.setTaskConfig(taskConfig);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.helix.HelixAdmin;
 import org.apache.helix.model.ExternalView;
 import org.apache.helix.model.InstanceConfig;
+import org.apache.pinot.common.restlet.resources.ValidDocIdsBitmapResponse;
 import org.apache.pinot.common.utils.config.InstanceUtils;
 import org.apache.pinot.controller.helix.core.minion.ClusterInfoAccessor;
 import org.apache.pinot.controller.util.ServerSegmentMetadataReader;
@@ -37,7 +38,6 @@ import org.apache.pinot.spi.plugin.PluginManager;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.IngestionConfigUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
-import org.roaringbitmap.RoaringBitmap;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -139,8 +139,8 @@ public class MinionTaskUtils {
     return dirInStr;
   }
 
-  public static RoaringBitmap getValidDocIds(String tableNameWithType, String segmentName, Map<String, String> configs,
-      MinionContext minionContext) {
+  public static ValidDocIdsBitmapResponse getValidDocIdsBitmap(String tableNameWithType, String segmentName,
+      Map<String, String> configs, MinionContext minionContext) {
     HelixAdmin helixAdmin = minionContext.getHelixManager().getClusterManagmentTool();
     String clusterName = minionContext.getHelixManager().getClusterName();
 
@@ -151,7 +151,7 @@ public class MinionTaskUtils {
     // We only need aggregated table size and the total number of docs/rows. Skipping column related stats, by
     // passing an empty list.
     ServerSegmentMetadataReader serverSegmentMetadataReader = new ServerSegmentMetadataReader();
-    return serverSegmentMetadataReader.getValidDocIdsFromServer(tableNameWithType, segmentName, endpoint, 60_000);
+    return serverSegmentMetadataReader.getValidDocIdsBitmapFromServer(tableNameWithType, segmentName, endpoint, 60_000);
   }
 
   public static String getServer(String segmentName, String tableNameWithType, HelixAdmin helixAdmin,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -140,7 +140,7 @@ public class MinionTaskUtils {
   }
 
   public static ValidDocIdsBitmapResponse getValidDocIdsBitmap(String tableNameWithType, String segmentName,
-      String validDocIdType, MinionContext minionContext) {
+      String validDocIdsType, MinionContext minionContext) {
     HelixAdmin helixAdmin = minionContext.getHelixManager().getClusterManagmentTool();
     String clusterName = minionContext.getHelixManager().getClusterName();
 
@@ -152,7 +152,7 @@ public class MinionTaskUtils {
     // passing an empty list.
     ServerSegmentMetadataReader serverSegmentMetadataReader = new ServerSegmentMetadataReader();
     return serverSegmentMetadataReader.getValidDocIdsBitmapFromServer(tableNameWithType, segmentName, endpoint,
-        validDocIdType, 60_000);
+        validDocIdsType, 60_000);
   }
 
   public static String getServer(String segmentName, String tableNameWithType, HelixAdmin helixAdmin,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/MinionTaskUtils.java
@@ -140,7 +140,7 @@ public class MinionTaskUtils {
   }
 
   public static ValidDocIdsBitmapResponse getValidDocIdsBitmap(String tableNameWithType, String segmentName,
-      Map<String, String> configs, MinionContext minionContext) {
+      String validDocIdType, MinionContext minionContext) {
     HelixAdmin helixAdmin = minionContext.getHelixManager().getClusterManagmentTool();
     String clusterName = minionContext.getHelixManager().getClusterName();
 
@@ -151,7 +151,8 @@ public class MinionTaskUtils {
     // We only need aggregated table size and the total number of docs/rows. Skipping column related stats, by
     // passing an empty list.
     ServerSegmentMetadataReader serverSegmentMetadataReader = new ServerSegmentMetadataReader();
-    return serverSegmentMetadataReader.getValidDocIdsBitmapFromServer(tableNameWithType, segmentName, endpoint, 60_000);
+    return serverSegmentMetadataReader.getValidDocIdsBitmapFromServer(tableNameWithType, segmentName, endpoint,
+        validDocIdType, 60_000);
   }
 
   public static String getServer(String segmentName, String tableNameWithType, HelixAdmin helixAdmin,

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -42,7 +42,7 @@ import org.slf4j.LoggerFactory;
 
 public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExecutor {
   private static final Logger LOGGER = LoggerFactory.getLogger(UpsertCompactionTaskExecutor.class);
-  private static final String DEFAULT_VALID_DOC_ID_TYPE = "validDocIdsSnapshot";
+  private static final String DEFAULT_VALID_DOC_IDS_TYPE = "validDocIdsSnapshot";
 
   @Override
   protected SegmentConversionResult convert(PinotTaskConfig pinotTaskConfig, File indexDir, File workingDir)
@@ -57,10 +57,10 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
     TableConfig tableConfig = getTableConfig(tableNameWithType);
 
-    String validDocIdType =
-        configs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_ID_TYPE, DEFAULT_VALID_DOC_ID_TYPE);
+    String validDocIdsType =
+        configs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_TYPE, DEFAULT_VALID_DOC_IDS_TYPE);
     ValidDocIdsBitmapResponse validDocIdsBitmapResponse =
-        MinionTaskUtils.getValidDocIdsBitmap(tableNameWithType, segmentName, validDocIdType, MINION_CONTEXT);
+        MinionTaskUtils.getValidDocIdsBitmap(tableNameWithType, segmentName, validDocIdsType, MINION_CONTEXT);
 
     // Check crc from the downloaded segment against the crc returned from the server along with the valid doc id
     // bitmap. If this doesn't match, this means that we are hitting the race condition where the segment has been

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -23,6 +23,8 @@ import java.util.Collections;
 import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
+import org.apache.pinot.common.restlet.resources.ValidDocIdsBitmapResponse;
+import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
 import org.apache.pinot.plugin.minion.tasks.BaseSingleSegmentConversionExecutor;
@@ -53,7 +55,28 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
 
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
     TableConfig tableConfig = getTableConfig(tableNameWithType);
-    RoaringBitmap validDocIds = MinionTaskUtils.getValidDocIds(tableNameWithType, segmentName, configs, MINION_CONTEXT);
+    ValidDocIdsBitmapResponse validDocIdsBitmapResponse =
+        MinionTaskUtils.getValidDocIdsBitmap(tableNameWithType, segmentName, configs, MINION_CONTEXT);
+
+    // Check crc from the downloaded segment against the crc returned from the server along with the valid doc id
+    // bitmap. If this doesn't match, this means that we are hitting the race condition where the segment has been
+    // uploaded successfully while the server is still reloading the segment. Reloading can take a while when the
+    // offheap upsert is used because we will need to delete & add all primary keys.
+    // `BaseSingleSegmentConversionExecutor.executeTask()` already checks for the crc from the task generator
+    // against the crc from the current segment zk metadata, so we don't need to check that here.
+    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
+    String originalSegmentCrcFromTaskGenerator = configs.get(MinionConstants.ORIGINAL_SEGMENT_CRC_KEY);
+    String crcFromDeepStorageSegment = segmentMetadata.getCrc();
+    String crcFromValidDocIdsBitmap = validDocIdsBitmapResponse.getCrc();
+    if (!originalSegmentCrcFromTaskGenerator.equals(crcFromDeepStorageSegment)
+        || !originalSegmentCrcFromTaskGenerator.equals(crcFromValidDocIdsBitmap)) {
+      LOGGER.warn("CRC mismatch for segment: {}, expected: {}, actual crc from server: {}", segmentName,
+          crcFromDeepStorageSegment, validDocIdsBitmapResponse.getCrc());
+      return new SegmentConversionResult.Builder().setTableNameWithType(tableNameWithType).setSegmentName(segmentName)
+          .build();
+    }
+
+    RoaringBitmap validDocIds = RoaringBitmapUtils.deserialize(validDocIdsBitmapResponse.getBitmap());
 
     if (validDocIds.isEmpty()) {
       // prevents empty segment generation
@@ -68,7 +91,6 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
           .build();
     }
 
-    SegmentMetadataImpl segmentMetadata = new SegmentMetadataImpl(indexDir);
     try (CompactedPinotSegmentRecordReader compactedRecordReader = new CompactedPinotSegmentRecordReader(indexDir,
         validDocIds)) {
       SegmentGeneratorConfig config = getSegmentGeneratorConfig(workingDir, tableConfig, segmentMetadata, segmentName);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -59,7 +59,7 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
 
     String validDocIdsTypeStr =
         configs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_TYPE, ValidDocIdsType.SNAPSHOT.name());
-    ValidDocIdsType validDocIdsType = ValidDocIdsType.fromString(validDocIdsTypeStr);
+    ValidDocIdsType validDocIdsType = ValidDocIdsType.valueOf(validDocIdsTypeStr.toUpperCase());
     ValidDocIdsBitmapResponse validDocIdsBitmapResponse =
         MinionTaskUtils.getValidDocIdsBitmap(tableNameWithType, segmentName, validDocIdsType.toString(),
             MINION_CONTEXT);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskExecutor.java
@@ -24,6 +24,7 @@ import java.util.Map;
 import org.apache.commons.io.FileUtils;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadataCustomMapModifier;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsBitmapResponse;
+import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
 import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.core.common.MinionConstants;
 import org.apache.pinot.core.minion.PinotTaskConfig;
@@ -42,7 +43,6 @@ import org.slf4j.LoggerFactory;
 
 public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExecutor {
   private static final Logger LOGGER = LoggerFactory.getLogger(UpsertCompactionTaskExecutor.class);
-  private static final String DEFAULT_VALID_DOC_IDS_TYPE = "validDocIdsSnapshot";
 
   @Override
   protected SegmentConversionResult convert(PinotTaskConfig pinotTaskConfig, File indexDir, File workingDir)
@@ -57,10 +57,12 @@ public class UpsertCompactionTaskExecutor extends BaseSingleSegmentConversionExe
     String tableNameWithType = configs.get(MinionConstants.TABLE_NAME_KEY);
     TableConfig tableConfig = getTableConfig(tableNameWithType);
 
-    String validDocIdsType =
-        configs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_TYPE, DEFAULT_VALID_DOC_IDS_TYPE);
+    String validDocIdsTypeStr =
+        configs.getOrDefault(MinionConstants.UpsertCompactionTask.VALID_DOC_IDS_TYPE, ValidDocIdsType.SNAPSHOT.name());
+    ValidDocIdsType validDocIdsType = ValidDocIdsType.fromString(validDocIdsTypeStr);
     ValidDocIdsBitmapResponse validDocIdsBitmapResponse =
-        MinionTaskUtils.getValidDocIdsBitmap(tableNameWithType, segmentName, validDocIdsType, MINION_CONTEXT);
+        MinionTaskUtils.getValidDocIdsBitmap(tableNameWithType, segmentName, validDocIdsType.toString(),
+            MINION_CONTEXT);
 
     // Check crc from the downloaded segment against the crc returned from the server along with the valid doc id
     // bitmap. If this doesn't match, this means that we are hitting the race condition where the segment has been

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -54,7 +54,7 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
   private static final String DEFAULT_BUFFER_PERIOD = "7d";
   private static final double DEFAULT_INVALID_RECORDS_THRESHOLD_PERCENT = 0.0;
   private static final long DEFAULT_INVALID_RECORDS_THRESHOLD_COUNT = 0;
-  private static final String DEFAULT_VALID_DOC_ID_TYPE = "validDocIdsSnapshot";
+  private static final String DEFAULT_VALID_DOC_IDS_TYPE = "validDocIdsSnapshot";
 
   public static class SegmentSelectionResult {
 
@@ -127,27 +127,27 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
 
       // TODO: currently, we put segmentNames=null to get metadata for all segments. We can change this to get
       // valid doc id metadata in batches with the loop.
-      String validDocIdType =
-          taskConfigs.getOrDefault(UpsertCompactionTask.VALID_DOC_ID_TYPE, DEFAULT_VALID_DOC_ID_TYPE);
+      String validDocIdsType =
+          taskConfigs.getOrDefault(UpsertCompactionTask.VALID_DOC_IDS_TYPE, DEFAULT_VALID_DOC_IDS_TYPE);
 
-      // Validate that the snapshot is enabled if validDocIdType is validDocIdsSnapshot
-      if (validDocIdType.equals(DEFAULT_VALID_DOC_ID_TYPE)) {
+      // Validate that the snapshot is enabled if validDocIdsType is validDocIdsSnapshot
+      if (validDocIdsType.equals(DEFAULT_VALID_DOC_IDS_TYPE)) {
         UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
         Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
         Preconditions.checkState(upsertConfig.isEnableSnapshot(), String.format(
-            "'enableSnapshot' from UpsertConfig must be enabled for UpsertCompactionTask with validDocIdType = %s",
-            validDocIdType));
-      } else if (validDocIdType.equals("queryableDocIds")) {
+            "'enableSnapshot' from UpsertConfig must be enabled for UpsertCompactionTask with validDocIdsType = %s",
+            validDocIdsType));
+      } else if (validDocIdsType.equals("queryableDocIds")) {
         UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
         Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
         Preconditions.checkNotNull(upsertConfig.getDeleteRecordColumn(),
-            String.format("deleteRecordColumn must be provided for " + "UpsertCompactionTask with validDocIdType = %s",
-                validDocIdType));
+            String.format("deleteRecordColumn must be provided for " + "UpsertCompactionTask with validDocIdsType = %s",
+                validDocIdsType));
       }
 
       List<ValidDocIdMetadataInfo> validDocIdMetadataList =
           serverSegmentMetadataReader.getValidDocIdMetadataFromServer(tableNameWithType, serverToSegments,
-              serverToEndpoints, null, 60_000, validDocIdType);
+              serverToEndpoints, null, 60_000, validDocIdsType);
 
       Map<String, SegmentZKMetadata> completedSegmentsMap =
           completedSegments.stream().collect(Collectors.toMap(SegmentZKMetadata::getSegmentName, Function.identity()));
@@ -175,7 +175,7 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
         configs.put(MinionConstants.DOWNLOAD_URL_KEY, segment.getDownloadUrl());
         configs.put(MinionConstants.UPLOAD_URL_KEY, _clusterInfoAccessor.getVipUrl() + "/segments");
         configs.put(MinionConstants.ORIGINAL_SEGMENT_CRC_KEY, String.valueOf(segment.getCrc()));
-        configs.put(UpsertCompactionTask.VALID_DOC_ID_TYPE, validDocIdType);
+        configs.put(UpsertCompactionTask.VALID_DOC_IDS_TYPE, validDocIdsType);
         pinotTaskConfigs.add(new PinotTaskConfig(UpsertCompactionTask.TASK_TYPE, configs));
         numTasks++;
       }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -132,8 +132,8 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
       // By default, we use 'snapshot' for validDocIdsType. This means that we will use the validDocIds bitmap from
       // the snapshot from Pinot segment. This will require 'enableSnapshot' from UpsertConfig to be set to true.
       String validDocIdsTypeStr =
-          taskConfigs.getOrDefault(UpsertCompactionTask.VALID_DOC_IDS_TYPE, ValidDocIdsType.SNAPSHOT.name());
-      ValidDocIdsType validDocIdsType = ValidDocIdsType.fromString(validDocIdsTypeStr);
+          taskConfigs.getOrDefault(UpsertCompactionTask.VALID_DOC_IDS_TYPE, ValidDocIdsType.SNAPSHOT.toString());
+      ValidDocIdsType validDocIdsType = ValidDocIdsType.valueOf(validDocIdsTypeStr.toUpperCase());
 
       // Validate that the snapshot is enabled if validDocIdsType is validDocIdsSnapshot
       if (validDocIdsType == ValidDocIdsType.SNAPSHOT) {
@@ -142,7 +142,7 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
         Preconditions.checkState(upsertConfig.isEnableSnapshot(), String.format(
             "'enableSnapshot' from UpsertConfig must be enabled for UpsertCompactionTask with validDocIdsType = %s",
             validDocIdsType));
-      } else if (validDocIdsType == ValidDocIdsType.ON_HEAP_WITH_DELETE) {
+      } else if (validDocIdsType == ValidDocIdsType.IN_MEMORY_WITH_DELETE) {
         UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
         Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
         Preconditions.checkNotNull(upsertConfig.getDeleteRecordColumn(),

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGenerator.java
@@ -31,6 +31,7 @@ import org.apache.helix.task.TaskState;
 import org.apache.pinot.common.exception.InvalidConfigException;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.ValidDocIdMetadataInfo;
+import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
 import org.apache.pinot.controller.helix.core.minion.generator.BaseTaskGenerator;
 import org.apache.pinot.controller.helix.core.minion.generator.TaskGeneratorUtils;
@@ -50,11 +51,11 @@ import org.slf4j.LoggerFactory;
 
 @TaskGenerator
 public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
+
   private static final Logger LOGGER = LoggerFactory.getLogger(UpsertCompactionTaskGenerator.class);
   private static final String DEFAULT_BUFFER_PERIOD = "7d";
   private static final double DEFAULT_INVALID_RECORDS_THRESHOLD_PERCENT = 0.0;
   private static final long DEFAULT_INVALID_RECORDS_THRESHOLD_COUNT = 0;
-  private static final String DEFAULT_VALID_DOC_IDS_TYPE = "validDocIdsSnapshot";
 
   public static class SegmentSelectionResult {
 
@@ -127,17 +128,21 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
 
       // TODO: currently, we put segmentNames=null to get metadata for all segments. We can change this to get
       // valid doc id metadata in batches with the loop.
-      String validDocIdsType =
-          taskConfigs.getOrDefault(UpsertCompactionTask.VALID_DOC_IDS_TYPE, DEFAULT_VALID_DOC_IDS_TYPE);
+
+      // By default, we use 'snapshot' for validDocIdsType. This means that we will use the validDocIds bitmap from
+      // the snapshot from Pinot segment. This will require 'enableSnapshot' from UpsertConfig to be set to true.
+      String validDocIdsTypeStr =
+          taskConfigs.getOrDefault(UpsertCompactionTask.VALID_DOC_IDS_TYPE, ValidDocIdsType.SNAPSHOT.name());
+      ValidDocIdsType validDocIdsType = ValidDocIdsType.fromString(validDocIdsTypeStr);
 
       // Validate that the snapshot is enabled if validDocIdsType is validDocIdsSnapshot
-      if (validDocIdsType.equals(DEFAULT_VALID_DOC_IDS_TYPE)) {
+      if (validDocIdsType == ValidDocIdsType.SNAPSHOT) {
         UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
         Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
         Preconditions.checkState(upsertConfig.isEnableSnapshot(), String.format(
             "'enableSnapshot' from UpsertConfig must be enabled for UpsertCompactionTask with validDocIdsType = %s",
             validDocIdsType));
-      } else if (validDocIdsType.equals("queryableDocIds")) {
+      } else if (validDocIdsType == ValidDocIdsType.ON_HEAP_WITH_DELETE) {
         UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
         Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
         Preconditions.checkNotNull(upsertConfig.getDeleteRecordColumn(),
@@ -147,7 +152,7 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
 
       List<ValidDocIdMetadataInfo> validDocIdMetadataList =
           serverSegmentMetadataReader.getValidDocIdMetadataFromServer(tableNameWithType, serverToSegments,
-              serverToEndpoints, null, 60_000, validDocIdsType);
+              serverToEndpoints, null, 60_000, validDocIdsType.toString());
 
       Map<String, SegmentZKMetadata> completedSegmentsMap =
           completedSegments.stream().collect(Collectors.toMap(SegmentZKMetadata::getSegmentName, Function.identity()));
@@ -175,7 +180,7 @@ public class UpsertCompactionTaskGenerator extends BaseTaskGenerator {
         configs.put(MinionConstants.DOWNLOAD_URL_KEY, segment.getDownloadUrl());
         configs.put(MinionConstants.UPLOAD_URL_KEY, _clusterInfoAccessor.getVipUrl() + "/segments");
         configs.put(MinionConstants.ORIGINAL_SEGMENT_CRC_KEY, String.valueOf(segment.getCrc()));
-        configs.put(UpsertCompactionTask.VALID_DOC_IDS_TYPE, validDocIdsType);
+        configs.put(UpsertCompactionTask.VALID_DOC_IDS_TYPE, validDocIdsType.toString());
         pinotTaskConfigs.add(new PinotTaskConfig(UpsertCompactionTask.TASK_TYPE, configs));
         numTasks++;
       }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
@@ -186,9 +186,9 @@ public class UpsertCompactionTaskGeneratorTest {
       throws IOException {
     Map<String, String> compactionConfigs = getCompactionConfigs("1", "10");
     String json = "[{" + "\"totalValidDocs\" : 50," + "\"totalInvalidDocs\" : 50," + "\"segmentName\" : \""
-        + _completedSegment.getSegmentName() + "\"," + "\"totalDocs\" : 100" + ", \"crc\": \""
+        + _completedSegment.getSegmentName() + "\"," + "\"totalDocs\" : 100" + ", \"segmentCrc\": \""
         + _completedSegment.getCrc() + "\"}," + "{" + "\"totalValidDocs\" : 0," + "\"totalInvalidDocs\" : 10,"
-        + "\"segmentName\" : \"" + _completedSegment2.getSegmentName() + "\", " + "\"crc\" : \""
+        + "\"segmentName\" : \"" + _completedSegment2.getSegmentName() + "\", " + "\"segmentCrc\" : \""
         + _completedSegment2.getCrc() + "\"," + "\"totalDocs\" : 10" + "}]";
     List<ValidDocIdMetadataInfo> validDocIdMetadataInfo =
         JsonUtils.stringToObject(json, new TypeReference<ArrayList<ValidDocIdMetadataInfo>>() {
@@ -225,9 +225,9 @@ public class UpsertCompactionTaskGeneratorTest {
 
     // Test the case where the completedSegment from api has different crc than segment from zk metadata.
     json = "[{" + "\"totalValidDocs\" : 50," + "\"totalInvalidDocs\" : 50," + "\"segmentName\" : \""
-        + _completedSegment.getSegmentName() + "\"," + "\"totalDocs\" : 100" + ", \"crc\": \""
+        + _completedSegment.getSegmentName() + "\"," + "\"totalDocs\" : 100" + ", \"segmentCrc\": \""
         + "1234567890" + "\"}," + "{" + "\"totalValidDocs\" : 0," + "\"totalInvalidDocs\" : 10,"
-        + "\"segmentName\" : \"" + _completedSegment2.getSegmentName() + "\", " + "\"crc\" : \""
+        + "\"segmentName\" : \"" + _completedSegment2.getSegmentName() + "\", " + "\"segmentCrc\" : \""
         + _completedSegment2.getCrc() + "\","
         + "\"totalDocs\" : 10" + "}]";
     validDocIdMetadataInfo = JsonUtils.stringToObject(json, new TypeReference<ArrayList<ValidDocIdMetadataInfo>>() {

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/test/java/org/apache/pinot/plugin/minion/tasks/upsertcompaction/UpsertCompactionTaskGeneratorTest.java
@@ -41,6 +41,7 @@ import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.JsonUtils;
 import org.apache.pinot.spi.utils.TimeUtils;
 import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 import org.testng.collections.Lists;
@@ -184,11 +185,11 @@ public class UpsertCompactionTaskGeneratorTest {
   public void testProcessValidDocIdMetadata()
       throws IOException {
     Map<String, String> compactionConfigs = getCompactionConfigs("1", "10");
-    List<ValidDocIdMetadataInfo> validDocIdMetadataInfoList = new ArrayList<>();
     String json = "[{" + "\"totalValidDocs\" : 50," + "\"totalInvalidDocs\" : 50," + "\"segmentName\" : \""
-        + _completedSegment.getSegmentName() + "\"," + "\"totalDocs\" : 100" + "}," + "{" + "\"totalValidDocs\" : 0,"
-        + "\"totalInvalidDocs\" : 10," + "\"segmentName\" : \"" + _completedSegment2.getSegmentName() + "\","
-        + "\"totalDocs\" : 10" + "}]";
+        + _completedSegment.getSegmentName() + "\"," + "\"totalDocs\" : 100" + ", \"crc\": \""
+        + _completedSegment.getCrc() + "\"}," + "{" + "\"totalValidDocs\" : 0," + "\"totalInvalidDocs\" : 10,"
+        + "\"segmentName\" : \"" + _completedSegment2.getSegmentName() + "\", " + "\"crc\" : \""
+        + _completedSegment2.getCrc() + "\"," + "\"totalDocs\" : 10" + "}]";
     List<ValidDocIdMetadataInfo> validDocIdMetadataInfo =
         JsonUtils.stringToObject(json, new TypeReference<ArrayList<ValidDocIdMetadataInfo>>() {
         });
@@ -221,6 +222,27 @@ public class UpsertCompactionTaskGeneratorTest {
             validDocIdMetadataInfo);
     assertEquals(segmentSelectionResult.getSegmentsForCompaction().get(0).getSegmentName(),
         _completedSegment.getSegmentName());
+
+    // Test the case where the completedSegment from api has different crc than segment from zk metadata.
+    json = "[{" + "\"totalValidDocs\" : 50," + "\"totalInvalidDocs\" : 50," + "\"segmentName\" : \""
+        + _completedSegment.getSegmentName() + "\"," + "\"totalDocs\" : 100" + ", \"crc\": \""
+        + "1234567890" + "\"}," + "{" + "\"totalValidDocs\" : 0," + "\"totalInvalidDocs\" : 10,"
+        + "\"segmentName\" : \"" + _completedSegment2.getSegmentName() + "\", " + "\"crc\" : \""
+        + _completedSegment2.getCrc() + "\","
+        + "\"totalDocs\" : 10" + "}]";
+    validDocIdMetadataInfo = JsonUtils.stringToObject(json, new TypeReference<ArrayList<ValidDocIdMetadataInfo>>() {
+    });
+    segmentSelectionResult =
+        UpsertCompactionTaskGenerator.processValidDocIdMetadata(compactionConfigs, _completedSegmentsMap,
+            validDocIdMetadataInfo);
+
+    // completedSegment is supposed to be filtered out
+    Assert.assertEquals(segmentSelectionResult.getSegmentsForCompaction().size(), 0);
+
+    // completedSegment2 is still supposed to be deleted
+    Assert.assertEquals(segmentSelectionResult.getSegmentsForDeletion().size(), 1);
+    assertEquals(segmentSelectionResult.getSegmentsForDeletion().get(0),
+        _completedSegment2.getSegmentName());
   }
 
   private Map<String, String> getCompactionConfigs(String invalidRecordsThresholdPercent,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -669,6 +669,20 @@ public final class TableConfigUtils {
               taskTypeConfig.containsKey("invalidRecordsThresholdPercent") || taskTypeConfig.containsKey(
                   "invalidRecordsThresholdCount"),
               "invalidRecordsThresholdPercent or invalidRecordsThresholdCount or both must be provided");
+          String validDocIdType = taskTypeConfig.getOrDefault("validDocIdType", "validDocIdsSnapshot");
+          if (validDocIdType.equals("validDocIdsSnapshot")) {
+            UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
+            Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
+            Preconditions.checkState(upsertConfig.isEnableSnapshot(), String.format(
+                "'enableSnapshot' from UpsertConfig must be enabled for UpsertCompactionTask with validDocIdType = "
+                    + "%s", validDocIdType));
+          } else if (validDocIdType.equals("queryableDocIds")) {
+            UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
+            Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
+            Preconditions.checkNotNull(upsertConfig.getDeleteRecordColumn(), String.format(
+                "deleteRecordColumn must be provided for " + "UpsertCompactionTask with validDocIdType = %s",
+                validDocIdType));
+          }
         }
       }
     }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -669,14 +669,14 @@ public final class TableConfigUtils {
               taskTypeConfig.containsKey("invalidRecordsThresholdPercent") || taskTypeConfig.containsKey(
                   "invalidRecordsThresholdCount"),
               "invalidRecordsThresholdPercent or invalidRecordsThresholdCount or both must be provided");
-          String validDocIdsType = taskTypeConfig.getOrDefault("validDocIdsType", "validDocIdsSnapshot");
-          if (validDocIdsType.equals("validDocIdsSnapshot")) {
+          String validDocIdsType = taskTypeConfig.getOrDefault("validDocIdsType", "snapshot");
+          if (validDocIdsType.equals("snapshot")) {
             UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
             Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
             Preconditions.checkState(upsertConfig.isEnableSnapshot(), String.format(
                 "'enableSnapshot' from UpsertConfig must be enabled for UpsertCompactionTask with validDocIdsType = "
                     + "%s", validDocIdsType));
-          } else if (validDocIdsType.equals("queryableDocIds")) {
+          } else if (validDocIdsType.equals("onHeapWithDelete")) {
             UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
             Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
             Preconditions.checkNotNull(upsertConfig.getDeleteRecordColumn(), String.format(

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -669,19 +669,19 @@ public final class TableConfigUtils {
               taskTypeConfig.containsKey("invalidRecordsThresholdPercent") || taskTypeConfig.containsKey(
                   "invalidRecordsThresholdCount"),
               "invalidRecordsThresholdPercent or invalidRecordsThresholdCount or both must be provided");
-          String validDocIdType = taskTypeConfig.getOrDefault("validDocIdType", "validDocIdsSnapshot");
-          if (validDocIdType.equals("validDocIdsSnapshot")) {
+          String validDocIdsType = taskTypeConfig.getOrDefault("validDocIdsType", "validDocIdsSnapshot");
+          if (validDocIdsType.equals("validDocIdsSnapshot")) {
             UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
             Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
             Preconditions.checkState(upsertConfig.isEnableSnapshot(), String.format(
-                "'enableSnapshot' from UpsertConfig must be enabled for UpsertCompactionTask with validDocIdType = "
-                    + "%s", validDocIdType));
-          } else if (validDocIdType.equals("queryableDocIds")) {
+                "'enableSnapshot' from UpsertConfig must be enabled for UpsertCompactionTask with validDocIdsType = "
+                    + "%s", validDocIdsType));
+          } else if (validDocIdsType.equals("queryableDocIds")) {
             UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
             Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
             Preconditions.checkNotNull(upsertConfig.getDeleteRecordColumn(), String.format(
-                "deleteRecordColumn must be provided for " + "UpsertCompactionTask with validDocIdType = %s",
-                validDocIdType));
+                "deleteRecordColumn must be provided for " + "UpsertCompactionTask with validDocIdsType = %s",
+                validDocIdsType));
           }
         }
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -40,6 +40,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.request.context.FunctionContext;
 import org.apache.pinot.common.request.context.RequestContextUtils;
+import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
 import org.apache.pinot.common.tier.TierFactory;
 import org.apache.pinot.common.utils.config.TagNameUtils;
 import org.apache.pinot.segment.local.function.FunctionEvaluator;
@@ -670,13 +671,13 @@ public final class TableConfigUtils {
                   "invalidRecordsThresholdCount"),
               "invalidRecordsThresholdPercent or invalidRecordsThresholdCount or both must be provided");
           String validDocIdsType = taskTypeConfig.getOrDefault("validDocIdsType", "snapshot");
-          if (validDocIdsType.equals("snapshot")) {
+          if (validDocIdsType.equals(ValidDocIdsType.SNAPSHOT.toString())) {
             UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
             Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
             Preconditions.checkState(upsertConfig.isEnableSnapshot(), String.format(
                 "'enableSnapshot' from UpsertConfig must be enabled for UpsertCompactionTask with validDocIdsType = "
                     + "%s", validDocIdsType));
-          } else if (validDocIdsType.equals("onHeapWithDelete")) {
+          } else if (validDocIdsType.equals(ValidDocIdsType.IN_MEMORY_WITH_DELETE.toString())) {
             UpsertConfig upsertConfig = tableConfig.getUpsertConfig();
             Preconditions.checkNotNull(upsertConfig, "UpsertConfig must be provided for UpsertCompactionTask");
             Preconditions.checkNotNull(upsertConfig.getDeleteRecordColumn(), String.format(

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -2300,8 +2300,10 @@ public class TableConfigUtilsTest {
     Map<String, String> upsertCompactionTaskConfig =
         ImmutableMap.of("bufferTimePeriod", "5d", "invalidRecordsThresholdPercent", "1", "invalidRecordsThresholdCount",
             "1");
+    UpsertConfig upsertConfig = new UpsertConfig(UpsertConfig.Mode.FULL);
+    upsertConfig.setEnableSnapshot(true);
     TableConfig tableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL))
+        .setUpsertConfig(upsertConfig)
         .setTaskConfig(new TableTaskConfig(ImmutableMap.of("UpsertCompactionTask", upsertCompactionTaskConfig)))
         .build();
 
@@ -2310,7 +2312,7 @@ public class TableConfigUtilsTest {
     // test with invalid invalidRecordsThresholdPercents
     upsertCompactionTaskConfig = ImmutableMap.of("invalidRecordsThresholdPercent", "0");
     TableConfig zeroPercentTableConfig = new TableConfigBuilder(TableType.REALTIME).setTableName(TABLE_NAME)
-        .setUpsertConfig(new UpsertConfig(UpsertConfig.Mode.FULL))
+        .setUpsertConfig(upsertConfig)
         .setTaskConfig(new TableTaskConfig(ImmutableMap.of("UpsertCompactionTask", upsertCompactionTaskConfig)))
         .build();
     Assert.assertThrows(IllegalStateException.class,

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/resources/TablesResource.java
@@ -476,7 +476,7 @@ public class TablesResource {
   public ValidDocIdsBitmapResponse downloadValidDocIdsBitmap(
       @ApiParam(value = "Name of the table with type REALTIME", required = true, example = "myTable_REALTIME")
       @PathParam("tableNameWithType") String tableNameWithType,
-      @ApiParam(value = "Valid doc id type", example = "snapshot|onHeap|onHeapWithDelete")
+      @ApiParam(value = "Valid doc id type", example = "SNAPSHOT|IN_MEMORY|IN_MEMORY_WITH_DELETE")
       @QueryParam("validDocIdsType") String validDocIdsType,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName,
       @Context HttpHeaders httpHeaders) {
@@ -504,7 +504,7 @@ public class TablesResource {
 
       final Pair<ValidDocIdsType, MutableRoaringBitmap> validDocIdsSnapshotPair =
           getValidDocIds(indexSegment, validDocIdsType);
-      String finalValidDocIdsType = validDocIdsSnapshotPair.getLeft().toString();
+      ValidDocIdsType finalValidDocIdsType = validDocIdsSnapshotPair.getLeft();
       MutableRoaringBitmap validDocIdSnapshot = validDocIdsSnapshotPair.getRight();
 
       if (validDocIdSnapshot == null) {
@@ -536,7 +536,7 @@ public class TablesResource {
       @ApiParam(value = "Name of the table with type REALTIME", required = true, example = "myTable_REALTIME")
       @PathParam("tableNameWithType") String tableNameWithType,
       @ApiParam(value = "Name of the segment", required = true) @PathParam("segmentName") @Encoded String segmentName,
-      @ApiParam(value = "Valid doc id type", example = "snapshot|onHeap|onHeapWithDelete")
+      @ApiParam(value = "Valid doc id type", example = "SNAPSHOT|IN_MEMORY|IN_MEMORY_WITH_DELETE")
       @QueryParam("validDocIdsType") String validDocIdsType, @Context HttpHeaders httpHeaders) {
     segmentName = URIUtils.decode(segmentName);
     LOGGER.info("Received a request to download validDocIds for segment {} table {}", segmentName, tableNameWithType);
@@ -591,7 +591,7 @@ public class TablesResource {
   public String getValidDocIdMetadata(
       @ApiParam(value = "Table name including type", required = true, example = "myTable_REALTIME")
       @PathParam("tableNameWithType") String tableNameWithType,
-      @ApiParam(value = "Valid doc id type", example = "snapshot|onHeap|onHeapWithDelete")
+      @ApiParam(value = "Valid doc id type", example = "SNAPSHOT|IN_MEMORY|IN_MEMORY_WITH_DELETE")
       @QueryParam("validDocIdsType") String validDocIdsType,
       @ApiParam(value = "Segment name", allowMultiple = true) @QueryParam("segmentNames") List<String> segmentNames) {
     return ResourceUtils.convertToJsonString(
@@ -610,7 +610,7 @@ public class TablesResource {
   public String getValidDocIdMetadata(
       @ApiParam(value = "Table name including type", required = true, example = "myTable_REALTIME")
       @PathParam("tableNameWithType") String tableNameWithType,
-      @ApiParam(value = "Valid doc id type", example = "snapshot|onHeap|onHeapWithDelete")
+      @ApiParam(value = "Valid doc id type", example = "SNAPSHOT|IN_MEMORY|IN_MEMORY_WITH_DELETE")
       @QueryParam("validDocIdsType") String validDocIdsType, TableSegments tableSegments) {
     List<String> segmentNames = tableSegments.getSegments();
     return ResourceUtils.convertToJsonString(
@@ -684,13 +684,13 @@ public class TablesResource {
       // By default, we read the valid doc ids from snapshot.
       return Pair.of(ValidDocIdsType.SNAPSHOT, ((ImmutableSegmentImpl) indexSegment).loadValidDocIdsFromSnapshot());
     }
-    ValidDocIdsType validDocIdsType = ValidDocIdsType.fromString(validDocIdsTypeStr);
+    ValidDocIdsType validDocIdsType = ValidDocIdsType.valueOf(validDocIdsTypeStr.toUpperCase());
     switch (validDocIdsType) {
       case SNAPSHOT:
         return Pair.of(validDocIdsType, ((ImmutableSegmentImpl) indexSegment).loadValidDocIdsFromSnapshot());
-      case ON_HEAP:
+      case IN_MEMORY:
         return Pair.of(validDocIdsType, indexSegment.getValidDocIds().getMutableRoaringBitmap());
-      case ON_HEAP_WITH_DELETE:
+      case IN_MEMORY_WITH_DELETE:
         return Pair.of(validDocIdsType, indexSegment.getQueryableDocIds().getMutableRoaringBitmap());
       default:
         // By default, we read the valid doc ids from snapshot.

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -319,7 +319,7 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(validDocIdMetadata.get("totalValidDocs").asInt(), 8);
     Assert.assertEquals(validDocIdMetadata.get("totalInvalidDocs").asInt(), 99992);
     Assert.assertEquals(validDocIdMetadata.get("segmentCrc").asText(), "1265679343");
-    Assert.assertEquals(validDocIdMetadata.get("validDocIdsType").asText(), "snapshot");
+    Assert.assertEquals(validDocIdMetadata.get("validDocIdsType").asText(), "SNAPSHOT");
   }
 
   @Test
@@ -345,7 +345,7 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(validDocIdMetadata.get("totalValidDocs").asInt(), 8);
     Assert.assertEquals(validDocIdMetadata.get("totalInvalidDocs").asInt(), 99992);
     Assert.assertEquals(validDocIdMetadata.get("segmentCrc").asText(), "1265679343");
-    Assert.assertEquals(validDocIdMetadata.get("validDocIdsType").asText(), "snapshot");
+    Assert.assertEquals(validDocIdMetadata.get("validDocIdsType").asText(), "SNAPSHOT");
   }
 
   // Verify metadata file from segments.
@@ -418,7 +418,7 @@ public class TablesResourceTest extends BaseResourceTest {
         validDocIdsSnapshot.getMutableRoaringBitmap());
 
     // Check onHeap type
-    response = _webTarget.path(snapshotPath).queryParam("validDocIdsType", ValidDocIdsType.ON_HEAP).request()
+    response = _webTarget.path(snapshotPath).queryParam("validDocIdsType", ValidDocIdsType.IN_MEMORY).request()
         .get(Response.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     validDocIdsSnapshotBitmap = response.readEntity(byte[].class);
@@ -428,7 +428,7 @@ public class TablesResourceTest extends BaseResourceTest {
 
     // Check onHeapWithDelete type
     response =
-        _webTarget.path(snapshotPath).queryParam("validDocIdsType", ValidDocIdsType.ON_HEAP_WITH_DELETE.toString())
+        _webTarget.path(snapshotPath).queryParam("validDocIdsType", ValidDocIdsType.IN_MEMORY_WITH_DELETE.toString())
             .request().get(Response.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     validDocIdsSnapshotBitmap = response.readEntity(byte[].class);
@@ -482,8 +482,9 @@ public class TablesResourceTest extends BaseResourceTest {
         validDocIdsSnapshot.getMutableRoaringBitmap());
 
     // Check onHeap type
-    response = _webTarget.path(snapshotPath).queryParam("validDocIdsType", ValidDocIdsType.ON_HEAP.toString()).request()
-        .get(ValidDocIdsBitmapResponse.class);
+    response =
+        _webTarget.path(snapshotPath).queryParam("validDocIdsType", ValidDocIdsType.IN_MEMORY.toString()).request()
+            .get(ValidDocIdsBitmapResponse.class);
     Assert.assertNotNull(response);
     Assert.assertEquals(response.getSegmentCrc(), "1265679343");
     Assert.assertEquals(response.getSegmentName(), segment.getSegmentName());
@@ -494,7 +495,7 @@ public class TablesResourceTest extends BaseResourceTest {
 
     // Check onHeapWithDelete type
     response =
-        _webTarget.path(snapshotPath).queryParam("validDocIdsType", ValidDocIdsType.ON_HEAP_WITH_DELETE.toString())
+        _webTarget.path(snapshotPath).queryParam("validDocIdsType", ValidDocIdsType.IN_MEMORY_WITH_DELETE.toString())
             .request().get(ValidDocIdsBitmapResponse.class);
     Assert.assertNotNull(response);
     Assert.assertEquals(response.getSegmentCrc(), "1265679343");

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -318,7 +318,7 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(validDocIdMetadata.get("totalValidDocs").asInt(), 8);
     Assert.assertEquals(validDocIdMetadata.get("totalInvalidDocs").asInt(), 99992);
     Assert.assertEquals(validDocIdMetadata.get("segmentCrc").asText(), "1265679343");
-    Assert.assertEquals(validDocIdMetadata.get("validDocIdType").asText(), "validDocIdsSnapshot");
+    Assert.assertEquals(validDocIdMetadata.get("validDocIdsType").asText(), "validDocIdsSnapshot");
   }
 
   @Test
@@ -344,7 +344,7 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(validDocIdMetadata.get("totalValidDocs").asInt(), 8);
     Assert.assertEquals(validDocIdMetadata.get("totalInvalidDocs").asInt(), 99992);
     Assert.assertEquals(validDocIdMetadata.get("segmentCrc").asText(), "1265679343");
-    Assert.assertEquals(validDocIdMetadata.get("validDocIdType").asText(), "validDocIdsSnapshot");
+    Assert.assertEquals(validDocIdMetadata.get("validDocIdsType").asText(), "validDocIdsSnapshot");
   }
 
   // Verify metadata file from segments.
@@ -408,7 +408,7 @@ public class TablesResourceTest extends BaseResourceTest {
 
     // Check validDocIdsSnapshot type
     response =
-        _webTarget.path(snapshotPath).queryParam("validDocIdType", "validDocIdsSnapshot").request().get(Response.class);
+        _webTarget.path(snapshotPath).queryParam("validDocIdsType", "validDocIdsSnapshot").request().get(Response.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     validDocIdsSnapshotBitmap = response.readEntity(byte[].class);
     Assert.assertNotNull(validDocIdsSnapshotBitmap);
@@ -416,7 +416,7 @@ public class TablesResourceTest extends BaseResourceTest {
         validDocIdsSnapshot.getMutableRoaringBitmap());
 
     // Check validDocIds type
-    response = _webTarget.path(snapshotPath).queryParam("validDocIdType", "validDocIds").request().get(Response.class);
+    response = _webTarget.path(snapshotPath).queryParam("validDocIdsType", "validDocIds").request().get(Response.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     validDocIdsSnapshotBitmap = response.readEntity(byte[].class);
     Assert.assertNotNull(validDocIdsSnapshotBitmap);
@@ -425,7 +425,7 @@ public class TablesResourceTest extends BaseResourceTest {
 
     // Check queryableDocIds type
     response =
-        _webTarget.path(snapshotPath).queryParam("validDocIdType", "queryableDocIds").request().get(Response.class);
+        _webTarget.path(snapshotPath).queryParam("validDocIdsType", "queryableDocIds").request().get(Response.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     validDocIdsSnapshotBitmap = response.readEntity(byte[].class);
     Assert.assertNotNull(validDocIdsSnapshotBitmap);
@@ -466,7 +466,7 @@ public class TablesResourceTest extends BaseResourceTest {
         validDocIdsSnapshot.getMutableRoaringBitmap());
 
     // Check validDocIdsSnapshot type
-    response = _webTarget.path(snapshotPath).queryParam("validDocIdType", "validDocIdsSnapshot").request()
+    response = _webTarget.path(snapshotPath).queryParam("validDocIdsType", "validDocIdsSnapshot").request()
         .get(ValidDocIdsBitmapResponse.class);
     Assert.assertNotNull(response);
     Assert.assertEquals(response.getSegmentCrc(), "1265679343");
@@ -477,7 +477,7 @@ public class TablesResourceTest extends BaseResourceTest {
         validDocIdsSnapshot.getMutableRoaringBitmap());
 
     // Check validDocIds type
-    response = _webTarget.path(snapshotPath).queryParam("validDocIdType", "validDocIds").request()
+    response = _webTarget.path(snapshotPath).queryParam("validDocIdsType", "validDocIds").request()
         .get(ValidDocIdsBitmapResponse.class);
     Assert.assertNotNull(response);
     Assert.assertEquals(response.getSegmentCrc(), "1265679343");
@@ -488,7 +488,7 @@ public class TablesResourceTest extends BaseResourceTest {
         validDocIds.getMutableRoaringBitmap());
 
     // Check queryableDocIds type
-    response = _webTarget.path(snapshotPath).queryParam("validDocIdType", "queryableDocIds").request()
+    response = _webTarget.path(snapshotPath).queryParam("validDocIdsType", "queryableDocIds").request()
         .get(ValidDocIdsBitmapResponse.class);
     Assert.assertNotNull(response);
     Assert.assertEquals(response.getSegmentCrc(), "1265679343");

--- a/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
+++ b/pinot-server/src/test/java/org/apache/pinot/server/api/TablesResourceTest.java
@@ -34,6 +34,7 @@ import org.apache.pinot.common.restlet.resources.TableMetadataInfo;
 import org.apache.pinot.common.restlet.resources.TableSegments;
 import org.apache.pinot.common.restlet.resources.TablesList;
 import org.apache.pinot.common.restlet.resources.ValidDocIdsBitmapResponse;
+import org.apache.pinot.common.restlet.resources.ValidDocIdsType;
 import org.apache.pinot.common.utils.RoaringBitmapUtils;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
@@ -318,7 +319,7 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(validDocIdMetadata.get("totalValidDocs").asInt(), 8);
     Assert.assertEquals(validDocIdMetadata.get("totalInvalidDocs").asInt(), 99992);
     Assert.assertEquals(validDocIdMetadata.get("segmentCrc").asText(), "1265679343");
-    Assert.assertEquals(validDocIdMetadata.get("validDocIdsType").asText(), "validDocIdsSnapshot");
+    Assert.assertEquals(validDocIdMetadata.get("validDocIdsType").asText(), "snapshot");
   }
 
   @Test
@@ -344,7 +345,7 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(validDocIdMetadata.get("totalValidDocs").asInt(), 8);
     Assert.assertEquals(validDocIdMetadata.get("totalInvalidDocs").asInt(), 99992);
     Assert.assertEquals(validDocIdMetadata.get("segmentCrc").asText(), "1265679343");
-    Assert.assertEquals(validDocIdMetadata.get("validDocIdsType").asText(), "validDocIdsSnapshot");
+    Assert.assertEquals(validDocIdMetadata.get("validDocIdsType").asText(), "snapshot");
   }
 
   // Verify metadata file from segments.
@@ -406,26 +407,29 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(new ImmutableRoaringBitmap(ByteBuffer.wrap(validDocIdsSnapshotBitmap)).toMutableRoaringBitmap(),
         validDocIdsSnapshot.getMutableRoaringBitmap());
 
-    // Check validDocIdsSnapshot type
+    // Check snapshot type
     response =
-        _webTarget.path(snapshotPath).queryParam("validDocIdsType", "validDocIdsSnapshot").request().get(Response.class);
+        _webTarget.path(snapshotPath).queryParam("validDocIdsType", ValidDocIdsType.SNAPSHOT.toString()).request()
+            .get(Response.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     validDocIdsSnapshotBitmap = response.readEntity(byte[].class);
     Assert.assertNotNull(validDocIdsSnapshotBitmap);
     Assert.assertEquals(new ImmutableRoaringBitmap(ByteBuffer.wrap(validDocIdsSnapshotBitmap)).toMutableRoaringBitmap(),
         validDocIdsSnapshot.getMutableRoaringBitmap());
 
-    // Check validDocIds type
-    response = _webTarget.path(snapshotPath).queryParam("validDocIdsType", "validDocIds").request().get(Response.class);
+    // Check onHeap type
+    response = _webTarget.path(snapshotPath).queryParam("validDocIdsType", ValidDocIdsType.ON_HEAP).request()
+        .get(Response.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     validDocIdsSnapshotBitmap = response.readEntity(byte[].class);
     Assert.assertNotNull(validDocIdsSnapshotBitmap);
     Assert.assertEquals(new ImmutableRoaringBitmap(ByteBuffer.wrap(validDocIdsSnapshotBitmap)).toMutableRoaringBitmap(),
         validDocIds.getMutableRoaringBitmap());
 
-    // Check queryableDocIds type
+    // Check onHeapWithDelete type
     response =
-        _webTarget.path(snapshotPath).queryParam("validDocIdsType", "queryableDocIds").request().get(Response.class);
+        _webTarget.path(snapshotPath).queryParam("validDocIdsType", ValidDocIdsType.ON_HEAP_WITH_DELETE.toString())
+            .request().get(Response.class);
     Assert.assertEquals(response.getStatus(), Response.Status.OK.getStatusCode());
     validDocIdsSnapshotBitmap = response.readEntity(byte[].class);
     Assert.assertNotNull(validDocIdsSnapshotBitmap);
@@ -465,9 +469,10 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(new ImmutableRoaringBitmap(ByteBuffer.wrap(validDocIdsSnapshotBitmap)).toMutableRoaringBitmap(),
         validDocIdsSnapshot.getMutableRoaringBitmap());
 
-    // Check validDocIdsSnapshot type
-    response = _webTarget.path(snapshotPath).queryParam("validDocIdsType", "validDocIdsSnapshot").request()
-        .get(ValidDocIdsBitmapResponse.class);
+    // Check snapshot type
+    response =
+        _webTarget.path(snapshotPath).queryParam("validDocIdsType", ValidDocIdsType.SNAPSHOT.toString()).request()
+            .get(ValidDocIdsBitmapResponse.class);
     Assert.assertNotNull(response);
     Assert.assertEquals(response.getSegmentCrc(), "1265679343");
     Assert.assertEquals(response.getSegmentName(), segment.getSegmentName());
@@ -476,8 +481,8 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(new ImmutableRoaringBitmap(ByteBuffer.wrap(validDocIdsSnapshotBitmap)).toMutableRoaringBitmap(),
         validDocIdsSnapshot.getMutableRoaringBitmap());
 
-    // Check validDocIds type
-    response = _webTarget.path(snapshotPath).queryParam("validDocIdsType", "validDocIds").request()
+    // Check onHeap type
+    response = _webTarget.path(snapshotPath).queryParam("validDocIdsType", ValidDocIdsType.ON_HEAP.toString()).request()
         .get(ValidDocIdsBitmapResponse.class);
     Assert.assertNotNull(response);
     Assert.assertEquals(response.getSegmentCrc(), "1265679343");
@@ -487,9 +492,10 @@ public class TablesResourceTest extends BaseResourceTest {
     Assert.assertEquals(new ImmutableRoaringBitmap(ByteBuffer.wrap(validDocIdsSnapshotBitmap)).toMutableRoaringBitmap(),
         validDocIds.getMutableRoaringBitmap());
 
-    // Check queryableDocIds type
-    response = _webTarget.path(snapshotPath).queryParam("validDocIdsType", "queryableDocIds").request()
-        .get(ValidDocIdsBitmapResponse.class);
+    // Check onHeapWithDelete type
+    response =
+        _webTarget.path(snapshotPath).queryParam("validDocIdsType", ValidDocIdsType.ON_HEAP_WITH_DELETE.toString())
+            .request().get(ValidDocIdsBitmapResponse.class);
     Assert.assertNotNull(response);
     Assert.assertEquals(response.getSegmentCrc(), "1265679343");
     Assert.assertEquals(response.getSegmentName(), segment.getSegmentName());


### PR DESCRIPTION
The current code can face the race condition when the following condition is met:

1. Segment upload is complete for segment replacement and segment zk metadata is changed to point the new segment.
2. Server is still loading the segment (e.g. if offheap upsert is enabled, segment reload can take a while)
3. If minion picks up the compaction task at the above step, minion will download the new segment (replaced) while it will fetch the validDocId bitmap for old segment.

To avoid this scenario, we added the extra crc check on the minion side. Minion will check if the crc from downloaded segment and crc from server api for valid doc id bitmap are the same.

Changes from the PR:
1. Add the new API for fetching validDocId bitmap. the response is changed to JSON to include extra information like crc.
2. Wired the new API & added tests
3. Added the crc check on the minion task executor
4. Added the crc check on the task generator


## Release Note on the backward incompatibility
This PR is introducing backward incompatibility for UpsertCompactionTask. Previously, we allowed to configure the compaction task without the snapshot enabled. We found that using in-memory based validDocIds is a bit dangerous as it will not give us the consistency (e.g. fetching validDocIds bitmap while the server is restarting & updating validDocIds).

We now enforce the `enableSnapshot=true` for UpsertCompactionTask if the advanced customer wants to run the compaction with the in-memory validDocId bitmap.

```
{
  "upsertConfig": {
    "mode": "FULL",
    "enableSnapshot": true
  }
}
...
"task": {
  "taskTypeConfigsMap": {
    "UpsertCompactionTask": {
      "schedule": "0 */5 * ? * *",
      "bufferTimePeriod": "7d",
      "invalidRecordsThresholdPercent": "30",
      "invalidRecordsThresholdCount": "100000",
      "invalidDocIdsType": "SNAPSHOT/IN_MEMORY/IN_MEMORY_WITH_DELETE"
    }
  }
}
```
Also, we allow to configure `invalidDocIdsType` to UpsertCompactionTask for advanced user.
1. `snapshot`: Default validDocIds type. This indicates that the validDocIds bitmap is loaded from the snapshot from the Pinot segment. UpsertConfig's `enableSnapshot` must be enabled for this type.
2. `onHeap`: the validDocIds bitmap will be fetched from the server.
3. `onHeapWithDelete`: the validDocIds bitmap will be fetched from the server. This will also take account into the deleted documents. UpsertConfig's `deleteRecordColumn` must be provided for this type.