### PR TITLE
Add segment metadata deletion code to segment deletion path

### DIFF
--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/util/SegmentDeletionManagerTest.java
@@ -45,6 +45,7 @@ import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.filesystem.LocalPinotFS;
 import org.apache.pinot.spi.filesystem.PinotFSFactory;
+import org.apache.pinot.spi.ingestion.batch.spec.Constants;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.util.TestUtils;
 import org.joda.time.DateTime;
@@ -357,6 +358,9 @@ public class SegmentDeletionManagerTest {
     tableDir.mkdir();
     for (String segmentId : segmentIds) {
       createTestFileWithAge(tableDir.getAbsolutePath() + File.separator + segmentId, 0);
+      // Create segment metadata file
+      createTestFileWithAge(
+          tableDir.getAbsolutePath() + File.separator + segmentId + Constants.METADATA_TAR_GZ_FILE_EXT, 0);
     }
   }
 


### PR DESCRIPTION
**Whats in the PR:**
Added segment metadata deletion from remote store, in the segment deletion path.

**Why its needed:**
Through [PR](https://github.com/apache/pinot/pull/10034), we got the ability to upload segment metadata to remote store, which removes the need to download the entire segment to parse metadata, while creating segment metadata in Zk (metadata push in controller). This change here is to ensure that we always clean up segment metadata (catch all deletion), when the associated segment gets deleted from remote store. Segment and segment metadata are stored in the same remote directory. 


