### PR TITLE
Upgrade RoaringBitmap to 1.0.5 to pick up the fix for RangeBitmap.between()

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BitSlicedRangeIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/BitSlicedRangeIndexReader.java
@@ -188,8 +188,7 @@ public class BitSlicedRangeIndexReader implements RangeIndexReader<ImmutableRoar
         if (min == max) {
           return rangeBitmap.eq(min).toMutableRoaringBitmap();
         }
-        // TODO: found bug in between() and use gte(lte) as a workaround for now.
-        return rangeBitmap.gte(min, rangeBitmap.lte(max)).toMutableRoaringBitmap();
+        return rangeBitmap.between(min, max).toMutableRoaringBitmap();
       }
       return rangeBitmap.lte(max).toMutableRoaringBitmap();
     } else {

--- a/pom.xml
+++ b/pom.xml
@@ -414,7 +414,7 @@
       <dependency>
         <groupId>org.roaringbitmap</groupId>
         <artifactId>RoaringBitmap</artifactId>
-        <version>0.9.38</version>
+        <version>1.0.5</version>
       </dependency>
       <dependency>
         <groupId>com.101tec</groupId>


### PR DESCRIPTION
Revert the temporary workaround in #12595 