### PR TITLE
Modify consumingSegmentsInfo endpoint to indicate how many servers failed

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
@@ -94,7 +94,7 @@ public class ConsumingSegmentInfoReader {
     // Segments which are in CONSUMING state but found no consumer on the server
     Set<String> consumingSegments = _pinotHelixResourceManager.getConsumingSegments(tableNameWithType);
     consumingSegments.forEach(c -> consumingSegmentInfoMap.putIfAbsent(c, Collections.emptyList()));
-    return new ConsumingSegmentsInfoMap(consumingSegmentInfoMap, response._failedResponseCount);
+    return new ConsumingSegmentsInfoMap(consumingSegmentInfoMap, response._failedResponseCount, response._failedParses);
   }
 
   /**
@@ -134,7 +134,7 @@ public class ConsumingSegmentInfoReader {
       LOGGER.warn("Failed to parse {} / {} segment size info responses from servers.", failedParses, serverUrls.size());
     }
     return new ConsumingSegmentsInfoFromServersResponse(
-        serverToConsumingSegmentInfoList, serviceResponse._failedResponseCount);
+        serverToConsumingSegmentInfoList, serviceResponse._failedResponseCount, failedParses);
   }
 
   private String generateServerURL(String tableNameWithType, String endpoint) {
@@ -193,12 +193,16 @@ public class ConsumingSegmentInfoReader {
     public TreeMap<String, List<ConsumingSegmentInfo>> _segmentToConsumingInfoMap;
     @JsonProperty("serversFailingToRespond")
     public int _serversFailingToRespond;
+    @JsonProperty("serversUnparsableRespond")
+    public int _serversUnparsableRespond;
 
     public ConsumingSegmentsInfoMap(@JsonProperty("segmentToConsumingInfoMap")
         TreeMap<String, List<ConsumingSegmentInfo>> segmentToConsumingInfoMap,
-        @JsonProperty("serversFailingToRespond") int serversFailingToRespond) {
+        @JsonProperty("serversFailingToRespond") int serversFailingToRespond,
+        @JsonProperty("serversUnparsableRespond") int serversUnparsableRespond) {
       _segmentToConsumingInfoMap = segmentToConsumingInfoMap;
       _serversFailingToRespond = serversFailingToRespond;
+      _serversUnparsableRespond = serversUnparsableRespond;
     }
   }
 
@@ -264,11 +268,14 @@ public class ConsumingSegmentInfoReader {
   public static class ConsumingSegmentsInfoFromServersResponse {
     private final Map<String, List<SegmentConsumerInfo>> _serverToSegmentConsumerInfoMap;
     private final int _failedResponseCount;
+    private final int _failedParses;
 
     public ConsumingSegmentsInfoFromServersResponse(
-        Map<String, List<SegmentConsumerInfo>> serverToSegmentConsumerInfoMap, int failedResponseCount) {
+        Map<String, List<SegmentConsumerInfo>> serverToSegmentConsumerInfoMap, int failedResponseCount,
+        int failedParses) {
       _serverToSegmentConsumerInfoMap = serverToSegmentConsumerInfoMap;
       _failedResponseCount = failedResponseCount;
+      _failedParses = failedParses;
     }
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/util/ConsumingSegmentInfoReader.java
@@ -75,8 +75,9 @@ public class ConsumingSegmentInfoReader {
         _pinotHelixResourceManager.getDataInstanceAdminEndpoints(serverToSegments.keySet());
 
     // Gets info for segments with LLRealtimeSegmentDataManager found in the table data manager
-    Map<String, List<SegmentConsumerInfo>> serverToSegmentConsumerInfoMap =
+    ConsumingSegmentsInfoFromServersResponse response =
         getConsumingSegmentsInfoFromServers(tableNameWithType, serverToEndpoints, timeoutMs);
+    Map<String, List<SegmentConsumerInfo>> serverToSegmentConsumerInfoMap = response._serverToSegmentConsumerInfoMap;
     TreeMap<String, List<ConsumingSegmentInfo>> consumingSegmentInfoMap = new TreeMap<>();
     for (Map.Entry<String, List<SegmentConsumerInfo>> entry : serverToSegmentConsumerInfoMap.entrySet()) {
       String serverName = entry.getKey();
@@ -93,14 +94,14 @@ public class ConsumingSegmentInfoReader {
     // Segments which are in CONSUMING state but found no consumer on the server
     Set<String> consumingSegments = _pinotHelixResourceManager.getConsumingSegments(tableNameWithType);
     consumingSegments.forEach(c -> consumingSegmentInfoMap.putIfAbsent(c, Collections.emptyList()));
-    return new ConsumingSegmentsInfoMap(consumingSegmentInfoMap);
+    return new ConsumingSegmentsInfoMap(consumingSegmentInfoMap, response._failedResponseCount);
   }
 
   /**
    * This method makes a MultiGet call to all servers to get the consuming segments info.
    * @return servers queried and a list of consumer status information for consuming segments on that server
    */
-  private Map<String, List<SegmentConsumerInfo>> getConsumingSegmentsInfoFromServers(String tableNameWithType,
+  private ConsumingSegmentsInfoFromServersResponse getConsumingSegmentsInfoFromServers(String tableNameWithType,
       BiMap<String, String> serverToEndpoints, int timeoutMs) {
     LOGGER.info("Reading consuming segment info from servers: {} for table: {}", serverToEndpoints.keySet(),
         tableNameWithType);
@@ -132,7 +133,8 @@ public class ConsumingSegmentInfoReader {
     if (failedParses != 0) {
       LOGGER.warn("Failed to parse {} / {} segment size info responses from servers.", failedParses, serverUrls.size());
     }
-    return serverToConsumingSegmentInfoList;
+    return new ConsumingSegmentsInfoFromServersResponse(
+        serverToConsumingSegmentInfoList, serviceResponse._failedResponseCount);
   }
 
   private String generateServerURL(String tableNameWithType, String endpoint) {
@@ -189,10 +191,14 @@ public class ConsumingSegmentInfoReader {
   @JsonIgnoreProperties(ignoreUnknown = true)
   static public class ConsumingSegmentsInfoMap {
     public TreeMap<String, List<ConsumingSegmentInfo>> _segmentToConsumingInfoMap;
+    @JsonProperty("serversFailingToRespond")
+    public int _serversFailingToRespond;
 
     public ConsumingSegmentsInfoMap(@JsonProperty("segmentToConsumingInfoMap")
-        TreeMap<String, List<ConsumingSegmentInfo>> segmentToConsumingInfoMap) {
+        TreeMap<String, List<ConsumingSegmentInfo>> segmentToConsumingInfoMap,
+        @JsonProperty("serversFailingToRespond") int serversFailingToRespond) {
       _segmentToConsumingInfoMap = segmentToConsumingInfoMap;
+      _serversFailingToRespond = serversFailingToRespond;
     }
   }
 
@@ -252,6 +258,17 @@ public class ConsumingSegmentInfoReader {
       _latestUpstreamOffsetMap = latestUpstreamOffsetMap;
       _recordsLagMap = recordsLagMap;
       _availabilityLagMap = availabilityLagMsMap;
+    }
+  }
+
+  public static class ConsumingSegmentsInfoFromServersResponse {
+    private final Map<String, List<SegmentConsumerInfo>> _serverToSegmentConsumerInfoMap;
+    private final int _failedResponseCount;
+
+    public ConsumingSegmentsInfoFromServersResponse(
+        Map<String, List<SegmentConsumerInfo>> serverToSegmentConsumerInfoMap, int failedResponseCount) {
+      _serverToSegmentConsumerInfoMap = serverToSegmentConsumerInfoMap;
+      _failedResponseCount = failedResponseCount;
     }
   }
 }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/RealtimeConsumerMonitorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/RealtimeConsumerMonitorTest.java
@@ -137,7 +137,7 @@ public class RealtimeConsumerMonitorTest {
 
     ConsumingSegmentInfoReader consumingSegmentReader = mock(ConsumingSegmentInfoReader.class);
     when(consumingSegmentReader.getConsumingSegmentsInfo(tableName, 10000))
-        .thenReturn(new ConsumingSegmentInfoReader.ConsumingSegmentsInfoMap(response, 0));
+        .thenReturn(new ConsumingSegmentInfoReader.ConsumingSegmentsInfoMap(response, 0, 0));
     RealtimeConsumerMonitor realtimeConsumerMonitor =
         new RealtimeConsumerMonitor(config, helixResourceManager, leadControllerManager,
             controllerMetrics, consumingSegmentReader);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/RealtimeConsumerMonitorTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/RealtimeConsumerMonitorTest.java
@@ -137,7 +137,7 @@ public class RealtimeConsumerMonitorTest {
 
     ConsumingSegmentInfoReader consumingSegmentReader = mock(ConsumingSegmentInfoReader.class);
     when(consumingSegmentReader.getConsumingSegmentsInfo(tableName, 10000))
-        .thenReturn(new ConsumingSegmentInfoReader.ConsumingSegmentsInfoMap(response));
+        .thenReturn(new ConsumingSegmentInfoReader.ConsumingSegmentsInfoMap(response, 0));
     RealtimeConsumerMonitor realtimeConsumerMonitor =
         new RealtimeConsumerMonitor(config, helixResourceManager, leadControllerManager,
             controllerMetrics, consumingSegmentReader);


### PR DESCRIPTION
Controller endpoint /table/consumingSegmentsInfo may return partial information when servers timeout or there is a parsing error dealing with their response. These cases registered as a log, but there is no notice in the response to understand if it is complete or shows partial information, so it is easy to think that the current issue is that there are segments we are not actually consuming from.

This PR tries to improve the usability of the endpoint by adding the new field `serversFailingToRespond` on /table/consumingSegmentsInfo that indicates the number of servers that have failed to answer