### PR TITLE
Add controller API to get allLiveInstances

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -109,6 +109,19 @@ public class PinotInstanceRestletResource {
   }
 
   @GET
+  @Path("/liveinstances")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_INSTANCE)
+  @Produces(MediaType.APPLICATION_JSON)
+  @ApiOperation(value = "List all live instances")
+  @ApiResponses(value = {
+          @ApiResponse(code = 200, message = "Success"),
+          @ApiResponse(code = 500, message = "Internal error")
+  })
+  public Instances getAllLiveInstances() {
+    return new Instances(_pinotHelixResourceManager.getAllLiveInstances());
+  }
+
+  @GET
   @Path("/instances/{instanceName}")
   @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_INSTANCE)
   @Produces(MediaType.APPLICATION_JSON)

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -415,6 +415,15 @@ public class PinotHelixResourceManager {
   }
 
   /**
+   * Get all live instance Ids.
+   *
+   * @return List of live instance Ids
+   */
+  public List<String> getAllLiveInstances() {
+    return _helixDataAccessor.getChildNames(_keyBuilder.liveInstances());
+  }
+
+  /**
    * Returns the config for all the Helix instances in the cluster.
    */
   public List<InstanceConfig> getAllHelixInstanceConfigs() {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -212,17 +212,23 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     String instanceName = "Server_localhost_" + NUM_SERVER_INSTANCES;
     List<String> allInstances = _helixResourceManager.getAllInstances();
     assertFalse(allInstances.contains(instanceName));
+    List<String> allLiveInstances = _helixResourceManager.getAllInstances();
+    assertFalse(allLiveInstances.contains(instanceName));
 
     Instance instance = new Instance("localhost", NUM_SERVER_INSTANCES, InstanceType.SERVER,
         Collections.singletonList(Helix.UNTAGGED_SERVER_INSTANCE), null, 0, 0, 0, 0, false);
     _helixResourceManager.addInstance(instance, false);
     allInstances = _helixResourceManager.getAllInstances();
     assertTrue(allInstances.contains(instanceName));
+    allLiveInstances = _helixResourceManager.getAllInstances();
+    assertTrue(allLiveInstances.contains(instanceName));
 
     // Remove the added instance
     assertTrue(_helixResourceManager.dropInstance(instanceName).isSuccessful());
     allInstances = _helixResourceManager.getAllInstances();
     assertFalse(allInstances.contains(instanceName));
+    allLiveInstances = _helixResourceManager.getAllInstances();
+    assertFalse(allLiveInstances.contains(instanceName));
   }
 
   @Test

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -220,8 +220,6 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     _helixResourceManager.addInstance(instance, false);
     allInstances = _helixResourceManager.getAllInstances();
     assertTrue(allInstances.contains(instanceName));
-    allLiveInstances = _helixResourceManager.getAllLiveInstances();
-    assertTrue(allLiveInstances.contains(instanceName));
 
     // Remove the added instance
     assertTrue(_helixResourceManager.dropInstance(instanceName).isSuccessful());

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -212,7 +212,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     String instanceName = "Server_localhost_" + NUM_SERVER_INSTANCES;
     List<String> allInstances = _helixResourceManager.getAllInstances();
     assertFalse(allInstances.contains(instanceName));
-    List<String> allLiveInstances = _helixResourceManager.getAllInstances();
+    List<String> allLiveInstances = _helixResourceManager.getAllLiveInstances();
     assertFalse(allLiveInstances.contains(instanceName));
 
     Instance instance = new Instance("localhost", NUM_SERVER_INSTANCES, InstanceType.SERVER,
@@ -220,14 +220,14 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     _helixResourceManager.addInstance(instance, false);
     allInstances = _helixResourceManager.getAllInstances();
     assertTrue(allInstances.contains(instanceName));
-    allLiveInstances = _helixResourceManager.getAllInstances();
+    allLiveInstances = _helixResourceManager.getAllLiveInstances();
     assertTrue(allLiveInstances.contains(instanceName));
 
     // Remove the added instance
     assertTrue(_helixResourceManager.dropInstance(instanceName).isSuccessful());
     allInstances = _helixResourceManager.getAllInstances();
     assertFalse(allInstances.contains(instanceName));
-    allLiveInstances = _helixResourceManager.getAllInstances();
+    allLiveInstances = _helixResourceManager.getAllLiveInstances();
     assertFalse(allLiveInstances.contains(instanceName));
   }
 


### PR DESCRIPTION
label:
api

Adding a controller API to get all live instances in the cluster.

- We fetch all instances for a cluster for attribution internally. Some of them are dead and causes issues in the attribution logic. Having /liveinstances endpoint will help in having the correct set of valid instances.

Updated UTs to test the change.