### PR TITLE
upgrade mockito version to 5.11.0

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -324,18 +324,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <!--
-      NOTE: use `mockito-inline` here instead of `mockito-core`, as mockito-core does not support mocking static function:
-      ```
-      org.mockito.exceptions.base.MockitoException:
-      The used MockMaker SubclassByteBuddyMockMaker does not support the creation of static mocks
-
-      Mockito's inline mock maker supports static mocks based on the Instrumentation API.
-      You can simply enable this mock mode, by placing the 'mockito-inline' artifact where you are currently using 'mockito-core'.
-      Note that Mockito's inline mock maker is not supported on Android.
-      ```
-      -->
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pinot-core/pom.xml
+++ b/pinot-core/pom.xml
@@ -213,7 +213,7 @@
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pinot-segment-local/pom.xml
+++ b/pinot-segment-local/pom.xml
@@ -108,10 +108,9 @@
       <artifactId>testng</artifactId>
       <scope>test</scope>
     </dependency>
-    <!-- required for static mock in IndexCreatorOverrideTest -->
     <dependency>
       <groupId>org.mockito</groupId>
-      <artifactId>mockito-inline</artifactId>
+      <artifactId>mockito-core</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1194,13 +1194,7 @@
       <dependency>
         <groupId>org.mockito</groupId>
         <artifactId>mockito-core</artifactId>
-        <version>5.5.0</version>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.mockito</groupId>
-        <artifactId>mockito-inline</artifactId>
-        <version>5.2.0</version>
+        <version>5.11.0</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
mockito 5.11.0 is the latest version of mockito.

## mockito-inline

mockito-inline no longer exists

see: https://github.com/mockito/mockito/issues/2877
