### PR TITLE
Allow Aggregations in Case Expressions

### DIFF
--- a/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
+++ b/pinot-common/src/main/java/org/apache/pinot/sql/parsers/CalciteSqlParser.java
@@ -747,18 +747,10 @@ public class CalciteSqlParser {
         for (int i = 0; i < whenOperands.size(); i++) {
           SqlNode whenSqlNode = whenOperands.get(i);
           Expression whenExpression = toExpression(whenSqlNode);
-          if (isAggregateExpression(whenExpression)) {
-            throw new SqlCompilationException(
-                "Aggregation functions inside WHEN Clause is not supported - " + whenSqlNode);
-          }
           caseFuncExpr.getFunctionCall().addToOperands(whenExpression);
 
           SqlNode thenSqlNode = thenOperands.get(i);
           Expression thenExpression = toExpression(thenSqlNode);
-          if (isAggregateExpression(thenExpression)) {
-            throw new SqlCompilationException(
-                "Aggregation functions inside THEN Clause is not supported - " + thenSqlNode);
-          }
           caseFuncExpr.getFunctionCall().addToOperands(thenExpression);
         }
         Expression elseExpression = toExpression(elseOperand);

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -144,7 +144,7 @@ public class CalciteSqlCompilerTest {
   @Test
   public void testAggregationInCaseWhenStatementsWithGroupBy() {
     //@formatter:off
-   PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
         "SELECT OrderID, SUM(Quantity),\n"
             + "CASE\n"
             + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
@@ -158,13 +158,14 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(caseStm.getOperator(), "case");
     Expression firstWhen = caseStm.getOperands().get(0);
     Assert.assertEquals(firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "sum");
-    Assert.assertEquals(firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall()
-        .getOperands().get(0).getIdentifier().getName(), "Quantity");
-
+    Assert.assertEquals(
+        firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier()
+            .getName(), "Quantity");
     Expression secondWhen = caseStm.getOperands().get(2);
     Assert.assertEquals(secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "sum");
-    Assert.assertEquals(secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall()
-        .getOperands().get(0).getIdentifier().getName(), "Quantity");
+    Assert.assertEquals(
+        secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier()
+            .getName(), "Quantity");
   }
 
   @Test
@@ -178,19 +179,19 @@ public class CalciteSqlCompilerTest {
             + "    ELSE 'The quantity is under 30'\n"
             + "END AS QuantityText\n"
             + "FROM OrderDetails\n");
-      //@formatter:on
-
+    //@formatter:on
     Function caseStm = pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall();
     Assert.assertEquals(caseStm.getOperator(), "case");
     Expression firstWhen = caseStm.getOperands().get(0);
     Assert.assertEquals(firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "sum");
-    Assert.assertEquals(firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall()
-        .getOperands().get(0).getIdentifier().getName(), "Quantity");
-
+    Assert.assertEquals(
+        firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier()
+            .getName(), "Quantity");
     Expression secondWhen = caseStm.getOperands().get(2);
     Assert.assertEquals(secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "sum");
-    Assert.assertEquals(secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall()
-        .getOperands().get(0).getIdentifier().getName(), "Quantity");
+    Assert.assertEquals(
+        secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier()
+            .getName(), "Quantity");
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -141,6 +141,28 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(caseFunc.getOperands().get(6).getLiteral().getFieldValue(), 0L);
   }
 
+  @Test()
+  public void testAggregationInCaseWhenStatements() {
+    // Not support Aggregation functions in case statements.
+    try {
+      //@formatter:off
+      CalciteSqlParser.compileToPinotQuery(
+          "SELECT OrderID, SUM(Quantity),\n"
+              + "CASE\n"
+              + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
+              + "    WHEN sum(Quantity) = 30 THEN 'The quantity is 30'\n"
+              + "    ELSE 'The quantity is under 30'\n"
+              + "END AS QuantityText\n"
+              + "FROM OrderDetails\n"
+              + "GROUP BY OrderID");
+      //@formatter:on
+    } catch (SqlCompilationException e) {
+      Assert.assertEquals(e.getMessage(),
+          "Aggregation functions inside WHEN Clause is not supported - SUM(`Quantity`) > 30");
+      throw e;
+    }
+  }
+
   @Test
   public void testQuotedStrings() {
     PinotQuery pinotQuery =

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -142,11 +142,10 @@ public class CalciteSqlCompilerTest {
   }
 
   @Test()
-  public void testAggregationInCaseWhenStatements() {
+  public void testAggregationInCaseWhenStatementsWithGroupBy() {
     // Not support Aggregation functions in case statements.
-    try {
       //@formatter:off
-      CalciteSqlParser.compileToPinotQuery(
+     PinotQuery pinotQuery =CalciteSqlParser.compileToPinotQuery(
           "SELECT OrderID, SUM(Quantity),\n"
               + "CASE\n"
               + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
@@ -156,11 +155,40 @@ public class CalciteSqlCompilerTest {
               + "FROM OrderDetails\n"
               + "GROUP BY OrderID");
       //@formatter:on
-    } catch (SqlCompilationException e) {
-      Assert.assertEquals(e.getMessage(),
-          "Aggregation functions inside WHEN Clause is not supported - SUM(`Quantity`) > 30");
-      throw e;
-    }
+    Function caseStm = pinotQuery.getSelectList().get(2).getFunctionCall().getOperands().get(0).getFunctionCall();
+    Assert.assertEquals(caseStm.getOperator(), "case");
+    Expression firstWhen = caseStm.getOperands().get(0);
+    Assert.assertEquals(firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "sum");
+    Assert.assertEquals(firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "Quantity");
+
+    Expression secondWhen = caseStm.getOperands().get(2);
+    Assert.assertEquals(secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "sum");
+    Assert.assertEquals(secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "Quantity");
+  }
+
+  @Test()
+  public void testAggregationInCaseWhenStatements() {
+    // Not support Aggregation functions in case statements.
+    //@formatter:off
+    PinotQuery pinotQuery =CalciteSqlParser.compileToPinotQuery(
+        "SELECT sum(Quantity),\n"
+            + "CASE\n"
+            + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
+            + "    WHEN sum(Quantity) = 30 THEN 'The quantity is 30'\n"
+            + "    ELSE 'The quantity is under 30'\n"
+            + "END AS QuantityText\n"
+            + "FROM OrderDetails\n");
+      //@formatter:on
+
+    Function caseStm = pinotQuery.getSelectList().get(1).getFunctionCall().getOperands().get(0).getFunctionCall();
+    Assert.assertEquals(caseStm.getOperator(), "case");
+    Expression firstWhen = caseStm.getOperands().get(0);
+    Assert.assertEquals(firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "sum");
+    Assert.assertEquals(firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "Quantity");
+
+    Expression secondWhen = caseStm.getOperands().get(2);
+    Assert.assertEquals(secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "sum");
+    Assert.assertEquals(secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "Quantity");
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -141,36 +141,36 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(caseFunc.getOperands().get(6).getLiteral().getFieldValue(), 0L);
   }
 
-  @Test()
+  @Test
   public void testAggregationInCaseWhenStatementsWithGroupBy() {
-    // Not support Aggregation functions in case statements.
-      //@formatter:off
-     PinotQuery pinotQuery =CalciteSqlParser.compileToPinotQuery(
-          "SELECT OrderID, SUM(Quantity),\n"
-              + "CASE\n"
-              + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
-              + "    WHEN sum(Quantity) = 30 THEN 'The quantity is 30'\n"
-              + "    ELSE 'The quantity is under 30'\n"
-              + "END AS QuantityText\n"
-              + "FROM OrderDetails\n"
-              + "GROUP BY OrderID");
-      //@formatter:on
+    //@formatter:off
+   PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
+        "SELECT OrderID, SUM(Quantity),\n"
+            + "CASE\n"
+            + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
+            + "    WHEN sum(Quantity) = 30 THEN 'The quantity is 30'\n"
+            + "    ELSE 'The quantity is under 30'\n"
+            + "END AS QuantityText\n"
+            + "FROM OrderDetails\n"
+            + "GROUP BY OrderID");
+    //@formatter:on
     Function caseStm = pinotQuery.getSelectList().get(2).getFunctionCall().getOperands().get(0).getFunctionCall();
     Assert.assertEquals(caseStm.getOperator(), "case");
     Expression firstWhen = caseStm.getOperands().get(0);
     Assert.assertEquals(firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "sum");
-    Assert.assertEquals(firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "Quantity");
+    Assert.assertEquals(firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().get(0).getIdentifier().getName(), "Quantity");
 
     Expression secondWhen = caseStm.getOperands().get(2);
     Assert.assertEquals(secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "sum");
-    Assert.assertEquals(secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "Quantity");
+    Assert.assertEquals(secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().get(0).getIdentifier().getName(), "Quantity");
   }
 
-  @Test()
+  @Test
   public void testAggregationInCaseWhenStatements() {
-    // Not support Aggregation functions in case statements.
     //@formatter:off
-    PinotQuery pinotQuery =CalciteSqlParser.compileToPinotQuery(
+    PinotQuery pinotQuery = CalciteSqlParser.compileToPinotQuery(
         "SELECT sum(Quantity),\n"
             + "CASE\n"
             + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
@@ -184,11 +184,13 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(caseStm.getOperator(), "case");
     Expression firstWhen = caseStm.getOperands().get(0);
     Assert.assertEquals(firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "sum");
-    Assert.assertEquals(firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "Quantity");
+    Assert.assertEquals(firstWhen.getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().get(0).getIdentifier().getName(), "Quantity");
 
     Expression secondWhen = caseStm.getOperands().get(2);
     Assert.assertEquals(secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperator(), "sum");
-    Assert.assertEquals(secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall().getOperands().get(0).getIdentifier().getName(), "Quantity");
+    Assert.assertEquals(secondWhen.getFunctionCall().getOperands().get(0).getFunctionCall()
+        .getOperands().get(0).getIdentifier().getName(), "Quantity");
   }
 
   @Test

--- a/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
+++ b/pinot-common/src/test/java/org/apache/pinot/sql/parsers/CalciteSqlCompilerTest.java
@@ -141,27 +141,6 @@ public class CalciteSqlCompilerTest {
     Assert.assertEquals(caseFunc.getOperands().get(6).getLiteral().getFieldValue(), 0L);
   }
 
-  @Test(expectedExceptions = SqlCompilationException.class)
-  public void testInvalidCaseWhenStatements() {
-    // Not support Aggregation functions in case statements.
-    try {
-      //@formatter:off
-      CalciteSqlParser.compileToPinotQuery(
-          "SELECT OrderID, Quantity,\n"
-              + "CASE\n"
-              + "    WHEN sum(Quantity) > 30 THEN 'The quantity is greater than 30'\n"
-              + "    WHEN sum(Quantity) = 30 THEN 'The quantity is 30'\n"
-              + "    ELSE 'The quantity is under 30'\n"
-              + "END AS QuantityText\n"
-              + "FROM OrderDetails");
-      //@formatter:on
-    } catch (SqlCompilationException e) {
-      Assert.assertEquals(e.getMessage(),
-          "Aggregation functions inside WHEN Clause is not supported - SUM(`Quantity`) > 30");
-      throw e;
-    }
-  }
-
   @Test
   public void testQuotedStrings() {
     PinotQuery pinotQuery =

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -275,14 +275,12 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     testQuery(query, h2Query);
 
     // Test aggregation functions in a CaseWhen statement
-    query =
-        "SELECT AirlineID, "
-            + "CASE WHEN Sum(ArrDelay) < 0 THEN 0 WHEN SUM(ArrDelay) > 0 THEN SUM(ArrDelay) END AS SumArrDelay"
-            + " FROM mytable GROUP BY AirlineID";
+    query = "SELECT AirlineID, "
+        + "CASE WHEN Sum(ArrDelay) < 0 THEN 0 WHEN SUM(ArrDelay) > 0 THEN SUM(ArrDelay) END AS SumArrDelay "
+        + "FROM mytable GROUP BY AirlineID";
     testQuery(query);
-    query =
-        "SELECT CASE WHEN Sum(ArrDelay) < 0 THEN 0 WHEN SUM(ArrDelay) > 0 THEN SUM(ArrDelay) END AS SumArrDelay"
-            + " FROM mytable";
+    query = "SELECT CASE WHEN Sum(ArrDelay) < 0 THEN 0 WHEN SUM(ArrDelay) > 0 THEN SUM(ArrDelay) END AS SumArrDelay "
+        + "FROM mytable";
     testQuery(query);
   }
 

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -273,6 +273,16 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
     h2Query = "SELECT DaysSinceEpoch - 25, COUNT(*) FROM mytable " + "GROUP BY DaysSinceEpoch "
         + "ORDER BY COUNT(*), DaysSinceEpoch DESC";
     testQuery(query, h2Query);
+
+    // Test aggregation functions in a CaseWhen statement
+    query =
+        "SELECT AirlineID, CASE WHEN Sum(ArrDelay) < 0 THEN 0 WHEN SUM(ArrDelay) > 0 THEN SUM(ArrDelay) END AS SumArrDelay"
+            + " FROM mytable GROUP BY AirlineID";
+    testQuery(query);
+    query =
+        "SELECT CASE WHEN Sum(ArrDelay) < 0 THEN 0 WHEN SUM(ArrDelay) > 0 THEN SUM(ArrDelay) END AS SumArrDelay"
+            + " FROM mytable";
+    testQuery(query);
   }
 
   private void testHardcodedQueriesV2()

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/BaseClusterIntegrationTestSet.java
@@ -276,7 +276,8 @@ public abstract class BaseClusterIntegrationTestSet extends BaseClusterIntegrati
 
     // Test aggregation functions in a CaseWhen statement
     query =
-        "SELECT AirlineID, CASE WHEN Sum(ArrDelay) < 0 THEN 0 WHEN SUM(ArrDelay) > 0 THEN SUM(ArrDelay) END AS SumArrDelay"
+        "SELECT AirlineID, "
+            + "CASE WHEN Sum(ArrDelay) < 0 THEN 0 WHEN SUM(ArrDelay) > 0 THEN SUM(ArrDelay) END AS SumArrDelay"
             + " FROM mytable GROUP BY AirlineID";
     testQuery(query);
     query =

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryTestSet.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/QueryTestSet.java
@@ -106,6 +106,9 @@ public class QueryTestSet {
             + " SUM(CASE WHEN a.col2 <> 'foo' AND a.col2 <> 'alice' THEN 1 ELSE 0 END) as unmatch_sum "
             + " FROM a WHERE a.ts >= 1600000000 GROUP BY a.col1"},
 
+        new Object[]{"SELECT a.col1, CASE WHEN sum(a.col3) = 0 THEN 0 ELSE SUM(a.col3) END AS match_sum "
+            + " FROM a WHERE a.ts >= 1600000000 GROUP BY a.col1"},
+
         new Object[]{"SELECT a.col1, b.col2 FROM a JOIN b ON a.col1 = b.col1 "
             + " WHERE a.col3 IN (1, 2, 3) OR (a.col3 > 10 AND a.col3 < 50)"},
 


### PR DESCRIPTION
(Bugfix)

In Calcite, this removes the check that prevents aggregation functions from being used within a Case/When expression in the V1 engine.

Testing:
1. Added a unit test for V2 engine
2. Validated locally with Pinot running the query: `select AirlineID, (CASE WHEN sum(ActualElapsedTime) > 0 THEN sum(ActualElapsedTime) ELSE 0 END) AS cpm from airlineStats group by AirlineID` and comparing the results between V1 and V2 engine.
