### PR TITLE
WIP: Async Kafka Consumer [POC]

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -684,4 +684,10 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
       _taskTypeMetricsUpdaterMap.put(taskType, taskTypeMetricsUpdater);
     }
   }
+
+  public static void main(String[] args) {
+    CronScheduleBuilder cronScheduleBuilder = CronScheduleBuilder.cronSchedule("0 18 * * * ?");
+    cronScheduleBuilder.build();
+
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -30,7 +30,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
@@ -22,7 +22,6 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Queue;
 import java.util.concurrent.TimeoutException;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
@@ -34,6 +33,7 @@ import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamMessage;
 import org.apache.pinot.spi.stream.StreamMessageMetadata;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.apache.pinot.spi.stream.buffer.MessageBatchBuffer;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -100,13 +100,13 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
 
   @Override
   public void fetchMessages(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset, int timeoutMillis,
-      Queue<MessageBatch> emitter)
+      MessageBatchBuffer emitter)
       throws TimeoutException {
     //TODO: Add EOS condition
     while (true) {
       try {
         MessageBatch<StreamMessage<byte[]>> messageBatch = fetchMessages(startOffset, endOffset, timeoutMillis);
-        emitter.offer(messageBatch);
+        emitter.put(messageBatch);
         return;
       } catch (Exception e) {
         LOGGER.warn("Timed out fetching messages, retrying", e);

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/pom.xml
@@ -134,6 +134,12 @@
       <version>${localstack-utils.version}</version>
     </dependency>
 
+    <dependency>
+      <groupId>org.slf4j</groupId>
+      <artifactId>jcl-over-slf4j</artifactId>
+      <version>${slf4j.version}</version>
+    </dependency>
+
   </dependencies>
   <profiles>
     <profile>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerFactory.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerFactory.java
@@ -21,6 +21,8 @@ package org.apache.pinot.plugin.stream.kinesis;
 import org.apache.pinot.spi.stream.PartitionGroupConsumer;
 import org.apache.pinot.spi.stream.PartitionGroupConsumptionStatus;
 import org.apache.pinot.spi.stream.PartitionLevelConsumer;
+import org.apache.pinot.spi.stream.StreamConfig;
+import org.apache.pinot.spi.stream.StreamConfigProperties;
 import org.apache.pinot.spi.stream.StreamConsumerFactory;
 import org.apache.pinot.spi.stream.StreamMetadataProvider;
 import org.apache.pinot.spi.stream.StreamPartitionMsgOffsetFactory;
@@ -48,7 +50,15 @@ public class KinesisConsumerFactory extends StreamConsumerFactory {
   @Override
   public PartitionGroupConsumer createPartitionGroupConsumer(String clientId,
       PartitionGroupConsumptionStatus partitionGroupConsumptionStatus) {
-    return new KinesisConsumerV2(new KinesisConfig(_streamConfig));
+    boolean isAsyncMode = _streamConfig.getStreamConfigsMap().get(StreamConfigProperties.ENABLE_ASYNC_CONFIG) != null
+        ? Boolean.parseBoolean(_streamConfig.getStreamConfigsMap().get(StreamConfigProperties.ENABLE_ASYNC_CONFIG))
+        : StreamConfig.DEFAULT_STREAM_CONSUMER_ENABLE_ASYNC;
+
+    if (isAsyncMode) {
+      return new KinesisConsumerV2(new KinesisConfig(_streamConfig));
+    } else {
+      return new KinesisConsumer(new KinesisConfig(_streamConfig));
+    }
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerFactory.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerFactory.java
@@ -48,7 +48,7 @@ public class KinesisConsumerFactory extends StreamConsumerFactory {
   @Override
   public PartitionGroupConsumer createPartitionGroupConsumer(String clientId,
       PartitionGroupConsumptionStatus partitionGroupConsumptionStatus) {
-    return new KinesisConsumer(new KinesisConfig(_streamConfig));
+    return new KinesisConsumerV2(new KinesisConfig(_streamConfig));
   }
 
   @Override

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerV2.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kinesis/src/main/java/org/apache/pinot/plugin/stream/kinesis/KinesisConsumerV2.java
@@ -1,0 +1,406 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.plugin.stream.kinesis;
+
+import com.google.common.annotations.VisibleForTesting;
+import com.google.common.base.Preconditions;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+import org.apache.pinot.spi.stream.PartitionGroupConsumer;
+import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
+import org.apache.pinot.spi.stream.buffer.MessageBatchBuffer;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import software.amazon.awssdk.core.exception.AbortedException;
+import software.amazon.awssdk.services.kinesis.KinesisClient;
+import software.amazon.awssdk.services.kinesis.model.ExpiredIteratorException;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsRequest;
+import software.amazon.awssdk.services.kinesis.model.GetRecordsResponse;
+import software.amazon.awssdk.services.kinesis.model.GetShardIteratorRequest;
+import software.amazon.awssdk.services.kinesis.model.InvalidArgumentException;
+import software.amazon.awssdk.services.kinesis.model.KinesisException;
+import software.amazon.awssdk.services.kinesis.model.ProvisionedThroughputExceededException;
+import software.amazon.awssdk.services.kinesis.model.ResourceNotFoundException;
+import software.amazon.awssdk.services.kinesis.model.ShardIteratorType;
+
+
+/**
+ * A {@link PartitionGroupConsumer} implementation for the Kinesis stream
+ */
+public class KinesisConsumerV2 extends KinesisConnectionHandler implements PartitionGroupConsumer {
+  private static final Logger LOGGER = LoggerFactory.getLogger(KinesisConsumerV2.class);
+  public static final long SLEEP_TIME_BETWEEN_REQUESTS = 1000L;
+  private final String _streamTopicName;
+  private final int _numMaxRecordsToFetch;
+  private final ExecutorService _executorService;
+  private final ShardIteratorType _shardIteratorType;
+  private final int _rpsLimit;
+
+  public KinesisConsumerV2(KinesisConfig kinesisConfig) {
+    super(kinesisConfig);
+    _streamTopicName = kinesisConfig.getStreamTopicName();
+    _numMaxRecordsToFetch = kinesisConfig.getNumMaxRecordsToFetch();
+    _shardIteratorType = kinesisConfig.getShardIteratorType();
+    _rpsLimit = kinesisConfig.getRpsLimit();
+    _executorService = Executors.newSingleThreadExecutor();
+  }
+
+  @VisibleForTesting
+  public KinesisConsumerV2(KinesisConfig kinesisConfig, KinesisClient kinesisClient) {
+    super(kinesisConfig, kinesisClient);
+    _kinesisClient = kinesisClient;
+    _streamTopicName = kinesisConfig.getStreamTopicName();
+    _numMaxRecordsToFetch = kinesisConfig.getNumMaxRecordsToFetch();
+    _shardIteratorType = kinesisConfig.getShardIteratorType();
+    _rpsLimit = kinesisConfig.getRpsLimit();
+    _executorService = Executors.newSingleThreadExecutor();
+  }
+
+  /**
+   * Fetch records from the Kinesis stream between the start and end KinesisCheckpoint
+   */
+  @Override
+  public KinesisRecordsBatch fetchMessages(StreamPartitionMsgOffset startCheckpoint,
+      StreamPartitionMsgOffset endCheckpoint, int timeoutMs) {
+    List<KinesisStreamMessage> recordList = new ArrayList<>();
+    Future<KinesisRecordsBatch> kinesisFetchResultFuture =
+        _executorService.submit(() -> getResult(startCheckpoint, endCheckpoint, recordList));
+
+    try {
+      return kinesisFetchResultFuture.get(timeoutMs, TimeUnit.MILLISECONDS);
+    } catch (TimeoutException e) {
+      kinesisFetchResultFuture.cancel(true);
+      return handleException((KinesisPartitionGroupOffset) startCheckpoint, recordList);
+    } catch (Exception e) {
+      return handleException((KinesisPartitionGroupOffset) startCheckpoint, recordList);
+    }
+  }
+
+  @Override
+  public void fetchMessages(StreamPartitionMsgOffset startCheckpoint, StreamPartitionMsgOffset endCheckpoint, int timeoutMs,
+      MessageBatchBuffer emitter)
+      throws Exception {
+    List<KinesisStreamMessage> recordList = new ArrayList<>();
+    Future<KinesisRecordsBatch> kinesisFetchResultFuture =
+        _executorService.submit(() -> getResult(startCheckpoint, endCheckpoint, recordList, emitter));
+  }
+
+  private KinesisRecordsBatch getResult(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset,
+      List<KinesisStreamMessage> recordList, MessageBatchBuffer messageBatchBuffer) {
+    KinesisPartitionGroupOffset kinesisStartCheckpoint = (KinesisPartitionGroupOffset) startOffset;
+
+    try {
+      if (_kinesisClient == null) {
+        createConnection();
+      }
+
+      // TODO: iterate upon all the shardIds in the map
+      //  Okay for now, since we have assumed that every partition group contains a single shard
+      Map<String, String> startShardToSequenceMap = kinesisStartCheckpoint.getShardToStartSequenceMap();
+      Preconditions.checkState(startShardToSequenceMap.size() == 1,
+          "Only 1 shard per consumer supported. Found: %s, in startShardToSequenceMap",
+          startShardToSequenceMap.keySet());
+      Map.Entry<String, String> startShardToSequenceNum = startShardToSequenceMap.entrySet().iterator().next();
+      String shardIterator = getShardIterator(startShardToSequenceNum.getKey(), startShardToSequenceNum.getValue());
+
+      String kinesisEndSequenceNumber = null;
+
+      if (endOffset != null) {
+        KinesisPartitionGroupOffset kinesisEndCheckpoint = (KinesisPartitionGroupOffset) endOffset;
+        Map<String, String> endShardToSequenceMap = kinesisEndCheckpoint.getShardToStartSequenceMap();
+        Preconditions.checkState(endShardToSequenceMap.size() == 1,
+            "Only 1 shard per consumer supported. Found: %s, in endShardToSequenceMap", endShardToSequenceMap.keySet());
+        kinesisEndSequenceNumber = endShardToSequenceMap.values().iterator().next();
+      }
+
+      String nextStartSequenceNumber;
+      boolean isEndOfShard = false;
+      long currentWindow = System.currentTimeMillis() / SLEEP_TIME_BETWEEN_REQUESTS;
+      int currentWindowRequests = 0;
+      while (shardIterator != null) {
+        GetRecordsRequest getRecordsRequest = GetRecordsRequest.builder().shardIterator(shardIterator).build();
+
+        long requestSentTime = System.currentTimeMillis() / 1000;
+        GetRecordsResponse getRecordsResponse = _kinesisClient.getRecords(getRecordsRequest);
+        isEndOfShard = getRecordsResponse.hasChildShards() && !getRecordsResponse.childShards().isEmpty();                                                          ;
+        if (!getRecordsResponse.records().isEmpty()) {
+          getRecordsResponse.records().forEach(record -> {
+            try {
+              List<KinesisStreamMessage> recordListSingle = Collections.singletonList(new KinesisStreamMessage(record.partitionKey().getBytes(StandardCharsets.UTF_8),
+                  record.data().asByteArray(), record.sequenceNumber(),
+                  (KinesisStreamMessageMetadata) _kinesisMetadataExtractor.extract(record),
+                  record.data().asByteArray().length));
+
+              messageBatchBuffer.put(new KinesisRecordsBatch(recordListSingle, startShardToSequenceNum.getKey(),
+                  getRecordsResponse.hasChildShards() && !getRecordsResponse.childShards().isEmpty()));
+            } catch (Exception e) {
+              throw new RuntimeException(e);
+            }
+          });
+          nextStartSequenceNumber = recordList.get(recordList.size() - 1).sequenceNumber();
+
+          if (kinesisEndSequenceNumber != null && kinesisEndSequenceNumber.compareTo(nextStartSequenceNumber) <= 0) {
+            break;
+          }
+
+          if (recordList.size() >= _numMaxRecordsToFetch) {
+            break;
+          }
+        }
+
+        if (getRecordsResponse.hasChildShards() && !getRecordsResponse.childShards().isEmpty()) {
+          //This statement returns true only when end of current shard has reached.
+          // hasChildShards only checks if the childShard is null and is a valid instance.
+          isEndOfShard = true;
+          break;
+        }
+
+        shardIterator = getRecordsResponse.nextShardIterator();
+
+        if (Thread.interrupted()) {
+          break;
+        }
+
+        // Kinesis enforces a limit of 5 .getRecords request per second on each shard from AWS end
+        // Beyond this limit we start getting ProvisionedThroughputExceededException which affect the ingestion
+        if (requestSentTime == currentWindow) {
+          currentWindowRequests++;
+        } else if (requestSentTime > currentWindow) {
+          currentWindow = requestSentTime;
+          currentWindowRequests = 0;
+        }
+
+        if (currentWindowRequests >= _rpsLimit) {
+          try {
+            Thread.sleep(SLEEP_TIME_BETWEEN_REQUESTS);
+          } catch (InterruptedException e) {
+            LOGGER.debug("Sleep interrupted while rate limiting Kinesis requests", e);
+            break;
+          }
+        }
+      }
+
+      return new KinesisRecordsBatch(recordList, startShardToSequenceNum.getKey(), isEndOfShard);
+    } catch (IllegalStateException e) {
+      debugOrLogWarning("Illegal state exception, connection is broken", e);
+      return handleException(kinesisStartCheckpoint, recordList);
+    } catch (ProvisionedThroughputExceededException e) {
+      debugOrLogWarning("The request rate for the stream is too high", e);
+      return handleException(kinesisStartCheckpoint, recordList);
+    } catch (ExpiredIteratorException e) {
+      debugOrLogWarning("ShardIterator expired while trying to fetch records", e);
+      return handleException(kinesisStartCheckpoint, recordList);
+    } catch (ResourceNotFoundException | InvalidArgumentException e) {
+      // aws errors
+      LOGGER.error("Encountered AWS error while attempting to fetch records", e);
+      return handleException(kinesisStartCheckpoint, recordList);
+    } catch (KinesisException e) {
+      debugOrLogWarning("Encountered unknown unrecoverable AWS exception", e);
+      throw new RuntimeException(e);
+    } catch (AbortedException e) {
+      if (!(e.getCause() instanceof InterruptedException)) {
+        debugOrLogWarning("Task aborted due to exception", e);
+      }
+      return handleException(kinesisStartCheckpoint, recordList);
+    } catch (Throwable e) {
+      // non transient errors
+      LOGGER.error("Unknown fetchRecords exception", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  private KinesisRecordsBatch getResult(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset,
+      List<KinesisStreamMessage> recordList) {
+    KinesisPartitionGroupOffset kinesisStartCheckpoint = (KinesisPartitionGroupOffset) startOffset;
+
+    try {
+      if (_kinesisClient == null) {
+        createConnection();
+      }
+
+      // TODO: iterate upon all the shardIds in the map
+      //  Okay for now, since we have assumed that every partition group contains a single shard
+      Map<String, String> startShardToSequenceMap = kinesisStartCheckpoint.getShardToStartSequenceMap();
+      Preconditions.checkState(startShardToSequenceMap.size() == 1,
+          "Only 1 shard per consumer supported. Found: %s, in startShardToSequenceMap",
+          startShardToSequenceMap.keySet());
+      Map.Entry<String, String> startShardToSequenceNum = startShardToSequenceMap.entrySet().iterator().next();
+      String shardIterator = getShardIterator(startShardToSequenceNum.getKey(), startShardToSequenceNum.getValue());
+
+      String kinesisEndSequenceNumber = null;
+
+      if (endOffset != null) {
+        KinesisPartitionGroupOffset kinesisEndCheckpoint = (KinesisPartitionGroupOffset) endOffset;
+        Map<String, String> endShardToSequenceMap = kinesisEndCheckpoint.getShardToStartSequenceMap();
+        Preconditions.checkState(endShardToSequenceMap.size() == 1,
+            "Only 1 shard per consumer supported. Found: %s, in endShardToSequenceMap", endShardToSequenceMap.keySet());
+        kinesisEndSequenceNumber = endShardToSequenceMap.values().iterator().next();
+      }
+
+      String nextStartSequenceNumber;
+      boolean isEndOfShard = false;
+      long currentWindow = System.currentTimeMillis() / SLEEP_TIME_BETWEEN_REQUESTS;
+      int currentWindowRequests = 0;
+      while (shardIterator != null) {
+        GetRecordsRequest getRecordsRequest = GetRecordsRequest.builder().shardIterator(shardIterator).build();
+
+        long requestSentTime = System.currentTimeMillis() / 1000;
+        GetRecordsResponse getRecordsResponse = _kinesisClient.getRecords(getRecordsRequest);
+
+        if (!getRecordsResponse.records().isEmpty()) {
+          getRecordsResponse.records().forEach(record -> {
+            recordList.add(
+            new KinesisStreamMessage(record.partitionKey().getBytes(StandardCharsets.UTF_8),
+                record.data().asByteArray(), record.sequenceNumber(),
+                (KinesisStreamMessageMetadata) _kinesisMetadataExtractor.extract(record),
+                record.data().asByteArray().length));
+          });
+          nextStartSequenceNumber = recordList.get(recordList.size() - 1).sequenceNumber();
+
+          if (kinesisEndSequenceNumber != null && kinesisEndSequenceNumber.compareTo(nextStartSequenceNumber) <= 0) {
+            break;
+          }
+
+          if (recordList.size() >= _numMaxRecordsToFetch) {
+            break;
+          }
+        }
+
+        if (getRecordsResponse.hasChildShards() && !getRecordsResponse.childShards().isEmpty()) {
+          //This statement returns true only when end of current shard has reached.
+          // hasChildShards only checks if the childShard is null and is a valid instance.
+          isEndOfShard = true;
+          break;
+        }
+
+        shardIterator = getRecordsResponse.nextShardIterator();
+
+        if (Thread.interrupted()) {
+          break;
+        }
+
+        // Kinesis enforces a limit of 5 .getRecords request per second on each shard from AWS end
+        // Beyond this limit we start getting ProvisionedThroughputExceededException which affect the ingestion
+        if (requestSentTime == currentWindow) {
+          currentWindowRequests++;
+        } else if (requestSentTime > currentWindow) {
+          currentWindow = requestSentTime;
+          currentWindowRequests = 0;
+        }
+
+        if (currentWindowRequests >= _rpsLimit) {
+          try {
+            Thread.sleep(SLEEP_TIME_BETWEEN_REQUESTS);
+          } catch (InterruptedException e) {
+            LOGGER.debug("Sleep interrupted while rate limiting Kinesis requests", e);
+            break;
+          }
+        }
+      }
+
+      return new KinesisRecordsBatch(recordList, startShardToSequenceNum.getKey(), isEndOfShard);
+    } catch (IllegalStateException e) {
+      debugOrLogWarning("Illegal state exception, connection is broken", e);
+      return handleException(kinesisStartCheckpoint, recordList);
+    } catch (ProvisionedThroughputExceededException e) {
+      debugOrLogWarning("The request rate for the stream is too high", e);
+      return handleException(kinesisStartCheckpoint, recordList);
+    } catch (ExpiredIteratorException e) {
+      debugOrLogWarning("ShardIterator expired while trying to fetch records", e);
+      return handleException(kinesisStartCheckpoint, recordList);
+    } catch (ResourceNotFoundException | InvalidArgumentException e) {
+      // aws errors
+      LOGGER.error("Encountered AWS error while attempting to fetch records", e);
+      return handleException(kinesisStartCheckpoint, recordList);
+    } catch (KinesisException e) {
+      debugOrLogWarning("Encountered unknown unrecoverable AWS exception", e);
+      throw new RuntimeException(e);
+    } catch (AbortedException e) {
+      if (!(e.getCause() instanceof InterruptedException)) {
+        debugOrLogWarning("Task aborted due to exception", e);
+      }
+      return handleException(kinesisStartCheckpoint, recordList);
+    } catch (Throwable e) {
+      // non transient errors
+      LOGGER.error("Unknown fetchRecords exception", e);
+      throw new RuntimeException(e);
+    }
+  }
+
+  private void debugOrLogWarning(String message, Throwable throwable) {
+    if (LOGGER.isDebugEnabled()) {
+      LOGGER.debug(message, throwable);
+    } else {
+      LOGGER.warn(message + ": " + throwable.getMessage());
+    }
+  }
+
+  private KinesisRecordsBatch handleException(KinesisPartitionGroupOffset start,
+      List<KinesisStreamMessage> recordList) {
+    String shardId = start.getShardToStartSequenceMap().entrySet().iterator().next().getKey();
+
+    if (!recordList.isEmpty()) {
+      String nextStartSequenceNumber = recordList.get(recordList.size() - 1).sequenceNumber();
+      Map<String, String> newCheckpoint = new HashMap<>(start.getShardToStartSequenceMap());
+      newCheckpoint.put(newCheckpoint.keySet().iterator().next(), nextStartSequenceNumber);
+    }
+    return new KinesisRecordsBatch(recordList, shardId, false);
+  }
+
+  private String getShardIterator(String shardId, String sequenceNumber) {
+    GetShardIteratorRequest.Builder requestBuilder =
+        GetShardIteratorRequest.builder().streamName(_streamTopicName).shardId(shardId);
+
+    if (sequenceNumber != null) {
+      requestBuilder = requestBuilder.startingSequenceNumber(sequenceNumber)
+          .shardIteratorType(ShardIteratorType.AFTER_SEQUENCE_NUMBER);
+    } else {
+      requestBuilder = requestBuilder.shardIteratorType(_shardIteratorType);
+    }
+
+    return _kinesisClient.getShardIterator(requestBuilder.build()).shardIterator();
+  }
+
+  @Override
+  public void close() {
+    super.close();
+    shutdownAndAwaitTermination();
+  }
+
+  void shutdownAndAwaitTermination() {
+    _executorService.shutdown();
+    try {
+      if (!_executorService.awaitTermination(60, TimeUnit.SECONDS)) {
+        _executorService.shutdownNow();
+      }
+    } catch (InterruptedException ie) {
+      _executorService.shutdownNow();
+      Thread.currentThread().interrupt();
+    }
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
@@ -21,6 +21,8 @@ package org.apache.pinot.spi.stream;
 import java.io.Closeable;
 import java.util.Queue;
 import java.util.concurrent.TimeoutException;
+import org.apache.pinot.spi.stream.buffer.MessageBatchBuffer;
+
 
 /**
  * Consumer interface for consuming from a partition group of a stream
@@ -59,8 +61,11 @@ public interface PartitionGroupConsumer extends Closeable {
   MessageBatch fetchMessages(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset, int timeoutMs)
       throws TimeoutException;
 
-  void fetchMessages(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset,
-      int timeoutMillis, Queue<MessageBatch> emitter) throws TimeoutException;
+  default void fetchMessages(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset,
+      int timeoutMillis, MessageBatchBuffer emitter) throws Exception {
+    MessageBatch messageBatch = fetchMessages(startOffset, endOffset, timeoutMillis);
+    emitter.put(messageBatch);
+  }
 
   /**
    * Checkpoints the consumption state of the stream partition group in the source

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.stream;
 
 import java.io.Closeable;
+import java.util.Queue;
 import java.util.concurrent.TimeoutException;
 
 /**
@@ -57,6 +58,9 @@ public interface PartitionGroupConsumer extends Closeable {
    */
   MessageBatch fetchMessages(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset, int timeoutMs)
       throws TimeoutException;
+
+  void fetchMessages(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset,
+      int timeoutMillis, Queue<MessageBatch> emitter) throws TimeoutException;
 
   /**
    * Checkpoints the consumption state of the stream partition group in the source

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionGroupConsumer.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.spi.stream;
 
 import java.io.Closeable;
-import java.util.Queue;
 import java.util.concurrent.TimeoutException;
 import org.apache.pinot.spi.stream.buffer.MessageBatchBuffer;
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLevelConsumer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLevelConsumer.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.spi.stream;
 
 import java.io.Closeable;
+import java.util.Queue;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
 
@@ -62,5 +63,15 @@ public interface PartitionLevelConsumer extends Closeable, PartitionGroupConsume
     long startOffsetLong = ((LongMsgOffset) startOffset).getOffset();
     long endOffsetLong = endOffset == null ? Long.MAX_VALUE : ((LongMsgOffset) endOffset).getOffset();
     return fetchMessages(startOffsetLong, endOffsetLong, timeoutMillis);
+  }
+
+  default void fetchMessages(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset endOffset,
+      int timeoutMillis, Queue<MessageBatch> emitter)
+      throws java.util.concurrent.TimeoutException {
+    // TODO Issue 5359 remove this default implementation once all kafka consumers have migrated to use this API
+    long startOffsetLong = ((LongMsgOffset) startOffset).getOffset();
+    long endOffsetLong = endOffset == null ? Long.MAX_VALUE : ((LongMsgOffset) endOffset).getOffset();
+    MessageBatch messageBatch = fetchMessages(startOffsetLong, endOffsetLong, timeoutMillis);
+    emitter.add(messageBatch);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLevelConsumer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/PartitionLevelConsumer.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.spi.stream;
 
 import java.io.Closeable;
-import java.util.Queue;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.annotations.InterfaceStability;
 import org.apache.pinot.spi.stream.buffer.MessageBatchBuffer;

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -50,6 +50,8 @@ public class StreamConfig {
   public static final int DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS = 5_000;
   public static final int DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS_KINESIS = 600_000;
   public static final int DEFAULT_IDLE_TIMEOUT_MILLIS = 3 * 60 * 1000;
+  public static final boolean DEFAULT_STREAM_CONSUMER_ENABLE_ASYNC = false;
+  public static final int DEFAULT_STREAM_CONSUMER_BUFFER_CAPACITY = 10000;
 
   private static final double CONSUMPTION_RATE_LIMIT_NOT_SPECIFIED = -1;
 
@@ -83,6 +85,9 @@ public class StreamConfig {
   // segment commit protocol. By default, segment is uploaded to the controller during commit.
   // If this flag is set to true, the segment is uploaded to deep store.
   private final boolean _serverUploadToDeepStore;
+
+  private boolean _enableAsyncConsumer = DEFAULT_STREAM_CONSUMER_ENABLE_ASYNC;
+  private int _consumerBufferCapacity = DEFAULT_STREAM_CONSUMER_BUFFER_CAPACITY;
 
   /**
    * Initializes a StreamConfig using the map of stream configs from the table config
@@ -201,7 +206,31 @@ public class StreamConfig {
     String rate = streamConfigMap.get(StreamConfigProperties.TOPIC_CONSUMPTION_RATE_LIMIT);
     _topicConsumptionRateLimit = rate != null ? Double.parseDouble(rate) : CONSUMPTION_RATE_LIMIT_NOT_SPECIFIED;
 
+    _enableAsyncConsumer = streamConfigMap.get(StreamConfigProperties.ENABLE_ASYNC_CONFIG) != null
+        ? Boolean.parseBoolean(streamConfigMap.get(StreamConfigProperties.ENABLE_ASYNC_CONFIG))
+        : DEFAULT_STREAM_CONSUMER_ENABLE_ASYNC;
+
+    _consumerBufferCapacity = streamConfigMap.get(StreamConfigProperties.ASYNC_BUFFER_CAPACITY_CONFIG) != null
+        ? Integer.parseInt(streamConfigMap.get(StreamConfigProperties.ASYNC_BUFFER_CAPACITY_CONFIG))
+        : DEFAULT_STREAM_CONSUMER_BUFFER_CAPACITY;
+
     _streamConfigMap.putAll(streamConfigMap);
+  }
+
+  public boolean isEnableAsyncConsumer() {
+    return _enableAsyncConsumer;
+  }
+
+  public void setEnableAsyncConsumer(boolean enableAsyncConsumer) {
+    _enableAsyncConsumer = enableAsyncConsumer;
+  }
+
+  public int getConsumerBufferCapacity() {
+    return _consumerBufferCapacity;
+  }
+
+  public void setConsumerBufferCapacity(int consumerBufferCapacity) {
+    _consumerBufferCapacity = consumerBufferCapacity;
   }
 
   public static void validateConsumerType(String streamType, Map<String, String> streamConfigMap) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -116,6 +116,8 @@ public class StreamConfigProperties {
    * Config used to indicate whether server should by-pass controller and directly upload the segment to the deep store
    */
   public static final String SERVER_UPLOAD_TO_DEEPSTORE = "realtime.segment.serverUploadToDeepStore";
+  public static final String ENABLE_ASYNC_CONFIG = "consumer.enableAsync";
+  public static final String ASYNC_BUFFER_CAPACITY_CONFIG = "consumer.bufferCapacity";
 
   /**
    * Helper method to create a stream specific property

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/buffer/MessageBatchBuffer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/buffer/MessageBatchBuffer.java
@@ -1,0 +1,9 @@
+package org.apache.pinot.spi.stream.buffer;
+
+public interface MessageBatchBuffer<T> {
+  // Adds an item to the buffer. If the buffer is full, this method should block until space becomes available.
+  void put(T item) throws Exception;
+
+  // Removes and returns an item from the buffer. If the buffer is empty, this method should block until an item becomes available.
+  T get() throws Exception;
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/buffer/MessageBatchBuffer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/buffer/MessageBatchBuffer.java
@@ -1,9 +1,18 @@
 package org.apache.pinot.spi.stream.buffer;
 
-public interface MessageBatchBuffer<T> {
+public interface MessageBatchBuffer<T> extends AutoCloseable {
   // Adds an item to the buffer. If the buffer is full, this method should block until space becomes available.
   void put(T item) throws Exception;
 
   // Removes and returns an item from the buffer. If the buffer is empty, this method should block until an item becomes available.
   T get() throws Exception;
+
+  // Returns the number of items in the buffer.
+  int size();
+
+  // Returns true if the buffer is empty, false otherwise.
+  boolean isEmpty();
+
+// Returns true if the buffer is full, false otherwise.
+  boolean isFull();
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/buffer/OnHeapMessageBatchBuffer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/buffer/OnHeapMessageBatchBuffer.java
@@ -1,0 +1,51 @@
+package org.apache.pinot.spi.stream.buffer;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.pinot.spi.stream.MessageBatch;
+
+
+public class OnHeapMessageBatchBuffer implements MessageBatchBuffer<MessageBatch> {
+  private final List<MessageBatch> buffer; // to store elements
+  private final int capacity; // maximum number of elements in the buffer
+
+  public OnHeapMessageBatchBuffer(int capacity) {
+    this.capacity = capacity;
+    this.buffer = new ArrayList<>(capacity);
+  }
+
+  @Override
+  public synchronized void put(MessageBatch element) throws Exception {
+    // Wait until the buffer has space
+    while (buffer.size() == capacity) {
+      wait();
+    }
+    buffer.add(element); // Add the new element to the buffer
+    notifyAll(); // Notify all waiting threads that an element has been added
+  }
+
+  @Override
+  public synchronized MessageBatch get() throws Exception {
+    // Wait until the buffer is not empty
+    while (buffer.isEmpty()) {
+      wait();
+    }
+    MessageBatch element = buffer.remove(0); // Remove an element from the buffer
+    notifyAll(); // Notify all waiting threads that an element has been removed
+    return element;
+  }
+
+  // Additional utility methods
+
+  public synchronized int size() {
+    return buffer.size();
+  }
+
+  public synchronized boolean isEmpty() {
+    return buffer.isEmpty();
+  }
+
+  public synchronized boolean isFull() {
+    return buffer.size() == capacity;
+  }
+}

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/buffer/OnHeapMessageBatchBuffer.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/buffer/OnHeapMessageBatchBuffer.java
@@ -5,7 +5,7 @@ import java.util.List;
 import org.apache.pinot.spi.stream.MessageBatch;
 
 
-public class OnHeapMessageBatchBuffer implements MessageBatchBuffer<MessageBatch> {
+public class OnHeapMessageBatchBuffer implements MessageBatchBuffer<MessageBatch>, AutoCloseable {
   private final List<MessageBatch> buffer; // to store elements
   private final int capacity; // maximum number of elements in the buffer
 
@@ -37,15 +37,24 @@ public class OnHeapMessageBatchBuffer implements MessageBatchBuffer<MessageBatch
 
   // Additional utility methods
 
-  public synchronized int size() {
+  @Override
+  public int size() {
     return buffer.size();
   }
 
-  public synchronized boolean isEmpty() {
+  @Override
+  public boolean isEmpty() {
     return buffer.isEmpty();
   }
 
-  public synchronized boolean isFull() {
+  @Override
+  public boolean isFull() {
     return buffer.size() == capacity;
+  }
+
+  @Override
+  public void close()
+      throws Exception {
+    buffer.clear();
   }
 }


### PR DESCRIPTION
Allow pinot to publish records as soon as they are available instead of reaching the timeout. 

Can be enabled with `consumer.enableAsync: true` in stream configs

You can also configure the buffer capacity in terms of number of records as `consumer.bufferCapacity: 10000`. Better would be to have buffer capacity in bytes.