### PR TITLE
Enhance commit threshold to accept size threshold without setting rows to 0

### DIFF
--- a/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentFlushThresholdComputer.java
+++ b/pinot-controller/src/main/java/org/apache/pinot/controller/helix/core/realtime/segment/SegmentFlushThresholdComputer.java
@@ -58,9 +58,12 @@ class SegmentFlushThresholdComputer {
 
   public int computeThreshold(StreamConfig streamConfig, CommittingSegmentDescriptor committingSegmentDescriptor,
       @Nullable SegmentZKMetadata committingSegmentZKMetadata, String newSegmentName) {
-    final long desiredSegmentSizeBytes = streamConfig.getFlushThresholdSegmentSizeBytes();
-    final long optimalSegmentSizeBytesMin = desiredSegmentSizeBytes / 2;
-    final double optimalSegmentSizeBytesMax = desiredSegmentSizeBytes * 1.5;
+    long desiredSegmentSizeBytes = streamConfig.getFlushThresholdSegmentSizeBytes();
+    if (desiredSegmentSizeBytes <= 0) {
+      desiredSegmentSizeBytes = StreamConfig.DEFAULT_FLUSH_THRESHOLD_SEGMENT_SIZE_BYTES;
+    }
+    long optimalSegmentSizeBytesMin = desiredSegmentSizeBytes / 2;
+    double optimalSegmentSizeBytesMax = desiredSegmentSizeBytes * 1.5;
 
     if (committingSegmentZKMetadata == null) { // first segment of the partition, hence committing segment is null
       if (_latestSegmentRowsToSizeRatio > 0) { // new partition group added case

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeSegmentDataManager.java
@@ -1455,10 +1455,12 @@ public class RealtimeSegmentDataManager extends SegmentDataManager {
     }
 
     // Read the max number of rows
-    int segmentMaxRowCount = _streamConfig.getFlushThresholdRows();
-    int flushThresholdSize = segmentZKMetadata.getSizeThresholdToFlushSegment();
-    if (flushThresholdSize > 0) {
-      segmentMaxRowCount = flushThresholdSize;
+    int segmentMaxRowCount = segmentZKMetadata.getSizeThresholdToFlushSegment();
+    if (segmentMaxRowCount <= 0) {
+      segmentMaxRowCount = _streamConfig.getFlushThresholdRows();
+    }
+    if (segmentMaxRowCount <= 0) {
+      segmentMaxRowCount = StreamConfig.DEFAULT_FLUSH_THRESHOLD_ROWS;
     }
     _segmentMaxRowCount = segmentMaxRowCount;
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -155,26 +155,19 @@ public final class TableConfigUtils {
     if (!skipTypes.contains(ValidationType.ALL)) {
       validateTableSchemaConfig(tableConfig);
       validateValidationConfig(tableConfig, schema);
-
-      StreamConfig streamConfig = null;
       validateIngestionConfig(tableConfig, schema, disableGroovy);
+
       // Only allow realtime tables with non-null stream.type and LLC consumer.type
       if (tableConfig.getTableType() == TableType.REALTIME) {
         Map<String, String> streamConfigMap = IngestionConfigUtils.getStreamConfigMap(tableConfig);
+        StreamConfig streamConfig;
         try {
           // Validate that StreamConfig can be created
           streamConfig = new StreamConfig(tableConfig.getTableName(), streamConfigMap);
         } catch (Exception e) {
           throw new IllegalStateException("Could not create StreamConfig using the streamConfig map", e);
         }
-        validateDecoder(streamConfig);
-        // if segmentSizeBytes is specified, rows must be zero.
-        if (streamConfigMap.containsKey(StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_SEGMENT_SIZE)
-            || streamConfigMap.containsKey(StreamConfigProperties.DEPRECATED_SEGMENT_FLUSH_DESIRED_SIZE)) {
-          Preconditions.checkState(streamConfig.getFlushThresholdRows() == 0,
-              String.format("Invalid config: %s=%d, it must be set to 0 for size based segment threshold to work.",
-                  StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_ROWS, streamConfig.getFlushThresholdRows()));
-        }
+        validateStreamConfig(streamConfig);
       }
       validateTierConfigList(tableConfig.getTierConfigsList());
       validateIndexingConfig(tableConfig.getIndexingConfig(), schema);
@@ -590,7 +583,17 @@ public final class TableConfigUtils {
   }
 
   @VisibleForTesting
-  static void validateDecoder(StreamConfig streamConfig) {
+  static void validateStreamConfig(StreamConfig streamConfig) {
+    // Validate flush threshold
+    Preconditions.checkState(streamConfig.getFlushThresholdTimeMillis() > 0, "Invalid flush threshold time: %s",
+        streamConfig.getFlushThresholdTimeMillis());
+    int flushThresholdRows = streamConfig.getFlushThresholdRows();
+    long flushThresholdSegmentSizeBytes = streamConfig.getFlushThresholdSegmentSizeBytes();
+    Preconditions.checkState(!(flushThresholdRows > 0 && flushThresholdSegmentSizeBytes > 0),
+        "Flush threshold rows: %s and flush threshold segment size: %s cannot be both set", flushThresholdRows,
+        flushThresholdSegmentSizeBytes);
+
+    // Validate decoder
     if (streamConfig.getDecoderClass().equals("org.apache.pinot.plugin.inputformat.protobuf.ProtoBufMessageDecoder")) {
       String descriptorFilePath = "descriptorFile";
       String protoClassName = "protoClassName";

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/stream/StreamConfig.java
@@ -222,7 +222,6 @@ public class StreamConfig {
   }
 
   private long extractFlushThresholdSegmentSize(Map<String, String> streamConfigMap) {
-    long segmentSizeBytes = -1;
     String key = StreamConfigProperties.SEGMENT_FLUSH_THRESHOLD_SEGMENT_SIZE;
     String flushThresholdSegmentSizeStr = streamConfigMap.get(key);
     if (flushThresholdSegmentSizeStr == null) {
@@ -230,19 +229,14 @@ public class StreamConfig {
       key = StreamConfigProperties.DEPRECATED_SEGMENT_FLUSH_DESIRED_SIZE;
       flushThresholdSegmentSizeStr = streamConfigMap.get(key);
     }
-
     if (flushThresholdSegmentSizeStr != null) {
       try {
-        segmentSizeBytes = DataSizeUtils.toBytes(flushThresholdSegmentSizeStr);
+        return DataSizeUtils.toBytes(flushThresholdSegmentSizeStr);
       } catch (Exception e) {
-        LOGGER.warn("Invalid config {}: {}, defaulting to: {}", key, flushThresholdSegmentSizeStr,
-            DataSizeUtils.fromBytes(DEFAULT_FLUSH_THRESHOLD_SEGMENT_SIZE_BYTES));
+        throw new IllegalArgumentException("Invalid config " + key + ": " + flushThresholdSegmentSizeStr);
       }
-    }
-    if (segmentSizeBytes > 0) {
-      return segmentSizeBytes;
     } else {
-      return DEFAULT_FLUSH_THRESHOLD_SEGMENT_SIZE_BYTES;
+      return -1;
     }
   }
 
@@ -261,17 +255,12 @@ public class StreamConfig {
     }
     if (flushThresholdRowsStr != null) {
       try {
-        int flushThresholdRows = Integer.parseInt(flushThresholdRowsStr);
-        // Flush threshold rows 0 means using segment size based flush threshold
-        Preconditions.checkState(flushThresholdRows >= 0);
-        return flushThresholdRows;
+        return Integer.parseInt(flushThresholdRowsStr);
       } catch (Exception e) {
-        LOGGER.warn("Invalid config {}: {}, defaulting to: {}", key, flushThresholdRowsStr,
-            DEFAULT_FLUSH_THRESHOLD_ROWS);
-        return DEFAULT_FLUSH_THRESHOLD_ROWS;
+        throw new IllegalArgumentException("Invalid config " + key + ": " + flushThresholdRowsStr);
       }
     } else {
-      return DEFAULT_FLUSH_THRESHOLD_ROWS;
+      return -1;
     }
   }
 
@@ -291,9 +280,7 @@ public class StreamConfig {
           // For backward-compatibility, parse it as milliseconds value
           return Long.parseLong(flushThresholdTimeStr);
         } catch (NumberFormatException nfe) {
-          LOGGER.warn("Invalid config {}: {}, defaulting to: {}", key, flushThresholdTimeStr,
-              DEFAULT_FLUSH_THRESHOLD_TIME_MILLIS);
-          return DEFAULT_FLUSH_THRESHOLD_TIME_MILLIS;
+          throw new IllegalArgumentException("Invalid config " + key + ": " + flushThresholdTimeStr);
         }
       }
     } else {

--- a/pinot-spi/src/test/java/org/apache/pinot/spi/config/ConfigUtilsTest.java
+++ b/pinot-spi/src/test/java/org/apache/pinot/spi/config/ConfigUtilsTest.java
@@ -28,10 +28,10 @@ import org.apache.pinot.spi.env.PinotConfiguration;
 import org.apache.pinot.spi.stream.OffsetCriteria;
 import org.apache.pinot.spi.stream.StreamConfig;
 import org.apache.pinot.spi.stream.StreamConfigProperties;
-import org.testng.Assert;
 import org.testng.annotations.Test;
 
 import static org.testng.Assert.assertEquals;
+import static org.testng.Assert.assertFalse;
 import static org.testng.Assert.assertTrue;
 
 
@@ -68,19 +68,17 @@ public class ConfigUtilsTest {
 
     Map<String, String> streamConfigMap = new HashMap<>();
     streamConfigMap.put(StreamConfigProperties.STREAM_TYPE, streamType);
-    streamConfigMap
-        .put(StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME),
-            topic);
-    streamConfigMap.put(StreamConfigProperties
-            .constructStreamProperty(streamType, StreamConfigProperties.STREAM_CONSUMER_FACTORY_CLASS),
-        consumerFactoryClass);
-    streamConfigMap
-        .put(StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_DECODER_CLASS),
-            decoderClass);
-    streamConfigMap
-        .put(StreamConfigProperties.constructStreamProperty(streamType, "aws.accessKey"), "${AWS_ACCESS_KEY}");
-    streamConfigMap
-        .put(StreamConfigProperties.constructStreamProperty(streamType, "aws.secretKey"), "${AWS_SECRET_KEY}");
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_TOPIC_NAME), topic);
+    streamConfigMap.put(StreamConfigProperties.constructStreamProperty(streamType,
+        StreamConfigProperties.STREAM_CONSUMER_FACTORY_CLASS), consumerFactoryClass);
+    streamConfigMap.put(
+        StreamConfigProperties.constructStreamProperty(streamType, StreamConfigProperties.STREAM_DECODER_CLASS),
+        decoderClass);
+    streamConfigMap.put(StreamConfigProperties.constructStreamProperty(streamType, "aws.accessKey"),
+        "${AWS_ACCESS_KEY}");
+    streamConfigMap.put(StreamConfigProperties.constructStreamProperty(streamType, "aws.secretKey"),
+        "${AWS_SECRET_KEY}");
     indexingConfig.setStreamConfigs(streamConfigMap);
 
     Map<String, String> environment =
@@ -99,24 +97,19 @@ public class ConfigUtilsTest {
 
     // Mandatory values + defaults
     StreamConfig streamConfig = new StreamConfig(tableName, indexingConfig.getStreamConfigs());
-    Assert.assertEquals(streamConfig.getType(), streamType);
-    Assert.assertEquals(streamConfig.getTopicName(), topic);
-    Assert.assertEquals(streamConfig.getConsumerFactoryClassName(), defaultConsumerFactoryClass);
-    Assert.assertEquals(streamConfig.getDecoderClass(), defaultDecoderClass);
-    Assert.assertEquals(streamConfig.getStreamConfigsMap().get("stream.fakeStream.aws.accessKey"),
-        "default_aws_access_key");
-    Assert.assertEquals(streamConfig.getStreamConfigsMap().get("stream.fakeStream.aws.secretKey"),
-        "default_aws_secret_key");
-    Assert.assertEquals(streamConfig.getDecoderProperties().size(), 0);
-    Assert
-        .assertEquals(streamConfig.getOffsetCriteria(), new OffsetCriteria.OffsetCriteriaBuilder().withOffsetLargest());
-    Assert
-        .assertEquals(streamConfig.getConnectionTimeoutMillis(), StreamConfig.DEFAULT_STREAM_CONNECTION_TIMEOUT_MILLIS);
-    Assert.assertEquals(streamConfig.getFetchTimeoutMillis(), StreamConfig.DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS);
-    Assert.assertEquals(streamConfig.getFlushThresholdRows(), StreamConfig.DEFAULT_FLUSH_THRESHOLD_ROWS);
-    Assert.assertEquals(streamConfig.getFlushThresholdTimeMillis(), StreamConfig.DEFAULT_FLUSH_THRESHOLD_TIME_MILLIS);
-    Assert.assertEquals(streamConfig.getFlushThresholdSegmentSizeBytes(),
-        StreamConfig.DEFAULT_FLUSH_THRESHOLD_SEGMENT_SIZE_BYTES);
+    assertEquals(streamConfig.getType(), streamType);
+    assertEquals(streamConfig.getTopicName(), topic);
+    assertEquals(streamConfig.getConsumerFactoryClassName(), defaultConsumerFactoryClass);
+    assertEquals(streamConfig.getDecoderClass(), defaultDecoderClass);
+    assertEquals(streamConfig.getStreamConfigsMap().get("stream.fakeStream.aws.accessKey"), "default_aws_access_key");
+    assertEquals(streamConfig.getStreamConfigsMap().get("stream.fakeStream.aws.secretKey"), "default_aws_secret_key");
+    assertEquals(streamConfig.getDecoderProperties().size(), 0);
+    assertEquals(streamConfig.getOffsetCriteria(), new OffsetCriteria.OffsetCriteriaBuilder().withOffsetLargest());
+    assertEquals(streamConfig.getConnectionTimeoutMillis(), StreamConfig.DEFAULT_STREAM_CONNECTION_TIMEOUT_MILLIS);
+    assertEquals(streamConfig.getFetchTimeoutMillis(), StreamConfig.DEFAULT_STREAM_FETCH_TIMEOUT_MILLIS);
+    assertEquals(streamConfig.getFlushThresholdTimeMillis(), StreamConfig.DEFAULT_FLUSH_THRESHOLD_TIME_MILLIS);
+    assertEquals(streamConfig.getFlushThresholdRows(), -1);
+    assertEquals(streamConfig.getFlushThresholdSegmentSizeBytes(), -1);
   }
 
   @Test
@@ -132,8 +125,8 @@ public class ConfigUtilsTest {
     PinotConfiguration config = new PinotConfiguration(nestedMap);
 
     String configString = config.toString();
-    Assert.assertTrue(configString.contains("credentials"));
-    Assert.assertFalse(configString.contains("verysecret"));
-    Assert.assertFalse(configString.contains("secrettoken"));
+    assertTrue(configString.contains("credentials"));
+    assertFalse(configString.contains("verysecret"));
+    assertFalse(configString.contains("secrettoken"));
   }
 }

--- a/pinot-tools/src/main/resources/conf/sample_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/conf/sample_realtime_table_config.json
@@ -32,7 +32,7 @@
       "stream.kafka.consumer.prop.auto.offset.reset": "largest",
       "stream.kafka.broker.list": "localhost:19092",
       "realtime.segment.flush.threshold.time": "12h",
-      "realtime.segment.flush.threshold.size": "100M"
+      "realtime.segment.flush.threshold.size": "100000"
     }
   },
   "metadata": {

--- a/pinot-tools/src/main/resources/examples/stream/meetupRsvp/meetupRsvp_realtime_table_config.json
+++ b/pinot-tools/src/main/resources/examples/stream/meetupRsvp/meetupRsvp_realtime_table_config.json
@@ -20,9 +20,7 @@
           "stream.kafka.consumer.prop.auto.offset.reset": "largest",
           "stream.kafka.zk.broker.url": "localhost:2191/kafka",
           "stream.kafka.broker.list": "localhost:19092",
-          "stream.kafka.metadata.populate": "true",
-          "realtime.segment.flush.threshold.time": "12h",
-          "realtime.segment.flush.threshold.size": "10K"
+          "stream.kafka.metadata.populate": "true"
         }
       ]
     }


### PR DESCRIPTION
Currently in order to use segment size based commit threshold, rows must be explicitly set to 0. This is very confusing because usually people only set the threshold they want to honor.

With the PR:
- When `rows == 0`: use segment size based (backward compatible)
- When `rows > 0`: use rows
- When `rows < 0` (or not set):
  - When `segment size > 0`: use segment size
  - When `segment size <= 0` (or not set): use default rows

Also fail the invalid config instead of silently using default value.