### PR TITLE
12508: Feature add segment rows flush config

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FixedFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FixedFlushThresholdUpdater.java
@@ -18,33 +18,22 @@
  */
 package org.apache.pinot.controller.helix.core.realtime.segment;
 
-import com.google.common.annotations.VisibleForTesting;
 import javax.annotation.Nullable;
 import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.spi.stream.StreamConfig;
 
 
-/**
- * The default flush threshold updation strategy, which computes the flush threshold size of the segment
- * by dividing the flush threshold of the table by the max number of partitions consuming on an instance
- */
 public class FixedFlushThresholdUpdater implements FlushThresholdUpdater {
-  private final int _tableFlushSize;
+  private final int _flushThreshold;
 
-  FixedFlushThresholdUpdater(int tableFlushSize) {
-    _tableFlushSize = tableFlushSize;
+  FixedFlushThresholdUpdater(int flushThreshold) {
+    _flushThreshold = flushThreshold;
   }
 
   @Override
   public void updateFlushThreshold(StreamConfig streamConfig, SegmentZKMetadata newSegmentZKMetadata,
       CommittingSegmentDescriptor committingSegmentDescriptor, @Nullable SegmentZKMetadata committingSegmentZKMetadata,
       int maxNumPartitionsPerInstance) {
-    // Configure the segment size flush limit based on the maximum number of partitions allocated to an instance
-    newSegmentZKMetadata.setSizeThresholdToFlushSegment(_tableFlushSize);
-  }
-
-  @VisibleForTesting
-  int getTableFlushSize() {
-    return _tableFlushSize;
+    newSegmentZKMetadata.setSizeThresholdToFlushSegment(_flushThreshold);
   }
 }

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FixedFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FixedFlushThresholdUpdater.java
@@ -28,10 +28,10 @@ import org.apache.pinot.spi.stream.StreamConfig;
  * The default flush threshold updation strategy, which computes the flush threshold size of the segment
  * by dividing the flush threshold of the table by the max number of partitions consuming on an instance
  */
-public class SegmentRowsBasedFlushThresholdUpdater implements FlushThresholdUpdater {
+public class FixedFlushThresholdUpdater implements FlushThresholdUpdater {
   private final int _tableFlushSize;
 
-  SegmentRowsBasedFlushThresholdUpdater(int tableFlushSize) {
+  FixedFlushThresholdUpdater(int tableFlushSize) {
     _tableFlushSize = tableFlushSize;
   }
 

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
@@ -33,8 +33,9 @@ public class FlushThresholdUpdateManager {
    * Check table config for flush size.
    *
    * If flush size > 0, create a new DefaultFlushThresholdUpdater with given flush size.
-   * If flush size <= 0, create new SegmentSizeBasedFlushThresholdUpdater if not already created. Create only 1 per
-   * table because we want to maintain tuning information for the table in the updater.
+   * If flush size <= 0, create new SegmentRowsBasedFlushThresholdUpdater if flushThresholdSegmentRows > 0.
+   * If flush size <= 0 AND segment.row <=0, create new SegmentSizeBasedFlushThresholdUpdater if not already created.
+   * Create only 1 per table because we want to maintain tuning information for the table in the updater.
    */
   public FlushThresholdUpdater getFlushThresholdUpdater(StreamConfig streamConfig) {
     String realtimeTableName = streamConfig.getTableNameWithType();

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
@@ -40,14 +40,18 @@ public class FlushThresholdUpdateManager {
     String realtimeTableName = streamConfig.getTableNameWithType();
 
     int flushThresholdRows = streamConfig.getFlushThresholdRows();
+    int flushThresholdSegmentRows = streamConfig.getFlushThresholdSegmentRows();
+
     if (flushThresholdRows > 0) {
       _flushThresholdUpdaterMap.remove(realtimeTableName);
       return new DefaultFlushThresholdUpdater(flushThresholdRows);
     }
-
+    if (flushThresholdSegmentRows > 0) {
+      return new SegmentRowsBasedFlushThresholdUpdater(flushThresholdSegmentRows);
+    } 
     // Legacy behavior: when flush threshold rows is explicitly set to 0, use segment size based flush threshold
     long flushThresholdSegmentSizeBytes = streamConfig.getFlushThresholdSegmentSizeBytes();
-    if (flushThresholdRows == 0 || flushThresholdSegmentSizeBytes > 0) {
+    if (flushThresholdRows == 0 || flushThresholdSegmentRows == 0 || flushThresholdSegmentSizeBytes > 0) {
       return _flushThresholdUpdaterMap.computeIfAbsent(realtimeTableName,
           k -> new SegmentSizeBasedFlushThresholdUpdater());
     } else {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdateManager.java
@@ -53,11 +53,12 @@ public class FlushThresholdUpdateManager {
       return new DefaultFlushThresholdUpdater(flushThresholdRows);
     }
     if (flushThresholdSegmentRows > 0) {
+      _flushThresholdUpdaterMap.remove(realtimeTableName);
       return new FixedFlushThresholdUpdater(flushThresholdSegmentRows);
-    } 
+    }
     // Legacy behavior: when flush threshold rows is explicitly set to 0, use segment size based flush threshold
     long flushThresholdSegmentSizeBytes = streamConfig.getFlushThresholdSegmentSizeBytes();
-    if (flushThresholdRows == 0 || flushThresholdSegmentRows == 0 || flushThresholdSegmentSizeBytes > 0) {
+    if (flushThresholdRows == 0 || flushThresholdSegmentSizeBytes > 0) {
       return _flushThresholdUpdaterMap.computeIfAbsent(realtimeTableName,
           k -> new SegmentSizeBasedFlushThresholdUpdater());
     } else {

--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentRowsBasedFlushThresholdUpdater.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentRowsBasedFlushThresholdUpdater.java
@@ -1,0 +1,50 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.controller.helix.core.realtime.segment;
+
+import com.google.common.annotations.VisibleForTesting;
+import javax.annotation.Nullable;
+import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
+import org.apache.pinot.spi.stream.StreamConfig;
+
+
+/**
+ * The default flush threshold updation strategy, which computes the flush threshold size of the segment
+ * by dividing the flush threshold of the table by the max number of partitions consuming on an instance
+ */
+public class SegmentRowsBasedFlushThresholdUpdater implements FlushThresholdUpdater {
+  private final int _tableFlushSize;
+
+  SegmentRowsBasedFlushThresholdUpdater(int tableFlushSize) {
+    _tableFlushSize = tableFlushSize;
+  }
+
+  @Override
+  public void updateFlushThreshold(StreamConfig streamConfig, SegmentZKMetadata newSegmentZKMetadata,
+      CommittingSegmentDescriptor committingSegmentDescriptor, @Nullable SegmentZKMetadata committingSegmentZKMetadata,
+      int maxNumPartitionsPerInstance) {
+    // Configure the segment size flush limit based on the maximum number of partitions allocated to an instance
+    newSegmentZKMetadata.setSizeThresholdToFlushSegment(_tableFlushSize);
+  }
+
+  @VisibleForTesting
+  int getTableFlushSize() {
+    return _tableFlushSize;
+  }
+}

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddIngestionComponent.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddIngestionComponent.tsx
@@ -92,6 +92,7 @@ export default function AddIngestionComponent({
             "stream.kafka.consumer.factory.class.name":"org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.class.name":"org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
             "realtime.segment.flush.threshold.rows": "0",
+            "realtime.segment.flush.threshold.segment.rows": "0",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.segment.size": "100M"
         }

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddRealTimeIngestionComponent.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddRealTimeIngestionComponent.tsx
@@ -92,6 +92,7 @@ export default function AddRealTimeIngestionComponent({
             "stream.kafka.consumer.factory.class.name":"org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
             "stream.kafka.decoder.class.name":"org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
             "realtime.segment.flush.threshold.rows": "0",
+            "realtime.segment.flush.threshold.segment.rows": "0",
             "realtime.segment.flush.threshold.time": "24h",
             "realtime.segment.flush.threshold.segment.size": "100M"
         }

--- a/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddRealtimeTableOp.tsx
+++ b/pinot-controller/src/main/resources/app/components/Homepage/Operations/AddRealtimeTableOp.tsx
@@ -100,6 +100,7 @@ const defaultTableObj = {
       "stream.kafka.consumer.factory.class.name": "org.apache.pinot.plugin.stream.kafka20.KafkaConsumerFactory",
       "stream.kafka.decoder.class.name": "org.apache.pinot.plugin.stream.kafka.KafkaJSONMessageDecoder",
       "realtime.segment.flush.threshold.rows": "0",
+      "realtime.segment.flush.threshold.segment.rows": "0",
       "realtime.segment.flush.threshold.time": "24h",
       "realtime.segment.flush.threshold.segment.size": "100M"
     }

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -102,14 +102,17 @@ public class FlushThresholdUpdaterTest {
     assertNotSame(flushThresholdUpdater, segmentBasedflushThresholdUpdater);
   }
 
-  private StreamConfig mockStreamConfig(int flushThresholdRows, long flushThresholdSegmentSize) {
-    assertNotSame(flushThresholdUpdateManager.getFlushThresholdUpdater(autotuneStreamConfig),
-        autotuneFlushThresholdUpdater);
+    private StreamConfig mockStreamConfig(int flushThresholdRows, long flushThresholdSegmentSize) {
+    StreamConfig streamConfig = mock(StreamConfig.class);
+    when(streamConfig.getTableNameWithType()).thenReturn(REALTIME_TABLE_NAME);
+    when(streamConfig.getFlushThresholdRows()).thenReturn(flushThresholdRows);
+    when(streamConfig.getFlushThresholdSegmentSizeBytes()).thenReturn(flushThresholdSegmentSize);
+    return streamConfig;
   }
 
   @Test
   public void testDefaultFlushThreshold() {
-    StreamConfig streamConfig = mockStreamConfig(10000);
+    StreamConfig streamConfig = mockStreamConfig(10000, 0);
     DefaultFlushThresholdUpdater flushThresholdUpdater = new DefaultFlushThresholdUpdater(10000);
     SegmentZKMetadata newSegmentZKMetadata = getNewSegmentZKMetadata(0);
     CommittingSegmentDescriptor committingSegmentDescriptor = getCommittingSegmentDescriptor(0L);
@@ -135,14 +138,6 @@ public class FlushThresholdUpdaterTest {
 
     // 10000 -> 10000
     assertEquals(newSegmentZKMetadata.getSizeThresholdToFlushSegment(), 10000);
-  }
-
-  private StreamConfig mockStreamConfig(int flushThresholdRows) {
-    StreamConfig streamConfig = mock(StreamConfig.class);
-    when(streamConfig.getTableNameWithType()).thenReturn(REALTIME_TABLE_NAME);
-    when(streamConfig.getFlushThresholdRows()).thenReturn(flushThresholdRows);
-    when(streamConfig.getFlushThresholdSegmentSizeBytes()).thenReturn(flushThresholdSegmentSize);
-    return streamConfig;
   }
 
   private StreamConfig mockSegmentRowsStreamConfig(int flushThresholdSegmentRows) {

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -65,6 +65,13 @@ public class FlushThresholdUpdaterTest {
     assertTrue(flushThresholdUpdater instanceof DefaultFlushThresholdUpdater);
     assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(), 1234);
 
+    // Flush threshold rows set to 0 and Segment Rows larger than 0 - SegmentRowsBasedFlushThresholdUpdater should be returned
+    FlushThresholdUpdater segmentRowsFlushThresholdUpdater = flushThresholdUpdateManager
+        .getFlushThresholdUpdater(mockSegmentRowsStreamConfig(StreamConfig.DEFAULT_FLUSH_THRESHOLD_ROWS));
+    assertTrue(segmentRowsFlushThresholdUpdater instanceof SegmentRowsBasedFlushThresholdUpdater);
+    assertEquals(((SegmentRowsBasedFlushThresholdUpdater) segmentRowsFlushThresholdUpdater).getTableFlushSize(),
+        StreamConfig.DEFAULT_FLUSH_THRESHOLD_ROWS);
+
     // Flush threshold rows set to 0 - SegmentSizeBasedFlushThresholdUpdater should be returned
     FlushThresholdUpdater segmentBasedflushThresholdUpdater =
         flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(0, -1));
@@ -99,6 +106,14 @@ public class FlushThresholdUpdaterTest {
     when(streamConfig.getTableNameWithType()).thenReturn(REALTIME_TABLE_NAME);
     when(streamConfig.getFlushThresholdRows()).thenReturn(flushThresholdRows);
     when(streamConfig.getFlushThresholdSegmentSizeBytes()).thenReturn(flushThresholdSegmentSize);
+    return streamConfig;
+  }
+
+  private StreamConfig mockSegmentRowsStreamConfig(int flushThresholdSegmentRows) {
+    StreamConfig streamConfig = mock(StreamConfig.class);
+    when(streamConfig.getTableNameWithType()).thenReturn(REALTIME_TABLE_NAME);
+    when(streamConfig.getFlushThresholdRows()).thenReturn(0);
+    when(streamConfig.getFlushThresholdSegmentRows()).thenReturn(flushThresholdSegmentRows);
     return streamConfig;
   }
 

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -53,42 +53,38 @@ public class FlushThresholdUpdaterTest {
   public void testFlushThresholdUpdateManager() {
     FlushThresholdUpdateManager flushThresholdUpdateManager = new FlushThresholdUpdateManager();
 
-    // Neither flush threshold rows nor segment size is set - DefaultFlushThresholdUpdater should be returned
+    // None of the flush threshold set - DefaultFlushThresholdUpdater should be returned
     FlushThresholdUpdater flushThresholdUpdater =
-        flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(-1, -1));
+        flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(-1, -1, -1));
     assertTrue(flushThresholdUpdater instanceof DefaultFlushThresholdUpdater);
     assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(),
         StreamConfig.DEFAULT_FLUSH_THRESHOLD_ROWS);
 
     // Flush threshold rows larger than 0 - DefaultFlushThresholdUpdater should be returned
-    flushThresholdUpdater = flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(1234, -1));
+    flushThresholdUpdater = flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(1234, -1, -1));
     assertTrue(flushThresholdUpdater instanceof DefaultFlushThresholdUpdater);
     assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(), 1234);
 
-    // Flush threshold rows set to 0 and Segment Rows larger than 0 -
-    // FixedFlushThresholdUpdater should be returned
-    FlushThresholdUpdater segmentRowsFlushThresholdUpdater = flushThresholdUpdateManager.getFlushThresholdUpdater(
-        mockSegmentRowsStreamConfig(StreamConfig.DEFAULT_FLUSH_THRESHOLD_ROWS));
-    assertTrue(segmentRowsFlushThresholdUpdater instanceof FixedFlushThresholdUpdater);
-    assertEquals(((FixedFlushThresholdUpdater) segmentRowsFlushThresholdUpdater).getTableFlushSize(),
-        StreamConfig.DEFAULT_FLUSH_THRESHOLD_ROWS);
+    // Flush threshold segment rows larger than 0 - FixedFlushThresholdUpdater should be returned
+    flushThresholdUpdater = flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(-1, 1234, -1));
+    assertTrue(flushThresholdUpdater instanceof FixedFlushThresholdUpdater);
 
     // Flush threshold rows set to 0 - SegmentSizeBasedFlushThresholdUpdater should be returned
     FlushThresholdUpdater segmentBasedflushThresholdUpdater =
-        flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(0, -1));
+        flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(0, -1, -1));
     assertTrue(segmentBasedflushThresholdUpdater instanceof SegmentSizeBasedFlushThresholdUpdater);
 
     // Flush threshold segment size larger than 0 - SegmentSizeBasedFlushThresholdUpdater should be returned
-    flushThresholdUpdater = flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(-1, 1234));
+    flushThresholdUpdater = flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(0, -1, 1234));
     assertSame(flushThresholdUpdater, segmentBasedflushThresholdUpdater);
 
     // Flush threshold rows set larger than 0 - DefaultFlushThresholdUpdater should be returned
-    flushThresholdUpdater = flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(12345, -1));
+    flushThresholdUpdater = flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(12345, -1, -1));
     assertTrue(flushThresholdUpdater instanceof DefaultFlushThresholdUpdater);
     assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(), 12345);
 
     // Call again with flush threshold rows set to 0 - a different Object should be returned
-    flushThresholdUpdater = flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(0, -1));
+    flushThresholdUpdater = flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(0, -1, -1));
     assertTrue(flushThresholdUpdater instanceof SegmentSizeBasedFlushThresholdUpdater);
     assertNotSame(flushThresholdUpdater, segmentBasedflushThresholdUpdater);
     segmentBasedflushThresholdUpdater = flushThresholdUpdater;
@@ -97,54 +93,18 @@ public class FlushThresholdUpdaterTest {
     flushThresholdUpdateManager.clearFlushThresholdUpdater(REALTIME_TABLE_NAME);
 
     // Call again with flush threshold rows set to 0 - a different Object should be returned
-    flushThresholdUpdater = flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(0, -1));
+    flushThresholdUpdater = flushThresholdUpdateManager.getFlushThresholdUpdater(mockStreamConfig(0, -1, -1));
     assertTrue(flushThresholdUpdater instanceof SegmentSizeBasedFlushThresholdUpdater);
     assertNotSame(flushThresholdUpdater, segmentBasedflushThresholdUpdater);
   }
 
-    private StreamConfig mockStreamConfig(int flushThresholdRows, long flushThresholdSegmentSize) {
+  private StreamConfig mockStreamConfig(int flushThresholdRows, int flushThresholdSegmentRows,
+      long flushThresholdSegmentSize) {
     StreamConfig streamConfig = mock(StreamConfig.class);
     when(streamConfig.getTableNameWithType()).thenReturn(REALTIME_TABLE_NAME);
     when(streamConfig.getFlushThresholdRows()).thenReturn(flushThresholdRows);
-    when(streamConfig.getFlushThresholdSegmentSizeBytes()).thenReturn(flushThresholdSegmentSize);
-    return streamConfig;
-  }
-
-  @Test
-  public void testDefaultFlushThreshold() {
-    StreamConfig streamConfig = mockStreamConfig(10000, 0);
-    DefaultFlushThresholdUpdater flushThresholdUpdater = new DefaultFlushThresholdUpdater(10000);
-    SegmentZKMetadata newSegmentZKMetadata = getNewSegmentZKMetadata(0);
-    CommittingSegmentDescriptor committingSegmentDescriptor = getCommittingSegmentDescriptor(0L);
-    int maxNumPartitionsPerInstance = 4;
-
-    flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor, null,
-        maxNumPartitionsPerInstance);
-
-    // 10000 / 4 partition => 2500
-    assertEquals(newSegmentZKMetadata.getSizeThresholdToFlushSegment(), 2500);
-  }
-
-  @Test
-  public void testSegmentRowBasedFlushThreshold() {
-    StreamConfig streamConfig = mockSegmentRowsStreamConfig(10000);
-    FixedFlushThresholdUpdater flushThresholdUpdater = new FixedFlushThresholdUpdater(10000);
-    SegmentZKMetadata newSegmentZKMetadata = getNewSegmentZKMetadata(0);
-    CommittingSegmentDescriptor committingSegmentDescriptor = getCommittingSegmentDescriptor(0L);
-    int maxNumPartitionsPerInstance = 4;
-
-    flushThresholdUpdater.updateFlushThreshold(streamConfig, newSegmentZKMetadata, committingSegmentDescriptor, null,
-        maxNumPartitionsPerInstance);
-
-    // 10000 -> 10000
-    assertEquals(newSegmentZKMetadata.getSizeThresholdToFlushSegment(), 10000);
-  }
-
-  private StreamConfig mockSegmentRowsStreamConfig(int flushThresholdSegmentRows) {
-    StreamConfig streamConfig = mock(StreamConfig.class);
-    when(streamConfig.getTableNameWithType()).thenReturn(REALTIME_TABLE_NAME);
-    when(streamConfig.getFlushThresholdRows()).thenReturn(0);
     when(streamConfig.getFlushThresholdSegmentRows()).thenReturn(flushThresholdSegmentRows);
+    when(streamConfig.getFlushThresholdSegmentSizeBytes()).thenReturn(flushThresholdSegmentSize);
     return streamConfig;
   }
 
@@ -177,8 +137,8 @@ public class FlushThresholdUpdaterTest {
     long segmentSizeLowerLimit = (long) (desiredSegmentSizeBytes * 0.99);
     long segmentSizeHigherLimit = (long) (desiredSegmentSizeBytes * 1.01);
 
-    for (long[] segmentSizesMB : Arrays
-        .asList(EXPONENTIAL_GROWTH_SEGMENT_SIZES_MB, LOGARITHMIC_GROWTH_SEGMENT_SIZES_MB, STEPS_SEGMENT_SIZES_MB)) {
+    for (long[] segmentSizesMB : Arrays.asList(EXPONENTIAL_GROWTH_SEGMENT_SIZES_MB, LOGARITHMIC_GROWTH_SEGMENT_SIZES_MB,
+        STEPS_SEGMENT_SIZES_MB)) {
       SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater = new SegmentSizeBasedFlushThresholdUpdater();
 
       // Start consumption
@@ -214,8 +174,8 @@ public class FlushThresholdUpdaterTest {
     long segmentSizeLowerLimit = (long) (desiredSegmentSizeBytes * 0.99);
     long segmentSizeHigherLimit = (long) (desiredSegmentSizeBytes * 1.01);
 
-    for (long[] segmentSizesMB : Arrays
-        .asList(EXPONENTIAL_GROWTH_SEGMENT_SIZES_MB, LOGARITHMIC_GROWTH_SEGMENT_SIZES_MB, STEPS_SEGMENT_SIZES_MB)) {
+    for (long[] segmentSizesMB : Arrays.asList(EXPONENTIAL_GROWTH_SEGMENT_SIZES_MB, LOGARITHMIC_GROWTH_SEGMENT_SIZES_MB,
+        STEPS_SEGMENT_SIZES_MB)) {
       SegmentSizeBasedFlushThresholdUpdater flushThresholdUpdater = new SegmentSizeBasedFlushThresholdUpdater();
 
       // Start consumption

--- a/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
+++ b/pinot-controller/src/test/java/org/apache/pinot/controller/helix/core/realtime/segment/FlushThresholdUpdaterTest.java
@@ -65,11 +65,12 @@ public class FlushThresholdUpdaterTest {
     assertTrue(flushThresholdUpdater instanceof DefaultFlushThresholdUpdater);
     assertEquals(((DefaultFlushThresholdUpdater) flushThresholdUpdater).getTableFlushSize(), 1234);
 
-    // Flush threshold rows set to 0 and Segment Rows larger than 0 - SegmentRowsBasedFlushThresholdUpdater should be returned
-    FlushThresholdUpdater segmentRowsFlushThresholdUpdater = flushThresholdUpdateManager
-        .getFlushThresholdUpdater(mockSegmentRowsStreamConfig(StreamConfig.DEFAULT_FLUSH_THRESHOLD_ROWS));
-    assertTrue(segmentRowsFlushThresholdUpdater instanceof SegmentRowsBasedFlushThresholdUpdater);
-    assertEquals(((SegmentRowsBasedFlushThresholdUpdater) segmentRowsFlushThresholdUpdater).getTableFlushSize(),
+    // Flush threshold rows set to 0 and Segment Rows larger than 0 -
+    // FixedFlushThresholdUpdater should be returned
+    FlushThresholdUpdater segmentRowsFlushThresholdUpdater = flushThresholdUpdateManager.getFlushThresholdUpdater(
+        mockSegmentRowsStreamConfig(StreamConfig.DEFAULT_FLUSH_THRESHOLD_ROWS));
+    assertTrue(segmentRowsFlushThresholdUpdater instanceof FixedFlushThresholdUpdater);
+    assertEquals(((FixedFlushThresholdUpdater) segmentRowsFlushThresholdUpdater).getTableFlushSize(),
         StreamConfig.DEFAULT_FLUSH_THRESHOLD_ROWS);
 
     // Flush threshold rows set to 0 - SegmentSizeBasedFlushThresholdUpdater should be returned
@@ -124,7 +125,7 @@ public class FlushThresholdUpdaterTest {
   @Test
   public void testSegmentRowBasedFlushThreshold() {
     StreamConfig streamConfig = mockSegmentRowsStreamConfig(10000);
-    SegmentRowsBasedFlushThresholdUpdater flushThresholdUpdater = new SegmentRowsBasedFlushThresholdUpdater(10000);
+    FixedFlushThresholdUpdater flushThresholdUpdater = new FixedFlushThresholdUpdater(10000);
     SegmentZKMetadata newSegmentZKMetadata = getNewSegmentZKMetadata(0);
     CommittingSegmentDescriptor committingSegmentDescriptor = getCommittingSegmentDescriptor(0L);
     int maxNumPartitionsPerInstance = 4;

--- a/pinot-core/src/test/java/org/apache/pinot/core/realtime/stream/StreamConfigTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/realtime/stream/StreamConfigTest.java
@@ -146,6 +146,7 @@ public class StreamConfigTest {
     assertEquals(streamConfig.getFetchTimeoutMillis(), StreamConfig.DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS);
     assertEquals(streamConfig.getFlushThresholdTimeMillis(), StreamConfig.DEFAULT_FLUSH_THRESHOLD_TIME_MILLIS);
     assertEquals(streamConfig.getFlushThresholdRows(), -1);
+    assertEquals(streamConfig.getFlushThresholdSegmentRows(), -1);
     assertEquals(streamConfig.getFlushThresholdSegmentSizeBytes(), -1);
 
     String offsetCriteria = "smallest";
@@ -183,6 +184,7 @@ public class StreamConfigTest {
     assertEquals(streamConfig.getFlushThresholdTimeMillis(),
         (long) TimeUtils.convertPeriodToMillis(flushThresholdTime));
     assertEquals(streamConfig.getFlushThresholdRows(), Integer.parseInt(flushThresholdRows));
+    assertEquals(streamConfig.getFlushThresholdSegmentRows(), -1);
     assertEquals(streamConfig.getFlushThresholdSegmentSizeBytes(), DataSizeUtils.toBytes(flushSegmentSize));
 
     // Backward compatibility check for flushThresholdTime
@@ -329,6 +331,7 @@ public class StreamConfigTest {
     streamConfig = new StreamConfig(tableName, streamConfigMap);
     assertEquals(streamConfig.getFlushThresholdTimeMillis(), StreamConfig.DEFAULT_FLUSH_THRESHOLD_TIME_MILLIS);
     assertEquals(streamConfig.getFlushThresholdRows(), -1);
+    assertEquals(streamConfig.getFlushThresholdSegmentRows(), -1);
     assertEquals(streamConfig.getFlushThresholdSegmentSizeBytes(), -1);
 
     // Use regular values if provided
@@ -338,6 +341,7 @@ public class StreamConfigTest {
     assertEquals(streamConfig.getFlushThresholdTimeMillis(),
         (long) TimeUtils.convertPeriodToMillis(flushThresholdTime));
     assertEquals(streamConfig.getFlushThresholdRows(), Integer.parseInt(flushThresholdRows));
+    assertEquals(streamConfig.getFlushThresholdSegmentRows(), -1);
     assertEquals(streamConfig.getFlushThresholdSegmentSizeBytes(), -1);
 
     // Use regular values if both regular and llc config exists
@@ -350,6 +354,7 @@ public class StreamConfigTest {
     assertEquals(streamConfig.getFlushThresholdTimeMillis(),
         (long) TimeUtils.convertPeriodToMillis(flushThresholdTime));
     assertEquals(streamConfig.getFlushThresholdRows(), Integer.parseInt(flushThresholdRows));
+    assertEquals(streamConfig.getFlushThresholdSegmentRows(), -1);
     assertEquals(streamConfig.getFlushThresholdSegmentSizeBytes(), -1);
 
     // Use llc values if only llc config exists
@@ -359,6 +364,7 @@ public class StreamConfigTest {
     assertEquals(streamConfig.getFlushThresholdTimeMillis(),
         (long) TimeUtils.convertPeriodToMillis(flushThresholdTimeLLC));
     assertEquals(streamConfig.getFlushThresholdRows(), Integer.parseInt(flushThresholdRowsLLC));
+    assertEquals(streamConfig.getFlushThresholdSegmentRows(), -1);
     assertEquals(streamConfig.getFlushThresholdSegmentSizeBytes(), -1);
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -588,10 +588,21 @@ public final class TableConfigUtils {
     Preconditions.checkState(streamConfig.getFlushThresholdTimeMillis() > 0, "Invalid flush threshold time: %s",
         streamConfig.getFlushThresholdTimeMillis());
     int flushThresholdRows = streamConfig.getFlushThresholdRows();
+    int flushThresholdSegmentRows = streamConfig.getFlushThresholdSegmentRows();
     long flushThresholdSegmentSizeBytes = streamConfig.getFlushThresholdSegmentSizeBytes();
-    Preconditions.checkState(!(flushThresholdRows > 0 && flushThresholdSegmentSizeBytes > 0),
-        "Flush threshold rows: %s and flush threshold segment size: %s cannot be both set", flushThresholdRows,
-        flushThresholdSegmentSizeBytes);
+    int numFlushThresholdSet = 0;
+    if (flushThresholdRows > 0) {
+      numFlushThresholdSet++;
+    }
+    if (flushThresholdSegmentRows > 0) {
+      numFlushThresholdSet++;
+    }
+    if (flushThresholdSegmentSizeBytes > 0) {
+      numFlushThresholdSet++;
+    }
+    Preconditions.checkState(numFlushThresholdSet <= 1,
+        "Only 1 of flush threshold (rows: %s, segment rows: %s, segment size: %s) can be set", flushThresholdRows,
+        flushThresholdSegmentRows, flushThresholdSegmentSizeBytes);
 
     // Validate decoder
     if (streamConfig.getDecoderClass().equals("org.apache.pinot.plugin.inputformat.protobuf.ProtoBufMessageDecoder")) {

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -38,6 +38,7 @@ public class StreamConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(StreamConfig.class);
 
   public static final int DEFAULT_FLUSH_THRESHOLD_ROWS = 5_000_000;
+  public static final int DEFAULT_FLUSH_THRESHOLD_SEGMENT_ROWS = 5_000_000;
   public static final long DEFAULT_FLUSH_THRESHOLD_TIME_MILLIS = TimeUnit.MILLISECONDS.convert(6, TimeUnit.HOURS);
   public static final long DEFAULT_FLUSH_THRESHOLD_SEGMENT_SIZE_BYTES = 200 * 1024 * 1024; // 200M
   public static final int DEFAULT_FLUSH_AUTOTUNE_INITIAL_ROWS = 100_000;
@@ -276,13 +277,13 @@ public class StreamConfig {
         Preconditions.checkState(flushThresholdRows >= 0);
         return flushThresholdRows;
       } catch (Exception e) {
-        // yet to decide on default value of this property
         LOGGER.warn("Invalid config {}: {}, defaulting to: {}", key, flushThresholdSegmentRowsStr,
-            DEFAULT_FLUSH_THRESHOLD_ROWS);
-        return DEFAULT_FLUSH_THRESHOLD_ROWS;
+            DEFAULT_FLUSH_THRESHOLD_SEGMENT_ROWS);
+        return DEFAULT_FLUSH_THRESHOLD_SEGMENT_ROWS;
       }
     } else {
-      return DEFAULT_FLUSH_THRESHOLD_ROWS;
+      // when not specified, make the default value as 0.
+      return 0;
     }
   }
 
@@ -363,7 +364,7 @@ public class StreamConfig {
   public int getFlushThresholdRows() {
     return _flushThresholdRows;
   }
-  
+
   public int getFlushThresholdSegmentRows() {
     return _flushThresholdSegmentRows;
   }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -38,7 +38,6 @@ public class StreamConfig {
   private static final Logger LOGGER = LoggerFactory.getLogger(StreamConfig.class);
 
   public static final int DEFAULT_FLUSH_THRESHOLD_ROWS = 5_000_000;
-  public static final int DEFAULT_FLUSH_THRESHOLD_SEGMENT_ROWS = 5_000_000;
   public static final long DEFAULT_FLUSH_THRESHOLD_TIME_MILLIS = TimeUnit.MILLISECONDS.convert(6, TimeUnit.HOURS);
   public static final long DEFAULT_FLUSH_THRESHOLD_SEGMENT_SIZE_BYTES = 200 * 1024 * 1024; // 200M
   public static final int DEFAULT_FLUSH_AUTOTUNE_INITIAL_ROWS = 100_000;
@@ -267,23 +266,17 @@ public class StreamConfig {
     }
   }
 
-    protected int extractFlushThresholdSegmentRows(Map<String, String> streamConfigMap) {
+  protected int extractFlushThresholdSegmentRows(Map<String, String> streamConfigMap) {
     String key = StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_SEGMENT_ROWS;
     String flushThresholdSegmentRowsStr = streamConfigMap.get(key);
     if (flushThresholdSegmentRowsStr != null) {
       try {
-        int flushThresholdRows = Integer.parseInt(flushThresholdSegmentRowsStr);
-        // Flush threshold rows 0 means using segment size based flush threshold
-        Preconditions.checkState(flushThresholdRows >= 0);
-        return flushThresholdRows;
+        return Integer.parseInt(flushThresholdSegmentRowsStr);
       } catch (Exception e) {
-        LOGGER.warn("Invalid config {}: {}, defaulting to: {}", key, flushThresholdSegmentRowsStr,
-            DEFAULT_FLUSH_THRESHOLD_SEGMENT_ROWS);
-        return DEFAULT_FLUSH_THRESHOLD_SEGMENT_ROWS;
+        throw new IllegalArgumentException("Invalid config " + key + ": " + flushThresholdSegmentRowsStr);
       }
     } else {
-      // when not specified, make the default value as 0.
-      return 0;
+      return -1;
     }
   }
 
@@ -405,11 +398,11 @@ public class StreamConfig {
         + ", _decoderClass='" + _decoderClass + '\'' + ", _decoderProperties=" + _decoderProperties
         + ", _connectionTimeoutMillis=" + _connectionTimeoutMillis + ", _fetchTimeoutMillis=" + _fetchTimeoutMillis
         + ", _idleTimeoutMillis=" + _idleTimeoutMillis + ", _flushThresholdRows=" + _flushThresholdRows
-        + ", _flushThresholdTimeMillis=" + _flushThresholdTimeMillis + ", _flushThresholdSegmentSizeBytes="
-        + _flushThresholdSegmentSizeBytes + ", _flushAutotuneInitialRows=" + _flushAutotuneInitialRows + ", _groupId='"
-        + _groupId + '\'' + ", _topicConsumptionRateLimit=" + _topicConsumptionRateLimit + ", _streamConfigMap="
-        + _streamConfigMap + ", _offsetCriteria=" + _offsetCriteria + ", _serverUploadToDeepStore="
-        + _serverUploadToDeepStore + ", _flushThresholdSegmentRows=" + _flushThresholdSegmentRows + '}';
+        + ", _flushThresholdSegmentRows=" + _flushThresholdSegmentRows + ", _flushThresholdTimeMillis="
+        + _flushThresholdTimeMillis + ", _flushThresholdSegmentSizeBytes=" + _flushThresholdSegmentSizeBytes
+        + ", _flushAutotuneInitialRows=" + _flushAutotuneInitialRows + ", _groupId='" + _groupId + '\''
+        + ", _topicConsumptionRateLimit=" + _topicConsumptionRateLimit + ", _streamConfigMap=" + _streamConfigMap
+        + ", _offsetCriteria=" + _offsetCriteria + ", _serverUploadToDeepStore=" + _serverUploadToDeepStore + '}';
   }
 
   @Override

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -66,6 +66,7 @@ public class StreamConfig {
   private final long _idleTimeoutMillis;
 
   private final int _flushThresholdRows;
+  private final int _flushThresholdSegmentRows;
   private final long _flushThresholdTimeMillis;
   private final long _flushThresholdSegmentSizeBytes;
   private final int _flushAutotuneInitialRows; // initial num rows to use for SegmentSizeBasedFlushThresholdUpdater
@@ -176,6 +177,7 @@ public class StreamConfig {
     _idleTimeoutMillis = idleTimeoutMillis;
 
     _flushThresholdRows = extractFlushThresholdRows(streamConfigMap);
+    _flushThresholdSegmentRows = extractFlushThresholdSegmentRows(streamConfigMap);
     _flushThresholdTimeMillis = extractFlushThresholdTimeMillis(streamConfigMap);
     _flushThresholdSegmentSizeBytes = extractFlushThresholdSegmentSize(streamConfigMap);
     _serverUploadToDeepStore = Boolean.parseBoolean(
@@ -264,6 +266,26 @@ public class StreamConfig {
     }
   }
 
+    protected int extractFlushThresholdSegmentRows(Map<String, String> streamConfigMap) {
+    String key = StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_SEGMENT_ROWS;
+    String flushThresholdSegmentRowsStr = streamConfigMap.get(key);
+    if (flushThresholdSegmentRowsStr != null) {
+      try {
+        int flushThresholdRows = Integer.parseInt(flushThresholdSegmentRowsStr);
+        // Flush threshold rows 0 means using segment size based flush threshold
+        Preconditions.checkState(flushThresholdRows >= 0);
+        return flushThresholdRows;
+      } catch (Exception e) {
+        // yet to decide on default value of this property
+        LOGGER.warn("Invalid config {}: {}, defaulting to: {}", key, flushThresholdSegmentRowsStr,
+            DEFAULT_FLUSH_THRESHOLD_ROWS);
+        return DEFAULT_FLUSH_THRESHOLD_ROWS;
+      }
+    } else {
+      return DEFAULT_FLUSH_THRESHOLD_ROWS;
+    }
+  }
+
   protected long extractFlushThresholdTimeMillis(Map<String, String> streamConfigMap) {
     String key = StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_TIME;
     String flushThresholdTimeStr = streamConfigMap.get(key);
@@ -341,6 +363,10 @@ public class StreamConfig {
   public int getFlushThresholdRows() {
     return _flushThresholdRows;
   }
+  
+  public int getFlushThresholdSegmentRows() {
+    return _flushThresholdSegmentRows;
+  }
 
   public long getFlushThresholdTimeMillis() {
     return _flushThresholdTimeMillis;
@@ -382,7 +408,7 @@ public class StreamConfig {
         + _flushThresholdSegmentSizeBytes + ", _flushAutotuneInitialRows=" + _flushAutotuneInitialRows + ", _groupId='"
         + _groupId + '\'' + ", _topicConsumptionRateLimit=" + _topicConsumptionRateLimit + ", _streamConfigMap="
         + _streamConfigMap + ", _offsetCriteria=" + _offsetCriteria + ", _serverUploadToDeepStore="
-        + _serverUploadToDeepStore + '}';
+        + _serverUploadToDeepStore + ", _flushThresholdSegmentRows=" + _flushThresholdSegmentRows + '}';
   }
 
   @Override
@@ -396,6 +422,7 @@ public class StreamConfig {
     StreamConfig that = (StreamConfig) o;
     return _connectionTimeoutMillis == that._connectionTimeoutMillis && _fetchTimeoutMillis == that._fetchTimeoutMillis
         && _idleTimeoutMillis == that._idleTimeoutMillis && _flushThresholdRows == that._flushThresholdRows
+        && _flushThresholdSegmentRows == that._flushThresholdSegmentRows
         && _flushThresholdTimeMillis == that._flushThresholdTimeMillis
         && _flushThresholdSegmentSizeBytes == that._flushThresholdSegmentSizeBytes
         && _flushAutotuneInitialRows == that._flushAutotuneInitialRows
@@ -412,7 +439,8 @@ public class StreamConfig {
   public int hashCode() {
     return Objects.hash(_type, _topicName, _tableNameWithType, _consumerFactoryClassName, _decoderClass,
         _decoderProperties, _connectionTimeoutMillis, _fetchTimeoutMillis, _idleTimeoutMillis, _flushThresholdRows,
-        _flushThresholdTimeMillis, _flushThresholdSegmentSizeBytes, _flushAutotuneInitialRows, _groupId,
-        _topicConsumptionRateLimit, _streamConfigMap, _offsetCriteria, _serverUploadToDeepStore);
+        _flushThresholdSegmentRows, _flushThresholdTimeMillis, _flushThresholdSegmentSizeBytes,
+        _flushAutotuneInitialRows, _groupId, _topicConsumptionRateLimit, _streamConfigMap, _offsetCriteria,
+        _serverUploadToDeepStore);
   }
 }

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -81,6 +81,7 @@ public class StreamConfigProperties {
    */
   public static final String DEPRECATED_SEGMENT_FLUSH_THRESHOLD_ROWS = "realtime.segment.flush.threshold.size";
   public static final String SEGMENT_FLUSH_THRESHOLD_ROWS = "realtime.segment.flush.threshold.rows";
+  public static final String SEGMENT_FLUSH_THRESHOLD_SEGMENT_ROWS = "realtime.segment.flush.threshold.segment.rows";
 
   /**
    * @deprecated because the property key is confusing (desired size is not indicative of segment size).

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfigProperties.java
@@ -81,6 +81,11 @@ public class StreamConfigProperties {
    */
   public static final String DEPRECATED_SEGMENT_FLUSH_THRESHOLD_ROWS = "realtime.segment.flush.threshold.size";
   public static final String SEGMENT_FLUSH_THRESHOLD_ROWS = "realtime.segment.flush.threshold.rows";
+
+  /**
+   * Config is similar to {@link StreamConfigProperties#SEGMENT_FLUSH_THRESHOLD_ROWS} but independent of
+   * partition count. This is useful when we want to flush segment exactly based on number of rows in a segment
+   */
   public static final String SEGMENT_FLUSH_THRESHOLD_SEGMENT_ROWS = "realtime.segment.flush.threshold.segment.rows";
 
   /**

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/ConfigUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/ConfigUtilsTest.java
@@ -109,6 +109,7 @@ public class ConfigUtilsTest {
     assertEquals(streamConfig.getFetchTimeoutMillis(), StreamConfig.DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS);
     assertEquals(streamConfig.getFlushThresholdTimeMillis(), StreamConfig.DEFAULT_FLUSH_THRESHOLD_TIME_MILLIS);
     assertEquals(streamConfig.getFlushThresholdRows(), -1);
+    assertEquals(streamConfig.getFlushThresholdSegmentRows(), -1);
     assertEquals(streamConfig.getFlushThresholdSegmentSizeBytes(), -1);
   }
 


### PR DESCRIPTION
Adding new config "realtime.segment.flush.threshold.segment.rows" for real-time table to configure the segment threshold independent of max partitions

**Behavior:**
- If flush rows > 0, create a new DefaultFlushThresholdUpdater with the given flush size.
- If flush segment rows > 0, create a new FixedFlushThresholdUpdater with the given flush size.
- If flush segment size > 0, create a new SegmentSizeBasedFlushThresholdUpdater if not already created. Create only 1 per table because we want to maintain tuning information for the table in the updater.

**Legacy behavior:**
- If flush rows = 0, use segment size based flush threshold.
- If none of the above are set, create a new DefaultFlushThresholdUpdater.
   - If flush size > 0, create a new DefaultFlushThresholdUpdater with given flush size.

**Issue[12508]:**
https://github.com/apache/pinot/issues/12508
 When realtime.segment.flush.threshold.rows is used, the flush threshold for the new CONSUMING segment is determined by both this value and the max partitions consumed by any server. This is not very straight forward, and rebalancing a table could cause new consuming segment size to change.

In order to tackle this problem, we may add a new config (proposing realtime.segment.flush.threshold.segment.rows) which works independent of partitions consumed.
