### PR TITLE
bugfix: do not move src ByteBuffer position for LZ4 length prefixed decompress

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/compression/LZ4WithLengthDecompressor.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/io/compression/LZ4WithLengthDecompressor.java
@@ -41,7 +41,11 @@ class LZ4WithLengthDecompressor implements ChunkDecompressor {
   @Override
   public int decompress(ByteBuffer compressedInput, ByteBuffer decompressedOutput)
       throws IOException {
-    _decompressor.decompress(compressedInput, decompressedOutput);
+    // LZ4DecompressorWithLength.decompress(src, out) should not be called directly as it can move src.position
+    // beyond src.limit(). This implementation only moves dest.position
+    _decompressor.decompress(compressedInput, compressedInput.position(), decompressedOutput,
+        decompressedOutput.position());
+    decompressedOutput.position(decompressedOutput.position() + decompressedLength(compressedInput));
     decompressedOutput.flip();
     return decompressedOutput.limit();
   }


### PR DESCRIPTION
Addresses https://github.com/apache/pinot/issues/12534 

Based on my understanding, calling `_decompressor.decompress(compressedInput, decompressedOutput)` is problematic because it [moves the position](https://javadoc.io/doc/org.lz4/lz4-java/1.6.0/net/jpountz/lz4/LZ4DecompressorWithLength.html#decompress(java.nio.ByteBuffer,%20java.nio.ByteBuffer)) of the src and dest ByteBuffers. It is possible to move the position of the src buffer beyond the limit of the buffer (see issue for details).

The change calls the [same underlying method](https://github.com/lz4/lz4-java/blob/master/src/java/net/jpountz/lz4/LZ4DecompressorWithLength.java#L246), but only moves the position of the dest buffer. The reason why this was a V4 raw index writer/reader version issue is that this only happens with the length prefixed LZ4 library, and this code path is not used for other raw index writer versions.


Testing: Set up a unit test locally, now able to read a previously unreadable segment when loading/iterating through a problematic column using PinotSegmentRecordReader