### PR TITLE
Fix connection issues if using JDBC and Hikari (#12267)

### DIFF
--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/base/AbstractBaseConnection.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/base/AbstractBaseConnection.java
@@ -189,7 +189,7 @@ public abstract class AbstractBaseConnection implements Connection {
   @Override
   public void setTransactionIsolation(int level)
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    // no-op
   }
 
   @Override
@@ -299,7 +299,7 @@ public abstract class AbstractBaseConnection implements Connection {
   @Override
   public void rollback()
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    // no-op
   }
 
   @Override

--- a/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/base/AbstractBaseStatement.java
+++ b/pinot-clients/pinot-jdbc-client/src/main/java/org/apache/pinot/client/base/AbstractBaseStatement.java
@@ -164,7 +164,7 @@ public abstract class AbstractBaseStatement implements Statement {
   @Override
   public void setQueryTimeout(int seconds)
       throws SQLException {
-    throw new SQLFeatureNotSupportedException();
+    // no-op
   }
 
   @Override


### PR DESCRIPTION
Fixes #12267 

These methods prevent an applications using JDBC and Hikari connecting to Pinot because they automatically throw exceptions.