### PR TITLE
Supporting human-readable format when configuring broker response size

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1787,7 +1787,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     strResponseSize = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES);
     if (strResponseSize != null) {
       Long maxQueryResponseSizeBrokerConfig = DataSizeUtils.toBytes(strResponseSize);
-      if(maxQueryResponseSizeBrokerConfig != null ) {
+      if (maxQueryResponseSizeBrokerConfig != null) {
         queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
             Long.toString(maxQueryResponseSizeBrokerConfig / numServers));
       }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1773,8 +1773,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     // BrokerConfig
-    Long maxServerResponseSizeBrokerConfig = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES,
-        Long.class);
+    Long maxServerResponseSizeBrokerConfig =
+        _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES, Long.class);
     Long mBytes = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_MEGA_BYTES, Long.class);
     if (mBytes != null) {
       maxServerResponseSizeBrokerConfig = (maxServerResponseSizeBrokerConfig == null)
@@ -1785,8 +1785,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
       return;
     }
 
-    Long maxQueryResponseSizeBrokerConfig = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES,
-        Long.class);
+    Long maxQueryResponseSizeBrokerConfig =
+        _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES, Long.class);
     mBytes = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_MEGA_BYTES, Long.class);
     if (mBytes != null) {
       maxQueryResponseSizeBrokerConfig = (maxQueryResponseSizeBrokerConfig == null)

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1773,19 +1773,23 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     // BrokerConfig
-    Long v1 = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES, Long.class);
-    Long v2 = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_MEGA_BYTES, Long.class);
-    v2 = (v2 != null) ? v2 * 1_000_000 : null;
-    Long maxServerResponseSizeBrokerConfig = (v1 != null && v2 != null) ? Math.min(v1, v2) : (v1 != null ? v1 : v2);
+    Long maxServerResponseSizeBrokerConfig = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES,
+        Long.class);
+    Long mBytes = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_MEGA_BYTES, Long.class);
+    if (mBytes != null) {
+      maxServerResponseSizeBrokerConfig = (maxServerResponseSizeBrokerConfig == null) ? mBytes * 1_000_000 : Math.min(maxServerResponseSizeBrokerConfig, mBytes * 1_000_000);
+    }
     if (maxServerResponseSizeBrokerConfig != null) {
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES, Long.toString(maxServerResponseSizeBrokerConfig));
       return;
     }
 
-    v1 = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES, Long.class);
-    v2 = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_MEGA_BYTES, Long.class);
-    v2 = (v2 != null) ? v2 * 1_000_000 : null;
-    Long maxQueryResponseSizeBrokerConfig = (v1 != null && v2 != null) ? Math.min(v1, v2) : (v1 != null ? v1 : v2);
+    Long maxQueryResponseSizeBrokerConfig = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES,
+        Long.class);
+    mBytes = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_MEGA_BYTES, Long.class);
+    if (mBytes != null) {
+      maxQueryResponseSizeBrokerConfig = (maxQueryResponseSizeBrokerConfig == null) ? mBytes * 1_000_000 : Math.min(maxQueryResponseSizeBrokerConfig, mBytes * 1_000_000);
+    }
     if (maxQueryResponseSizeBrokerConfig != null) {
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
           Long.toString(maxQueryResponseSizeBrokerConfig / numServers));

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1777,18 +1777,20 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     String strResponseSize = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES);
     if (strResponseSize != null) {
       Long maxServerResponseSizeBrokerConfig = DataSizeUtils.toBytes(strResponseSize);
-      if (maxServerResponseSizeBrokerConfig != null)
+      if (maxServerResponseSizeBrokerConfig != null) {
         queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
-           Long.toString(maxServerResponseSizeBrokerConfig));
+            Long.toString(maxServerResponseSizeBrokerConfig));
+      }
       return;
     }
 
     strResponseSize = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES);
     if (strResponseSize != null) {
       Long maxQueryResponseSizeBrokerConfig = DataSizeUtils.toBytes(strResponseSize);
-      if(maxQueryResponseSizeBrokerConfig != null )
+      if(maxQueryResponseSizeBrokerConfig != null ) {
         queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
-          Long.toString(maxQueryResponseSizeBrokerConfig / numServers));
+            Long.toString(maxQueryResponseSizeBrokerConfig / numServers));
+      }
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1783,7 +1783,7 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     strSize = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES);
     if (strSize != null) {
-      Long maxQueryResponseSizeBrokerConfig = DataSizeUtils.toBytes((strSize);
+      Long maxQueryResponseSizeBrokerConfig = DataSizeUtils.toBytes(strSize);
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
           Long.toString(maxQueryResponseSizeBrokerConfig / numServers));
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1773,14 +1773,17 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     // BrokerConfig
-    Long maxServerResponseSizeBrokerConfig =
-        _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES, Long.class);
+    Long v1 = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES, Long.class);
+    Long v2 = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_MEGA_BYTES, Long.class) * 1_000_000;
+    Long maxServerResponseSizeBrokerConfig = (v1 != null && v2 != null) ? Math.min(v1, v2) : (v1 != null ? v1 : v2);
     if (maxServerResponseSizeBrokerConfig != null) {
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES, Long.toString(maxServerResponseSizeBrokerConfig));
       return;
     }
-    Long maxQueryResponseSizeBrokerConfig =
-        _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES, Long.class);
+
+    v1 = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES, Long.class);
+    v2 = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_MEGA_BYTES, Long.class) * 1_000_000;
+    Long maxQueryResponseSizeBrokerConfig = (v1 != null && v2 != null) ? Math.min(v1, v2) : (v1 != null ? v1 : v2);
     if (maxQueryResponseSizeBrokerConfig != null) {
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
           Long.toString(maxQueryResponseSizeBrokerConfig / numServers));

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1777,8 +1777,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         Long.class);
     Long mBytes = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_MEGA_BYTES, Long.class);
     if (mBytes != null) {
-      maxServerResponseSizeBrokerConfig = (maxServerResponseSizeBrokerConfig == null) ?
-          mBytes * 1_000_000 : Math.min(maxServerResponseSizeBrokerConfig, mBytes * 1_000_000);
+      maxServerResponseSizeBrokerConfig = (maxServerResponseSizeBrokerConfig == null)
+          ? mBytes * 1_000_000 : Math.min(maxServerResponseSizeBrokerConfig, mBytes * 1_000_000);
     }
     if (maxServerResponseSizeBrokerConfig != null) {
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES, Long.toString(maxServerResponseSizeBrokerConfig));
@@ -1789,8 +1789,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         Long.class);
     mBytes = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_MEGA_BYTES, Long.class);
     if (mBytes != null) {
-      maxQueryResponseSizeBrokerConfig = (maxQueryResponseSizeBrokerConfig == null) ?
-          mBytes * 1_000_000 : Math.min(maxQueryResponseSizeBrokerConfig, mBytes * 1_000_000);
+      maxQueryResponseSizeBrokerConfig = (maxQueryResponseSizeBrokerConfig == null)
+          ? mBytes * 1_000_000 : Math.min(maxQueryResponseSizeBrokerConfig, mBytes * 1_000_000);
     }
     if (maxQueryResponseSizeBrokerConfig != null) {
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1777,7 +1777,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         Long.class);
     Long mBytes = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_MEGA_BYTES, Long.class);
     if (mBytes != null) {
-      maxServerResponseSizeBrokerConfig = (maxServerResponseSizeBrokerConfig == null) ? mBytes * 1_000_000 : Math.min(maxServerResponseSizeBrokerConfig, mBytes * 1_000_000);
+      maxServerResponseSizeBrokerConfig = (maxServerResponseSizeBrokerConfig == null) ?
+          mBytes * 1_000_000 : Math.min(maxServerResponseSizeBrokerConfig, mBytes * 1_000_000);
     }
     if (maxServerResponseSizeBrokerConfig != null) {
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES, Long.toString(maxServerResponseSizeBrokerConfig));
@@ -1788,7 +1789,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
         Long.class);
     mBytes = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_MEGA_BYTES, Long.class);
     if (mBytes != null) {
-      maxQueryResponseSizeBrokerConfig = (maxQueryResponseSizeBrokerConfig == null) ? mBytes * 1_000_000 : Math.min(maxQueryResponseSizeBrokerConfig, mBytes * 1_000_000);
+      maxQueryResponseSizeBrokerConfig = (maxQueryResponseSizeBrokerConfig == null) ?
+          mBytes * 1_000_000 : Math.min(maxQueryResponseSizeBrokerConfig, mBytes * 1_000_000);
     }
     if (maxQueryResponseSizeBrokerConfig != null) {
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -101,9 +101,9 @@ import org.apache.pinot.spi.utils.BytesUtils;
 import org.apache.pinot.spi.utils.CommonConstants;
 import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
+import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.apache.pinot.spi.utils.TimestampIndexUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
-import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
@@ -1777,14 +1777,17 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     String strResponseSize = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES);
     if (strResponseSize != null) {
       Long maxServerResponseSizeBrokerConfig = DataSizeUtils.toBytes(strResponseSize);
-      queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES, Long.toString(maxServerResponseSizeBrokerConfig));
+      if (maxServerResponseSizeBrokerConfig != null)
+        queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
+           Long.toString(maxServerResponseSizeBrokerConfig));
       return;
     }
 
     strResponseSize = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES);
     if (strResponseSize != null) {
       Long maxQueryResponseSizeBrokerConfig = DataSizeUtils.toBytes(strResponseSize);
-      queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
+      if(maxQueryResponseSizeBrokerConfig != null )
+        queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
           Long.toString(maxQueryResponseSizeBrokerConfig / numServers));
     }
   }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -103,6 +103,7 @@ import org.apache.pinot.spi.utils.CommonConstants.Broker;
 import org.apache.pinot.spi.utils.CommonConstants.Broker.Request.QueryOptionKey;
 import org.apache.pinot.spi.utils.TimestampIndexUtils;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
+import org.apache.pinot.spi.utils.DataSizeUtils;
 import org.apache.pinot.sql.FilterKind;
 import org.apache.pinot.sql.parsers.CalciteSqlCompiler;
 import org.apache.pinot.sql.parsers.CalciteSqlParser;
@@ -1773,26 +1774,16 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     // BrokerConfig
-    Long maxServerResponseSizeBrokerConfig =
-        _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES, Long.class);
-    Long mBytes = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_MEGA_BYTES, Long.class);
-    if (mBytes != null) {
-      maxServerResponseSizeBrokerConfig = (maxServerResponseSizeBrokerConfig == null)
-          ? mBytes * 1_000_000 : Math.min(maxServerResponseSizeBrokerConfig, mBytes * 1_000_000);
-    }
-    if (maxServerResponseSizeBrokerConfig != null) {
+    String strSize = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES);
+    if (strSize != null) {
+      Long maxServerResponseSizeBrokerConfig = DataSizeUtils.toBytes(strSize);
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES, Long.toString(maxServerResponseSizeBrokerConfig));
       return;
     }
 
-    Long maxQueryResponseSizeBrokerConfig =
-        _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES, Long.class);
-    mBytes = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_MEGA_BYTES, Long.class);
-    if (mBytes != null) {
-      maxQueryResponseSizeBrokerConfig = (maxQueryResponseSizeBrokerConfig == null)
-          ? mBytes * 1_000_000 : Math.min(maxQueryResponseSizeBrokerConfig, mBytes * 1_000_000);
-    }
-    if (maxQueryResponseSizeBrokerConfig != null) {
+    strSize = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES);
+    if (strSize != null) {
+      Long maxQueryResponseSizeBrokerConfig = DataSizeUtils.toBytes((strSize);
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
           Long.toString(maxQueryResponseSizeBrokerConfig / numServers));
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1774,7 +1774,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
 
     // BrokerConfig
     Long v1 = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES, Long.class);
-    Long v2 = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_MEGA_BYTES, Long.class) * 1_000_000;
+    Long v2 = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_MEGA_BYTES, Long.class);
+    v2 = (v2 != null) ? v2 * 1_000_000 : null;
     Long maxServerResponseSizeBrokerConfig = (v1 != null && v2 != null) ? Math.min(v1, v2) : (v1 != null ? v1 : v2);
     if (maxServerResponseSizeBrokerConfig != null) {
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES, Long.toString(maxServerResponseSizeBrokerConfig));
@@ -1782,7 +1783,8 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     v1 = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES, Long.class);
-    v2 = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_MEGA_BYTES, Long.class) * 1_000_000;
+    v2 = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_MEGA_BYTES, Long.class);
+    v2 = (v2 != null) ? v2 * 1_000_000 : null;
     Long maxQueryResponseSizeBrokerConfig = (v1 != null && v2 != null) ? Math.min(v1, v2) : (v1 != null ? v1 : v2);
     if (maxQueryResponseSizeBrokerConfig != null) {
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1777,20 +1777,16 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     String strResponseSize = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES);
     if (strResponseSize != null) {
       Long maxServerResponseSizeBrokerConfig = DataSizeUtils.toBytes(strResponseSize);
-      if (maxServerResponseSizeBrokerConfig != null) {
-        queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
-            Long.toString(maxServerResponseSizeBrokerConfig));
-      }
+      queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
+          Long.toString(maxServerResponseSizeBrokerConfig));
       return;
     }
 
     strResponseSize = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES);
     if (strResponseSize != null) {
       Long maxQueryResponseSizeBrokerConfig = DataSizeUtils.toBytes(strResponseSize);
-      if (maxQueryResponseSizeBrokerConfig != null) {
-        queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
-            Long.toString(maxQueryResponseSizeBrokerConfig / numServers));
-      }
+      queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
+          Long.toString(maxQueryResponseSizeBrokerConfig / numServers));
     }
   }
 

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1774,16 +1774,16 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     // BrokerConfig
-    String strSize = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES);
-    if (strSize != null) {
-      Long maxServerResponseSizeBrokerConfig = DataSizeUtils.toBytes(strSize);
+    String strResponseSize = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES);
+    if (strResponseSize != null) {
+      Long maxServerResponseSizeBrokerConfig = DataSizeUtils.toBytes(strResponseSize);
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES, Long.toString(maxServerResponseSizeBrokerConfig));
       return;
     }
 
-    strSize = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES);
-    if (strSize != null) {
-      Long maxQueryResponseSizeBrokerConfig = DataSizeUtils.toBytes(strSize);
+    strResponseSize = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES);
+    if (strResponseSize != null) {
+      Long maxQueryResponseSizeBrokerConfig = DataSizeUtils.toBytes(strResponseSize);
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
           Long.toString(maxQueryResponseSizeBrokerConfig / numServers));
     }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/requesthandler/BaseBrokerRequestHandler.java
@@ -1774,19 +1774,17 @@ public abstract class BaseBrokerRequestHandler implements BrokerRequestHandler {
     }
 
     // BrokerConfig
-    String strResponseSize = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES);
-    if (strResponseSize != null) {
-      Long maxServerResponseSizeBrokerConfig = DataSizeUtils.toBytes(strResponseSize);
+    String maxServerResponseSizeBrokerConfig = _config.getProperty(Broker.CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES);
+    if (maxServerResponseSizeBrokerConfig != null) {
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
-          Long.toString(maxServerResponseSizeBrokerConfig));
+          Long.toString(DataSizeUtils.toBytes(maxServerResponseSizeBrokerConfig)));
       return;
     }
 
-    strResponseSize = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES);
-    if (strResponseSize != null) {
-      Long maxQueryResponseSizeBrokerConfig = DataSizeUtils.toBytes(strResponseSize);
+    String maxQueryResponseSizeBrokerConfig = _config.getProperty(Broker.CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES);
+    if (maxQueryResponseSizeBrokerConfig != null) {
       queryOptions.put(QueryOptionKey.MAX_SERVER_RESPONSE_SIZE_BYTES,
-          Long.toString(maxQueryResponseSizeBrokerConfig / numServers));
+          Long.toString(DataSizeUtils.toBytes(maxQueryResponseSizeBrokerConfig) / numServers));
     }
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -329,12 +329,12 @@ public class CommonConstants {
 
     // Broker config indicating the maximum serialized response size across all servers for a query. This value is
     // equally divided across all servers processing the query.
-    // The value can be in human readable size (e.g. '150K', '150KB', '0.15MB') or in bytes (e.g. '150000').
+    // The value can be in human readable format (e.g. '150K', '150KB', '0.15MB') or in bytes (e.g. '150000').
     public static final String CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES = "pinot.broker.max.query.response.size.bytes";
 
     // Broker config indicating the maximum length of the serialized response per server for a query.
-    // If both "server.response.size" and "query.response.size" are present, then the "server.response.size" takes
-    // precedence over "query.response.size".
+    // If both "server.response.size" and "query.response.size" are set, then the "server.response.size" takes
+    // precedence over "query.response.size" (i.e., "query.response.size" will be ignored).
     public static final String CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES = "pinot.broker.max.server.response.size.bytes";
 
     public static class Request {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -337,7 +337,6 @@ public class CommonConstants {
     // precedence over "query.response.size" (i.e., "query.response.size" will be ignored).
     public static final String CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES = "pinot.broker.max.server.response.size.bytes";
 
-    
     public static class Request {
       public static final String SQL = "sql";
       public static final String TRACE = "trace";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -329,7 +329,7 @@ public class CommonConstants {
 
     // Broker config indicating the maximum serialized response size across all servers for a query. This value is
     // equally divided across all servers processing the query.
-    // The value can be in human readable format (e.g. '150K', '150KB', '0.15MB') or in bytes (e.g. '150000').
+    // The value can be in human readable format (e.g. '200K', '200KB', '0.2MB') or in raw bytes (e.g. '200000').
     public static final String CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES = "pinot.broker.max.query.response.size.bytes";
 
     // Broker config indicating the maximum length of the serialized response per server for a query.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -330,14 +330,16 @@ public class CommonConstants {
     // Broker config indicating the maximum serialized response size across all servers for a query. This value is
     // equally divided across all servers processing the query.
     // If both configs are present, then the "server.response.size" takes precedence over "query.response.size".
-    // For each config, the value can be specified in two ways: raw_bytes and mega_bytes; the smaller one takes precedence.
+    // For each config, the value can be specified in two ways: raw_bytes and mega_bytes; the smaller takes precedence.
     // Example of setting to 10MB: "10240000" (in raw byte), or "10" (in mega byte).
     public static final String CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES = "pinot.broker.max.query.response.size.bytes";
-    public static final String CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_MEGA_BYTES = "pinot.broker.max.query.response.size.megabytes";
+    public static final String CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_MEGA_BYTES =
+        "pinot.broker.max.query.response.size.megabytes";
 
     // Broker config indicating the maximum length of the serialized response per server for a query.
     public static final String CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES = "pinot.broker.max.server.response.size.bytes";
-    public static final String CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_MEGA_BYTES = "pinot.broker.max.server.response.size.megabytes";
+    public static final String CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_MEGA_BYTES =
+        "pinot.broker.max.server.response.size.megabytes";
 
     public static class Request {
       public static final String SQL = "sql";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -329,17 +329,13 @@ public class CommonConstants {
 
     // Broker config indicating the maximum serialized response size across all servers for a query. This value is
     // equally divided across all servers processing the query.
-    // If both configs are present, then the "server.response.size" takes precedence over "query.response.size".
-    // For each config, the value can be specified in two ways: raw_bytes and mega_bytes; the smaller takes precedence.
-    // Example of setting to 10MB: "10240000" (in raw byte), or "10" (in mega byte).
+    // The value can be in human readable size (e.g. '150K', '150KB', '0.15MB') or in bytes (e.g. '150000').
     public static final String CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES = "pinot.broker.max.query.response.size.bytes";
-    public static final String CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_MEGA_BYTES =
-        "pinot.broker.max.query.response.size.megabytes";
 
     // Broker config indicating the maximum length of the serialized response per server for a query.
+    // If both "server.response.size" and "query.response.size" are present, then the "server.response.size" takes
+    // precedence over "query.response.size".
     public static final String CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES = "pinot.broker.max.server.response.size.bytes";
-    public static final String CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_MEGA_BYTES =
-        "pinot.broker.max.server.response.size.megabytes";
 
     public static class Request {
       public static final String SQL = "sql";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -329,11 +329,15 @@ public class CommonConstants {
 
     // Broker config indicating the maximum serialized response size across all servers for a query. This value is
     // equally divided across all servers processing the query.
+    // If both configs are present, then the "server.response.size" takes precedence over "query.response.size".
+    // For each config, the value can be specified in two ways: raw_bytes and mega_bytes; the smaller one takes precedence.
+    // Example of setting to 10MB: "10240000" (in raw byte), or "10" (in mega byte).
     public static final String CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_BYTES = "pinot.broker.max.query.response.size.bytes";
+    public static final String CONFIG_OF_MAX_QUERY_RESPONSE_SIZE_MEGA_BYTES = "pinot.broker.max.query.response.size.megabytes";
 
     // Broker config indicating the maximum length of the serialized response per server for a query.
     public static final String CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES = "pinot.broker.max.server.response.size.bytes";
-
+    public static final String CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_MEGA_BYTES = "pinot.broker.max.server.response.size.megabytes";
 
     public static class Request {
       public static final String SQL = "sql";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/utils/CommonConstants.java
@@ -337,6 +337,7 @@ public class CommonConstants {
     // precedence over "query.response.size" (i.e., "query.response.size" will be ignored).
     public static final String CONFIG_OF_MAX_SERVER_RESPONSE_SIZE_BYTES = "pinot.broker.max.server.response.size.bytes";
 
+    
     public static class Request {
       public static final String SQL = "sql";
       public static final String TRACE = "trace";


### PR DESCRIPTION
Currently when specifying the response size limit,  raw_byte is used. Since most scenarios will need to set the limit to multiple-MB, using raw_byte is inconvenient and error-prone.   For instance, 128MB would be 128000000. 
i.e., "pinot.broker.max.query.response.size.bytes":"128000000"

This PR allows specifying the response size limit in human readable format (e.g., '128MB', '128M'). 

Also add clarifications about how the existing configs works:  If both query.response.size and server.response.size are given, then the server.response.size will take precedence (i.e., ignoring the query.response.size value).  
Underlying the hood, the server.response.size will be checked first. If it has a value, then the feature will stop processing the query.response.size. 
So the users are expected to only set one of the two options (query.response.size or server.response.size).
