### PR TITLE
Add splitPartWithLimit and splitPartFromEnd UDFs

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -584,14 +584,16 @@ public class StringFunctions {
    * TODO: Revisit if index should be one-based (both Presto and Postgres use one-based index, which starts with 1)
    * @param input
    * @param delimiter
-   * @param index
+   * @param index we allow negative value for index which indicates the index from the end.
    * @return splits string on specified delimiter and returns String at specified index from the split.
    */
   @ScalarFunction
   public static String splitPart(String input, String delimiter, int index) {
     String[] splitString = StringUtils.splitByWholeSeparator(input, delimiter);
-    if (index < splitString.length) {
+    if (index >= 0 && index < splitString.length) {
       return splitString[index];
+    } else if (index < 0 && index >= -splitString.length) {
+      return splitString[splitString.length + index];
     } else {
       return "null";
     }
@@ -601,30 +603,16 @@ public class StringFunctions {
    * @param input the input String to be split into parts.
    * @param delimiter the specified delimiter to split the input string.
    * @param index the specified index for the splitted parts to be returned.
-   * @param max the max count of parts that the input string can be splitted into.
+   * @param limit the max count of parts that the input string can be splitted into.
    * @return splits string on the delimiter with the limit count and returns String at specified index from the split.
    */
   @ScalarFunction
-  public static String splitPart(String input, String delimiter, int index, int max) {
-    String[] splitString = StringUtils.splitByWholeSeparator(input, delimiter, max);
-    if (index < splitString.length) {
+  public static String splitPart(String input, String delimiter, int index, int limit) {
+    String[] splitString = StringUtils.splitByWholeSeparator(input, delimiter, limit);
+    if (index >= 0 && index < splitString.length) {
       return splitString[index];
-    } else {
-      return "null";
-    }
-  }
-
-  /**
-   * @param input the input String to be split into parts.
-   * @param delimiter the specified delimiter to split the input string.
-   * @param index the specified index for the splitted parts to be returned.
-   * @return splits string on the delimiter with the limit count and returns String at specified index from the split.
-   */
-  @ScalarFunction
-  public static String splitPartFromEnd(String input, String delimiter, int index) {
-    String[] splitString = StringUtils.splitByWholeSeparator(input, delimiter);
-    if (index < splitString.length) {
-      return splitString[splitString.length - 1 - index];
+    } else if (index < 0 && index >= -splitString.length) {
+      return splitString[splitString.length + index];
     } else {
       return "null";
     }

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -602,12 +602,12 @@ public class StringFunctions {
   /**
    * @param input the input String to be split into parts.
    * @param delimiter the specified delimiter to split the input string.
-   * @param index the specified index for the splitted parts to be returned.
    * @param limit the max count of parts that the input string can be splitted into.
+   * @param index the specified index for the splitted parts to be returned.
    * @return splits string on the delimiter with the limit count and returns String at specified index from the split.
    */
   @ScalarFunction
-  public static String splitPart(String input, String delimiter, int index, int limit) {
+  public static String splitPart(String input, String delimiter, int limit, int index) {
     String[] splitString = StringUtils.splitByWholeSeparator(input, delimiter, limit);
     if (index >= 0 && index < splitString.length) {
       return splitString[index];

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -598,7 +598,6 @@ public class StringFunctions {
   }
 
   /**
-   * TODO: Revisit if index should be one-based (both Presto and Postgres use one-based index, which starts with 1)
    * @param input the input String to be split into parts.
    * @param delimiter the specified delimiter to split the input string.
    * @param index the specified index for the splitted parts to be returned.
@@ -616,7 +615,6 @@ public class StringFunctions {
   }
 
   /**
-   * TODO: Revisit if index should be one-based (both Presto and Postgres use one-based index, which starts with 1)
    * @param input the input String to be split into parts.
    * @param delimiter the specified delimiter to split the input string.
    * @param index the specified index for the splitted parts to be returned.

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -49,7 +49,6 @@ public class StringFunctions {
   private final static Pattern LTRIM = Pattern.compile("^\\s+");
   private final static Pattern RTRIM = Pattern.compile("\\s+$");
 
-
   /**
    * @see StringUtils#reverse(String)
    * @param input
@@ -593,6 +592,41 @@ public class StringFunctions {
     String[] splitString = StringUtils.splitByWholeSeparator(input, delimiter);
     if (index < splitString.length) {
       return splitString[index];
+    } else {
+      return "null";
+    }
+  }
+
+  /**
+   * TODO: Revisit if index should be one-based (both Presto and Postgres use one-based index, which starts with 1)
+   * @param input the input String to be split into parts.
+   * @param delimiter the specified delimiter to split the input string.
+   * @param index the specified index for the splitted parts to be returned.
+   * @param max the max count of parts that the input string can be splitted into.
+   * @return splits string on the delimiter with the limit count and returns String at specified index from the split.
+   */
+  @ScalarFunction
+  public static String splitPart(String input, String delimiter, int index, int max) {
+    String[] splitString = StringUtils.splitByWholeSeparator(input, delimiter, max);
+    if (index < splitString.length) {
+      return splitString[index];
+    } else {
+      return "null";
+    }
+  }
+
+  /**
+   * TODO: Revisit if index should be one-based (both Presto and Postgres use one-based index, which starts with 1)
+   * @param input the input String to be split into parts.
+   * @param delimiter the specified delimiter to split the input string.
+   * @param index the specified index for the splitted parts to be returned.
+   * @return splits string on the delimiter with the limit count and returns String at specified index from the split.
+   */
+  @ScalarFunction
+  public static String splitPartFromEnd(String input, String delimiter, int index) {
+    String[] splitString = StringUtils.splitByWholeSeparator(input, delimiter);
+    if (index < splitString.length) {
+      return splitString[splitString.length - 1 - index];
     } else {
       return "null";
     }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -86,6 +86,6 @@ public class StringFunctionsTest {
   public void testSplitPart(String input, String delimiter, int index, int limit, String expectedToken,
       String expectedTokenWithLimitCounts) {
     assertEquals(StringFunctions.splitPart(input, delimiter, index), expectedToken);
-    assertEquals(StringFunctions.splitPart(input, delimiter, index, limit), expectedTokenWithLimitCounts);
+    assertEquals(StringFunctions.splitPart(input, delimiter, limit, index), expectedTokenWithLimitCounts);
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -26,6 +26,25 @@ import static org.testng.Assert.assertEquals;
 
 public class StringFunctionsTest {
 
+  @DataProvider(name = "splitPartTestCases")
+  public static Object[][] splitPartTestCases() {
+    return new Object[][]{
+        {"org.apache.pinot.common.function", ".", 0, 100, "org", "org", "function"},
+        {"org.apache.pinot.common.function", ".", 10, 100, "null", "null", "null"},
+        {"org.apache.pinot.common.function", ".", 1, 0, "apache", "apache", "common"},
+        {"org.apache.pinot.common.function", ".", 1, 1, "apache", "null", "common"},
+        {"org.apache.pinot.common.function", ".", 0, 1, "org", "org.apache.pinot.common.function", "function"},
+        {"org.apache.pinot.common.function", ".", 1, 2, "apache", "apache.pinot.common.function", "common"},
+        {"org.apache.pinot.common.function", ".", 2, 3, "pinot", "pinot.common.function", "pinot"},
+        {"org.apache.pinot.common.function", ".", 3, 4, "common", "common.function", "apache"},
+        {"org.apache.pinot.common.function", ".", 4, 5, "function", "function", "org"},
+        {"org.apache.pinot.common.function", ".", 5, 6, "null", "null", "null"},
+        {"org.apache.pinot.common.function", ".", 3, 3, "common", "null", "apache"},
+        {"+++++", "+", 0, 100, "", "", ""},
+        {"+++++", "+", 1, 100, "null", "null", "null"},
+    };
+  }
+
   @DataProvider(name = "isJson")
   public static Object[][] isJsonTestCases() {
     return new Object[][]{
@@ -39,5 +58,13 @@ public class StringFunctionsTest {
   @Test(dataProvider = "isJson")
   public void testIsJson(String input, boolean expectedValue) {
     assertEquals(StringFunctions.isJson(input), expectedValue);
+  }
+
+  @Test(dataProvider = "splitPartTestCases")
+  public void testSplitPark(String input, String delimiter, int index, int max, String expectedToken,
+      String expectedTokenWithLimitCounts, String expectedTokenFromEnd) {
+    assertEquals(StringFunctions.splitPart(input, delimiter, index), expectedToken);
+    assertEquals(StringFunctions.splitPart(input, delimiter, index, max), expectedTokenWithLimitCounts);
+    assertEquals(StringFunctions.splitPartFromEnd(input, delimiter, index), expectedTokenFromEnd);
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -29,19 +29,41 @@ public class StringFunctionsTest {
   @DataProvider(name = "splitPartTestCases")
   public static Object[][] splitPartTestCases() {
     return new Object[][]{
-        {"org.apache.pinot.common.function", ".", 0, 100, "org", "org", "function"},
-        {"org.apache.pinot.common.function", ".", 10, 100, "null", "null", "null"},
-        {"org.apache.pinot.common.function", ".", 1, 0, "apache", "apache", "common"},
-        {"org.apache.pinot.common.function", ".", 1, 1, "apache", "null", "common"},
-        {"org.apache.pinot.common.function", ".", 0, 1, "org", "org.apache.pinot.common.function", "function"},
-        {"org.apache.pinot.common.function", ".", 1, 2, "apache", "apache.pinot.common.function", "common"},
-        {"org.apache.pinot.common.function", ".", 2, 3, "pinot", "pinot.common.function", "pinot"},
-        {"org.apache.pinot.common.function", ".", 3, 4, "common", "common.function", "apache"},
-        {"org.apache.pinot.common.function", ".", 4, 5, "function", "function", "org"},
-        {"org.apache.pinot.common.function", ".", 5, 6, "null", "null", "null"},
-        {"org.apache.pinot.common.function", ".", 3, 3, "common", "null", "apache"},
-        {"+++++", "+", 0, 100, "", "", ""},
-        {"+++++", "+", 1, 100, "null", "null", "null"},
+        {"org.apache.pinot.common.function", ".", 0, 100, "org", "org"},
+        {"org.apache.pinot.common.function", ".", 10, 100, "null", "null"},
+        {"org.apache.pinot.common.function", ".", 1, 0, "apache", "apache"},
+        {"org.apache.pinot.common.function", ".", 1, 1, "apache", "null"},
+        {"org.apache.pinot.common.function", ".", 0, 1, "org", "org.apache.pinot.common.function"},
+        {"org.apache.pinot.common.function", ".", 1, 2, "apache", "apache.pinot.common.function"},
+        {"org.apache.pinot.common.function", ".", 2, 3, "pinot", "pinot.common.function"},
+        {"org.apache.pinot.common.function", ".", 3, 4, "common", "common.function"},
+        {"org.apache.pinot.common.function", ".", 4, 5, "function", "function"},
+        {"org.apache.pinot.common.function", ".", 5, 6, "null", "null"},
+        {"org.apache.pinot.common.function", ".", 3, 3, "common", "null"},
+        {"+++++", "+", 0, 100, "", ""},
+        {"+++++", "+", 1, 100, "null", "null"},
+        // note that splitPart will split with limit first, then lookup by index from START or END.
+        {"org.apache.pinot.common.function", ".", -1, 100, "function", "function"},
+        {"org.apache.pinot.common.function", ".", -10, 100, "null", "null"},
+        {"org.apache.pinot.common.function", ".", -2, 0, "common", "common"}, // Case: limit=0 is not taking effect.
+        {"org.apache.pinot.common.function", ".", -1, 1, "function", "org.apache.pinot.common.function"},
+        {"org.apache.pinot.common.function", ".", -2, 1, "common", "null"},
+        {"org.apache.pinot.common.function", ".", -1, 2, "function", "apache.pinot.common.function"},
+        {"org.apache.pinot.common.function", ".", -2, 2, "common", "org"},
+        {"org.apache.pinot.common.function", ".", -1, 3, "function", "pinot.common.function"},
+        {"org.apache.pinot.common.function", ".", -3, 3, "pinot", "org"},
+        {"org.apache.pinot.common.function", ".", -4, 3, "apache", "null"},
+        {"org.apache.pinot.common.function", ".", -1, 4, "function", "common.function"},
+        {"org.apache.pinot.common.function", ".", -3, 4, "pinot", "apache"},
+        {"org.apache.pinot.common.function", ".", -4, 4, "apache", "org"},
+        {"org.apache.pinot.common.function", ".", -1, 5, "function", "function"},
+        {"org.apache.pinot.common.function", ".", -5, 5, "org", "org"},
+        {"org.apache.pinot.common.function", ".", -6, 5, "null", "null"},
+        {"org.apache.pinot.common.function", ".", -1, 6, "function", "function"},
+        {"org.apache.pinot.common.function", ".", -5, 6, "org", "org"},
+        {"org.apache.pinot.common.function", ".", -6, 6, "null", "null"},
+        {"+++++", "+", -1, 100, "", ""},
+        {"+++++", "+", -2, 100, "null", "null"},
     };
   }
 
@@ -61,10 +83,9 @@ public class StringFunctionsTest {
   }
 
   @Test(dataProvider = "splitPartTestCases")
-  public void testSplitPart(String input, String delimiter, int index, int max, String expectedToken,
-      String expectedTokenWithLimitCounts, String expectedTokenFromEnd) {
+  public void testSplitPart(String input, String delimiter, int index, int limit, String expectedToken,
+      String expectedTokenWithLimitCounts) {
     assertEquals(StringFunctions.splitPart(input, delimiter, index), expectedToken);
-    assertEquals(StringFunctions.splitPart(input, delimiter, index, max), expectedTokenWithLimitCounts);
-    assertEquals(StringFunctions.splitPartFromEnd(input, delimiter, index), expectedTokenFromEnd);
+    assertEquals(StringFunctions.splitPart(input, delimiter, index, limit), expectedTokenWithLimitCounts);
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -61,7 +61,7 @@ public class StringFunctionsTest {
   }
 
   @Test(dataProvider = "splitPartTestCases")
-  public void testSplitPark(String input, String delimiter, int index, int max, String expectedToken,
+  public void testSplitPart(String input, String delimiter, int index, int max, String expectedToken,
       String expectedTokenWithLimitCounts, String expectedTokenFromEnd) {
     assertEquals(StringFunctions.splitPart(input, delimiter, index), expectedToken);
     assertEquals(StringFunctions.splitPart(input, delimiter, index, max), expectedTokenWithLimitCounts);


### PR DESCRIPTION
`feature`:  Adding splitPartWithLimit and splitPartFromEnd UDFs

Context:

We are onboarding a use case and trying the increase query throughput. We tested the QPS cannot further improved with the existing REGEXP_LIKE, text_match queries. 

One of the scenario is that, we are matching a regex on a column with long string values, this can be inefficient for matching. We are leverage the splitPart UDF to split into substring values and matches each substring using inverted indexes separately.

it can be used by the following transformation config
```
       {
          "columnName": "long_string_start_0",
          "transformFunction": "splitPart(long_string, "_", 0, 4)"
        },
       {
          "columnName": "long_string_start_1",
          "transformFunction": "splitPart(long_string, "_", 1, 4)"
        },
       {
          "columnName": "long_string_end_0",
          "transformFunction": "splitPartFromEnd(long_string, "_", 0)"
        },
       {
          "columnName": "long_string_end_1",
          "transformFunction": "splitPartFromEnd(long_string, "_", 1)"
        },
```