### PR TITLE
Ability to track offsets of filtered events

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/ingestion/StreamIngestionConfig.java
@@ -37,6 +37,9 @@ public class StreamIngestionConfig extends BaseJsonConfig {
   @JsonPropertyDescription("Whether to use column major mode when creating the segment.")
   private boolean _columnMajorSegmentBuilderEnabled = true;
 
+  @JsonPropertyDescription("Whether to track offsets of the filtered stream messages during consumption.")
+  private boolean _trackFilteredMessageOffsets = false;
+
   @JsonCreator
   public StreamIngestionConfig(@JsonProperty("streamConfigMaps") List<Map<String, String>> streamConfigMaps) {
     _streamConfigMaps = streamConfigMaps;
@@ -52,5 +55,13 @@ public class StreamIngestionConfig extends BaseJsonConfig {
 
   public boolean getColumnMajorSegmentBuilderEnabled() {
     return _columnMajorSegmentBuilderEnabled;
+  }
+
+  public void setTrackFilteredMessageOffsets(boolean trackFilteredMessageOffsets) {
+    _trackFilteredMessageOffsets = trackFilteredMessageOffsets;
+  }
+
+  public boolean isTrackFilteredMessageOffsets() {
+    return _trackFilteredMessageOffsets;
   }
 }


### PR DESCRIPTION
label:
`observability`

- Adding ability to track offsets of filtered events. Publishing this log every 1 minute along with `Consumed x events` log. Added a separate log and did not clubbing with consumed events for easy debuggability. This will only happen when `trackFilteredMessageOffset` flag is enabled in Ingestion configs.