### PR TITLE
Ignore case when checking for Direct Memory OOM

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/DirectOOMHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/DirectOOMHandler.java
@@ -22,6 +22,7 @@ import io.netty.channel.ChannelHandlerContext;
 import io.netty.channel.ChannelInboundHandlerAdapter;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.commons.lang3.StringUtils;
 import org.apache.pinot.common.metrics.BrokerMeter;
 import org.apache.pinot.common.metrics.BrokerMetrics;
 import org.apache.pinot.spi.exception.QueryCancelledException;
@@ -65,7 +66,9 @@ public class DirectOOMHandler extends ChannelInboundHandlerAdapter {
   @Override
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
     // catch direct memory oom here
-    if (cause instanceof OutOfMemoryError && cause.getMessage().contains("Direct buffer")) {
+    ;
+    if (cause instanceof OutOfMemoryError
+        && StringUtils.containsIgnoreCase(cause.getMessage(), "direct buffer")) {
       BrokerMetrics.get().addMeteredGlobalValue(BrokerMeter.DIRECT_MEMORY_OOM, 1L);
       // only one thread can get here and do the shutdown
       if (DIRECT_OOM_SHUTTING_DOWN.compareAndSet(false, true)) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/transport/DirectOOMHandler.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/transport/DirectOOMHandler.java
@@ -66,7 +66,6 @@ public class DirectOOMHandler extends ChannelInboundHandlerAdapter {
   @Override
   public void exceptionCaught(ChannelHandlerContext ctx, Throwable cause) throws Exception {
     // catch direct memory oom here
-    ;
     if (cause instanceof OutOfMemoryError
         && StringUtils.containsIgnoreCase(cause.getMessage(), "direct buffer")) {
       BrokerMetrics.get().addMeteredGlobalValue(BrokerMeter.DIRECT_MEMORY_OOM, 1L);


### PR DESCRIPTION
We have seen cases where the fault message for a Direct Memory OOM uses different casing for the phrase `Direct buffer`.  Which meant the Direct Memory OOM Handler in the Pinot Netty code was not triggered and, so, the OOM was not cleaned up, leaving Pinot in a failed state.

This PR changes the `if` check to ignore case when checking the fault message.