### PR TITLE
Add base class for merging and accumulating custom objects

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountIntegerTupleSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountIntegerTupleSketchAggregationFunction.java
@@ -19,11 +19,10 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
-import org.apache.datasketches.tuple.CompactSketch;
-import org.apache.datasketches.tuple.Union;
 import org.apache.datasketches.tuple.aninteger.IntegerSummary;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.segment.local.customobject.TupleIntSketchAccumulator;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
 
@@ -46,9 +45,10 @@ public class DistinctCountIntegerTupleSketchAggregationFunction extends IntegerT
   }
 
   @Override
-  public Comparable extractFinalResult(List<CompactSketch<IntegerSummary>> integerSummarySketches) {
-    Union<IntegerSummary> union = new Union<>(_entries, _setOps);
-    integerSummarySketches.forEach(union::union);
-    return Double.valueOf(union.getResult().getEstimate()).longValue();
+  public Comparable extractFinalResult(TupleIntSketchAccumulator accumulator) {
+    accumulator.setNominalEntries(_nominalEntries);
+    accumulator.setSetOperations(_setOps);
+    accumulator.setThreshold(_accumulatorThreshold);
+    return Double.valueOf(accumulator.getResult().getEstimate()).longValue();
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawCPCSketchAggregationFunction.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/DistinctCountRawCPCSketchAggregationFunction.java
@@ -19,9 +19,9 @@
 package org.apache.pinot.core.query.aggregation.function;
 
 import java.util.List;
-import org.apache.datasketches.cpc.CpcSketch;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.common.utils.DataSchema.ColumnDataType;
+import org.apache.pinot.segment.local.customobject.CpcSketchAccumulator;
 import org.apache.pinot.segment.local.customobject.SerializedCPCSketch;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 
@@ -47,7 +47,9 @@ public class DistinctCountRawCPCSketchAggregationFunction extends DistinctCountC
   }
 
   @Override
-  public SerializedCPCSketch extractFinalResult(CpcSketch sketch) {
-    return new SerializedCPCSketch(sketch);
+  public SerializedCPCSketch extractFinalResult(CpcSketchAccumulator intermediateResult) {
+    intermediateResult.setLgNominalEntries(_lgNominalEntries);
+    intermediateResult.setThreshold(_accumulatorThreshold);
+    return new SerializedCPCSketch(intermediateResult.getResult());
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/CpcSketchAccumulator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/CpcSketchAccumulator.java
@@ -1,0 +1,79 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.customobject;
+
+import javax.annotation.Nonnull;
+import org.apache.datasketches.cpc.CpcSketch;
+import org.apache.datasketches.cpc.CpcUnion;
+
+
+/**
+ * Intermediate state used by {@code DistinctCountCPCSketchAggregationFunction} which gives
+ * the end user more control over how sketches are merged for performance.
+ * The end user can set parameters that trade-off more memory usage for more pre-aggregation.
+ */
+public class CpcSketchAccumulator extends CustomObjectAccumulator<CpcSketch> {
+  private int _lgNominalEntries = 4;
+  private CpcUnion _union;
+
+  public CpcSketchAccumulator() {
+  }
+
+  // Note: The accumulator is serialized as a sketch.  This means that the majority of the processing
+  // happens on serialization. Therefore, when deserialized, the values may be null and will
+  // require re-initialisation. Since the primary use case is at query time for the Broker
+  // and Server, these properties are already in memory and are re-set.
+  public CpcSketchAccumulator(int lgNominalEntries, int threshold) {
+    super(threshold);
+    _lgNominalEntries = lgNominalEntries;
+  }
+
+  public void setLgNominalEntries(int lgNominalEntries) {
+    _lgNominalEntries = lgNominalEntries;
+  }
+
+  @Nonnull
+  @Override
+  public CpcSketch getResult() {
+    return unionAll();
+  }
+
+  private CpcSketch unionAll() {
+    if (_union == null) {
+      _union = new CpcUnion(_lgNominalEntries);
+    }
+    // Return the default update "gadget" sketch as a compact sketch
+    if (isEmpty()) {
+      return _union.getResult();
+    }
+    // Corner-case: the parameters are not strictly respected when there is a single sketch.
+    // This single sketch might have been the result of a previously accumulated union and
+    // would already have the parameters set.  The sketch is returned as-is without adjusting
+    // nominal entries which requires an additional union operation.
+    if (getNumInputs() == 1) {
+      return _accumulator.get(0);
+    }
+
+    for (CpcSketch accumulatedSketch : _accumulator) {
+      _union.update(accumulatedSketch);
+    }
+
+    return _union.getResult();
+  }
+}

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/CustomObjectAccumulator.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/customobject/CustomObjectAccumulator.java
@@ -1,0 +1,121 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.local.customobject;
+
+import com.google.common.base.Preconditions;
+import java.util.ArrayList;
+import javax.annotation.Nonnull;
+
+
+/**
+ * Intermediate state used by some aggregation functions which gives the end user more control over how custom objects
+ * are merged for performance reasons.  Some custom objects such as DataSketches have better merge performance when
+ * more than two items are merged at once through the elimination of intermediate bookkeeping overheads.
+ *
+ * The end user can set a value for the "threshold" parameter that defers the merge operation until at least as many
+ * items are ready to be merged, or the callee forces the merge directly via "getResult" - e.g. on serialization.
+ * This data structure trades-off more memory usage for a greater degree of pre-aggregation in the accumulator state.
+ */
+public abstract class CustomObjectAccumulator<T> {
+  protected ArrayList<T> _accumulator;
+  private int _threshold;
+  private int _numInputs = 0;
+
+  public CustomObjectAccumulator() {
+    this(2);
+  }
+
+  public CustomObjectAccumulator(int threshold) {
+    setThreshold(threshold);
+  }
+
+  /**
+   * Sets the threshold that determines how much memory to use for the internal accumulator state before
+   * the intermediate state is merged.
+   * @param threshold the threshold [> 0].
+   */
+  public void setThreshold(int threshold) {
+    Preconditions.checkArgument(threshold > 0, "Invalid threshold: %s, must be positive", threshold);
+    _threshold = threshold;
+  }
+
+  /**
+   * Returns the configured threshold for this accumulator.
+   */
+  public int getThreshold() {
+    return _threshold;
+  }
+
+  /**
+   * Returns the number of inputs that have been added to the accumulator state.
+   */
+  public int getNumInputs() {
+    return _numInputs;
+  }
+
+  /**
+   * Returns true if no inputs have been added to the accumulator state.
+   */
+  public boolean isEmpty() {
+    return _numInputs == 0;
+  }
+
+  @Nonnull
+  /**
+   * Forces the item T in internal state to be merged with all pending items in the accumulator state
+   * and returns the result.  This should not result in the accumulator state being updated or cleared.
+   * @return T result of the merge.
+   */
+  public abstract T getResult();
+
+  /**
+   * Merges another accumulator with this one, by extracting the result from "other".
+   * @param other the custom object accumulator to merge.
+   */
+  public void merge(CustomObjectAccumulator<T> other) {
+    if (other.isEmpty()) {
+      return;
+    }
+    T result = other.getResult();
+    applyInternal(result);
+  }
+
+  /**
+   * Adds a new item to the accumulator state.  If the accumulator state is equal to the threshold value,
+   * the internal state is updated and the accumulator state is cleared.
+   * @param item the item to add to the accumulator state, cannot be null.
+   */
+  public void apply(T item) {
+    Preconditions.checkNotNull(item);
+    applyInternal(item);
+  }
+
+  private void applyInternal(T item) {
+    if (_accumulator == null) {
+      _accumulator = new ArrayList<>(_threshold);
+    }
+    _accumulator.add(item);
+    _numInputs += 1;
+
+    if (_accumulator.size() >= _threshold) {
+      getResult();
+      _accumulator.clear();
+    }
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/customobject/CpcSketchAccumulatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/customobject/CpcSketchAccumulatorTest.java
@@ -1,0 +1,92 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.segment.local.customobject;
+
+import java.util.stream.IntStream;
+import org.apache.datasketches.cpc.CpcSketch;
+import org.testng.Assert;
+import org.testng.annotations.Test;
+
+
+public class CpcSketchAccumulatorTest {
+  private final int _lgNominalEntries = 20;
+  private final double _epsilon = 0.5;
+
+  @Test
+  public void testEmptyAccumulator() {
+    CpcSketchAccumulator accumulator = new CpcSketchAccumulator(_lgNominalEntries, 2);
+    Assert.assertTrue(accumulator.isEmpty());
+    Assert.assertEquals(accumulator.getResult().getEstimate(), 0.0);
+  }
+
+  @Test
+  public void testAccumulatorWithSingleSketch() {
+    CpcSketch sketch = new CpcSketch(_lgNominalEntries);
+    IntStream.range(0, 1000).forEach(sketch::update);
+
+    CpcSketchAccumulator accumulator = new CpcSketchAccumulator(_lgNominalEntries, 2);
+    accumulator.apply(sketch);
+
+    Assert.assertFalse(accumulator.isEmpty());
+    Assert.assertEquals(accumulator.getResult().getEstimate(), sketch.getEstimate());
+  }
+
+  @Test
+  public void testAccumulatorMerge() {
+    CpcSketch sketch1 = new CpcSketch(_lgNominalEntries);
+    IntStream.range(0, 1000).forEach(sketch1::update);
+    CpcSketch sketch2 = new CpcSketch(_lgNominalEntries);
+    IntStream.range(1000, 2000).forEach(sketch2::update);
+
+    CpcSketchAccumulator accumulator1 = new CpcSketchAccumulator(_lgNominalEntries, 3);
+    accumulator1.apply(sketch1);
+    CpcSketchAccumulator accumulator2 = new CpcSketchAccumulator(_lgNominalEntries, 3);
+    accumulator2.apply(sketch2);
+    accumulator1.merge(accumulator2);
+
+    Assert.assertEquals(accumulator1.getResult().getEstimate(), sketch1.getEstimate() + sketch2.getEstimate(),
+        _epsilon);
+  }
+
+  @Test
+  public void testThresholdBehavior() {
+    CpcSketch sketch1 = new CpcSketch(_lgNominalEntries);
+    IntStream.range(0, 1000).forEach(sketch1::update);
+    CpcSketch sketch2 = new CpcSketch(_lgNominalEntries);
+    IntStream.range(1000, 2000).forEach(sketch2::update);
+
+    CpcSketchAccumulator accumulator = new CpcSketchAccumulator(_lgNominalEntries, 3);
+    accumulator.apply(sketch1);
+    accumulator.apply(sketch2);
+
+    Assert.assertEquals(accumulator.getResult().getEstimate(), sketch1.getEstimate() + sketch2.getEstimate(), _epsilon);
+  }
+
+  @Test
+  public void testUnionWithEmptyInput() {
+    CpcSketchAccumulator accumulator = new CpcSketchAccumulator(_lgNominalEntries, 3);
+    CpcSketchAccumulator emptyAccumulator = new CpcSketchAccumulator(_lgNominalEntries, 3);
+
+    accumulator.merge(emptyAccumulator);
+
+    Assert.assertTrue(accumulator.isEmpty());
+    Assert.assertEquals(accumulator.getResult().getEstimate(), 0.0);
+  }
+}

--- a/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/customobject/TupleIntSketchAccumulatorTest.java
+++ b/pinot-segment-local/src/test/java/org/apache/pinot/segment/local/customobject/TupleIntSketchAccumulatorTest.java
@@ -1,0 +1,106 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pinot.segment.local.customobject;
+
+import java.util.stream.IntStream;
+import org.apache.datasketches.tuple.CompactSketch;
+import org.apache.datasketches.tuple.aninteger.IntegerSketch;
+import org.apache.datasketches.tuple.aninteger.IntegerSummary;
+import org.apache.datasketches.tuple.aninteger.IntegerSummarySetOperations;
+import org.testng.Assert;
+import org.testng.annotations.BeforeMethod;
+import org.testng.annotations.Test;
+
+
+public class TupleIntSketchAccumulatorTest {
+  private IntegerSummarySetOperations _setOps;
+  private final int _lgK = 12;
+  private final int _nominalEntries = (int) Math.pow(2, _lgK);
+
+  @BeforeMethod
+  public void setUp() {
+    _setOps = new IntegerSummarySetOperations(IntegerSummary.Mode.Sum, IntegerSummary.Mode.Sum);
+  }
+
+  @Test
+  public void testEmptyAccumulator() {
+    TupleIntSketchAccumulator accumulator = new TupleIntSketchAccumulator(_setOps, _nominalEntries, 2);
+    Assert.assertTrue(accumulator.isEmpty());
+    Assert.assertEquals(accumulator.getResult().getEstimate(), 0.0);
+  }
+
+  @Test
+  public void testAccumulatorWithSingleSketch() {
+    IntegerSketch input = new IntegerSketch(_lgK, IntegerSummary.Mode.Sum);
+    IntStream.range(0, 1000).forEach(i -> input.update(i, 1));
+    CompactSketch<IntegerSummary> sketch = input.compact();
+
+    TupleIntSketchAccumulator accumulator = new TupleIntSketchAccumulator(_setOps, _nominalEntries, 2);
+    accumulator.apply(sketch);
+
+    Assert.assertFalse(accumulator.isEmpty());
+    Assert.assertEquals(accumulator.getResult().getEstimate(), sketch.getEstimate());
+  }
+
+  @Test
+  public void testAccumulatorMerge() {
+    IntegerSketch input1 = new IntegerSketch(_lgK, IntegerSummary.Mode.Sum);
+    IntStream.range(0, 1000).forEach(i -> input1.update(i, 1));
+    CompactSketch<IntegerSummary> sketch1 = input1.compact();
+    IntegerSketch input2 = new IntegerSketch(_lgK, IntegerSummary.Mode.Sum);
+    IntStream.range(1000, 2000).forEach(i -> input2.update(i, 1));
+    CompactSketch<IntegerSummary> sketch2 = input2.compact();
+
+    TupleIntSketchAccumulator accumulator1 = new TupleIntSketchAccumulator(_setOps, _nominalEntries, 3);
+    accumulator1.apply(sketch1);
+    TupleIntSketchAccumulator accumulator2 = new TupleIntSketchAccumulator(_setOps, _nominalEntries, 3);
+    accumulator2.apply(sketch2);
+    accumulator1.merge(accumulator2);
+
+    Assert.assertEquals(accumulator1.getResult().getEstimate(), sketch1.getEstimate() + sketch2.getEstimate());
+  }
+
+  @Test
+  public void testThresholdBehavior() {
+    IntegerSketch input1 = new IntegerSketch(_lgK, IntegerSummary.Mode.Sum);
+    IntStream.range(0, 1000).forEach(i -> input1.update(i, 1));
+    CompactSketch<IntegerSummary> sketch1 = input1.compact();
+    IntegerSketch input2 = new IntegerSketch(_lgK, IntegerSummary.Mode.Sum);
+    IntStream.range(1000, 2000).forEach(i -> input2.update(i, 1));
+    CompactSketch<IntegerSummary> sketch2 = input2.compact();
+
+    TupleIntSketchAccumulator accumulator = new TupleIntSketchAccumulator(_setOps, _nominalEntries, 3);
+    accumulator.apply(sketch1);
+    accumulator.apply(sketch2);
+
+    Assert.assertEquals(accumulator.getResult().getEstimate(), sketch1.getEstimate() + sketch2.getEstimate());
+  }
+
+  @Test
+  public void testUnionWithEmptyInput() {
+    TupleIntSketchAccumulator accumulator = new TupleIntSketchAccumulator(_setOps, _nominalEntries, 3);
+    TupleIntSketchAccumulator emptyAccumulator = new TupleIntSketchAccumulator(_setOps, _nominalEntries, 3);
+
+    accumulator.merge(emptyAccumulator);
+
+    Assert.assertTrue(accumulator.isEmpty());
+    Assert.assertEquals(accumulator.getResult().getEstimate(), 0.0);
+  }
+}


### PR DESCRIPTION
Adds a base class for common capabilities to allow any custom object to use an internal array buffer at query time to offset the cost of expensive merges for more memory usage. The Apache Datasketches Theta, Tuple and Cpc sketches initially make use of this functionality.

The changes in this PR introduce a different intermediate result type for the Datasketches CPC and Tuple aggregation functions. The change has already been introduced for Theta sketches in https://github.com/apache/pinot/pull/12042. The reason for using merges with more inputs so is to amortize the cost of intermediate bookkeeping datastructures necessary to perform unions on two sketches at a time.  The end user is in control of the degree to which the internal inputs accumulate before being merged.

For Tuple sketches, the "early-stop" optimisation in set operations circumvents further processing when retained items fall above the minimum theta value (Broder rule). This applies to other set operation expressions as well.

When using JMH benchmarks to simulate this scenario, the speedup achieved by accumulating sketches prior to union is often an improvement by a factor of 3.

Reference:
https://github.com/apache/datasketches-java/issues/326#issuecomment-663154127
https://datasketches.apache.org/docs/Theta/ThetaSize.html

Note:
This PR should be tagged as `upgrade-incompat` for users who are making use of the ApacheDatasketches Tuple sketch.
  
Release notes:
- additional parameters are now permitted for the `distinctCountCpcSketch` and `distinctCountTupleSketch` query aggregation functions to control merge thresholds.
