### PR TITLE
Metrics for Realtime Rows Fetched and Stream Consumer Create Exceptions

### DIFF
--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -93,6 +93,9 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeOffsetCommits\"><>(\\w+)"
   name: "pinot_server_realtime_offsetCommits_$1"
   cache: true
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeRowsConsumed\"><>(\\w+)"
+  name: "pinot_server_realtime_rowsConsumed_$1"
+  cache: true
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)Exceptions\"><>(\\w+)"
   name: "pinot_server_realtime_exceptions_$1_$2"
   cache: true

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -77,7 +77,7 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeConsumptionExceptions\"><>(\\w+)"
   name: "pinot_server_realtime_consumptionExceptions_$1"
   cache: true
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed|realtimeLastFetchedBatchSize)\"><>(\\w+)"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed|realtimeLastFetchedBatchSize|streamConsumerCreateExceptions)\"><>(\\w+)"
   name: "pinot_server_$5_$6"
   cache: true
   labels:

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -77,7 +77,7 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeConsumptionExceptions\"><>(\\w+)"
   name: "pinot_server_realtime_consumptionExceptions_$1"
   cache: true
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed)\"><>(\\w+)"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed|realtimeLastFetchedBatchSize)\"><>(\\w+)"
   name: "pinot_server_$5_$6"
   cache: true
   labels:
@@ -92,9 +92,6 @@ rules:
     table: "$1"
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeOffsetCommits\"><>(\\w+)"
   name: "pinot_server_realtime_offsetCommits_$1"
-  cache: true
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeRowsConsumed\"><>(\\w+)"
-  name: "pinot_server_realtime_rowsConsumed_$1"
   cache: true
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.(\\w+)Exceptions\"><>(\\w+)"
   name: "pinot_server_realtime_exceptions_$1_$2"

--- a/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
+++ b/docker/images/pinot/etc/jmx_prometheus_javaagent/configs/server.yml
@@ -77,7 +77,7 @@ rules:
 - pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.realtimeConsumptionExceptions\"><>(\\w+)"
   name: "pinot_server_realtime_consumptionExceptions_$1"
   cache: true
-- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed|realtimeLastFetchedBatchSize|streamConsumerCreateExceptions)\"><>(\\w+)"
+- pattern: "\"org.apache.pinot.common.metrics\"<type=\"ServerMetrics\", name=\"pinot.server.([^\\.]*?)_(OFFLINE|REALTIME)\\-(.+)\\-(\\w+).(invalidRealtimeRowsDropped|incompleteRealtimeRowsConsumed|rowsWithErrors|realtimeRowsConsumed|realtimeRowsFetched|streamConsumerCreateExceptions)\"><>(\\w+)"
   name: "pinot_server_$5_$6"
   cache: true
   labels:

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -68,7 +68,6 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   NETTY_POOLED_CHUNK_SIZE("bytes", true),
   // Ingestion delay metrics
   REALTIME_INGESTION_DELAY_MS("milliseconds", false),
-  REALTIME_LAST_FETCHED_BATCH_SIZE("rows", false),
   END_TO_END_REALTIME_INGESTION_DELAY_MS("milliseconds", false),
   // Needed to track if valid doc id snapshots are present for faster restarts
   UPSERT_VALID_DOC_ID_SNAPSHOT_COUNT("upsertValidDocIdSnapshotCount", false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerGauge.java
@@ -68,6 +68,7 @@ public enum ServerGauge implements AbstractMetrics.Gauge {
   NETTY_POOLED_CHUNK_SIZE("bytes", true),
   // Ingestion delay metrics
   REALTIME_INGESTION_DELAY_MS("milliseconds", false),
+  REALTIME_LAST_FETCHED_BATCH_SIZE("rows", false),
   END_TO_END_REALTIME_INGESTION_DELAY_MS("milliseconds", false),
   // Needed to track if valid doc id snapshots are present for faster restarts
   UPSERT_VALID_DOC_ID_SNAPSHOT_COUNT("upsertValidDocIdSnapshotCount", false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -34,6 +34,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   HELIX_ZOOKEEPER_RECONNECTS("reconnects", true),
   DELETED_SEGMENT_COUNT("segments", false),
   DELETE_TABLE_FAILURES("tables", false),
+  REALTIME_ROWS_FETCHED("rows", false),
   REALTIME_ROWS_CONSUMED("rows", true),
   REALTIME_ROWS_FILTERED("rows", false),
   INVALID_REALTIME_ROWS_DROPPED("rows", false),
@@ -41,6 +42,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   REALTIME_CONSUMPTION_EXCEPTIONS("exceptions", true),
   REALTIME_OFFSET_COMMITS("commits", true),
   REALTIME_OFFSET_COMMIT_EXCEPTIONS("exceptions", false),
+  STREAM_CONSUMER_CREATE_EXCEPTIONS("exceptions", false),
   // number of times partition of a record did not match the partition of the stream
   REALTIME_PARTITION_MISMATCH("mismatch", false),
   REALTIME_DEDUP_DROPPED("rows", false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -35,6 +35,7 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   DELETED_SEGMENT_COUNT("segments", false),
   DELETE_TABLE_FAILURES("tables", false),
   REALTIME_ROWS_CONSUMED("rows", true),
+  REALTIME_ROWS_FETCHED("rows", false),
   REALTIME_ROWS_FILTERED("rows", false),
   INVALID_REALTIME_ROWS_DROPPED("rows", false),
   INCOMPLETE_REALTIME_ROWS_CONSUMED("rows", false),

--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -34,7 +34,6 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   HELIX_ZOOKEEPER_RECONNECTS("reconnects", true),
   DELETED_SEGMENT_COUNT("segments", false),
   DELETE_TABLE_FAILURES("tables", false),
-  REALTIME_ROWS_FETCHED("rows", false),
   REALTIME_ROWS_CONSUMED("rows", true),
   REALTIME_ROWS_FILTERED("rows", false),
   INVALID_REALTIME_ROWS_DROPPED("rows", false),

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -324,9 +324,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
             _consumeEndTime += TimeUnit.HOURS.toMillis(TIME_EXTENSION_ON_EMPTY_SEGMENT_HOURS);
             return false;
           }
-          _segmentLogger.info(
-              "Stopping consumption due to time limit start={} now={} numRowsConsumed={} numRowsIndexed={}",
-              _startTimeMs, now, _numRowsConsumed, _numRowsIndexed);
+          _segmentLogger
+              .info("Stopping consumption due to time limit start={} now={} numRowsConsumed={} numRowsIndexed={}",
+                  _startTimeMs, now, _numRowsConsumed, _numRowsIndexed);
           _stopReason = SegmentCompletionProtocol.REASON_TIME_LIMIT;
           return true;
         } else if (_numRowsIndexed >= _segmentMaxRowCount) {
@@ -391,15 +391,15 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       throws Exception {
     _consecutiveErrorCount++;
     _serverMetrics.addMeteredGlobalValue(ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
-    _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS, 1L);
+    _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.REALTIME_CONSUMPTION_EXCEPTIONS,
+        1L);
     if (_consecutiveErrorCount > MAX_CONSECUTIVE_ERROR_COUNT) {
-      _segmentLogger.warn(
-          "Stream transient exception when fetching messages, stopping consumption after " + _consecutiveErrorCount
-              + " attempts", e);
+      _segmentLogger.warn("Stream transient exception when fetching messages, stopping consumption after "
+          + _consecutiveErrorCount + " attempts", e);
       throw e;
     } else {
-      _segmentLogger.warn(
-          "Stream transient exception when fetching messages, retrying (count=" + _consecutiveErrorCount + ")", e);
+      _segmentLogger.warn("Stream transient exception when fetching messages, retrying (count="
+          + _consecutiveErrorCount + ")", e);
       Uninterruptibles.sleepUninterruptibly(1, TimeUnit.SECONDS);
       recreateStreamConsumer("Too many transient errors");
     }
@@ -416,8 +416,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     long idleTimeoutMillis = _streamConfig.getIdleTimeoutMillis();
     _idleTimer.init();
 
-    StreamPartitionMsgOffset lastUpdatedOffset = _streamPartitionMsgOffsetFactory.create(
-        _currentOffset);  // so that we always update the metric when we enter this method.
+    StreamPartitionMsgOffset lastUpdatedOffset = _streamPartitionMsgOffsetFactory
+        .create(_currentOffset);  // so that we always update the metric when we enter this method.
 
     _segmentLogger.info("Starting consumption loop start offset {}, finalOffset {}", _currentOffset, _finalOffset);
     while (!_shouldStop && !endCriteriaReached()) {
@@ -498,8 +498,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           // Update the partition-consuming metric only if we have been idling beyond idle timeout.
           // Create a new stream consumer wrapper, in case we are stuck on something.
           _serverMetrics.setValueOfTableGauge(_clientId, ServerGauge.LLC_PARTITION_CONSUMING, 1);
-          recreateStreamConsumer(String.format("Total idle time: %d ms exceeded idle timeout: %d ms",
-              timeSinceStreamLastCreatedOrConsumedMs, idleTimeoutMillis));
+          recreateStreamConsumer(
+              String.format("Total idle time: %d ms exceeded idle timeout: %d ms",
+                  timeSinceStreamLastCreatedOrConsumedMs, idleTimeoutMillis));
           _idleTimer.markStreamCreated();
         }
       }
@@ -565,8 +566,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         //    is a rare case, and we really don't know how to handle this at this time.
         //    Throw an exception.
         //
-        _segmentLogger.error("Buffer full with {} rows consumed (row limit {}, indexed {})", _numRowsConsumed,
-            _numRowsIndexed, _segmentMaxRowCount);
+        _segmentLogger
+            .error("Buffer full with {} rows consumed (row limit {}, indexed {})", _numRowsConsumed, _numRowsIndexed,
+                _segmentMaxRowCount);
         throw new RuntimeException("Realtime segment full");
       }
 
@@ -593,8 +595,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
         }
         if (reusedResult.getSkippedRowCount() > 0) {
-          realtimeRowsDroppedMeter = _serverMetrics.addMeteredTableValue(_clientId, ServerMeter.REALTIME_ROWS_FILTERED,
-              reusedResult.getSkippedRowCount(), realtimeRowsDroppedMeter);
+          realtimeRowsDroppedMeter =
+              _serverMetrics.addMeteredTableValue(_clientId, ServerMeter.REALTIME_ROWS_FILTERED,
+                  reusedResult.getSkippedRowCount(), realtimeRowsDroppedMeter);
         }
         if (reusedResult.getIncompleteRowCount() > 0) {
           realtimeIncompleteRowsConsumedMeter =
@@ -619,7 +622,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
             _numRowsErrored++;
             String errorMessage = String.format("Caught exception while indexing the record: %s", transformedRow);
             _segmentLogger.error(errorMessage, e);
-            _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
+            _realtimeTableDataManager.addSegmentError(_segmentNameStr,
+                new SegmentErrorInfo(now(), errorMessage, e));
           }
         }
       }
@@ -708,8 +712,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
                 TimeUnit.MILLISECONDS.toSeconds(initialConsumptionEnd - _startTimeMs));
           } else if (_state == State.CATCHING_UP) {
             catchUpTimeMillis += now() - lastCatchUpStart;
-            _serverMetrics.setValueOfTableGauge(_clientId, ServerGauge.LAST_REALTIME_SEGMENT_CATCHUP_DURATION_SECONDS,
-                TimeUnit.MILLISECONDS.toSeconds(catchUpTimeMillis));
+            _serverMetrics
+                .setValueOfTableGauge(_clientId, ServerGauge.LAST_REALTIME_SEGMENT_CATCHUP_DURATION_SECONDS,
+                    TimeUnit.MILLISECONDS.toSeconds(catchUpTimeMillis));
           }
 
           // If we are sending segmentConsumed() to the controller, we are in HOLDING state.
@@ -797,7 +802,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         _segmentLogger.error(errorMessage, e);
         postStopConsumedMsg(e.getClass().getName());
         _state = State.ERROR;
-        _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
+        _realtimeTableDataManager
+            .addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
         _serverMetrics.setValueOfTableGauge(_clientId, ServerGauge.LLC_PARTITION_CONSUMING, 0);
         return;
       }
@@ -805,8 +811,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       removeSegmentFile();
 
       if (initialConsumptionEnd != 0L) {
-        _serverMetrics.setValueOfTableGauge(_clientId, ServerGauge.LAST_REALTIME_SEGMENT_COMPLETION_DURATION_SECONDS,
-            TimeUnit.MILLISECONDS.toSeconds(now() - initialConsumptionEnd));
+        _serverMetrics
+            .setValueOfTableGauge(_clientId, ServerGauge.LAST_REALTIME_SEGMENT_COMPLETION_DURATION_SECONDS,
+                TimeUnit.MILLISECONDS.toSeconds(now() - initialConsumptionEnd));
       }
       // There is a race condition that the destroy() method can be called which ends up calling stop on the consumer.
       // The destroy() method does not wait for the thread to terminate (and reasonably so, we dont want to wait
@@ -880,9 +887,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
    */
   public Map<String, ConsumerPartitionState> getConsumerPartitionState() {
     String partitionGroupId = String.valueOf(_partitionGroupId);
-    return Collections.singletonMap(partitionGroupId,
-        new ConsumerPartitionState(partitionGroupId, getCurrentOffset(), getLastConsumedTimestamp(),
-            fetchLatestStreamOffset(5_000), _lastRowMetadata));
+    return Collections.singletonMap(partitionGroupId, new ConsumerPartitionState(partitionGroupId, getCurrentOffset(),
+        getLastConsumedTimestamp(), fetchLatestStreamOffset(5_000), _lastRowMetadata));
   }
 
   /**
@@ -977,7 +983,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         String errorMessage =
             String.format("Caught exception while moving index directory from: %s to: %s", tempIndexDir, indexDir);
         _segmentLogger.error(errorMessage, e);
-        _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
+        _realtimeTableDataManager
+            .addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
         return null;
       } finally {
         FileUtils.deleteQuietly(tempSegmentFolder);
@@ -997,7 +1004,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           String errorMessage =
               String.format("Caught exception while taring index directory from: %s to: %s", indexDir, segmentTarFile);
           _segmentLogger.error(errorMessage, e);
-          _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
+          _realtimeTableDataManager
+              .addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
           return null;
         }
 
@@ -1006,16 +1014,17 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
           String errorMessage = String.format("Failed to find file: %s under index directory: %s",
               V1Constants.MetadataKeys.METADATA_FILE_NAME, indexDir);
           _segmentLogger.error(errorMessage);
-          _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, null));
+          _realtimeTableDataManager
+              .addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, null));
           return null;
         }
         File creationMetaFile = SegmentDirectoryPaths.findCreationMetaFile(indexDir);
         if (creationMetaFile == null) {
-          String errorMessage =
-              String.format("Failed to find file: %s under index directory: %s", V1Constants.SEGMENT_CREATION_META,
-                  indexDir);
+          String errorMessage = String.format("Failed to find file: %s under index directory: %s",
+              V1Constants.SEGMENT_CREATION_META, indexDir);
           _segmentLogger.error(errorMessage);
-          _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, null));
+          _realtimeTableDataManager
+              .addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, null));
           return null;
         }
         Map<String, File> metadataFiles = new HashMap<>();
@@ -1031,7 +1040,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     } catch (InterruptedException e) {
       String errorMessage = "Interrupted while waiting for semaphore";
       _segmentLogger.error(errorMessage, e);
-      _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
+      _realtimeTableDataManager
+          .addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), errorMessage, e));
       return null;
     } finally {
       if (_segBuildSemaphore != null) {
@@ -1144,7 +1154,6 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     final Logger _logger;
     final ServerSegmentCompletionProtocolHandler _protocolHandler;
     final String _reason;
-
     private ConsumptionStopIndicator(StreamPartitionMsgOffset offset, String segmentName, String instanceId,
         ServerSegmentCompletionProtocolHandler protocolHandler, String reason, Logger logger) {
       _offset = offset;
@@ -1168,9 +1177,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
   // Inform the controller that the server had to stop consuming due to an error.
   protected void postStopConsumedMsg(String reason) {
-    ConsumptionStopIndicator indicator =
-        new ConsumptionStopIndicator(_currentOffset, _segmentNameStr, _instanceId, _protocolHandler, reason,
-            _segmentLogger);
+    ConsumptionStopIndicator indicator = new ConsumptionStopIndicator(_currentOffset,
+        _segmentNameStr, _instanceId, _protocolHandler, reason, _segmentLogger);
     do {
       SegmentCompletionProtocol.Response response = indicator.postSegmentStoppedConsuming();
       if (response.getStatus() == SegmentCompletionProtocol.ControllerResponseStatus.PROCESSED) {
@@ -1209,8 +1217,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       _leaseExtender.removeSegment(_segmentNameStr);
       final StreamPartitionMsgOffset endOffset =
           _streamPartitionMsgOffsetFactory.create(segmentZKMetadata.getEndOffset());
-      _segmentLogger.info("State: {}, transitioning from CONSUMING to ONLINE (startOffset: {}, endOffset: {})",
-          _state.toString(), _startOffset, endOffset);
+      _segmentLogger
+          .info("State: {}, transitioning from CONSUMING to ONLINE (startOffset: {}, endOffset: {})", _state.toString(),
+              _startOffset, endOffset);
       stop();
       _segmentLogger.info("Consumer thread stopped in state {}", _state.toString());
 
@@ -1238,12 +1247,13 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
               // Allow to catch up upto final offset, and then replace.
               if (_currentOffset.compareTo(endOffset) > 0) {
                 // We moved ahead of the offset that is committed in ZK.
-                _segmentLogger.warn("Current offset {} ahead of the offset in zk {}. Downloading to replace",
-                    _currentOffset, endOffset);
+                _segmentLogger
+                    .warn("Current offset {} ahead of the offset in zk {}. Downloading to replace", _currentOffset,
+                        endOffset);
                 downloadSegmentAndReplace(segmentZKMetadata);
               } else if (_currentOffset.compareTo(endOffset) == 0) {
-                _segmentLogger.info("Current offset {} matches offset in zk {}. Replacing segment", _currentOffset,
-                    endOffset);
+                _segmentLogger
+                    .info("Current offset {} matches offset in zk {}. Replacing segment", _currentOffset, endOffset);
                 buildSegmentAndReplace();
               } else {
                 _segmentLogger.info("Attempting to catch up from offset {} to {} ", _currentOffset, endOffset);
@@ -1253,8 +1263,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
                   _segmentLogger.info("Caught up to offset {}", _currentOffset);
                   buildSegmentAndReplace();
                 } else {
-                  _segmentLogger.info("Could not catch up to offset (current = {}). Downloading to replace",
-                      _currentOffset);
+                  _segmentLogger
+                      .info("Could not catch up to offset (current = {}). Downloading to replace", _currentOffset);
                   downloadSegmentAndReplace(segmentZKMetadata);
                 }
               }
@@ -1277,8 +1287,8 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
   protected void downloadSegmentAndReplace(SegmentZKMetadata segmentZKMetadata) {
     closeStreamConsumers();
-    _realtimeTableDataManager.downloadAndReplaceSegment(_segmentNameStr, segmentZKMetadata, _indexLoadingConfig,
-        _tableConfig);
+    _realtimeTableDataManager
+        .downloadAndReplaceSegment(_segmentNameStr, segmentZKMetadata, _indexLoadingConfig, _tableConfig);
   }
 
   protected long now() {
@@ -1366,8 +1376,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     _leaseExtender = SegmentBuildTimeLeaseExtender.getLeaseExtender(_tableNameWithType);
     _protocolHandler = new ServerSegmentCompletionProtocolHandler(_serverMetrics, _tableNameWithType);
     CompletionConfig completionConfig = _tableConfig.getValidationConfig().getCompletionConfig();
-    _segmentCompletionMode = completionConfig != null && CompletionMode.DOWNLOAD.toString()
-        .equalsIgnoreCase(completionConfig.getCompletionMode()) ? CompletionMode.DOWNLOAD : CompletionMode.DEFAULT;
+    _segmentCompletionMode = completionConfig != null
+        && CompletionMode.DOWNLOAD.toString().equalsIgnoreCase(completionConfig.getCompletionMode())
+        ? CompletionMode.DOWNLOAD : CompletionMode.DEFAULT;
 
     String timeColumnName = tableConfig.getValidationConfig().getTimeColumnName();
     // TODO Validate configs
@@ -1415,9 +1426,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
             firstSortedColumn, llcSegmentName);
         sortedColumn = firstSortedColumn;
       } else {
-        _segmentLogger.warn(
-            "Sorted column name: {} from RealtimeDataResourceZKMetadata is not existed in schema for segment {}.",
-            firstSortedColumn, llcSegmentName);
+        _segmentLogger
+            .warn("Sorted column name: {} from RealtimeDataResourceZKMetadata is not existed in schema for segment {}.",
+                firstSortedColumn, llcSegmentName);
         sortedColumn = null;
       }
     }
@@ -1441,26 +1452,27 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
 
     _nullHandlingEnabled = indexingConfig.isNullHandlingEnabled();
 
-    _columnIndicesForRealtimeTable =
-        new ColumnIndicesForRealtimeTable(sortedColumn, new ArrayList<>(indexLoadingConfig.getInvertedIndexColumns()),
-            new ArrayList<>(indexLoadingConfig.getTextIndexColumns()),
-            new ArrayList<>(indexLoadingConfig.getFSTIndexColumns()),
-            new ArrayList<>(indexLoadingConfig.getNoDictionaryColumns()),
-            new ArrayList<>(indexLoadingConfig.getVarLengthDictionaryColumns()));
+    _columnIndicesForRealtimeTable = new ColumnIndicesForRealtimeTable(sortedColumn,
+        new ArrayList<>(indexLoadingConfig.getInvertedIndexColumns()),
+        new ArrayList<>(indexLoadingConfig.getTextIndexColumns()),
+        new ArrayList<>(indexLoadingConfig.getFSTIndexColumns()),
+        new ArrayList<>(indexLoadingConfig.getNoDictionaryColumns()),
+        new ArrayList<>(indexLoadingConfig.getVarLengthDictionaryColumns()));
 
     // Start new realtime segment
     String consumerDir = realtimeTableDataManager.getConsumerDir();
     RealtimeSegmentConfig.Builder realtimeSegmentConfigBuilder =
         new RealtimeSegmentConfig.Builder(indexLoadingConfig).setTableNameWithType(_tableNameWithType)
-            .setSegmentName(_segmentNameStr).setStreamName(streamTopic).setSchema(_schema)
-            .setTimeColumnName(timeColumnName).setCapacity(_segmentMaxRowCount)
-            .setAvgNumMultiValues(indexLoadingConfig.getRealtimeAvgMultiValueCount())
-            .setSegmentZKMetadata(segmentZKMetadata).setOffHeap(_isOffHeap).setMemoryManager(_memoryManager)
+            .setSegmentName(_segmentNameStr)
+            .setStreamName(streamTopic).setSchema(_schema).setTimeColumnName(timeColumnName)
+            .setCapacity(_segmentMaxRowCount).setAvgNumMultiValues(indexLoadingConfig.getRealtimeAvgMultiValueCount())
+            .setSegmentZKMetadata(segmentZKMetadata)
+            .setOffHeap(_isOffHeap).setMemoryManager(_memoryManager)
             .setStatsHistory(realtimeTableDataManager.getStatsHistory())
             .setAggregateMetrics(indexingConfig.isAggregateMetrics())
             .setIngestionAggregationConfigs(IngestionConfigUtils.getAggregationConfigs(tableConfig))
-            .setNullHandlingEnabled(_nullHandlingEnabled).setConsumerDir(consumerDir)
-            .setUpsertMode(tableConfig.getUpsertMode())
+            .setNullHandlingEnabled(_nullHandlingEnabled)
+            .setConsumerDir(consumerDir).setUpsertMode(tableConfig.getUpsertMode())
             .setPartitionUpsertMetadataManager(partitionUpsertMetadataManager)
             .setPartitionDedupMetadataManager(partitionDedupMetadataManager)
             .setUpsertComparisonColumns(tableConfig.getUpsertComparisonColumns())
@@ -1515,24 +1527,26 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       setConsumeEndTime(segmentZKMetadata, _consumeStartTime);
       _segmentCommitterFactory =
           new SegmentCommitterFactory(_segmentLogger, _protocolHandler, tableConfig, indexLoadingConfig, serverMetrics);
-      _segmentLogger.info("Starting consumption on realtime consuming segment {} maxRowCount {} maxEndTime {}",
-          llcSegmentName, _segmentMaxRowCount, new DateTime(_consumeEndTime, DateTimeZone.UTC));
+      _segmentLogger
+          .info("Starting consumption on realtime consuming segment {} maxRowCount {} maxEndTime {}", llcSegmentName,
+              _segmentMaxRowCount, new DateTime(_consumeEndTime, DateTimeZone.UTC));
     } catch (Exception e) {
       // In case of exception thrown here, segment goes to ERROR state. Then any attempt to reset the segment from
       // ERROR -> OFFLINE -> CONSUMING via Helix Admin fails because the semaphore is acquired, but not released.
       // Hence releasing the semaphore here to unblock reset operation via Helix Admin.
       _partitionGroupConsumerSemaphore.release();
-      _realtimeTableDataManager.addSegmentError(_segmentNameStr,
-          new SegmentErrorInfo(now(), "Failed to initialize segment data manager", e));
-      _segmentLogger.warn("Scheduling task to call controller to mark the segment as OFFLINE in Ideal State due"
-          + " to initialization error: '{}'", e.getMessage());
+      _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(),
+          "Failed to initialize segment data manager", e));
+      _segmentLogger.warn(
+          "Scheduling task to call controller to mark the segment as OFFLINE in Ideal State due"
+           + " to initialization error: '{}'",
+          e.getMessage());
       // Since we are going to throw exception from this thread (helix execution thread), the externalview
       // entry for this segment will be ERROR. We allow time for Helix to make this transition, and then
       // invoke controller API mark it OFFLINE in the idealstate.
       new Thread(() -> {
-        ConsumptionStopIndicator indicator =
-            new ConsumptionStopIndicator(_currentOffset, _segmentNameStr, _instanceId, _protocolHandler,
-                "Consuming segment initialization error", _segmentLogger);
+        ConsumptionStopIndicator indicator = new ConsumptionStopIndicator(_currentOffset, _segmentNameStr, _instanceId,
+            _protocolHandler, "Consuming segment initialization error", _segmentLogger);
         try {
           // Allow 30s for Helix to mark currentstate and externalview to ERROR, because
           // we are about to receive an ERROR->OFFLINE state transition once we call
@@ -1586,9 +1600,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     try {
       return _partitionMetadataProvider.fetchStreamPartitionOffset(offsetCriteria, maxWaitTimeMs);
     } catch (Exception e) {
-      _segmentLogger.warn(String.format(
-          "Cannot fetch stream offset with criteria %s for clientId %s and partitionGroupId %d with maxWaitTime %d",
-          offsetCriteria, _clientId, _partitionGroupId, maxWaitTimeMs), e);
+      _segmentLogger.warn(
+          String.format(
+              "Cannot fetch stream offset with criteria %s for clientId %s and partitionGroupId %d with maxWaitTime %d",
+              offsetCriteria, _clientId, _partitionGroupId, maxWaitTimeMs), e);
     }
     return null;
   }
@@ -1654,16 +1669,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       closePartitionGroupConsumer();
     }
     _segmentLogger.info("Creating new stream consumer for topic partition {} , reason: {}", _clientId, reason);
-    try {
-      _partitionGroupConsumer =
-          _streamConsumerFactory.createPartitionGroupConsumer(_clientId, _partitionGroupConsumptionStatus);
-      _partitionGroupConsumer.start(_currentOffset);
-    } catch (Exception e) {
-      _segmentLogger.error("Faced exception while trying to recreate stream consumer for topic partition {} reason {}",
-          _clientId, reason, e);
-      _serverMetrics.addMeteredTableValue(_clientId, ServerMeter.STREAM_CONSUMER_CREATE_EXCEPTIONS, 1L);
-      throw e;
-    }
+    _partitionGroupConsumer =
+        _streamConsumerFactory.createPartitionGroupConsumer(_clientId, _partitionGroupConsumptionStatus);
+    _partitionGroupConsumer.start(_currentOffset);
   }
 
   /**
@@ -1671,19 +1679,12 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
    * Assumes there is a valid instance of {@link PartitionGroupConsumer}
    */
   private void recreateStreamConsumer(String reason) {
-    try {
-      _segmentLogger.info("Recreating stream consumer for topic partition {}, reason: {}", _clientId, reason);
-      _currentOffset = _partitionGroupConsumer.checkpoint(_currentOffset);
-      closePartitionGroupConsumer();
-      _partitionGroupConsumer =
-          _streamConsumerFactory.createPartitionGroupConsumer(_clientId, _partitionGroupConsumptionStatus);
-      _partitionGroupConsumer.start(_currentOffset);
-    } catch (Exception e) {
-      _segmentLogger.error("Faced exception while trying to recreate stream consumer for topic partition {}", _clientId,
-          e);
-      _serverMetrics.addMeteredTableValue(_clientId, ServerMeter.STREAM_CONSUMER_CREATE_EXCEPTIONS, 1L);
-      throw e;
-    }
+    _segmentLogger.info("Recreating stream consumer for topic partition {}, reason: {}", _clientId, reason);
+    _currentOffset = _partitionGroupConsumer.checkpoint(_currentOffset);
+    closePartitionGroupConsumer();
+    _partitionGroupConsumer =
+        _streamConsumerFactory.createPartitionGroupConsumer(_clientId, _partitionGroupConsumptionStatus);
+    _partitionGroupConsumer.start(_currentOffset);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -429,7 +429,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
             _partitionGroupConsumer.fetchMessages(_currentOffset, null, _streamConfig.getFetchTimeoutMillis());
         //track realtime rows fetched on a table level. This included valid + invalid rows
         _serverMetrics.addMeteredTableValue(_clientId, ServerMeter.REALTIME_ROWS_FETCHED,
-            messageBatch.getMessageCount());
+            messageBatch.getUnfilteredMessageCount());
         if (_segmentLogger.isDebugEnabled()) {
           _segmentLogger.debug("message batch received. filtered={} unfiltered={} endOfPartitionGroup={}",
               messageBatch.getMessageCount(), messageBatch.getUnfilteredMessageCount(),

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1683,10 +1683,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
    * Assumes there is a valid instance of {@link PartitionGroupConsumer}
    */
   private void recreateStreamConsumer(String reason) {
-    try {
       _segmentLogger.info("Recreating stream consumer for topic partition {}, reason: {}", _clientId, reason);
       _currentOffset = _partitionGroupConsumer.checkpoint(_currentOffset);
       closePartitionGroupConsumer();
+    try {
       _partitionGroupConsumer =
           _streamConsumerFactory.createPartitionGroupConsumer(_clientId, _partitionGroupConsumptionStatus);
       _partitionGroupConsumer.start(_currentOffset);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1687,10 +1687,12 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       _segmentLogger.info("Recreating stream consumer for topic partition {}, reason: {}", _clientId, reason);
       _currentOffset = _partitionGroupConsumer.checkpoint(_currentOffset);
       closePartitionGroupConsumer();
-      _partitionGroupConsumer = _streamConsumerFactory.createPartitionGroupConsumer(_clientId, _partitionGroupConsumptionStatus);
+      _partitionGroupConsumer =
+          _streamConsumerFactory.createPartitionGroupConsumer(_clientId, _partitionGroupConsumptionStatus);
       _partitionGroupConsumer.start(_currentOffset);
     } catch (Exception e) {
-      _segmentLogger.error("Faced exception while trying to recreate stream consumer for topic partition {}", _clientId, e);
+      _segmentLogger.error("Faced exception while trying to recreate stream consumer for topic partition {}", _clientId,
+          e);
       _serverMetrics.addMeteredTableValue(_clientId, ServerMeter.STREAM_CONSUMER_CREATE_EXCEPTIONS, 1L);
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1749,7 +1749,6 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     }
   }
 
-
   @Override
   public MutableSegment getSegment() {
     return _realtimeSegment;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1694,6 +1694,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       _segmentLogger.error("Faced exception while trying to recreate stream consumer for topic partition {}", _clientId,
           e);
       _serverMetrics.addMeteredTableValue(_clientId, ServerMeter.STREAM_CONSUMER_CREATE_EXCEPTIONS, 1L);
+      throw e;
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1749,6 +1749,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     }
   }
 
+
   @Override
   public MutableSegment getSegment() {
     return _realtimeSegment;


### PR DESCRIPTION


This PR adds two metrics in `RealtimeSegmentDataManager`:


 ~~1. `REALTIME_ROWS_FETCHED`: This is a new gauge that can assume the following values:~~

~~- 0: When there were no messages in the last batch. This can happen when there are no messages or very low vol of messages in the stream partition.~~
~~-  &gt; 0 : When messages were fetched in the last batch.~~
~~- -1: When there were exceptions fetching the message batch from the stream partition.~~

~~This metric can be used to identify the 1st case of no messages in a stream partition as:~~

~~`max_over_time(pinot_server_realtimeLastFetchedBatchSize_Value{}[15m])`: This expr checks the max batch size consumed in the last 15m. If it's 0, it means no ingestion has happened in the last 15m. We can use this as a source alert to silence other alerts such as `RealtimeIngestionStopped`.~~

1. `REALTIME_ROWS_FETCHED`: This is a new meter that tracks the number of rows fetched from the stream partition. This basically tracks how many rows there are in the batch, before processing anything. 

This metric can be use to detect is there is no data in the stream partition as:

`rate(pinot_server_realtimeRowsFetched_Count{}[1m]) == 0`

**Why can't we reuse `pinot_server_realtimeRowsConsumed`?**

`pinot_server_realtimeRowsConsumed` tracks the number of rows that were successfully indexed. If there were problems transforming/indexing the row, those rows aren't counted in this. So it makes it hard to calculate the total number of rows being fetched from the partition stream.

2. `STREAM_CONSUMER_CREATE_EXCEPTIONS`: If we face exceptions trying to create a stream consumer.

Testing:

`rate(pinot_server_realtimeRowsFetched_Count{}[1m])`:

- When there were messages in the last fetched batch:

<img width="1573" alt="Screenshot 2024-02-29 at 5 43 30 PM" src="https://github.com/apache/pinot/assets/84911643/2733f2cc-2ad5-49a3-bbca-6eb4e8e943ae">

- No data in input stream

![Uploading Screenshot 2024-02-29 at 5.48.44 PM.png…]()


-  Exposed metric:

<img width="1719" alt="Screenshot 2024-02-29 at 5 33 35 PM" src="https://github.com/apache/pinot/assets/84911643/c588a020-bda7-4abf-81a4-59bcfa1d2fde">

`STREAM_CONSUMER_CREATE_EXCEPTIONS`:

<img width="885" alt="Screenshot 2024-02-29 at 3 22 49 PM" src="https://github.com/apache/pinot/assets/84911643/e9a45e29-ecfb-42ab-bf3e-e279a5d2b8ec">


<img width="1643" alt="Screenshot 2024-02-29 at 3 26 08 PM" src="https://github.com/apache/pinot/assets/84911643/6bf5f17a-1d33-49a9-b4c9-4a57296e483b">

