### PR TITLE
Hash Function for UUID Primary Keys

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/HashUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/HashUtils.java
@@ -57,9 +57,9 @@ public class HashUtils {
       UUID uuid;
       try {
         uuid = UUID.fromString(new String(tempBytes, StandardCharsets.UTF_8));
-      } catch (Exception ignored) {
-        // All bytes of the UUID in case of failures will be set to 0
-        uuid = new UUID(0L, 0L);
+      } catch (Exception e) {
+        // In case of failures, make the hash no-op.
+        return bytes;
       }
       long lsb = uuid.getLeastSignificantBits();
       long msb = uuid.getMostSignificantBits();

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/HashUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/HashUtils.java
@@ -86,8 +86,8 @@ public class HashUtils {
     byte[][] allValueBytes = new byte[values.length][];
     int totalLen = 0;
     for (int j = 0; j < allValueBytes.length; j++) {
-      allValueBytes[j] = values[j] == null ? "null".getBytes(StandardCharsets.UTF_8) :
-          values[j].toString().getBytes(StandardCharsets.UTF_8);
+      allValueBytes[j] = values[j] == null ? "null".getBytes(StandardCharsets.UTF_8)
+          : values[j].toString().getBytes(StandardCharsets.UTF_8);
       totalLen += allValueBytes[j].length;
     }
     byte[] result = new byte[totalLen];

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/HashUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/HashUtils.java
@@ -44,8 +44,7 @@ public class HashUtils {
    * Returns a byte array that is a concatenation of the binary representation of each of the passed UUID values. This
    * is done by getting a String from each value by calling {@link Object#toString()}, which is then used to create a
    * {@link UUID} object. The 16 bytes of each UUID are appended to a buffer which is then returned in the result.
-   * If any of the value is not a valid UUID, then this function appends the UTF-8 string bytes of all elements and
-   * returns that in the result.
+   * If any of the values is not a valid UUID, then we return the result of {@link #concatenate}.
    */
   public static byte[] hashUUID(Object[] values) {
     byte[] result = new byte[values.length * 16];
@@ -54,10 +53,9 @@ public class HashUtils {
       if (value == null) {
         return concatenate(values);
       }
-      String uuidString = value.toString();
       UUID uuid;
       try {
-        uuid = UUID.fromString(uuidString);
+        uuid = UUID.fromString(value.toString());
       } catch (Throwable t) {
         return concatenate(values);
       }
@@ -82,12 +80,16 @@ public class HashUtils {
     }
   }
 
+  /**
+   * Concatenates the string representation of all values into a single byte array. Each element is appended with a
+   * byte-0 delimiter.
+   */
   private static byte[] concatenate(Object[] values) {
     byte[][] allValueBytes = new byte[values.length][];
     int totalLen = 0;
     for (int j = 0; j < allValueBytes.length; j++) {
-      allValueBytes[j] = values[j] == null ? "null".getBytes(StandardCharsets.UTF_8)
-          : values[j].toString().getBytes(StandardCharsets.UTF_8);
+      allValueBytes[j] = values[j] == null ? "null\0".getBytes(StandardCharsets.UTF_8)
+          : (values[j].toString() + "\0").getBytes(StandardCharsets.UTF_8);
       totalLen += allValueBytes[j].length;
     }
     byte[] result = new byte[totalLen];

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/HashUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/HashUtilsTest.java
@@ -40,8 +40,15 @@ public class HashUtilsTest {
     testHashUUID(new UUID[]{UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()});
 
     // Test failure scenario
-    String[] invalidUUID = new String[]{"some-random-string"};
-    Assert.assertEquals(HashUtils.hashUUID(invalidUUID), invalidUUID[0].getBytes(StandardCharsets.UTF_8));
+    String[] invalidUUIDs = new String[]{"some-random-string"};
+    Assert.assertEquals(HashUtils.hashUUID(invalidUUIDs), invalidUUIDs[0].getBytes(StandardCharsets.UTF_8));
+    // Test scenario when one of the values is null
+    invalidUUIDs = new String[]{UUID.randomUUID().toString(), null};
+    byte[] hashResult = HashUtils.hashUUID(invalidUUIDs);
+    Assert.assertNotNull(hashResult);
+    byte[] lastFourBytes = new byte[4];
+    System.arraycopy(hashResult, hashResult.length - 4, lastFourBytes, 0, lastFourBytes.length);
+    Assert.assertEquals(new String(lastFourBytes, StandardCharsets.UTF_8), "null");
   }
 
   private void testHashUUID(UUID[] uuids) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/HashUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/HashUtilsTest.java
@@ -38,6 +38,12 @@ public class HashUtilsTest {
   public void testHashUUIDv4() {
     testHashUUIDv4(new UUID[]{UUID.randomUUID()});
     testHashUUIDv4(new UUID[]{UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()});
+
+    // Test failure scenario
+    byte[] invalidType4UUID = new byte[8];
+    // Set byte 0 to an arbitrary value. Hash function below should return the input array as is.
+    invalidType4UUID[0] = 0x10;
+    Assert.assertEquals(HashUtils.hashUUIDv4(invalidType4UUID), invalidType4UUID);
   }
 
   private void testHashUUIDv4(UUID[] uuids) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/HashUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/HashUtilsTest.java
@@ -35,26 +35,17 @@ public class HashUtilsTest {
   }
 
   @Test
-  public void testHashUUIDv4() {
-    testHashUUIDv4(new UUID[]{UUID.randomUUID()});
-    testHashUUIDv4(new UUID[]{UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()});
+  public void testHashUUID() {
+    testHashUUID(new UUID[]{UUID.randomUUID()});
+    testHashUUID(new UUID[]{UUID.randomUUID(), UUID.randomUUID(), UUID.randomUUID()});
 
     // Test failure scenario
-    byte[] invalidType4UUID = new byte[8];
-    // Set byte 0 to an arbitrary value. Hash function below should return the input array as is.
-    invalidType4UUID[0] = 0x10;
-    Assert.assertEquals(HashUtils.hashUUIDv4(invalidType4UUID), invalidType4UUID);
+    String[] invalidUUID = new String[]{"some-random-string"};
+    Assert.assertEquals(HashUtils.hashUUID(invalidUUID), invalidUUID[0].getBytes(StandardCharsets.UTF_8));
   }
 
-  private void testHashUUIDv4(UUID[] uuids) {
-    StringBuilder concatenatedUUID = new StringBuilder();
-    for (UUID uuid : uuids) {
-      concatenatedUUID.append(uuid);
-    }
-    byte[] inputBytes = concatenatedUUID.toString().getBytes(StandardCharsets.UTF_8);
-    // Ensure test data is valid. Each UUID in string form should be 36 bytes.
-    Assert.assertEquals(inputBytes.length, 36 * uuids.length);
-    byte[] convertedBytes = HashUtils.hashUUIDv4(inputBytes);
+  private void testHashUUID(UUID[] uuids) {
+    byte[] convertedBytes = HashUtils.hashUUID(uuids);
     // After hashing, each UUID should take 16 bytes.
     Assert.assertEquals(convertedBytes.length, 16 * uuids.length);
     // Below we reconstruct each UUID from the reduced 16-byte representation, and ensure it is the same as the input.

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/HashUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/HashUtilsTest.java
@@ -22,6 +22,7 @@ import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
 import java.nio.charset.StandardCharsets;
 import java.util.UUID;
+import org.apache.pinot.spi.data.readers.PrimaryKey;
 import org.apache.pinot.spi.utils.BytesUtils;
 import org.testng.Assert;
 import org.testng.annotations.Test;
@@ -43,7 +44,7 @@ public class HashUtilsTest {
 
     // Test failure scenario when there's a non-null invalid uuid value
     String[] invalidUUIDs = new String[]{"some-random-string"};
-    byte[] hashResult = HashUtils.hashUUID(invalidUUIDs);
+    byte[] hashResult = HashUtils.hashUUID(new PrimaryKey(invalidUUIDs));
     // In case of failures, each element is prepended with length
     byte[] expectedResult = new byte[invalidUUIDs[0].length() + 4];
     ByteBuffer tempByteBuffer = ByteBuffer.wrap(expectedResult).order(ByteOrder.BIG_ENDIAN);
@@ -52,7 +53,7 @@ public class HashUtilsTest {
     Assert.assertEquals(hashResult, expectedResult);
     // Test failure scenario when one of the values is null
     invalidUUIDs = new String[]{UUID.randomUUID().toString(), null};
-    hashResult = HashUtils.hashUUID(invalidUUIDs);
+    hashResult = HashUtils.hashUUID(new PrimaryKey(invalidUUIDs));
     expectedResult = new byte[invalidUUIDs[0].length() + "null".length() + 8];
     tempByteBuffer = ByteBuffer.wrap(expectedResult).order(ByteOrder.BIG_ENDIAN);
     tempByteBuffer.putInt(invalidUUIDs[0].length());
@@ -63,7 +64,7 @@ public class HashUtilsTest {
   }
 
   private void testHashUUID(UUID[] uuids) {
-    byte[] convertedBytes = HashUtils.hashUUID(uuids);
+    byte[] convertedBytes = HashUtils.hashUUID(new PrimaryKey(uuids));
     // After hashing, each UUID should take 16 bytes.
     Assert.assertEquals(convertedBytes.length, 16 * uuids.length);
     // Below we reconstruct each UUID from the reduced 16-byte representation, and ensure it is the same as the input.

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/HashFunction.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/HashFunction.java
@@ -19,5 +19,5 @@
 package org.apache.pinot.spi.config.table;
 
 public enum HashFunction {
-  NONE, MD5, MURMUR3, UUID_V4
+  NONE, MD5, MURMUR3, UUID
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/HashFunction.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/HashFunction.java
@@ -19,5 +19,5 @@
 package org.apache.pinot.spi.config.table;
 
 public enum HashFunction {
-  NONE, MD5, MURMUR3
+  NONE, MD5, MURMUR3, UUID_V4
 }


### PR DESCRIPTION
This can help reduce memory (disk for off-heap hashmap) usage for scenarios where all columns of the Primary Key are UUIDs (as defined in RFC 4122). This can also handle scenarios where some values are not valid UUIDs, by simply switching to being a no-op hash-function.

Using Murmur's 128 bit hash-function will either give the same or higher space savings (in case of composite keys), but it risks hash collision. Though chances of that are extremely low, we usually avoid any exposure for critical use-cases.

**Test Plan:** Added UTs. Also tested this in our cluster and some results are as follows.

### Testing on Cluster (~35% Old Gen improvement)

Onboarded some test tables to one of our large servers. Each server ingested from the same Kafka topic, and both of them ended up with ~397M primary keys.

You can see the memory savings in the graph below. At 17:21 I triggered a full GC by running `jmap -histo:live` on both servers. I triggered a full GC again a few minutes later which corresponds to the second dip in old gen.

<img width="1724" alt="image" src="https://github.com/apache/pinot/assets/8644710/ed4096f8-1b45-4d38-899d-f438b2d7aed2">

Here's the output of `jmap -histo:live` in the two servers:

Server with no hashing:

```
num     #instances         #bytes  class name (module)
-------------------------------------------------------
   1:     405356239    26288334696  [B (java.base@11.0.22)
   2:     405016060    19440770880  java.util.concurrent.ConcurrentHashMap$Node (java.base@11.0.22)
   3:     396819098    15872763920  org.apache.pinot.segment.local.upsert.ConcurrentMapPartitionUpsertMetadataManager$RecordLocation
   4:     396947570    13331326424  [Ljava.lang.Object; (java.base@11.0.22)
   5:     405208908    12966685056  java.lang.String (java.base@11.0.22)
   6:     396819098     9523658352  org.apache.pinot.spi.data.readers.PrimaryKey
   7:          8304     6710581760  [Ljava.util.concurrent.ConcurrentHashMap$Node; (java.base@11.0.22)
   8:     118497450     3966607216  [C (java.base@11.0.22)
   9:      61298209     3432699704  java.nio.HeapCharBuffer (java.base@11.0.22)
  10:      57191904     3235026912  [Lorg.roaringbitmap.buffer.MappeableContainer;
...
```

Server with UUID hashing:

```
 num     #instances         #bytes  class name (module)
-------------------------------------------------------
   1:     404045476    19394182848  java.util.concurrent.ConcurrentHashMap$Node (java.base@11.0.22)
   2:     404386800    16702510464  [B (java.base@11.0.22)
   3:     396820100    15872804000  org.apache.pinot.segment.local.upsert.ConcurrentMapPartitionUpsertMetadataManager$RecordLocation
   4:     396820101    12698243232  org.apache.pinot.spi.utils.ByteArray
   5:          8152     6621435072  [Ljava.util.concurrent.ConcurrentHashMap$Node; (java.base@11.0.22)
   6:         15846     2171269472  [I (java.base@11.0.22)
   7:      30760333     1066705472  [C (java.base@11.0.22)
   8:      15922426      891655856  java.nio.HeapCharBuffer (java.base@11.0.22)
   9:      14830564      838747616  [Lorg.roaringbitmap.buffer.MappeableContainer;
  10:      14830564      593222560  org.roaringbitmap.buffer.MutableRoaringArray
...
```