### PR TITLE
12435: fix for quick start Cluster Manager issue

### DIFF
--- a/pinot-controller/src/main/resources/app/components/AsyncInstanceTable.tsx
+++ b/pinot-controller/src/main/resources/app/components/AsyncInstanceTable.tsx
@@ -88,7 +88,7 @@ export const AsyncInstanceTable = ({
 
   useEffect(() => {
     const instances = fetchInstances(instanceType, tenant);
-    if (showInstanceDetails) {
+    if (showInstanceDetails && cluster.length > 0) {
       const instanceDetails = instances.then(async (instancesData) => {
         const liveInstanceArr = await PinotMethodUtils.getLiveInstance(cluster);
         return PinotMethodUtils.getInstanceData(

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitMVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitMVForwardIndexReader.java
@@ -102,6 +102,13 @@ public final class FixedBitMVForwardIndexReader implements ForwardIndexReader<Fi
   }
 
   @Override
+  public void readDictIds(int[] docIds, int length, int[] dictIdBuffer, Context context) {
+    for (int i = 0; i < length; i++) {
+      dictIdBuffer[i] = _rawDataReader.readInt(docIds[i]);
+    }
+  }
+
+  @Override
   public int getDictIdMV(int docId, int[] dictIdBuffer, Context context) {
     int contextDocId = context._docId;
     int contextEndOffset = context._endOffset;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitMVForwardIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/forward/FixedBitMVForwardIndexReader.java
@@ -102,13 +102,6 @@ public final class FixedBitMVForwardIndexReader implements ForwardIndexReader<Fi
   }
 
   @Override
-  public void readDictIds(int[] docIds, int length, int[] dictIdBuffer, Context context) {
-    for (int i = 0; i < length; i++) {
-      dictIdBuffer[i] = _rawDataReader.readInt(docIds[i]);
-    }
-  }
-
-  @Override
   public int getDictIdMV(int docId, int[] dictIdBuffer, Context context) {
     int contextDocId = context._docId;
     int contextEndOffset = context._endOffset;


### PR DESCRIPTION
while working on my local build, I saw the `//LIVEINSTANCES` issue and found the reported [bug](https://github.com/apache/pinot/issues/12435) related to it. 

I think, this issue got introduced with the [PR](https://github.com/apache/pinot/pull/12210), Just putting a simple fix for the issue.

<img width="1839" alt="Screenshot 2024-03-08 at 3 07 30 PM" src="https://github.com/apache/pinot/assets/1076944/0dc34acf-6856-4f62-af52-a7cd3e01e100">



cc: @jadami10, @xiangfu0 
