### PR TITLE
[CVE-2022-39135] Bump up the calcite version to 1.32.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2149,13 +2149,6 @@
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>javacc-maven-plugin</artifactId>
         <version>2.6</version>
-        <dependencies>
-          <dependency>
-            <groupId>net.java.dev.javacc</groupId>
-            <artifactId>javacc</artifactId>
-            <version>7.0.13</version>
-          </dependency>
-        </dependencies>
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -137,7 +137,7 @@
     <jsonpath.version>2.9.0</jsonpath.version>
     <jsonsmart.version>2.5.0</jsonsmart.version>
     <quartz.version>2.3.2</quartz.version>
-    <calcite.version>1.30.0</calcite.version>
+    <calcite.version>1.32.0</calcite.version>
     <lucene.version>9.8.0</lucene.version>
     <reflections.version>0.9.11</reflections.version>
     <!-- commons-configuration, hadoop-common, hadoop-client use commons-lang -->


### PR DESCRIPTION
- Bumping up the calcite version from 1.30.0 to 1.32.0