### PR TITLE
Fix the double unescape of property value

### DIFF
--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/ColumnMetadataTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/index/ColumnMetadataTest.java
@@ -73,9 +73,9 @@ public class ColumnMetadataTest {
     final String filePath =
         TestUtils.getFileFromResourceUrl(ColumnMetadataTest.class.getClassLoader().getResource(AVRO_DATA));
     // Intentionally changed this to TimeUnit.Hours to make it non-default for testing.
-    SegmentGeneratorConfig config = SegmentTestUtils
-        .getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), INDEX_DIR, "daysSinceEpoch", TimeUnit.HOURS,
-            "testTable");
+    SegmentGeneratorConfig config =
+        SegmentTestUtils.getSegmentGenSpecWithSchemAndProjectedColumns(new File(filePath), INDEX_DIR, "daysSinceEpoch",
+            TimeUnit.HOURS, "testTable");
     config.setSegmentNamePostfix("1");
     return config;
   }
@@ -223,6 +223,7 @@ public class ColumnMetadataTest {
     PropertiesConfiguration propertiesConfiguration = CommonsConfigurationUtils.fromFile(metadataFile);
     ColumnMetadataImpl installationOutput =
         ColumnMetadataImpl.fromPropertiesConfiguration("installation_output", propertiesConfiguration);
-    Assert.assertNotNull(installationOutput);
+    Assert.assertEquals(installationOutput.getMinValue(),
+        "\r\n\r\n  utils   em::C:\\dir\\utils\r\nPSParentPath            : Mi");
   }
 }


### PR DESCRIPTION
The context is in #12393 
The root cause is that we did 2 unescapes when reading the property value (one implicit unescape within the `getProperty()`).
This PR fixes this behavior so that we can properly read old metadata files. One behavior change when upgrading from Configuration to Configuration2 is that character with surrogates are no longer supported. When surrogates are encountered, treat the value as invalid.