### PR TITLE
Fixing quickstart table baseballStats minion ingestion

### DIFF
--- a/pinot-tools/src/main/resources/examples/minions/batch/baseballStats/baseballStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/minions/batch/baseballStats/baseballStats_offline_table_config.json
@@ -27,7 +27,8 @@
       "batchConfigMaps": [
         {
           "inputDirURI": "examples/minions/batch/baseballStats/rawdata",
-          "inputFormat": "csv"
+          "inputFormat": "csv",
+          "overwriteOutput": "true"
         }
       ],
       "segmentNameSpec": {},


### PR DESCRIPTION
quickstart might not load segments if the output directory already exists.