### PR TITLE
Better handling of null tableNames

### DIFF
--- a/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/DynamicBrokerSelector.java
+++ b/pinot-clients/pinot-java-client/src/main/java/org/apache/pinot/client/DynamicBrokerSelector.java
@@ -89,7 +89,7 @@ public class DynamicBrokerSelector implements BrokerSelector, IZkDataListener {
   @Nullable
   @Override
   public String selectBroker(String... tableNames) {
-    if (tableNames != null) {
+    if (!(tableNames == null || tableNames.length == 0 || tableNames[0] == null)) {
       // getting list of brokers hosting all the tables.
       List<String> list = BrokerSelectorUtils.getTablesCommonBrokers(Arrays.asList(tableNames),
           _tableToBrokerListMapRef.get());


### PR DESCRIPTION
Robust handling of null tableName to resolve below stack trace when the caller invoked this method as:
```
String tableName = null;
brokerSelector.selectBroker(tableName);
```


```
Caused by: java.lang.NullPointerException: Cannot invoke "String.replace(java.lang.CharSequence, java.lang.CharSequence)" because "tableName" is null
 ┊at org.apache.pinot.client.utils.BrokerSelectorUtils.getTableNameWithoutSuffix(BrokerSelectorUtils.java:69)
 ┊at org.apache.pinot.client.utils.BrokerSelectorUtils.getTablesCommonBrokers(BrokerSelectorUtils.java:42)
 ┊at org.apache.pinot.client.DynamicBrokerSelector.selectBroker(DynamicBrokerSelector.java:94)
```