### PR TITLE
Update 'instances' API with ability to filter by tag

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/api/resources/PinotInstanceRestletResource.java
@@ -104,7 +104,11 @@ public class PinotInstanceRestletResource {
       @ApiResponse(code = 200, message = "Success"),
       @ApiResponse(code = 500, message = "Internal error")
   })
-  public Instances getAllInstances() {
+  public Instances getAllInstances(
+      @ApiParam("Filter by tag") @QueryParam("tag") String tag) {
+    if (tag != null) {
+      return new Instances(_pinotHelixResourceManager.getAllInstancesWithTag(tag));
+    }
     return new Instances(_pinotHelixResourceManager.getAllInstances());
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManager.java
@@ -415,6 +415,15 @@ public class PinotHelixResourceManager {
   }
 
   /**
+   * Get Ids of all instance with the given tag.
+   *
+   * @return List of instance Ids
+   */
+  public List<String> getAllInstancesWithTag(String tag) {
+    return HelixHelper.getInstancesWithTag(_helixZkManager, tag);
+  }
+
+  /**
    * Get all live instance Ids.
    *
    * @return List of live instance Ids

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -147,6 +147,16 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     assertEquals(_helixResourceManager.getOnlineUnTaggedServerInstanceList().size(), 0);
   }
 
+  public void testGetInstancesByTag() {
+    List<String> controllersByTag = _helixResourceManager.getAllInstancesWithTag("controller");
+    List<InstanceConfig> controllerConfigs = _helixResourceManager.getAllControllerInstanceConfigs();
+
+    assertEquals(controllersByTag.size(), controllerConfigs.size());
+    for (InstanceConfig c: controllerConfigs) {
+      assertTrue(controllersByTag.contains(c.getInstanceName()));
+    }
+  }
+
   @Test
   public void testGetDataInstanceAdminEndpoints()
       throws Exception {
@@ -411,6 +421,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
           && externalView.getStateMap(REALTIME_TABLE_NAME) == null;
     }, 60_000L, "Failed to get all brokers DROPPED");
   }
+
 
   private void waitForTableOnlineInBrokerResourceEV(String tableNameWithType) {
     TestUtils.waitForCondition(aVoid -> {
@@ -1378,6 +1389,8 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, OFFLINE_TABLE_NAME);
     assertNull(segmentLineage);
   }
+
+
 
   private static void assertSetEquals(Collection<String> actual, String... expected) {
     Set<String> actualSet = actual instanceof Set ? (Set<String>) actual : new HashSet<>(actual);

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -147,6 +147,7 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     assertEquals(_helixResourceManager.getOnlineUnTaggedServerInstanceList().size(), 0);
   }
 
+  @Test
   public void testGetInstancesByTag() {
     List<String> controllersByTag = _helixResourceManager.getAllInstancesWithTag("controller");
     List<InstanceConfig> controllerConfigs = _helixResourceManager.getAllControllerInstanceConfigs();

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/PinotHelixResourceManagerStatelessTest.java
@@ -422,7 +422,6 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     }, 60_000L, "Failed to get all brokers DROPPED");
   }
 
-
   private void waitForTableOnlineInBrokerResourceEV(String tableNameWithType) {
     TestUtils.waitForCondition(aVoid -> {
       ExternalView externalView = _helixAdmin.getResourceExternalView(_clusterName, Helix.BROKER_RESOURCE_INSTANCE);
@@ -1389,8 +1388,6 @@ public class PinotHelixResourceManagerStatelessTest extends ControllerTest {
     segmentLineage = SegmentLineageAccessHelper.getSegmentLineage(_propertyStore, OFFLINE_TABLE_NAME);
     assertNull(segmentLineage);
   }
-
-
 
   private static void assertSetEquals(Collection<String> actual, String... expected) {
     Set<String> actualSet = actual instanceof Set ? (Set<String>) actual : new HashSet<>(actual);


### PR DESCRIPTION
This is an optional query param, which can be used to filter instances for various purposes. Example: `fetch all controller instances', 'fetch all instances located in zone' etc.

![Screenshot 2024-03-06 at 18 15 00](https://github.com/apache/pinot/assets/212284/7eecac4f-e270-4a3b-b70e-ceb73be0c75d)


`feature`