### PR TITLE
Add isJson UDF

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -28,7 +28,6 @@ import java.util.Base64;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.RegexpPatternConverterUtils;
 import org.apache.pinot.spi.annotations.ScalarFunction;
@@ -836,21 +835,17 @@ public class StringFunctions {
 
   /**
    * Checks whether the input string can be parsed into a json node or not. Useful for scenarios where we want
-   * to filter out malformed json. In case of nulls, it is treated as valid json as in partial-upsert we might
-   * want to treat that column value as valid.
+   * to filter out malformed json. In case of nulls we return null itself, as null can be treated as valid json
+   * in partial-upsert scenarios. Upto the user to use null response accordingly.
    *
    * @param inputStr Input string to test for valid json
-   * @param acceptNull boolean value to decide whether null is accepted as a valid json or not
-   * @return in case of null value, it returns whatever acceptNull parameter value is. In case of non-null,
-   *         it returns true in case of valid json parsing else false
+   * @return in case of null value, it returns null. In case of non-null, it returns true in case of valid json
+   * parsing else false
    *
    */
-  @ScalarFunction(nullableParameters = true, names = {"isJson", "is_json"})
-  public static boolean isJson(@Nullable String inputStr, boolean acceptNull) {
+  @ScalarFunction(names = {"isJson", "is_json"})
+  public static boolean isJson(String inputStr) {
     try {
-      if (inputStr == null) {
-        return acceptNull;
-      }
       JsonUtils.stringToJsonNode(inputStr);
       return true;
     } catch (Exception e) {

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -28,6 +28,7 @@ import java.util.Base64;
 import java.util.UUID;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import javax.annotation.Nullable;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.RegexpPatternConverterUtils;
 import org.apache.pinot.spi.annotations.ScalarFunction;
@@ -840,8 +841,8 @@ public class StringFunctions {
    *
    * @param inputStr Input string to test for valid json
    */
-  @ScalarFunction
-  public static boolean isJson(String inputStr) {
+  @ScalarFunction(nullableParameters = true, names = {"isJson", "is_json"})
+  public static boolean isJson(@Nullable String inputStr) {
     try {
       if (inputStr == null) {
         return true;

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -840,12 +840,16 @@ public class StringFunctions {
    * want to treat that column value as valid.
    *
    * @param inputStr Input string to test for valid json
+   * @param acceptNull boolean value to decide whether null is accepted as a valid json or not
+   * @return in case of null value, it returns whatever acceptNull parameter value is. In case of non-null,
+   *         it returns true in case of valid json parsing else false
+   *
    */
   @ScalarFunction(nullableParameters = true, names = {"isJson", "is_json"})
-  public static boolean isJson(@Nullable String inputStr) {
+  public static boolean isJson(@Nullable String inputStr, boolean acceptNull) {
     try {
       if (inputStr == null) {
-        return true;
+        return acceptNull;
       }
       JsonUtils.stringToJsonNode(inputStr);
       return true;

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.common.function.scalar;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -32,6 +31,7 @@ import java.util.regex.Pattern;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.utils.RegexpPatternConverterUtils;
 import org.apache.pinot.spi.annotations.ScalarFunction;
+import org.apache.pinot.spi.utils.JsonUtils;
 
 
 /**
@@ -48,7 +48,6 @@ public class StringFunctions {
 
   private final static Pattern LTRIM = Pattern.compile("^\\s+");
   private final static Pattern RTRIM = Pattern.compile("\\s+$");
-  private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 
   /**
@@ -847,7 +846,7 @@ public class StringFunctions {
       if (inputStr == null) {
         return true;
       }
-      OBJECT_MAPPER.readTree(inputStr);
+      JsonUtils.stringToJsonNode(inputStr);
       return true;
     } catch (Exception e) {
       return false;

--- a/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/function/scalar/StringFunctions.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.common.function.scalar;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.UnsupportedEncodingException;
 import java.net.URLDecoder;
 import java.net.URLEncoder;
@@ -47,6 +48,7 @@ public class StringFunctions {
 
   private final static Pattern LTRIM = Pattern.compile("^\\s+");
   private final static Pattern RTRIM = Pattern.compile("\\s+$");
+  private final static ObjectMapper OBJECT_MAPPER = new ObjectMapper();
 
 
   /**
@@ -830,5 +832,25 @@ public class StringFunctions {
   public static boolean like(String inputStr, String likePatternStr) {
     String regexPatternStr = RegexpPatternConverterUtils.likeToRegexpLike(likePatternStr);
     return regexpLike(inputStr, regexPatternStr);
+  }
+
+  /**
+   * Checks whether the input string can be parsed into a json node or not. Useful for scenarios where we want
+   * to filter out malformed json. In case of nulls, it is treated as valid json as in partial-upsert we might
+   * want to treat that column value as valid.
+   *
+   * @param inputStr Input string to test for valid json
+   */
+  @ScalarFunction
+  public static boolean isJson(String inputStr) {
+    try {
+      if (inputStr == null) {
+        return true;
+      }
+      OBJECT_MAPPER.readTree(inputStr);
+      return true;
+    } catch (Exception e) {
+      return false;
+    }
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.common.function.scalar;
+
+import org.testng.annotations.DataProvider;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+
+
+public class StringFunctionsTest {
+
+  @DataProvider(name = "isJson")
+  public static Object[][] isJsonTestCases() {
+    return new Object[][]{
+        {null, true},
+        {"", true},
+        {"{\"key\": \"value\"}", true},
+        {"{\"key\": \"value\", }", false},
+        {"{\"key\": \"va", false},
+    };
+  }
+
+  @Test(dataProvider = "isJson")
+  public void testIsJson(String input, boolean expectedValue) {
+    assertEquals(StringFunctions.isJson(input), expectedValue);
+  }
+}

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -29,21 +29,15 @@ public class StringFunctionsTest {
   @DataProvider(name = "isJson")
   public static Object[][] isJsonTestCases() {
     return new Object[][]{
-        {null, true, true},
-        {null, false, false},
-        {"", true, true},
-        {"{\"key\": \"value\"}", true, true},
-        {"{\"key\": \"value\", }", true, false},
-        {"{\"key\": \"va", true, false},
-        {"", false, true},
-        {"{\"key\": \"value\"}", false, true},
-        {"{\"key\": \"value\", }", false, false},
-        {"{\"key\": \"va", false, false},
+        {"", true},
+        {"{\"key\": \"value\"}", true},
+        {"{\"key\": \"value\", }", false},
+        {"{\"key\": \"va", false}
     };
   }
 
   @Test(dataProvider = "isJson")
-  public void testIsJson(String input, boolean acceptNull, boolean expectedValue) {
-    assertEquals(StringFunctions.isJson(input, acceptNull), expectedValue);
+  public void testIsJson(String input, boolean expectedValue) {
+    assertEquals(StringFunctions.isJson(input), expectedValue);
   }
 }

--- a/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/common/function/scalar/StringFunctionsTest.java
@@ -29,16 +29,21 @@ public class StringFunctionsTest {
   @DataProvider(name = "isJson")
   public static Object[][] isJsonTestCases() {
     return new Object[][]{
-        {null, true},
-        {"", true},
-        {"{\"key\": \"value\"}", true},
-        {"{\"key\": \"value\", }", false},
-        {"{\"key\": \"va", false},
+        {null, true, true},
+        {null, false, false},
+        {"", true, true},
+        {"{\"key\": \"value\"}", true, true},
+        {"{\"key\": \"value\", }", true, false},
+        {"{\"key\": \"va", true, false},
+        {"", false, true},
+        {"{\"key\": \"value\"}", false, true},
+        {"{\"key\": \"value\", }", false, false},
+        {"{\"key\": \"va", false, false},
     };
   }
 
   @Test(dataProvider = "isJson")
-  public void testIsJson(String input, boolean expectedValue) {
-    assertEquals(StringFunctions.isJson(input), expectedValue);
+  public void testIsJson(String input, boolean acceptNull, boolean expectedValue) {
+    assertEquals(StringFunctions.isJson(input, acceptNull), expectedValue);
   }
 }


### PR DESCRIPTION
label:
`feature`

### WHY ARE WE ADDING THIS?

- This will be helpful in validating String-columns with json-indexes during ingestion time. We can use this UDF as a filter-transform config.
- If we do not use `skipInvalidJson` in json-index config introduced in #12238 then the ingestion stops in case of malformed / truncated json.
- If we use `skipInvalidJson` in json-index, then ingestion in not stopped but the record becomes un-queryable with json_match queries anyways. We also end up persisting malformed data in the table which can potentially cause that particular primary-key to not come in query response at all (if using upsert). This is again an issue. Additionally, there is no log / metric to track such scenarios where `skipInvalidJson` got applied.

Adding a json-validator as a UDF so that we can use it in filterTransform config, add alerts on `NUMBER_ROWS_FILTERED` metric and using this #12602 immediately track the events which are malformed / truncated.

### UDFS IN OTHER DBS

Saw few DBs have similar relatable functionalities too.
- Amazon Redshift ([IS_VALID_JSON](https://docs.aws.amazon.com/redshift/latest/dg/IS_VALID_JSON.html))
- Snowflake ([CHECK_JSON](https://docs.snowflake.com/en/sql-reference/functions/check_json))

Did not find anything similar in Postgresql though.

### Null value

Putting nulls as a valid json here as during partial-upserts we are okay with having nulls. They will be overwritten. 
But open to suggestions on how can we handle nulls differently.