### PR TITLE
bugfix: re-add support for `not text_match`

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/TextMatchFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/TextMatchFilterOperator.java
@@ -43,8 +43,7 @@ public class TextMatchFilterOperator extends BaseFilterOperator {
   private final TextMatchPredicate _predicate;
 
   public TextMatchFilterOperator(TextIndexReader textIndexReader, TextMatchPredicate predicate, int numDocs) {
-    // This filter operator does not support AND/OR/NOT operations.
-    super(0, false);
+    super(numDocs, false);
     _textIndexReader = textIndexReader;
     _predicate = predicate;
     _numDocs = numDocs;

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -1331,6 +1331,24 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
   }
 
   /**
+   * Test NotFilterOperator with index based doc id iterator (text_match)
+   * @throws Exception
+   */
+  @Test
+  public void testTextSearchWithInverse()
+      throws Exception {
+
+    // all skills except the first 28 in createTestData contain 'software engineering' or 'software' or 'engineering'
+    List<Object[]> expected = new ArrayList<>();
+    for (int i = 0; i < 28; i++) {
+      expected.add(new Object[]{1000 + i});
+    }
+
+    String query = "SELECT INT_COL FROM MyTable WHERE NOT TEXT_MATCH(SKILLS_TEXT_COL, 'software') LIMIT 50000";
+    testTextSearchSelectQueryHelper(query, 28, false, expected);
+  }
+
+  /**
    * Test the reference counting mechanism of {@link SearcherManager}
    * used by {@link RealtimeLuceneTextIndex}
    * for near realtime text search.


### PR DESCRIPTION
https://github.com/apache/pinot/pull/11185 incidentally caused a regression with inverse `text_match` - due to setting `_numDocs` as 0 in `BaseFilterOperator`,  `.getFalses()` always returns an empty set. This PR reverts the behavior and allows for `not text_match` to work again.

tag: `bugfix`
