### PR TITLE
Fix Bug in Handling Equal Comparison Column Values in Upsert

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -27,9 +27,11 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
@@ -46,6 +48,7 @@ import org.apache.pinot.common.metrics.ServerTimer;
 import org.apache.pinot.segment.local.indexsegment.immutable.EmptyIndexSegment;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
 import org.apache.pinot.segment.local.segment.readers.PinotSegmentColumnReader;
+import org.apache.pinot.segment.local.utils.HashUtils;
 import org.apache.pinot.segment.local.utils.SegmentLocks;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
@@ -599,6 +602,46 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
       _lastOutOfOrderEventReportTimeNs = currentTimeNs;
       _numOutOfOrderEvents = 0;
     }
+  }
+
+  /**
+   * When we have to process a new segment, if there are comparison value ties for the same primary-key within the
+   * segment, then for Partial Upsert tables we need to make sure that the record location map is updated only
+   * for the latest version of the record. This is specifically a concern for Partial Upsert tables because Realtime
+   * consumption can potentially end up reading the wrong version of a record, which will lead to permanent
+   * data-inconsistency.
+   *
+   * <p>
+   *  This function returns an iterator that will de-dup records with the same primary-key. Moreover, for comparison
+   *  ties, it will only keep the latest record. This iterator can then further be used to update the primary-key
+   *  record location map safely.
+   * </p>
+   *
+   * @param recordInfoIterator iterator over the new segment
+   * @param hashFunction       hash function configured for Upsert's primary keys
+   * @return iterator that returns de-duplicated records. To resolve ties for comparison column values, we prefer to
+   *         return the latest record.
+   */
+  @SuppressWarnings({"rawtypes", "unchecked"})
+  protected static Iterator<RecordInfo> resolveComparisonTies(
+      Iterator<RecordInfo> recordInfoIterator, HashFunction hashFunction) {
+    Map<Object, RecordInfo> deDuplicatedRecordInfo = new HashMap<>();
+    while (recordInfoIterator.hasNext()) {
+      RecordInfo recordInfo = recordInfoIterator.next();
+      Comparable newComparisonValue = recordInfo.getComparisonValue();
+      deDuplicatedRecordInfo.compute(HashUtils.hashPrimaryKey(recordInfo.getPrimaryKey(), hashFunction),
+          (key, maxComparisonValueRecordInfo) -> {
+            if (maxComparisonValueRecordInfo == null) {
+              return recordInfo;
+            }
+            int comparisonResult = newComparisonValue.compareTo(maxComparisonValueRecordInfo.getComparisonValue());
+            if (comparisonResult >= 0) {
+              return recordInfo;
+            }
+            return maxComparisonValueRecordInfo;
+          });
+    }
+    return deDuplicatedRecordInfo.values().iterator();
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -101,7 +101,8 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
               // doc ids for the old segment because it has not been replaced yet. We pass in an optional valid doc ids
               // snapshot for the old segment, which can be updated and used to track the docs not replaced yet.
               if (currentSegment == oldSegment) {
-                if (comparisonResult >= 0) {
+                // TODO: DO NOT MERGE. This will break both partial-upsert and upsert tables when sorted column is set.
+                if (comparisonResult > 0 || (comparisonResult == 0 && newDocId == currentDocId)) {
                   addDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
                   if (validDocIdsForOldSegment != null) {
                     validDocIdsForOldSegment.remove(currentDocId);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -73,7 +73,7 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
 
     // Within the segment, if there are comparison column ties, we only need to keep the latest recordInfo.
     // Resolving ties before updating the map will make sure that the map doesn't point to an old version of a record
-    // when there are comparison column ties for a primary key in the next iteration.
+    // when there are comparison column ties for a primary key.
     // Refer to issue for more details: https://github.com/apache/pinot/issues/12398
     Map<Object, RecordInfo> deDupedRecordInfo = new HashMap<>();
     while (recordInfoIterator.hasNext()) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -378,28 +378,6 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     verifyAddReplaceRemoveSegmentWithRecordDelete(HashFunction.MURMUR3, true);
   }
 
-  @Test
-  public void testResolveComparisonTies() {
-    ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
-        new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0,
-            _contextBuilder.setHashFunction(HashFunction.NONE).build());
-    int[] primaryKeys = new int[]{0, 1, 2, 0, 1, 0};
-    int[] timestamps = new int[]{0, 0, 0, 0, 0, 0};
-    int numRecords = primaryKeys.length;
-    List<RecordInfo> recordInfoList = getRecordInfoList(numRecords, primaryKeys, timestamps, null);
-    Iterator<RecordInfo> deDuplicatedRecords = upsertMetadataManager.resolveComparisonTies(recordInfoList.iterator());
-    Map<PrimaryKey, RecordInfo> recordsByPrimaryKeys = new HashMap<>();
-    while (deDuplicatedRecords.hasNext()) {
-      RecordInfo recordInfo = deDuplicatedRecords.next();
-      assertFalse(recordsByPrimaryKeys.containsKey(recordInfo.getPrimaryKey()));
-      recordsByPrimaryKeys.put(recordInfo.getPrimaryKey(), recordInfo);
-    }
-    assertEquals(recordsByPrimaryKeys.size(), 3);
-    assertEquals(recordsByPrimaryKeys.get(makePrimaryKey(0)).getDocId(), 5);
-    assertEquals(recordsByPrimaryKeys.get(makePrimaryKey(1)).getDocId(), 4);
-    assertEquals(recordsByPrimaryKeys.get(makePrimaryKey(2)).getDocId(), 2);
-  }
-
   private void verifyAddReplaceRemoveSegmentWithRecordDelete(HashFunction hashFunction, boolean enableSnapshot)
       throws IOException {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -22,7 +22,6 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManagerTest.java
@@ -22,6 +22,7 @@ import java.io.File;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -377,43 +378,26 @@ public class ConcurrentMapPartitionUpsertMetadataManagerTest {
     verifyAddReplaceRemoveSegmentWithRecordDelete(HashFunction.MURMUR3, true);
   }
 
-  // TODO: Will be updated/deleted after discussion.
   @Test
-  public void testAddReplaceWithEqualComparisonColumn() {
-    final boolean enableSnapshot = false;
+  public void testResolveComparisonTies() {
     ConcurrentMapPartitionUpsertMetadataManager upsertMetadataManager =
         new ConcurrentMapPartitionUpsertMetadataManager(REALTIME_TABLE_NAME, 0,
             _contextBuilder.setHashFunction(HashFunction.NONE).build());
-    Map<Object, RecordLocation> recordLocationMap = upsertMetadataManager._primaryKeyToRecordLocationMap;
-    Set<IndexSegment> trackedSegments = upsertMetadataManager._trackedSegments;
-    // Add the first segment
-    int numRecords = 6;
     int[] primaryKeys = new int[]{0, 1, 2, 0, 1, 0};
     int[] timestamps = new int[]{0, 0, 0, 0, 0, 0};
-    ThreadSafeMutableRoaringBitmap validDocIds1 = new ThreadSafeMutableRoaringBitmap();
-    List<PrimaryKey> primaryKeys1 = getPrimaryKeyList(numRecords, primaryKeys);
-    ImmutableSegmentImpl segment1 = mockImmutableSegment(1, validDocIds1, null, primaryKeys1);
-    List<RecordInfo> recordInfoList1;
-    if (enableSnapshot) {
-      // get recordInfo from validDocIdSnapshot.
-      // segment1 snapshot: 0 -> {5, 100}, 1 -> {4, 120}, 2 -> {2, 100}
-      int[] docIds1 = new int[]{2, 4, 5};
-      MutableRoaringBitmap validDocIdsSnapshot1 = new MutableRoaringBitmap();
-      validDocIdsSnapshot1.add(docIds1);
-      recordInfoList1 = getRecordInfoList(validDocIdsSnapshot1, primaryKeys, timestamps, null);
-    } else {
-      // get recordInfo by iterating all records.
-      recordInfoList1 = getRecordInfoList(numRecords, primaryKeys, timestamps, null);
+    int numRecords = primaryKeys.length;
+    List<RecordInfo> recordInfoList = getRecordInfoList(numRecords, primaryKeys, timestamps, null);
+    Iterator<RecordInfo> deDuplicatedRecords = upsertMetadataManager.resolveComparisonTies(recordInfoList.iterator());
+    Map<PrimaryKey, RecordInfo> recordsByPrimaryKeys = new HashMap<>();
+    while (deDuplicatedRecords.hasNext()) {
+      RecordInfo recordInfo = deDuplicatedRecords.next();
+      assertFalse(recordsByPrimaryKeys.containsKey(recordInfo.getPrimaryKey()));
+      recordsByPrimaryKeys.put(recordInfo.getPrimaryKey(), recordInfo);
     }
-    upsertMetadataManager.addSegment(segment1, validDocIds1, null, recordInfoList1.iterator());
-    trackedSegments.add(segment1);
-
-    // Replace (reload) the first segment
-    ThreadSafeMutableRoaringBitmap newValidDocIds1 = new ThreadSafeMutableRoaringBitmap();
-    ImmutableSegmentImpl newSegment1 = mockImmutableSegment(1, newValidDocIds1, null, primaryKeys1);
-    upsertMetadataManager.replaceSegment(newSegment1, newValidDocIds1, null, recordInfoList1.iterator(), segment1);
-    trackedSegments.add(newSegment1);
-    trackedSegments.remove(segment1);
+    assertEquals(recordsByPrimaryKeys.size(), 3);
+    assertEquals(recordsByPrimaryKeys.get(makePrimaryKey(0)).getDocId(), 5);
+    assertEquals(recordsByPrimaryKeys.get(makePrimaryKey(1)).getDocId(), 4);
+    assertEquals(recordsByPrimaryKeys.get(makePrimaryKey(2)).getDocId(), 2);
   }
 
   private void verifyAddReplaceRemoveSegmentWithRecordDelete(HashFunction hashFunction, boolean enableSnapshot)


### PR DESCRIPTION
See issue for explanation of the issue: #12398

This PR fixes the issue by de-duplicating the records before the map is updated. This adds a small cost in terms of memory, but it should be quite low (e.g. for 1M records, with 32 byte primary-keys, we will have 32MB + memory address and other Record info parameter costs).

There's a small latency cost also added due to the extra dedup step. But we think it's quite low compared to the rest of operations so shouldn't be too big an issue (e.g. after dedup the ConcurrentHashMap is updated for all records, which can contend with Realtime ingestion and other `addOrReplaceSegment` calls).

We only do this for Partial Upsert tables right now since Full Upsert tables don't suffer from the issue mentioned in #12398.

**Test Plan:** Added a unit-test.