### PR TITLE
Fix the race condition in H3InclusionIndexFilterOperator

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/filter/H3InclusionIndexFilterOperator.java
@@ -80,31 +80,29 @@ public class H3InclusionIndexFilterOperator extends BaseFilterOperator {
 
   @Override
   protected BlockDocIdSet getTrues() {
-    // get the set of H3 cells at the specified resolution which completely cover the input shape and potential cover.
-    Pair<LongSet, LongSet> fullCoverAndPotentialCoverCells = _queryContext
-        .getOrComputeSharedValue(Pair.class, LITERAL_H3_CELLS_CACHE_NAME,
+    // NOTE: LHS is the fully covered cells, RHS is the potentially covered cells (excluding fully covered cells).
+    Pair<LongSet, LongSet> fullyAndPotentiallyCoveredCells =
+        _queryContext.getOrComputeSharedValue(Pair.class, LITERAL_H3_CELLS_CACHE_NAME,
             k -> H3Utils.coverGeometryInH3(_geometry, _h3IndexReader.getH3IndexResolution().getLowestResolution()));
 
-    LongSet fullyCoverH3Cells = fullCoverAndPotentialCoverCells.getLeft();
-    LongSet potentialCoverH3Cells = fullCoverAndPotentialCoverCells.getRight();
+    LongSet fullyCoveredCells = fullyAndPotentiallyCoveredCells.getLeft();
+    LongSet potentiallyCoveredCells = fullyAndPotentiallyCoveredCells.getRight();
 
-    int i = 0;
-    ImmutableRoaringBitmap[] fullMatchDocIds = new ImmutableRoaringBitmap[fullyCoverH3Cells.size()];
-    LongIterator fullyCoverH3CellsIterator = fullyCoverH3Cells.iterator();
-    while (fullyCoverH3CellsIterator.hasNext()) {
-      fullMatchDocIds[i++] = _h3IndexReader.getDocIds(fullyCoverH3CellsIterator.nextLong());
+    int numFullyCoveredCells = fullyCoveredCells.size();
+    ImmutableRoaringBitmap[] fullMatchDocIds = new ImmutableRoaringBitmap[numFullyCoveredCells];
+    LongIterator fullyCoveredCellsIterator = fullyCoveredCells.iterator();
+    for (int i = 0; i < numFullyCoveredCells; i++) {
+      fullMatchDocIds[i] = _h3IndexReader.getDocIds(fullyCoveredCellsIterator.nextLong());
     }
     MutableRoaringBitmap fullMatch = BufferFastAggregation.or(fullMatchDocIds);
 
-    // remove full match from potential match to get potential not match cells.
-    i = 0;
-    potentialCoverH3Cells.removeAll(fullyCoverH3Cells);
-    ImmutableRoaringBitmap[] potentialNotMatchDocIds = new ImmutableRoaringBitmap[potentialCoverH3Cells.size()];
-    LongIterator potentialMatchH3CellsIterator = potentialCoverH3Cells.iterator();
-    while (potentialMatchH3CellsIterator.hasNext()) {
-      potentialNotMatchDocIds[i++] = _h3IndexReader.getDocIds(potentialMatchH3CellsIterator.nextLong());
+    int numPotentiallyCoveredCells = potentiallyCoveredCells.size();
+    ImmutableRoaringBitmap[] potentialMatchDocIds = new ImmutableRoaringBitmap[numPotentiallyCoveredCells];
+    LongIterator potentiallyCoveredCellsIterator = potentiallyCoveredCells.iterator();
+    for (int i = 0; i < numPotentiallyCoveredCells; i++) {
+      potentialMatchDocIds[i] = _h3IndexReader.getDocIds(potentiallyCoveredCellsIterator.nextLong());
     }
-    MutableRoaringBitmap potentialMatch = BufferFastAggregation.or(potentialNotMatchDocIds);
+    MutableRoaringBitmap potentialMatch = BufferFastAggregation.or(potentialMatchDocIds);
 
     if (_isPositiveCheck) {
       return getFilterBlock(fullMatch, potentialMatch);


### PR DESCRIPTION
Fix the race condition in `H3InclusionIndexFilterOperator` where the cached value is modified:
- Change `H3Utils` to directly return potentially covered cells excluding the fully covered cells
- Optimize `H3Utils` accordingly