### PR TITLE
[multistage] support database/namespace in v2

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/jdbc/CalciteSchemaBuilder.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/jdbc/CalciteSchemaBuilder.java
@@ -61,4 +61,15 @@ public class CalciteSchemaBuilder {
     }
     return rootSchema;
   }
+
+  public static CalciteSchema asSubSchema(Schema root, String name) {
+    CalciteSchema subSchema = CalciteSchema.createRootSchema(false, false, name, root);
+    SchemaPlus schemaPlus = subSchema.plus();
+    for (Map.Entry<String, List<Function>> e : FunctionRegistry.getRegisteredCalciteFunctionMap().entrySet()) {
+      for (Function f : e.getValue()) {
+        schemaPlus.add(e.getKey(), f);
+      }
+    }
+    return subSchema;
+  }
 }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -21,7 +21,9 @@ package org.apache.pinot.query;
 import com.google.common.annotations.VisibleForTesting;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Map;
 import java.util.Properties;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -83,6 +85,7 @@ import org.apache.pinot.sql.parsers.parser.SqlPhysicalExplain;
  * <p>It provide the higher level entry interface to convert a SQL string into a {@link DispatchableSubPlan}.
  */
 public class QueryEnvironment {
+  private static final String DATABASE_KEY = "database";
   // Calcite configurations
   private final FrameworkConfig _config;
 
@@ -105,26 +108,10 @@ public class QueryEnvironment {
     _workerManager = workerManager;
     _tableCache = tableCache;
 
-    // catalog
-    Properties catalogReaderConfigProperties = new Properties();
-    catalogReaderConfigProperties.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), "true");
-    _catalogReader = new PinotCalciteCatalogReader(_rootSchema, _rootSchema.path(null), _typeFactory,
-        new CalciteConnectionConfigImpl(catalogReaderConfigProperties));
-
-    _config = Frameworks.newConfigBuilder().traitDefs()
-        .operatorTable(new PinotChainedSqlOperatorTable(Arrays.asList(
-            PinotOperatorTable.instance(),
-            _catalogReader)))
-        .defaultSchema(_rootSchema.plus())
-        .sqlToRelConverterConfig(SqlToRelConverter.config()
-            .withHintStrategyTable(getHintStrategyTable())
-            .withTrimUnusedFields(true)
-            // SUB-QUERY Threshold is useless as we are encoding all IN clause in-line anyway
-            .withInSubQueryThreshold(Integer.MAX_VALUE)
-            .addRelBuilderConfigTransform(c -> c.withPushJoinCondition(true))
-            .addRelBuilderConfigTransform(c -> c.withAggregateUnique(true))
-            .addRelBuilderConfigTransform(c -> c.withPruneInputOfAggregate(false)))
-        .build();
+    // catalog & config
+    _catalogReader = getCatalog(null);
+    _config = getConfig(_catalogReader);
+    // opt programs
     _optProgram = getOptProgram();
     _traitProgram = getTraitProgram();
   }
@@ -142,8 +129,7 @@ public class QueryEnvironment {
    * @return QueryPlannerResult containing the dispatchable query plan and the relRoot.
    */
   public QueryPlannerResult planQuery(String sqlQuery, SqlNodeAndOptions sqlNodeAndOptions, long requestId) {
-    try (PlannerContext plannerContext = new PlannerContext(_config, _catalogReader, _typeFactory, _optProgram,
-        _traitProgram)) {
+    try (PlannerContext plannerContext = getPlannerContext(sqlNodeAndOptions.getOptions())) {
       plannerContext.setOptions(sqlNodeAndOptions.getOptions());
       RelRoot relRoot = compileQuery(sqlNodeAndOptions.getSqlNode(), plannerContext);
       // TODO: current code only assume one SubPlan per query, but we should support multiple SubPlans per query.
@@ -171,8 +157,7 @@ public class QueryEnvironment {
    * @return QueryPlannerResult containing the explained query plan and the relRoot.
    */
   public QueryPlannerResult explainQuery(String sqlQuery, SqlNodeAndOptions sqlNodeAndOptions, long requestId) {
-    try (PlannerContext plannerContext = new PlannerContext(_config, _catalogReader, _typeFactory, _optProgram,
-        _traitProgram)) {
+    try (PlannerContext plannerContext = getPlannerContext(sqlNodeAndOptions.getOptions())) {
       SqlExplain explain = (SqlExplain) sqlNodeAndOptions.getSqlNode();
       plannerContext.setOptions(sqlNodeAndOptions.getOptions());
       RelRoot relRoot = compileQuery(explain.getExplicandum(), plannerContext);
@@ -205,8 +190,11 @@ public class QueryEnvironment {
   }
 
   public List<String> getTableNamesForQuery(String sqlQuery) {
-    try (PlannerContext plannerContext = new PlannerContext(_config, _catalogReader, _typeFactory, _optProgram,
-        _traitProgram)) {
+    return getTableNamesForQuery(sqlQuery, Collections.emptyMap());
+  }
+
+  public List<String> getTableNamesForQuery(String sqlQuery, Map<String, String> options) {
+    try (PlannerContext plannerContext = getPlannerContext(options)) {
       SqlNode sqlNode = CalciteSqlParser.compileToSqlNodeAndOptions(sqlQuery).getSqlNode();
       if (sqlNode.getKind().equals(SqlKind.EXPLAIN)) {
         sqlNode = ((SqlExplain) sqlNode).getExplicandum();
@@ -341,6 +329,41 @@ public class QueryEnvironment {
   // --------------------------------------------------------------------------
   // utils
   // --------------------------------------------------------------------------
+
+  private Prepare.CatalogReader getCatalog(String path) {
+    Properties catalogReaderConfigProperties = new Properties();
+    catalogReaderConfigProperties.setProperty(CalciteConnectionProperty.CASE_SENSITIVE.camelName(), "true");
+    return new PinotCalciteCatalogReader(_rootSchema, _rootSchema.path(path), _typeFactory,
+        new CalciteConnectionConfigImpl(catalogReaderConfigProperties));
+  }
+
+  private FrameworkConfig getConfig(Prepare.CatalogReader catalogReader) {
+    return Frameworks.newConfigBuilder().traitDefs()
+        .operatorTable(new PinotChainedSqlOperatorTable(Arrays.asList(
+            PinotOperatorTable.instance(),
+            catalogReader)))
+        .defaultSchema(catalogReader.getRootSchema().plus())
+        .sqlToRelConverterConfig(SqlToRelConverter.config()
+            .withHintStrategyTable(getHintStrategyTable())
+            .withTrimUnusedFields(true)
+            // SUB-QUERY Threshold is useless as we are encoding all IN clause in-line anyway
+            .withInSubQueryThreshold(Integer.MAX_VALUE)
+            .addRelBuilderConfigTransform(c -> c.withPushJoinCondition(true))
+            .addRelBuilderConfigTransform(c -> c.withAggregateUnique(true))
+            .addRelBuilderConfigTransform(c -> c.withPruneInputOfAggregate(false)))
+        .build();
+  }
+
+  private PlannerContext getPlannerContext(Map<String, String> options) {
+    String database = options.getOrDefault(DATABASE_KEY, "default");
+    if (database.equalsIgnoreCase("default")) {
+      return new PlannerContext(_config, _catalogReader, _typeFactory, _optProgram, _traitProgram);
+    } else {
+      Prepare.CatalogReader catalogReader = getCatalog(database);
+      FrameworkConfig config = getConfig(catalogReader);
+      return new PlannerContext(config, catalogReader, _typeFactory, _optProgram, _traitProgram);
+    }
+  }
 
   private HintStrategyTable getHintStrategyTable() {
     return PinotHintStrategyTable.PINOT_HINT_STRATEGY_TABLE;

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
@@ -171,7 +171,7 @@ public class PinotCatalog implements Schema {
 
   @Override
   public Set<String> getSubSchemaNames() {
-    return Collections.emptySet();
+    return _subCatalog.keySet();
   }
 
   @Override

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/catalog/PinotCatalog.java
@@ -20,8 +20,13 @@ package org.apache.pinot.query.catalog;
 
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.apache.calcite.jdbc.CalciteSchema;
+import org.apache.calcite.jdbc.CalciteSchemaBuilder;
 import org.apache.calcite.linq4j.tree.Expression;
 import org.apache.calcite.rel.type.RelProtoDataType;
 import org.apache.calcite.schema.Function;
@@ -44,7 +49,13 @@ import static java.util.Objects.requireNonNull;
  */
 public class PinotCatalog implements Schema {
 
+  public static final String DEFAULT_DB_NAME = "default";
+
   private final TableCache _tableCache;
+
+  private final Map<String, CalciteSchema> _subCatalog;
+
+  private final String _databaseName;
 
   /**
    * PinotCatalog needs have access to the actual {@link TableCache} object because TableCache hosts the actual
@@ -52,6 +63,32 @@ public class PinotCatalog implements Schema {
    */
   public PinotCatalog(TableCache tableCache) {
     _tableCache = tableCache;
+    _databaseName = null;
+    // create all databases
+    // TODO: we need to monitor table cache changes to register newly created databases
+    // TODO: we also need to monitor table that needs to be put into the right places
+    _subCatalog = constructSubCatalogs(_tableCache);
+  }
+
+  private PinotCatalog(String databaseName, TableCache tableCache) {
+    _tableCache = tableCache;
+    _databaseName = databaseName;
+    _subCatalog = null;
+  }
+
+  private Map<String, CalciteSchema> constructSubCatalogs(TableCache tableCache) {
+    Map<String, CalciteSchema> subCatalog = new HashMap<>();
+    for (String physicalTableName : tableCache.getTableNameMap().keySet()) {
+      String[] nameSplit = physicalTableName.split("\\.");
+      if (nameSplit.length > 1) {
+        String databaseName = nameSplit[0];
+        subCatalog.putIfAbsent(databaseName,
+            CalciteSchemaBuilder.asSubSchema(new PinotCatalog(databaseName, tableCache), databaseName));
+      }
+    }
+    subCatalog.put(DEFAULT_DB_NAME,
+        CalciteSchemaBuilder.asSubSchema(new PinotCatalog(DEFAULT_DB_NAME, tableCache), DEFAULT_DB_NAME));
+    return subCatalog;
   }
 
   /**
@@ -61,12 +98,22 @@ public class PinotCatalog implements Schema {
    */
   @Override
   public Table getTable(String name) {
-    String tableName = TableNameBuilder.extractRawTableName(name);
+    String rawTableName = TableNameBuilder.extractRawTableName(name);
+    String tableName;
+    if (_databaseName != null) {
+      tableName = constructPhysicalTableName(_databaseName, rawTableName);
+    } else {
+      tableName = rawTableName;
+    }
     org.apache.pinot.spi.data.Schema schema = _tableCache.getSchema(tableName);
     if (schema == null) {
       throw new IllegalArgumentException(String.format("Could not find schema for table: '%s'", tableName));
     }
     return new PinotTable(schema);
+  }
+
+  public static String constructPhysicalTableName(String databaseName, String tableName) {
+    return databaseName.equals(DEFAULT_DB_NAME) ? tableName : databaseName + "." + tableName;
   }
 
   /**
@@ -75,7 +122,14 @@ public class PinotCatalog implements Schema {
    */
   @Override
   public Set<String> getTableNames() {
-    return _tableCache.getTableNameMap().keySet();
+    if (_databaseName != null) {
+      return _databaseName.equals(DEFAULT_DB_NAME) ? _tableCache.getTableNameMap().keySet().stream()
+          .filter(n -> n.split("\\.").length == 1).collect(Collectors.toSet())
+          : _tableCache.getTableNameMap().keySet().stream().filter(n -> n.startsWith(_databaseName))
+              .collect(Collectors.toSet());
+    } else {
+      return Collections.emptySet();
+    }
   }
 
   @Override
@@ -108,7 +162,11 @@ public class PinotCatalog implements Schema {
 
   @Override
   public Schema getSubSchema(String name) {
-    return null;
+    if (_subCatalog != null && _subCatalog.containsKey(name)) {
+      return _subCatalog.get(name).schema;
+    } else {
+      return null;
+    }
   }
 
   @Override

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/planner/logical/RelToPlanNodeConverter.java
@@ -49,6 +49,7 @@ import org.apache.calcite.rel.type.RelRecordType;
 import org.apache.calcite.sql.type.SqlTypeName;
 import org.apache.pinot.common.utils.DataSchema;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.query.catalog.PinotCatalog;
 import org.apache.pinot.query.planner.plannode.AggregateNode;
 import org.apache.pinot.query.planner.plannode.ExchangeNode;
 import org.apache.pinot.query.planner.plannode.FilterNode;
@@ -173,7 +174,13 @@ public final class RelToPlanNodeConverter {
   }
 
   private static PlanNode convertLogicalTableScan(LogicalTableScan node, int currentStageId) {
-    String tableName = node.getTable().getQualifiedName().get(0);
+    String tableName;
+    if (node.getTable().getQualifiedName().size() == 1) {
+      tableName = node.getTable().getQualifiedName().get(0);
+    } else {
+      tableName = PinotCatalog.constructPhysicalTableName(
+          node.getTable().getQualifiedName().get(0), node.getTable().getQualifiedName().get(1));
+    }
     List<String> columnNames =
         node.getRowType().getFieldList().stream().map(RelDataTypeField::getName).collect(Collectors.toList());
     return new TableScanNode(currentStageId, toDataSchema(node.getRowType()), node.getHints(), tableName, columnNames);
@@ -287,7 +294,12 @@ public final class RelToPlanNodeConverter {
       // Calcite encloses table and schema names in square brackets to properly quote and delimit them in SQL
       // statements, particularly to handle cases when they contain special characters or reserved keywords.
       String tableName = qualifiedTableName.replaceAll("^\\[(.*)\\]$", "$1");
-      tableNames.add(tableName);
+      String[] split = tableName.split(", ");
+      if (split.length == 1) {
+        tableNames.add(tableName);
+      } else {
+        tableNames.add(PinotCatalog.constructPhysicalTableName(split[0], split[1]));
+      }
     }
     return tableNames;
   }

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_offline_table_config.json
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_offline_table_config.json
@@ -1,5 +1,5 @@
 {
-  "tableName": "airlineStats",
+  "tableName": "db1.airlineStats",
   "tableType": "OFFLINE",
   "segmentsConfig": {
     "timeColumnName": "DaysSinceEpoch",

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_schema.json
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/airlineStats_schema.json
@@ -344,5 +344,5 @@
       "granularity": "1:SECONDS"
     }
   ],
-  "schemaName": "airlineStats"
+  "schemaName": "db1.airlineStats"
 }

--- a/pinot-tools/src/main/resources/examples/batch/airlineStats/ingestionJobSpec.yaml
+++ b/pinot-tools/src/main/resources/examples/batch/airlineStats/ingestionJobSpec.yaml
@@ -99,13 +99,13 @@ recordReaderSpec:
 tableSpec:
 
   # tableName: Table name
-  tableName: 'airlineStats'
+  tableName: 'db1.airlineStats'
 
   # schemaURI: defines where to read the table schema, supports PinotFS or HTTP.
   # E.g.
   #   hdfs://path/to/table_schema.json
   #   http://localhost:9000/tables/myTable/schema
-  schemaURI: 'http://localhost:9000/tables/airlineStats/schema'
+  schemaURI: 'http://localhost:9000/tables/db1.airlineStats/schema'
 
   # tableConfigURI: defines where to reade the table config.
   # Supports using PinotFS or HTTP.
@@ -114,7 +114,7 @@ tableSpec:
   #   http://localhost:9000/tables/myTable
   # Note that the API to read Pinot table config directly from pinot controller contains a JSON wrapper.
   # The real table config is the object under the field 'OFFLINE'.
-  tableConfigURI: 'http://localhost:9000/tables/airlineStats'
+  tableConfigURI: 'http://localhost:9000/tables/db1.airlineStats'
 
 # pinotClusterSpecs: defines the Pinot Cluster Access Point.
 pinotClusterSpecs:


### PR DESCRIPTION
this is a follow-up from #8713

Changes
=== 

after this PR, the following 3 should be equivalent on multi-stage engine

```
-- method 1 fully-qualify
select * from default.airlineStats limit 10

-- method 2 with default db 
select * from airlineStats limit 10

-- method 3 setting specific db
SET database='default';
select * from airlineStats limit 10
```

Next Steps
===
* [x] test against non-`default` database settings
both method 1 & 3 works:
```
set database='db1'; select * from airlineStats limit 10
select * from db1.airlineStats limit 10
```

* [ ] test against multiple identical table names on different DB: `db1.tbl` and `db2.tbl`
* [ ] test against multiple identical table names on custom DB and default DB: `db1.tbl` and `default.tbl`

