### PR TITLE
Revert " Adding record reader config/context param to record transformer (#12520)"

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/CompositeTransformer.java
@@ -28,7 +28,7 @@ import org.apache.pinot.segment.local.utils.IngestionUtils;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.data.Schema;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+
 
 /**
  * The {@code CompositeTransformer} class performs multiple transforms based on the inner {@link RecordTransformer}s.
@@ -115,19 +115,12 @@ public class CompositeTransformer implements RecordTransformer {
 
   @Nullable
   @Override
-  public GenericRow transform(GenericRow genericRow) {
-    return transform(genericRow, null);
-  }
-
-  @Nullable
-  @Override
-  public GenericRow transform(GenericRow record,
-      RecordReaderConfig recordReaderConfig) {
+  public GenericRow transform(GenericRow record) {
     for (RecordTransformer transformer : _transformers) {
       if (!IngestionUtils.shouldIngestRow(record)) {
         return record;
       }
-      record = transformer.transform(record, recordReaderConfig);
+      record = transformer.transform(record);
       if (record == null) {
         return null;
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformer.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/recordtransformer/RecordTransformer.java
@@ -21,7 +21,7 @@ package org.apache.pinot.segment.local.recordtransformer;
 import java.io.Serializable;
 import javax.annotation.Nullable;
 import org.apache.pinot.spi.data.readers.GenericRow;
-import org.apache.pinot.spi.data.readers.RecordReaderConfig;
+
 
 /**
  * The record transformer which takes a {@link GenericRow} and transform it based on some custom rules.
@@ -43,14 +43,4 @@ public interface RecordTransformer extends Serializable {
    */
   @Nullable
   GenericRow transform(GenericRow record);
-
-  /**
-   * Transforms a record based on some custom rules using record reader context.
-   * @param record Record to transform
-   * @return Transformed record, or {@code null} if the record does not follow certain rules.
-   */
-  @Nullable
-  default GenericRow transform(GenericRow record, RecordReaderConfig recordReaderConfig) {
-    return transform(record);
-  }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFileConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/readers/RecordReaderFileConfig.java
@@ -29,7 +29,7 @@ import javax.annotation.Nullable;
  * RecordReader can be initialized just when its about to be used, which avoids early/eager
  * initialization/memory allocation.
  */
-public class RecordReaderFileConfig implements RecordReaderConfig {
+public class RecordReaderFileConfig {
   public final FileFormat _fileFormat;
   public final File _dataFile;
   public final Set<String> _fieldsToRead;


### PR DESCRIPTION
This reverts commit f0fcbd8701e025495a136e644262c83607e1eaa7.

The interface RecordRecordConfig was mistaken as the TransformerContext, that's supposed to be added and passed to transform() to access context like where the record comes from.