### PR TITLE
[Multi-stage] Optimize query dispatch

### DIFF
--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/AsyncQueryDispatchResponse.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/AsyncQueryDispatchResponse.java
@@ -30,27 +30,22 @@ import org.apache.pinot.query.routing.QueryServerInstance;
  * {@link #getThrowable()} to check if it is null.
  */
 class AsyncQueryDispatchResponse {
-  private final QueryServerInstance _virtualServer;
-  private final int _stageId;
+  private final QueryServerInstance _serverInstance;
   private final Worker.QueryResponse _queryResponse;
   private final Throwable _throwable;
 
-  public AsyncQueryDispatchResponse(QueryServerInstance virtualServer, int stageId, Worker.QueryResponse queryResponse,
+  public AsyncQueryDispatchResponse(QueryServerInstance serverInstance, @Nullable Worker.QueryResponse queryResponse,
       @Nullable Throwable throwable) {
-    _virtualServer = virtualServer;
-    _stageId = stageId;
+    _serverInstance = serverInstance;
     _queryResponse = queryResponse;
     _throwable = throwable;
   }
 
-  public QueryServerInstance getVirtualServer() {
-    return _virtualServer;
+  public QueryServerInstance getServerInstance() {
+    return _serverInstance;
   }
 
-  public int getStageId() {
-    return _stageId;
-  }
-
+  @Nullable
   public Worker.QueryResponse getQueryResponse() {
     return _queryResponse;
   }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchClient.java
@@ -26,8 +26,6 @@ import java.util.function.Consumer;
 import org.apache.pinot.common.proto.PinotQueryWorkerGrpc;
 import org.apache.pinot.common.proto.Worker;
 import org.apache.pinot.query.routing.QueryServerInstance;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 
 /**
@@ -37,8 +35,8 @@ import org.slf4j.LoggerFactory;
  *       let that take care of pooling. (2) Create a DispatchClient interface and implement pooled/non-pooled versions.
  */
 class DispatchClient {
-  private static final Logger LOGGER = LoggerFactory.getLogger(DispatchClient.class);
   private static final StreamObserver<Worker.CancelResponse> NO_OP_CANCEL_STREAM_OBSERVER = new CancelObserver();
+
   private final ManagedChannel _channel;
   private final PinotQueryWorkerGrpc.PinotQueryWorkerStub _dispatchStub;
 
@@ -51,23 +49,13 @@ class DispatchClient {
     return _channel;
   }
 
-  public void submit(Worker.QueryRequest request, int stageId, QueryServerInstance virtualServer, Deadline deadline,
+  public void submit(Worker.QueryRequest request, QueryServerInstance virtualServer, Deadline deadline,
       Consumer<AsyncQueryDispatchResponse> callback) {
-    try {
-      _dispatchStub.withDeadline(deadline).submit(request, new DispatchObserver(stageId, virtualServer, callback));
-    } catch (Exception e) {
-      LOGGER.error("Query Dispatch failed at client-side", e);
-      callback.accept(new AsyncQueryDispatchResponse(
-          virtualServer, stageId, Worker.QueryResponse.getDefaultInstance(), e));
-    }
+    _dispatchStub.withDeadline(deadline).submit(request, new DispatchObserver(virtualServer, callback));
   }
 
   public void cancel(long requestId) {
-    try {
-      Worker.CancelRequest cancelRequest = Worker.CancelRequest.newBuilder().setRequestId(requestId).build();
-      _dispatchStub.cancel(cancelRequest, NO_OP_CANCEL_STREAM_OBSERVER);
-    } catch (Exception e) {
-      LOGGER.error("Query Cancellation failed at client-side", e);
-    }
+    Worker.CancelRequest cancelRequest = Worker.CancelRequest.newBuilder().setRequestId(requestId).build();
+    _dispatchStub.cancel(cancelRequest, NO_OP_CANCEL_STREAM_OBSERVER);
   }
 }

--- a/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchObserver.java
+++ b/pinot-query-runtime/src/main/java/org/apache/pinot/query/service/dispatch/DispatchObserver.java
@@ -28,15 +28,13 @@ import org.apache.pinot.query.routing.QueryServerInstance;
  * A {@link StreamObserver} used by {@link DispatchClient} to subscribe to the response of a async Query Dispatch call.
  */
 class DispatchObserver implements StreamObserver<Worker.QueryResponse> {
-  private int _stageId;
-  private QueryServerInstance _virtualServer;
-  private Consumer<AsyncQueryDispatchResponse> _callback;
+  private final QueryServerInstance _serverInstance;
+  private final Consumer<AsyncQueryDispatchResponse> _callback;
+
   private Worker.QueryResponse _queryResponse;
 
-  public DispatchObserver(int stageId, QueryServerInstance virtualServer,
-      Consumer<AsyncQueryDispatchResponse> callback) {
-    _stageId = stageId;
-    _virtualServer = virtualServer;
+  public DispatchObserver(QueryServerInstance serverInstance, Consumer<AsyncQueryDispatchResponse> callback) {
+    _serverInstance = serverInstance;
     _callback = callback;
   }
 
@@ -48,12 +46,11 @@ class DispatchObserver implements StreamObserver<Worker.QueryResponse> {
   @Override
   public void onError(Throwable throwable) {
     _callback.accept(
-        new AsyncQueryDispatchResponse(_virtualServer, _stageId, Worker.QueryResponse.getDefaultInstance(),
-            throwable));
+        new AsyncQueryDispatchResponse(_serverInstance, Worker.QueryResponse.getDefaultInstance(), throwable));
   }
 
   @Override
   public void onCompleted() {
-    _callback.accept(new AsyncQueryDispatchResponse(_virtualServer, _stageId, _queryResponse, null));
+    _callback.accept(new AsyncQueryDispatchResponse(_serverInstance, _queryResponse, null));
   }
 }


### PR DESCRIPTION
- Do the server independent serialization only once per stage
- Send one plan per server instead of one plan per stage per server
- Parallel execute the server dependent serialization