### PR TITLE
missed to delete the temp dir

### DIFF
--- a/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
+++ b/pinot-integration-test-base/src/test/java/org/apache/pinot/integration/tests/ClusterTest.java
@@ -346,7 +346,7 @@ public abstract class ClusterTest extends ControllerTest {
     for (BaseServerStarter serverStarter : _serverStarters) {
       serverStarter.stop();
     }
-    FileUtils.deleteQuietly(new File(_baseInstanceDataDir + File.separator + "PinotServer"));
+    FileUtils.deleteQuietly(new File(_baseInstanceDataDir));
     _serverStarters = null;
     _serverGrpcPort = 0;
     _serverAdminApiPort = 0;

--- a/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
+++ b/pinot-integration-tests/src/test/java/org/apache/pinot/integration/tests/PartialUpsertTableRebalanceIntegrationTest.java
@@ -28,6 +28,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.commons.io.FileUtils;
 import org.apache.helix.model.IdealState;
 import org.apache.pinot.client.ResultSetGroup;
 import org.apache.pinot.common.exception.HttpErrorStatusException;
@@ -299,12 +300,14 @@ public class PartialUpsertTableRebalanceIntegrationTest extends BaseClusterInteg
   }
 
   @AfterClass
-  public void tearDown() {
+  public void tearDown()
+      throws IOException {
     stopServer();
     stopBroker();
     stopController();
     stopKafka();
     stopZk();
+    FileUtils.deleteDirectory(_tempDir);
   }
 
   @Override


### PR DESCRIPTION
missed to delete the temp dir after finishing the tests. the other upsert test cases cleaned up the temp dir in tearDown()