### PR TITLE
Fix pinot-parquet NoClassFound issue

### DIFF
--- a/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
+++ b/pinot-plugins/pinot-input-format/pinot-parquet/pom.xml
@@ -68,7 +68,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-mapreduce-client-core</artifactId>
-      <scope>test</scope>
+      <scope>${hadoop.dependencies.scope}</scope>
     </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -792,6 +792,10 @@
             <groupId>org.apache.hadoop.thirdparty</groupId>
             <artifactId>hadoop-shaded-protobuf_3_7</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>org.jboss.xnio</groupId>
+            <artifactId>xnio-api</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>
@@ -923,6 +927,18 @@
           <exclusion>
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-yarn-client</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-yarn-common</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-hdfs-client</artifactId>
           </exclusion>
         </exclusions>
       </dependency>


### PR DESCRIPTION
ParquetUtils.hasAvroSchemaInFileMetadata() may throw exception when using it.
So still need to put `hadoop-mapreduce-client-core` as dependency.

```
java.lang.NoClassDefFoundError: org/apache/hadoop/mapreduce/lib/input/FileInputFormat
	at java.base/java.lang.ClassLoader.defineClass1(Native Method) ~[?:?]
	at java.base/java.lang.ClassLoader.defineClass(ClassLoader.java:1017) ~[?:?]
	at java.base/java.security.SecureClassLoader.defineClass(SecureClassLoader.java:174) ~[?:?]
	at java.base/jdk.internal.loader.BuiltinClassLoader.defineClass(BuiltinClassLoader.java:800) ~[?:?]
	at java.base/jdk.internal.loader.BuiltinClassLoader.findClassOnClassPathOrNull(BuiltinClassLoader.java:698) ~[?:?]
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClassOrNull(BuiltinClassLoader.java:621) ~[?:?]
	at java.base/jdk.internal.loader.BuiltinClassLoader.loadClass(BuiltinClassLoader.java:579) ~[?:?]
	at java.base/jdk.internal.loader.ClassLoaders$AppClassLoader.loadClass(ClassLoaders.java:178) ~[?:?]
	at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:522) ~[?:?]
	at org.apache.parquet.HadoopReadOptions$Builder.<init>(HadoopReadOptions.java:112) ~[parquet-hadoop-1.13.1.jar:1.13.1]
	at org.apache.parquet.HadoopReadOptions.builder(HadoopReadOptions.java:89) ~[parquet-hadoop-1.13.1.jar:1.13.1]
	at org.apache.parquet.hadoop.ParquetFileReader.readFooter(ParquetFileReader.java:523) ~[parquet-hadoop-1.13.1.jar:1.13.1]
	at org.apache.parquet.hadoop.ParquetFileReader.readFooter(ParquetFileReader.java:478) ~[parquet-hadoop-1.13.1.jar:1.13.1]
	at org.apache.pinot.plugin.inputformat.parquet.ParquetUtils.hasAvroSchemaInFileMetadata(ParquetUtils.java:81) ~[pinot-parquet-1.2.0-20240309.090137-47.jar:1.2.0-SNAPSHOT-b2689bcd8034fe17a627bcec1d46c850c5290104]
	at org.apache.pinot.plugin.inputformat.parquet.ParquetRecordReader.init(ParquetRecordReader.java:54) ~[pinot-parquet-1.2.0-20240309.090137-47.jar:1.2.0-SNAPSHOT-b2689bcd8034fe17a627bcec1d46c850c5290104]
	at org.apache.pinot.spi.data.readers.RecordReaderFactory.getRecordReaderByClass(RecordReaderFactory.java:148) ~[pinot-spi-1.2.0-20240309.090137-49.jar:1.2.0-SNAPSHOT-b2689bcd8034fe17a627bcec1d46c850c5290104]
	at org.apache.pinot.spi.data.readers.RecordReaderFactory.getRecordReader(RecordReaderFactory.java:171) ~[pinot-spi-1.2.0-20240309.090137-49.jar:1.2.0-SNAPSHOT-b2689bcd8034fe17a627bcec1d46c850c5290104]
	at org.apache.pinot.spi.data.readers.RecordReaderFactory.getRecordReader(RecordReaderFactory.java:158) ~[pinot-spi-1.2.0-20240309.090137-49.jar:1.2.0-SNAPSHOT-b2689bcd8034fe17a627bcec1d46c850c5290104]
```