### PR TITLE
Initialize OOM protection on grpc path

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/grpc/GrpcQueryServer.java
@@ -51,6 +51,7 @@ import org.apache.pinot.core.query.request.ServerQueryRequest;
 import org.apache.pinot.core.query.scheduler.resources.ResourceManager;
 import org.apache.pinot.server.access.AccessControl;
 import org.apache.pinot.server.access.GrpcRequesterIdentity;
+import org.apache.pinot.spi.trace.Tracing;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -146,6 +147,8 @@ public class GrpcQueryServer extends PinotQueryServerGrpc.PinotQueryServerImplBa
       responseObserver.onError(Status.INVALID_ARGUMENT.withDescription("Bad request").withCause(e).asException());
       return;
     }
+
+    Tracing.ThreadAccountantOps.setupRunner(queryRequest.getQueryId());
 
     // Table level access control
     GrpcRequesterIdentity requestIdentity = new GrpcRequesterIdentity(request.getMetadataMap());


### PR DESCRIPTION
Observed an issue while testing [release-1.1.0-rc0](https://github.com/apache/pinot/tree/release-1.1.0-rc0) on with trino connector.

Running a query `select * from pinot.default.my_table limit 10;` on Trino always returns 0 rows.
Debugging Trino connector revealed that a grpc response from Pinot returns exception.

```
InternalError:
java.lang.NullPointerException
	at org.apache.pinot.core.accounting.PerQueryCPUMemAccountantFactory$PerQueryCPUMemResourceUsageAccountant.sampleThreadBytesAllocated(PerQueryCPUMemAccountantFactory.java:212)
	at org.apache.pinot.core.accounting.PerQueryCPUMemAccountantFactory$PerQueryCPUMemResourceUsageAccountant.sampleUsage(PerQueryCPUMemAccountantFactory.java:167)
	at org.apache.pinot.spi.trace.Tracing$ThreadAccountantOps.sample(Tracing.java:253)
	at org.apache.pinot.spi.trace.Tracing$ThreadAccountantOps.sampleAndCheckInterruption(Tracing.java:290)
```

We have the following OOM protection config:
```
pinot.query.scheduler.accounting.factory.name=org.apache.pinot.core.accounting.PerQueryCPUMemAccountantFactory│
pinot.server.instance.enableThreadAllocatedBytesMeasurement=true│
pinot.query.scheduler.accounting.enable.thread.memory.sampling=true│
pinot.query.scheduler.accounting.oom.enable.killing.query=true│
pinot.query.scheduler.accounting.accounting.oom.panic.heap.usage.ratio=0.98│
pinot.query.scheduler.accounting.accounting.oom.critical.heap.usage.ratio=0.95
```

Temporarily turning off OOM protection fixes the issue.

I believe OOM protection may not be initialised properly on gRPC path (which Trino connector uses).
This regression is potentially introduced with #11942 

This PR proposes a fix by initialising OOM protection on gRPC path.
Tested with locally with Trino connector.


