### PR TITLE
Logging a warn message instead of throwing exception for adhoc trigger

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/minion/PinotTaskManager.java
@@ -47,7 +47,6 @@ import org.apache.pinot.common.minion.TaskGeneratorMostRecentRunInfo;
 import org.apache.pinot.common.minion.TaskManagerStatusCache;
 import org.apache.pinot.controller.ControllerConf;
 import org.apache.pinot.controller.LeadControllerManager;
-import org.apache.pinot.controller.api.exception.NoTaskScheduledException;
 import org.apache.pinot.controller.api.exception.TaskAlreadyExistsException;
 import org.apache.pinot.controller.api.exception.UnknownTaskTypeException;
 import org.apache.pinot.controller.helix.core.PinotHelixResourceManager;
@@ -212,7 +211,7 @@ public class PinotTaskManager extends ControllerPeriodicTask<Void> {
               taskGenerator.getMaxAttemptsPerTask()));
     }
     if (responseMap.isEmpty()) {
-      throw new NoTaskScheduledException("No task scheduled for 'tableName': " + tableName);
+      LOGGER.warn("No task submitted for tableName: {}", tableName);
     }
     return responseMap;
   }


### PR DESCRIPTION
**Whats in the PR:**
Logging a warn message when no task is submitted, instead of throwing an exception. 

**Why its needed:**
The underlying task implementation need not generate a task for various reasons (eg: not re-ingesting same data). When there are no issues with the task trigger itself (eg: invalid inputs), we should not be throwing an exception which misleads users of this API into thinking theres an issue in the way, api is used. Also the logic in createTask does allow for empty task from individual taskType. We can stick to a warn message when none of the taskTypes generates a task. We do propagate the exception when there are invalid inputs or underlying task implementation throws an exception.

if (pinotTaskConfigs.isEmpty()) {
        LOGGER.warn("No ad-hoc task generated for task type: {}", taskType);
        continue;
      }