### PR TITLE
Detect expired messages in Kafka. Log and set a gauge.

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
+++ b/pinot-common/src/main/java/org/apache/pinot/common/metrics/ServerMeter.java
@@ -111,7 +111,8 @@ public enum ServerMeter implements AbstractMetrics.Meter {
   NUM_SEGMENTS_PRUNED_BY_VALUE("numSegmentsPrunedByValue", false),
   LARGE_QUERY_RESPONSES_SENT("largeResponses", false),
   TOTAL_THREAD_CPU_TIME_MILLIS("millis", false),
-  LARGE_QUERY_RESPONSE_SIZE_EXCEPTIONS("exceptions", false);
+  LARGE_QUERY_RESPONSE_SIZE_EXCEPTIONS("exceptions", false),
+  STREAM_DATA_LOSS("streamDataLoss", false);
 
   private final String _meterName;
   private final String _unit;

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -913,7 +913,7 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
    * @param batchFirstOffset The offset of the first message in the batch.
    */
   private void validateStartOffset(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset batchFirstOffset) {
-    if (batchFirstOffset != null && batchFirstOffset.compareTo(startOffset) > 0) {
+    if (batchFirstOffset.compareTo(startOffset) > 0) {
       _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.STREAM_DATA_LOSS, 1L);
       String message = "startOffset(" + startOffset
           + ") is older than topic's beginning offset(" + batchFirstOffset + ")";
@@ -921,9 +921,6 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       _realtimeTableDataManager.addSegmentError(_segmentNameStr,
           new SegmentErrorInfo(now(), message, null)
       );
-    } else {
-      // Record that this batch has no data loss.
-      _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.STREAM_DATA_LOSS, 0L);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -918,6 +918,9 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
       _realtimeTableDataManager.addSegmentError(_segmentNameStr,
           new SegmentErrorInfo(now(), message, null)
       );
+    } else {
+      // Record that this batch has no data loss.
+      _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.STREAM_DATA_LOSS, 0L);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -456,7 +456,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
         throw t;
       }
 
-      validateStartOffset(_currentOffset, messageBatch.getFirstMessageOffset());
+      StreamPartitionMsgOffset batchFirstOffset = messageBatch.getFirstMessageOffset();
+      if (batchFirstOffset != null) {
+        validateStartOffset(_currentOffset, batchFirstOffset);
+      }
 
       boolean endCriteriaReached = processStreamEvents(messageBatch, idlePipeSleepTimeMillis);
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -915,12 +915,10 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
   private void validateStartOffset(StreamPartitionMsgOffset startOffset, StreamPartitionMsgOffset batchFirstOffset) {
     if (batchFirstOffset.compareTo(startOffset) > 0) {
       _serverMetrics.addMeteredTableValue(_tableStreamName, ServerMeter.STREAM_DATA_LOSS, 1L);
-      String message = "startOffset(" + startOffset
-          + ") is older than topic's beginning offset(" + batchFirstOffset + ")";
+      String message =
+          "startOffset(" + startOffset + ") is older than topic's beginning offset(" + batchFirstOffset + ")";
       _segmentLogger.error(message);
-      _realtimeTableDataManager.addSegmentError(_segmentNameStr,
-          new SegmentErrorInfo(now(), message, null)
-      );
+      _realtimeTableDataManager.addSegmentError(_segmentNameStr, new SegmentErrorInfo(now(), message, null));
     }
   }
 

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
@@ -37,6 +37,7 @@ public class KafkaMessageBatch implements MessageBatch<StreamMessage<byte[]>> {
 
   /**
    * @param unfilteredMessageCount how many messages were received from the topic before being filtered
+   * @param firstOffset the offset of the first message in the batch
    * @param lastOffset the offset of the last message in the batch
    * @param batch the messages, which may be smaller than {@see unfilteredMessageCount}
    * @param lastMessageMetadata metadata for last filtered message in the batch, useful for estimating ingestion delay

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaMessageBatch.java
@@ -31,6 +31,7 @@ import org.apache.pinot.spi.stream.StreamPartitionMsgOffset;
 public class KafkaMessageBatch implements MessageBatch<StreamMessage<byte[]>> {
   private final List<StreamMessage<byte[]>> _messageList;
   private final int _unfilteredMessageCount;
+  private final long _firstOffset;
   private final long _lastOffset;
   private final StreamMessageMetadata _lastMessageMetadata;
 
@@ -41,9 +42,10 @@ public class KafkaMessageBatch implements MessageBatch<StreamMessage<byte[]>> {
    * @param lastMessageMetadata metadata for last filtered message in the batch, useful for estimating ingestion delay
    *                            when a batch has all messages filtered.
    */
-  public KafkaMessageBatch(int unfilteredMessageCount, long lastOffset, List<StreamMessage<byte[]>> batch,
-      StreamMessageMetadata lastMessageMetadata) {
+  public KafkaMessageBatch(int unfilteredMessageCount, long firstOffset, long lastOffset,
+      List<StreamMessage<byte[]>> batch, StreamMessageMetadata lastMessageMetadata) {
     _messageList = batch;
+    _firstOffset = firstOffset;
     _lastOffset = lastOffset;
     _unfilteredMessageCount = unfilteredMessageCount;
     _lastMessageMetadata = lastMessageMetadata;
@@ -110,5 +112,10 @@ public class KafkaMessageBatch implements MessageBatch<StreamMessage<byte[]>> {
   @Override
   public StreamMessage getStreamMessage(int index) {
     return _messageList.get(index);
+  }
+
+  @Override
+  public StreamPartitionMsgOffset getFirstMessageOffset() {
+    return new LongMsgOffset(_firstOffset);
   }
 }

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
@@ -72,8 +72,8 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
     long firstOffset = startOffset;
     long lastOffset = startOffset;
     StreamMessageMetadata rowMetadata = null;
-    if (!consumerRecords.isEmpty()) {
-      firstOffset = consumerRecords.iterator().next().offset();
+    if (!messageAndOffsets.isEmpty()) {
+      firstOffset = messageAndOffsets.get(0).offset();
     }
     for (ConsumerRecord<String, Bytes> messageAndOffset : messageAndOffsets) {
       long offset = messageAndOffset.offset();

--- a/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
+++ b/pinot-plugins/pinot-stream-ingestion/pinot-kafka-2.0/src/main/java/org/apache/pinot/plugin/stream/kafka20/KafkaPartitionLevelConsumer.java
@@ -69,8 +69,12 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
     ConsumerRecords<String, Bytes> consumerRecords = _consumer.poll(Duration.ofMillis(timeoutMillis));
     List<ConsumerRecord<String, Bytes>> messageAndOffsets = consumerRecords.records(_topicPartition);
     List<StreamMessage<byte[]>> filtered = new ArrayList<>(messageAndOffsets.size());
+    long firstOffset = startOffset;
     long lastOffset = startOffset;
     StreamMessageMetadata rowMetadata = null;
+    if (!consumerRecords.isEmpty()) {
+      firstOffset = consumerRecords.iterator().next().offset();
+    }
     for (ConsumerRecord<String, Bytes> messageAndOffset : messageAndOffsets) {
       long offset = messageAndOffset.offset();
       _lastFetchedOffset = offset;
@@ -90,6 +94,6 @@ public class KafkaPartitionLevelConsumer extends KafkaPartitionLevelConnectionHa
             endOffset);
       }
     }
-    return new KafkaMessageBatch(messageAndOffsets.size(), lastOffset, filtered, rowMetadata);
+    return new KafkaMessageBatch(messageAndOffsets.size(), firstOffset, lastOffset, filtered, rowMetadata);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/MessageBatch.java
@@ -119,6 +119,17 @@ public interface MessageBatch<T> {
   }
 
   /**
+   * Return the offset of the first message in the batch.
+   * The first offset of the batch is useful to determine if there were gaps in the stream.
+   *
+   * @return null by default
+   */
+  @Nullable
+  default public StreamPartitionMsgOffset getFirstMessageOffset() {
+    return null;
+  }
+
+  /**
    * This is useful while determining ingestion delay for a message batch. Retaining metadata for last filtered message
    * in a batch can enable us to estimate the ingestion delay for the batch.
    * Note that a batch can be fully filtered, and we can still retain the metadata for the last filtered message to


### PR DESCRIPTION
Pinot may take multiple hours between polling a partition in a Kafka topic. One specific example is that Pinot took a long time to flush a segment to disk. In the meantime, messages in Kafka can expire if message retention time is small.
If `auto.offset.reset` is set to smallest, then Kafka will silently move the offset to the first available message leading to data loss.
RealtimeSegmentValidationManager is a cron that runs every hour and detects where the offset of a segment in zookeeper is in the past when compared to the smallest offset in Kafka. However since it runs every hour, it may miss the data loss if it happens between runs.

This commit compares the startOffset to the batchFirstOffset. 
* startOffset: Offset requested by the database for the next batch.
* batchFirstOffset: First offset of the batch of messages received from the stream. 
If startOffset < batchFirstOffset, then log the condition as well as set a meter to 1.

This test is implemented only for Kafka Streams.