### PR TITLE
Fix file handle leaks in Pinot Driver (apache#12263)

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotDriverTest.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotDriverTest.java
@@ -30,6 +30,8 @@ import org.testng.annotations.Test;
 
 public class PinotDriverTest {
   static final String DB_URL = "jdbc:pinot://localhost:8000?controller=localhost:9000";
+  static final String BAD_URL = "jdbc:someOtherDB://localhost:8000?controller=localhost:9000";
+  static final String GOOD_URL_NO_CONNECTION = "jdbc:pinot://localhost:1111?controller=localhost:2222";
 
   @Test(enabled = false)
   public void testDriver()
@@ -58,5 +60,28 @@ public class PinotDriverTest {
     statement.close();
     ;
     conn.close();
+  }
+
+  @Test
+  public void testDriverBadURL() {
+    try {
+      DriverManager.getConnection(BAD_URL);
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage().contains("No suitable driver found"));
+    }
+  }
+
+  @Test
+  public void testDriverGoodURLNoConnection() {
+    try {
+      DriverManager.getConnection(GOOD_URL_NO_CONNECTION);
+    } catch (Exception e) {
+      Assert.assertTrue(e.getMessage().contains("Failed to connect to url"));
+    }
+  }
+
+  @Test
+  public void testResourcesClosingSafely() {
+
   }
 }

--- a/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotDriverTest.java
+++ b/pinot-clients/pinot-jdbc-client/src/test/java/org/apache/pinot/client/PinotDriverTest.java
@@ -79,9 +79,4 @@ public class PinotDriverTest {
       Assert.assertTrue(e.getMessage().contains("Failed to connect to url"));
     }
   }
-
-  @Test
-  public void testResourcesClosingSafely() {
-
-  }
 }


### PR DESCRIPTION
PinotDriver.connect() leaks the PinotClientTransport and PinotControllerTransport if an exception is thrown.

I added unit tests to test both a bad URL and a good URL that doesn't connect.

I performed manual tests of the closeResourceSafely method as it is a small private method.  I performed the test by debugging the code through that method and verify the two resource do indeed close if there is an exception thrown.
