### PR TITLE
Upgrade hadoop version to 3.3.6

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -282,12 +282,6 @@
     <dependency>
       <groupId>org.apache.helix</groupId>
       <artifactId>helix-core</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>it.unimi.dsi</groupId>

--- a/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-protobuf/pom.xml
@@ -119,16 +119,6 @@
       <groupId>io.confluent</groupId>
       <artifactId>kafka-protobuf-serializer</artifactId>
       <version>${confluent.version}</version>
-      <exclusions>
-        <exclusion>
-          <groupId>org.jetbrains.kotlin</groupId>
-          <artifactId>kotlin-stdlib-common</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>com.squareup.okio</groupId>
-          <artifactId>okio</artifactId>
-        </exclusion>
-      </exclusions>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>

--- a/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-pulsar/pom.xml
@@ -51,7 +51,6 @@
     <javax.annotation-api.version>1.2</javax.annotation-api.version>
     <commons-collections.version>4.4</commons-collections.version>
     <grpc-protobuf-lite.version>1.19.0</grpc-protobuf-lite.version>
-    <okio.version>1.6.0</okio.version>
   </properties>
 
   <dependencies>
@@ -164,7 +163,6 @@
     <dependency>
       <groupId>com.squareup.okio</groupId>
       <artifactId>okio</artifactId>
-      <version>${okio.version}</version>
     </dependency>
     <dependency>
       <groupId>io.prometheus</groupId>

--- a/pinot-tools/pom.xml
+++ b/pinot-tools/pom.xml
@@ -157,10 +157,6 @@
       <scope>runtime</scope>
       <exclusions>
         <exclusion>
-          <groupId>javax.xml.bind</groupId>
-          <artifactId>jaxb-api</artifactId>
-        </exclusion>
-        <exclusion>
           <groupId>com.google.errorprone</groupId>
           <artifactId>error_prone_annotations</artifactId>
         </exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
     <grizzly.version>2.4.4</grizzly.version>
     <hk2.version>2.6.1</hk2.version>
     <swagger.version>1.6.9</swagger.version>
-    <hadoop.version>3.2.4</hadoop.version>
+    <hadoop.version>3.3.6</hadoop.version>
     <antlr.version>4.6</antlr.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <jsonsmart.version>2.5.0</jsonsmart.version>
@@ -197,6 +197,9 @@
     <commons-configuration2.version>2.9.0</commons-configuration2.version>
 
     <kotlin.stdlib.version>1.7.22</kotlin.stdlib.version>
+    <okio.version>2.10.0</okio.version>
+    <reload4j.version>1.2.25</reload4j.version>
+    <javax.xml.bind.version>2.3.1</javax.xml.bind.version>
   </properties>
 
   <profiles>
@@ -569,6 +572,16 @@
         <version>1.1.1</version>
       </dependency>
       <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>${javax.xml.bind.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>ch.qos.reload4j</groupId>
+        <artifactId>reload4j</artifactId>
+        <version>${reload4j.version}</version>
+      </dependency>
+      <dependency>
         <groupId>org.apache.helix</groupId>
         <artifactId>helix-core</artifactId>
         <version>${helix.version}</version>
@@ -892,10 +905,6 @@
         <version>${hadoop.version}</version>
         <scope>provided</scope>
         <exclusions>
-          <exclusion>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-          </exclusion>
           <exclusion>
             <groupId>org.codehaus.jackson</groupId>
             <artifactId>jackson-core-asl</artifactId>
@@ -1340,6 +1349,16 @@
         <groupId>org.jetbrains.kotlin</groupId>
         <artifactId>kotlin-stdlib</artifactId>
         <version>${kotlin.stdlib.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jetbrains.kotlin</groupId>
+        <artifactId>kotlin-stdlib-common</artifactId>
+        <version>${kotlin.stdlib.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio</artifactId>
+        <version>${okio.version}</version>
       </dependency>
       <dependency>
         <groupId>com.fasterxml.woodstox</groupId>


### PR DESCRIPTION
1. Upgrade hadoop version to 3.3.6 to fix cve.
2. Consolidate the libraries for:
- javax.xml.bind:jaxb-api
- org.jetbrains.kotlin:kotlin-stdlib-common
- com.squareup.okio:okio
