### PR TITLE
Update kotlin and okio dependency version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -196,10 +196,8 @@
     <flink.version>1.14.6</flink.version>
     <commons-configuration2.version>2.9.0</commons-configuration2.version>
 
-    <kotlin.stdlib.version>1.7.22</kotlin.stdlib.version>
-    <okio.version>2.10.0</okio.version>
-    <reload4j.version>1.2.25</reload4j.version>
-    <javax.xml.bind.version>2.3.1</javax.xml.bind.version>
+    <kotlin.stdlib.version>1.9.22</kotlin.stdlib.version>
+    <okio.version>3.8.0</okio.version>
   </properties>
 
   <profiles>
@@ -572,16 +570,6 @@
         <version>1.1.1</version>
       </dependency>
       <dependency>
-        <groupId>javax.xml.bind</groupId>
-        <artifactId>jaxb-api</artifactId>
-        <version>${javax.xml.bind.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>ch.qos.reload4j</groupId>
-        <artifactId>reload4j</artifactId>
-        <version>${reload4j.version}</version>
-      </dependency>
-      <dependency>
         <groupId>org.apache.helix</groupId>
         <artifactId>helix-core</artifactId>
         <version>${helix.version}</version>
@@ -944,6 +932,18 @@
         <artifactId>hadoop-hdfs-client</artifactId>
         <version>${hadoop.version}</version>
         <scope>provided</scope>
+      </dependency>
+      <!-- Solve the dependency converge issue within hadoop libraries -->
+      <dependency>
+        <groupId>ch.qos.reload4j</groupId>
+        <artifactId>reload4j</artifactId>
+        <version>1.2.25</version>
+      </dependency>
+      <!-- Solve the dependency converge issue between hadoop-common and orc-core -->
+      <dependency>
+        <groupId>javax.xml.bind</groupId>
+        <artifactId>jaxb-api</artifactId>
+        <version>2.3.1</version>
       </dependency>
 
       <!-- Metrics -->
@@ -1358,6 +1358,11 @@
       <dependency>
         <groupId>com.squareup.okio</groupId>
         <artifactId>okio</artifactId>
+        <version>${okio.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>com.squareup.okio</groupId>
+        <artifactId>okio-jvm</artifactId>
         <version>${okio.version}</version>
       </dependency>
       <dependency>


### PR DESCRIPTION
Also removes the variables for `reload4j` and `jaxb-api` version as they are no longer maintained and we shouldn't need to update them