### PR TITLE
Add more validations for upserts

### DIFF
--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java
@@ -823,6 +823,10 @@ public final class TableConfigUtils {
       Preconditions.checkState(upsertConfig.isEnableSnapshot(), "Upsert TTL must have snapshot enabled");
     }
 
+    if (upsertConfig.isEnablePreload()) {
+      Preconditions.checkState(upsertConfig.isEnableSnapshot(), "Upsert Preload must have snapshot enabled");
+    }
+
     if (upsertConfig.getDeletedKeysTTL() > 0) {
       Preconditions.checkState(upsertConfig.getDeleteRecordColumn() != null,
           "Deleted Keys TTL can only be enabled with deleteRecordColumn set.");

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -29,6 +29,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.Serializable;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -785,6 +786,13 @@ public final class Schema implements Serializable {
         return false;
       }
     }
+
+    List<String> primaryKeyColumns = getPrimaryKeyColumns();
+    List<String> oldPrimaryKeyColumns = oldSchema.getPrimaryKeyColumns();
+    if (!Arrays.equals(primaryKeyColumns.toArray(), oldPrimaryKeyColumns.toArray())) {
+      return false;
+    }
+
     return true;
   }
 

--- a/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
+++ b/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java
@@ -789,6 +789,11 @@ public final class Schema implements Serializable {
 
     List<String> primaryKeyColumns = getPrimaryKeyColumns();
     List<String> oldPrimaryKeyColumns = oldSchema.getPrimaryKeyColumns();
+
+    if (primaryKeyColumns == null) {
+      return oldPrimaryKeyColumns == null;
+    }
+
     if (!Arrays.equals(primaryKeyColumns.toArray(), oldPrimaryKeyColumns.toArray())) {
       return false;
     }


### PR DESCRIPTION
<!-- pinot-pr-flow:start -->

### PR flow

Added preload snapshot validation and primary‑key compatibility check for upserts\.

```mermaid
flowchart TD
  N0["validateTTLForUpsertConfig #40;F1#41;"]:::stModified
  N1["Check Upsert TTL #62;0 #61;#62; snapshot enabled #40;F1#41;"]:::stUnchanged
  N2["Check Upsert Preload enabled #61;#62; snapshot enabled #40;F1#41;"]:::stAdded
  N3["isBackwardCompatibleWith #40;Schema#41; #40;F2#41;"]:::stModified
  N4["Get primary key columns from both schemas #40;F2#41;"]:::stAdded
  N5["Compare primary key arrays #40;Arrays#46;equals#41; #40;F2#41;"]:::stAdded
  N0 -->|"calls"| N1
  N1 -->|"next statement"| N2
  N3 -->|"calls"| N4
  N4 -->|"calls"| N5
  classDef stAdded fill:#dafbe1,stroke:#1a7f37,color:#1f2328,stroke-width:2px
  classDef stModified fill:#fff8c5,stroke:#9a6700,color:#1f2328,stroke-width:2px
  classDef stRemoved fill:#ffebe9,stroke:#cf222e,color:#1f2328,stroke-width:2px
  classDef stUnchanged fill:#f6f8fa,stroke:#656d76,color:#1f2328,stroke-width:1px
```

AI-generated · Green: added · Yellow: modified · Red: removed · Gray: existing

<details>
<summary>Diff evidence</summary>

- F1: pinot\-segment\-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils\.java — [before](https://github.com/apache/pinot/blob/cb3ccdcaeec4387adced4e7210435ec6260807c7/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java) · [after](https://github.com/apache/pinot/blob/119bc06578ca5ddbc5b823b6f19c653d3fa96ce7/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/utils/TableConfigUtils.java)
- F2: pinot\-spi/src/main/java/org/apache/pinot/spi/data/Schema\.java — [before](https://github.com/apache/pinot/blob/cb3ccdcaeec4387adced4e7210435ec6260807c7/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java) · [after](https://github.com/apache/pinot/blob/119bc06578ca5ddbc5b823b6f19c653d3fa96ce7/pinot-spi/src/main/java/org/apache/pinot/spi/data/Schema.java)

</details>

- [ ] Regenerate PR flow

<!-- pinot-pr-flow:meta eyJiYXNlX3NoYSI6ImNiM2NjZGNhZWVjNDM4N2FkY2VkNGU3MjEwNDM1ZWM2MjYwODA3YzciLCJjb250ZXh0X2hhc2giOiJjMDkwYzQ3NDhiYTI1YzJiZDhjMWYxMDJiMmFlOTBiZGM5ZWE3ZWIyYTM4ZTNhMTc1ZTFjMDg2MzA3YTc2OTljIiwiZ2VuZXJhdGVkX2F0IjoxNzg5MDEzNTE3LCJoZWFkX3NoYSI6IjExOWJjMDY1NzhjYTVkZGJjNWI4MjNiNmYxOWM2NTNkM2ZhOTZjZTciLCJtb2RlbCI6Im52aWRpYS9uZW1vdHJvbi0zLXN1cGVyLTEyMGItYTEyYjpmcmVlIiwib2JzZXJ2ZWRfYmFzZV9zaGEiOiJkZGMzZDBiMWQxMzdlYzQyMGU1YjY4ZDM3NmZkZDkyNjViZTc3MjljIiwicG9saWN5IjoicGlub3QtcHItZmxvdy12MSJ9 -->
<!-- pinot-pr-flow:signature 83acb1ad16d36460fae1bfd7fa78accb3f5f652ed607a96bd1dd238e3a6621e1 -->
<!-- pinot-pr-flow:end -->

* Do not allow users to change primary key columns 
* Check if snapshot is enabled already if preload is enabled