### PR TITLE
fixing CVE critical issues by resolving kerby/jline and wildfly libraries

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -198,6 +198,9 @@
 
     <kotlin.stdlib.version>1.9.22</kotlin.stdlib.version>
     <okio.version>3.8.0</okio.version>
+    <kerby.version>2.0.3</kerby.version>
+    <jline.version>3.22.0</jline.version>
+    <wildfly.version>1.5.4.Final</wildfly.version>
   </properties>
 
   <profiles>
@@ -845,6 +848,10 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -925,6 +932,10 @@
             <groupId>commons-logging</groupId>
             <artifactId>commons-logging</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>io.netty</groupId>
+            <artifactId>netty</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -944,6 +955,26 @@
         <groupId>javax.xml.bind</groupId>
         <artifactId>jaxb-api</artifactId>
         <version>2.3.1</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.kerby</groupId>
+        <artifactId>kerb-core</artifactId>
+        <version>${kerby.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.kerby</groupId>
+        <artifactId>kerb-simplekdc</artifactId>
+        <version>${kerby.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.jline</groupId>
+        <artifactId>jline</artifactId>
+        <version>${jline.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.common</groupId>
+        <artifactId>wildfly-common</artifactId>
+        <version>${wildfly.version}</version>
       </dependency>
 
       <!-- Metrics -->


### PR DESCRIPTION
1. Remove io.netty:netty library
2. Consolidate org.apache.kerby:kerb-core and org.apache.kerby:kerb-simplekdc version to 2.0.3
3. Consolidate org.jline:jline version to 3.22.0
4. Consolidate org.wildfly.common:wildfly-common version to 1.5.4.Final