### PR TITLE
validate DropwizardMetricName equals

### DIFF
--- a/pinot-plugins/pinot-metrics/pinot-dropwizard/src/main/java/org/apache/pinot/plugin/metrics/dropwizard/DropwizardMetricName.java
+++ b/pinot-plugins/pinot-metrics/pinot-dropwizard/src/main/java/org/apache/pinot/plugin/metrics/dropwizard/DropwizardMetricName.java
@@ -18,10 +18,11 @@
  */
 package org.apache.pinot.plugin.metrics.dropwizard;
 
+import java.util.Objects;
 import org.apache.pinot.spi.metrics.PinotMetricName;
 
 
-public class DropwizardMetricName implements PinotMetricName {
+public final class DropwizardMetricName implements PinotMetricName {
   private final String _metricName;
 
   public DropwizardMetricName(Class<?> klass, String name) {
@@ -49,7 +50,7 @@ public class DropwizardMetricName implements PinotMetricName {
       return false;
     }
     DropwizardMetricName that = (DropwizardMetricName) obj;
-    return _metricName.equals(that._metricName);
+    return Objects.equals(_metricName, that._metricName);
   }
 
   /**
@@ -57,7 +58,7 @@ public class DropwizardMetricName implements PinotMetricName {
    */
   @Override
   public int hashCode() {
-    return _metricName.hashCode();
+    return Objects.hashCode(_metricName);
   }
 
   @Override

--- a/pinot-plugins/pinot-metrics/pinot-dropwizard/src/test/java/org/apache/pinot/plugin/metrics/dropwizard/DropwizardMetricNameTest.java
+++ b/pinot-plugins/pinot-metrics/pinot-dropwizard/src/test/java/org/apache/pinot/plugin/metrics/dropwizard/DropwizardMetricNameTest.java
@@ -1,0 +1,31 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.plugin.metrics.dropwizard;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.testng.annotations.Test;
+
+
+public class DropwizardMetricNameTest {
+  @Test
+  public void testEqualsContract() {
+    EqualsVerifier.forClass(DropwizardMetricName.class).verify();
+  }
+}

--- a/pinot-plugins/pom.xml
+++ b/pinot-plugins/pom.xml
@@ -64,6 +64,11 @@
       <artifactId>testng</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>nl.jqno.equalsverifier</groupId>
+      <artifactId>equalsverifier</artifactId>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <profiles>
     <profile>


### PR DESCRIPTION
We use the equalsverifier library to validate our 'equals' method

https://jqno.nl/equalsverifier/


