### PR TITLE
reduce enum array allocation in TimerContext

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/TimerContext.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/request/context/TimerContext.java
@@ -25,10 +25,11 @@ import org.apache.pinot.common.metrics.ServerQueryPhase;
 
 
 public class TimerContext {
+  private static final int SERVER_QUERY_PHASE_COUNT = ServerQueryPhase.values().length;
   private final String _tableNameWithType;
   private final ServerMetrics _serverMetrics;
   private final long _queryArrivalTimeMs;
-  private final Timer[] _phaseTimers = new Timer[ServerQueryPhase.values().length];
+  private final Timer[] _phaseTimers = new Timer[SERVER_QUERY_PHASE_COUNT];
 
   public class Timer {
     private final ServerQueryPhase _queryPhase;


### PR DESCRIPTION
# Motivation

reduce enum array allocation in TimerContext

# Modifications

cache ServerQueryPhase.values().length in a static variable

# Result

ServerQueryPhase.values() method is invoked exactly once

# Additional context

https://www.gamlor.info/wordpress/2017/08/javas-enum-values-hidden-allocations/
