### PR TITLE
Add a post-validator visitor that verifies there are no cast to bytes

### DIFF
--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/QueryEnvironment.java
@@ -72,6 +72,7 @@ import org.apache.pinot.query.planner.physical.DispatchableSubPlan;
 import org.apache.pinot.query.planner.physical.PinotDispatchPlanner;
 import org.apache.pinot.query.routing.WorkerManager;
 import org.apache.pinot.query.type.TypeFactory;
+import org.apache.pinot.query.validate.BytesCastVisitor;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
 import org.apache.pinot.sql.parsers.SqlNodeAndOptions;
 import org.apache.pinot.sql.parsers.parser.SqlPhysicalExplain;
@@ -294,6 +295,7 @@ public class QueryEnvironment {
       throw new IllegalArgumentException(
           String.format("unsupported SQL query, cannot validate out a valid sql from:\n%s", parsed));
     }
+    validated.accept(new BytesCastVisitor(plannerContext.getValidator()));
     return validated;
   }
 

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/BytesCastVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/BytesCastVisitor.java
@@ -41,7 +41,6 @@ public class BytesCastVisitor extends SqlBasicVisitor<Void> {
     _originalValidator = originalValidator;
   }
 
-  @SuppressWarnings("checkstyle:WhitespaceAround")
   @Override
   public Void visit(SqlCall call) {
     if (call.getOperator() instanceof SqlCastFunction) {

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/BytesCastVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/BytesCastVisitor.java
@@ -64,7 +64,7 @@ public class BytesCastVisitor extends SqlBasicVisitor<Void> {
         message += " Try to wrap the expression in hexToBytes (like hexToBytes(" + srcNode + "))";
       }
       SqlParserPos pos = call.getParserPosition();
-      RuntimeException ex = new RuntimeException(message);
+      RuntimeException ex = new InvalidCastException(message);
       throw Static.RESOURCE.validatorContext(pos.getLineNum(), pos.getColumnNum(), pos.getEndLineNum(),
           pos.getEndColumnNum()).ex(ex);
     }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/BytesCastVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/BytesCastVisitor.java
@@ -1,0 +1,73 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.validate;
+
+import com.google.common.base.Preconditions;
+import java.util.List;
+import org.apache.calcite.rel.type.RelDataType;
+import org.apache.calcite.sql.SqlCall;
+import org.apache.calcite.sql.SqlCharStringLiteral;
+import org.apache.calcite.sql.SqlDataTypeSpec;
+import org.apache.calcite.sql.SqlNode;
+import org.apache.calcite.sql.fun.SqlCastFunction;
+import org.apache.calcite.sql.parser.SqlParserPos;
+import org.apache.calcite.sql.type.SqlTypeUtil;
+import org.apache.calcite.sql.util.SqlBasicVisitor;
+import org.apache.calcite.sql.validate.SqlValidator;
+import org.apache.calcite.util.Static;
+
+
+public class BytesCastVisitor extends SqlBasicVisitor<Void> {
+
+  private final SqlValidator _originalValidator;
+
+  public BytesCastVisitor(SqlValidator originalValidator) {
+    _originalValidator = originalValidator;
+  }
+
+  @SuppressWarnings("checkstyle:WhitespaceAround")
+  @Override
+  public Void visit(SqlCall call) {
+    if (call.getOperator() instanceof SqlCastFunction) {
+      List<SqlNode> operands = call.getOperandList();
+      SqlNode sqlNode = operands.get(1);
+      Preconditions.checkState(sqlNode instanceof SqlDataTypeSpec);
+      RelDataType toType = ((SqlDataTypeSpec) sqlNode).deriveType(_originalValidator);
+      if (!SqlTypeUtil.isBinary(toType)) {
+        return super.visit(call);
+      }
+      SqlNode srcNode = operands.get(0);
+      RelDataType fromType = _originalValidator.getValidatedNodeTypeIfKnown(srcNode);
+      if (fromType != null && SqlTypeUtil.isBinary(fromType)) {
+        return super.visit(call);
+      }
+      String message = "Cannot cast " + srcNode + " as " + toType + ".";
+      if (srcNode instanceof SqlCharStringLiteral) {
+        message += " Try to use binary literal instead (like x" + srcNode + ")";
+      } else if (fromType != null && SqlTypeUtil.isCharacter(fromType)) {
+        message += " Try to wrap the expression in hexToBytes (like hexToBytes(" + srcNode + "))";
+      }
+      SqlParserPos pos = call.getParserPosition();
+      RuntimeException ex = new RuntimeException(message);
+      throw Static.RESOURCE.validatorContext(pos.getLineNum(), pos.getColumnNum(), pos.getEndLineNum(),
+          pos.getEndColumnNum()).ex(ex);
+    }
+    return super.visit(call);
+  }
+}

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/BytesCastVisitor.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/BytesCastVisitor.java
@@ -59,7 +59,7 @@ public class BytesCastVisitor extends SqlBasicVisitor<Void> {
       }
       String message = "Cannot cast " + srcNode + " as " + toType + ".";
       if (srcNode instanceof SqlCharStringLiteral) {
-        message += " Try to use binary literal instead (like x" + srcNode + ")";
+        message += " Try to use binary literal instead (like X" + srcNode + ")";
       } else if (fromType != null && SqlTypeUtil.isCharacter(fromType)) {
         message += " Try to wrap the expression in hexToBytes (like hexToBytes(" + srcNode + "))";
       }

--- a/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/InvalidCastException.java
+++ b/pinot-query-planner/src/main/java/org/apache/pinot/query/validate/InvalidCastException.java
@@ -1,0 +1,25 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.query.validate;
+
+public class InvalidCastException extends RuntimeException {
+  public InvalidCastException(String message) {
+    super(message);
+  }
+}


### PR DESCRIPTION
This PR adds a check that fails if there is an implicit or explicit cast from to Bytes.

I still need to add some automatic tests, but I've tested manually. In a query like:
```sql
select * from starbucksStores where location_st_point = 
'80c062bc98021f94f1404e9bda0f6b0202'
limit 10
```

The message shown is: ` From line 0, column 0 to line 2, column 36: Cannot cast '80c062bc98021f94f1404e9bda0f6b0202' as VARBINARY. Try to use binary literal instead (like x'80c062bc98021f94f1404e9bda0f6b0202')`

In a query like:
```sql
select * from starbucksStores 
where OCTET_LENGTH(
  substring('80c062bc98021f94f1404e9bda0f6b0202', 2)
) > 0 limit 10
```

The message shown is: `From line 0, column 0 to line 3, column 52: Cannot cast SUBSTRING('80c062bc98021f94f1404e9bda0f6b0202' FROM 2) as VARBINARY. Try to wrap the expression in hexToBytes (like hexToBytes(SUBSTRING('80c062bc98021f94f1404e9bda0f6b0202' FROM 2)))`

Two things that we can try to improve (although priority doesn't seem high):
- Given in this cases the cast expression was implicit, start position seem to be line 0 column 0. It would be great to find a way to show a more precise start position
- As shown in the second case, the suggested expression is not exactly like the original one.

Related to https://github.com/apache/pinot/issues/12457