### PR TITLE
Fix the incorrect cast from String to Bytes in V2

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/StringToByteCastRule.java
+++ b/pinot-query-planner/src/main/java/org/apache/calcite/rel/rules/StringToByteCastRule.java
@@ -1,0 +1,158 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.calcite.rel.rules;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.calcite.plan.RelOptCluster;
+import org.apache.calcite.plan.RelOptRule;
+import org.apache.calcite.plan.RelOptRuleCall;
+import org.apache.calcite.rel.AbstractRelNode;
+import org.apache.calcite.rel.core.Filter;
+import org.apache.calcite.rel.core.Join;
+import org.apache.calcite.rel.core.Project;
+import org.apache.calcite.rel.logical.LogicalFilter;
+import org.apache.calcite.rel.logical.LogicalJoin;
+import org.apache.calcite.rel.logical.LogicalProject;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.rex.RexBuilder;
+import org.apache.calcite.rex.RexCall;
+import org.apache.calcite.rex.RexNode;
+import org.apache.calcite.rex.RexShuttle;
+import org.apache.calcite.sql.PinotSqlTransformFunction;
+import org.apache.calcite.sql.SqlFunctionCategory;
+import org.apache.calcite.sql.SqlKind;
+import org.apache.calcite.sql.type.SqlTypeName;
+
+
+
+/**
+ * A transformation rule that looks for castings from String to Bytes and substitute them with {@code hexToByte()}
+ * calls. This is needed because Calcite and Pinot conversion semantic is different and although most of the time the
+ * conversion is done by Pinot, at simplification time Calcite may try to apply its own conversion if the converted
+ * value is a literal.
+ */
+// TODO: Verify that all other conversions are compatible
+public abstract class StringToByteCastRule extends RelOptRule implements TransformationRule {
+
+  private static final PinotSqlTransformFunction HEX_TO_BYTES =
+      new PinotSqlTransformFunction("hexToBytes", SqlKind.OTHER_FUNCTION, null, null, null,
+          SqlFunctionCategory.STRING);
+
+  public StringToByteCastRule(Class<? extends AbstractRelNode> relNode) {
+    super(operand(relNode, any()), "StringToBinary");
+  }
+
+  public abstract void onMatch(RelOptRuleCall call);
+
+  protected RexShuttle getRexShuttle(RexBuilder rexBuilder) {
+    return new RexShuttle() {
+      @Override
+      public RexNode visitCall(RexCall call) {
+        RexNode rexNode = super.visitCall(call);
+
+        if (!call.getOperator().getKind().equals(SqlKind.CAST)) {
+          return rexNode;
+        }
+        String returnTypeName = call.getType().getSqlTypeName().getName();
+        if (!returnTypeName.equalsIgnoreCase("VARBINARY") && !returnTypeName.equalsIgnoreCase("BINARY")) {
+          return rexNode;
+        }
+        RexNode operand = call.getOperands().get(0);
+
+        RelDataType sourceType = operand.getType();
+        SqlTypeName sqlSourceType = sourceType.getSqlTypeName();
+        String sourceTypeName = sqlSourceType.getName();
+        if (!sourceTypeName.equalsIgnoreCase("CHAR") && !sourceTypeName.equalsIgnoreCase("VARCHAR")) {
+          return rexNode;
+        }
+
+        return rexBuilder.makeCall(call.getType(), HEX_TO_BYTES, Collections.singletonList(operand));
+      }
+    };
+  }
+
+  public static class OnProject extends StringToByteCastRule {
+
+    public static final StringToByteCastRule.OnProject INSTANCE = new StringToByteCastRule.OnProject();
+
+    public OnProject() {
+      super(LogicalProject.class);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      Project project = call.rel(0);
+
+      RelOptCluster cluster = project.getCluster();
+
+      RexShuttle rexShuttle = getRexShuttle(cluster.getRexBuilder());
+      List<RexNode> newProjects = project.getProjects().stream()
+          .map(rexNode -> rexNode.accept(rexShuttle))
+          .collect(Collectors.toList());
+
+      Project newProject = project.copy(project.getTraitSet(), project.getInput(), newProjects, project.getRowType());
+      call.transformTo(newProject);
+    }
+  }
+
+  public static class OnFilter extends StringToByteCastRule {
+
+    public static final StringToByteCastRule.OnFilter INSTANCE = new StringToByteCastRule.OnFilter();
+
+    public OnFilter() {
+      super(LogicalFilter.class);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      Filter filter = call.rel(0);
+
+      RelOptCluster cluster = filter.getCluster();
+
+      RexNode newCondition = filter.getCondition().accept(getRexShuttle(cluster.getRexBuilder()));
+
+      Filter newFilter = filter.copy(filter.getTraitSet(), filter.getInput(), newCondition);
+      call.transformTo(newFilter);
+    }
+  }
+
+  public static class OnJoin extends StringToByteCastRule {
+
+    public static final StringToByteCastRule.OnJoin INSTANCE = new StringToByteCastRule.OnJoin();
+
+    public OnJoin() {
+      super(LogicalJoin.class);
+    }
+
+    @Override
+    public void onMatch(RelOptRuleCall call) {
+      LogicalJoin join = call.rel(0);
+
+      RelOptCluster cluster = join.getCluster();
+
+      RexNode newCondition = join.getCondition().accept(getRexShuttle(cluster.getRexBuilder()));
+
+      Join newJoin = join.copy(join.getTraitSet(), newCondition, join.getLeft(), join.getRight(), join.getJoinType(),
+          join.isSemiJoinDone());
+      call.transformTo(newJoin);
+    }
+  }
+}

--- a/pinot-query-planner/src/test/java/org/apache/pinot/query/queries/StringToBytesPlansTest.java
+++ b/pinot-query-planner/src/test/java/org/apache/pinot/query/queries/StringToBytesPlansTest.java
@@ -1,0 +1,82 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.queries;
+
+import org.apache.pinot.query.QueryEnvironmentTestBase;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class StringToBytesPlansTest extends QueryEnvironmentTestBase {
+
+
+  @Test
+  public void explicitCastOnProjection() {
+    //language=SQL
+    assertEquivalentPlan(
+        "select cast(a.col2 as BINARY) from a",
+        "select hexToBytes(a.col2) from a"
+    );
+  }
+
+  @Test
+  public void explicitLiteralCastOnProjection() {
+    //language=SQL
+    assertEquivalentPlan(
+        "select length(cast('80c062bf21bba70a9b404e969de0503750' as BINARY)) > 4 from a",
+        "select length(hexToBytes('80c062bf21bba70a9b404e969de0503750')) > 4 from a"
+    );
+  }
+
+  @Test
+  public void explicitCastOnFilter() {
+    //language=SQL
+    assertEquivalentPlan(
+        "select * from a where bytesToHex(cast(a.col2 as BINARY)) = 'noop'",
+        "select * from a where bytesToHex(hexToBytes(a.col2)) = 'noop'"
+    );
+  }
+
+  @Test
+  public void explicitLiteralCastOnFilter() {
+    //language=SQL
+    assertEquivalentPlan(
+        "select * from a where length(cast('80c062bf21bba70a9b404e969de0503750' as BINARY)) > 4",
+        "select * from a where length(hexToBytes('80c062bf21bba70a9b404e969de0503750')) > 4"
+    );
+  }
+
+  @Test
+  public void explicitCastOnJoin() {
+    //language=SQL
+    assertEquivalentPlan(
+        "select * from a join a as a2 on a.col2 = bytesToHex(cast(a.col2 as BINARY))",
+        "select * from a join a as a2 on a.col2 = bytesToHex(hexToBytes(a.col2))"
+    );
+  }
+
+  void assertEquivalentPlan(String rawQuery, String expected) {
+    String explain = "explain plan for ";
+    String expectedPlan = _queryEnvironment.explainQuery(explain + expected, RANDOM_REQUEST_ID_GEN.nextLong());
+    String rawPlan = _queryEnvironment.explainQuery(explain + rawQuery, RANDOM_REQUEST_ID_GEN.nextLong());
+    Assert.assertEquals(rawPlan, expectedPlan,
+        String.format("Plan for %s doesn't match with the plan of the equivalent query %s",
+            rawQuery, expected));
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/reader/ForwardIndexReader.java
@@ -319,7 +319,7 @@ public interface ForwardIndexReader<T extends ForwardIndexReaderContext> extends
         }
         break;
       default:
-        throw new IllegalArgumentException();
+        throw new IllegalArgumentException("It is not defined how to read " + getStoredType());
     }
   }
 


### PR DESCRIPTION
Tags: bugfix

## The problem

In V2, expressions like `cast('stringLiteral' as BINARY)` were incorrectly executed. This also includes common patterns like `bytesColumn = 'some hex literal'`.

For example, using table `starbucksStores` from `GenericQuickstart`, the following query failed in V2 while worked in V1:
```sql
select location_st_point from starbucksStores where location_st_point = '80c062bf21bba70a9b404e969de0503750' limit 10
```

### Low level description

The exception we got was:

```
Caused by: java.lang.AssertionError: value 00ba86d4ebda4d5f8da9ba2cf3053208 does not match type class org.apache.calcite.avatica.util.ByteString
 at org.apache.calcite.linq4j.tree.ConstantExpression.<init>(ConstantExpression.java:51)
 at org.apache.calcite.linq4j.tree.Expressions.constant(Expressions.java:576)
 at org.apache.calcite.linq4j.tree.OptimizeShuttle.visit(OptimizeShuttle.java:291)
 at org.apache.calcite.linq4j.tree.UnaryExpression.accept(UnaryExpression.java:39))
```

When the query is received, the expected algorithm is:
1. Calcite parsed the SQL
2. Calcite transformed the SQL to Relational Algrebra (`SqlNode` to `RelRoot`). In order to do so, an implicit call from String (`VARCHAR`) to Bytes (`VARBINARY`) is created.
3. We call `sqlToRelConverter.trimUnusedFields` to simplify the query before optimize.
4. Optimize. Here the CAST should be executed calling `hexToBinary`.

What actually happened is that in 3. (`sqlToRelConverter.trimUnusedFields`) the expression `CAST(stringLiteral as VARBINARY)` was simplified by Calcite. There is a known bug in Calcite that fails in this kind of casts. There is a patch to solve if (see https://github.com/apache/calcite/pull/3635) but at the time of writing this is not what we want. Specifically, the patch plans to apply some custom semantic (compatible with MySQL and Postgres) on that conversion. That semantic is valid, but it is not what we do in V1. Therefore even if the bug is fixed in Calcite it won't behave as V1 users would expect and as a result they could find unexpected results when migrating queries from V1 to V2.

## The fix

In order to fix the problem, a couple of new transformation rules has been introduced. These rules look for calls to `cast(somethingOfTypeString as VARBINARY)` and transform that to `hexToBytes(somethingOfTypeString)`. These rules have to be applied before `sqlToRelConverter.trimUnusedFields` is called. Given that method needs to be called before the current optimizers are used, we need to add a new optimizer for these rules.

### Details

Right now these rules are only applied on filter, projection and joins. We may need to add them to other `Rel`s in the future.

cc @walterddr @Jackie-Jiang @xiangfu0 