### PR TITLE
enable Netty native transports by default

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/config/NettyConfig.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/config/NettyConfig.java
@@ -26,7 +26,7 @@ import org.apache.pinot.spi.env.PinotConfiguration;
  */
 public class NettyConfig {
   private static final String NATIVE_TRANSPORTS_ENABLED = "native.transports.enabled";
-  private boolean _nativeTransportsEnabled = false;
+  private boolean _nativeTransportsEnabled = true;
 
   private static String key(String namespace, String suffix) {
     return namespace + "." + suffix;

--- a/pinot-common/src/test/java/org/apache/pinot/common/config/NettyConfigTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/config/NettyConfigTest.java
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.config;
+
+import org.apache.pinot.spi.env.PinotConfiguration;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertTrue;
+
+
+public class NettyConfigTest {
+  @Test
+  public void nettyNativeTransportsAreEnabledByDefault() {
+    assertTrue(new NettyConfig().isNativeTransportsEnabled());
+
+    PinotConfiguration pinotConfiguration = new PinotConfiguration();
+    NettyConfig extractedConfig = NettyConfig.extractNettyConfig(pinotConfiguration, "foobar");
+    assertTrue(extractedConfig.isNativeTransportsEnabled());
+  }
+}


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Default Netty native transports enabled; tests verify constructor and config extraction yield true\.

```mermaid
flowchart TD
  N0["#95;nativeTransportsEnabled default true #40;F1#41;"]:::stModified
  N1["new NettyConfig#40;#41; #40;F2#41;"]:::stAdded
  N2["isNativeTransportsEnabled#40;#41; on instance #40;F2#41;"]:::stAdded
  N3["assertTrue#40;result#41; #40;F2#41;"]:::stAdded
  N4["new PinotConfiguration#40;#41; #40;F2#41;"]:::stAdded
  N5["extractNettyConfig#40;config#44; ns#41; #40;F2#41;"]:::stAdded
  N6["isNativeTransportsEnabled#40;#41; on extracted #40;F2#41;"]:::stAdded
  N7["assertTrue#40;result#41; #40;F2#41;"]:::stAdded
  N1 -->|"calls"| N2
  N2 -->|"passes result"| N3
  N4 -->|"passes as arg"| N5
  N5 -->|"returns object"| N6
  N6 -->|"passes result"| N7
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-common/src/main/java/org/apache/pinot/common/config/NettyConfig\.java — [before](https://github.com/apache/pinot/blob/6bbbf0c34ce0a68ed919f73bacbba68cbc569579/pinot-common/src/main/java/org/apache/pinot/common/config/NettyConfig.java) · [after](https://github.com/apache/pinot/blob/e6f158bd44ee463532d00d654bccb2db1d9cbb66/pinot-common/src/main/java/org/apache/pinot/common/config/NettyConfig.java)
- F2: pinot\-common/src/test/java/org/apache/pinot/common/config/NettyConfigTest\.java — [after](https://github.com/apache/pinot/blob/e6f158bd44ee463532d00d654bccb2db1d9cbb66/pinot-common/src/test/java/org/apache/pinot/common/config/NettyConfigTest.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6IjZiYmJmMGMzNGNlMGE2OGVkOTE5ZjczYmFjYmJhNjhjYmM1Njk1NzkiLCJjb250ZXh0X2hhc2giOiJjMjYwYzhiZDdmZGFlYTJjYWU5ODNhMGIwZmEzOGQ5ZmQzOTcxOGM3ZGM0NTNiYjNhODY4NmMyNThmZGM5YjY2IiwiZ2VuZXJhdGVkX2F0IjoxNzg5NTI2MjA1LCJoZWFkX3NoYSI6ImU2ZjE1OGJkNDRlZTQ2MzUzMmQwMGQ2NTRiY2NiMmRiMWQ5Y2JiNjYiLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiI2YmJiZjBjMzRjZTBhNjhlZDkxOWY3M2JhY2JiYTY4Y2JjNTY5NTc5IiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 78160c44a3207d88bd43302436e2ddada9b58843602cf7f0423e30539ccf260b -->
<!-- pinot-pr-flow:end -->

enable Netty native transports (epoll, kqueue) by default

