### PR TITLE
Assign default value to newly added derived column upon reload

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -368,17 +368,15 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
           for (String argument : arguments) {
             ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(argument);
             if (columnMetadata == null) {
-              LOGGER.warn("Skip creating derived column: {} because argument: {} does not exist in the segment", column,
-                  argument);
-              if (errorOnFailure) {
-                throw new RuntimeException(String.format(
-                    "Failed to create derived column: %s because argument: %s does not exist in the segment", column,
-                    argument));
-              }
-              return false;
-            }
-            // TODO: Support creation of derived columns from forward index disabled columns
-            if (!_segmentWriter.hasIndexFor(argument, StandardIndexes.forward())) {
+              // replace the transform function with the default value for the derived column
+              String expression = _schema.getFieldSpecFor(column).getDefaultNullValueString();
+              LOGGER.warn("Assigning default value '{}' to derived column: {} because argument: {} does not exist in "
+                      + "the segment", expression, column, argument);
+              argumentsMetadata.clear();
+              functionEvaluator = FunctionEvaluatorFactory.getExpressionEvaluator(expression);
+              break;
+            } else if (!_segmentWriter.hasIndexFor(argument, StandardIndexes.forward())) {
+              // TODO: Support creation of derived columns from forward index disabled columns
               throw new UnsupportedOperationException(String.format("Operation not supported! Cannot create a derived "
                   + "column %s because argument: %s does not have a forward index. Enable forward index and "
                   + "refresh/backfill the segments to create a derived column from source column %s", column, argument,

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/loader/defaultcolumn/BaseDefaultColumnHandler.java
@@ -368,14 +368,10 @@ public abstract class BaseDefaultColumnHandler implements DefaultColumnHandler {
           for (String argument : arguments) {
             ColumnMetadata columnMetadata = _segmentMetadata.getColumnMetadataFor(argument);
             if (columnMetadata == null) {
-              LOGGER.warn("Skip creating derived column: {} because argument: {} does not exist in the segment", column,
-                  argument);
-              if (errorOnFailure) {
-                throw new RuntimeException(String.format(
-                    "Failed to create derived column: %s because argument: %s does not exist in the segment", column,
-                    argument));
-              }
-              return false;
+              LOGGER.warn("Assigning default value to derived column: {} because argument: {} does not exist in the "
+                  + "segment", column, argument);
+              createDefaultValueColumnV1Indices(column);
+              return true;
             }
             // TODO: Support creation of derived columns from forward index disabled columns
             if (!_segmentWriter.hasIndexFor(argument, StandardIndexes.forward())) {


### PR DESCRIPTION
This change is intended to handle the case where the derived column depends on upstream data which is not a column in the table schema. Currently it fails reloading the existing segments as existing segments don’t have this data available. With this PR the newly added derived column will be assigned the default null value in such cases so that user is able to query the column across all segments.
