### PR TITLE
Adding support of insecure TLS

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/config/TlsConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/TlsConfig.java
@@ -35,6 +35,7 @@ public class TlsConfig {
   private String _trustStorePath;
   private String _trustStorePassword;
   private String _sslProvider = SslProvider.JDK.toString();
+  private boolean _insecure = false;
 
   public TlsConfig() {
     // left blank
@@ -117,5 +118,13 @@ public class TlsConfig {
 
   public boolean isCustomized() {
     return StringUtils.isNoneBlank(_keyStorePath) || StringUtils.isNoneBlank(_trustStorePath);
+  }
+
+  public boolean isInsecure() {
+    return _insecure;
+  }
+
+  public void setInsecure(boolean insecure) {
+    _insecure = insecure;
   }
 }

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/TlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/TlsUtils.java
@@ -24,6 +24,7 @@ import io.netty.handler.ssl.ClientAuth;
 import io.netty.handler.ssl.SslContext;
 import io.netty.handler.ssl.SslContextBuilder;
 import io.netty.handler.ssl.SslProvider;
+import io.netty.handler.ssl.util.InsecureTrustManagerFactory;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.MalformedURLException;
@@ -80,6 +81,7 @@ public final class TlsUtils {
   private static final String FILE_SCHEME = "file";
   private static final String FILE_SCHEME_PREFIX = FILE_SCHEME + "://";
   private static final String FILE_SCHEME_PREFIX_WITHOUT_SLASH = FILE_SCHEME + ":";
+  private static final String INSECURE = "insecure";
 
   private static final AtomicReference<SSLContext> SSL_CONTEXT_REF = new AtomicReference<>();
 
@@ -126,6 +128,8 @@ public final class TlsUtils {
         pinotConfig.getProperty(key(namespace, TRUSTSTORE_PASSWORD), defaultConfig.getTrustStorePassword()));
     tlsConfig.setSslProvider(
         pinotConfig.getProperty(key(namespace, SSL_PROVIDER), defaultConfig.getSslProvider()));
+    tlsConfig.setInsecure(
+        pinotConfig.getProperty(key(namespace, INSECURE), defaultConfig.isInsecure()));
 
     return tlsConfig;
   }
@@ -178,8 +182,11 @@ public final class TlsUtils {
    * @return TrustManagerFactory
    */
   public static TrustManagerFactory createTrustManagerFactory(TlsConfig tlsConfig) {
-    return createTrustManagerFactory(tlsConfig.getTrustStorePath(), tlsConfig.getTrustStorePassword(),
-        tlsConfig.getTrustStoreType());
+    if (tlsConfig.isInsecure()) {
+     return  InsecureTrustManagerFactory.INSTANCE;
+    } else {
+      return createTrustManagerFactory(tlsConfig.getTrustStorePath(), tlsConfig.getTrustStorePassword(), tlsConfig.getTrustStoreType());
+    }
   }
 
   /**

--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/TlsUtils.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/TlsUtils.java
@@ -183,9 +183,10 @@ public final class TlsUtils {
    */
   public static TrustManagerFactory createTrustManagerFactory(TlsConfig tlsConfig) {
     if (tlsConfig.isInsecure()) {
-     return  InsecureTrustManagerFactory.INSTANCE;
+      return InsecureTrustManagerFactory.INSTANCE;
     } else {
-      return createTrustManagerFactory(tlsConfig.getTrustStorePath(), tlsConfig.getTrustStorePassword(), tlsConfig.getTrustStoreType());
+      return createTrustManagerFactory(tlsConfig.getTrustStorePath(), tlsConfig.getTrustStorePassword(),
+          tlsConfig.getTrustStoreType());
     }
   }
 


### PR DESCRIPTION
`feature`

# How to use
What is insecure mode - [curl -k
](https://curl.se/docs/manpage.html#-k)

`insecure` mode is disabled by default, and the property to enable is <namespace>.insecure=true
`TlsUtils.createTrustManagerFactory` method creates an instance of trust manager factory according to the insecure mode.
