### PR TITLE
Validate Duplicate Config Properties

### DIFF
--- a/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/env/CommonsConfigurationUtils.java
@@ -125,7 +125,19 @@ public class CommonsConfigurationUtils {
     } else {
       fileHandler.setFile(file);
     }
+    checkForDuplicateKeys(config);
     return config;
+  }
+
+  private static void checkForDuplicateKeys(PropertiesConfiguration config) throws ConfigurationException {
+    Iterator<String> keys = config.getKeys();
+    while (keys.hasNext()) {
+      String key = keys.next();
+      Object value = config.getProperty(key);
+      if (!(value instanceof String)) {
+        throw new ConfigurationException(String.format("duplicate key found in properties configuration file %s", key));
+      }
+    }
   }
 
   /**

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/env/CommonsConfigurationUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/env/CommonsConfigurationUtilsTest.java
@@ -20,7 +20,10 @@ package org.apache.pinot.spi.env;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URL;
+
 import org.apache.commons.configuration2.PropertiesConfiguration;
+import org.apache.commons.configuration2.ex.ConfigurationException;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -28,8 +31,8 @@ import org.testng.annotations.AfterClass;
 import org.testng.annotations.BeforeClass;
 import org.testng.annotations.Test;
 
-import static org.testng.Assert.assertEquals;
-import static org.testng.Assert.assertTrue;
+import static org.testng.Assert.*;
+import static org.testng.Assert.fail;
 
 
 public class CommonsConfigurationUtilsTest {
@@ -88,6 +91,25 @@ public class CommonsConfigurationUtilsTest {
     for (int i = 0; i < NUM_ROUNDS; i++) {
       testPropertyValueWithSpecialCharacters(RandomStringUtils.randomAscii(5));
       testPropertyValueWithSpecialCharacters(StringUtils.remove(RandomStringUtils.random(5), '\0'));
+    }
+  }
+
+  @Test
+  public void testDuplicateKeysInPropertiesFile() throws Exception {
+    String propertiesFile = "pinot-configuration-duplicate-keys";
+    String duplicatePropertyKey = "controller.data.dir";
+
+    URL resource = CommonsConfigurationUtilsTest.class.getClassLoader().getResource(propertiesFile);
+    if(resource == null) {
+      fail("unable to get test file");
+    }
+
+    File file = new File(resource.getFile());
+    try {
+      CommonsConfigurationUtils.fromFile(file);
+      fail("expecting ConfigurationException");
+    } catch (ConfigurationException e) {
+      assert(e.getMessage()).equals(String.format("duplicate key found in properties configuration file %s", duplicatePropertyKey));
     }
   }
 

--- a/pinot-spi/src/test/resources/pinot-configuration-duplicate-keys
+++ b/pinot-spi/src/test/resources/pinot-configuration-duplicate-keys
@@ -1,0 +1,2 @@
+controller.data.dir = /tmp/PinotController
+controller.data.dir = /tmp/PinotController


### PR DESCRIPTION
The default behavior of PropertiesConfiguration when reading a .properties file is to create an array of the duplicate values for the key instead of a single string.  This change throws a ConfigurationException if someone mistakenly adds duplicate keys.

Reference issue https://github.com/apache/pinot/issues/7882
