### PR TITLE
Removed antlr from the dependency

### DIFF
--- a/pinot-common/pom.xml
+++ b/pinot-common/pom.xml
@@ -57,19 +57,6 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.antlr</groupId>
-        <artifactId>antlr4-maven-plugin</artifactId>
-        <version>${antlr.version}</version>
-        <executions>
-          <execution>
-            <id>antlr</id>
-            <goals>
-              <goal>antlr4</goal>
-            </goals>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
         <groupId>org.xolstice.maven.plugins</groupId>
         <artifactId>protobuf-maven-plugin</artifactId>
       </plugin>
@@ -217,10 +204,6 @@
     <dependency>
       <groupId>org.apache.httpcomponents</groupId>
       <artifactId>httpcore</artifactId>
-    </dependency>
-    <dependency>
-      <groupId>org.antlr</groupId>
-      <artifactId>antlr4-runtime</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.calcite</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -133,7 +133,6 @@
     <hk2.version>2.6.1</hk2.version>
     <swagger.version>1.6.9</swagger.version>
     <hadoop.version>3.3.6</hadoop.version>
-    <antlr.version>4.13.1</antlr.version>
     <jsonpath.version>2.9.0</jsonpath.version>
     <jsonsmart.version>2.5.0</jsonsmart.version>
     <quartz.version>2.3.2</quartz.version>
@@ -1087,11 +1086,6 @@
         <groupId>com.tdunning</groupId>
         <artifactId>t-digest</artifactId>
         <version>3.2</version>
-      </dependency>
-      <dependency>
-        <groupId>org.antlr</groupId>
-        <artifactId>antlr4-runtime</artifactId>
-        <version>${antlr.version}</version>
       </dependency>
       <dependency>
         <groupId>com.jayway.jsonpath</groupId>


### PR DESCRIPTION
The dependency on antlr causes problems in our build environment as it changes versions.

We should no longer depend on antlr in the main pom since pinot does not use antlr anymore (PQL is removed)
