### PR TITLE
Fix backward compatible issue in DistinctCountThetaSketchAggregationFunction

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawThetaSketchAggregationFunction.java
@@ -53,7 +53,8 @@ public class DistinctCountRawThetaSketchAggregationFunction extends DistinctCoun
     int numAccumulators = accumulators.size();
     List<Sketch> mergedSketches = new ArrayList<>(numAccumulators);
 
-    for (ThetaSketchAccumulator accumulator : accumulators) {
+    for (Object object : accumulators) {
+      ThetaSketchAccumulator accumulator = convertSketchAccumulator(object);
       accumulator.setThreshold(_accumulatorThreshold);
       accumulator.setSetOperationBuilder(_setOperationBuilder);
       mergedSketches.add(accumulator.getResult());

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountThetaSketchAggregationFunction.java
@@ -947,12 +947,9 @@ public class DistinctCountThetaSketchAggregationFunction
     }
 
     if (result.get(0) instanceof Sketch) {
-      int numSketches = result.size();
-      ArrayList<ThetaSketchAccumulator> thetaSketchAccumulators = new ArrayList<>(numSketches);
+      ArrayList<ThetaSketchAccumulator> thetaSketchAccumulators = new ArrayList<>(result.size());
       for (Object o : result) {
-        ThetaSketchAccumulator thetaSketchAccumulator =
-            new ThetaSketchAccumulator(_setOperationBuilder, _accumulatorThreshold);
-        thetaSketchAccumulator.apply((Sketch) o);
+        ThetaSketchAccumulator thetaSketchAccumulator = convertSketchAccumulator(o);
         thetaSketchAccumulators.add(thetaSketchAccumulator);
       }
       return thetaSketchAccumulators;
@@ -974,12 +971,9 @@ public class DistinctCountThetaSketchAggregationFunction
     }
 
     if (result.get(0) instanceof Sketch) {
-      int numSketches = result.size();
-      ArrayList<ThetaSketchAccumulator> thetaSketchAccumulators = new ArrayList<>(numSketches);
+      ArrayList<ThetaSketchAccumulator> thetaSketchAccumulators = new ArrayList<>(result.size());
       for (Object o : result) {
-        ThetaSketchAccumulator thetaSketchAccumulator =
-            new ThetaSketchAccumulator(_setOperationBuilder, _accumulatorThreshold);
-        thetaSketchAccumulator.apply((Sketch) o);
+        ThetaSketchAccumulator thetaSketchAccumulator = convertSketchAccumulator(o);
         thetaSketchAccumulators.add(thetaSketchAccumulator);
       }
       return thetaSketchAccumulators;
@@ -1024,7 +1018,8 @@ public class DistinctCountThetaSketchAggregationFunction
     int numAccumulators = accumulators.size();
     List<Sketch> mergedSketches = new ArrayList<>(numAccumulators);
 
-    for (ThetaSketchAccumulator accumulator : accumulators) {
+    for (Object accumulatorObject : accumulators) {
+      ThetaSketchAccumulator accumulator = convertSketchAccumulator(accumulatorObject);
       accumulator.setThreshold(_accumulatorThreshold);
       accumulator.setSetOperationBuilder(_setOperationBuilder);
       mergedSketches.add(accumulator.getResult());
@@ -1037,14 +1032,14 @@ public class DistinctCountThetaSketchAggregationFunction
   // The AggregationDataTableReducer casts intermediate results to Objects and although the code compiles,
   // types might still be incompatible at runtime due to type erasure.
   // Due to performance overheads of redundant casts, this should be removed at some future point.
-  private ThetaSketchAccumulator convertSketchAccumulator(Object mergeResult) {
-    if (mergeResult instanceof Sketch) {
-      Sketch sketch = (Sketch) mergeResult;
+  protected ThetaSketchAccumulator convertSketchAccumulator(Object result) {
+    if (result instanceof Sketch) {
+      Sketch sketch = (Sketch) result;
       ThetaSketchAccumulator accumulator = new ThetaSketchAccumulator(_setOperationBuilder, _accumulatorThreshold);
       accumulator.apply(sketch);
       return accumulator;
     }
-    return (ThetaSketchAccumulator) mergeResult;
+    return (ThetaSketchAccumulator) result;
   }
 
   /**


### PR DESCRIPTION
This PR fixes a backward incompatible issue introduced by this PR: https://github.com/apache/pinot/pull/12042

Printed stacktrace from the broker log:
```
Caused by: java.lang.ClassCastException: class org.apache.datasketches.theta.DirectCompactSketch cannot be cast to class org.apache.pinot.segment.local.customobject.ThetaSketchAccumulator (org.apache.datasketches.theta.DirectCompactSketch and org.apache.pinot.segment.local.customobject.ThetaSketchAccumulator are in unnamed module of loader org.eclipse.jetty.webapp.WebAppClassLoader @3b2f4a93)
        at org.apache.pinot.core.query.aggregation.function.DistinctCountThetaSketchAggregationFunction.extractFinalResult(DistinctCountThetaSketchAggregationFunction.java:1019) ~[org.apache.pinot.pinot-core.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.core.query.aggregation.function.DistinctCountThetaSketchAggregationFunction.extractFinalResult(DistinctCountThetaSketchAggregationFunction.java:82) ~[org.apache.pinot.pinot-core.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.core.data.table.TableResizer$AggregationFunctionExtractor.extract(TableResizer.java:446) ~[org.apache.pinot.pinot-core.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.core.data.table.TableResizer.getIntermediateRecord(TableResizer.java:169) ~[org.apache.pinot.pinot-core.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.core.data.table.TableResizer.getSortedTopRecords(TableResizer.java:280) ~[org.apache.pinot.pinot-core.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.core.data.table.TableResizer.getTopRecords(TableResizer.java:266) ~[org.apache.pinot.pinot-core.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.core.data.table.IndexedTable.finish(IndexedTable.java:151) ~[org.apache.pinot.pinot-core.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.core.data.table.Table.finish(Table.java:59) ~[org.apache.pinot.pinot-core.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.core.query.reduce.GroupByDataTableReducer.getIndexedTable(GroupByDataTableReducer.java:386) ~[org.apache.pinot.pinot-core.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.core.query.reduce.GroupByDataTableReducer.reduceWithIntermediateResult(GroupByDataTableReducer.java:146) ~[org.apache.pinot.pinot-core.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.core.query.reduce.GroupByDataTableReducer.reduceAndSetResults(GroupByDataTableReducer.java:114) ~[org.apache.pinot.pinot-core.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.core.query.reduce.BrokerReduceService.reduceOnDataTable(BrokerReduceService.java:158) ~[org.apache.pinot.pinot-core.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.broker.requesthandler.SingleConnectionBrokerRequestHandler.processBrokerRequest(SingleConnectionBrokerRequestHandler.java:150) ~[org.apache.pinot.pinot-broker.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:766) ~[org.apache.pinot.pinot-broker.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.broker.requesthandler.BaseBrokerRequestHandler.handleRequest(BaseBrokerRequestHandler.java:282) ~[org.apache.pinot.pinot-broker.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.broker.requesthandler.BrokerRequestHandlerDelegate.handleRequest(BrokerRequestHandlerDelegate.java:107) ~[org.apache.pinot.pinot-broker.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
        at org.apache.pinot.broker.requesthandler.BrokerRequestHandler.handleRequest(BrokerRequestHandler.java:48) ~[org.apache.pinot.pinot-broker.jar:1.1.0e54888f597105216666ee3b0f4d28596434e9652]
```

