### PR TITLE
Fixing high severity CVEs in pinot-adls/pinot-orc/pinot-parquet

### DIFF
--- a/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
+++ b/pinot-plugins/pinot-file-system/pinot-adls/pom.xml
@@ -34,6 +34,7 @@
   <properties>
     <pinot.root>${basedir}/../../..</pinot.root>
     <phase.prop>package</phase.prop>
+    <wildfly-openssl.version>1.1.3.Final</wildfly-openssl.version>
   </properties>
   <dependencies>
     <dependency>
@@ -93,6 +94,21 @@
         <groupId>com.microsoft.azure</groupId>
         <artifactId>msal4j</artifactId>
         <version>1.13.5</version>
+      </dependency>
+      <dependency>
+        <groupId>net.minidev</groupId>
+        <artifactId>json-smart</artifactId>
+        <version>${jsonsmart.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.openssl</groupId>
+        <artifactId>wildfly-openssl</artifactId>
+        <version>${wildfly-openssl.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.wildfly.openssl</groupId>
+        <artifactId>wildfly-openssl-java</artifactId>
+        <version>${wildfly-openssl.version}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>

--- a/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-orc/pom.xml
@@ -70,5 +70,9 @@
       <artifactId>xml-apis</artifactId>
       <scope>compile</scope>
     </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
   </dependencies>
 </project>

--- a/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
@@ -64,5 +64,9 @@
       <groupId>org.codehaus.woodstox</groupId>
       <artifactId>stax2-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
1. Upgrade `net.minidev:json-smart` to version 2.5.0 to fix CVE-2023-1370
2. Upgrade `org.wildfly.openssl:wildfly-openssl` to version 1.1.3.Final to fix CVE-2020-25644
3. Upgrade `org.wildfly.openssl:wildfly-openssl-java` to version 1.1.3.Final to fix CVE-2020-25644
4. Explicitly put `com.google.protobuf:protobuf-java` version 3.25.2 to pinot-orc pom file
4. Explicitly put `com.google.protobuf:protobuf-java` version 3.25.2 to pinot-parquet pom file 