### PR TITLE
Ensure FieldConfig.getEncodingType() is never null

### DIFF
--- a/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/utils/config/TableConfigSerDeTest.java
@@ -536,7 +536,7 @@ public class TableConfigSerDeTest {
 
     FieldConfig secondFieldConfig = fieldConfigList.get(1);
     assertEquals(secondFieldConfig.getName(), "column2");
-    assertNull(secondFieldConfig.getEncodingType());
+    assertEquals(secondFieldConfig.getEncodingType(), FieldConfig.EncodingType.DICTIONARY);
     assertNull(secondFieldConfig.getIndexType());
     assertEquals(secondFieldConfig.getIndexTypes().size(), 0);
     assertNull(secondFieldConfig.getProperties());

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -101,7 +101,7 @@ public class FieldConfig extends BaseJsonConfig {
       @JsonProperty(value = "tierOverwrites") @Nullable JsonNode tierOverwrites) {
     Preconditions.checkArgument(name != null, "'name' must be configured");
     _name = name;
-    _encodingType = encodingType;
+    _encodingType = encodingType == null ? EncodingType.DICTIONARY : encodingType;
     _indexTypes = indexTypes != null ? indexTypes : (
         indexType == null ? Lists.newArrayList() : Lists.newArrayList(indexType));
     _compressionCodec = compressionCodec;


### PR DESCRIPTION
This small PR ensures that `FieldConfig.getEncodingType()` is never null.

That method should in fact never return null in the past given it wasn't annotated with `@Nullable`, but there was no check to ensure that. This was in fact pretty common when the FieldConfig was deserialized from a JSON document like in TableConfigs.

With this PR, whenever these objects are created their value will be DICTIONARY by default. As seen in `DictionaryIndexType.createDeserializer()`, this was the logical default value before this PR, but there are some checks that may fail before reaching that code. One of the examples is the recently added check in `TableConfigUtils.validateFieldConfigList()`.

I've been looking for usages of `FieldConfig.getEncodingType()` that assume the value may be null, but didn't find them.