### PR TITLE
Supported readDictIds method for multivalue columns in forward index.

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitMVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitMVForwardIndexReader.java
@@ -102,6 +102,13 @@ public final class FixedBitMVForwardIndexReader implements ForwardIndexReader<Fi
   }
 
   @Override
+  public void readDictIds(int[] docIds, int length, int[] dictIdBuffer, Context context) {
+    for (int i = 0; i < length; i++) {
+      dictIdBuffer[i] = _rawDataReader.readInt(docIds[i]);
+    }
+  }
+
+  @Override
   public int getDictIdMV(int docId, int[] dictIdBuffer, Context context) {
     int contextDocId = context._docId;
     int contextEndOffset = context._endOffset;


### PR DESCRIPTION
As per the [issue](https://github.com/apache/pinot/issues/12374), aggregation binary transformation functions are not supported for multivalue columns. This PR intends to provide the needed support. 

As per the stack trace provided in the issue itself
```bash
queryExecutionError:
java.lang.UnsupportedOperationException
	at org.apache.pinot.segment.spi.index.reader.ForwardIndexReader.readDictIds(ForwardIndexReader.java:118)
	at org.apache.pinot.core.common.DataFetcher$ColumnValueReader.readStringValues(DataFetcher.java:570)
	at org.apache.pinot.core.common.DataFetcher.fetchStringValues(DataFetcher.java:239)
	at org.apache.pinot.core.common.DataBlockCache.getStringValuesForSVColumn(DataBlockCache.java:277)
```

In this PR, we added the missing method in the `FixedBitMVForwardIndexReader.java` to provide the required support.

cc: @Jackie-Jiang 