### PR TITLE
do not throw exception for unsupported min/max no dictionary columns

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/columnminmaxvalue/ColumnMinMaxValueGenerator.java
@@ -43,11 +43,14 @@ import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.utils.ByteArray;
 import org.apache.pinot.spi.utils.BytesUtils;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import static org.apache.pinot.spi.data.FieldSpec.DataType;
 
 
 public class ColumnMinMaxValueGenerator {
+  private static final Logger LOGGER = LoggerFactory.getLogger(ColumnMinMaxValueGenerator.class);
   private final SegmentMetadata _segmentMetadata;
   private final SegmentDirectory.Writer _segmentWriter;
   private final ColumnMinMaxValueGeneratorMode _columnMinMaxValueGeneratorMode;
@@ -341,7 +344,12 @@ public class ColumnMinMaxValueGenerator {
             break;
           }
           default:
-            throw new IllegalStateException("Unsupported data type: " + dataType + " for column: " + columnName);
+            // Support for no dictionary columns was added in https://github.com/apache/pinot/pull/10891,
+            // but it did not take into account all data types. For now, we return early here never setting
+            // min/max values rather than throwing an exception.
+            LOGGER.warn("Unsupported data type: {} for column: {}. Skipping setting min/max values", dataType,
+                columnName);
+            return;
         }
       }
     }


### PR DESCRIPTION
This is a bugfix related to #10891. That PR added support for setting min/max column metadata for no dictionary columns, but it didn't add support for all data types. This specifically affected us because we use no dictionary columns + ingestion aggregation. By returning rather than throwing an exception, we effectively revert to the previous behavior of not having the metadata.

I've added unit tests with no data just to ensure this doesn't break. I've also tested on a broken cluster internally where segment commits were failing with the `IllegalStateException`. Segment commits were able to proceed with this fix.

Ideally we would add support for all data types, but I want to unblock this cluster upgrade before undertaking a larger fix. The code isn't particularly complicated, but setting up more robust unit tests that test all data types will take me some time.