### PR TITLE
Add round-robin logic during downloadSegmentFromPeer

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/RoundRobinURIProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/RoundRobinURIProvider.java
@@ -23,6 +23,7 @@ import java.net.InetAddress;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.UnknownHostException;
+import java.util.List;
 import java.util.Random;
 import org.apache.http.client.utils.URIBuilder;
 
@@ -50,6 +51,14 @@ public class RoundRobinURIProvider {
         String ip = addresses[i].getHostAddress();
         _uris[i] = uriBuilder.setHost(ip).build();
       }
+    }
+    _index = new Random().nextInt(_uris.length);
+  }
+
+  public RoundRobinURIProvider(List<URI> uris) {
+    _uris = new URI[uris.size()];
+    for (int i = 0; i < uris.size(); i++) {
+      _uris[i] = uris.get(i);
     }
     _index = new Random().nextInt(_uris.length);
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/RoundRobinURIProvider.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/RoundRobinURIProvider.java
@@ -44,7 +44,7 @@ public class RoundRobinURIProvider {
     if (resolveHost) {
       _uris = resolveHostsToIPAddresses(originalUris);
     } else {
-      _uris = originalUris;
+      _uris = List.copyOf(originalUris);
     }
     _index = new Random().nextInt(_uris.size());
   }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
@@ -90,7 +90,7 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
     if (uris == null || uris.isEmpty()) {
       throw new IllegalArgumentException("The input uri list is null or empty");
     }
-    RoundRobinURIProvider roundRobinURIProvider = new RoundRobinURIProvider(uris);
+    RoundRobinURIProvider roundRobinURIProvider = new RoundRobinURIProvider(uris, false);
     RetryPolicies.exponentialBackoffRetryPolicy(_retryCount, _retryWaitMs, _retryDelayScaleFactor).attempt(() -> {
       URI uri = roundRobinURIProvider.next();
       try {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/BaseSegmentFetcher.java
@@ -21,10 +21,10 @@ package org.apache.pinot.common.utils.fetcher;
 import java.io.File;
 import java.net.URI;
 import java.util.List;
-import java.util.Random;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 import org.apache.pinot.common.auth.AuthProviderUtils;
+import org.apache.pinot.common.utils.RoundRobinURIProvider;
 import org.apache.pinot.spi.auth.AuthProvider;
 import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.utils.CommonConstants;
@@ -90,9 +90,9 @@ public abstract class BaseSegmentFetcher implements SegmentFetcher {
     if (uris == null || uris.isEmpty()) {
       throw new IllegalArgumentException("The input uri list is null or empty");
     }
-    Random r = new Random();
+    RoundRobinURIProvider roundRobinURIProvider = new RoundRobinURIProvider(uris);
     RetryPolicies.exponentialBackoffRetryPolicy(_retryCount, _retryWaitMs, _retryDelayScaleFactor).attempt(() -> {
-      URI uri = uris.get(r.nextInt(uris.size()));
+      URI uri = roundRobinURIProvider.next();
       try {
         fetchSegmentToLocalWithoutRetry(uri, dest);
         _logger.info("Fetched segment from: {} to: {} of size: {}", uri, dest, dest.length());

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/fetcher/HttpSegmentFetcher.java
@@ -68,7 +68,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
       throws Exception {
     // Create a RoundRobinURIProvider to round robin IP addresses when retry uploading. Otherwise may always try to
     // download from a same broken host as: 1) DNS may not RR the IP addresses 2) OS cache the DNS resolution result.
-    RoundRobinURIProvider uriProvider = new RoundRobinURIProvider(downloadURI);
+    RoundRobinURIProvider uriProvider = new RoundRobinURIProvider(List.of(downloadURI), true);
 
     int retryCount = getRetryCount(uriProvider);
 
@@ -124,7 +124,7 @@ public class HttpSegmentFetcher extends BaseSegmentFetcher {
       throws Exception {
     // Create a RoundRobinURIProvider to round robin IP addresses when retry uploading. Otherwise, may always try to
     // download from a same broken host as: 1) DNS may not RR the IP addresses 2) OS cache the DNS resolution result.
-    RoundRobinURIProvider uriProvider = new RoundRobinURIProvider(downloadURI);
+    RoundRobinURIProvider uriProvider = new RoundRobinURIProvider(List.of(downloadURI), true);
 
     int retryCount = getRetryCount(uriProvider);
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/RoundRobinURIProviderTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/RoundRobinURIProviderTest.java
@@ -162,7 +162,7 @@ public class RoundRobinURIProviderTest {
 
     for (TestCase testCase : testCases) {
       String uri = testCase._originalUri;
-      RoundRobinURIProvider uriProvider = new RoundRobinURIProvider(new URI(uri));
+      RoundRobinURIProvider uriProvider = new RoundRobinURIProvider(List.of(new URI(uri)), true);
       int n = testCase._expectedUris.size();
       int previousIndex = -1;
       int currentIndex;

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/SegmentConversionUtils.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/SegmentConversionUtils.java
@@ -117,7 +117,7 @@ public class SegmentConversionUtils {
       throws Exception {
     // Create a RoundRobinURIProvider to round-robin IP addresses when retry uploading. Otherwise, it may always try to
     // upload to a same broken host as: 1) DNS may not RR the IP addresses 2) OS cache the DNS resolution result.
-    RoundRobinURIProvider uriProvider = new RoundRobinURIProvider(new URI(uploadURL));
+    RoundRobinURIProvider uriProvider = new RoundRobinURIProvider(List.of(new URI(uploadURL)), true);
     // Generate retry policy based on the config
     String maxNumAttemptsConfigStr = configs.get(MinionConstants.MAX_NUM_ATTEMPTS_KEY);
     int maxNumAttemptsFromConfig =


### PR DESCRIPTION
label: `bugfix`

During downloadSegmentFromPeer : https://github.com/apache/pinot/blob/041e04078f5a94fca92c805a8db8fdf1f904a985/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java#L596-L598

We saw that in some scenarios, the download segment request went to the same peer even if the segment had multiple replicas. 

Logs:

```
host1	WARN	Download and move segment tableName__3__7940__20240201T1322Z from peer with scheme http failed.	2024-02-02T04:40:43.510+00:00
host1	WARN	Caught exception while fetching segment from: http://host2:25602/segments/tableName_REALTIME/tableName__3__7940__20240201T1322Z to: /data/upinot/stream-pinot-server/dataDir/tableName_REALTIME/tmp/tmp-tableName__3__7940__20240201T1322Z.1706848841111/tableName__3__7940__20240201T1322Z.tar.gz	2024-02-02T04:40:43.504+00:00
host1	WARN	Caught exception while downloading segment from: http://host2:25602/segments/tableName_REALTIME/tableName__3__7940__20240201T1322Z to: /data/upinot/stream-pinot-server/dataDir/tableName_REALTIME/tmp/tmp-tableName__3__7940__20240201T1322Z.1706848841111/tableName__3__7940__20240201T1322Z.tar.gz	2024-02-02T04:40:43.503+00:00
host2	INFO	Received a request to download segment tableName__3__7940__20240201T1322Z for table tableName_REALTIME	2024-02-02T04:40:43.502+00:00
host1	WARN	Caught exception while downloading segment from: http://host2:25602/segments/tableName_REALTIME/tableName__3__7940__20240201T1322Z to: /data/upinot/stream-pinot-server/dataDir/tableName_REALTIME/tmp/tmp-tableName__3__7940__20240201T1322Z.1706848841111/tableName__3__7940__20240201T1322Z.tar.gz	2024-02-02T04:40:41.583+00:00
host1	WARN	Caught exception while fetching segment from: http://host2:25602/segments/tableName_REALTIME/tableName__3__7940__20240201T1322Z to: /data/upinot/stream-pinot-server/dataDir/tableName_REALTIME/tmp/tmp-tableName__3__7940__20240201T1322Z.1706848841111/tableName__3__7940__20240201T1322Z.tar.gz	2024-02-02T04:40:41.583+00:00
host2	INFO	Received a request to download segment tableName__3__7940__20240201T1322Z for table tableName_REALTIME	2024-02-02T04:40:41.581+00:00
host1	WARN	Caught exception while downloading segment from: http://host2:25602/segments/tableName_REALTIME/tableName__3__7940__20240201T1322Z to: /data/upinot/stream-pinot-server/dataDir/tableName_REALTIME/tmp/tmp-tableName__3__7940__20240201T1322Z.1706848841111/tableName__3__7940__20240201T1322Z.tar.gz	2024-02-02T04:40:41.273+00:00
host1	WARN	Caught exception while fetching segment from: http://host2:25602/segments/tableName_REALTIME/tableName__3__7940__20240201T1322Z to: /data/upinot/stream-pinot-server/dataDir/tableName_REALTIME/tmp/tmp-tableName__3__7940__20240201T1322Z.1706848841111/tableName__3__7940__20240201T1322Z.tar.gz	2024-02-02T04:40:41.273+00:00
```

This patch adds a round-robin logic to ensure we hit other peers as well to download replica.