### PR TITLE
Add upsert-snapshot timer metric

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerTimer.java
@@ -50,7 +50,8 @@ public enum ServerTimer implements AbstractMetrics.Timer {
       + "activities cpu time + response serialization cpu time) for query processing on server."),
 
   UPSERT_REMOVE_EXPIRED_PRIMARY_KEYS_TIME_MS("milliseconds", false,
-      "Total time taken to delete expired primary keys based on metadataTTL or deletedKeysTTL");
+      "Total time taken to delete expired primary keys based on metadataTTL or deletedKeysTTL"),
+  UPSERT_SNAPSHOT_TIME_MS("milliseconds", false, "Total time taken to take upsert table snapshot");
 
   private final String _timerName;
   private final boolean _global;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -667,7 +667,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
         ServerGauge.UPSERT_PRIMARY_KEYS_IN_SNAPSHOT_COUNT, numPrimaryKeysInSnapshot);
     _logger.info(
         "Finished taking snapshot for {} immutable segments with {} primary keys (out of {} total segments, "
-            + "{} consuming segments) in {} ms", numImmutableSegments, numPrimaryKeysInSnapshot, numTrackedSegments,
+            + "{} are consuming segments) in {} ms", numImmutableSegments, numPrimaryKeysInSnapshot, numTrackedSegments,
         numConsumingSegments, System.currentTimeMillis() - startTimeMs);
   }
 


### PR DESCRIPTION
label:
- `observability`

This patch adds metrics to report the time taken by the upsert-snapshot workflow.

Also improves logging by adding number of consuming segments. At present, log comes as:
```
Finished taking snapshot for 120 immutable segments with 7794903 primary keys (out of 121 total segments) in 2343ms
```
Adding number of consuming segments will give clarity if the 1 missed is consuming segment or not.
