### PR TITLE
Upgrade google library versions

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-gcs/pom.xml
@@ -38,21 +38,15 @@
     <phase.prop>package</phase.prop>
   </properties>
   <dependencies>
-    <!-- google cloud storage -->
     <dependency>
       <groupId>com.google.cloud</groupId>
       <artifactId>google-cloud-storage</artifactId>
-      <version>1.113.1</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.guava</groupId>
-          <artifactId>guava</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.j2objc</groupId>
-          <artifactId>j2objc-annotations</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>2.34.0</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.cloud</groupId>
+      <artifactId>google-cloud-nio</artifactId>
+      <version>0.127.13</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>
@@ -61,18 +55,12 @@
     <dependency>
       <groupId>com.google.api-client</groupId>
       <artifactId>google-api-client</artifactId>
-      <version>1.30.10</version>
+      <version>2.3.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.http-client</groupId>
       <artifactId>google-http-client</artifactId>
-      <version>1.36.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.j2objc</groupId>
-          <artifactId>j2objc-annotations</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>1.44.1</version>
     </dependency>
     <!-- Due to dependency convergence issues with google cloud storage: https://github.com/googleapis/google-cloud-java/issues/4175 -->
     <dependency>
@@ -82,34 +70,13 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-iam-v1</artifactId>
-      <version>1.0.0</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.api.grpc</groupId>
-          <artifactId>proto-google-common-protos</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>com.google.apis</groupId>
-      <artifactId>google-api-services-storage</artifactId>
-      <version>v1-rev20200814-1.30.10</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.api-client</groupId>
-          <artifactId>google-api-client</artifactId>
-        </exclusion>
-      </exclusions>
+      <version>1.29.0</version>
     </dependency>
     <dependency>
       <groupId>com.google.api</groupId>
       <artifactId>gax-httpjson</artifactId>
-      <version>0.75.2</version>
+      <version>2.43.0</version>
       <exclusions>
-        <exclusion>
-          <groupId>com.google.http-client</groupId>
-          <artifactId>google-http-client</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>org.threeten</groupId>
           <artifactId>threetenbp</artifactId>
@@ -135,17 +102,6 @@
     <dependency>
       <groupId>org.glassfish.jersey.core</groupId>
       <artifactId>jersey-server</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-nio</artifactId>
-      <version>0.120.0-alpha</version>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.cloud</groupId>
-          <artifactId>google-cloud-storage</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
   </dependencies>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
@@ -53,12 +53,6 @@
     <dependency>
       <groupId>com.google.protobuf</groupId>
       <artifactId>protobuf-java</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>com.google.j2objc</groupId>
-          <artifactId>j2objc-annotations</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>com.github.os72</groupId>
@@ -133,14 +127,6 @@
         <exclusion>
           <groupId>com.squareup.okio</groupId>
           <artifactId>okio</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.errorprone</groupId>
-          <artifactId>error_prone_annotations</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.google.j2objc</groupId>
-          <artifactId>j2objc-annotations</artifactId>
         </exclusion>
       </exclusions>
     </dependency>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
@@ -141,7 +141,6 @@
     <dependency>
       <groupId>com.google.api.grpc</groupId>
       <artifactId>proto-google-common-protos</artifactId>
-      <version>${grpc-proto.version}</version>
     </dependency>
     <dependency>
       <groupId>io.grpc</groupId>
@@ -151,11 +150,6 @@
     <dependency>
       <groupId>commons-codec</groupId>
       <artifactId>commons-codec</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>com.google.errorprone</groupId>
-      <artifactId>error_prone_annotations</artifactId>
-      <version>2.23.0</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>
@@ -182,10 +176,6 @@
       <artifactId>grpc-protobuf-lite</artifactId>
       <version>${grpc-protobuf-lite.version}</version>
       <exclusions>
-        <exclusion>
-          <groupId>com.google.errorprone</groupId>
-          <artifactId>error_prone_annotations</artifactId>
-        </exclusion>
         <exclusion>
           <groupId>io.grpc</groupId>
           <artifactId>grpc-context</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -165,11 +165,17 @@
     <woodstox.version>6.4.0</woodstox.version>
     <sslcontext.kickstart.version>8.2.0</sslcontext.kickstart.version>
 
+    <!-- google libraries -->
+    <guava.version>33.0.0-jre</guava.version>
+    <error_prone_annotations.version>2.24.1</error_prone_annotations.version>
+    <protobuf.version>3.25.2</protobuf.version>
+    <proto-google-common-protos.version>2.34.0</proto-google-common-protos.version>
+    <grpc.version>1.61.1</grpc.version>
+
+    <confluent.version>7.2.6</confluent.version>
+
     <!-- Sets the VM argument line used when unit tests are run. -->
     <argLine>-Xms4g -Xmx4g</argLine>
-    <protobuf.version>3.24.3</protobuf.version>
-    <grpc.version>1.59.0</grpc.version>
-    <confluent.version>7.2.6</confluent.version>
 
     <!-- Checkstyle violation prop.-->
     <checkstyle.violation.severity>warning</checkstyle.violation.severity>
@@ -191,8 +197,6 @@
 
     <flink.version>1.14.6</flink.version>
     <commons-configuration2.version>2.9.0</commons-configuration2.version>
-
-    <proto.google.common.protos.version>2.29.0</proto.google.common.protos.version>
 
     <kotlin.stdlib.version>1.7.22</kotlin.stdlib.version>
   </properties>
@@ -441,12 +445,8 @@
       <dependency>
         <groupId>com.google.guava</groupId>
         <artifactId>guava</artifactId>
-        <version>32.1.3-jre</version>
+        <version>${guava.version}</version>
         <exclusions>
-          <exclusion>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>org.checkerframework</groupId>
             <artifactId>checker-qual</artifactId>
@@ -454,10 +454,9 @@
         </exclusions>
       </dependency>
       <dependency>
-        <groupId>com.google.auto.service</groupId>
-        <artifactId>auto-service</artifactId>
-        <version>1.1.1</version>
-        <optional>true</optional> <!-- This is only needed at compilation time as an annotation processor -->
+        <groupId>com.google.errorprone</groupId>
+        <artifactId>error_prone_annotations</artifactId>
+        <version>${error_prone_annotations.version}</version>
       </dependency>
       <dependency>
         <groupId>commons-cli</groupId>
@@ -827,10 +826,10 @@
         <version>${hadoop.version}</version>
         <scope>provided</scope>
         <exclusions>
-            <exclusion>
-              <groupId>com.zaxxer</groupId>
-              <artifactId>HikariCP-java7</artifactId>
-            </exclusion>
+          <exclusion>
+            <groupId>com.zaxxer</groupId>
+            <artifactId>HikariCP-java7</artifactId>
+          </exclusion>
           <exclusion>
             <groupId>com.sun.jersey</groupId>
             <artifactId>jersey-core</artifactId>
@@ -1043,10 +1042,6 @@
             <groupId>com.google.code.findbugs</groupId>
             <artifactId>jsr305</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>com.google.errorprone</groupId>
-            <artifactId>error_prone_annotations</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -1060,9 +1055,20 @@
         <version>0.18.1</version>
       </dependency>
       <dependency>
+        <groupId>com.google.auto.service</groupId>
+        <artifactId>auto-service</artifactId>
+        <version>1.1.1</version>
+        <optional>true</optional> <!-- This is only needed at compilation time as an annotation processor -->
+      </dependency>
+      <dependency>
         <groupId>com.google.code.findbugs</groupId>
         <artifactId>jsr305</artifactId>
         <version>3.0.2</version>
+      </dependency>
+      <dependency>
+        <groupId>com.google.j2objc</groupId>
+        <artifactId>j2objc-annotations</artifactId>
+        <version>2.8</version>
       </dependency>
       <dependency>
         <groupId>org.glassfish.jersey.containers</groupId>
@@ -1263,6 +1269,11 @@
       </dependency>
       <dependency>
         <groupId>io.grpc</groupId>
+        <artifactId>grpc-context</artifactId>
+        <version>${grpc.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.grpc</groupId>
         <artifactId>grpc-netty-shaded</artifactId>
         <version>${grpc.version}</version>
       </dependency>
@@ -1279,7 +1290,7 @@
       <dependency>
         <groupId>com.google.api.grpc</groupId>
         <artifactId>proto-google-common-protos</artifactId>
-        <version>${proto.google.common.protos.version}</version>
+        <version>${proto-google-common-protos.version}</version>
       </dependency>
       <!-- geo dependencies -->
       <dependency>


### PR DESCRIPTION
Upgrade following libraries to latest stable one:

- In root pom:
guava: `33.0.0-jre`
error_prone_annotations: `2.24.1`
protobuf: `3.25.2`
proto-google-common-protos: `2.34.0`
grpc: `1.61.1`
auto-service (very old library): `1.1.1`
j2objc-annotations (very old library): `2.8`

- GCS pom:
google-cloud-storage: `2.34.0`
google-cloud-nio: `0.127.13`
google-api-client: `2.3.0`
google-http-client: `1.44.1`
proto-google-iam-v1: `1.29.0`
gax-httpjson: `2.43.0`