### PR TITLE
enable Netty leak detection

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -82,6 +82,7 @@ import org.slf4j.LoggerFactory;
 import org.testng.Assert;
 import org.testng.SkipException;
 import org.testng.annotations.DataProvider;
+import org.testng.annotations.Listeners;
 
 import static org.apache.pinot.integration.tests.ClusterIntegrationTestUtils.getBrokerQueryApiUrl;
 import static org.testng.Assert.assertEquals;
@@ -92,6 +93,7 @@ import static org.testng.Assert.assertTrue;
 /**
  * Base class for integration tests that involve a complete Pinot cluster.
  */
+@Listeners(NettyTestNGListener.class)
 public abstract class ClusterTest extends ControllerTest {
   protected static final int DEFAULT_BROKER_PORT = 18099;
   protected static final Random RANDOM = new Random(System.currentTimeMillis());

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/NettyLeakListener.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/NettyLeakListener.java
@@ -1,0 +1,57 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import io.netty.util.ResourceLeakDetector.LeakListener;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+public class NettyLeakListener implements LeakListener {
+    private final List<String> _leaks = new CopyOnWriteArrayList<>();
+
+    @Override
+    public void onLeak(String resourceType, String records) {
+        _leaks.add(resourceType);
+    }
+
+    public int getLeakCount() {
+        return _leaks.size();
+    }
+
+    public void assertZeroLeaks() {
+        assertZeroLeaks(null);
+    }
+
+    public void assertZeroLeaks(String detail) {
+        if (!_leaks.isEmpty()) {
+            StringBuilder message = new StringBuilder("Netty leaks: ");
+            if (detail != null) {
+                message.append(detail);
+                message.append(" ");
+            }
+            message.append(_leaks);
+            throw new IllegalStateException(message.toString());
+        }
+    }
+
+    @Override
+    public String toString() {
+        return "leakCount=" + this.getLeakCount();
+    }
+}

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/NettyLeakListener.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/NettyLeakListener.java
@@ -22,36 +22,37 @@ import io.netty.util.ResourceLeakDetector.LeakListener;
 import java.util.List;
 import java.util.concurrent.CopyOnWriteArrayList;
 
+
 public class NettyLeakListener implements LeakListener {
-    private final List<String> _leaks = new CopyOnWriteArrayList<>();
+  private final List<String> _leaks = new CopyOnWriteArrayList<>();
 
-    @Override
-    public void onLeak(String resourceType, String records) {
-        _leaks.add(resourceType);
-    }
+  @Override
+  public void onLeak(String resourceType, String records) {
+    _leaks.add(resourceType);
+  }
 
-    public int getLeakCount() {
-        return _leaks.size();
-    }
+  public int getLeakCount() {
+    return _leaks.size();
+  }
 
-    public void assertZeroLeaks() {
-        assertZeroLeaks(null);
-    }
+  public void assertZeroLeaks() {
+    assertZeroLeaks(null);
+  }
 
-    public void assertZeroLeaks(String detail) {
-        if (!_leaks.isEmpty()) {
-            StringBuilder message = new StringBuilder("Netty leaks: ");
-            if (detail != null) {
-                message.append(detail);
-                message.append(" ");
-            }
-            message.append(_leaks);
-            throw new IllegalStateException(message.toString());
-        }
+  public void assertZeroLeaks(String detail) {
+    if (!_leaks.isEmpty()) {
+      StringBuilder message = new StringBuilder("Netty leaks: ");
+      if (detail != null) {
+        message.append(detail);
+        message.append(" ");
+      }
+      message.append(_leaks);
+      throw new IllegalStateException(message.toString());
     }
+  }
 
-    @Override
-    public String toString() {
-        return "leakCount=" + this.getLeakCount();
-    }
+  @Override
+  public String toString() {
+    return "leakCount=" + this.getLeakCount();
+  }
 }

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/NettyTestNGListener.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/NettyTestNGListener.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.integration.tests;
+
+import io.netty.buffer.ByteBufUtil;
+import org.testng.IInvokedMethod;
+import org.testng.IInvokedMethodListener;
+import org.testng.ITestContext;
+import org.testng.ITestResult;
+
+public class NettyTestNGListener implements IInvokedMethodListener {
+    private static final NettyLeakListener NETTY_LEAK_LISTENER;
+    private static final String LEAK_DETECTION_LEVEL_PROP_KEY = "io.netty.leakDetection.level";
+
+    static {
+        if (System.getProperty(LEAK_DETECTION_LEVEL_PROP_KEY) == null) {
+            System.setProperty(LEAK_DETECTION_LEVEL_PROP_KEY, "paranoid");
+        }
+        NETTY_LEAK_LISTENER = new NettyLeakListener();
+        ByteBufUtil.setLeakListener(NETTY_LEAK_LISTENER);
+    }
+
+    @Override
+    public void beforeInvocation(
+            IInvokedMethod method, ITestResult testResult, ITestContext context) {
+        NETTY_LEAK_LISTENER.assertZeroLeaks();
+    }
+
+    @Override
+    public void afterInvocation(
+            IInvokedMethod method, ITestResult testResult, ITestContext context) {
+        NETTY_LEAK_LISTENER.assertZeroLeaks();
+    }
+}

--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/NettyTestNGListener.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/NettyTestNGListener.java
@@ -24,27 +24,26 @@ import org.testng.IInvokedMethodListener;
 import org.testng.ITestContext;
 import org.testng.ITestResult;
 
+
 public class NettyTestNGListener implements IInvokedMethodListener {
-    private static final NettyLeakListener NETTY_LEAK_LISTENER;
-    private static final String LEAK_DETECTION_LEVEL_PROP_KEY = "io.netty.leakDetection.level";
+  private static final NettyLeakListener NETTY_LEAK_LISTENER;
+  private static final String LEAK_DETECTION_LEVEL_PROP_KEY = "io.netty.leakDetection.level";
 
-    static {
-        if (System.getProperty(LEAK_DETECTION_LEVEL_PROP_KEY) == null) {
-            System.setProperty(LEAK_DETECTION_LEVEL_PROP_KEY, "paranoid");
-        }
-        NETTY_LEAK_LISTENER = new NettyLeakListener();
-        ByteBufUtil.setLeakListener(NETTY_LEAK_LISTENER);
+  static {
+    if (System.getProperty(LEAK_DETECTION_LEVEL_PROP_KEY) == null) {
+      System.setProperty(LEAK_DETECTION_LEVEL_PROP_KEY, "paranoid");
     }
+    NETTY_LEAK_LISTENER = new NettyLeakListener();
+    ByteBufUtil.setLeakListener(NETTY_LEAK_LISTENER);
+  }
 
-    @Override
-    public void beforeInvocation(
-            IInvokedMethod method, ITestResult testResult, ITestContext context) {
-        NETTY_LEAK_LISTENER.assertZeroLeaks();
-    }
+  @Override
+  public void beforeInvocation(IInvokedMethod method, ITestResult testResult, ITestContext context) {
+    NETTY_LEAK_LISTENER.assertZeroLeaks();
+  }
 
-    @Override
-    public void afterInvocation(
-            IInvokedMethod method, ITestResult testResult, ITestContext context) {
-        NETTY_LEAK_LISTENER.assertZeroLeaks();
-    }
+  @Override
+  public void afterInvocation(IInvokedMethod method, ITestResult testResult, ITestContext context) {
+    NETTY_LEAK_LISTENER.assertZeroLeaks();
+  }
 }


### PR DESCRIPTION
Motivation:

detect Netty leaks using Netty's paranoid leak detector

Modifications:

- add a Netty leak listener class
- add a TestNG listener class

Result:

TestNG listener verifies that there are zero Netty leaks
