### PR TITLE
verify FilterContext equals

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/request/context/FilterContext.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/request/context/FilterContext.java
@@ -30,7 +30,7 @@ import org.apache.pinot.common.request.context.predicate.Predicate;
  * The {@code FilterContext} class encapsulates the information of a filter in the query. Both WHERE clause and HAVING
  * clause are modeled as a filter.
  */
-public class FilterContext {
+public final class FilterContext {
   public static final FilterContext CONSTANT_TRUE = new FilterContext(Type.CONSTANT, null, null, true);
   public static final FilterContext CONSTANT_FALSE = new FilterContext(Type.CONSTANT, null, null, false);
 

--- a/pinot-common/src/test/java/org/apache/pinot/common/request/context/FilterContextTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/request/context/FilterContextTest.java
@@ -1,0 +1,32 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.request.context;
+
+import nl.jqno.equalsverifier.EqualsVerifier;
+import org.testng.annotations.Test;
+
+
+public class FilterContextTest {
+
+  @Test
+  public void equalsVerifier() {
+    EqualsVerifier.forClass(FilterContext.class)
+        .withPrefabValues(FilterContext.class, FilterContext.CONSTANT_TRUE, FilterContext.CONSTANT_FALSE).verify();
+  }
+}


### PR DESCRIPTION
use the equalsverifier library to validate our 'equals' method

https://jqno.nl/equalsverifier/

https://jqno.nl/equalsverifier/errormessages/recursive-datastructure/

