### PR TITLE
Fix issue with startree index metadata loading for columns with '__' in name

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -91,6 +91,8 @@ abstract class BaseStarTreeV2Test<R, A> {
 
   private static final int NUM_SEGMENT_RECORDS = 100_000;
   private static final int MAX_LEAF_RECORDS = RANDOM.nextInt(100) + 1;
+  // Using column names with '__' to make sure regular table columns with '__' in the name aren't wrongly interpreted
+  // as AggregationFunctionColumnPair
   private static final String DIMENSION_D1 = "d1__COLUMN_NAME";
   private static final String DIMENSION_D2 = "__d2";
   private static final int DIMENSION_CARDINALITY = 100;

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -91,32 +91,35 @@ abstract class BaseStarTreeV2Test<R, A> {
 
   private static final int NUM_SEGMENT_RECORDS = 100_000;
   private static final int MAX_LEAF_RECORDS = RANDOM.nextInt(100) + 1;
-  private static final String DIMENSION_D1 = "d1";
-  private static final String DIMENSION_D2 = "d2";
+  private static final String DIMENSION_D1 = "d1__COLUMN_NAME";
+  private static final String DIMENSION_D2 = "__d2";
   private static final int DIMENSION_CARDINALITY = 100;
   private static final String METRIC = "m";
 
   // Supported filters
-  private static final String QUERY_FILTER_AND = " WHERE d1 = 0 AND d2 < 10";
+  private static final String QUERY_FILTER_AND = " WHERE d1__COLUMN_NAME = 0 AND __d2 < 10";
   // StarTree supports OR predicates only on a single dimension
-  private static final String QUERY_FILTER_OR = " WHERE d1 > 10 OR d1 < 50";
-  private static final String QUERY_FILTER_COMPLEX_OR_MULTIPLE_DIMENSIONS = " WHERE d2 < 95 AND (d1 > 10 OR d1 < 50)";
+  private static final String QUERY_FILTER_OR = " WHERE d1__COLUMN_NAME > 10 OR d1__COLUMN_NAME < 50";
+  private static final String QUERY_FILTER_COMPLEX_OR_MULTIPLE_DIMENSIONS =
+      " WHERE __d2 < 95 AND (d1__COLUMN_NAME > 10 OR d1__COLUMN_NAME < 50)";
   private static final String QUERY_FILTER_COMPLEX_AND_MULTIPLE_DIMENSIONS_THREE_PREDICATES =
-      " WHERE d2 < 95 AND d2 > 25 AND (d1 > 10 OR d1 < 50)";
+      " WHERE __d2 < 95 AND __d2 > 25 AND (d1__COLUMN_NAME > 10 OR d1__COLUMN_NAME < 50)";
   private static final String QUERY_FILTER_COMPLEX_OR_MULTIPLE_DIMENSIONS_THREE_PREDICATES =
-      " WHERE (d2 > 95 OR d2 < 25) AND (d1 > 10 OR d1 < 50)";
-  private static final String QUERY_FILTER_COMPLEX_OR_SINGLE_DIMENSION = " WHERE d1 = 95 AND (d1 > 90 OR d1 < 100)";
+      " WHERE (__d2 > 95 OR __d2 < 25) AND (d1__COLUMN_NAME > 10 OR d1__COLUMN_NAME < 50)";
+  private static final String QUERY_FILTER_COMPLEX_OR_SINGLE_DIMENSION =
+      " WHERE d1__COLUMN_NAME = 95 AND (d1__COLUMN_NAME > 90 OR d1__COLUMN_NAME < 100)";
 
   // Unsupported filters
-  private static final String QUERY_FILTER_OR_MULTIPLE_DIMENSIONS = " WHERE d1 > 10 OR d2 < 50";
-  private static final String QUERY_FILTER_OR_ON_AND = " WHERE (d1 > 10 AND d1 < 50) OR d1 < 50";
-  private static final String QUERY_FILTER_OR_ON_NOT = " WHERE (NOT d1 > 10) OR d1 < 50";
+  private static final String QUERY_FILTER_OR_MULTIPLE_DIMENSIONS = " WHERE d1__COLUMN_NAME > 10 OR __d2 < 50";
+  private static final String QUERY_FILTER_OR_ON_AND =
+      " WHERE (d1__COLUMN_NAME > 10 AND d1__COLUMN_NAME < 50) OR d1__COLUMN_NAME < 50";
+  private static final String QUERY_FILTER_OR_ON_NOT = " WHERE (NOT d1__COLUMN_NAME > 10) OR d1__COLUMN_NAME < 50";
   // Always false filters
-  private static final String QUERY_FILTER_ALWAYS_FALSE = " WHERE d1 > 100";
-  private static final String QUERY_FILTER_OR_ALWAYS_FALSE = " WHERE d1 > 100 OR d1 < 0";
+  private static final String QUERY_FILTER_ALWAYS_FALSE = " WHERE d1__COLUMN_NAME > 100";
+  private static final String QUERY_FILTER_OR_ALWAYS_FALSE = " WHERE d1__COLUMN_NAME > 100 OR d1__COLUMN_NAME < 0";
 
-  private static final String QUERY_GROUP_BY = " GROUP BY d2";
-  private static final String FILTER_AGG_CLAUSE = " FILTER(WHERE d1 > 10)";
+  private static final String QUERY_GROUP_BY = " GROUP BY __d2";
+  private static final String FILTER_AGG_CLAUSE = " FILTER(WHERE d1__COLUMN_NAME > 10)";
 
   private ValueAggregator _valueAggregator;
   private DataType _aggregatedValueType;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexMapUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexMapUtils.java
@@ -27,7 +27,6 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
-import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration2.PropertiesConfiguration;
@@ -199,9 +198,13 @@ public class StarTreeIndexMapUtils {
           column = StringUtils.join(split, KEY_SEPARATOR, 1, columnSplitEndIndex);
         }
         // Convert metric (function-column pair) to stored name for backward-compatibility
-        Optional<AggregationFunctionColumnPair> functionColumnPair = AggregationFunctionColumnPair.accept(column);
-        if (functionColumnPair.isPresent()) {
-          column = AggregationFunctionColumnPair.resolveToStoredType(functionColumnPair.get()).toColumnName();
+        if (column.contains(AggregationFunctionColumnPair.DELIMITER)) {
+          try {
+            AggregationFunctionColumnPair functionColumnPair = AggregationFunctionColumnPair.fromColumnName(column);
+            column = AggregationFunctionColumnPair.resolveToStoredType(functionColumnPair).toColumnName();
+          } catch (Exception e) {
+            // Ignoring this exception for columns that are not metric (function-column pair)
+          }
         }
         indexKey = new IndexKey(IndexType.FORWARD_INDEX, column);
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexMapUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexMapUtils.java
@@ -27,6 +27,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import org.apache.commons.configuration2.PropertiesConfiguration;
@@ -198,9 +199,9 @@ public class StarTreeIndexMapUtils {
           column = StringUtils.join(split, KEY_SEPARATOR, 1, columnSplitEndIndex);
         }
         // Convert metric (function-column pair) to stored name for backward-compatibility
-        if (AggregationFunctionColumnPair.accept(column)) {
-          AggregationFunctionColumnPair functionColumnPair = AggregationFunctionColumnPair.fromColumnName(column);
-          column = AggregationFunctionColumnPair.resolveToStoredType(functionColumnPair).toColumnName();
+        Optional<AggregationFunctionColumnPair> functionColumnPair = AggregationFunctionColumnPair.accept(column);
+        if (functionColumnPair.isPresent()) {
+          column = AggregationFunctionColumnPair.resolveToStoredType(functionColumnPair.get()).toColumnName();
         }
         indexKey = new IndexKey(IndexType.FORWARD_INDEX, column);
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexMapUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/startree/v2/store/StarTreeIndexMapUtils.java
@@ -198,7 +198,7 @@ public class StarTreeIndexMapUtils {
           column = StringUtils.join(split, KEY_SEPARATOR, 1, columnSplitEndIndex);
         }
         // Convert metric (function-column pair) to stored name for backward-compatibility
-        if (column.contains(AggregationFunctionColumnPair.DELIMITER)) {
+        if (AggregationFunctionColumnPair.accept(column)) {
           AggregationFunctionColumnPair functionColumnPair = AggregationFunctionColumnPair.fromColumnName(column);
           column = AggregationFunctionColumnPair.resolveToStoredType(functionColumnPair).toColumnName();
         }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/AggregationFunctionColumnPair.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/AggregationFunctionColumnPair.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.spi.index.startree;
 
 import java.util.Comparator;
+import java.util.Optional;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.config.table.StarTreeAggregationConfig;
 
@@ -57,16 +58,16 @@ public class AggregationFunctionColumnPair implements Comparable<AggregationFunc
     return functionType.getName() + DELIMITER + column;
   }
 
-  public static boolean accept(String columnName) {
+  public static Optional<AggregationFunctionColumnPair> accept(String columnName) {
     try {
       String[] parts = columnName.split(DELIMITER, 2);
       if (parts.length != 2) {
-        return false;
+        return Optional.empty();
       }
-      fromFunctionAndColumnName(parts[0], parts[1]);
-      return true;
+      AggregationFunctionColumnPair result = fromFunctionAndColumnName(parts[0], parts[1]);
+      return Optional.of(result);
     } catch (IllegalArgumentException e) {
-      return false;
+      return Optional.empty();
     }
   }
 

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/AggregationFunctionColumnPair.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/AggregationFunctionColumnPair.java
@@ -57,6 +57,16 @@ public class AggregationFunctionColumnPair implements Comparable<AggregationFunc
     return functionType.getName() + DELIMITER + column;
   }
 
+  public static boolean accept(String columnName) {
+    try {
+      String[] parts = columnName.split(DELIMITER, 2);
+      fromFunctionAndColumnName(parts[0], parts[1]);
+      return true;
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
+  }
+
   public static AggregationFunctionColumnPair fromColumnName(String columnName) {
     String[] parts = columnName.split(DELIMITER, 2);
     return fromFunctionAndColumnName(parts[0], parts[1]);

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/AggregationFunctionColumnPair.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/AggregationFunctionColumnPair.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.segment.spi.index.startree;
 
 import java.util.Comparator;
-import java.util.Optional;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.spi.config.table.StarTreeAggregationConfig;
 
@@ -56,19 +55,6 @@ public class AggregationFunctionColumnPair implements Comparable<AggregationFunc
 
   public static String toColumnName(AggregationFunctionType functionType, String column) {
     return functionType.getName() + DELIMITER + column;
-  }
-
-  public static Optional<AggregationFunctionColumnPair> accept(String columnName) {
-    try {
-      String[] parts = columnName.split(DELIMITER, 2);
-      if (parts.length != 2) {
-        return Optional.empty();
-      }
-      AggregationFunctionColumnPair result = fromFunctionAndColumnName(parts[0], parts[1]);
-      return Optional.of(result);
-    } catch (IllegalArgumentException e) {
-      return Optional.empty();
-    }
   }
 
   public static AggregationFunctionColumnPair fromColumnName(String columnName) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/AggregationFunctionColumnPair.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/startree/AggregationFunctionColumnPair.java
@@ -60,6 +60,9 @@ public class AggregationFunctionColumnPair implements Comparable<AggregationFunc
   public static boolean accept(String columnName) {
     try {
       String[] parts = columnName.split(DELIMITER, 2);
+      if (parts.length != 2) {
+        return false;
+      }
       fromFunctionAndColumnName(parts[0], parts[1]);
       return true;
     } catch (IllegalArgumentException e) {


### PR DESCRIPTION
https://github.com/apache/pinot/pull/12164/files introduced shared aggregation which assumes all metadata entries with '__' in the name are AggregationFunctionColumnPair.

This breaks startree index loading for indexes build on columns with '__' in their name.

cc: @davecromberge @gortiz 