### PR TITLE
Remove all table metrics when a table is deleted

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -135,7 +135,7 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
 
   public void removePhaseTiming(String tableName, QP phase) {
     String fullTimerName = _metricPrefix + getTableName(tableName) + "." + phase.getQueryPhaseName();
-    removeTimedValue(fullTimerName);
+    removeTimer(fullTimerName);
   }
 
   public void addPhaseTiming(String tableName, QP phase, long duration, TimeUnit timeUnit) {
@@ -197,16 +197,6 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
     addValueToTimer(fullTimerName, duration, timeUnit);
   }
 
-  public void removeTimedValue(final String fullTimerName) {
-    PinotMetricUtils
-        .removeMetric(_metricsRegistry, PinotMetricUtils.makePinotMetricName(_clazz, fullTimerName));
-  }
-
-  public void removeTimedValue(final String tableName, final T timer) {
-    final String fullTimerName = _metricPrefix + getTableName(tableName) + "." + timer.getTimerName();
-    removeTimedValue(fullTimerName);
-  }
-
   /**
    * Logs the timing for a metric
    *
@@ -223,10 +213,14 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
     }
   }
 
-  public void removeTimer(String tableName, T timer) {
-    String fullTimerName = _metricPrefix + getTableName(tableName) + "." + timer.getTimerName();
-    PinotMetricName metricName = PinotMetricUtils.makePinotMetricName(_clazz, fullTimerName);
-    PinotMetricUtils.removeMetric(_metricsRegistry, metricName);
+  public void removeTimer(final String fullTimerName) {
+    PinotMetricUtils
+        .removeMetric(_metricsRegistry, PinotMetricUtils.makePinotMetricName(_clazz, fullTimerName));
+  }
+
+  public void removeTableTimer(final String tableName, final T timer) {
+    final String fullTimerName = _metricPrefix + getTableName(tableName) + "." + timer.getTimerName();
+    removeTimer(fullTimerName);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -208,6 +208,12 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
     }
   }
 
+  public void removeTimer(String tableName, T timer) {
+    String fullTimerName = _metricPrefix + getTableName(tableName) + "." + timer.getTimerName();
+    PinotMetricName metricName = PinotMetricUtils.makePinotMetricName(_clazz, fullTimerName);
+    PinotMetricUtils.removeMetric(_metricsRegistry, metricName);
+  }
+
   /**
    * Logs a value to a meter.
    *

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/AbstractMetrics.java
@@ -133,6 +133,11 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
     }
   }
 
+  public void removePhaseTiming(String tableName, QP phase) {
+    String fullTimerName = _metricPrefix + getTableName(tableName) + "." + phase.getQueryPhaseName();
+    removeTimedValue(fullTimerName);
+  }
+
   public void addPhaseTiming(String tableName, QP phase, long duration, TimeUnit timeUnit) {
     String fullTimerName = _metricPrefix + getTableName(tableName) + "." + phase.getQueryPhaseName();
     addValueToTimer(fullTimerName, duration, timeUnit);
@@ -190,6 +195,16 @@ public abstract class AbstractMetrics<QP extends AbstractMetrics.QueryPhase, M e
   public void addTimedValue(final String key, final T timer, final long duration, final TimeUnit timeUnit) {
     final String fullTimerName = _metricPrefix + key + "." + timer.getTimerName();
     addValueToTimer(fullTimerName, duration, timeUnit);
+  }
+
+  public void removeTimedValue(final String fullTimerName) {
+    PinotMetricUtils
+        .removeMetric(_metricsRegistry, PinotMetricUtils.makePinotMetricName(_clazz, fullTimerName));
+  }
+
+  public void removeTimedValue(final String tableName, final T timer) {
+    final String fullTimerName = _metricPrefix + getTableName(tableName) + "." + timer.getTimerName();
+    removeTimedValue(fullTimerName);
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.metrics;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.common.Utils;
 
 
@@ -29,19 +30,19 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
 
   REPLICATION_FROM_CONFIG("replicas", false),
   // Number of complete replicas of table in external view containing all segments online in ideal state
-  NUMBER_OF_REPLICAS("replicas", false),
+  NUMBER_OF_REPLICAS("replicas", Long.MIN_VALUE),
 
   // Percentage of complete online replicas in external view as compared to replicas in ideal state
-  PERCENT_OF_REPLICAS("percent", false),
+  PERCENT_OF_REPLICAS("percent", Long.MIN_VALUE),
 
-  SEGMENTS_IN_ERROR_STATE("segments", false),
+  SEGMENTS_IN_ERROR_STATE("segments", Long.MIN_VALUE),
 
   // Percentage of segments with at least one online replica in external view as compared to total number of segments in
   // ideal state
-  PERCENT_SEGMENTS_AVAILABLE("segments", false),
+  PERCENT_SEGMENTS_AVAILABLE("segments", Long.MIN_VALUE),
 
   // Number of segments running with less than expected replicas in external view
-  SEGMENTS_WITH_LESS_REPLICAS("segments", false),
+  SEGMENTS_WITH_LESS_REPLICAS("segments", Long.MIN_VALUE),
 
   SEGMENT_COUNT("SegmentCount", false),
 
@@ -163,11 +164,27 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   private final String _gaugeName;
   private final String _unit;
   private final boolean _global;
+  @Nullable
+  private final Long _defaultValueOnReset;
 
   ControllerGauge(String unit, boolean global) {
     _unit = unit;
     _global = global;
     _gaugeName = Utils.toCamelCase(name().toLowerCase());
+    _defaultValueOnReset = null;
+  }
+
+  /**
+   * Creates a Gauge with a default value on reset.
+   *
+   * These gauges are always table based (aka not global) and they are automatically reset to the given value whenever
+   * it is considered they should be reset (ie when the table is disabled).
+   */
+  ControllerGauge(String unit, long defaultValueOnReset) {
+    _unit = unit;
+    _global = false;
+    _gaugeName = Utils.toCamelCase(name().toLowerCase());
+    _defaultValueOnReset = defaultValueOnReset;
   }
 
   @Override
@@ -188,5 +205,10 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   @Override
   public boolean isGlobal() {
     return _global;
+  }
+
+  @Nullable
+  public Long getDefaultValueOnReset() {
+    return _defaultValueOnReset;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ControllerGauge.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.common.metrics;
 
-import javax.annotation.Nullable;
 import org.apache.pinot.common.Utils;
 
 
@@ -30,19 +29,19 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
 
   REPLICATION_FROM_CONFIG("replicas", false),
   // Number of complete replicas of table in external view containing all segments online in ideal state
-  NUMBER_OF_REPLICAS("replicas", Long.MIN_VALUE),
+  NUMBER_OF_REPLICAS("replicas", false),
 
   // Percentage of complete online replicas in external view as compared to replicas in ideal state
-  PERCENT_OF_REPLICAS("percent", Long.MIN_VALUE),
+  PERCENT_OF_REPLICAS("percent", false),
 
-  SEGMENTS_IN_ERROR_STATE("segments", Long.MIN_VALUE),
+  SEGMENTS_IN_ERROR_STATE("segments", false),
 
   // Percentage of segments with at least one online replica in external view as compared to total number of segments in
   // ideal state
-  PERCENT_SEGMENTS_AVAILABLE("segments", Long.MIN_VALUE),
+  PERCENT_SEGMENTS_AVAILABLE("segments", false),
 
   // Number of segments running with less than expected replicas in external view
-  SEGMENTS_WITH_LESS_REPLICAS("segments", Long.MIN_VALUE),
+  SEGMENTS_WITH_LESS_REPLICAS("segments", false),
 
   SEGMENT_COUNT("SegmentCount", false),
 
@@ -164,27 +163,11 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   private final String _gaugeName;
   private final String _unit;
   private final boolean _global;
-  @Nullable
-  private final Long _defaultValueOnReset;
 
   ControllerGauge(String unit, boolean global) {
     _unit = unit;
     _global = global;
     _gaugeName = Utils.toCamelCase(name().toLowerCase());
-    _defaultValueOnReset = null;
-  }
-
-  /**
-   * Creates a Gauge with a default value on reset.
-   *
-   * These gauges are always table based (aka not global) and they are automatically reset to the given value whenever
-   * it is considered they should be reset (ie when the table is disabled).
-   */
-  ControllerGauge(String unit, long defaultValueOnReset) {
-    _unit = unit;
-    _global = false;
-    _gaugeName = Utils.toCamelCase(name().toLowerCase());
-    _defaultValueOnReset = defaultValueOnReset;
   }
 
   @Override
@@ -205,10 +188,5 @@ public enum ControllerGauge implements AbstractMetrics.Gauge {
   @Override
   public boolean isGlobal() {
     return _global;
-  }
-
-  @Nullable
-  public Long getDefaultValueOnReset() {
-    return _defaultValueOnReset;
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -99,8 +99,6 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
 
   @Override
   protected void setUpTask() {
-    LOGGER.info("Initializing table metrics for all the tables.");
-    setStatusToDefault();
   }
 
   @Override
@@ -375,18 +373,8 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     }
   }
 
-  private void setStatusToDefault() {
-    List<String> allTableNames = _pinotHelixResourceManager.getAllTables();
-
-    for (String tableName : allTableNames) {
-      removeMetricsForTable(tableName);
-    }
-  }
-
   @Override
   public void cleanUpTask() {
-    LOGGER.info("Resetting table metrics for all the tables.");
-    setStatusToDefault();
   }
 
   @VisibleForTesting

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -125,7 +125,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     } catch (Exception e) {
       LOGGER.error("Caught exception while updating segment status for table {}", tableNameWithType, e);
       // Remove the metric for this table
-      resetTableMetrics(tableNameWithType);
+      removeMetricsForTable(tableNameWithType);
     }
     context._processedTables.add(tableNameWithType);
   }
@@ -189,7 +189,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
 
     if (idealState == null) {
       LOGGER.warn("Table {} has null ideal state. Skipping segment status checks", tableNameWithType);
-      resetTableMetrics(tableNameWithType);
+      removeMetricsForTable(tableNameWithType);
       return;
     }
 
@@ -197,7 +197,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
       if (context._logDisabledTables) {
         LOGGER.warn("Table {} is disabled. Skipping segment status checks", tableNameWithType);
       }
-      resetTableMetrics(tableNameWithType);
+      removeMetricsForTable(tableNameWithType);
       context._disabledTables.add(tableNameWithType);
       return;
     }
@@ -379,15 +379,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
     List<String> allTableNames = _pinotHelixResourceManager.getAllTables();
 
     for (String tableName : allTableNames) {
-      resetTableMetrics(tableName);
-    }
-  }
-
-  private void resetTableMetrics(String tableName) {
-    for (ControllerGauge gauge : ControllerGauge.values()) {
-      if (gauge.getDefaultValueOnReset() != null) {
-        _controllerMetrics.setValueOfTableGauge(tableName, gauge, gauge.getDefaultValueOnReset());
-      }
+      removeMetricsForTable(tableName);
     }
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -38,7 +38,9 @@ import org.apache.pinot.common.lineage.SegmentLineageAccessHelper;
 import org.apache.pinot.common.lineage.SegmentLineageUtils;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.metrics.ControllerGauge;
+import org.apache.pinot.common.metrics.ControllerMeter;
 import org.apache.pinot.common.metrics.ControllerMetrics;
+import org.apache.pinot.common.metrics.ControllerTimer;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -354,20 +356,23 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
 
   private void removeMetricsForTable(String tableNameWithType) {
     LOGGER.info("Removing metrics from {} given it is not a table known by Helix", tableNameWithType);
-    _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.NUMBER_OF_REPLICAS);
-    _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.PERCENT_OF_REPLICAS);
-    _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE);
-    _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.IDEALSTATE_ZNODE_SIZE);
-    _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.IDEALSTATE_ZNODE_BYTE_SIZE);
-    _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.SEGMENT_COUNT);
-    _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.SEGMENT_COUNT_INCLUDING_REPLACED);
+    for (ControllerGauge metric : ControllerGauge.values()) {
+      if (!metric.isGlobal()) {
+        _controllerMetrics.removeTableGauge(tableNameWithType, metric);
+      }
+    }
 
-    _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.SEGMENTS_IN_ERROR_STATE);
-    _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.SEGMENTS_WITH_LESS_REPLICAS);
-    _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE);
-    _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.TABLE_DISABLED);
-    _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.TABLE_CONSUMPTION_PAUSED);
-    _controllerMetrics.removeTableGauge(tableNameWithType, ControllerGauge.TABLE_REBALANCE_IN_PROGRESS);
+    for (ControllerMeter metric : ControllerMeter.values()) {
+      if (!metric.isGlobal()) {
+        _controllerMetrics.removeTableMeter(tableNameWithType, metric);
+      }
+    }
+
+    for (ControllerTimer metric : ControllerTimer.values()) {
+      if (!metric.isGlobal()) {
+        _controllerMetrics.removeTimer(tableNameWithType, metric);
+      }
+    }
   }
 
   private void setStatusToDefault() {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -384,12 +384,11 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
   }
 
   private void resetTableMetrics(String tableName) {
-    _controllerMetrics.setValueOfTableGauge(tableName, ControllerGauge.NUMBER_OF_REPLICAS, Long.MIN_VALUE);
-    _controllerMetrics.setValueOfTableGauge(tableName, ControllerGauge.PERCENT_OF_REPLICAS, Long.MIN_VALUE);
-    _controllerMetrics.setValueOfTableGauge(tableName, ControllerGauge.SEGMENTS_IN_ERROR_STATE, Long.MIN_VALUE);
-    _controllerMetrics.setValueOfTableGauge(tableName, ControllerGauge.SEGMENTS_WITH_LESS_REPLICAS,
-        Long.MIN_VALUE);
-    _controllerMetrics.setValueOfTableGauge(tableName, ControllerGauge.PERCENT_SEGMENTS_AVAILABLE, Long.MIN_VALUE);
+    for (ControllerGauge gauge : ControllerGauge.values()) {
+      if (gauge.getDefaultValueOnReset() != null) {
+        _controllerMetrics.setValueOfTableGauge(tableName, gauge, gauge.getDefaultValueOnReset());
+      }
+    }
   }
 
   @Override

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/SegmentStatusChecker.java
@@ -370,7 +370,7 @@ public class SegmentStatusChecker extends ControllerPeriodicTask<SegmentStatusCh
 
     for (ControllerTimer metric : ControllerTimer.values()) {
       if (!metric.isGlobal()) {
-        _controllerMetrics.removeTimer(tableNameWithType, metric);
+        _controllerMetrics.removeTableTimer(tableNameWithType, metric);
       }
     }
   }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/SegmentStatusCheckerTest.java
@@ -452,14 +452,14 @@ public class SegmentStatusCheckerTest {
     _segmentStatusChecker.setTableSizeReader(_tableSizeReader);
     _segmentStatusChecker.start();
     _segmentStatusChecker.run();
-    Assert.assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, tableName,
-            ControllerGauge.SEGMENTS_IN_ERROR_STATE), Long.MIN_VALUE);
-    Assert.assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, tableName,
-        ControllerGauge.SEGMENTS_WITH_LESS_REPLICAS), Long.MIN_VALUE);
-    Assert.assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, tableName,
-            ControllerGauge.NUMBER_OF_REPLICAS), Long.MIN_VALUE);
-    Assert.assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, tableName,
-            ControllerGauge.PERCENT_OF_REPLICAS), Long.MIN_VALUE);
+    Assert.assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, tableName,
+            ControllerGauge.SEGMENTS_IN_ERROR_STATE));
+    Assert.assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, tableName,
+        ControllerGauge.SEGMENTS_WITH_LESS_REPLICAS));
+    Assert.assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, tableName,
+            ControllerGauge.NUMBER_OF_REPLICAS));
+    Assert.assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, tableName,
+            ControllerGauge.PERCENT_OF_REPLICAS));
     Assert.assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, tableName,
             ControllerGauge.TABLE_COMPRESSED_SIZE));
   }
@@ -820,10 +820,10 @@ public class SegmentStatusCheckerTest {
     _segmentStatusChecker.start();
     _segmentStatusChecker.run();
 
-    Assert.assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, tableName,
-        ControllerGauge.SEGMENTS_IN_ERROR_STATE), Long.MIN_VALUE);
-    Assert.assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, tableName,
-        ControllerGauge.SEGMENTS_IN_ERROR_STATE), Long.MIN_VALUE);
+    Assert.assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, tableName,
+        ControllerGauge.SEGMENTS_IN_ERROR_STATE));
+    Assert.assertFalse(MetricValueUtils.tableGaugeExists(_controllerMetrics, tableName,
+        ControllerGauge.SEGMENTS_IN_ERROR_STATE));
     Assert.assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, tableName,
         ControllerGauge.NUMBER_OF_REPLICAS), nReplicasExpectedValue);
     Assert.assertEquals(MetricValueUtils.getTableGaugeValue(_controllerMetrics, tableName,

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/IngestionDelayTracker.java
@@ -185,6 +185,8 @@ public class IngestionDelayTracker {
     // If we are removing a partition we should stop reading its ideal state.
     _partitionsMarkedForVerification.remove(partitionGroupId);
     _serverMetrics.removePartitionGauge(_metricName, partitionGroupId, ServerGauge.REALTIME_INGESTION_DELAY_MS);
+    _serverMetrics.removePartitionGauge(_metricName, partitionGroupId,
+        ServerGauge.END_TO_END_REALTIME_INGESTION_DELAY_MS);
   }
 
   /*

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerPeriodicTasksIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/ControllerPeriodicTasksIntegrationTest.java
@@ -223,8 +223,7 @@ public class ControllerPeriodicTasksIntegrationTest extends BaseClusterIntegrati
         return false;
       }
       if (!checkSegmentStatusCheckerMetrics(controllerMetrics,
-          TableNameBuilder.OFFLINE.tableNameWithType(disabledTable), null, Long.MIN_VALUE, Long.MIN_VALUE,
-          Long.MIN_VALUE, Long.MIN_VALUE)) {
+          TableNameBuilder.OFFLINE.tableNameWithType(disabledTable), null, 0, 0, 0, 0)) {
         return false;
       }
       String tableNameWithType = TableNameBuilder.OFFLINE.tableNameWithType(getTableName());

--- a/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentMessageHandlerFactory.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/starter/helix/SegmentMessageHandlerFactory.java
@@ -185,7 +185,7 @@ public class SegmentMessageHandlerFactory implements MessageHandlerFactory {
             .forEach(g -> _metrics.removeTableGauge(_tableNameWithType, g));
         Arrays.stream(ServerTimer.values())
             .filter(t -> !t.isGlobal())
-            .forEach(t -> _metrics.removeTimedValue(_tableNameWithType, t));
+            .forEach(t -> _metrics.removeTableTimer(_tableNameWithType, t));
         Arrays.stream(ServerQueryPhase.values())
             .forEach(p -> _metrics.removePhaseTiming(_tableNameWithType, p));
       } catch (Exception e) {


### PR DESCRIPTION
When a table is deleted from a server or a controller steps back and stops being the leader of a table, all metrics should be deleted. Previously just a list of them were deleted. This is a very error prone process. Some metrics were not listed there and some other were removed twice for some reason. The metrics that were not deleted at that point did not disappear until the controller was restarted.

This PR changes the way metrics are removed so we iterate over all enum values and delete any of them that is not global.
In case we want to keep some specific metric, we can just explicitly ignore them in `SegmentStatusChecker` and `SegmentMessageHandlerFactory`. About the latest, I'm not 100% sure if this is the place where metrics should be removed from the server. Can @Jackie-Jiang or some other committer confirm that?

Related to #12344 