### PR TITLE
Fixing the multiple files concurrent write issue when reloading SSLFactory

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/TlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/TlsUtils.java
@@ -451,8 +451,8 @@ public final class TlsUtils {
               + "(built from key store {} and truststore {})",
               changedFile, baseSslFactory, keyStorePath, trustStorePath);
           try {
-            // Need to retry a few times because when one file is updated, the file may not have been fully written
-            // yet, so we need to wait a bit and retry.
+            // Need to retry a few times because when one file (key store or trust store) is updated, the other file
+            // (trust store or key store) may not have been fully written yet, so we need to wait a bit and retry.
             RetryPolicies.fixedDelayRetryPolicy(maxSslFactoryReloadingAttempts, sslFactoryReloadingRetryDelayMs)
                 .attempt(() -> {
                   try {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/TlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/TlsUtils.java
@@ -57,6 +57,7 @@ import org.apache.commons.lang.StringUtils;
 import org.apache.http.ssl.SSLContexts;
 import org.apache.pinot.common.config.TlsConfig;
 import org.apache.pinot.spi.env.PinotConfiguration;
+import org.apache.pinot.spi.utils.retry.RetryPolicies;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -439,6 +440,8 @@ public final class TlsUtils {
     Map<WatchKey, Set<Path>> watchKeyPathMap = new HashMap<>();
     registerFile(watchService, watchKeyPathMap, keyStorePath);
     registerFile(watchService, watchKeyPathMap, trustStorePath);
+    int maxSslFactoryReloadingAttempts = 3;
+    int sslFactoryReloadingRetryDelayMs = 1000;
     WatchKey key;
     while ((key = watchService.take()) != null) {
       for (WatchEvent<?> event : key.pollEvents()) {
@@ -447,12 +450,32 @@ public final class TlsUtils {
           LOGGER.info("Detected change in file: {}, try to renew SSLFactory {} "
               + "(built from key store {} and truststore {})",
               changedFile, baseSslFactory, keyStorePath, trustStorePath);
-          SSLFactory updatedSslFactory = createSSLFactory(
-              keyStoreType, keyStorePath, keyStorePassword, trustStoreType, trustStorePath, trustStorePassword,
-              sslContextProtocol, secureRandom, false);
-          SSLFactoryUtils.reload(baseSslFactory, updatedSslFactory);
-          LOGGER.info("Successfully renewed SSLFactory {} (built from key store {} and truststore {}) "
-                  + "on file {} changes", baseSslFactory, keyStorePath, trustStorePath, changedFile);
+          try {
+            // Need to retry a few times because when one file is updated, the file may not have been fully written
+            // yet, so we need to wait a bit and retry.
+            RetryPolicies.fixedDelayRetryPolicy(maxSslFactoryReloadingAttempts, sslFactoryReloadingRetryDelayMs)
+                .attempt(() -> {
+                  try {
+                    SSLFactory updatedSslFactory =
+                        createSSLFactory(keyStoreType, keyStorePath, keyStorePassword, trustStoreType, trustStorePath,
+                            trustStorePassword, sslContextProtocol, secureRandom, false);
+                    SSLFactoryUtils.reload(baseSslFactory, updatedSslFactory);
+                    LOGGER.info("Successfully renewed SSLFactory {} (built from key store {} and truststore {}) on file"
+                        + " {} changes", baseSslFactory, keyStorePath, trustStorePath, changedFile);
+                    return true;
+                  } catch (Exception e) {
+                    LOGGER.info(
+                        "Encountered issues when renewing SSLFactory {} (built from key store {} and truststore {}) on "
+                            + "file {} changes", baseSslFactory, keyStorePath, trustStorePath, changedFile, e);
+                    return false;
+                  }
+                });
+          } catch (Exception e) {
+            LOGGER.error(
+                "Failed to renew SSLFactory {} (built from key store {} and truststore {}) on file {} changes after {} "
+                    + "retries", baseSslFactory, keyStorePath, trustStorePath, changedFile,
+                maxSslFactoryReloadingAttempts, e);
+          }
         }
       }
       key.reset();


### PR DESCRIPTION
In our tests, we found that when reloading SSLFactory, need to retry a few times because when one file (key store or trust store) is updated, the other file (trust store or key store) may not have been fully written yet, so we need to wait a bit and retry.