### PR TITLE
Revert "Bump org.apache.maven.scm:maven-scm-provider-gitexe from 1.94 to 2.0.1 (#12472)"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1642,7 +1642,7 @@
             <dependency>
               <groupId>org.apache.maven.scm</groupId>
               <artifactId>maven-scm-provider-gitexe</artifactId>
-              <version>2.0.1</version>
+              <version>1.9.4</version>
             </dependency>
           </dependencies>
           <configuration>


### PR DESCRIPTION
Revert "Bump org.apache.maven.scm:maven-scm-provider-gitexe from 1.94 to 2.0.1 (#12472)"