### PR TITLE
First attempt to support timestamp implicit columns in V2

### DIFF
--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/TimestampIndexTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/custom/TimestampIndexTest.java
@@ -1,0 +1,140 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests.custom;
+
+import com.beust.jcommander.internal.Lists;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.google.common.collect.ImmutableList;
+import java.io.File;
+import java.util.TimeZone;
+import org.apache.avro.Schema.Field;
+import org.apache.avro.Schema.Type;
+import org.apache.avro.file.DataFileWriter;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericDatumWriter;
+import org.apache.pinot.common.function.scalar.DateTimeFunctions;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TimestampConfig;
+import org.apache.pinot.spi.config.table.TimestampIndexGranularity;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.annotations.AfterClass;
+import org.testng.annotations.BeforeClass;
+import org.testng.annotations.Test;
+
+import static org.apache.avro.Schema.create;
+import static org.testng.Assert.assertEquals;
+
+
+@Test(suiteName = "CustomClusterIntegrationTest")
+public class TimestampIndexTest extends CustomDataQueryClusterIntegrationTest {
+
+  private static final String DEFAULT_TABLE_NAME = "TimestampTest";
+  private static final String TIMESTAMP_BASE = "tsBase";
+
+  private static final TimeZone DEFAULT_TIME_ZONE = TimeZone.getDefault();
+
+  @Override
+  protected long getCountStarResult() {
+    return 1000;
+  }
+
+  @BeforeClass
+  public void setUpTimeZone() {
+    TimeZone.setDefault(TimeZone.getTimeZone("GMT"));
+  }
+
+  @AfterClass
+  public void removeTimeZone() {
+    TimeZone.setDefault(DEFAULT_TIME_ZONE);
+  }
+
+  @Test(dataProvider = "useBothQueryEngines")
+  public void testFirstWithTimeQueries(boolean useMultiStageQueryEngine)
+      throws Exception {
+    setUseMultiStageQueryEngine(useMultiStageQueryEngine);
+    String query = String.format(
+        "SELECT tsBase FROM %s\n",
+        getTableName());
+    JsonNode jsonNode = postQuery(query);
+    assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(0).longValue(), 1546300800000L);
+    assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(1).longValue(), 1546300800000L);
+    assertEquals(jsonNode.get("resultTable").get("rows").get(0).get(2).longValue(), 1546300800000L);
+  }
+
+  @Override
+  public String getTableName() {
+    return DEFAULT_TABLE_NAME;
+  }
+
+  @Override
+  public Schema createSchema() {
+    return new Schema.SchemaBuilder().setSchemaName(getTableName())
+        .addSingleValueDimension(TIMESTAMP_BASE, FieldSpec.DataType.TIMESTAMP)
+        .build();
+  }
+
+  @Override
+  public TableConfig createOfflineTableConfig() {
+    return new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName(getTableName())
+        .setFieldConfigList(Lists.newArrayList(
+            new FieldConfig.Builder(TIMESTAMP_BASE)
+                .withEncodingType(FieldConfig.EncodingType.DICTIONARY)
+                .withTimestampConfig(
+                    new TimestampConfig(Lists.newArrayList(
+                        TimestampIndexGranularity.DAY,
+                        TimestampIndexGranularity.HOUR
+                    ))
+                )
+                .build()
+        ))
+        .build();
+  }
+
+  @Override
+  public File createAvroFile()
+      throws Exception {
+    // create avro schema
+    org.apache.avro.Schema avroSchema = org.apache.avro.Schema.createRecord("myRecord", null, null, false);
+    avroSchema.setFields(ImmutableList.of(
+        new Field(TIMESTAMP_BASE, create(Type.LONG), null, null)
+    ));
+
+    // create avro file
+    File avroFile = new File(_tempDir, "data.avro");
+    try (DataFileWriter<GenericData.Record> fileWriter = new DataFileWriter<>(new GenericDatumWriter<>(avroSchema))) {
+      fileWriter.create(avroSchema, avroFile);
+      long tsBaseLong = DateTimeFunctions.fromDateTime("2019-01-01 00:00:00", "yyyy-MM-dd HH:mm:ss");
+      for (int i = 0; i < getCountStarResult(); i++) {
+        // create avro record
+        GenericData.Record record = new GenericData.Record(avroSchema);
+        record.put(TIMESTAMP_BASE, tsBaseLong);
+
+        // add avro record to file
+        fileWriter.append(record);
+        tsBaseLong += 86400000;
+      }
+    }
+    return avroFile;
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
@@ -35,6 +35,7 @@ import org.apache.calcite.schema.Table;
 import org.apache.pinot.calcite.jdbc.CalciteSchemaBuilder;
 import org.apache.pinot.common.config.provider.TableCache;
 import org.apache.pinot.common.utils.DatabaseUtils;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 import static java.util.Objects.requireNonNull;
@@ -77,8 +78,10 @@ public class PinotCatalog implements Schema {
     String tableName = _tableCache.getActualTableName(physicalTableName);
     Preconditions.checkArgument(tableName != null, String.format("Table does not exist: '%s'", physicalTableName));
     org.apache.pinot.spi.data.Schema schema = _tableCache.getSchema(tableName);
+    // TODO: This is not correct!
+    TableConfig tableConfig = _tableCache.getTableConfig(tableName + "_OFFLINE");
     Preconditions.checkArgument(schema != null, String.format("Could not find schema for table: '%s'", tableName));
-    return new PinotTable(schema);
+    return new PinotTable(schema, tableConfig);
   }
 
   /**

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotTable.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotTable.java
@@ -26,7 +26,9 @@ import org.apache.calcite.rel.type.RelDataTypeFactory;
 import org.apache.calcite.schema.ScannableTable;
 import org.apache.calcite.schema.impl.AbstractTable;
 import org.apache.pinot.query.type.TypeFactory;
+import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.TimestampIndexUtils;
 
 
 /**
@@ -36,10 +38,11 @@ import org.apache.pinot.spi.data.Schema;
  * {@link RelDataType} of the table to the planner.
  */
 public class PinotTable extends AbstractTable implements ScannableTable {
-  private Schema _schema;
+  private final Schema _schema;
 
-  public PinotTable(Schema schema) {
-    _schema = schema;
+  public PinotTable(Schema schema, TableConfig tableConfig) {
+    _schema = schema.clone();
+    TimestampIndexUtils.applyTimestampIndex(tableConfig, _schema);
   }
 
   @Override

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/type/TypeFactory.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.query.type;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
@@ -66,7 +67,8 @@ public class TypeFactory extends JavaTypeFactoryImpl {
     return builder.build();
   }
 
-  private RelDataType toRelDataType(FieldSpec fieldSpec, Predicate<FieldSpec> isNullable) {
+  @VisibleForTesting
+  public RelDataType toRelDataType(FieldSpec fieldSpec, Predicate<FieldSpec> isNullable) {
     RelDataType type = createSqlType(getSqlTypeName(fieldSpec));
     boolean isArray = !fieldSpec.isSingleValueField();
     if (isArray) {

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/catalog/PinotTableTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/catalog/PinotTableTest.java
@@ -1,0 +1,75 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.catalog;
+
+import com.beust.jcommander.internal.Lists;
+import java.util.List;
+import java.util.Locale;
+import java.util.stream.Collectors;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rel.type.RelDataTypeField;
+import org.apache.pinot.query.type.TypeFactory;
+import org.apache.pinot.query.type.TypeSystem;
+import org.apache.pinot.spi.config.table.FieldConfig;
+import org.apache.pinot.spi.config.table.TableConfig;
+import org.apache.pinot.spi.config.table.TableType;
+import org.apache.pinot.spi.config.table.TimestampConfig;
+import org.apache.pinot.spi.config.table.TimestampIndexGranularity;
+import org.apache.pinot.spi.data.FieldSpec;
+import org.apache.pinot.spi.data.Schema;
+import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class PinotTableTest {
+
+  @Test
+  public void testTimestampFields() {
+    Schema schema = new Schema.SchemaBuilder()
+        .setSchemaName("myTable")
+        .addSingleValueDimension("ts", FieldSpec.DataType.TIMESTAMP)
+        .build();
+    TableConfig tableConfig = new TableConfigBuilder(TableType.OFFLINE)
+        .setTableName("myTable")
+        .setFieldConfigList(Lists.newArrayList(
+            new FieldConfig.Builder("ts")
+                .withTimestampConfig(
+                    new TimestampConfig(Lists.newArrayList(
+                        TimestampIndexGranularity.DAY,
+                        TimestampIndexGranularity.HOUR
+                    ))
+                )
+                .build()
+        ))
+        .build();
+
+    PinotTable pinotTable = new PinotTable(schema, tableConfig);
+    TypeFactory relDataTypeFactory = new TypeFactory(new TypeSystem());
+    RelDataType rowType = pinotTable.getRowType(relDataTypeFactory);
+
+    List<String> actualFieldNames = rowType.getFieldList().stream()
+        .map(RelDataTypeField::getName)
+        .map(name -> name.toLowerCase(Locale.US))
+        .collect(Collectors.toList());
+    List<String> expectedFieldNames = Lists.newArrayList("$ts$day", "$ts$hour", "ts");
+
+    Assert.assertEquals(actualFieldNames, expectedFieldNames, "Unexpected field list");
+  }
+}


### PR DESCRIPTION
As explained in [the documentation](https://docs.pinot.apache.org/basics/indexing/timestamp-index#usage), timestamp indexes create one new column per defined granularity. These columns are accessible as:

```
select ts, $ts$DAY from airlineStats limit 10
```

But the field is not added to Calcite Catalog.