### PR TITLE
Add Prefix, Suffix and Ngram UDFs

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -584,38 +584,64 @@ public class StringFunctions {
 
   /**
    * @param input an input string for prefix strings generations.
-   * @param length the max length of the prefix strings for the string.
-   * @param regexChar the character for regex matching to be added to prefix strings generated. e.g. '^'
+   * @param maxlength the max length of the prefix strings for the string.
    * @return generate an array of prefix strings of the string that are shorter than the specified length.
    */
   @ScalarFunction
-  public static String[] prefix(String input, int length, String regexChar) {
+  public static String[] prefixes(String input, int maxlength) {
     ObjectSet<String> prefixSet = new ObjectLinkedOpenHashSet<>();
-    for (int prefixLength = 1; prefixLength <= length && prefixLength <= input.length(); prefixLength++) {
-      if (regexChar != null) {
-        prefixSet.add(regexChar + input.substring(0, prefixLength));
-      } else {
-        prefixSet.add(input.substring(0, prefixLength));
-      }
+    for (int prefixLength = 1; prefixLength <= maxlength && prefixLength <= input.length(); prefixLength++) {
+      prefixSet.add(input.substring(0, prefixLength));
+    }
+    return prefixSet.toArray(new String[0]);
+  }
+
+  /**
+   * @param input an input string for prefix strings generations.
+   * @param maxlength the max length of the prefix strings for the string.
+   * @param regexChar the character for regex matching to be added to prefix strings generated. e.g. '^'
+   * @return generate an array of prefix matchers of the string that are shorter than the specified length.
+   */
+  @ScalarFunction
+  public static String[] prefixMatchers(String input, int maxlength, String regexChar) {
+    if (regexChar == null) {
+      return prefixes(input, maxlength);
+    }
+    ObjectSet<String> prefixSet = new ObjectLinkedOpenHashSet<>();
+    for (int prefixLength = 1; prefixLength <= maxlength && prefixLength <= input.length(); prefixLength++) {
+      prefixSet.add(regexChar + input.substring(0, prefixLength));
     }
     return prefixSet.toArray(new String[0]);
   }
 
   /**
    * @param input an input string for suffix strings generations.
-   * @param length the max length of the suffix strings for the string.
-   * @param regexChar the character for regex matching to be added to suffix strings generated. e.g. '$'
+   * @param maxlength the max length of the suffix strings for the string.
    * @return generate an array of suffix strings of the string that are shorter than the specified length.
    */
   @ScalarFunction
-  public static String[] suffix(String input, int length, String regexChar) {
+  public static String[] suffixes(String input, int maxlength) {
     ObjectSet<String> suffixSet = new ObjectLinkedOpenHashSet<>();
-    for (int suffixLength = 1; suffixLength <= length && suffixLength <= input.length(); suffixLength++) {
-      if (regexChar != null) {
-        suffixSet.add(input.substring(input.length() - suffixLength) + regexChar);
-      } else {
-        suffixSet.add(input.substring(input.length() - suffixLength));
-      }
+    for (int suffixLength = 1; suffixLength <= maxlength && suffixLength <= input.length(); suffixLength++) {
+      suffixSet.add(input.substring(input.length() - suffixLength));
+    }
+    return suffixSet.toArray(new String[0]);
+  }
+
+  /**
+   * @param input an input string for suffix strings generations.
+   * @param maxlength the max length of the suffix strings for the string.
+   * @param regexChar the character for regex matching to be added to suffix strings generated. e.g. '$'
+   * @return generate an array of suffix matchers of the string that are shorter than the specified length.
+   */
+  @ScalarFunction
+  public static String[] suffixMatchers(String input, int maxlength, String regexChar) {
+    if (regexChar == null) {
+      return suffixes(input, maxlength);
+    }
+    ObjectSet<String> suffixSet = new ObjectLinkedOpenHashSet<>();
+    for (int suffixLength = 1; suffixLength <= maxlength && suffixLength <= input.length(); suffixLength++) {
+      suffixSet.add(input.substring(input.length() - suffixLength) + regexChar);
     }
     return suffixSet.toArray(new String[0]);
   }
@@ -626,7 +652,7 @@ public class StringFunctions {
    * @return generate an array of ngram of the string that length are exactly matching the specified length.
    */
   @ScalarFunction
-  public static String[] ngram(String input, int length) {
+  public static String[] ngrams(String input, int length) {
     if (length == 0 || length > input.length()) {
       return new String[0];
     }
@@ -644,7 +670,7 @@ public class StringFunctions {
    * @return generate an array of ngram of the string that length are within the specified range [minGram, maxGram].
    */
   @ScalarFunction
-  public static String[] ngram(String input, int minGram, int maxGram) {
+  public static String[] ngrams(String input, int minGram, int maxGram) {
     ObjectSet<String> ngramSet = new ObjectLinkedOpenHashSet<>();
     for (int n = minGram; n <= maxGram && n <= input.length(); n++) {
       if (n == 0) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -604,7 +604,7 @@ public class StringFunctions {
    * @param prefix the prefix to be prepended to prefix strings generated. e.g. '^' for regex matching
    * @return generate an array of prefix matchers of the string that are shorter than the specified length.
    */
-  @ScalarFunction(nullableParameters = true, names = {"prefix"})
+  @ScalarFunction(nullableParameters = true, names = {"prefixesWithPrefix", "prefixes_with_prefix"})
   public static String[] prefixesWithPrefix(String input, int maxlength, @Nullable String prefix) {
     if (prefix == null) {
       return prefixes(input, maxlength);
@@ -638,7 +638,7 @@ public class StringFunctions {
    * @param suffix the suffix string to be appended for suffix strings generated. e.g. '$' for regex matching.
    * @return generate an array of suffix matchers of the string that are shorter than the specified length.
    */
-  @ScalarFunction(nullableParameters = true, names = {"suffix"})
+  @ScalarFunction(nullableParameters = true, names = {"suffixesWithSuffix", "suffixes_with_suffix"})
   public static String[] suffixesWithSuffix(String input, int maxlength, @Nullable String suffix) {
     if (suffix == null) {
       return suffixes(input, maxlength);

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -18,7 +18,9 @@
  */
 package org.apache.pinot.common.function.scalar;
 
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
+import it.unimi.dsi.fastutil.objects.ObjectList;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -30,6 +32,7 @@ import java.util.Base64;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.RegexpPatternConverterUtils;
 import org.apache.pinot.spi.annotations.ScalarFunction;
@@ -588,12 +591,12 @@ public class StringFunctions {
    * @return generate an array of prefix strings of the string that are shorter than the specified length.
    */
   @ScalarFunction
-  public static String[] uniquePrefixes(String input, int maxlength) {
-    ObjectSet<String> prefixSet = new ObjectLinkedOpenHashSet<>();
+  public static String[] prefixes(String input, int maxlength) {
+    ObjectList<String> prefixList = new ObjectArrayList<>();
     for (int prefixLength = 1; prefixLength <= maxlength && prefixLength <= input.length(); prefixLength++) {
-      prefixSet.add(input.substring(0, prefixLength));
+      prefixList.add(input.substring(0, prefixLength));
     }
-    return prefixSet.toArray(new String[0]);
+    return prefixList.toArray(new String[0]);
   }
 
   /**
@@ -603,15 +606,15 @@ public class StringFunctions {
    * @return generate an array of prefix matchers of the string that are shorter than the specified length.
    */
   @ScalarFunction
-  public static String[] uniquePrefixesWithPrefix(String input, int maxlength, String prefix) {
+  public static String[] prefixesWithPrefix(String input, int maxlength, @Nullable String prefix) {
     if (prefix == null) {
-      return uniquePrefixes(input, maxlength);
+      return prefixes(input, maxlength);
     }
-    ObjectSet<String> prefixSet = new ObjectLinkedOpenHashSet<>();
+    ObjectList<String> prefixList = new ObjectArrayList<>();
     for (int prefixLength = 1; prefixLength <= maxlength && prefixLength <= input.length(); prefixLength++) {
-      prefixSet.add(prefix + input.substring(0, prefixLength));
+      prefixList.add(prefix + input.substring(0, prefixLength));
     }
-    return prefixSet.toArray(new String[0]);
+    return prefixList.toArray(new String[0]);
   }
 
   /**
@@ -620,12 +623,12 @@ public class StringFunctions {
    * @return generate an array of suffix strings of the string that are shorter than the specified length.
    */
   @ScalarFunction
-  public static String[] uniqueSuffixes(String input, int maxlength) {
-    ObjectSet<String> suffixSet = new ObjectLinkedOpenHashSet<>();
+  public static String[] suffixes(String input, int maxlength) {
+    ObjectList<String> suffixList = new ObjectArrayList<>();
     for (int suffixLength = 1; suffixLength <= maxlength && suffixLength <= input.length(); suffixLength++) {
-      suffixSet.add(input.substring(input.length() - suffixLength));
+      suffixList.add(input.substring(input.length() - suffixLength));
     }
-    return suffixSet.toArray(new String[0]);
+    return suffixList.toArray(new String[0]);
   }
 
   /**
@@ -635,21 +638,21 @@ public class StringFunctions {
    * @return generate an array of suffix matchers of the string that are shorter than the specified length.
    */
   @ScalarFunction
-  public static String[] uniqueSuffixesWithSuffix(String input, int maxlength, String suffix) {
+  public static String[] suffixesWithSuffix(String input, int maxlength, @Nullable String suffix) {
     if (suffix == null) {
-      return uniqueSuffixes(input, maxlength);
+      return suffixes(input, maxlength);
     }
-    ObjectSet<String> suffixSet = new ObjectLinkedOpenHashSet<>();
+    ObjectList<String> suffixList = new ObjectArrayList<>();
     for (int suffixLength = 1; suffixLength <= maxlength && suffixLength <= input.length(); suffixLength++) {
-      suffixSet.add(input.substring(input.length() - suffixLength) + suffix);
+      suffixList.add(input.substring(input.length() - suffixLength) + suffix);
     }
-    return suffixSet.toArray(new String[0]);
+    return suffixList.toArray(new String[0]);
   }
 
   /**
    * @param input an input string for ngram generations.
    * @param length the max length of the ngram for the string.
-   * @return generate an array of ngram of the string that length are exactly matching the specified length.
+   * @return generate an array of unique ngram of the string that length are exactly matching the specified length.
    */
   @ScalarFunction
   public static String[] uniqueNgrams(String input, int length) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -18,9 +18,7 @@
  */
 package org.apache.pinot.common.function.scalar;
 
-import it.unimi.dsi.fastutil.objects.ObjectArrayList;
 import it.unimi.dsi.fastutil.objects.ObjectLinkedOpenHashSet;
-import it.unimi.dsi.fastutil.objects.ObjectList;
 import it.unimi.dsi.fastutil.objects.ObjectSet;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
@@ -592,11 +590,12 @@ public class StringFunctions {
    */
   @ScalarFunction
   public static String[] prefixes(String input, int maxlength) {
-    ObjectList<String> prefixList = new ObjectArrayList<>();
-    for (int prefixLength = 1; prefixLength <= maxlength && prefixLength <= input.length(); prefixLength++) {
-      prefixList.add(input.substring(0, prefixLength));
+    int arrLength = Math.min(maxlength, input.length());
+    String[] prefixArr = new String[arrLength];
+    for (int prefixIdx = 1; prefixIdx <= arrLength; prefixIdx++) {
+      prefixArr[prefixIdx - 1] = input.substring(0, prefixIdx);
     }
-    return prefixList.toArray(new String[0]);
+    return prefixArr;
   }
 
   /**
@@ -605,16 +604,17 @@ public class StringFunctions {
    * @param prefix the prefix to be prepended to prefix strings generated. e.g. '^' for regex matching
    * @return generate an array of prefix matchers of the string that are shorter than the specified length.
    */
-  @ScalarFunction
+  @ScalarFunction(nullableParameters = true, names = {"prefix"})
   public static String[] prefixesWithPrefix(String input, int maxlength, @Nullable String prefix) {
     if (prefix == null) {
       return prefixes(input, maxlength);
     }
-    ObjectList<String> prefixList = new ObjectArrayList<>();
-    for (int prefixLength = 1; prefixLength <= maxlength && prefixLength <= input.length(); prefixLength++) {
-      prefixList.add(prefix + input.substring(0, prefixLength));
+    int arrLength = Math.min(maxlength, input.length());
+    String[] prefixArr = new String[arrLength];
+    for (int prefixIdx = 1; prefixIdx <= arrLength; prefixIdx++) {
+      prefixArr[prefixIdx - 1] = prefix + input.substring(0, prefixIdx);
     }
-    return prefixList.toArray(new String[0]);
+    return prefixArr;
   }
 
   /**
@@ -624,11 +624,12 @@ public class StringFunctions {
    */
   @ScalarFunction
   public static String[] suffixes(String input, int maxlength) {
-    ObjectList<String> suffixList = new ObjectArrayList<>();
-    for (int suffixLength = 1; suffixLength <= maxlength && suffixLength <= input.length(); suffixLength++) {
-      suffixList.add(input.substring(input.length() - suffixLength));
+    int arrLength = Math.min(maxlength, input.length());
+    String[] suffixArr = new String[arrLength];
+    for (int suffixIdx = 1; suffixIdx <= arrLength; suffixIdx++) {
+      suffixArr[suffixIdx - 1] = input.substring(input.length() - suffixIdx);
     }
-    return suffixList.toArray(new String[0]);
+    return suffixArr;
   }
 
   /**
@@ -637,16 +638,17 @@ public class StringFunctions {
    * @param suffix the suffix string to be appended for suffix strings generated. e.g. '$' for regex matching.
    * @return generate an array of suffix matchers of the string that are shorter than the specified length.
    */
-  @ScalarFunction
+  @ScalarFunction(nullableParameters = true, names = {"suffix"})
   public static String[] suffixesWithSuffix(String input, int maxlength, @Nullable String suffix) {
     if (suffix == null) {
       return suffixes(input, maxlength);
     }
-    ObjectList<String> suffixList = new ObjectArrayList<>();
-    for (int suffixLength = 1; suffixLength <= maxlength && suffixLength <= input.length(); suffixLength++) {
-      suffixList.add(input.substring(input.length() - suffixLength) + suffix);
+    int arrLength = Math.min(maxlength, input.length());
+    String[] suffixArr = new String[arrLength];
+    for (int suffixIdx = 1; suffixIdx <= arrLength; suffixIdx++) {
+      suffixArr[suffixIdx - 1] = input.substring(input.length() - suffixIdx) + suffix;
     }
-    return suffixList.toArray(new String[0]);
+    return suffixArr;
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -588,7 +588,7 @@ public class StringFunctions {
    * @return generate an array of prefix strings of the string that are shorter than the specified length.
    */
   @ScalarFunction
-  public static String[] prefixes(String input, int maxlength) {
+  public static String[] uniquePrefixes(String input, int maxlength) {
     ObjectSet<String> prefixSet = new ObjectLinkedOpenHashSet<>();
     for (int prefixLength = 1; prefixLength <= maxlength && prefixLength <= input.length(); prefixLength++) {
       prefixSet.add(input.substring(0, prefixLength));
@@ -599,17 +599,17 @@ public class StringFunctions {
   /**
    * @param input an input string for prefix strings generations.
    * @param maxlength the max length of the prefix strings for the string.
-   * @param regexChar the character for regex matching to be added to prefix strings generated. e.g. '^'
+   * @param prefix the prefix to be prepended to prefix strings generated. e.g. '^' for regex matching
    * @return generate an array of prefix matchers of the string that are shorter than the specified length.
    */
   @ScalarFunction
-  public static String[] prefixMatchers(String input, int maxlength, String regexChar) {
-    if (regexChar == null) {
-      return prefixes(input, maxlength);
+  public static String[] uniquePrefixesWithPrefix(String input, int maxlength, String prefix) {
+    if (prefix == null) {
+      return uniquePrefixes(input, maxlength);
     }
     ObjectSet<String> prefixSet = new ObjectLinkedOpenHashSet<>();
     for (int prefixLength = 1; prefixLength <= maxlength && prefixLength <= input.length(); prefixLength++) {
-      prefixSet.add(regexChar + input.substring(0, prefixLength));
+      prefixSet.add(prefix + input.substring(0, prefixLength));
     }
     return prefixSet.toArray(new String[0]);
   }
@@ -620,7 +620,7 @@ public class StringFunctions {
    * @return generate an array of suffix strings of the string that are shorter than the specified length.
    */
   @ScalarFunction
-  public static String[] suffixes(String input, int maxlength) {
+  public static String[] uniqueSuffixes(String input, int maxlength) {
     ObjectSet<String> suffixSet = new ObjectLinkedOpenHashSet<>();
     for (int suffixLength = 1; suffixLength <= maxlength && suffixLength <= input.length(); suffixLength++) {
       suffixSet.add(input.substring(input.length() - suffixLength));
@@ -631,17 +631,17 @@ public class StringFunctions {
   /**
    * @param input an input string for suffix strings generations.
    * @param maxlength the max length of the suffix strings for the string.
-   * @param regexChar the character for regex matching to be added to suffix strings generated. e.g. '$'
+   * @param suffix the suffix string to be appended for suffix strings generated. e.g. '$' for regex matching.
    * @return generate an array of suffix matchers of the string that are shorter than the specified length.
    */
   @ScalarFunction
-  public static String[] suffixMatchers(String input, int maxlength, String regexChar) {
-    if (regexChar == null) {
-      return suffixes(input, maxlength);
+  public static String[] uniqueSuffixesWithSuffix(String input, int maxlength, String suffix) {
+    if (suffix == null) {
+      return uniqueSuffixes(input, maxlength);
     }
     ObjectSet<String> suffixSet = new ObjectLinkedOpenHashSet<>();
     for (int suffixLength = 1; suffixLength <= maxlength && suffixLength <= input.length(); suffixLength++) {
-      suffixSet.add(input.substring(input.length() - suffixLength) + regexChar);
+      suffixSet.add(input.substring(input.length() - suffixLength) + suffix);
     }
     return suffixSet.toArray(new String[0]);
   }
@@ -652,7 +652,7 @@ public class StringFunctions {
    * @return generate an array of ngram of the string that length are exactly matching the specified length.
    */
   @ScalarFunction
-  public static String[] ngrams(String input, int length) {
+  public static String[] uniqueNgrams(String input, int length) {
     if (length == 0 || length > input.length()) {
       return new String[0];
     }
@@ -670,7 +670,7 @@ public class StringFunctions {
    * @return generate an array of ngram of the string that length are within the specified range [minGram, maxGram].
    */
   @ScalarFunction
-  public static String[] ngrams(String input, int minGram, int maxGram) {
+  public static String[] uniqueNgrams(String input, int minGram, int maxGram) {
     ObjectSet<String> ngramSet = new ObjectLinkedOpenHashSet<>();
     for (int n = minGram; n <= maxGram && n <= input.length(); n++) {
       if (n == 0) {

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -70,25 +70,27 @@ public class StringFunctionsTest {
   @DataProvider(name = "isJson")
   public static Object[][] isJsonTestCases() {
     return new Object[][]{
-        {"", true}, {"{\"key\": \"value\"}", true}, {"{\"key\": \"value\", }", false}, {"{\"key\": \"va", false}
+        {"", true},
+        {"{\"key\": \"value\"}", true},
+        {"{\"key\": \"value\", }", false},
+        {"{\"key\": \"va", false}
     };
   }
 
   @DataProvider(name = "prefixAndSuffixTestCases")
   public static Object[][] prefixAndSuffixTestCases() {
     return new Object[][]{
-        {
-            "abcde", 3, new String[]{"a", "ab", "abc"}, new String[]{"e", "de", "cde"}, new String[]{
-            "^a", "^ab", "^abc"
-        }, new String[]{"e$", "de$", "cde$"}
-        }, {"abcde", 0, new String[]{}, new String[]{}, new String[]{}, new String[]{}}, {
-        "abcde", 9, new String[]{"a", "ab", "abc", "abcd", "abcde"}, new String[]{"e", "de", "cde", "bcde", "abcde"},
-        new String[]{"^a", "^ab", "^abc", "^abcd", "^abcde"}, new String[]{"e$", "de$", "cde$", "bcde$", "abcde$"}
-    }, {"a", 3, new String[]{"a"}, new String[]{"a"}, new String[]{"^a"}, new String[]{"a$"}}, {"a", 0,
-        new String[]{}, new String[]{}, new String[]{}, new String[]{}}, {"a", 9, new String[]{"a"},
-        new String[]{"a"}, new String[]{"^a"}, new String[]{"a$"}}, {"", 3, new String[]{}, new String[]{},
-        new String[]{}, new String[]{}}, {"", 0, new String[]{}, new String[]{}, new String[]{}, new String[]{}}, {""
-        , 9, new String[]{}, new String[]{}, new String[]{}, new String[]{}}
+        {"abcde", 3, new String[]{"a", "ab", "abc"}, new String[]{"e", "de", "cde"}, new String[]{
+            "^a", "^ab", "^abc"}, new String[]{"e$", "de$", "cde$"}},
+        {"abcde", 0, new String[]{}, new String[]{}, new String[]{}, new String[]{}},
+        {"abcde", 9, new String[]{"a", "ab", "abc", "abcd", "abcde"}, new String[]{"e", "de", "cde", "bcde", "abcde"},
+        new String[]{"^a", "^ab", "^abc", "^abcd", "^abcde"}, new String[]{"e$", "de$", "cde$", "bcde$", "abcde$"}},
+        {"a", 3, new String[]{"a"}, new String[]{"a"}, new String[]{"^a"}, new String[]{"a$"}},
+        {"a", 0, new String[]{}, new String[]{}, new String[]{}, new String[]{}},
+        {"a", 9, new String[]{"a"}, new String[]{"a"}, new String[]{"^a"}, new String[]{"a$"}},
+        {"", 3, new String[]{}, new String[]{}, new String[]{}, new String[]{}},
+        {"", 0, new String[]{}, new String[]{}, new String[]{}, new String[]{}},
+        {"", 9, new String[]{}, new String[]{}, new String[]{}, new String[]{}}
     };
   }
 
@@ -96,12 +98,17 @@ public class StringFunctionsTest {
   public static Object[][] ngramTestCases() {
     return new Object[][]{
         {"abcd", 0, 3, new String[]{"abc", "bcd"}, new String[]{"a", "b", "c", "d", "ab", "bc", "cd", "abc", "bcd"}},
-        {"abcd", 2, 2, new String[]{"ab", "bc", "cd"}, new String[]{"ab", "bc", "cd"}}, {"abcd", 3, 0, new String[]{}
-        , new String[]{}}, {"abc", 0, 3, new String[]{"abc"}, new String[]{"a", "b", "c", "ab", "bc", "abc"}}, {"abc"
-        , 3, 0, new String[]{}, new String[]{}}, {"abc", 3, 3, new String[]{"abc"}, new String[]{"abc"}}, {"a", 0, 3,
-        new String[]{}, new String[]{"a"}}, {"a", 2, 3, new String[]{}, new String[]{}}, {"a", 3, 3, new String[]{},
-        new String[]{}}, {"", 3, 0, new String[]{}, new String[]{}}, {"", 3, 3, new String[]{}, new String[]{}}, {"",
-        0, 3, new String[]{}, new String[]{}}
+        {"abcd", 2, 2, new String[]{"ab", "bc", "cd"}, new String[]{"ab", "bc", "cd"}},
+        {"abcd", 3, 0, new String[]{}, new String[]{}},
+        {"abc", 0, 3, new String[]{"abc"}, new String[]{"a", "b", "c", "ab", "bc", "abc"}},
+        {"abc", 3, 0, new String[]{}, new String[]{}},
+        {"abc", 3, 3, new String[]{"abc"}, new String[]{"abc"}},
+        {"a", 0, 3, new String[]{}, new String[]{"a"}},
+        {"a", 2, 3, new String[]{}, new String[]{}},
+        {"a", 3, 3, new String[]{}, new String[]{}},
+        {"", 3, 0, new String[]{}, new String[]{}},
+        {"", 3, 3, new String[]{}, new String[]{}},
+        {"", 0, 3, new String[]{}, new String[]{}}
     };
   }
 
@@ -120,10 +127,10 @@ public class StringFunctionsTest {
   @Test(dataProvider = "prefixAndSuffixTestCases")
   public void testPrefixAndSuffix(String input, int length, String[] expectedPrefix, String[] expectedSuffix,
       String[] expectedPrefixWithRegexChar, String[] expectedSuffixWithRegexChar) {
-    assertEquals(StringFunctions.uniquePrefixes(input, length), expectedPrefix);
-    assertEquals(StringFunctions.uniqueSuffixes(input, length), expectedSuffix);
-    assertEquals(StringFunctions.uniquePrefixesWithPrefix(input, length, "^"), expectedPrefixWithRegexChar);
-    assertEquals(StringFunctions.uniqueSuffixesWithSuffix(input, length, "$"), expectedSuffixWithRegexChar);
+    assertEquals(StringFunctions.prefixes(input, length), expectedPrefix);
+    assertEquals(StringFunctions.suffixes(input, length), expectedSuffix);
+    assertEquals(StringFunctions.prefixesWithPrefix(input, length, "^"), expectedPrefixWithRegexChar);
+    assertEquals(StringFunctions.suffixesWithSuffix(input, length, "$"), expectedSuffixWithRegexChar);
   }
 
   @Test(dataProvider = "ngramTestCases")

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -120,15 +120,15 @@ public class StringFunctionsTest {
   @Test(dataProvider = "prefixAndSuffixTestCases")
   public void testPrefixAndSuffix(String input, int length, String[] expectedPrefix, String[] expectedSuffix,
       String[] expectedPrefixWithRegexChar, String[] expectedSuffixWithRegexChar) {
-    assertEquals(StringFunctions.prefixes(input, length), expectedPrefix);
-    assertEquals(StringFunctions.suffixes(input, length), expectedSuffix);
-    assertEquals(StringFunctions.prefixMatchers(input, length, "^"), expectedPrefixWithRegexChar);
-    assertEquals(StringFunctions.suffixMatchers(input, length, "$"), expectedSuffixWithRegexChar);
+    assertEquals(StringFunctions.uniquePrefixes(input, length), expectedPrefix);
+    assertEquals(StringFunctions.uniqueSuffixes(input, length), expectedSuffix);
+    assertEquals(StringFunctions.uniquePrefixesWithPrefix(input, length, "^"), expectedPrefixWithRegexChar);
+    assertEquals(StringFunctions.uniqueSuffixesWithSuffix(input, length, "$"), expectedSuffixWithRegexChar);
   }
 
   @Test(dataProvider = "ngramTestCases")
   public void testNGram(String input, int minGram, int maxGram, String[] expectedExactNGram, String[] expectedNGram) {
-    assertEquals(StringFunctions.ngrams(input, maxGram), expectedExactNGram);
-    assertEquals(StringFunctions.ngrams(input, minGram, maxGram), expectedNGram);
+    assertEquals(StringFunctions.uniqueNgrams(input, maxGram), expectedExactNGram);
+    assertEquals(StringFunctions.uniqueNgrams(input, minGram, maxGram), expectedNGram);
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -70,10 +70,38 @@ public class StringFunctionsTest {
   @DataProvider(name = "isJson")
   public static Object[][] isJsonTestCases() {
     return new Object[][]{
-        {"", true},
-        {"{\"key\": \"value\"}", true},
-        {"{\"key\": \"value\", }", false},
-        {"{\"key\": \"va", false}
+        {"", true}, {"{\"key\": \"value\"}", true}, {"{\"key\": \"value\", }", false}, {"{\"key\": \"va", false}
+    };
+  }
+
+  @DataProvider(name = "prefixAndSuffixTestCases")
+  public static Object[][] prefixAndSuffixTestCases() {
+    return new Object[][]{
+        {
+            "abcde", 3, new String[]{"a", "ab", "abc"}, new String[]{"e", "de", "cde"}, new String[]{
+            "^a", "^ab", "^abc"
+        }, new String[]{"e$", "de$", "cde$"}
+        }, {"abcde", 0, new String[]{}, new String[]{}, new String[]{}, new String[]{}}, {
+        "abcde", 9, new String[]{"a", "ab", "abc", "abcd", "abcde"}, new String[]{"e", "de", "cde", "bcde", "abcde"},
+        new String[]{"^a", "^ab", "^abc", "^abcd", "^abcde"}, new String[]{"e$", "de$", "cde$", "bcde$", "abcde$"}
+    }, {"a", 3, new String[]{"a"}, new String[]{"a"}, new String[]{"^a"}, new String[]{"a$"}}, {"a", 0,
+        new String[]{}, new String[]{}, new String[]{}, new String[]{}}, {"a", 9, new String[]{"a"},
+        new String[]{"a"}, new String[]{"^a"}, new String[]{"a$"}}, {"", 3, new String[]{}, new String[]{},
+        new String[]{}, new String[]{}}, {"", 0, new String[]{}, new String[]{}, new String[]{}, new String[]{}}, {""
+        , 9, new String[]{}, new String[]{}, new String[]{}, new String[]{}}
+    };
+  }
+
+  @DataProvider(name = "ngramTestCases")
+  public static Object[][] ngramTestCases() {
+    return new Object[][]{
+        {"abcd", 0, 3, new String[]{"abc", "bcd"}, new String[]{"a", "b", "c", "d", "ab", "bc", "cd", "abc", "bcd"}},
+        {"abcd", 2, 2, new String[]{"ab", "bc", "cd"}, new String[]{"ab", "bc", "cd"}}, {"abcd", 3, 0, new String[]{}
+        , new String[]{}}, {"abc", 0, 3, new String[]{"abc"}, new String[]{"a", "b", "c", "ab", "bc", "abc"}}, {"abc"
+        , 3, 0, new String[]{}, new String[]{}}, {"abc", 3, 3, new String[]{"abc"}, new String[]{"abc"}}, {"a", 0, 3,
+        new String[]{}, new String[]{"a"}}, {"a", 2, 3, new String[]{}, new String[]{}}, {"a", 3, 3, new String[]{},
+        new String[]{}}, {"", 3, 0, new String[]{}, new String[]{}}, {"", 3, 3, new String[]{}, new String[]{}}, {"",
+        0, 3, new String[]{}, new String[]{}}
     };
   }
 
@@ -87,5 +115,20 @@ public class StringFunctionsTest {
       String expectedTokenWithLimitCounts) {
     assertEquals(StringFunctions.splitPart(input, delimiter, index), expectedToken);
     assertEquals(StringFunctions.splitPart(input, delimiter, limit, index), expectedTokenWithLimitCounts);
+  }
+
+  @Test(dataProvider = "prefixAndSuffixTestCases")
+  public void testPrefixAndSuffix(String input, int length, String[] expectedPrefix, String[] expectedSuffix,
+      String[] expectedPrefixWithRegexChar, String[] expectedSuffixWithRegexChar) {
+    assertEquals(StringFunctions.prefix(input, length, null), expectedPrefix);
+    assertEquals(StringFunctions.suffix(input, length, null), expectedSuffix);
+    assertEquals(StringFunctions.prefix(input, length, "^"), expectedPrefixWithRegexChar);
+    assertEquals(StringFunctions.suffix(input, length, "$"), expectedSuffixWithRegexChar);
+  }
+
+  @Test(dataProvider = "ngramTestCases")
+  public void testNGram(String input, int minGram, int maxGram, String[] expectedExactNGram, String[] expectedNGram) {
+    assertEquals(StringFunctions.ngram(input, maxGram), expectedExactNGram);
+    assertEquals(StringFunctions.ngram(input, minGram, maxGram), expectedNGram);
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -120,15 +120,15 @@ public class StringFunctionsTest {
   @Test(dataProvider = "prefixAndSuffixTestCases")
   public void testPrefixAndSuffix(String input, int length, String[] expectedPrefix, String[] expectedSuffix,
       String[] expectedPrefixWithRegexChar, String[] expectedSuffixWithRegexChar) {
-    assertEquals(StringFunctions.prefix(input, length, null), expectedPrefix);
-    assertEquals(StringFunctions.suffix(input, length, null), expectedSuffix);
-    assertEquals(StringFunctions.prefix(input, length, "^"), expectedPrefixWithRegexChar);
-    assertEquals(StringFunctions.suffix(input, length, "$"), expectedSuffixWithRegexChar);
+    assertEquals(StringFunctions.prefixes(input, length), expectedPrefix);
+    assertEquals(StringFunctions.suffixes(input, length), expectedSuffix);
+    assertEquals(StringFunctions.prefixMatchers(input, length, "^"), expectedPrefixWithRegexChar);
+    assertEquals(StringFunctions.suffixMatchers(input, length, "$"), expectedSuffixWithRegexChar);
   }
 
   @Test(dataProvider = "ngramTestCases")
   public void testNGram(String input, int minGram, int maxGram, String[] expectedExactNGram, String[] expectedNGram) {
-    assertEquals(StringFunctions.ngram(input, maxGram), expectedExactNGram);
-    assertEquals(StringFunctions.ngram(input, minGram, maxGram), expectedNGram);
+    assertEquals(StringFunctions.ngrams(input, maxGram), expectedExactNGram);
+    assertEquals(StringFunctions.ngrams(input, minGram, maxGram), expectedNGram);
   }
 }


### PR DESCRIPTION
`feature`: Adding ngram, prefix, postfix UDFs

Context:

We are onboarding a use case and trying the inrease query throughput. We tested the QPS cannot further improved with the existing REGEXP_LIKE queries or text_match queries. The queries as follows
```
select col1, col2 from table where REPEXP_LIKE(col3, '^data*')
select col1, col2 from table where REGEXP_LIKE(col3, 'data$')
select col1, col2 from table where REGEXP_LIKE(col3, '*data*')
select col1, col2 from table where TEXT_MATCH(col3, '/data*/')
...
```

The plan is to generated the derived columns that persisted prefix, postfix, and ngram to use inverted indexes to filter the result fast, and add the text match indexes to do validation after filtering to avoid false positive result. 

This patch is created to generate prefix, postfix, and ngrams for a field.
it can be used by the following transformation config
```
       {
          "columnName": "col_prefix",
          "transformFunction": "prefixes(col, 3, null)"
        },
       {
          "columnName": "col_suffix",
          "transformFunction": "suffixes(col, 3, null)"
        },
       {
          "columnName": "col_3gram",
          "transformFunction": "ngrams(col, 3)"
        },
       {
          "columnName": "col_1gram_2gram_3gram",
          "transformFunction": "ngrams(col, 1, 3)"
        },
```
