### PR TITLE
require noDictionaryColumns with aggregationConfigs

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -49,8 +49,6 @@ import org.apache.pinot.segment.local.recordtransformer.SchemaConformingTransfor
 import org.apache.pinot.segment.local.segment.creator.impl.inv.BitSlicedRangeIndexCreator;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.index.DictionaryIndexConfig;
-import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
-import org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil;
 import org.apache.pinot.segment.spi.index.IndexService;
 import org.apache.pinot.segment.spi.index.IndexType;
 import org.apache.pinot.segment.spi.index.StandardIndexes;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -48,6 +48,7 @@ import org.apache.pinot.segment.local.function.FunctionEvaluatorFactory;
 import org.apache.pinot.segment.local.recordtransformer.SchemaConformingTransformer;
 import org.apache.pinot.segment.local.segment.creator.impl.inv.BitSlicedRangeIndexCreator;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
+import org.apache.pinot.segment.spi.index.DictionaryIndexConfig;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigs;
 import org.apache.pinot.segment.spi.index.FieldIndexConfigsUtil;
 import org.apache.pinot.segment.spi.index.IndexService;
@@ -498,12 +499,10 @@ public final class TableConfigUtils {
         // That code will disable ingestion aggregation if all metrics aren't noDictionaryColumns.
         // But if you do that after the table is already created, all future aggregations will
         // just be the default value.
-        Map<String, FieldIndexConfigs> fieldIndexConfigsMap = FieldIndexConfigsUtil.createIndexConfigsByColName(
-            tableConfig, schema);
-        Set<String> noDictionaryColumns =
-            FieldIndexConfigsUtil.columnsWithIndexDisabled(StandardIndexes.dictionary(), fieldIndexConfigsMap);
+        Map<String, DictionaryIndexConfig> configPerCol = StandardIndexes.dictionary().getConfig(tableConfig, schema);
         aggregationColumns.forEach(column -> {
-          Preconditions.checkState(noDictionaryColumns.contains(column),
+          DictionaryIndexConfig dictConfig = configPerCol.get(column);
+          Preconditions.checkState(dictConfig != null && dictConfig.isDisabled(),
               "Aggregated column: %s must be a no-dictionary column", column);
         });
       }

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -593,7 +593,7 @@ public class TableConfigUtilsTest {
     ingestionConfig.setAggregationConfigs(aggregationConfigs);
     tableConfig =
         new TableConfigBuilder(TableType.REALTIME).setTableName("myTable_REALTIME").setTimeColumnName("timeColumn")
-            .setIngestionConfig(ingestionConfig).build();
+            .setIngestionConfig(ingestionConfig).setNoDictionaryColumns(List.of("d1", "d2", "d3", "d4", "d5")).build();
 
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, schema);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/TableConfigUtilsTest.java
@@ -517,7 +517,7 @@ public class TableConfigUtilsTest {
     try {
       TableConfigUtils.validateIngestionConfig(tableConfig, schema);
       Assert.fail("Should fail due to noDictionaryColumns being null");
-    } catch (NullPointerException e) {
+    } catch (IllegalStateException e) {
       // expected
     }
 


### PR DESCRIPTION
This is a `bugfix` to ensure someone does not incorrectly set up ingestion aggregation. Currently, `MutableSegmentImpl` will just disable aggregation if you do not have `noDictionaryColumns` for all `columnName` in `aggregationConfigs`. This caused an issue in one of our clusters because all of the aggregations showed up as `0`.

This will not break existing tables as validation is only done when the table is created or updated. But even if anyone was using these configs incorrectly and runs into this error message, they can just delete the configs since they're doing nothing anyway.

This was tested on an internal cluster where I verified:
- you cannot remove existing aggregation columns from noDictionaryConfigs
- you cannot add new aggregation columns without adding them to noDictionaryConfigs
- you cannot make a new table without all aggregation columns in noDictionaryConfigs