### PR TITLE
Add back some exclude deps from hadoop-mapreduce-client-core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -922,18 +922,6 @@
             <groupId>io.netty</groupId>
             <artifactId>netty</artifactId>
           </exclusion>
-          <exclusion>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-yarn-client</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-yarn-common</artifactId>
-          </exclusion>
-          <exclusion>
-            <groupId>org.apache.hadoop</groupId>
-            <artifactId>hadoop-hdfs-client</artifactId>
-          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
Add back some exclude deps from `hadoop-mapreduce-client-core`:
``` 
org.apache.hadoop:hadoop-yarn-client
org.apache.hadoop:hadoop-yarn-common
org.apache.hadoop:hadoop-hdfs-client
```