### PR TITLE
enable Netty native transports in ClusterTest

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -97,6 +97,7 @@ import static org.testng.Assert.assertTrue;
 public abstract class ClusterTest extends ControllerTest {
   protected static final int DEFAULT_BROKER_PORT = 18099;
   protected static final Random RANDOM = new Random(System.currentTimeMillis());
+  private static final boolean NETTY_CONFIG_NATIVE_TRANSPORTS_ENABLED = true;
 
   protected List<BaseBrokerStarter> _brokerStarters;
   protected List<BaseServerStarter> _serverStarters;
@@ -147,7 +148,9 @@ public abstract class ClusterTest extends ControllerTest {
   }
 
   protected PinotConfiguration getDefaultBrokerConfiguration() {
-    return new PinotConfiguration();
+    PinotConfiguration config = new PinotConfiguration();
+    config.setProperty("pinot.broker.netty.native.transports.enabled", NETTY_CONFIG_NATIVE_TRANSPORTS_ENABLED);
+    return config;
   }
 
   protected void overrideBrokerConf(PinotConfiguration brokerConf) {
@@ -254,6 +257,9 @@ public abstract class ClusterTest extends ControllerTest {
     serverConf.setProperty(Helix.KEY_OF_SERVER_NETTY_PORT, _serverNettyPort);
     _serverGrpcPort = NetUtils.findOpenPort(Server.DEFAULT_GRPC_PORT + new Random().nextInt(10000) + serverId);
     serverConf.setProperty(Server.CONFIG_OF_GRPC_PORT, _serverGrpcPort);
+
+    serverConf.setProperty(Server.SERVER_NETTY_PREFIX + ".native.transports.enabled",
+        NETTY_CONFIG_NATIVE_TRANSPORTS_ENABLED);
 
     // Thread time measurement is disabled by default, enable it in integration tests.
     // TODO: this can be removed when we eventually enable thread time measurement by default.


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Enable Netty native transports in broker and server configs via constant flag\.

```mermaid
flowchart TD
  N0["NETTY#95;CONFIG#95;NATIVE#95;TRANSPORTS#95;ENABLED #61; true #40;F1#41;"]:::stAdded
  N1["Set broker property pinot#46;broker#46;netty#46;native#46;transports#46;enabled #40;F1#41;"]:::stModified
  N2["Set server property SERVER#95;NETTY#95;PREFIX#46;native#46;transports#46;enabled #40;F1#41;"]:::stModified
  N0 -->|"uses"| N1
  N0 -->|"uses"| N2
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-integration\-test\-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest\.java — [before](https://github.com/apache/pinot/blob/3b45dd6ed205c55fc58eefff91d592aeb35882b4/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java) · [after](https://github.com/apache/pinot/blob/031634c46557c1c9343f9a9dfc2ec093a28c9c65/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjNiNDVkZDZlZDIwNWM1NWZjNThlZWZmZjkxZDU5MmFlYjM1ODgyYjQiLCJjb250ZXh0X2hhc2giOiI1NmJlNTFkMzRhNTZjODBlMmRjOGVjZTAxMTFlZjBhMjc5MGQ1YzFlMmIyZDYyYTJmMjE2MDI0YzA1MTU1MDdiIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MTIyNDczLCJoZWFkX3NoYSI6IjAzMTYzNGM0NjU1N2MxYzkzNDNmOWE5ZGZjMmVjMDkzYTI4YzljNjUiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiIzYjQ1ZGQ2ZWQyMDVjNTVmYzU4ZWVmZmY5MWQ1OTJhZWIzNTg4MmI0IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 89a74a73f3ec4c27ba719bfeceb8c7218152af910470c1347d7a2fd06dc2e0d4 -->
<!-- pinot-pr-flow:end -->

## Motivation

by default NettyConfig does not use native transports.

## Modifications

- update Netty properties in ClusterTest.java

## Result

This change enables Netty native transports for all integration tests.


