### PR TITLE
Add support for phrase search with wildcard and prefix matching for Lucene indexed tables

### DIFF
--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -295,7 +295,8 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
             + "distributed storage, concurrency, multi-threading, apache airflow"});
 
     String query =
-        "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '*ealtime streaming system*') LIMIT 50000";
+        "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '*ealtime streaming system*') "
+            + "LIMIT 50000";
     testTextSearchSelectQueryHelper(query, expected.size(), false, expected);
 
     // Search /*java realtime stream system*, only 1 result left./
@@ -304,7 +305,8 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
         "Distributed systems, Java, realtime streaming systems, Machine learning, spark, Kubernetes, distributed "
             + "storage, concurrency, multi-threading"});
     String query1 =
-        "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '*ava realtime streaming system*') LIMIT 50000";
+        "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '*ava realtime streaming "
+            + "system*') LIMIT 50000";
     testTextSearchSelectQueryHelper(query1, expected1.size(), false, expected1);
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/TextSearchQueriesTest.java
@@ -308,6 +308,16 @@ public class TextSearchQueriesTest extends BaseQueriesTest {
         "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '*ava realtime streaming "
             + "system*') LIMIT 50000";
     testTextSearchSelectQueryHelper(query1, expected1.size(), false, expected1);
+
+    String query2 =
+        "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '*ava realtime streaming "
+            + "system* AND *chine learn*') LIMIT 50000";
+    testTextSearchSelectQueryHelper(query2, expected1.size(), false, expected1);
+
+    String query3 =
+        "SELECT INT_COL, SKILLS_TEXT_COL FROM MyTable WHERE TEXT_MATCH(SKILLS_TEXT_COL, '*ava realtime streaming "
+            + "system* AND *chine learner*') LIMIT 50000";
+    testTextSearchSelectQueryHelper(query3, 0, false, new ArrayList<>());
   }
 
   /**

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/RealtimeLuceneTextIndex.java
@@ -123,7 +123,9 @@ public class RealtimeLuceneTextIndex implements MutableTextIndex {
       IndexSearcher indexSearcher = null;
       try {
         QueryParser parser = new QueryParser(_column, _analyzer);
-        parser.setAllowLeadingWildcard(true);
+        if (_enablePrefixSuffixMatchingInPhraseQueries) {
+          parser.setAllowLeadingWildcard(true);
+        }
         Query query = parser.parse(searchQuery);
         if (_enablePrefixSuffixMatchingInPhraseQueries) {
           query = LuceneTextIndexUtils.convertToMultiTermSpanQuery(query);

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/readers/text/LuceneTextIndexReader.java
@@ -155,7 +155,11 @@ public class LuceneTextIndexReader implements TextIndexReader {
       // be instantiated per query. Analyzer on the other hand is stateless
       // and can be created upfront.
       QueryParser parser = new QueryParser(_column, _analyzer);
-      parser.setAllowLeadingWildcard(true);
+      // Phrase search with prefix/suffix matching may have leading *. E.g., `*pache pinot` which can be stripped by
+      // the query parser. To support the feature, we need to explicitly set the config to be true.
+      if (_enablePrefixSuffixMatchingInPhraseQueries) {
+        parser.setAllowLeadingWildcard(true);
+      }
       if (_useANDForMultiTermQueries) {
         parser.setDefaultOperator(QueryParser.Operator.AND);
       }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexConfigBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexConfigBuilder.java
@@ -50,6 +50,7 @@ public class TextIndexConfigBuilder extends TextIndexConfig.AbstractBuilder {
           textIndexProperties.get(FieldConfig.TEXT_INDEX_USE_AND_FOR_MULTI_TERM_QUERIES));
       _stopWordsInclude = TextIndexUtils.extractStopWordsInclude(textIndexProperties);
       _stopWordsExclude = TextIndexUtils.extractStopWordsExclude(textIndexProperties);
+      _enablePrefixSuffixMatchingInPhraseQueries = Boolean.parseBoolean(textIndexProperties.get(FieldConfig.TEXT_INDEX_ENABLE_PREFIX_SUFFIX_PHRASE_QUERIES));
 
       if (textIndexProperties.get(FieldConfig.TEXT_INDEX_LUCENE_USE_COMPOUND_FILE) != null) {
         _luceneUseCompoundFile =

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexConfigBuilder.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/segment/index/text/TextIndexConfigBuilder.java
@@ -50,7 +50,8 @@ public class TextIndexConfigBuilder extends TextIndexConfig.AbstractBuilder {
           textIndexProperties.get(FieldConfig.TEXT_INDEX_USE_AND_FOR_MULTI_TERM_QUERIES));
       _stopWordsInclude = TextIndexUtils.extractStopWordsInclude(textIndexProperties);
       _stopWordsExclude = TextIndexUtils.extractStopWordsExclude(textIndexProperties);
-      _enablePrefixSuffixMatchingInPhraseQueries = Boolean.parseBoolean(textIndexProperties.get(FieldConfig.TEXT_INDEX_ENABLE_PREFIX_SUFFIX_PHRASE_QUERIES));
+      _enablePrefixSuffixMatchingInPhraseQueries =
+          Boolean.parseBoolean(textIndexProperties.get(FieldConfig.TEXT_INDEX_ENABLE_PREFIX_SUFFIX_PHRASE_QUERIES));
 
       if (textIndexProperties.get(FieldConfig.TEXT_INDEX_LUCENE_USE_COMPOUND_FILE) != null) {
         _luceneUseCompoundFile =

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtils.java
@@ -26,6 +26,7 @@ import org.apache.lucene.queries.spans.SpanTermQuery;
 import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
@@ -61,7 +62,8 @@ public class LuceneTextIndexUtils {
       return query;
     }
     SpanNearQuery spanNearQuery = new SpanNearQuery(spanQueryLst.toArray(new SpanQuery[0]), 0, true);
-    LOGGER.error("The phrase query {} is re-written as {}", query, spanNearQuery);
+    IndexSearcher.setMaxClauseCount(Integer.MAX_VALUE);
+    LOGGER.info("The phrase query {} is re-written as {}", query, spanNearQuery);
     return spanNearQuery;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtils.java
@@ -26,7 +26,6 @@ import org.apache.lucene.queries.spans.SpanTermQuery;
 import org.apache.lucene.search.AutomatonQuery;
 import org.apache.lucene.search.BooleanClause;
 import org.apache.lucene.search.BooleanQuery;
-import org.apache.lucene.search.IndexSearcher;
 import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtils.java
@@ -31,22 +31,27 @@ import org.apache.lucene.search.PrefixQuery;
 import org.apache.lucene.search.Query;
 import org.apache.lucene.search.TermQuery;
 import org.apache.lucene.search.WildcardQuery;
+import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 
 public class LuceneTextIndexUtils {
-  private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(LuceneTextIndexUtils.class);
+  private static final Logger LOGGER = LoggerFactory.getLogger(LuceneTextIndexUtils.class);
 
   private LuceneTextIndexUtils() {
   }
 
-  // Convert a boolean query with literal matching for each clause to a span query which enables prefix and suffix
-  // matching for terms with .* prefix or suffix.
+  /**
+   *
+   * @param query a Lucene query
+   * @return a span query with 0 slop and the original clause order if the input query is boolean query with one or more
+   * prefix or wildcard subqueries; the same query otherwise.
+   */
   public static Query convertToMultiTermSpanQuery(Query query) {
     if (!(query instanceof BooleanQuery)) {
       return query;
     }
-    LOGGER.info("Perform rewriting for the phrase query {}.", query);
+    LOGGER.debug("Perform rewriting for the phrase query {}.", query);
     ArrayList<SpanQuery> spanQueryLst = new ArrayList<>();
     boolean prefixOrSuffixQueryFound = false;
     for (BooleanClause clause : ((BooleanQuery) query).clauses()) {
@@ -65,8 +70,7 @@ public class LuceneTextIndexUtils {
       return query;
     }
     SpanNearQuery spanNearQuery = new SpanNearQuery(spanQueryLst.toArray(new SpanQuery[0]), 0, true);
-    IndexSearcher.setMaxClauseCount(Integer.MAX_VALUE);
-    LOGGER.info("The phrase query {} is re-written as {}", query, spanNearQuery);
+    LOGGER.debug("The phrase query {} is re-written as {}", query, spanNearQuery);
     return spanNearQuery;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtils.java
@@ -1,0 +1,67 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils;
+
+import java.util.ArrayList;
+import org.apache.lucene.queries.spans.SpanMultiTermQueryWrapper;
+import org.apache.lucene.queries.spans.SpanNearQuery;
+import org.apache.lucene.queries.spans.SpanQuery;
+import org.apache.lucene.queries.spans.SpanTermQuery;
+import org.apache.lucene.search.AutomatonQuery;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.PrefixQuery;
+import org.apache.lucene.search.Query;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.WildcardQuery;
+import org.slf4j.LoggerFactory;
+
+
+public class LuceneTextIndexUtils {
+  private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(LuceneTextIndexUtils.class);
+
+  // Convert a boolean query with literal matching for each clause to a span query which enables prefix and suffix
+  // matching for terms with .* prefix or suffix.
+  public static Query convertToMultiTermSpanQuery(Query query) {
+    if (!(query instanceof BooleanQuery)) {
+      return query;
+    }
+    LOGGER.info("Perform rewriting for the phrase query {}.", query);
+    ArrayList<SpanQuery> spanQueryLst = new ArrayList<>();
+    boolean prefixOrSuffixQueryFound = false;
+    for (BooleanClause clause : ((BooleanQuery) query).clauses()) {
+      Query q = clause.getQuery();
+      if (q instanceof WildcardQuery || q instanceof PrefixQuery) {
+        prefixOrSuffixQueryFound = true;
+        spanQueryLst.add(new SpanMultiTermQueryWrapper<>((AutomatonQuery) q));
+      } else if (q instanceof TermQuery) {
+        spanQueryLst.add(new SpanTermQuery(((TermQuery) q).getTerm()));
+      } else {
+        LOGGER.info("query can not be handled currently {} ", q);
+        return query;
+      }
+    }
+    if (!prefixOrSuffixQueryFound) {
+      return query;
+    }
+    SpanNearQuery spanNearQuery = new SpanNearQuery(spanQueryLst.toArray(new SpanQuery[0]), 0, true);
+    LOGGER.error("The phrase query {} is re-written as {}", query, spanNearQuery);
+    return spanNearQuery;
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtils.java
@@ -37,6 +37,9 @@ import org.slf4j.LoggerFactory;
 public class LuceneTextIndexUtils {
   private static final org.slf4j.Logger LOGGER = LoggerFactory.getLogger(LuceneTextIndexUtils.class);
 
+  private LuceneTextIndexUtils() {
+  }
+
   // Convert a boolean query with literal matching for each clause to a span query which enables prefix and suffix
   // matching for terms with .* prefix or suffix.
   public static Query convertToMultiTermSpanQuery(Query query) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/LuceneMutableTextIndexTest.java
@@ -59,7 +59,7 @@ public class LuceneMutableTextIndexTest {
   public void setUp()
       throws Exception {
     TextIndexConfig config =
-            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null);
+            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false);
     _realtimeLuceneTextIndex =
         new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", config);
     String[][] documents = getTextData();

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/realtime/impl/invertedindex/NativeAndLuceneMutableTextIndexTest.java
@@ -72,7 +72,7 @@ public class NativeAndLuceneMutableTextIndexTest {
   public void setUp()
       throws Exception {
     TextIndexConfig config =
-        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null);
+        new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false);
     _realtimeLuceneTextIndex =
         new RealtimeLuceneTextIndex(TEXT_COLUMN_NAME, INDEX_DIR, "fooBar", config);
     _nativeMutableTextIndex = new NativeMutableTextIndex(TEXT_COLUMN_NAME);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/FilePerIndexDirectoryTest.java
@@ -202,7 +202,7 @@ public class FilePerIndexDirectoryTest {
   public void testRemoveTextIndices()
       throws IOException {
     TextIndexConfig config =
-            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null);
+            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false);
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
          LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, config);
         LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true, config)) {
@@ -265,7 +265,7 @@ public class FilePerIndexDirectoryTest {
   public void testGetColumnIndices()
       throws IOException {
     TextIndexConfig config =
-            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null);
+            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false);
     // Write sth to buffers and flush them to index files on disk
     try (FilePerIndexDirectory fpi = new FilePerIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, config);

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/segment/store/SingleFileIndexDirectoryTest.java
@@ -235,7 +235,7 @@ public class SingleFileIndexDirectoryTest {
   public void testRemoveTextIndices()
       throws IOException, ConfigurationException {
     TextIndexConfig config =
-            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null);
+            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false);
     try (SingleFileIndexDirectory sfd = new SingleFileIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, config);
         LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true, config)) {
@@ -341,7 +341,7 @@ public class SingleFileIndexDirectoryTest {
   public void testGetColumnIndices()
       throws Exception {
     TextIndexConfig config =
-            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null);
+            new TextIndexConfig(false, null, null, false, false, null, null, true, 500, null, false);
     try (SingleFileIndexDirectory sfd = new SingleFileIndexDirectory(TEMP_DIR, _segmentMetadata, ReadMode.mmap);
         LuceneTextIndexCreator fooCreator = new LuceneTextIndexCreator("foo", TEMP_DIR, true, config);
         LuceneTextIndexCreator barCreator = new LuceneTextIndexCreator("bar", TEMP_DIR, true, config)) {

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtilsTest.java
@@ -68,7 +68,7 @@ public class LuceneTextIndexUtilsTest {
         .add(new BooleanClause(prefixQuery, BooleanClause.Occur.SHOULD));
 
     SpanQuery[] spanQueries3 = {new SpanMultiTermQueryWrapper<>(wildcardQuery), new SpanMultiTermQueryWrapper<>(
-        prefixQuery), new SpanMultiTermQueryWrapper<>(prefixQuery),};
+        prefixQuery), new SpanMultiTermQueryWrapper<>(prefixQuery)};
     expectedQuery = new SpanNearQuery(spanQueries3, 0, true);
     Assert.assertEquals(expectedQuery, LuceneTextIndexUtils.convertToMultiTermSpanQuery(builder.build()));
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtilsTest.java
@@ -67,9 +67,8 @@ public class LuceneTextIndexUtilsTest {
         .add(new BooleanClause(prefixQuery, BooleanClause.Occur.SHOULD))
         .add(new BooleanClause(prefixQuery, BooleanClause.Occur.SHOULD));
 
-    SpanQuery[] spanQueries3 =
-        {new SpanMultiTermQueryWrapper<>(wildcardQuery), new SpanMultiTermQueryWrapper<>(prefixQuery),
-            new SpanMultiTermQueryWrapper<>(prefixQuery),};
+    SpanQuery[] spanQueries3 = {new SpanMultiTermQueryWrapper<>(wildcardQuery), new SpanMultiTermQueryWrapper<>(
+        prefixQuery), new SpanMultiTermQueryWrapper<>(prefixQuery),};
     expectedQuery = new SpanNearQuery(spanQueries3, 0, true);
     Assert.assertEquals(expectedQuery, LuceneTextIndexUtils.convertToMultiTermSpanQuery(builder.build()));
 

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtilsTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/utils/LuceneTextIndexUtilsTest.java
@@ -1,0 +1,101 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.utils;
+
+import org.apache.lucene.index.Term;
+import org.apache.lucene.queries.spans.SpanMultiTermQueryWrapper;
+import org.apache.lucene.queries.spans.SpanNearQuery;
+import org.apache.lucene.queries.spans.SpanQuery;
+import org.apache.lucene.queries.spans.SpanTermQuery;
+import org.apache.lucene.search.BooleanClause;
+import org.apache.lucene.search.BooleanQuery;
+import org.apache.lucene.search.PrefixQuery;
+import org.apache.lucene.search.RegexpQuery;
+import org.apache.lucene.search.TermQuery;
+import org.apache.lucene.search.WildcardQuery;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class LuceneTextIndexUtilsTest {
+  @Test
+  public void testBooleanQueryRewrittenToSpanQuery() {
+    // Test 1: The input is a boolean query with 2 clauses: "*pache pino*"
+    BooleanQuery.Builder builder = new BooleanQuery.Builder();
+    WildcardQuery wildcardQuery = new WildcardQuery(new Term("field", "*apche"));
+    PrefixQuery prefixQuery = new PrefixQuery(new Term("field", "pino"));
+    builder.add(new BooleanClause(wildcardQuery, BooleanClause.Occur.SHOULD))
+        .add(new BooleanClause(prefixQuery, BooleanClause.Occur.SHOULD));
+
+    SpanQuery[] spanQueries1 =
+        {new SpanMultiTermQueryWrapper<>(wildcardQuery), new SpanMultiTermQueryWrapper<>(prefixQuery)};
+    SpanQuery expectedQuery = new SpanNearQuery(spanQueries1, 0, true);
+    Assert.assertEquals(expectedQuery, LuceneTextIndexUtils.convertToMultiTermSpanQuery(builder.build()));
+
+    // Test 2: The input is a boolean query with 3 clauses: "*pache real pino*"
+    builder = new BooleanQuery.Builder();
+    Term term = new Term("field", "real");
+    builder.add(new BooleanClause(wildcardQuery, BooleanClause.Occur.SHOULD))
+        .add(new BooleanClause(new TermQuery(term), BooleanClause.Occur.SHOULD))
+        .add(new BooleanClause(prefixQuery, BooleanClause.Occur.SHOULD));
+
+    SpanQuery[] spanQueries2 =
+        {new SpanMultiTermQueryWrapper<>(wildcardQuery), new SpanTermQuery(term), new SpanMultiTermQueryWrapper<>(
+            prefixQuery)};
+    expectedQuery = new SpanNearQuery(spanQueries2, 0, true);
+    Assert.assertEquals(expectedQuery, LuceneTextIndexUtils.convertToMultiTermSpanQuery(builder.build()));
+
+    // Test 3: The input is a boolean query with 3 clauses: "*pache real* pino*"
+    builder = new BooleanQuery.Builder();
+    builder.add(new BooleanClause(wildcardQuery, BooleanClause.Occur.SHOULD))
+        .add(new BooleanClause(prefixQuery, BooleanClause.Occur.SHOULD))
+        .add(new BooleanClause(prefixQuery, BooleanClause.Occur.SHOULD));
+
+    SpanQuery[] spanQueries3 =
+        {new SpanMultiTermQueryWrapper<>(wildcardQuery), new SpanMultiTermQueryWrapper<>(prefixQuery),
+            new SpanMultiTermQueryWrapper<>(prefixQuery),};
+    expectedQuery = new SpanNearQuery(spanQueries3, 0, true);
+    Assert.assertEquals(expectedQuery, LuceneTextIndexUtils.convertToMultiTermSpanQuery(builder.build()));
+
+    // Test 4: The input is a boolean query with 1 clause: "*pino*".
+    WildcardQuery wildcardQuery1 = new WildcardQuery(new Term("field", "*pino*"));
+    builder = new BooleanQuery.Builder();
+    builder.add(new BooleanClause(wildcardQuery1, BooleanClause.Occur.SHOULD));
+    SpanQuery[] spanQueries4 = {new SpanMultiTermQueryWrapper<>(wildcardQuery1)};
+    expectedQuery = new SpanNearQuery(spanQueries4, 0, true);
+    Assert.assertEquals(expectedQuery, LuceneTextIndexUtils.convertToMultiTermSpanQuery(builder.build()));
+
+    // Test 5: Boolean queries without any wildcard/prefix subqueries are left unchanged.
+    builder = new BooleanQuery.Builder();
+    builder.add(new BooleanClause(new TermQuery(term), BooleanClause.Occur.SHOULD))
+        .add(new BooleanClause(new TermQuery(term), BooleanClause.Occur.SHOULD));
+    BooleanQuery q = builder.build();
+    Assert.assertEquals(q, LuceneTextIndexUtils.convertToMultiTermSpanQuery(q));
+  }
+
+  @Test
+  public void testQueryIsNotRewritten() {
+    // Test 1: Term query is not re-written.
+    TermQuery termQuery = new TermQuery(new Term("field", "real"));
+    Assert.assertEquals(termQuery, LuceneTextIndexUtils.convertToMultiTermSpanQuery(termQuery));
+    // Test 2: Regex query is not re-written.
+    RegexpQuery regexpQuery = new RegexpQuery(new Term("field", "\\d+"));
+    Assert.assertEquals(regexpQuery, LuceneTextIndexUtils.convertToMultiTermSpanQuery(regexpQuery));
+  }
+}

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/index/TextIndexConfig.java
@@ -38,6 +38,7 @@ public class TextIndexConfig extends IndexConfig {
   public static final TextIndexConfig DISABLED =
       new TextIndexConfig(true, null, null, false, false, Collections.emptyList(), Collections.emptyList(), false,
           LUCENE_INDEX_DEFAULT_MAX_BUFFER_SIZE_MB, null, false);
+  private static final boolean LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH = false;
   private final FSTType _fstType;
   @Nullable
   private final Object _rawValueForTextIndex;
@@ -75,7 +76,8 @@ public class TextIndexConfig extends IndexConfig {
     _luceneAnalyzerClass = (luceneAnalyzerClass == null || luceneAnalyzerClass.isEmpty())
         ? FieldConfig.TEXT_INDEX_DEFAULT_LUCENE_ANALYZER_CLASS : luceneAnalyzerClass;
     _enablePrefixSuffixMatchingInPhraseQueries =
-        enablePrefixSuffixMatchingInPhraseQueries == null ? false : enablePrefixSuffixMatchingInPhraseQueries;
+        enablePrefixSuffixMatchingInPhraseQueries == null ? LUCENE_INDEX_ENABLE_PREFIX_SUFFIX_MATCH_IN_PHRASE_SEARCH
+            : enablePrefixSuffixMatchingInPhraseQueries;
   }
 
   public FSTType getFstType() {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/config/table/FieldConfig.java
@@ -61,6 +61,8 @@ public class FieldConfig extends BaseJsonConfig {
   // Config to disable forward index
   public static final String FORWARD_INDEX_DISABLED = "forwardIndexDisabled";
   public static final String DEFAULT_FORWARD_INDEX_DISABLED = Boolean.FALSE.toString();
+  public static final String TEXT_INDEX_ENABLE_PREFIX_SUFFIX_PHRASE_QUERIES =
+      "enablePrefixSuffixMatchingInPhraseQueries";
 
   private final String _name;
   private final EncodingType _encodingType;


### PR DESCRIPTION
[Issue 10863](https://github.com/apache/pinot/issues/10863) Pinot's TEXT_MATCH filter today does not support phrase search with wildcard and prefix matching (e.g., "\*pache pino\*" to match "Apache Pinot") directly. The kind of queries is very common in use case like log search where user needs to search matching results in long text. Today one has to use external means to walk around this issue (e.g., concatenating all words in a paragraph into a longer string and performing regex query on it) and usually they will incur much higher query latency. 

This PR adds support to allow phrase search with wildcard and prefix matching for Lucene indexed tables. This feature is enabled through a config in the Lucene text indexed column. The default value is false (or not enabled). User can write a text match function to perform the filter (text_match(col, '\*pache pino\*')).

We have tested this feature in our internal env and it can process 150+G  of text data in 5 sec on 1 server. It can be 3x faster in phrase matching tests.

Instructions:
1. The PR has to be tagged with at least one of the following labels (*):
   1. `feature` (*)
   2. `bugfix`
   3. `performance`
   4. `ui`
   5. `backward-incompat`
   6. `release-notes` (**)
2. Remove these instructions before publishing the PR.
 
(*) Other labels to consider:
- `testing`
- `dependencies`
- `docker`
- `kubernetes`
- `observability`
- `security`
- `code-style`
- `extension-point`
- `refactor`
- `cleanup`

(**) Use `release-notes` label for scenarios like:
- New configuration options
- Deprecation of configurations
- Signature changes to public methods/interfaces
- New plugins added or old plugins removed
