### PR TITLE
cache ssl contexts and reuse them

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/config/TlsConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/TlsConfig.java
@@ -41,6 +41,7 @@ public class TlsConfig {
   private String _trustStorePath;
   private String _trustStorePassword;
   private String _sslProvider = SslProvider.JDK.toString();
+  // If true, the client will not verify the server's certificate
   private boolean _insecure = false;
 
   public TlsConfig() {
@@ -60,13 +61,5 @@ public class TlsConfig {
 
   public boolean isCustomized() {
     return StringUtils.isNoneBlank(_keyStorePath) || StringUtils.isNoneBlank(_trustStorePath);
-  }
-
-  public boolean isInsecure() {
-    return _insecure;
-  }
-
-  public void setInsecure(boolean insecure) {
-    _insecure = insecure;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/config/TlsConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/TlsConfig.java
@@ -20,12 +20,18 @@ package org.apache.pinot.common.config;
 
 import io.netty.handler.ssl.SslProvider;
 import java.security.KeyStore;
+import lombok.EqualsAndHashCode;
+import lombok.Getter;
+import lombok.Setter;
 import org.apache.commons.lang3.StringUtils;
 
 
 /**
  * Container object for TLS/SSL configuration of pinot clients and servers (netty, grizzly, etc.)
  */
+@Getter
+@Setter
+@EqualsAndHashCode
 public class TlsConfig {
   private boolean _clientAuthEnabled;
   private String _keyStoreType = KeyStore.getDefaultType();
@@ -50,70 +56,6 @@ public class TlsConfig {
     _trustStorePath = tlsConfig._trustStorePath;
     _trustStorePassword = tlsConfig._trustStorePassword;
     _sslProvider = tlsConfig._sslProvider;
-  }
-
-  public boolean isClientAuthEnabled() {
-    return _clientAuthEnabled;
-  }
-
-  public void setClientAuthEnabled(boolean clientAuthEnabled) {
-    _clientAuthEnabled = clientAuthEnabled;
-  }
-
-  public String getKeyStoreType() {
-    return _keyStoreType;
-  }
-
-  public void setKeyStoreType(String keyStoreType) {
-    _keyStoreType = keyStoreType;
-  }
-
-  public String getKeyStorePath() {
-    return _keyStorePath;
-  }
-
-  public void setKeyStorePath(String keyStorePath) {
-    _keyStorePath = keyStorePath;
-  }
-
-  public String getKeyStorePassword() {
-    return _keyStorePassword;
-  }
-
-  public void setKeyStorePassword(String keyStorePassword) {
-    _keyStorePassword = keyStorePassword;
-  }
-
-  public String getTrustStoreType() {
-    return _trustStoreType;
-  }
-
-  public void setTrustStoreType(String trustStoreType) {
-    _trustStoreType = trustStoreType;
-  }
-
-  public String getTrustStorePath() {
-    return _trustStorePath;
-  }
-
-  public void setTrustStorePath(String trustStorePath) {
-    _trustStorePath = trustStorePath;
-  }
-
-  public String getTrustStorePassword() {
-    return _trustStorePassword;
-  }
-
-  public void setTrustStorePassword(String trustStorePassword) {
-    _trustStorePassword = trustStorePassword;
-  }
-
-  public String getSslProvider() {
-    return _sslProvider;
-  }
-
-  public void setSslProvider(String sslProvider) {
-    _sslProvider = sslProvider;
   }
 
   public boolean isCustomized() {

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/GrpcQueryClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/grpc/GrpcQueryClient.java
@@ -45,6 +45,8 @@ public class GrpcQueryClient {
   private static final Logger LOGGER = LoggerFactory.getLogger(GrpcQueryClient.class);
   private static final int DEFAULT_CHANNEL_SHUTDOWN_TIMEOUT_SECOND = 10;
   // the key is the hashCode of the TlsConfig, the value is the SslContext
+  // We don't use TlsConfig as the map key because the TlsConfig is mutable, which means the hashCode can change. If the
+  // hashCode changes and the map is resized, the SslContext of the old hashCode will be lost.
   private static final Map<Integer, SslContext> CLIENT_SSL_CONTEXTS_CACHE = new ConcurrentHashMap<>();
 
   private final ManagedChannel _managedChannel;

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/ChannelHandlerFactory.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/ChannelHandlerFactory.java
@@ -39,9 +39,13 @@ import org.apache.pinot.spi.env.PinotConfiguration;
  */
 public class ChannelHandlerFactory {
   public static final String SSL = "ssl";
-  // the key is the hashCode of the TlsConfig, the value is the SslContext
+  // The key is the hashCode of the TlsConfig, the value is the SslContext
+  // We don't use TlsConfig as the map key because the TlsConfig is mutable, which means the hashCode can change. If the
+  // hashCode changes and the map is resized, the SslContext of the old hashCode will be lost.
   private static final Map<Integer, SslContext> CLIENT_SSL_CONTEXTS_CACHE = new ConcurrentHashMap<>();
   // the key is the hashCode of the TlsConfig, the value is the SslContext
+  // We don't use TlsConfig as the map key because the TlsConfig is mutable, which means the hashCode can change. If the
+  // hashCode changes and the map is resized, the SslContext of the old hashCode will be lost.
   private static final Map<Integer, SslContext> SERVER_SSL_CONTEXTS_CACHE = new ConcurrentHashMap<>();
 
   private ChannelHandlerFactory() {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
@@ -59,6 +59,8 @@ import org.slf4j.LoggerFactory;
 public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBase {
   private static final Logger LOGGER = LoggerFactory.getLogger(GrpcQueryServer.class);
   // the key is the hashCode of the TlsConfig, the value is the SslContext
+  // We don't use TlsConfig as the map key because the TlsConfig is mutable, which means the hashCode can change. If the
+  // hashCode changes and the map is resized, the SslContext of the old hashCode will be lost.
   private static final Map<Integer, SslContext> SERVER_SSL_CONTEXTS_CACHE = new ConcurrentHashMap<>();
 
   private final QueryExecutor _queryExecutor;


### PR DESCRIPTION
`performance`

Instead of creating a new SslContext for the same TlsConfig multiple times, this PR reuses the same SslContext if it's already created.

1. This saves memory by 
a. reducing the number of objects created.
b. only one thread (https://github.com/apache/pinot/blob/master/pinot-common/src/main/java/org/apache/pinot/common/utils/TlsUtils.java#L385) will be created for reloading the same tls store and trust store when tlsconfigs are the same.
2. This can also speed up execution because SslContext only needs to be created ones for the same TlsConfig

Reusing the same SslContext does not change the validation logic and does not introduce security flaws because the same key and ca are used in the old and new implementation.