### PR TITLE
Potential bug fix for supporting sorted-indexes for partial-upsert

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -788,7 +788,7 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
    */
   @SuppressWarnings({"rawtypes", "unchecked"})
   protected static Iterator<RecordInfo> resolveComparisonTies(Iterator<RecordInfo> recordInfoIterator,
-      HashFunction hashFunction) {
+      HashFunction hashFunction, List<Integer> originalDocIDPositionMappings) {
     Map<Object, RecordInfo> deDuplicatedRecordInfo = new HashMap<>();
     while (recordInfoIterator.hasNext()) {
       RecordInfo recordInfo = recordInfoIterator.next();
@@ -801,9 +801,13 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
             int comparisonResult = newComparisonValue.compareTo(maxComparisonValueRecordInfo.getComparisonValue());
             if (comparisonResult > 0) {
               return recordInfo;
-            }
-            if (comparisonResult == 0 && recordInfo.getDocId() > maxComparisonValueRecordInfo.getDocId()) {
-              return recordInfo;
+            } else if (comparisonResult == 0) {
+              // Check if mappings are empty or the current record has a higher doc ID position
+              if (originalDocIDPositionMappings.isEmpty()
+                  || originalDocIDPositionMappings.get(recordInfo.getDocId())
+                      > originalDocIDPositionMappings.get(maxComparisonValueRecordInfo.getDocId())) {
+                return recordInfo;
+              }
             }
             return maxComparisonValueRecordInfo;
           });

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -799,7 +799,10 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
               return recordInfo;
             }
             int comparisonResult = newComparisonValue.compareTo(maxComparisonValueRecordInfo.getComparisonValue());
-            if (comparisonResult >= 0) {
+            if (comparisonResult > 0) {
+              return recordInfo;
+            }
+            if (comparisonResult == 0 && recordInfo.getDocId() > maxComparisonValueRecordInfo.getDocId()) {
               return recordInfo;
             }
             return maxComparisonValueRecordInfo;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -19,8 +19,10 @@
 package org.apache.pinot.segment.local.upsert;
 
 import com.google.common.annotations.VisibleForTesting;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
+import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
@@ -72,8 +74,10 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
     String segmentName = segment.getSegmentName();
     segment.enableUpsert(this, validDocIds, queryableDocIds);
 
+    List<Integer> originalDocIDPositions = oldSegment != null
+        ? oldSegment.getOriginalDocIDPositionMapping() : Collections.emptyList();
     if (_partialUpsertHandler != null) {
-      recordInfoIterator = resolveComparisonTies(recordInfoIterator, _hashFunction);
+      recordInfoIterator = resolveComparisonTies(recordInfoIterator, _hashFunction, originalDocIDPositions);
     }
     AtomicInteger numKeysInWrongSegment = new AtomicInteger();
     while (recordInfoIterator.hasNext()) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
@@ -268,6 +268,25 @@ public class BasePartitionUpsertMetadataManagerTest {
     assertEquals(recordsByPrimaryKeys.get(makePrimaryKey(0)).getDocId(), 5);
     assertEquals(recordsByPrimaryKeys.get(makePrimaryKey(1)).getDocId(), 4);
     assertEquals(recordsByPrimaryKeys.get(makePrimaryKey(2)).getDocId(), 2);
+
+    // test for scenario where we are passing sorted-index
+    List<Integer> originalDocIDPositionMappings = Arrays.asList(5, 4, 3, 2, 1, 0);
+    // Resolve comparison ties
+    deDuplicatedRecords =
+        BasePartitionUpsertMetadataManager.resolveComparisonTies(recordInfoList.iterator(), HashFunction.NONE,
+            originalDocIDPositionMappings);
+    // Ensure we have only 1 record for each unique primary key
+    recordsByPrimaryKeys = new HashMap<>();
+    while (deDuplicatedRecords.hasNext()) {
+      RecordInfo recordInfo = deDuplicatedRecords.next();
+      assertFalse(recordsByPrimaryKeys.containsKey(recordInfo.getPrimaryKey()));
+      recordsByPrimaryKeys.put(recordInfo.getPrimaryKey(), recordInfo);
+    }
+    assertEquals(recordsByPrimaryKeys.size(), 3);
+    // Ensure that to resolve ties, we pick the docId corresponding to the max docId of the old mapping
+    assertEquals(recordsByPrimaryKeys.get(makePrimaryKey(0)).getDocId(), 0);
+    assertEquals(recordsByPrimaryKeys.get(makePrimaryKey(1)).getDocId(), 1);
+    assertEquals(recordsByPrimaryKeys.get(makePrimaryKey(2)).getDocId(), 2);
   }
 
   private static ThreadSafeMutableRoaringBitmap createValidDocIds(int... docIds) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManagerTest.java
@@ -254,7 +254,8 @@ public class BasePartitionUpsertMetadataManagerTest {
     }
     // Resolve comparison ties
     Iterator<RecordInfo> deDuplicatedRecords =
-        BasePartitionUpsertMetadataManager.resolveComparisonTies(recordInfoList.iterator(), HashFunction.NONE);
+        BasePartitionUpsertMetadataManager.resolveComparisonTies(recordInfoList.iterator(), HashFunction.NONE,
+            Collections.emptyList());
     // Ensure we have only 1 record for each unique primary key
     Map<PrimaryKey, RecordInfo> recordsByPrimaryKeys = new HashMap<>();
     while (deDuplicatedRecords.hasNext()) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.spi;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import javax.annotation.Nullable;
@@ -140,4 +141,11 @@ public interface IndexSegment {
    * Destroys segment in memory and closes file handlers if in MMAP mode.
    */
   void destroy();
+
+  /**
+   * Returns the mapping of original doc id position to current doc id position. Used in sorted value indexes.
+   */
+  default List<Integer> getOriginalDocIDPositionMapping() {
+    return Collections.emptyList();
+  }
 }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Flow shows sorted\-index mapping built in mutable segment, then used during upsert to break comparison ties by preferring higher original doc ID\.

```mermaid
flowchart TD
  N0["getSortedDocIdIterationOrderWithSortedColumn #40;F1#41;"]:::stModified
  N1["#95;originalDocIDPositionMapping #40;F1#41;"]:::stAdded
  N2["getOriginalDocIDPositionMapping #40;F1#41;"]:::stAdded
  N3["getOriginalDocIDPositionMapping #40;default#41; #40;F4#41;"]:::stAdded
  N4["addOrReplaceSegment #40;F3#41;"]:::stModified
  N5["resolveComparisonTies #40;F2#41;"]:::stModified
  N0 -->|"writes to"| N1
  N1 -->|"read by"| N2
  N2 -->|"overrides"| N3
  N4 -->|"calls"| N3
  N4 -->|"calls"| N5
  N1 -->|"uses for tie#45;breaking"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl\.java — [before](https://github.com/apache/pinot/blob/7ccd2164018505a25c1f91de437088f730e969ec/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java) · [after](https://github.com/apache/pinot/blob/f0d82d2873e42f29b8ba180c20a0e5297356a738/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/indexsegment/mutable/MutableSegmentImpl.java)
- F2: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager\.java — [before](https://github.com/apache/pinot/blob/7ccd2164018505a25c1f91de437088f730e969ec/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java) · [after](https://github.com/apache/pinot/blob/f0d82d2873e42f29b8ba180c20a0e5297356a738/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java)
- F3: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager\.java — [before](https://github.com/apache/pinot/blob/7ccd2164018505a25c1f91de437088f730e969ec/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java) · [after](https://github.com/apache/pinot/blob/f0d82d2873e42f29b8ba180c20a0e5297356a738/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java)
- F4: pinot\-segment\-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment\.java — [before](https://github.com/apache/pinot/blob/7ccd2164018505a25c1f91de437088f730e969ec/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment.java) · [after](https://github.com/apache/pinot/blob/f0d82d2873e42f29b8ba180c20a0e5297356a738/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/IndexSegment.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjdjY2QyMTY0MDE4NTA1YTI1YzFmOTFkZTQzNzA4OGY3MzBlOTY5ZWMiLCJjb250ZXh0X2hhc2giOiJjODhjYTVhMTZkNDllY2UyODg3MjQ4ZjdjZmEyMWU4MzQ2NzJjNzE5NWU0MThlYjU5ZGRiN2IzZDI4MmI4N2M3IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTI2MTUxLCJoZWFkX3NoYSI6ImYwZDgyZDI4NzNlNDJmMjliOGJhMTgwYzIwYTBlNTI5NzM1NmE3MzgiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI3Y2NkMjE2NDAxODUwNWEyNWMxZjkxZGU0MzcwODhmNzMwZTk2OWVjIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 591c5d169153073b0065b188c0841d9942ea9806f4f123f64412bdd2b5ebce1d -->
<!-- pinot-pr-flow:end -->

label:
`bugfix` 
`upsert` 

Potential fix for #12397 

As called out in the issue:

> With Partial Upserts, say we had 4 events for a given primary-key in the Mutable Segment: R0, R1, R2, R3. Let's also assume that the comparison column value of these events is: R0 < R1 < (R2 = R3).
> 
> If after applying the sorted column, their order changes to: R0, R1, R3, R2, then the UMM will start pointing to R2 as the valid doc.
> 

Now based on the assumption that R3's docId will be greater than R2's docId, raising this fix as an echancement to fix in #12395 where in case of same comparison column value we also check the docID value of the old mutable segment to know for a particular record which one to keep.

We keep the max-doc-id of older segment in making this decision. Say, in the example above; we will ensure to dedup R3 as the only record.

Tested in our local cluster by adding sorted-index column to a table with constant comparison column. Ensured that we are deduping the correct record and persisting it. Added UTs for updating the `resolvingComparisonTies` method.

cc @ankitsultana @Jackie-Jiang 
