### PR TITLE
use gte(lte) to replace between() which has a bug

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BitSlicedRangeIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BitSlicedRangeIndexReader.java
@@ -188,7 +188,8 @@ public class BitSlicedRangeIndexReader implements RangeIndexReader<ImmutableRoar
         if (min == max) {
           return rangeBitmap.eq(min).toMutableRoaringBitmap();
         }
-        return rangeBitmap.between(min, max).toMutableRoaringBitmap();
+        // TODO: found bug in between() and use gte(lte) as a workaround for now.
+        return rangeBitmap.gte(min, rangeBitmap.lte(max)).toMutableRoaringBitmap();
       }
       return rangeBitmap.lte(max).toMutableRoaringBitmap();
     } else {


### PR DESCRIPTION
We found a potential bug in between() method, which missed values within the range. It only happened for a certain list of values. In fact, the issue didn't even happen after changing the order of the values in the list. The issue can be worked around by using gte(lte) for now, until the between() method is patched.