### PR TITLE
Added /uptime and /start-time for all components. Addressed comments and fixed tests from pull request 12389. 

### DIFF
--- a/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerHealthCheck.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/api/resources/PinotBrokerHealthCheck.java
@@ -26,6 +26,9 @@ import io.swagger.annotations.ApiResponses;
 import io.swagger.annotations.Authorization;
 import io.swagger.annotations.SecurityDefinition;
 import io.swagger.annotations.SwaggerDefinition;
+import java.time.Duration;
+import java.time.Instant;
+import java.time.format.DateTimeFormatter;
 import javax.inject.Inject;
 import javax.inject.Named;
 import javax.ws.rs.GET;
@@ -58,6 +61,10 @@ public class PinotBrokerHealthCheck {
   @Inject
   private BrokerMetrics _brokerMetrics;
 
+  @Inject
+  @Named(BrokerAdminApiApplication.START_TIME)
+  private Instant _startTime;
+
   @GET
   @Produces(MediaType.TEXT_PLAIN)
   @Path("health")
@@ -78,5 +85,29 @@ public class PinotBrokerHealthCheck {
     Response response =
         Response.status(Response.Status.SERVICE_UNAVAILABLE).entity(errMessage).build();
     throw new WebApplicationException(errMessage, response);
+  }
+
+  @GET
+  @Produces(MediaType.TEXT_PLAIN)
+  @Path("uptime")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_HEALTH)
+  @ApiOperation(value = "Get broker uptime")
+  public long getUptime() {
+    if (_startTime == null) {
+      return 0;
+    }
+    Instant now = Instant.now();
+    Duration uptime = Duration.between(_startTime, now);
+    return uptime.getSeconds();
+  }
+
+  @GET
+  @Path("start-time")
+  @Authorize(targetType = TargetType.CLUSTER, action = Actions.Cluster.GET_HEALTH)
+  @ApiOperation(value = "Get broker start time")
+  @Produces(MediaType.TEXT_PLAIN)
+  public String getStartTime() {
+    DateTimeFormatter formatter = DateTimeFormatter.ISO_INSTANT;
+    return _startTime != null ? formatter.format(_startTime) : "";
   }
 }

--- a/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
+++ b/pinot-broker/src/main/java/org/apache/pinot/broker/broker/BrokerAdminApiApplication.java
@@ -23,6 +23,7 @@ import io.swagger.jaxrs.config.BeanConfig;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.Executor;
 import java.util.concurrent.ExecutorService;
@@ -60,6 +61,8 @@ public class BrokerAdminApiApplication extends ResourceConfig {
   public static final String PINOT_CONFIGURATION = "pinotConfiguration";
   public static final String BROKER_INSTANCE_ID = "brokerInstanceId";
 
+  public static final String START_TIME = "brokerStartTime";
+
   private final String _brokerResourcePackages;
   private final boolean _useHttps;
   private final boolean _swaggerBrokerEnabled;
@@ -89,7 +92,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
         .getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_TIMEOUT_MS,
             CommonConstants.Broker.DEFAULT_BROKER_TIMEOUT_MS);
     connMgr.setDefaultSocketConfig(SocketConfig.custom().setSoTimeout(timeoutMs).build());
-
+    Instant startTime = Instant.now();
     register(new AbstractBinder() {
       @Override
       protected void configure() {
@@ -109,6 +112,7 @@ public class BrokerAdminApiApplication extends ResourceConfig {
         bind(brokerConf.getProperty(CommonConstants.Broker.CONFIG_OF_BROKER_ID)).named(BROKER_INSTANCE_ID);
         bind(serverRoutingStatsManager).to(ServerRoutingStatsManager.class);
         bind(accessFactory).to(AccessControlFactory.class);
+        bind(startTime).named(BrokerAdminApiApplication.START_TIME);
       }
     });
     boolean enableBoundedJerseyThreadPoolExecutor = brokerConf

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/BaseControllerStarter.java
@@ -26,6 +26,7 @@ import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.io.OutputStream;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
@@ -486,6 +487,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
     LOGGER.info("Controller download url base: {}", _config.generateVipUrl());
     LOGGER.info("Injecting configuration and resource managers to the API context");
     // register all the controller objects for injection to jersey resources
+    Instant controllerStartTime = Instant.now();
     _adminApp.registerBinder(new AbstractBinder() {
       @Override
       protected void configure() {
@@ -506,6 +508,7 @@ public abstract class BaseControllerStarter implements ServiceStartable {
         bind(_sqlQueryExecutor).to(SqlQueryExecutor.class);
         bind(_pinotLLCRealtimeSegmentManager).to(PinotLLCRealtimeSegmentManager.class);
         bind(_tenantRebalancer).to(TenantRebalancer.class);
+        bind(controllerStartTime).named(ControllerAdminApiApplication.START_TIME);
         String loggerRootDir = _config.getProperty(CommonConstants.Controller.CONFIG_OF_LOGGER_ROOT_DIR);
         if (loggerRootDir != null) {
           bind(new LocalLogFileServer(loggerRootDir)).to(LogFileServer.class);

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/ControllerAdminApiApplication.java
@@ -45,6 +45,8 @@ import org.glassfish.jersey.server.ResourceConfig;
 public class ControllerAdminApiApplication extends ResourceConfig {
   public static final String PINOT_CONFIGURATION = "pinotConfiguration";
 
+  public static final String START_TIME = "controllerStartTime";
+
   private final String _controllerResourcePackages;
   private final boolean _useHttps;
   private HttpServer _httpServer;

--- a/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
+++ b/pinot-minion/src/main/java/org/apache/pinot/minion/MinionAdminApiApplication.java
@@ -22,6 +22,7 @@ import io.swagger.jaxrs.config.BeanConfig;
 import java.io.IOException;
 import java.net.URL;
 import java.net.URLClassLoader;
+import java.time.Instant;
 import java.util.List;
 import org.apache.pinot.common.utils.log.DummyLogFileServer;
 import org.apache.pinot.common.utils.log.LocalLogFileServer;
@@ -50,6 +51,8 @@ public class MinionAdminApiApplication extends ResourceConfig {
   public static final String PINOT_CONFIGURATION = "pinotConfiguration";
   public static final String MINION_INSTANCE_ID = "minionInstanceId";
 
+  public static final String START_TIME = "minionStartTime";
+
   private HttpServer _httpServer;
   private final boolean _useHttps;
 
@@ -57,6 +60,7 @@ public class MinionAdminApiApplication extends ResourceConfig {
     packages(RESOURCE_PACKAGE);
     property(PINOT_CONFIGURATION, minionConf);
     _useHttps = Boolean.parseBoolean(minionConf.getProperty(CommonConstants.Minion.CONFIG_OF_SWAGGER_USE_HTTPS));
+    Instant minionStartTime = Instant.now();
     register(new AbstractBinder() {
       @Override
       protected void configure() {
@@ -68,6 +72,7 @@ public class MinionAdminApiApplication extends ResourceConfig {
         } else {
           bind(new DummyLogFileServer()).to(LogFileServer.class);
         }
+        bind(minionStartTime).named(START_TIME);
       }
     });
 

--- a/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
+++ b/pinot-server/src/main/java/org/apache/pinot/server/api/AdminApiApplication.java
@@ -24,6 +24,7 @@ import java.net.InetAddress;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.net.UnknownHostException;
+import java.time.Instant;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicBoolean;
 import javax.ws.rs.container.ContainerRequestContext;
@@ -55,6 +56,8 @@ public class AdminApiApplication extends ResourceConfig {
   public static final String PINOT_CONFIGURATION = "pinotConfiguration";
   public static final String SERVER_INSTANCE_ID = "serverInstanceId";
 
+  public static final String START_TIME = "serverStartTime";
+
   private final AtomicBoolean _shutDownInProgress = new AtomicBoolean();
   private final ServerInstance _serverInstance;
   private HttpServer _httpServer;
@@ -69,6 +72,7 @@ public class AdminApiApplication extends ResourceConfig {
         CommonConstants.Server.DEFAULT_SERVER_RESOURCE_PACKAGES);
     packages(_adminApiResourcePackages);
     property(PINOT_CONFIGURATION, serverConf);
+    Instant serverStartTime = Instant.now();
 
     register(new AbstractBinder() {
       @Override
@@ -85,6 +89,7 @@ public class AdminApiApplication extends ResourceConfig {
         } else {
           bind(new DummyLogFileServer()).to(LogFileServer.class);
         }
+        bind(serverStartTime).named(START_TIME);
       }
     });
 


### PR DESCRIPTION
Addresses #12298. Added /uptime and /start-time for all components. Addressed comments and verified tests pass from pull request [12389](https://github.com/apache/pinot/pull/12389) (Closed that request because the history of that PR got messy). Tested /uptime and /start-time endpoints on my local machine. See the attached images

![uptime](https://github.com/apache/pinot/assets/20127725/1ada9324-272d-4fe5-9d5a-2f68bf240dfc)
![start-time](https://github.com/apache/pinot/assets/20127725/8866142f-d84a-4344-a5ef-34bc93faa48d)
