### PR TITLE
Bugfix. Maintain literal data type during function evaluation

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -56,7 +56,7 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
     switch (expression.getType()) {
       case LITERAL:
         // TODO: pass literal with type into ConstantExecutionNode.
-        return new ConstantExecutionNode(expression.getLiteral().getStringValue());
+        return new ConstantExecutionNode(expression.getLiteral().getValue());
       case IDENTIFIER:
         String columnName = expression.getIdentifier();
         ColumnExecutionNode columnExecutionNode = new ColumnExecutionNode(columnName, _arguments.size());
@@ -276,14 +276,14 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
   }
 
   private static class ConstantExecutionNode implements ExecutableNode {
-    final String _value;
+    final Object _value;
 
-    ConstantExecutionNode(String value) {
+    ConstantExecutionNode(Object value) {
       _value = value;
     }
 
     @Override
-    public String execute(GenericRow row) {
+    public Object execute(GenericRow row) {
       return _value;
     }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluator.java
@@ -55,7 +55,6 @@ public class InbuiltFunctionEvaluator implements FunctionEvaluator {
   private ExecutableNode planExecution(ExpressionContext expression) {
     switch (expression.getType()) {
       case LITERAL:
-        // TODO: pass literal with type into ConstantExecutionNode.
         return new ConstantExecutionNode(expression.getLiteral().getValue());
       case IDENTIFIER:
         String columnName = expression.getIdentifier();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluatorTest.java
@@ -1,0 +1,66 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.function;
+
+import org.apache.pinot.common.function.FunctionUtils;
+import org.apache.pinot.common.utils.PinotDataType;
+import org.apache.pinot.spi.data.readers.GenericRow;
+import org.testng.annotations.Test;
+
+import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertNotNull;
+
+
+public class InbuiltFunctionEvaluatorTest {
+
+  @Test
+  public void booleanLiteralTest() {
+    checkBooleanLiteralExpression("true", 1);
+    checkBooleanLiteralExpression("false", 0);
+    checkBooleanLiteralExpression("True", 1);
+    checkBooleanLiteralExpression("False", 0);
+    checkBooleanLiteralExpression("1", 1);
+    checkBooleanLiteralExpression("0", 0);
+  }
+
+  private void checkBooleanLiteralExpression(String expression, int value) {
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
+    Object output = evaluator.evaluate(new GenericRow());
+    Class<?> outputValueClass = output.getClass();
+    PinotDataType outputType = FunctionUtils.getArgumentType(outputValueClass);
+    assertNotNull(outputType);
+    // as INT is the stored type for BOOLEAN
+    assertEquals(outputType.toInt(output), value);
+  }
+
+  @Test
+  public void integerLiteralTest() {
+    checkIntegerLiteralExpression("1", 1);
+  }
+
+  private void checkIntegerLiteralExpression(String expression, int value) {
+    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
+    Object output = evaluator.evaluate(new GenericRow());
+    Class<?> outputValueClass = output.getClass();
+    PinotDataType outputType = FunctionUtils.getArgumentType(outputValueClass);
+    assertNotNull(outputType);
+    // as INT is the stored type for BOOLEAN
+    assertEquals(outputType.toInt(output), value);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/function/InbuiltFunctionEvaluatorTest.java
@@ -48,19 +48,4 @@ public class InbuiltFunctionEvaluatorTest {
     // as INT is the stored type for BOOLEAN
     assertEquals(outputType.toInt(output), value);
   }
-
-  @Test
-  public void integerLiteralTest() {
-    checkIntegerLiteralExpression("1", 1);
-  }
-
-  private void checkIntegerLiteralExpression(String expression, int value) {
-    InbuiltFunctionEvaluator evaluator = new InbuiltFunctionEvaluator(expression);
-    Object output = evaluator.evaluate(new GenericRow());
-    Class<?> outputValueClass = output.getClass();
-    PinotDataType outputType = FunctionUtils.getArgumentType(outputValueClass);
-    assertNotNull(outputType);
-    // as INT is the stored type for BOOLEAN
-    assertEquals(outputType.toInt(output), value);
-  }
 }


### PR DESCRIPTION
Currently the `ConstantExecutionNode `  stores the literal value as String which creates problems while dealing with boolean literals as the execution returns a String and ends up doing `STRING.toInt` (`toInt` as boolean has stored type as int)on a `"true"` value while it should be doing `BOOLEAN.toInt` instead.
