### PR TITLE
[Enhancement][WIP] Distribute Mapper Output Threshold Across Concurrent Tasks

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/common/MinionConstants.java
@@ -53,6 +53,7 @@ public class MinionConstants {
   public static final String TIMEOUT_MS_KEY_SUFFIX = ".timeoutMs";
   public static final String NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY_SUFFIX = ".numConcurrentTasksPerInstance";
   public static final String MAX_ATTEMPTS_PER_TASK_KEY_SUFFIX = ".maxAttemptsPerTask";
+  public static final String NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY = "numConcurrentTasksPerInstance";
 
   /**
    * Table level configs

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorConfig.java
@@ -46,11 +46,12 @@ public class SegmentProcessorConfig {
   private final Map<String, AggregationFunctionType> _aggregationTypes;
   private final SegmentConfig _segmentConfig;
   private final Consumer<Object> _progressObserver;
+  private final int _numConcurrentTasksPerInstance;
 
   private SegmentProcessorConfig(TableConfig tableConfig, Schema schema, TimeHandlerConfig timeHandlerConfig,
       List<PartitionerConfig> partitionerConfigs, MergeType mergeType,
       Map<String, AggregationFunctionType> aggregationTypes, SegmentConfig segmentConfig,
-      Consumer<Object> progressObserver) {
+      Consumer<Object> progressObserver, int numConcurrentTasksPerInstance) {
     TimestampIndexUtils.applyTimestampIndex(tableConfig, schema);
     _tableConfig = tableConfig;
     _schema = schema;
@@ -62,6 +63,7 @@ public class SegmentProcessorConfig {
     _progressObserver = (progressObserver != null) ? progressObserver : p -> {
       // Do nothing.
     };
+    _numConcurrentTasksPerInstance = numConcurrentTasksPerInstance;
   }
 
   /**
@@ -136,6 +138,7 @@ public class SegmentProcessorConfig {
     private Map<String, AggregationFunctionType> _aggregationTypes;
     private SegmentConfig _segmentConfig;
     private Consumer<Object> _progressObserver;
+    private int _numConcurrentTasksPerInstance = 1;
 
     public Builder setTableConfig(TableConfig tableConfig) {
       _tableConfig = tableConfig;
@@ -177,6 +180,11 @@ public class SegmentProcessorConfig {
       return this;
     }
 
+    public Builder setNumConcurrentTasksPerInstance(int numConcurrentTasksPerInstance) {
+      _numConcurrentTasksPerInstance = numConcurrentTasksPerInstance;
+      return this;
+    }
+
     public SegmentProcessorConfig build() {
       Preconditions.checkState(_tableConfig != null, "Must provide table config in SegmentProcessorConfig");
       Preconditions.checkState(_schema != null, "Must provide schema in SegmentProcessorConfig");
@@ -197,7 +205,7 @@ public class SegmentProcessorConfig {
         _segmentConfig = new SegmentConfig.Builder().build();
       }
       return new SegmentProcessorConfig(_tableConfig, _schema, _timeHandlerConfig, _partitionerConfigs, _mergeType,
-          _aggregationTypes, _segmentConfig, _progressObserver);
+          _aggregationTypes, _segmentConfig, _progressObserver, _numConcurrentTasksPerInstance);
     }
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorConfig.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/segment/processing/framework/SegmentProcessorConfig.java
@@ -119,6 +119,10 @@ public class SegmentProcessorConfig {
     return _progressObserver;
   }
 
+  public int getNumConcurrentTasksPerInstance() {
+    return _numConcurrentTasksPerInstance;
+  }
+
   @Override
   public String toString() {
     return "SegmentProcessorConfig{" + "_tableConfig=" + _tableConfig + ", _schema=" + _schema + ", _timeHandlerConfig="

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskExecutor.java
@@ -89,6 +89,10 @@ public class MergeRollupTaskExecutor extends BaseMultipleSegmentsConversionExecu
     // Progress observer
     segmentProcessorConfigBuilder.setProgressObserver(p -> _eventObserver.notifyProgress(_pinotTaskConfig, p));
 
+    // Set the number of concurrent tasks per instance
+    segmentProcessorConfigBuilder.setNumConcurrentTasksPerInstance(
+        Integer.parseInt(configs.getOrDefault(MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY, "1")));
+
     SegmentProcessorConfig segmentProcessorConfig = segmentProcessorConfigBuilder.build();
 
     List<RecordReader> recordReaders = new ArrayList<>(numInputSegments);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -721,6 +721,12 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
             MergeRollupTask.MERGED_SEGMENT_NAME_PREFIX + mergeLevel + DELIMITER_IN_SEGMENT_NAME
                 + System.currentTimeMillis() + partitionSuffix + DELIMITER_IN_SEGMENT_NAME + i
                 + DELIMITER_IN_SEGMENT_NAME + TableNameBuilder.extractRawTableName(tableNameWithType));
+
+        // Add the number of concurrent tasks to the taskConfig for the segment processor.
+        String configKey = MergeRollupTask.TASK_TYPE + MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY_SUFFIX;
+        String configValue = _clusterInfoAccessor.getClusterConfig(configKey);
+        configs.put(MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY, configValue);
+
         pinotTaskConfigs.add(new PinotTaskConfig(MergeRollupTask.TASK_TYPE, configs));
       }
     }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/mergerollup/MergeRollupTaskGenerator.java
@@ -723,9 +723,8 @@ public class MergeRollupTaskGenerator extends BaseTaskGenerator {
                 + DELIMITER_IN_SEGMENT_NAME + TableNameBuilder.extractRawTableName(tableNameWithType));
 
         // Add the number of concurrent tasks to the taskConfig for the segment processor.
-        String configKey = MergeRollupTask.TASK_TYPE + MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY_SUFFIX;
-        String configValue = _clusterInfoAccessor.getClusterConfig(configKey);
-        configs.put(MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY, configValue);
+        configs.put(MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY,
+            String.valueOf(getNumConcurrentTasksPerInstance()));
 
         pinotTaskConfigs.add(new PinotTaskConfig(MergeRollupTask.TASK_TYPE, configs));
       }

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskExecutor.java
@@ -155,6 +155,10 @@ public class RealtimeToOfflineSegmentsTaskExecutor extends BaseMultipleSegmentsC
     // Progress observer
     segmentProcessorConfigBuilder.setProgressObserver(p -> _eventObserver.notifyProgress(_pinotTaskConfig, p));
 
+    // Set the number of concurrent tasks per instance
+    segmentProcessorConfigBuilder.setNumConcurrentTasksPerInstance(
+        Integer.parseInt(configs.getOrDefault(MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY, "1")));
+
     SegmentProcessorConfig segmentProcessorConfig = segmentProcessorConfigBuilder.build();
 
     List<RecordReader> recordReaders = new ArrayList<>(numInputSegments);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -231,9 +231,8 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
       }
 
       // Add the number of concurrent tasks to the taskConfig for the segment processor.
-      String configKey = taskType + MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY_SUFFIX;
-      String configValue = _clusterInfoAccessor.getClusterConfig(configKey);
-      configs.put(MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY, configValue);
+      configs.put(MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY,
+          String.valueOf(getNumConcurrentTasksPerInstance()));
 
       pinotTaskConfigs.add(new PinotTaskConfig(taskType, configs));
       LOGGER.info("Finished generating task configs for table: {} for task: {}", realtimeTableName, taskType);

--- a/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
+++ b/pinot-plugins/pinot-minion-tasks/pinot-minion-builtin-tasks/src/main/java/org/apache/pinot/plugin/minion/tasks/realtimetoofflinesegments/RealtimeToOfflineSegmentsTaskGenerator.java
@@ -230,6 +230,11 @@ public class RealtimeToOfflineSegmentsTaskGenerator extends BaseTaskGenerator {
         configs.put(RealtimeToOfflineSegmentsTask.MAX_NUM_RECORDS_PER_SEGMENT_KEY, maxNumRecordsPerSegment);
       }
 
+      // Add the number of concurrent tasks to the taskConfig for the segment processor.
+      String configKey = taskType + MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY_SUFFIX;
+      String configValue = _clusterInfoAccessor.getClusterConfig(configKey);
+      configs.put(MinionConstants.NUM_CONCURRENT_TASKS_PER_INSTANCE_KEY, configValue);
+
       pinotTaskConfigs.add(new PinotTaskConfig(taskType, configs));
       LOGGER.info("Finished generating task configs for table: {} for task: {}", realtimeTableName, taskType);
     }


### PR DESCRIPTION
# Issue

Currently if we bound the mapper output size using `segmentMapperFileSizeThresholdInBytes`, we might get into the issue of crossing the threshold overall for the task in case there are concurrent tasks running. The actual disk usage across the all the concurrent tasks might be (number of concurrent tasks * `segmentMapperFileSizeThresholdInBytes`). 

For example let's say the number of concurrent tasks = 2 and `segmentMapperFileSizeThresholdInBytes` is set at 60GB. It might happen that both the tasks get into the map phase and each task gets the mapper output threshold as 60GB increasing the total disk usage to 120GB.

# Solution

Distribute the threshold across the threads i.e. if number of concurrent tasks = n and mapper output size threshold is = x, Each task should have it's mapper output size threshold configured as x/n. 

We achieve it by the following steps : 

- We pass the number of concurrent tasks to the respective task configs through the task generators of the tasks using `SegmentProcessorFramework`

- We pass the number of concurrent tasks into `SegmentProcessorConfig` of the task executor so that `SegmentProcessorFramework` can distribute the threshold equally among the concurrent tasks.