### PR TITLE
Propagate Disable User Agent Config to Http Client

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/utils/http/HttpClient.java
@@ -479,6 +479,9 @@ public class HttpClient implements AutoCloseable {
     if (httpClientConfig.getMaxConnPerRoute() > 0) {
       httpClientBuilder.setMaxConnPerRoute(httpClientConfig.getMaxConnPerRoute());
     }
+    if (httpClientConfig.isDisableDefaultUserAgent()) {
+      httpClientBuilder.disableDefaultUserAgent();
+    }
     return httpClientBuilder.build();
   }
 


### PR DESCRIPTION
In #10895 I introduced this config, but I had made an error. I never actually set this config in the final Apache HttpClient that gets created. This fixes that.

**Test Plan**: Several integration/unit-tests that run as part of the PR use the HttpClient so that should take care of smoke testing.

**Side Note:** The reason we had to do this was because we were running into a JDK bug we reported in #10894. But I think a better way to avoid this issue to set the `http.agent` system property, since the commons http-client does this:

<img width="665" alt="image" src="https://github.com/apache/pinot/assets/8644710/f91731f5-952b-42b3-9c06-9143315258ce">
