### PR TITLE
add SegmentContext to collect validDocIds bitmaps for many segments together

### DIFF
--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -438,7 +438,7 @@ public abstract class BaseTableDataManager implements TableDataManager {
   @Override
   public List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
       Map<String, String> queryOptions) {
-    List<SegmentContext> segmentContexts = new ArrayList<>();
+    List<SegmentContext> segmentContexts = new ArrayList<>(selectedSegments.size());
     selectedSegments.forEach(s -> segmentContexts.add(new SegmentContext(s)));
     return segmentContexts;
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/BaseTableDataManager.java
@@ -63,6 +63,8 @@ import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoa
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.index.loader.LoaderUtils;
 import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.segment.spi.index.metadata.SegmentMetadataImpl;
 import org.apache.pinot.segment.spi.loader.SegmentDirectoryLoader;
@@ -431,6 +433,14 @@ public abstract class BaseTableDataManager implements TableDataManager {
       return _errorCache.asMap().entrySet().stream().filter(map -> map.getKey().getLeft().equals(_tableNameWithType))
           .collect(Collectors.toMap(map -> map.getKey().getRight(), Map.Entry::getValue));
     }
+  }
+
+  @Override
+  public List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
+      Map<String, String> queryOptions) {
+    List<SegmentContext> segmentContexts = new ArrayList<>();
+    selectedSegments.forEach(s -> segmentContexts.add(new SegmentContext(s)));
+    return segmentContexts;
   }
 
   @Override

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -23,6 +23,7 @@ import com.google.common.base.Preconditions;
 import java.io.File;
 import java.io.IOException;
 import java.net.URI;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
@@ -305,10 +306,12 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   @Override
   public List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
       Map<String, String> queryOptions) {
+    List<SegmentContext> segmentContexts = new ArrayList<>();
+    selectedSegments.forEach(s -> segmentContexts.add(new SegmentContext(s)));
     if (isUpsertEnabled() && !QueryOptionsUtils.isSkipUpsert(queryOptions)) {
-      return _tableUpsertMetadataManager.getSegmentContexts(selectedSegments);
+      _tableUpsertMetadataManager.setSegmentContexts(segmentContexts);
     }
-    return super.getSegmentContexts(selectedSegments, queryOptions);
+    return segmentContexts;
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -46,6 +46,7 @@ import org.apache.pinot.common.metrics.ServerGauge;
 import org.apache.pinot.common.utils.LLCSegmentName;
 import org.apache.pinot.common.utils.SegmentUtils;
 import org.apache.pinot.common.utils.TarGzCompressionUtils;
+import org.apache.pinot.common.utils.config.QueryOptionsUtils;
 import org.apache.pinot.common.utils.fetcher.SegmentFetcherFactory;
 import org.apache.pinot.core.data.manager.BaseTableDataManager;
 import org.apache.pinot.core.data.manager.offline.ImmutableSegmentDataManager;
@@ -299,6 +300,15 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   public void onConsumingToOnline(String segmentNameStr) {
     LLCSegmentName segmentName = new LLCSegmentName(segmentNameStr);
     _ingestionDelayTracker.markPartitionForVerification(segmentName.getPartitionGroupId());
+  }
+
+  @Override
+  public Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
+      Map<String, String> queryOptions) {
+    if (isUpsertEnabled() && !QueryOptionsUtils.isSkipUpsert(queryOptions)) {
+      return _tableUpsertMetadataManager.getSegmentContexts(selectedSegments);
+    }
+    return null;
   }
 
   /**
@@ -788,14 +798,5 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       isValid = false;
     }
     return isValid;
-  }
-
-  @Override
-  public Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
-      boolean isSkipUpsert) {
-    if (!isSkipUpsert && isUpsertEnabled()) {
-      return _tableUpsertMetadataManager.getSegmentContexts(selectedSegments);
-    }
-    return null;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -791,7 +791,11 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   }
 
   @Override
-  public Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments) {
-    return isUpsertEnabled() ? _tableUpsertMetadataManager.getSegmentContexts(selectedSegments) : null;
+  public Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
+      boolean isSkipUpsert) {
+    if (!isSkipUpsert && isUpsertEnabled()) {
+      return _tableUpsertMetadataManager.getSegmentContexts(selectedSegments);
+    }
+    return null;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -303,12 +303,12 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   }
 
   @Override
-  public Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
+  public List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
       Map<String, String> queryOptions) {
     if (isUpsertEnabled() && !QueryOptionsUtils.isSkipUpsert(queryOptions)) {
       return _tableUpsertMetadataManager.getSegmentContexts(selectedSegments);
     }
-    return null;
+    return super.getSegmentContexts(selectedSegments, queryOptions);
   }
 
   /**

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -306,7 +306,7 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
   @Override
   public List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
       Map<String, String> queryOptions) {
-    List<SegmentContext> segmentContexts = new ArrayList<>();
+    List<SegmentContext> segmentContexts = new ArrayList<>(selectedSegments.size());
     selectedSegments.forEach(s -> segmentContexts.add(new SegmentContext(s)));
     if (isUpsertEnabled() && !QueryOptionsUtils.isSkipUpsert(queryOptions)) {
       _tableUpsertMetadataManager.setSegmentContexts(segmentContexts);

--- a/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/data/manager/realtime/RealtimeTableDataManager.java
@@ -67,6 +67,7 @@ import org.apache.pinot.segment.local.utils.SegmentLocks;
 import org.apache.pinot.segment.local.utils.tablestate.TableStateUtils;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.DedupConfig;
 import org.apache.pinot.spi.config.table.IndexingConfig;
@@ -787,5 +788,10 @@ public class RealtimeTableDataManager extends BaseTableDataManager {
       isValid = false;
     }
     return isValid;
+  }
+
+  @Override
+  public Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments) {
+    return isUpsertEnabled() ? _tableUpsertMetadataManager.getSegmentContexts(selectedSegments) : null;
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/InstanceResponseOperator.java
@@ -29,7 +29,7 @@ import org.apache.pinot.core.operator.blocks.results.ExceptionResultsBlock;
 import org.apache.pinot.core.operator.combine.BaseCombineOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.FetchContext;
-import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.spi.accounting.ThreadResourceUsageProvider;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.apache.pinot.spi.exception.QueryCancelledException;
@@ -40,15 +40,15 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
   private static final String EXPLAIN_NAME = "INSTANCE_RESPONSE";
 
   protected final BaseCombineOperator<?> _combineOperator;
-  protected final List<IndexSegment> _indexSegments;
+  protected final List<SegmentContext> _segmentContexts;
   protected final List<FetchContext> _fetchContexts;
   protected final int _fetchContextSize;
   protected final QueryContext _queryContext;
 
-  public InstanceResponseOperator(BaseCombineOperator<?> combineOperator, List<IndexSegment> indexSegments,
+  public InstanceResponseOperator(BaseCombineOperator<?> combineOperator, List<SegmentContext> segmentContexts,
       List<FetchContext> fetchContexts, QueryContext queryContext) {
     _combineOperator = combineOperator;
-    _indexSegments = indexSegments;
+    _segmentContexts = segmentContexts;
     _fetchContexts = fetchContexts;
     _fetchContextSize = fetchContexts.size();
     _queryContext = queryContext;
@@ -128,13 +128,13 @@ public class InstanceResponseOperator extends BaseOperator<InstanceResponseBlock
 
   public void prefetchAll() {
     for (int i = 0; i < _fetchContextSize; i++) {
-      _indexSegments.get(i).prefetch(_fetchContexts.get(i));
+      _segmentContexts.get(i).getIndexSegment().prefetch(_fetchContexts.get(i));
     }
   }
 
   public void releaseAll() {
     for (int i = 0; i < _fetchContextSize; i++) {
-      _indexSegments.get(i).release(_fetchContexts.get(i));
+      _segmentContexts.get(i).getIndexSegment().release(_fetchContexts.get(i));
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingInstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingInstanceResponseOperator.java
@@ -30,7 +30,7 @@ import org.apache.pinot.core.operator.combine.BaseCombineOperator;
 import org.apache.pinot.core.query.executor.ResultsBlockStreamer;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.FetchContext;
-import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.spi.exception.EarlyTerminationException;
 import org.apache.pinot.spi.exception.QueryCancelledException;
 import org.apache.pinot.spi.trace.Tracing;
@@ -42,9 +42,9 @@ public class StreamingInstanceResponseOperator extends InstanceResponseOperator 
   private final BaseStreamingCombineOperator<?> _streamingCombineOperator;
   private final ResultsBlockStreamer _streamer;
 
-  public StreamingInstanceResponseOperator(BaseCombineOperator<?> combinedOperator, List<IndexSegment> indexSegments,
+  public StreamingInstanceResponseOperator(BaseCombineOperator<?> combinedOperator, List<SegmentContext> segmentContexts,
       List<FetchContext> fetchContexts, ResultsBlockStreamer streamer, QueryContext queryContext) {
-    super(combinedOperator, indexSegments, fetchContexts, queryContext);
+    super(combinedOperator, segmentContexts, fetchContexts, queryContext);
     _streamingCombineOperator =
         combinedOperator instanceof BaseStreamingCombineOperator ? (BaseStreamingCombineOperator<?>) combinedOperator
             : null;

--- a/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingInstanceResponseOperator.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/operator/streaming/StreamingInstanceResponseOperator.java
@@ -42,8 +42,9 @@ public class StreamingInstanceResponseOperator extends InstanceResponseOperator 
   private final BaseStreamingCombineOperator<?> _streamingCombineOperator;
   private final ResultsBlockStreamer _streamer;
 
-  public StreamingInstanceResponseOperator(BaseCombineOperator<?> combinedOperator, List<SegmentContext> segmentContexts,
-      List<FetchContext> fetchContexts, ResultsBlockStreamer streamer, QueryContext queryContext) {
+  public StreamingInstanceResponseOperator(BaseCombineOperator<?> combinedOperator,
+      List<SegmentContext> segmentContexts, List<FetchContext> fetchContexts, ResultsBlockStreamer streamer,
+      QueryContext queryContext) {
     super(combinedOperator, segmentContexts, fetchContexts, queryContext);
     _streamingCombineOperator =
         combinedOperator instanceof BaseStreamingCombineOperator ? (BaseStreamingCombineOperator<?>) combinedOperator

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AcquireReleaseColumnsSegmentPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AcquireReleaseColumnsSegmentPlanNode.java
@@ -20,7 +20,7 @@ package org.apache.pinot.core.plan;
 
 import org.apache.pinot.core.operator.AcquireReleaseColumnsSegmentOperator;
 import org.apache.pinot.segment.spi.FetchContext;
-import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 
 
 /**
@@ -36,13 +36,13 @@ import org.apache.pinot.segment.spi.IndexSegment;
 public class AcquireReleaseColumnsSegmentPlanNode implements PlanNode {
 
   private final PlanNode _childPlanNode;
-  private final IndexSegment _indexSegment;
+  private final SegmentContext _segmentContext;
   private final FetchContext _fetchContext;
 
-  public AcquireReleaseColumnsSegmentPlanNode(PlanNode childPlanNode, IndexSegment indexSegment,
+  public AcquireReleaseColumnsSegmentPlanNode(PlanNode childPlanNode, SegmentContext segmentContext,
       FetchContext fetchContext) {
     _childPlanNode = childPlanNode;
-    _indexSegment = indexSegment;
+    _segmentContext = segmentContext;
     _fetchContext = fetchContext;
   }
 
@@ -52,6 +52,6 @@ public class AcquireReleaseColumnsSegmentPlanNode implements PlanNode {
    */
   @Override
   public AcquireReleaseColumnsSegmentOperator run() {
-    return new AcquireReleaseColumnsSegmentOperator(_childPlanNode, _indexSegment, _fetchContext);
+    return new AcquireReleaseColumnsSegmentOperator(_childPlanNode, _segmentContext.getIndexSegment(), _fetchContext);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/AggregationPlanNode.java
@@ -91,7 +91,7 @@ public class AggregationPlanNode implements PlanNode {
     assert aggregationFunctions != null;
 
     int numTotalDocs = _indexSegment.getSegmentMetadata().getTotalDocs();
-    FilterPlanNode filterPlanNode = new FilterPlanNode(_segmentContext, _queryContext, null);
+    FilterPlanNode filterPlanNode = new FilterPlanNode(_segmentContext, _queryContext);
     BaseFilterOperator filterOperator = filterPlanNode.run();
 
     if (!_queryContext.isNullHandlingEnabled()) {

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DistinctPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DistinctPlanNode.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.core.plan;
 
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.BaseProjectOperator;
@@ -27,6 +28,7 @@ import org.apache.pinot.core.operator.query.DictionaryBasedDistinctOperator;
 import org.apache.pinot.core.operator.query.DistinctOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
 
@@ -36,10 +38,17 @@ import org.apache.pinot.segment.spi.index.reader.NullValueVectorReader;
  */
 public class DistinctPlanNode implements PlanNode {
   private final IndexSegment _indexSegment;
+  private final SegmentContext _segmentContext;
   private final QueryContext _queryContext;
 
   public DistinctPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
+    this(indexSegment, null, queryContext);
+  }
+
+  public DistinctPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext,
+      QueryContext queryContext) {
     _indexSegment = indexSegment;
+    _segmentContext = segmentContext;
     _queryContext = queryContext;
   }
 
@@ -70,7 +79,8 @@ public class DistinctPlanNode implements PlanNode {
     }
 
     BaseProjectOperator<?> projectOperator =
-        new ProjectPlanNode(_indexSegment, _queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
+        new ProjectPlanNode(_indexSegment, _segmentContext, _queryContext, expressions,
+            DocIdSetPlanNode.MAX_DOC_PER_CALL, null).run();
     return new DistinctOperator(_indexSegment, _queryContext, projectOperator);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DistinctPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DistinctPlanNode.java
@@ -19,7 +19,6 @@
 package org.apache.pinot.core.plan;
 
 import java.util.List;
-import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.BaseProjectOperator;
@@ -41,13 +40,8 @@ public class DistinctPlanNode implements PlanNode {
   private final SegmentContext _segmentContext;
   private final QueryContext _queryContext;
 
-  public DistinctPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
-    this(indexSegment, null, queryContext);
-  }
-
-  public DistinctPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext,
-      QueryContext queryContext) {
-    _indexSegment = indexSegment;
+  public DistinctPlanNode(SegmentContext segmentContext, QueryContext queryContext) {
+    _indexSegment = segmentContext.getIndexSegment();
     _segmentContext = segmentContext;
     _queryContext = queryContext;
   }
@@ -79,8 +73,7 @@ public class DistinctPlanNode implements PlanNode {
     }
 
     BaseProjectOperator<?> projectOperator =
-        new ProjectPlanNode(_indexSegment, _segmentContext, _queryContext, expressions,
-            DocIdSetPlanNode.MAX_DOC_PER_CALL, null).run();
+        new ProjectPlanNode(_segmentContext, _queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
     return new DistinctOperator(_indexSegment, _queryContext, projectOperator);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DocIdSetPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DocIdSetPlanNode.java
@@ -23,21 +23,29 @@ import org.apache.pinot.core.operator.DocIdSetOperator;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 
 
 public class DocIdSetPlanNode implements PlanNode {
   public static final int MAX_DOC_PER_CALL = 10_000;
 
   private final IndexSegment _indexSegment;
+  private final SegmentContext _segmentContext;
   private final QueryContext _queryContext;
   private final int _maxDocPerCall;
   private final BaseFilterOperator _filterOperator;
 
   public DocIdSetPlanNode(IndexSegment indexSegment, QueryContext queryContext, int maxDocPerCall,
       @Nullable BaseFilterOperator filterOperator) {
+    this(indexSegment, null, queryContext, maxDocPerCall, filterOperator);
+  }
+
+  public DocIdSetPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext, QueryContext queryContext,
+      int maxDocPerCall, @Nullable BaseFilterOperator filterOperator) {
     assert maxDocPerCall > 0 && maxDocPerCall <= MAX_DOC_PER_CALL;
 
     _indexSegment = indexSegment;
+    _segmentContext = segmentContext;
     _queryContext = queryContext;
     _maxDocPerCall = maxDocPerCall;
     _filterOperator = filterOperator;
@@ -45,8 +53,7 @@ public class DocIdSetPlanNode implements PlanNode {
 
   @Override
   public DocIdSetOperator run() {
-    return new DocIdSetOperator(
-        _filterOperator != null ? _filterOperator : new FilterPlanNode(_indexSegment, _queryContext).run(),
-        _maxDocPerCall);
+    return new DocIdSetOperator(_filterOperator != null ? _filterOperator
+        : new FilterPlanNode(_indexSegment, _segmentContext, _queryContext, null).run(), _maxDocPerCall);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DocIdSetPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DocIdSetPlanNode.java
@@ -45,7 +45,7 @@ public class DocIdSetPlanNode implements PlanNode {
   @Override
   public DocIdSetOperator run() {
     return new DocIdSetOperator(
-        _filterOperator != null ? _filterOperator : new FilterPlanNode(_segmentContext, _queryContext, null).run(),
+        _filterOperator != null ? _filterOperator : new FilterPlanNode(_segmentContext, _queryContext).run(),
         _maxDocPerCall);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/DocIdSetPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/DocIdSetPlanNode.java
@@ -22,29 +22,20 @@ import javax.annotation.Nullable;
 import org.apache.pinot.core.operator.DocIdSetOperator;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
-import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 
 
 public class DocIdSetPlanNode implements PlanNode {
   public static final int MAX_DOC_PER_CALL = 10_000;
-
-  private final IndexSegment _indexSegment;
   private final SegmentContext _segmentContext;
   private final QueryContext _queryContext;
   private final int _maxDocPerCall;
   private final BaseFilterOperator _filterOperator;
 
-  public DocIdSetPlanNode(IndexSegment indexSegment, QueryContext queryContext, int maxDocPerCall,
+  public DocIdSetPlanNode(SegmentContext segmentContext, QueryContext queryContext, int maxDocPerCall,
       @Nullable BaseFilterOperator filterOperator) {
-    this(indexSegment, null, queryContext, maxDocPerCall, filterOperator);
-  }
-
-  public DocIdSetPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext, QueryContext queryContext,
-      int maxDocPerCall, @Nullable BaseFilterOperator filterOperator) {
     assert maxDocPerCall > 0 && maxDocPerCall <= MAX_DOC_PER_CALL;
 
-    _indexSegment = indexSegment;
     _segmentContext = segmentContext;
     _queryContext = queryContext;
     _maxDocPerCall = maxDocPerCall;
@@ -53,7 +44,8 @@ public class DocIdSetPlanNode implements PlanNode {
 
   @Override
   public DocIdSetOperator run() {
-    return new DocIdSetOperator(_filterOperator != null ? _filterOperator
-        : new FilterPlanNode(_indexSegment, _segmentContext, _queryContext, null).run(), _maxDocPerCall);
+    return new DocIdSetOperator(
+        _filterOperator != null ? _filterOperator : new FilterPlanNode(_segmentContext, _queryContext, null).run(),
+        _maxDocPerCall);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -73,17 +73,8 @@ public class FilterPlanNode implements PlanNode {
   // Cache the predicate evaluators
   private final List<Pair<Predicate, PredicateEvaluator>> _predicateEvaluators = new ArrayList<>(4);
 
-  public FilterPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
-    this(indexSegment, null, queryContext, null);
-  }
-
-  public FilterPlanNode(IndexSegment indexSegment, QueryContext queryContext, @Nullable FilterContext filter) {
-    this(indexSegment, null, queryContext, filter);
-  }
-
-  public FilterPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext, QueryContext queryContext,
-      @Nullable FilterContext filter) {
-    _indexSegment = indexSegment;
+  public FilterPlanNode(SegmentContext segmentContext, QueryContext queryContext, @Nullable FilterContext filter) {
+    _indexSegment = segmentContext.getIndexSegment();
     _segmentContext = segmentContext;
     _queryContext = queryContext;
     _filter = filter != null ? filter : _queryContext.getFilter();
@@ -91,8 +82,7 @@ public class FilterPlanNode implements PlanNode {
 
   @Override
   public BaseFilterOperator run() {
-    MutableRoaringBitmap queryableDocIdsSnapshot =
-        _segmentContext == null ? null : _segmentContext.getQueryableDocIdsSnapshot();
+    MutableRoaringBitmap queryableDocIdsSnapshot = _segmentContext.getQueryableDocIdsSnapshot();
     int numDocs = _indexSegment.getSegmentMetadata().getTotalDocs();
 
     if (_filter != null) {
@@ -180,16 +170,16 @@ public class FilterPlanNode implements PlanNode {
       if (arguments.get(0).getType() == ExpressionContext.Type.IDENTIFIER
           && arguments.get(1).getType() == ExpressionContext.Type.LITERAL) {
         String columnName = arguments.get(0).getIdentifier();
-        return _indexSegment.getDataSource(columnName).getH3Index() != null && _queryContext.isIndexUseAllowed(
-            columnName, FieldConfig.IndexType.H3);
+        return _indexSegment.getDataSource(columnName).getH3Index() != null
+            && _queryContext.isIndexUseAllowed(columnName, FieldConfig.IndexType.H3);
       }
       return false;
     } else {
       if (arguments.get(1).getType() == ExpressionContext.Type.IDENTIFIER
           && arguments.get(0).getType() == ExpressionContext.Type.LITERAL) {
         String columnName = arguments.get(1).getIdentifier();
-        return _indexSegment.getDataSource(columnName).getH3Index() != null && _queryContext.isIndexUseAllowed(
-            columnName, FieldConfig.IndexType.H3);
+        return _indexSegment.getDataSource(columnName).getH3Index() != null
+            && _queryContext.isIndexUseAllowed(columnName, FieldConfig.IndexType.H3);
       }
       return false;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -53,6 +53,7 @@ import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.local.realtime.impl.invertedindex.NativeMutableTextIndex;
 import org.apache.pinot.segment.local.segment.index.readers.text.NativeTextIndexReader;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.index.reader.JsonIndexReader;
@@ -66,6 +67,7 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 public class FilterPlanNode implements PlanNode {
   private final IndexSegment _indexSegment;
+  private final SegmentContext _segmentContext;
   private final QueryContext _queryContext;
   private final FilterContext _filter;
 
@@ -73,27 +75,35 @@ public class FilterPlanNode implements PlanNode {
   private final List<Pair<Predicate, PredicateEvaluator>> _predicateEvaluators = new ArrayList<>(4);
 
   public FilterPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
-    this(indexSegment, queryContext, null);
+    this(indexSegment, null, queryContext, null);
   }
 
   public FilterPlanNode(IndexSegment indexSegment, QueryContext queryContext, @Nullable FilterContext filter) {
+    this(indexSegment, null, queryContext, filter);
+  }
+
+  public FilterPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext, QueryContext queryContext,
+      @Nullable FilterContext filter) {
     _indexSegment = indexSegment;
+    _segmentContext = segmentContext;
     _queryContext = queryContext;
     _filter = filter != null ? filter : _queryContext.getFilter();
   }
 
   @Override
   public BaseFilterOperator run() {
-    // NOTE: Snapshot the queryableDocIds before reading the numDocs to prevent the latest updates getting lost
-    MutableRoaringBitmap queryableDocIdSnapshot = null;
-    if (!_queryContext.isSkipUpsert()) {
+    MutableRoaringBitmap queryableDocIdsSnapshot = null;
+    if (_segmentContext != null) {
+      queryableDocIdsSnapshot = _segmentContext.getQueryableDocIdsSnapshot();
+    } else if (!_queryContext.isSkipUpsert()) {
+      // NOTE: Snapshot the queryableDocIds before reading the numDocs to prevent the latest updates getting lost
       ThreadSafeMutableRoaringBitmap queryableDocIds = _indexSegment.getQueryableDocIds();
       if (queryableDocIds != null) {
-        queryableDocIdSnapshot = queryableDocIds.getMutableRoaringBitmap();
+        queryableDocIdsSnapshot = queryableDocIds.getMutableRoaringBitmap();
       } else {
         ThreadSafeMutableRoaringBitmap validDocIds = _indexSegment.getValidDocIds();
         if (validDocIds != null) {
-          queryableDocIdSnapshot = validDocIds.getMutableRoaringBitmap();
+          queryableDocIdsSnapshot = validDocIds.getMutableRoaringBitmap();
         }
       }
     }
@@ -101,15 +111,15 @@ public class FilterPlanNode implements PlanNode {
 
     if (_filter != null) {
       BaseFilterOperator filterOperator = constructPhysicalOperator(_filter, numDocs);
-      if (queryableDocIdSnapshot != null) {
-        BaseFilterOperator validDocFilter = new BitmapBasedFilterOperator(queryableDocIdSnapshot, false, numDocs);
+      if (queryableDocIdsSnapshot != null) {
+        BaseFilterOperator validDocFilter = new BitmapBasedFilterOperator(queryableDocIdsSnapshot, false, numDocs);
         return FilterOperatorUtils.getAndFilterOperator(_queryContext, Arrays.asList(filterOperator, validDocFilter),
             numDocs);
       } else {
         return filterOperator;
       }
-    } else if (queryableDocIdSnapshot != null) {
-      return new BitmapBasedFilterOperator(queryableDocIdSnapshot, false, numDocs);
+    } else if (queryableDocIdsSnapshot != null) {
+      return new BitmapBasedFilterOperator(queryableDocIdsSnapshot, false, numDocs);
     } else {
       return new MatchAllFilterOperator(numDocs);
     }
@@ -184,16 +194,16 @@ public class FilterPlanNode implements PlanNode {
       if (arguments.get(0).getType() == ExpressionContext.Type.IDENTIFIER
           && arguments.get(1).getType() == ExpressionContext.Type.LITERAL) {
         String columnName = arguments.get(0).getIdentifier();
-        return _indexSegment.getDataSource(columnName).getH3Index() != null
-            && _queryContext.isIndexUseAllowed(columnName, FieldConfig.IndexType.H3);
+        return _indexSegment.getDataSource(columnName).getH3Index() != null && _queryContext.isIndexUseAllowed(
+            columnName, FieldConfig.IndexType.H3);
       }
       return false;
     } else {
       if (arguments.get(1).getType() == ExpressionContext.Type.IDENTIFIER
           && arguments.get(0).getType() == ExpressionContext.Type.LITERAL) {
         String columnName = arguments.get(1).getIdentifier();
-        return _indexSegment.getDataSource(columnName).getH3Index() != null
-            && _queryContext.isIndexUseAllowed(columnName, FieldConfig.IndexType.H3);
+        return _indexSegment.getDataSource(columnName).getH3Index() != null && _queryContext.isIndexUseAllowed(
+            columnName, FieldConfig.IndexType.H3);
       }
       return false;
     }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/FilterPlanNode.java
@@ -73,6 +73,10 @@ public class FilterPlanNode implements PlanNode {
   // Cache the predicate evaluators
   private final List<Pair<Predicate, PredicateEvaluator>> _predicateEvaluators = new ArrayList<>(4);
 
+  public FilterPlanNode(SegmentContext segmentContext, QueryContext queryContext) {
+    this(segmentContext, queryContext, null);
+  }
+
   public FilterPlanNode(SegmentContext segmentContext, QueryContext queryContext, @Nullable FilterContext filter) {
     _indexSegment = segmentContext.getIndexSegment();
     _segmentContext = segmentContext;

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
@@ -56,7 +56,7 @@ public class GroupByPlanNode implements PlanNode {
   }
 
   private GroupByOperator buildNonFilteredGroupByPlan() {
-    FilterPlanNode filterPlanNode = new FilterPlanNode(_segmentContext, _queryContext, null);
+    FilterPlanNode filterPlanNode = new FilterPlanNode(_segmentContext, _queryContext);
     BaseFilterOperator filterOperator = filterPlanNode.run();
     AggregationFunctionUtils.AggregationInfo aggregationInfo =
         AggregationFunctionUtils.buildAggregationInfo(_segmentContext, _queryContext,

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.core.plan;
 
+import javax.annotation.Nullable;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
@@ -26,6 +27,7 @@ import org.apache.pinot.core.operator.query.GroupByOperator;
 import org.apache.pinot.core.query.aggregation.function.AggregationFunctionUtils;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 
 
 /**
@@ -33,10 +35,17 @@ import org.apache.pinot.segment.spi.IndexSegment;
  */
 public class GroupByPlanNode implements PlanNode {
   private final IndexSegment _indexSegment;
+  private final SegmentContext _segmentContext;
   private final QueryContext _queryContext;
 
   public GroupByPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
+    this(indexSegment, null, queryContext);
+  }
+
+  public GroupByPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext,
+      QueryContext queryContext) {
     _indexSegment = indexSegment;
+    _segmentContext = segmentContext;
     _queryContext = queryContext;
   }
 
@@ -48,15 +57,15 @@ public class GroupByPlanNode implements PlanNode {
 
   private FilteredGroupByOperator buildFilteredGroupByPlan() {
     return new FilteredGroupByOperator(_queryContext,
-        AggregationFunctionUtils.buildFilteredAggregationInfos(_indexSegment, _queryContext),
+        AggregationFunctionUtils.buildFilteredAggregationInfos(_indexSegment, _segmentContext, _queryContext),
         _indexSegment.getSegmentMetadata().getTotalDocs());
   }
 
   private GroupByOperator buildNonFilteredGroupByPlan() {
-    FilterPlanNode filterPlanNode = new FilterPlanNode(_indexSegment, _queryContext);
+    FilterPlanNode filterPlanNode = new FilterPlanNode(_indexSegment, _segmentContext, _queryContext, null);
     BaseFilterOperator filterOperator = filterPlanNode.run();
     AggregationFunctionUtils.AggregationInfo aggregationInfo =
-        AggregationFunctionUtils.buildAggregationInfo(_indexSegment, _queryContext,
+        AggregationFunctionUtils.buildAggregationInfo(_indexSegment, _segmentContext, _queryContext,
             _queryContext.getAggregationFunctions(), _queryContext.getFilter(), filterOperator,
             filterPlanNode.getPredicateEvaluators());
     return new GroupByOperator(_queryContext, aggregationInfo, _indexSegment.getSegmentMetadata().getTotalDocs());

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/GroupByPlanNode.java
@@ -18,7 +18,6 @@
  */
 package org.apache.pinot.core.plan;
 
-import javax.annotation.Nullable;
 import org.apache.pinot.core.common.Operator;
 import org.apache.pinot.core.operator.blocks.results.GroupByResultsBlock;
 import org.apache.pinot.core.operator.filter.BaseFilterOperator;
@@ -38,13 +37,8 @@ public class GroupByPlanNode implements PlanNode {
   private final SegmentContext _segmentContext;
   private final QueryContext _queryContext;
 
-  public GroupByPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
-    this(indexSegment, null, queryContext);
-  }
-
-  public GroupByPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext,
-      QueryContext queryContext) {
-    _indexSegment = indexSegment;
+  public GroupByPlanNode(SegmentContext segmentContext, QueryContext queryContext) {
+    _indexSegment = segmentContext.getIndexSegment();
     _segmentContext = segmentContext;
     _queryContext = queryContext;
   }
@@ -57,15 +51,15 @@ public class GroupByPlanNode implements PlanNode {
 
   private FilteredGroupByOperator buildFilteredGroupByPlan() {
     return new FilteredGroupByOperator(_queryContext,
-        AggregationFunctionUtils.buildFilteredAggregationInfos(_indexSegment, _segmentContext, _queryContext),
+        AggregationFunctionUtils.buildFilteredAggregationInfos(_segmentContext, _queryContext),
         _indexSegment.getSegmentMetadata().getTotalDocs());
   }
 
   private GroupByOperator buildNonFilteredGroupByPlan() {
-    FilterPlanNode filterPlanNode = new FilterPlanNode(_indexSegment, _segmentContext, _queryContext, null);
+    FilterPlanNode filterPlanNode = new FilterPlanNode(_segmentContext, _queryContext, null);
     BaseFilterOperator filterOperator = filterPlanNode.run();
     AggregationFunctionUtils.AggregationInfo aggregationInfo =
-        AggregationFunctionUtils.buildAggregationInfo(_indexSegment, _segmentContext, _queryContext,
+        AggregationFunctionUtils.buildAggregationInfo(_segmentContext, _queryContext,
             _queryContext.getAggregationFunctions(), _queryContext.getFilter(), filterOperator,
             filterPlanNode.getPredicateEvaluators());
     return new GroupByOperator(_queryContext, aggregationInfo, _indexSegment.getSegmentMetadata().getTotalDocs());

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/InstanceResponsePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/InstanceResponsePlanNode.java
@@ -22,25 +22,25 @@ import java.util.List;
 import org.apache.pinot.core.operator.InstanceResponseOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.FetchContext;
-import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 
 
 public class InstanceResponsePlanNode implements PlanNode {
   protected final CombinePlanNode _combinePlanNode;
-  protected final List<IndexSegment> _indexSegments;
+  protected final List<SegmentContext> _segmentContexts;
   protected final List<FetchContext> _fetchContexts;
   protected final QueryContext _queryContext;
 
-  public InstanceResponsePlanNode(CombinePlanNode combinePlanNode, List<IndexSegment> indexSegments,
+  public InstanceResponsePlanNode(CombinePlanNode combinePlanNode, List<SegmentContext> segmentContexts,
       List<FetchContext> fetchContexts, QueryContext queryContext) {
     _combinePlanNode = combinePlanNode;
-    _indexSegments = indexSegments;
+    _segmentContexts = segmentContexts;
     _fetchContexts = fetchContexts;
     _queryContext = queryContext;
   }
 
   @Override
   public InstanceResponseOperator run() {
-    return new InstanceResponseOperator(_combinePlanNode.run(), _indexSegments, _fetchContexts, _queryContext);
+    return new InstanceResponseOperator(_combinePlanNode.run(), _segmentContexts, _fetchContexts, _queryContext);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
@@ -49,24 +49,19 @@ public class ProjectPlanNode implements PlanNode {
   private final int _maxDocsPerCall;
   private final BaseFilterOperator _filterOperator;
 
-  public ProjectPlanNode(IndexSegment indexSegment, QueryContext queryContext,
-      Collection<ExpressionContext> expressions, int maxDocsPerCall) {
-    this(indexSegment, null, queryContext, expressions, maxDocsPerCall, null);
-  }
-
-  public ProjectPlanNode(IndexSegment indexSegment, QueryContext queryContext,
+  public ProjectPlanNode(SegmentContext segmentContext, QueryContext queryContext,
       Collection<ExpressionContext> expressions, int maxDocsPerCall, @Nullable BaseFilterOperator filterOperator) {
-    this(indexSegment, null, queryContext, expressions, maxDocsPerCall, filterOperator);
-  }
-
-  public ProjectPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext, QueryContext queryContext,
-      Collection<ExpressionContext> expressions, int maxDocsPerCall, @Nullable BaseFilterOperator filterOperator) {
-    _indexSegment = indexSegment;
+    _indexSegment = segmentContext.getIndexSegment();
     _segmentContext = segmentContext;
     _queryContext = queryContext;
     _expressions = expressions;
     _maxDocsPerCall = maxDocsPerCall;
     _filterOperator = filterOperator;
+  }
+
+  public ProjectPlanNode(SegmentContext segmentContext, QueryContext queryContext,
+      Collection<ExpressionContext> expressions, int maxDocsPerCall) {
+    this(segmentContext, queryContext, expressions, maxDocsPerCall, null);
   }
 
   @Override
@@ -83,7 +78,7 @@ public class ProjectPlanNode implements PlanNode {
     projectionColumns.forEach(column -> dataSourceMap.put(column, _indexSegment.getDataSource(column)));
     // NOTE: Skip creating DocIdSetOperator when maxDocsPerCall is 0 (for selection query with LIMIT 0)
     DocIdSetOperator docIdSetOperator =
-        _maxDocsPerCall > 0 ? new DocIdSetPlanNode(_indexSegment, _segmentContext, _queryContext, _maxDocsPerCall,
+        _maxDocsPerCall > 0 ? new DocIdSetPlanNode(_segmentContext, _queryContext, _maxDocsPerCall,
             _filterOperator).run() : null;
     ProjectionOperator projectionOperator =
         ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator);

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/ProjectPlanNode.java
@@ -34,6 +34,7 @@ import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.operator.transform.TransformOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 
 
@@ -42,23 +43,30 @@ import org.apache.pinot.segment.spi.datasource.DataSource;
  */
 public class ProjectPlanNode implements PlanNode {
   private final IndexSegment _indexSegment;
+  private final SegmentContext _segmentContext;
   private final QueryContext _queryContext;
   private final Collection<ExpressionContext> _expressions;
   private final int _maxDocsPerCall;
   private final BaseFilterOperator _filterOperator;
 
   public ProjectPlanNode(IndexSegment indexSegment, QueryContext queryContext,
+      Collection<ExpressionContext> expressions, int maxDocsPerCall) {
+    this(indexSegment, null, queryContext, expressions, maxDocsPerCall, null);
+  }
+
+  public ProjectPlanNode(IndexSegment indexSegment, QueryContext queryContext,
+      Collection<ExpressionContext> expressions, int maxDocsPerCall, @Nullable BaseFilterOperator filterOperator) {
+    this(indexSegment, null, queryContext, expressions, maxDocsPerCall, filterOperator);
+  }
+
+  public ProjectPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext, QueryContext queryContext,
       Collection<ExpressionContext> expressions, int maxDocsPerCall, @Nullable BaseFilterOperator filterOperator) {
     _indexSegment = indexSegment;
+    _segmentContext = segmentContext;
     _queryContext = queryContext;
     _expressions = expressions;
     _maxDocsPerCall = maxDocsPerCall;
     _filterOperator = filterOperator;
-  }
-
-  public ProjectPlanNode(IndexSegment indexSegment, QueryContext queryContext,
-      Collection<ExpressionContext> expressions, int maxDocsPerCall) {
-    this(indexSegment, queryContext, expressions, maxDocsPerCall, null);
   }
 
   @Override
@@ -75,8 +83,8 @@ public class ProjectPlanNode implements PlanNode {
     projectionColumns.forEach(column -> dataSourceMap.put(column, _indexSegment.getDataSource(column)));
     // NOTE: Skip creating DocIdSetOperator when maxDocsPerCall is 0 (for selection query with LIMIT 0)
     DocIdSetOperator docIdSetOperator =
-        _maxDocsPerCall > 0 ? new DocIdSetPlanNode(_indexSegment, _queryContext, _maxDocsPerCall, _filterOperator).run()
-            : null;
+        _maxDocsPerCall > 0 ? new DocIdSetPlanNode(_indexSegment, _segmentContext, _queryContext, _maxDocsPerCall,
+            _filterOperator).run() : null;
     ProjectionOperator projectionOperator =
         ProjectionOperatorUtils.getProjectionOperator(dataSourceMap, docIdSetOperator);
     return hasNonIdentifierExpression ? new TransformOperator(_queryContext, projectionOperator, _expressions)

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/StreamingInstanceResponsePlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/StreamingInstanceResponsePlanNode.java
@@ -24,21 +24,21 @@ import org.apache.pinot.core.operator.streaming.StreamingInstanceResponseOperato
 import org.apache.pinot.core.query.executor.ResultsBlockStreamer;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.FetchContext;
-import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 
 
 public class StreamingInstanceResponsePlanNode extends InstanceResponsePlanNode {
   private final ResultsBlockStreamer _streamer;
 
-  public StreamingInstanceResponsePlanNode(CombinePlanNode combinePlanNode, List<IndexSegment> indexSegments,
+  public StreamingInstanceResponsePlanNode(CombinePlanNode combinePlanNode, List<SegmentContext> segmentContexts,
       List<FetchContext> fetchContexts, QueryContext queryContext, ResultsBlockStreamer streamer) {
-    super(combinePlanNode, indexSegments, fetchContexts, queryContext);
+    super(combinePlanNode, segmentContexts, fetchContexts, queryContext);
     _streamer = streamer;
   }
 
   @Override
   public InstanceResponseOperator run() {
-    return new StreamingInstanceResponseOperator(_combinePlanNode.run(), _indexSegments, _fetchContexts, _streamer,
+    return new StreamingInstanceResponseOperator(_combinePlanNode.run(), _segmentContexts, _fetchContexts, _streamer,
         _queryContext);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/StreamingSelectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/StreamingSelectionPlanNode.java
@@ -20,12 +20,14 @@ package org.apache.pinot.core.plan;
 
 import com.google.common.base.Preconditions;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.operator.BaseProjectOperator;
 import org.apache.pinot.core.operator.streaming.StreamingSelectionOnlyOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.selection.SelectionOperatorUtils;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 
 
 /**
@@ -35,20 +37,28 @@ import org.apache.pinot.segment.spi.IndexSegment;
  */
 public class StreamingSelectionPlanNode implements PlanNode {
   private final IndexSegment _indexSegment;
+  private final SegmentContext _segmentContext;
   private final QueryContext _queryContext;
 
   public StreamingSelectionPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
+    this(indexSegment, null, queryContext);
+  }
+
+  public StreamingSelectionPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext,
+      QueryContext queryContext) {
     Preconditions.checkState(queryContext.getOrderByExpressions() == null,
         "Selection order-by is not supported for streaming");
     _indexSegment = indexSegment;
+    _segmentContext = segmentContext;
     _queryContext = queryContext;
   }
 
   @Override
   public StreamingSelectionOnlyOperator run() {
     List<ExpressionContext> expressions = SelectionOperatorUtils.extractExpressions(_queryContext, _indexSegment);
-    BaseProjectOperator<?> projectOperator = new ProjectPlanNode(_indexSegment, _queryContext, expressions,
-        Math.min(_queryContext.getLimit(), DocIdSetPlanNode.MAX_DOC_PER_CALL)).run();
+    BaseProjectOperator<?> projectOperator =
+        new ProjectPlanNode(_indexSegment, _segmentContext, _queryContext, expressions,
+            Math.min(_queryContext.getLimit(), DocIdSetPlanNode.MAX_DOC_PER_CALL), null).run();
     return new StreamingSelectionOnlyOperator(_indexSegment, _queryContext, expressions, projectOperator);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/StreamingSelectionPlanNode.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/StreamingSelectionPlanNode.java
@@ -20,7 +20,6 @@ package org.apache.pinot.core.plan;
 
 import com.google.common.base.Preconditions;
 import java.util.List;
-import javax.annotation.Nullable;
 import org.apache.pinot.common.request.context.ExpressionContext;
 import org.apache.pinot.core.operator.BaseProjectOperator;
 import org.apache.pinot.core.operator.streaming.StreamingSelectionOnlyOperator;
@@ -40,15 +39,10 @@ public class StreamingSelectionPlanNode implements PlanNode {
   private final SegmentContext _segmentContext;
   private final QueryContext _queryContext;
 
-  public StreamingSelectionPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
-    this(indexSegment, null, queryContext);
-  }
-
-  public StreamingSelectionPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext,
-      QueryContext queryContext) {
+  public StreamingSelectionPlanNode(SegmentContext segmentContext, QueryContext queryContext) {
     Preconditions.checkState(queryContext.getOrderByExpressions() == null,
         "Selection order-by is not supported for streaming");
-    _indexSegment = indexSegment;
+    _indexSegment = segmentContext.getIndexSegment();
     _segmentContext = segmentContext;
     _queryContext = queryContext;
   }
@@ -56,9 +50,8 @@ public class StreamingSelectionPlanNode implements PlanNode {
   @Override
   public StreamingSelectionOnlyOperator run() {
     List<ExpressionContext> expressions = SelectionOperatorUtils.extractExpressions(_queryContext, _indexSegment);
-    BaseProjectOperator<?> projectOperator =
-        new ProjectPlanNode(_indexSegment, _segmentContext, _queryContext, expressions,
-            Math.min(_queryContext.getLimit(), DocIdSetPlanNode.MAX_DOC_PER_CALL), null).run();
+    BaseProjectOperator<?> projectOperator = new ProjectPlanNode(_segmentContext, _queryContext, expressions,
+        Math.min(_queryContext.getLimit(), DocIdSetPlanNode.MAX_DOC_PER_CALL)).run();
     return new StreamingSelectionOnlyOperator(_indexSegment, _queryContext, expressions, projectOperator);
   }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/InstancePlanMakerImplV2.java
@@ -25,7 +25,6 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import javax.annotation.Nullable;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.commons.collections.MapUtils;
 import org.apache.pinot.common.metrics.ServerMetrics;
@@ -135,42 +134,33 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
         _minServerGroupTrimSize, _groupByTrimThreshold);
   }
 
-  @Override
-  public Plan makeInstancePlan(List<IndexSegment> indexSegments, QueryContext queryContext,
-      ExecutorService executorService, ServerMetrics serverMetrics) {
-    return makeInstancePlan(indexSegments, null, queryContext, executorService, serverMetrics);
-  }
-
-  public Plan makeInstancePlan(List<IndexSegment> indexSegments,
-      @Nullable Map<IndexSegment, SegmentContext> segmentContexts, QueryContext queryContext,
+  public Plan makeInstancePlan(List<SegmentContext> segmentContexts, QueryContext queryContext,
       ExecutorService executorService, ServerMetrics serverMetrics) {
     applyQueryOptions(queryContext);
 
-    int numSegments = indexSegments.size();
+    int numSegments = segmentContexts.size();
     List<PlanNode> planNodes = new ArrayList<>(numSegments);
     List<FetchContext> fetchContexts;
-
     if (queryContext.isEnablePrefetch()) {
       fetchContexts = new ArrayList<>(numSegments);
-      for (IndexSegment indexSegment : indexSegments) {
-        FetchContext fetchContext = _fetchPlanner.planFetchForProcessing(indexSegment, queryContext);
+      for (SegmentContext segmentContext : segmentContexts) {
+        FetchContext fetchContext =
+            _fetchPlanner.planFetchForProcessing(segmentContext.getIndexSegment(), queryContext);
         fetchContexts.add(fetchContext);
-        SegmentContext segmentContext = segmentContexts == null ? null : segmentContexts.get(indexSegment);
         planNodes.add(
-            new AcquireReleaseColumnsSegmentPlanNode(makeSegmentPlanNode(indexSegment, segmentContext, queryContext),
-                indexSegment, fetchContext));
+            new AcquireReleaseColumnsSegmentPlanNode(makeSegmentPlanNode(segmentContext, queryContext), segmentContext,
+                fetchContext));
       }
     } else {
       fetchContexts = Collections.emptyList();
-      for (IndexSegment indexSegment : indexSegments) {
-        SegmentContext segmentContext = segmentContexts == null ? null : segmentContexts.get(indexSegment);
-        planNodes.add(makeSegmentPlanNode(indexSegment, segmentContext, queryContext));
+      for (SegmentContext segmentContext : segmentContexts) {
+        planNodes.add(makeSegmentPlanNode(segmentContext, queryContext));
       }
     }
 
     CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, queryContext, executorService, null);
     return new GlobalPlanImplV0(
-        new InstanceResponsePlanNode(combinePlanNode, indexSegments, fetchContexts, queryContext));
+        new InstanceResponsePlanNode(combinePlanNode, segmentContexts, fetchContexts, queryContext));
   }
 
   private void applyQueryOptions(QueryContext queryContext) {
@@ -241,66 +231,45 @@ public class InstancePlanMakerImplV2 implements PlanMaker {
   }
 
   @Override
-  public PlanNode makeSegmentPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
-    return makeSegmentPlanNode(indexSegment, null, queryContext);
-  }
-
-  @Override
-  public PlanNode makeSegmentPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext,
-      QueryContext queryContext) {
-    rewriteQueryContextWithHints(queryContext, indexSegment);
+  public PlanNode makeSegmentPlanNode(SegmentContext segmentContext, QueryContext queryContext) {
+    rewriteQueryContextWithHints(queryContext, segmentContext.getIndexSegment());
     if (QueryContextUtils.isAggregationQuery(queryContext)) {
       List<ExpressionContext> groupByExpressions = queryContext.getGroupByExpressions();
       if (groupByExpressions != null) {
         // Group-by query
-        return new GroupByPlanNode(indexSegment, segmentContext, queryContext);
+        return new GroupByPlanNode(segmentContext, queryContext);
       } else {
         // Aggregation query
-        return new AggregationPlanNode(indexSegment, segmentContext, queryContext);
+        return new AggregationPlanNode(segmentContext, queryContext);
       }
     } else if (QueryContextUtils.isSelectionQuery(queryContext)) {
-      return new SelectionPlanNode(indexSegment, segmentContext, queryContext);
+      return new SelectionPlanNode(segmentContext, queryContext);
     } else {
       assert QueryContextUtils.isDistinctQuery(queryContext);
-      return new DistinctPlanNode(indexSegment, segmentContext, queryContext);
+      return new DistinctPlanNode(segmentContext, queryContext);
     }
   }
 
-  @Override
-  public Plan makeStreamingInstancePlan(List<IndexSegment> indexSegments, QueryContext queryContext,
-      ExecutorService executorService, ResultsBlockStreamer streamer, ServerMetrics serverMetrics) {
-    return makeStreamingInstancePlan(indexSegments, null, queryContext, executorService, streamer, serverMetrics);
-  }
-
-  public Plan makeStreamingInstancePlan(List<IndexSegment> indexSegments,
-      @Nullable Map<IndexSegment, SegmentContext> segmentContexts, QueryContext queryContext,
+  public Plan makeStreamingInstancePlan(List<SegmentContext> segmentContexts, QueryContext queryContext,
       ExecutorService executorService, ResultsBlockStreamer streamer, ServerMetrics serverMetrics) {
     applyQueryOptions(queryContext);
-
-    List<PlanNode> planNodes = new ArrayList<>(indexSegments.size());
-    for (IndexSegment indexSegment : indexSegments) {
-      SegmentContext segmentContext = segmentContexts == null ? null : segmentContexts.get(indexSegment);
-      planNodes.add(makeStreamingSegmentPlanNode(indexSegment, segmentContext, queryContext));
+    List<PlanNode> planNodes = new ArrayList<>(segmentContexts.size());
+    for (SegmentContext segmentContext : segmentContexts) {
+      planNodes.add(makeStreamingSegmentPlanNode(segmentContext, queryContext));
     }
     CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, queryContext, executorService, streamer);
     return new GlobalPlanImplV0(
-        new StreamingInstanceResponsePlanNode(combinePlanNode, indexSegments, Collections.emptyList(), queryContext,
+        new StreamingInstanceResponsePlanNode(combinePlanNode, segmentContexts, Collections.emptyList(), queryContext,
             streamer));
   }
 
   @Override
-  public PlanNode makeStreamingSegmentPlanNode(IndexSegment indexSegment, QueryContext queryContext) {
-    return makeStreamingSegmentPlanNode(indexSegment, null, queryContext);
-  }
-
-  @Override
-  public PlanNode makeStreamingSegmentPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext,
-      QueryContext queryContext) {
+  public PlanNode makeStreamingSegmentPlanNode(SegmentContext segmentContext, QueryContext queryContext) {
     if (QueryContextUtils.isSelectionOnlyQuery(queryContext) && queryContext.getLimit() != 0) {
       // Use streaming operator only for non-empty selection-only query
-      return new StreamingSelectionPlanNode(indexSegment, segmentContext, queryContext);
+      return new StreamingSelectionPlanNode(segmentContext, queryContext);
     } else {
-      return makeSegmentPlanNode(indexSegment, queryContext);
+      return makeSegmentPlanNode(segmentContext, queryContext);
     }
   }
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/PlanMaker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/PlanMaker.java
@@ -19,13 +19,16 @@
 package org.apache.pinot.core.plan.maker;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.ExecutorService;
+import javax.annotation.Nullable;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.plan.Plan;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.core.query.executor.ResultsBlockStreamer;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.env.PinotConfiguration;
 
@@ -47,10 +50,21 @@ public interface PlanMaker {
   Plan makeInstancePlan(List<IndexSegment> indexSegments, QueryContext queryContext, ExecutorService executorService,
       ServerMetrics serverMetrics);
 
+  default Plan makeInstancePlan(List<IndexSegment> indexSegments,
+      @Nullable Map<IndexSegment, SegmentContext> segmentContexts, QueryContext queryContext,
+      ExecutorService executorService, ServerMetrics serverMetrics) {
+    return makeInstancePlan(indexSegments, queryContext, executorService, serverMetrics);
+  }
+
   /**
    * Returns a segment level {@link PlanNode} which contains the logical execution plan for one segment.
    */
   PlanNode makeSegmentPlanNode(IndexSegment indexSegment, QueryContext queryContext);
+
+  default PlanNode makeSegmentPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext,
+      QueryContext queryContext) {
+    return makeSegmentPlanNode(indexSegment, queryContext);
+  }
 
   /**
    * Returns an instance level {@link Plan} for a streaming query which contains the logical execution plan for multiple
@@ -59,9 +73,20 @@ public interface PlanMaker {
   Plan makeStreamingInstancePlan(List<IndexSegment> indexSegments, QueryContext queryContext,
       ExecutorService executorService, ResultsBlockStreamer streamer, ServerMetrics serverMetrics);
 
+  default Plan makeStreamingInstancePlan(List<IndexSegment> indexSegments,
+      @Nullable Map<IndexSegment, SegmentContext> segmentContexts, QueryContext queryContext,
+      ExecutorService executorService, ResultsBlockStreamer streamer, ServerMetrics serverMetrics) {
+    return makeStreamingInstancePlan(indexSegments, queryContext, executorService, streamer, serverMetrics);
+  }
+
   /**
    * Returns a segment level {@link PlanNode} for a streaming query which contains the logical execution plan for one
    * segment.
    */
   PlanNode makeStreamingSegmentPlanNode(IndexSegment indexSegment, QueryContext queryContext);
+
+  default PlanNode makeStreamingSegmentPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext,
+      QueryContext queryContext) {
+    return makeStreamingSegmentPlanNode(indexSegment, queryContext);
+  }
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/PlanMaker.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/plan/maker/PlanMaker.java
@@ -19,15 +19,12 @@
 package org.apache.pinot.core.plan.maker;
 
 import java.util.List;
-import java.util.Map;
 import java.util.concurrent.ExecutorService;
-import javax.annotation.Nullable;
 import org.apache.pinot.common.metrics.ServerMetrics;
 import org.apache.pinot.core.plan.Plan;
 import org.apache.pinot.core.plan.PlanNode;
 import org.apache.pinot.core.query.executor.ResultsBlockStreamer;
 import org.apache.pinot.core.query.request.context.QueryContext;
-import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.spi.annotations.InterfaceAudience;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -47,46 +44,24 @@ public interface PlanMaker {
   /**
    * Returns an instance level {@link Plan} which contains the logical execution plan for multiple segments.
    */
-  Plan makeInstancePlan(List<IndexSegment> indexSegments, QueryContext queryContext, ExecutorService executorService,
-      ServerMetrics serverMetrics);
-
-  default Plan makeInstancePlan(List<IndexSegment> indexSegments,
-      @Nullable Map<IndexSegment, SegmentContext> segmentContexts, QueryContext queryContext,
-      ExecutorService executorService, ServerMetrics serverMetrics) {
-    return makeInstancePlan(indexSegments, queryContext, executorService, serverMetrics);
-  }
+  Plan makeInstancePlan(List<SegmentContext> segmentContexts, QueryContext queryContext,
+      ExecutorService executorService, ServerMetrics serverMetrics);
 
   /**
    * Returns a segment level {@link PlanNode} which contains the logical execution plan for one segment.
    */
-  PlanNode makeSegmentPlanNode(IndexSegment indexSegment, QueryContext queryContext);
-
-  default PlanNode makeSegmentPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext,
-      QueryContext queryContext) {
-    return makeSegmentPlanNode(indexSegment, queryContext);
-  }
+  PlanNode makeSegmentPlanNode(SegmentContext segmentContext, QueryContext queryContext);
 
   /**
    * Returns an instance level {@link Plan} for a streaming query which contains the logical execution plan for multiple
    * segments.
    */
-  Plan makeStreamingInstancePlan(List<IndexSegment> indexSegments, QueryContext queryContext,
+  Plan makeStreamingInstancePlan(List<SegmentContext> segmentContexts, QueryContext queryContext,
       ExecutorService executorService, ResultsBlockStreamer streamer, ServerMetrics serverMetrics);
-
-  default Plan makeStreamingInstancePlan(List<IndexSegment> indexSegments,
-      @Nullable Map<IndexSegment, SegmentContext> segmentContexts, QueryContext queryContext,
-      ExecutorService executorService, ResultsBlockStreamer streamer, ServerMetrics serverMetrics) {
-    return makeStreamingInstancePlan(indexSegments, queryContext, executorService, streamer, serverMetrics);
-  }
 
   /**
    * Returns a segment level {@link PlanNode} for a streaming query which contains the logical execution plan for one
    * segment.
    */
-  PlanNode makeStreamingSegmentPlanNode(IndexSegment indexSegment, QueryContext queryContext);
-
-  default PlanNode makeStreamingSegmentPlanNode(IndexSegment indexSegment, @Nullable SegmentContext segmentContext,
-      QueryContext queryContext) {
-    return makeStreamingSegmentPlanNode(indexSegment, queryContext);
-  }
+  PlanNode makeStreamingSegmentPlanNode(SegmentContext segmentContext, QueryContext queryContext);
 }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -47,7 +47,6 @@ import org.apache.pinot.core.plan.ProjectPlanNode;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.startree.StarTreeUtils;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
-import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.index.startree.AggregationFunctionColumnPair;
 
@@ -244,16 +243,15 @@ public class AggregationFunctionUtils {
   /**
    * Builds {@link AggregationInfo} for aggregations.
    */
-  public static AggregationInfo buildAggregationInfo(IndexSegment indexSegment, @Nullable SegmentContext segmentContext,
-      QueryContext queryContext, AggregationFunction[] aggregationFunctions, @Nullable FilterContext filter,
-      BaseFilterOperator filterOperator, List<Pair<Predicate, PredicateEvaluator>> predicateEvaluators) {
+  public static AggregationInfo buildAggregationInfo(SegmentContext segmentContext, QueryContext queryContext,
+      AggregationFunction[] aggregationFunctions, @Nullable FilterContext filter, BaseFilterOperator filterOperator,
+      List<Pair<Predicate, PredicateEvaluator>> predicateEvaluators) {
     BaseProjectOperator<?> projectOperator = null;
 
     // TODO: Create a short-circuit ProjectOperator when filter result is empty
     if (!filterOperator.isResultEmpty()) {
-      projectOperator =
-          StarTreeUtils.createStarTreeBasedProjectOperator(indexSegment, queryContext, aggregationFunctions, filter,
-              predicateEvaluators);
+      projectOperator = StarTreeUtils.createStarTreeBasedProjectOperator(segmentContext.getIndexSegment(), queryContext,
+          aggregationFunctions, filter, predicateEvaluators);
     }
 
     if (projectOperator != null) {
@@ -262,8 +260,9 @@ public class AggregationFunctionUtils {
       Set<ExpressionContext> expressionsToTransform =
           AggregationFunctionUtils.collectExpressionsToTransform(aggregationFunctions,
               queryContext.getGroupByExpressions());
-      projectOperator = new ProjectPlanNode(indexSegment, segmentContext, queryContext, expressionsToTransform,
-          DocIdSetPlanNode.MAX_DOC_PER_CALL, filterOperator).run();
+      projectOperator =
+          new ProjectPlanNode(segmentContext, queryContext, expressionsToTransform, DocIdSetPlanNode.MAX_DOC_PER_CALL,
+              filterOperator).run();
       return new AggregationInfo(aggregationFunctions, projectOperator, false);
     }
   }
@@ -271,11 +270,11 @@ public class AggregationFunctionUtils {
   /**
    * Builds swim-lanes (list of {@link AggregationInfo}) for filtered aggregations.
    */
-  public static List<AggregationInfo> buildFilteredAggregationInfos(IndexSegment indexSegment,
-      @Nullable SegmentContext segmentContext, QueryContext queryContext) {
+  public static List<AggregationInfo> buildFilteredAggregationInfos(SegmentContext segmentContext,
+      QueryContext queryContext) {
     assert queryContext.getAggregationFunctions() != null && queryContext.getFilteredAggregationFunctions() != null;
 
-    FilterPlanNode mainFilterPlan = new FilterPlanNode(indexSegment, segmentContext, queryContext, null);
+    FilterPlanNode mainFilterPlan = new FilterPlanNode(segmentContext, queryContext, null);
     BaseFilterOperator mainFilterOperator = mainFilterPlan.run();
     List<Pair<Predicate, PredicateEvaluator>> mainPredicateEvaluators = mainFilterPlan.getPredicateEvaluators();
 
@@ -285,8 +284,8 @@ public class AggregationFunctionUtils {
       Set<ExpressionContext> expressions =
           collectExpressionsToTransform(aggregationFunctions, queryContext.getGroupByExpressions());
       BaseProjectOperator<?> projectOperator =
-          new ProjectPlanNode(indexSegment, segmentContext, queryContext, expressions,
-              DocIdSetPlanNode.MAX_DOC_PER_CALL, mainFilterOperator).run();
+          new ProjectPlanNode(segmentContext, queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL,
+              mainFilterOperator).run();
       return Collections.singletonList(new AggregationInfo(aggregationFunctions, projectOperator, false));
     }
 
@@ -307,7 +306,7 @@ public class AggregationFunctionUtils {
             combinedFilter = FilterContext.forAnd(List.of(mainFilter, filter));
           }
 
-          FilterPlanNode subFilterPlan = new FilterPlanNode(indexSegment, segmentContext, queryContext, filter);
+          FilterPlanNode subFilterPlan = new FilterPlanNode(segmentContext, queryContext, filter);
           BaseFilterOperator subFilterOperator = subFilterPlan.run();
           BaseFilterOperator combinedFilterOperator;
           if (mainFilterOperator.isResultMatchingAll() || subFilterOperator.isResultEmpty()) {
@@ -341,17 +340,17 @@ public class AggregationFunctionUtils {
       } else {
         AggregationFunction[] aggregationFunctions =
             filteredAggregationContext._aggregationFunctions.toArray(new AggregationFunction[0]);
-        aggregationInfos.add(buildAggregationInfo(indexSegment, segmentContext, queryContext, aggregationFunctions,
-            filteredAggregationContext._filter, filteredAggregationContext._filterOperator,
-            filteredAggregationContext._predicateEvaluators));
+        aggregationInfos.add(
+            buildAggregationInfo(segmentContext, queryContext, aggregationFunctions, filteredAggregationContext._filter,
+                filteredAggregationContext._filterOperator, filteredAggregationContext._predicateEvaluators));
       }
     }
 
     if (!nonFilteredFunctions.isEmpty()) {
       AggregationFunction[] aggregationFunctions = nonFilteredFunctions.toArray(new AggregationFunction[0]);
       aggregationInfos.add(
-          buildAggregationInfo(indexSegment, segmentContext, queryContext, aggregationFunctions, mainFilter,
-              mainFilterOperator, mainPredicateEvaluators));
+          buildAggregationInfo(segmentContext, queryContext, aggregationFunctions, mainFilter, mainFilterOperator,
+              mainPredicateEvaluators));
     }
 
     return aggregationInfos;

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/aggregation/function/AggregationFunctionUtils.java
@@ -274,7 +274,7 @@ public class AggregationFunctionUtils {
       QueryContext queryContext) {
     assert queryContext.getAggregationFunctions() != null && queryContext.getFilteredAggregationFunctions() != null;
 
-    FilterPlanNode mainFilterPlan = new FilterPlanNode(segmentContext, queryContext, null);
+    FilterPlanNode mainFilterPlan = new FilterPlanNode(segmentContext, queryContext);
     BaseFilterOperator mainFilterOperator = mainFilterPlan.run();
     List<Pair<Predicate, PredicateEvaluator>> mainPredicateEvaluators = mainFilterPlan.getPredicateEvaluators();
 

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -381,7 +381,8 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       }
     } else {
       TimerContext.Timer planBuildTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.BUILD_QUERY_PLAN);
-      Map<IndexSegment, SegmentContext> segmentContexts = tableDataManager.getSegmentContexts(selectedSegments);
+      Map<IndexSegment, SegmentContext> segmentContexts =
+          tableDataManager.getSegmentContexts(selectedSegments, queryContext.isSkipUpsert());
       Plan queryPlan =
           enableStreaming ? _planMaker.makeStreamingInstancePlan(selectedSegments, segmentContexts, queryContext,
               executorService, streamer, _serverMetrics)

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -70,6 +70,7 @@ import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.spi.data.FieldSpec;
 import org.apache.pinot.spi.env.PinotConfiguration;
@@ -256,8 +257,9 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
 
     InstanceResponseBlock instanceResponse = null;
     try {
-      instanceResponse = executeInternal(indexSegments, queryContext, timerContext, executorService, streamer,
-          queryRequest.isEnableStreaming());
+      instanceResponse =
+          executeInternal(tableDataManager, indexSegments, queryContext, timerContext, executorService, streamer,
+              queryRequest.isEnableStreaming());
     } catch (Exception e) {
       _serverMetrics.addMeteredTableValue(tableNameWithType, ServerMeter.QUERY_EXECUTION_EXCEPTIONS, 1);
       instanceResponse = new InstanceResponseBlock();
@@ -344,11 +346,11 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
   }
 
   // NOTE: This method might change indexSegments. Do not use it after calling this method.
-  private InstanceResponseBlock executeInternal(List<IndexSegment> indexSegments, QueryContext queryContext,
-      TimerContext timerContext, ExecutorService executorService, @Nullable ResultsBlockStreamer streamer,
-      boolean enableStreaming)
+  private InstanceResponseBlock executeInternal(TableDataManager tableDataManager, List<IndexSegment> indexSegments,
+      QueryContext queryContext, TimerContext timerContext, ExecutorService executorService,
+      @Nullable ResultsBlockStreamer streamer, boolean enableStreaming)
       throws Exception {
-    handleSubquery(queryContext, indexSegments, timerContext, executorService);
+    handleSubquery(queryContext, tableDataManager, indexSegments, timerContext, executorService);
 
     // Compute total docs for the table before pruning the segments
     long numTotalDocs = 0;
@@ -379,10 +381,12 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       }
     } else {
       TimerContext.Timer planBuildTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.BUILD_QUERY_PLAN);
+      Map<IndexSegment, SegmentContext> segmentContexts = tableDataManager.getSegmentContexts(selectedSegments);
       Plan queryPlan =
-          enableStreaming ? _planMaker.makeStreamingInstancePlan(selectedSegments, queryContext, executorService,
-              streamer, _serverMetrics)
-              : _planMaker.makeInstancePlan(selectedSegments, queryContext, executorService, _serverMetrics);
+          enableStreaming ? _planMaker.makeStreamingInstancePlan(selectedSegments, segmentContexts, queryContext,
+              executorService, streamer, _serverMetrics)
+              : _planMaker.makeInstancePlan(selectedSegments, segmentContexts, queryContext, executorService,
+                  _serverMetrics);
       planBuildTimer.stopAndRecord();
 
       TimerContext.Timer planExecTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.QUERY_PLAN_EXECUTION);
@@ -523,12 +527,13 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
    * Handles the subquery in the given query.
    * <p>Currently only supports subquery within the filter.
    */
-  private void handleSubquery(QueryContext queryContext, List<IndexSegment> indexSegments, TimerContext timerContext,
-      ExecutorService executorService)
+  private void handleSubquery(QueryContext queryContext, TableDataManager tableDataManager,
+      List<IndexSegment> indexSegments, TimerContext timerContext, ExecutorService executorService)
       throws Exception {
     FilterContext filter = queryContext.getFilter();
     if (filter != null && !filter.isConstant()) {
-      handleSubquery(filter, indexSegments, timerContext, executorService, queryContext.getEndTimeMs());
+      handleSubquery(filter, tableDataManager, indexSegments, timerContext, executorService,
+          queryContext.getEndTimeMs());
     }
   }
 
@@ -536,16 +541,17 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
    * Handles the subquery in the given filter.
    * <p>Currently only supports subquery within the lhs of the predicate.
    */
-  private void handleSubquery(FilterContext filter, List<IndexSegment> indexSegments, TimerContext timerContext,
-      ExecutorService executorService, long endTimeMs)
+  private void handleSubquery(FilterContext filter, TableDataManager tableDataManager, List<IndexSegment> indexSegments,
+      TimerContext timerContext, ExecutorService executorService, long endTimeMs)
       throws Exception {
     List<FilterContext> children = filter.getChildren();
     if (children != null) {
       for (FilterContext child : children) {
-        handleSubquery(child, indexSegments, timerContext, executorService, endTimeMs);
+        handleSubquery(child, tableDataManager, indexSegments, timerContext, executorService, endTimeMs);
       }
     } else {
-      handleSubquery(filter.getPredicate().getLhs(), indexSegments, timerContext, executorService, endTimeMs);
+      handleSubquery(filter.getPredicate().getLhs(), tableDataManager, indexSegments, timerContext, executorService,
+          endTimeMs);
     }
   }
 
@@ -556,8 +562,8 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
    * <p>Currently only supports ID_SET subquery within the IN_PARTITIONED_SUBQUERY transform function, which will be
    * rewritten to an IN_ID_SET transform function.
    */
-  private void handleSubquery(ExpressionContext expression, List<IndexSegment> indexSegments, TimerContext timerContext,
-      ExecutorService executorService, long endTimeMs)
+  private void handleSubquery(ExpressionContext expression, TableDataManager tableDataManager,
+      List<IndexSegment> indexSegments, TimerContext timerContext, ExecutorService executorService, long endTimeMs)
       throws Exception {
     FunctionContext function = expression.getFunction();
     if (function == null) {
@@ -584,7 +590,8 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       subquery.setEndTimeMs(endTimeMs);
       // Make a clone of indexSegments because the method might modify the list
       InstanceResponseBlock instanceResponse =
-          executeInternal(new ArrayList<>(indexSegments), subquery, timerContext, executorService, null, false);
+          executeInternal(tableDataManager, new ArrayList<>(indexSegments), subquery, timerContext, executorService,
+              null, false);
       BaseResultsBlock resultsBlock = instanceResponse.getResultsBlock();
       Preconditions.checkState(resultsBlock instanceof AggregationResultsBlock,
           "Got unexpected results block type: %s, expecting aggregation results",
@@ -598,7 +605,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
           ExpressionContext.forLiteralContext(FieldSpec.DataType.STRING, ((IdSet) result).toBase64String()));
     } else {
       for (ExpressionContext argument : arguments) {
-        handleSubquery(argument, indexSegments, timerContext, executorService, endTimeMs);
+        handleSubquery(argument, tableDataManager, indexSegments, timerContext, executorService, endTimeMs);
       }
     }
   }

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -382,7 +382,7 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
     } else {
       TimerContext.Timer planBuildTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.BUILD_QUERY_PLAN);
       Map<IndexSegment, SegmentContext> segmentContexts =
-          tableDataManager.getSegmentContexts(selectedSegments, queryContext.isSkipUpsert());
+          tableDataManager.getSegmentContexts(selectedSegments, queryContext.getQueryOptions());
       Plan queryPlan =
           enableStreaming ? _planMaker.makeStreamingInstancePlan(selectedSegments, segmentContexts, queryContext,
               executorService, streamer, _serverMetrics)

--- a/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
+++ b/pinot-core/src/main/java/org/apache/pinot/core/query/executor/ServerQueryExecutorV1Impl.java
@@ -381,13 +381,12 @@ public class ServerQueryExecutorV1Impl implements QueryExecutor {
       }
     } else {
       TimerContext.Timer planBuildTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.BUILD_QUERY_PLAN);
-      Map<IndexSegment, SegmentContext> segmentContexts =
+      List<SegmentContext> selectedSegmentContexts =
           tableDataManager.getSegmentContexts(selectedSegments, queryContext.getQueryOptions());
       Plan queryPlan =
-          enableStreaming ? _planMaker.makeStreamingInstancePlan(selectedSegments, segmentContexts, queryContext,
-              executorService, streamer, _serverMetrics)
-              : _planMaker.makeInstancePlan(selectedSegments, segmentContexts, queryContext, executorService,
-                  _serverMetrics);
+          enableStreaming ? _planMaker.makeStreamingInstancePlan(selectedSegmentContexts, queryContext, executorService,
+              streamer, _serverMetrics)
+              : _planMaker.makeInstancePlan(selectedSegmentContexts, queryContext, executorService, _serverMetrics);
       planBuildTimer.stopAndRecord();
 
       TimerContext.Timer planExecTimer = timerContext.startNewPhaseTimer(ServerQueryPhase.QUERY_PLAN_EXECUTION);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/combine/SelectionCombineOperatorTest.java
@@ -38,6 +38,7 @@ import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoa
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -240,7 +241,7 @@ public class SelectionCombineOperatorTest {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
     List<PlanNode> planNodes = new ArrayList<>(NUM_SEGMENTS);
     for (IndexSegment indexSegment : _indexSegments) {
-      planNodes.add(PLAN_MAKER.makeSegmentPlanNode(indexSegment, queryContext));
+      planNodes.add(PLAN_MAKER.makeSegmentPlanNode(new SegmentContext(indexSegment), queryContext));
     }
     queryContext.setEndTimeMs(System.currentTimeMillis() + Server.DEFAULT_QUERY_EXECUTOR_TIMEOUT_MS);
     CombinePlanNode combinePlanNode = new CombinePlanNode(planNodes, queryContext, EXECUTOR, null);

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/query/SelectionOrderByOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/query/SelectionOrderByOperatorTest.java
@@ -36,6 +36,7 @@ import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoa
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -131,8 +132,9 @@ public class SelectionOrderByOperatorTest {
   private List<Object[]> executeQuery(QueryContext queryContext) {
     List<ExpressionContext> expressions =
         SelectionOperatorUtils.extractExpressions(queryContext, _segmentWithNullValues);
-    BaseProjectOperator<?> projectOperator = new ProjectPlanNode(_segmentWithNullValues, queryContext, expressions,
-        DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
+    BaseProjectOperator<?> projectOperator =
+        new ProjectPlanNode(new SegmentContext(_segmentWithNullValues), queryContext, expressions,
+            DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
 
     SelectionOrderByOperator operator = new SelectionOrderByOperator(
         _segmentWithNullValues,

--- a/pinot-core/src/test/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyOperatorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/operator/streaming/StreamingSelectionOnlyOperatorTest.java
@@ -35,6 +35,7 @@ import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoa
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -76,8 +77,9 @@ public class StreamingSelectionOnlyOperatorTest {
     queryContext.setNullHandlingEnabled(true);
     List<ExpressionContext> expressions =
         SelectionOperatorUtils.extractExpressions(queryContext, _segmentWithNullValues);
-    BaseProjectOperator<?> projectOperator = new ProjectPlanNode(_segmentWithNullValues, queryContext, expressions,
-        DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
+    BaseProjectOperator<?> projectOperator =
+        new ProjectPlanNode(new SegmentContext(_segmentWithNullValues), queryContext, expressions,
+            DocIdSetPlanNode.MAX_DOC_PER_CALL).run();
 
     StreamingSelectionOnlyOperator operator = new StreamingSelectionOnlyOperator(
         _segmentWithNullValues,

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/FilterPlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/FilterPlanNodeTest.java
@@ -70,14 +70,16 @@ public class FilterPlanNodeTest {
 
     // Result should be invariant - always exactly 3 docs
     for (int i = 0; i < 10_000; i++) {
-      assertEquals(getNumberOfFilteredDocs(segment, new SegmentContext(segment), queryContext), 3);
+      SegmentContext segmentContext = new SegmentContext(segment);
+      segmentContext.setQueryableDocIdsSnapshot(SegmentContext.getQueryableDocIdsSnapshotFromSegment(segment));
+      assertEquals(getNumberOfFilteredDocs(segmentContext, queryContext), 3);
     }
 
     updater.join();
   }
 
-  private int getNumberOfFilteredDocs(IndexSegment segment, SegmentContext segmentContext, QueryContext queryContext) {
-    FilterPlanNode node = new FilterPlanNode(segment, segmentContext, queryContext, null);
+  private int getNumberOfFilteredDocs(SegmentContext segmentContext, QueryContext queryContext) {
+    FilterPlanNode node = new FilterPlanNode(segmentContext, queryContext, null);
     BaseFilterOperator op = node.run();
     int numDocsFiltered = 0;
     FilterBlock block = op.nextBlock();

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/FilterPlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/FilterPlanNodeTest.java
@@ -79,7 +79,7 @@ public class FilterPlanNodeTest {
   }
 
   private int getNumberOfFilteredDocs(SegmentContext segmentContext, QueryContext queryContext) {
-    FilterPlanNode node = new FilterPlanNode(segmentContext, queryContext, null);
+    FilterPlanNode node = new FilterPlanNode(segmentContext, queryContext);
     BaseFilterOperator op = node.run();
     int numDocsFiltered = 0;
     FilterBlock block = op.nextBlock();

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/FilterPlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/FilterPlanNodeTest.java
@@ -26,6 +26,7 @@ import org.apache.pinot.core.operator.filter.BaseFilterOperator;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.mockito.stubbing.Answer;
@@ -48,8 +49,8 @@ public class FilterPlanNodeTest {
     when(segment.getValidDocIds()).thenReturn(bitmap);
     AtomicInteger numDocs = new AtomicInteger(0);
     when(meta.getTotalDocs()).then((Answer<Integer>) invocationOnMock -> numDocs.get());
-    QueryContext ctx = mock(QueryContext.class);
-    when(ctx.getFilter()).thenReturn(null);
+    QueryContext queryContext = mock(QueryContext.class);
+    when(queryContext.getFilter()).thenReturn(null);
 
     numDocs.set(3);
     bitmap.add(0);
@@ -69,14 +70,14 @@ public class FilterPlanNodeTest {
 
     // Result should be invariant - always exactly 3 docs
     for (int i = 0; i < 10_000; i++) {
-      assertEquals(getNumberOfFilteredDocs(segment, ctx), 3);
+      assertEquals(getNumberOfFilteredDocs(segment, new SegmentContext(segment), queryContext), 3);
     }
 
     updater.join();
   }
 
-  private int getNumberOfFilteredDocs(IndexSegment segment, QueryContext ctx) {
-    FilterPlanNode node = new FilterPlanNode(segment, ctx);
+  private int getNumberOfFilteredDocs(IndexSegment segment, SegmentContext segmentContext, QueryContext queryContext) {
+    FilterPlanNode node = new FilterPlanNode(segment, segmentContext, queryContext, null);
     BaseFilterOperator op = node.run();
     int numDocsFiltered = 0;
     FilterBlock block = op.nextBlock();

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/FilterPlanNodeTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/FilterPlanNodeTest.java
@@ -71,7 +71,7 @@ public class FilterPlanNodeTest {
     // Result should be invariant - always exactly 3 docs
     for (int i = 0; i < 10_000; i++) {
       SegmentContext segmentContext = new SegmentContext(segment);
-      segmentContext.setQueryableDocIdsSnapshot(SegmentContext.getQueryableDocIdsSnapshotFromSegment(segment));
+      segmentContext.setQueryableDocIdsSnapshot(TestUtils.getQueryableDocIdsSnapshotFromSegment(segment));
       assertEquals(getNumberOfFilteredDocs(segmentContext, queryContext), 3);
     }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/TestUtils.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/TestUtils.java
@@ -16,28 +16,28 @@
  * specific language governing permissions and limitations
  * under the License.
  */
-package org.apache.pinot.segment.spi;
+package org.apache.pinot.core.plan;
 
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
-public class SegmentContext {
-  private final IndexSegment _indexSegment;
-  private MutableRoaringBitmap _queryableDocIdsSnapshot = null;
-
-  public SegmentContext(IndexSegment indexSegment) {
-    _indexSegment = indexSegment;
+public class TestUtils {
+  private TestUtils() {
   }
 
-  public IndexSegment getIndexSegment() {
-    return _indexSegment;
-  }
-
-  public MutableRoaringBitmap getQueryableDocIdsSnapshot() {
-    return _queryableDocIdsSnapshot;
-  }
-
-  public void setQueryableDocIdsSnapshot(MutableRoaringBitmap queryableDocIdsSnapshot) {
-    _queryableDocIdsSnapshot = queryableDocIdsSnapshot;
+  public static MutableRoaringBitmap getQueryableDocIdsSnapshotFromSegment(IndexSegment segment) {
+    MutableRoaringBitmap queryableDocIdsSnapshot = null;
+    ThreadSafeMutableRoaringBitmap queryableDocIds = segment.getQueryableDocIds();
+    if (queryableDocIds != null) {
+      queryableDocIdsSnapshot = queryableDocIds.getMutableRoaringBitmap();
+    } else {
+      ThreadSafeMutableRoaringBitmap validDocIds = segment.getValidDocIds();
+      if (validDocIds != null) {
+        queryableDocIdsSnapshot = validDocIds.getMutableRoaringBitmap();
+      }
+    }
+    return queryableDocIdsSnapshot;
   }
 }

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -40,6 +40,7 @@ import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationD
 import org.apache.pinot.segment.local.upsert.ConcurrentMapPartitionUpsertMetadataManager;
 import org.apache.pinot.segment.local.upsert.UpsertContext;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.creator.SegmentIndexCreationDriver;
 import org.apache.pinot.segment.spi.index.StandardIndexes;
@@ -155,7 +156,10 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
     Operator<?> operator = PLAN_MAKER.makeSegmentPlanNode(_indexSegment, queryContext).run();
     assertTrue(operatorClass.isInstance(operator));
-    Operator<?> upsertOperator = PLAN_MAKER.makeSegmentPlanNode(_upsertIndexSegment, queryContext).run();
+    Operator<?> upsertOperator =
+        PLAN_MAKER.makeSegmentPlanNode(_upsertIndexSegment, new SegmentContext(_upsertIndexSegment), queryContext)
+            .run();
+    System.out.println(upsertOperator.toExplainString());
     assertTrue(upsertOperatorClass.isInstance(upsertOperator));
   }
 
@@ -200,8 +204,8 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     });
     // MINMAXRANGE from dictionary with match all filter
     entries.add(new Object[]{
-        "select minmaxrange(daysSinceEpoch) from testTable where column1 > 10", NonScanBasedAggregationOperator.class,
-        AggregationOperator.class
+        "select minmaxrange(daysSinceEpoch) from testTable where column1 > 10", NonScanBasedAggregationOperator.class
+        , AggregationOperator.class
     });
     // Aggregation
     entries.add(new Object[]{

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -154,11 +154,13 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
   public void testPlanMaker(String query, Class<? extends Operator<?>> operatorClass,
       Class<? extends Operator<?>> upsertOperatorClass) {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
-    Operator<?> operator = PLAN_MAKER.makeSegmentPlanNode(_indexSegment, queryContext).run();
+    Operator<?> operator = PLAN_MAKER.makeSegmentPlanNode(new SegmentContext(_indexSegment), queryContext).run();
     assertTrue(operatorClass.isInstance(operator));
-    Operator<?> upsertOperator =
-        PLAN_MAKER.makeSegmentPlanNode(_upsertIndexSegment, new SegmentContext(_upsertIndexSegment), queryContext)
-            .run();
+
+    SegmentContext segmentContext = new SegmentContext(_upsertIndexSegment);
+    segmentContext.setQueryableDocIdsSnapshot(
+        SegmentContext.getQueryableDocIdsSnapshotFromSegment(_upsertIndexSegment));
+    Operator<?> upsertOperator = PLAN_MAKER.makeSegmentPlanNode(segmentContext, queryContext).run();
     assertTrue(upsertOperatorClass.isInstance(upsertOperator));
   }
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -159,7 +159,6 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     Operator<?> upsertOperator =
         PLAN_MAKER.makeSegmentPlanNode(_upsertIndexSegment, new SegmentContext(_upsertIndexSegment), queryContext)
             .run();
-    System.out.println(upsertOperator.toExplainString());
     assertTrue(upsertOperatorClass.isInstance(upsertOperator));
   }
 
@@ -204,8 +203,8 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     });
     // MINMAXRANGE from dictionary with match all filter
     entries.add(new Object[]{
-        "select minmaxrange(daysSinceEpoch) from testTable where column1 > 10", NonScanBasedAggregationOperator.class
-        , AggregationOperator.class
+        "select minmaxrange(daysSinceEpoch) from testTable where column1 > 10", NonScanBasedAggregationOperator.class,
+        AggregationOperator.class
     });
     // Aggregation
     entries.add(new Object[]{

--- a/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/plan/maker/MetadataAndDictionaryAggregationPlanMakerTest.java
@@ -32,6 +32,7 @@ import org.apache.pinot.core.operator.query.FastFilteredCountOperator;
 import org.apache.pinot.core.operator.query.GroupByOperator;
 import org.apache.pinot.core.operator.query.NonScanBasedAggregationOperator;
 import org.apache.pinot.core.operator.query.SelectionOnlyOperator;
+import org.apache.pinot.core.plan.TestUtils;
 import org.apache.pinot.core.query.request.context.QueryContext;
 import org.apache.pinot.core.query.request.context.utils.QueryContextConverterUtils;
 import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentImpl;
@@ -158,8 +159,7 @@ public class MetadataAndDictionaryAggregationPlanMakerTest {
     assertTrue(operatorClass.isInstance(operator));
 
     SegmentContext segmentContext = new SegmentContext(_upsertIndexSegment);
-    segmentContext.setQueryableDocIdsSnapshot(
-        SegmentContext.getQueryableDocIdsSnapshotFromSegment(_upsertIndexSegment));
+    segmentContext.setQueryableDocIdsSnapshot(TestUtils.getQueryableDocIdsSnapshotFromSegment(_upsertIndexSegment));
     Operator<?> upsertOperator = PLAN_MAKER.makeSegmentPlanNode(segmentContext, queryContext).run();
     assertTrue(upsertOperatorClass.isInstance(upsertOperator));
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/DictionaryBasedGroupKeyGeneratorTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoa
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -151,8 +152,8 @@ public class DictionaryBasedGroupKeyGeneratorTest {
     for (String column : MV_COLUMNS) {
       expressions.add(ExpressionContext.forIdentifier(column));
     }
-    ProjectPlanNode projectPlanNode =
-        new ProjectPlanNode(indexSegment, queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL);
+    ProjectPlanNode projectPlanNode = new ProjectPlanNode(new SegmentContext(indexSegment), queryContext, expressions,
+        DocIdSetPlanNode.MAX_DOC_PER_CALL);
     _projectOperator = projectPlanNode.run();
     _valueBlock = _projectOperator.nextBlock();
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/GroupByTrimTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/GroupByTrimTest.java
@@ -41,6 +41,7 @@ import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoa
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableType;
 import org.apache.pinot.spi.data.FieldSpec;
@@ -119,7 +120,8 @@ public class GroupByTrimTest {
     queryContext.setMinServerGroupTrimSize(minServerGroupTrimSize);
 
     // Create a query operator
-    Operator<GroupByResultsBlock> groupByOperator = new GroupByPlanNode(_indexSegment, queryContext).run();
+    Operator<GroupByResultsBlock> groupByOperator =
+        new GroupByPlanNode(new SegmentContext(_indexSegment), queryContext).run();
     GroupByCombineOperator combineOperator =
         new GroupByCombineOperator(Collections.singletonList(groupByOperator), queryContext, _executorService);
 

--- a/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/query/aggregation/groupby/NoDictionaryGroupKeyGeneratorTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.segment.local.indexsegment.immutable.ImmutableSegmentLoa
 import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationDriverImpl;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -154,8 +155,8 @@ public class NoDictionaryGroupKeyGeneratorTest {
     for (String column : COLUMNS) {
       expressions.add(ExpressionContext.forIdentifier(column));
     }
-    ProjectPlanNode projectPlanNode =
-        new ProjectPlanNode(_indexSegment, queryContext, expressions, DocIdSetPlanNode.MAX_DOC_PER_CALL);
+    ProjectPlanNode projectPlanNode = new ProjectPlanNode(new SegmentContext(_indexSegment), queryContext, expressions,
+        DocIdSetPlanNode.MAX_DOC_PER_CALL);
     _projectOperator = projectPlanNode.run();
     _valueBlock = _projectOperator.nextBlock();
   }

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -47,6 +47,7 @@ import org.apache.pinot.segment.local.startree.v2.builder.MultipleTreesBuilder;
 import org.apache.pinot.segment.spi.AggregationFunctionType;
 import org.apache.pinot.segment.spi.Constants;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.segment.spi.datasource.DataSource;
 import org.apache.pinot.segment.spi.index.reader.Dictionary;
@@ -230,7 +231,7 @@ abstract class BaseStarTreeV2Test<R, A> {
 
   private void testUnsupportedFilter(String query) {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
-    FilterPlanNode filterPlanNode = new FilterPlanNode(_indexSegment, queryContext);
+    FilterPlanNode filterPlanNode = new FilterPlanNode(new SegmentContext(_indexSegment), queryContext, null);
     filterPlanNode.run();
     Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap =
         StarTreeUtils.extractPredicateEvaluatorsMap(_indexSegment, queryContext.getFilter(),
@@ -262,7 +263,7 @@ abstract class BaseStarTreeV2Test<R, A> {
     List<String> groupByColumns = new ArrayList<>(groupByColumnSet);
 
     // Filter
-    FilterPlanNode filterPlanNode = new FilterPlanNode(_indexSegment, queryContext);
+    FilterPlanNode filterPlanNode = new FilterPlanNode(new SegmentContext(_indexSegment), queryContext, null);
     filterPlanNode.run();
     Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap =
         StarTreeUtils.extractPredicateEvaluatorsMap(_indexSegment, queryContext.getFilter(),
@@ -285,7 +286,8 @@ abstract class BaseStarTreeV2Test<R, A> {
         computeStarTreeResult(starTreeFilterPlanNode, starTreeAggregationColumnReaders, starTreeGroupByColumnReaders);
 
     // Extract values without star-tree
-    FilterPlanNode nonStarTreeFilterPlanNode = new FilterPlanNode(_indexSegment, queryContext);
+    FilterPlanNode nonStarTreeFilterPlanNode =
+        new FilterPlanNode(new SegmentContext(_indexSegment), queryContext, null);
     List<ForwardIndexReader> nonStarTreeAggregationColumnReaders = new ArrayList<>(numAggregations);
     List<Dictionary> nonStarTreeAggregationColumnDictionaries = new ArrayList<>(numAggregations);
     for (AggregationFunctionColumnPair aggregationFunctionColumnPair : aggregationFunctionColumnPairs) {

--- a/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
+++ b/pinot-core/src/test/java/org/apache/pinot/core/startree/v2/BaseStarTreeV2Test.java
@@ -231,7 +231,7 @@ abstract class BaseStarTreeV2Test<R, A> {
 
   private void testUnsupportedFilter(String query) {
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(query);
-    FilterPlanNode filterPlanNode = new FilterPlanNode(new SegmentContext(_indexSegment), queryContext, null);
+    FilterPlanNode filterPlanNode = new FilterPlanNode(new SegmentContext(_indexSegment), queryContext);
     filterPlanNode.run();
     Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap =
         StarTreeUtils.extractPredicateEvaluatorsMap(_indexSegment, queryContext.getFilter(),
@@ -263,7 +263,7 @@ abstract class BaseStarTreeV2Test<R, A> {
     List<String> groupByColumns = new ArrayList<>(groupByColumnSet);
 
     // Filter
-    FilterPlanNode filterPlanNode = new FilterPlanNode(new SegmentContext(_indexSegment), queryContext, null);
+    FilterPlanNode filterPlanNode = new FilterPlanNode(new SegmentContext(_indexSegment), queryContext);
     filterPlanNode.run();
     Map<String, List<CompositePredicateEvaluator>> predicateEvaluatorsMap =
         StarTreeUtils.extractPredicateEvaluatorsMap(_indexSegment, queryContext.getFilter(),
@@ -286,8 +286,7 @@ abstract class BaseStarTreeV2Test<R, A> {
         computeStarTreeResult(starTreeFilterPlanNode, starTreeAggregationColumnReaders, starTreeGroupByColumnReaders);
 
     // Extract values without star-tree
-    FilterPlanNode nonStarTreeFilterPlanNode =
-        new FilterPlanNode(new SegmentContext(_indexSegment), queryContext, null);
+    FilterPlanNode nonStarTreeFilterPlanNode = new FilterPlanNode(new SegmentContext(_indexSegment), queryContext);
     List<ForwardIndexReader> nonStarTreeAggregationColumnReaders = new ArrayList<>(numAggregations);
     List<Dictionary> nonStarTreeAggregationColumnDictionaries = new ArrayList<>(numAggregations);
     for (AggregationFunctionColumnPair aggregationFunctionColumnPair : aggregationFunctionColumnPairs) {

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BaseQueriesTest.java
@@ -245,7 +245,7 @@ public abstract class BaseQueriesTest {
   }
 
   private static List<SegmentContext> getSegmentContexts(List<IndexSegment> indexSegments) {
-    List<SegmentContext> segmentContexts = new ArrayList<>();
+    List<SegmentContext> segmentContexts = new ArrayList<>(indexSegments.size());
     indexSegments.forEach(s -> segmentContexts.add(new SegmentContext(s)));
     return segmentContexts;
   }

--- a/pinot-core/src/test/java/org/apache/pinot/queries/BooleanAggQueriesTest.java
+++ b/pinot-core/src/test/java/org/apache/pinot/queries/BooleanAggQueriesTest.java
@@ -42,6 +42,7 @@ import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationD
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -165,7 +166,7 @@ public class BooleanAggQueriesTest extends BaseQueriesTest {
 
     PinotQuery serverPinotQuery = GapfillUtils.stripGapfill(pinotQuery);
     QueryContext queryContext = QueryContextConverterUtils.getQueryContext(serverPinotQuery);
-    return (T) PLAN_MAKER.makeSegmentPlanNode(getIndexSegment(), queryContext).run();
+    return (T) PLAN_MAKER.makeSegmentPlanNode(new SegmentContext(getIndexSegment()), queryContext).run();
   }
 
   @Test(dataProvider = "nullHandling")

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNativeAndLuceneBasedLike.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNativeAndLuceneBasedLike.java
@@ -36,6 +36,7 @@ import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationD
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.FSTType;
 import org.apache.pinot.spi.config.table.FieldConfig;
@@ -171,7 +172,7 @@ public class BenchmarkNativeAndLuceneBasedLike {
   @Benchmark
   @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public void query(Blackhole bh) {
-    Operator<?> operator = _planMaker.makeSegmentPlanNode(_indexSegment, _queryContext).run();
+    Operator<?> operator = _planMaker.makeSegmentPlanNode(new SegmentContext(_indexSegment), _queryContext).run();
     bh.consume(operator);
     for (int i = 0; i < _numBlocks; i++) {
       bh.consume(operator.nextBlock());

--- a/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNativeVsLuceneTextIndex.java
+++ b/pinot-perf/src/main/java/org/apache/pinot/perf/BenchmarkNativeVsLuceneTextIndex.java
@@ -39,6 +39,7 @@ import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.FSTType;
 import org.apache.pinot.spi.config.table.FieldConfig;
@@ -204,7 +205,7 @@ public class BenchmarkNativeVsLuceneTextIndex {
   @Benchmark
   @CompilerControl(CompilerControl.Mode.DONT_INLINE)
   public void query(Blackhole bh) {
-    Operator<?> operator = _planMaker.makeSegmentPlanNode(_indexSegment, _queryContext).run();
+    Operator<?> operator = _planMaker.makeSegmentPlanNode(new SegmentContext(_indexSegment), _queryContext).run();
     for (int i = 0; i < _numBlocks; i++) {
       bh.consume(operator.nextBlock());
     }

--- a/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
+++ b/pinot-query-runtime/src/test/java/org/apache/pinot/query/testutils/MockInstanceDataManagerFactory.java
@@ -35,6 +35,7 @@ import org.apache.pinot.segment.local.segment.creator.impl.SegmentIndexCreationD
 import org.apache.pinot.segment.local.segment.readers.GenericRowRecordReader;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.creator.SegmentGeneratorConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.TableType;
@@ -46,6 +47,7 @@ import org.apache.pinot.spi.utils.builder.TableConfigBuilder;
 import org.apache.pinot.spi.utils.builder.TableNameBuilder;
 
 import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyMap;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -155,6 +157,10 @@ public class MockInstanceDataManagerFactory {
     when(tableDataManager.acquireSegments(anyList(), eq(null), anyList())).thenAnswer(invocation -> {
       List<String> segments = invocation.getArgument(0);
       return segments.stream().map(segmentDataManagerMap::get).collect(Collectors.toList());
+    });
+    when(tableDataManager.getSegmentContexts(anyList(), anyMap())).thenAnswer(invocation -> {
+      List<IndexSegment> segments = invocation.getArgument(0);
+      return segments.stream().map(SegmentContext::new).collect(Collectors.toList());
     });
     return tableDataManager;
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -256,10 +256,8 @@ public interface TableDataManager {
   default void onConsumingToOnline(String segmentNameStr) {
   }
 
-  // TODO: Should this interface be put in pinot.core where RealtimeTableDataManager/OfflineDataDataManager/etc.
-  //       classes are placed. Then we can pass queryContext into this method instead of individual query option.
   default Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
-      boolean isSkipUpsert) {
+      Map<String, String> queryOptions) {
     return null;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -256,7 +256,10 @@ public interface TableDataManager {
   default void onConsumingToOnline(String segmentNameStr) {
   }
 
-  default Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments) {
+  // TODO: Should this interface be put in pinot.core where RealtimeTableDataManager/OfflineDataDataManager/etc.
+  //       classes are placed. Then we can pass queryContext into this method instead of individual query option.
+  default Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
+      boolean isSkipUpsert) {
     return null;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -241,6 +241,13 @@ public interface TableDataManager {
   Map<String, SegmentErrorInfo> getSegmentErrors();
 
   /**
+   * Get more context for the selected segments for query execution, e.g. getting the validDocIds bitmaps for segments
+   * in upsert tables. This method allows contexts of many segments to be obtained together, making it easier to
+   * ensure data consistency across those segments if needed.
+   */
+  List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments, Map<String, String> queryOptions);
+
+  /**
    * Interface to handle segment state transitions from CONSUMING to DROPPED
    *
    * @param segmentNameStr name of segment for which the state change is being handled
@@ -254,10 +261,5 @@ public interface TableDataManager {
    * @param segmentNameStr name of segment for which the state change is being handled
    */
   default void onConsumingToOnline(String segmentNameStr) {
-  }
-
-  default Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments,
-      Map<String, String> queryOptions) {
-    return null;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/data/manager/TableDataManager.java
@@ -31,6 +31,8 @@ import org.apache.pinot.common.metadata.segment.SegmentZKMetadata;
 import org.apache.pinot.common.restlet.resources.SegmentErrorInfo;
 import org.apache.pinot.segment.local.segment.index.loader.IndexLoadingConfig;
 import org.apache.pinot.segment.spi.ImmutableSegment;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.SegmentMetadata;
 import org.apache.pinot.spi.config.instance.InstanceDataManagerConfig;
 import org.apache.pinot.spi.config.table.TableConfig;
@@ -252,5 +254,9 @@ public interface TableDataManager {
    * @param segmentNameStr name of segment for which the state change is being handled
    */
   default void onConsumingToOnline(String segmentNameStr) {
+  }
+
+  default Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments) {
+    return null;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -33,6 +33,7 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
@@ -65,6 +66,7 @@ import org.apache.pinot.segment.local.utils.SegmentLocks;
 import org.apache.pinot.segment.spi.ImmutableSegment;
 import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.MutableSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.segment.spi.V1Constants;
 import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.apache.pinot.segment.spi.store.SegmentDirectoryPaths;
@@ -1037,6 +1039,72 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     // the primary key count. So, we set the primary key count to 0 here.
     updatePrimaryKeyGauge(0);
     _logger.info("Closed the metadata manager");
+  }
+
+  protected void replaceDocId(ThreadSafeMutableRoaringBitmap validDocIds,
+      @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, IndexSegment oldSegment, int oldDocId, int newDocId,
+      RecordInfo recordInfo) {
+    removeDocId(oldSegment, oldDocId);
+    addDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
+  }
+
+  protected void replaceDocId(ThreadSafeMutableRoaringBitmap validDocIds,
+      @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, int oldDocId, int newDocId, RecordInfo recordInfo) {
+    validDocIds.replace(oldDocId, newDocId);
+    if (queryableDocIds != null) {
+      if (recordInfo.isDeleteRecord()) {
+        queryableDocIds.remove(oldDocId);
+      } else {
+        queryableDocIds.replace(oldDocId, newDocId);
+      }
+    }
+  }
+
+  protected void addDocId(ThreadSafeMutableRoaringBitmap validDocIds,
+      @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, int docId, RecordInfo recordInfo) {
+    validDocIds.add(docId);
+    if (queryableDocIds != null && !recordInfo.isDeleteRecord()) {
+      queryableDocIds.add(docId);
+    }
+  }
+
+  protected void removeDocId(IndexSegment segment, int docId) {
+    Objects.requireNonNull(segment.getValidDocIds()).remove(docId);
+    ThreadSafeMutableRoaringBitmap currentQueryableDocIds = segment.getQueryableDocIds();
+    if (currentQueryableDocIds != null) {
+      currentQueryableDocIds.remove(docId);
+    }
+  }
+
+  /**
+   * Use the segmentContexts to collect the contexts for selected segments. Reuse the segmentContext object if
+   * present, to avoid overwriting the contexts specified at the others places.
+   */
+  public void getUpsertView(List<IndexSegment> selectedSegments, Map<IndexSegment, SegmentContext> segmentContexts) {
+    for (IndexSegment segment : selectedSegments) {
+      if (_trackedSegments.contains(segment)) {
+        segmentContexts.computeIfAbsent(segment, k -> new SegmentContext())
+            .setQueryableDocIdsSnapshot(getSegmentUpsertView(segment));
+      }
+    }
+  }
+
+  /**
+   * The table partition's data view is formed with the validDocIds bitmap or queryableDocIds bitmap of its all
+   * segments. Using the queryableDocIds if existing.
+   */
+  private static MutableRoaringBitmap getSegmentUpsertView(IndexSegment segment) {
+    MutableRoaringBitmap upsertView = null;
+    ThreadSafeMutableRoaringBitmap queryableDocIds = segment.getQueryableDocIds();
+    if (queryableDocIds != null) {
+      upsertView = queryableDocIds.getMutableRoaringBitmap();
+    } else {
+      ThreadSafeMutableRoaringBitmap validDocIds = segment.getValidDocIds();
+      if (validDocIds != null) {
+        upsertView = validDocIds.getMutableRoaringBitmap();
+      }
+    }
+    return upsertView;
   }
 
   protected void doClose()

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -1084,27 +1084,9 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
     for (IndexSegment segment : selectedSegments) {
       if (_trackedSegments.contains(segment)) {
         segmentContexts.computeIfAbsent(segment, k -> new SegmentContext())
-            .setQueryableDocIdsSnapshot(getSegmentUpsertView(segment));
+            .setQueryableDocIdsSnapshot(SegmentContext.getQueryableDocIdsSnapshotFromSegment(segment));
       }
     }
-  }
-
-  /**
-   * The table partition's data view is formed with the validDocIds bitmap or queryableDocIds bitmap of its all
-   * segments. Using the queryableDocIds if existing.
-   */
-  private static MutableRoaringBitmap getSegmentUpsertView(IndexSegment segment) {
-    MutableRoaringBitmap upsertView = null;
-    ThreadSafeMutableRoaringBitmap queryableDocIds = segment.getQueryableDocIds();
-    if (queryableDocIds != null) {
-      upsertView = queryableDocIds.getMutableRoaringBitmap();
-    } else {
-      ThreadSafeMutableRoaringBitmap validDocIds = segment.getValidDocIds();
-      if (validDocIds != null) {
-        upsertView = validDocIds.getMutableRoaringBitmap();
-      }
-    }
-    return upsertView;
   }
 
   protected void doClose()

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BasePartitionUpsertMetadataManager.java
@@ -1080,11 +1080,12 @@ public abstract class BasePartitionUpsertMetadataManager implements PartitionUps
    * Use the segmentContexts to collect the contexts for selected segments. Reuse the segmentContext object if
    * present, to avoid overwriting the contexts specified at the others places.
    */
-  public void getUpsertView(List<IndexSegment> selectedSegments, Map<IndexSegment, SegmentContext> segmentContexts) {
+  public void getSegmentContexts(List<IndexSegment> selectedSegments, List<SegmentContext> segmentContexts) {
     for (IndexSegment segment : selectedSegments) {
       if (_trackedSegments.contains(segment)) {
-        segmentContexts.computeIfAbsent(segment, k -> new SegmentContext())
-            .setQueryableDocIdsSnapshot(SegmentContext.getQueryableDocIdsSnapshotFromSegment(segment));
+        SegmentContext segmentContext = new SegmentContext(segment);
+        segmentContext.setQueryableDocIdsSnapshot(SegmentContext.getQueryableDocIdsSnapshotFromSegment(segment));
+        segmentContexts.add(segmentContext);
       }
     }
   }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -20,15 +20,12 @@ package org.apache.pinot.segment.local.upsert;
 
 import com.google.common.base.Preconditions;
 import java.io.File;
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
-import org.apache.pinot.segment.spi.IndexSegment;
-import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
@@ -104,12 +101,5 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
   @Override
   public UpsertConfig.Mode getUpsertMode() {
     return _context.getPartialUpsertHandler() == null ? UpsertConfig.Mode.FULL : UpsertConfig.Mode.PARTIAL;
-  }
-
-  @Override
-  public List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments) {
-    List<SegmentContext> segmentContexts = new ArrayList<>();
-    selectedSegments.forEach(s -> segmentContexts.add(new SegmentContext(s)));
-    return segmentContexts;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/BaseTableUpsertMetadataManager.java
@@ -20,12 +20,15 @@ package org.apache.pinot.segment.local.upsert;
 
 import com.google.common.base.Preconditions;
 import java.io.File;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.commons.collections.CollectionUtils;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.spi.config.table.HashFunction;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
@@ -101,5 +104,12 @@ public abstract class BaseTableUpsertMetadataManager implements TableUpsertMetad
   @Override
   public UpsertConfig.Mode getUpsertMode() {
     return _context.getPartialUpsertHandler() == null ? UpsertConfig.Mode.FULL : UpsertConfig.Mode.PARTIAL;
+  }
+
+  @Override
+  public List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments) {
+    List<SegmentContext> segmentContexts = new ArrayList<>();
+    selectedSegments.forEach(s -> segmentContexts.add(new SegmentContext(s)));
+    return segmentContexts;
   }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapPartitionUpsertMetadataManager.java
@@ -136,8 +136,7 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
                   && LLCSegmentName.isLLCSegment(currentSegmentName)
                   && LLCSegmentName.getSequenceNumber(segmentName) > LLCSegmentName.getSequenceNumber(
                   currentSegmentName))) {
-                removeDocId(currentSegment, currentDocId);
-                addDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
+                replaceDocId(validDocIds, queryableDocIds, currentSegment, currentDocId, newDocId, recordInfo);
                 return new RecordLocation(segment, newDocId, newComparisonValue);
               } else {
                 return currentRecordLocation;
@@ -167,34 +166,6 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
       addDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
       _primaryKeyToRecordLocationMap.put(HashUtils.hashPrimaryKey(recordInfo.getPrimaryKey(), _hashFunction),
           new RecordLocation(segment, newDocId, newComparisonValue));
-    }
-  }
-
-  private static void replaceDocId(ThreadSafeMutableRoaringBitmap validDocIds,
-      @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, int oldDocId, int newDocId, RecordInfo recordInfo) {
-    validDocIds.replace(oldDocId, newDocId);
-    if (queryableDocIds != null) {
-      if (recordInfo.isDeleteRecord()) {
-        queryableDocIds.remove(oldDocId);
-      } else {
-        queryableDocIds.replace(oldDocId, newDocId);
-      }
-    }
-  }
-
-  private static void addDocId(ThreadSafeMutableRoaringBitmap validDocIds,
-      @Nullable ThreadSafeMutableRoaringBitmap queryableDocIds, int docId, RecordInfo recordInfo) {
-    validDocIds.add(docId);
-    if (queryableDocIds != null && !recordInfo.isDeleteRecord()) {
-      queryableDocIds.add(docId);
-    }
-  }
-
-  private static void removeDocId(IndexSegment segment, int docId) {
-    Objects.requireNonNull(segment.getValidDocIds()).remove(docId);
-    ThreadSafeMutableRoaringBitmap currentQueryableDocIds = segment.getQueryableDocIds();
-    if (currentQueryableDocIds != null) {
-      currentQueryableDocIds.remove(docId);
     }
   }
 
@@ -303,8 +274,7 @@ public class ConcurrentMapPartitionUpsertMetadataManager extends BasePartitionUp
               if (segment == currentSegment) {
                 replaceDocId(validDocIds, queryableDocIds, currentDocId, newDocId, recordInfo);
               } else {
-                removeDocId(currentSegment, currentDocId);
-                addDocId(validDocIds, queryableDocIds, newDocId, recordInfo);
+                replaceDocId(validDocIds, queryableDocIds, currentSegment, currentDocId, newDocId, recordInfo);
               }
               return new RecordLocation(segment, newDocId, newComparisonValue);
             } else {

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -19,13 +19,11 @@
 package org.apache.pinot.segment.local.upsert;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.ThreadSafe;
-import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 
 
@@ -60,10 +58,9 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   }
 
   @Override
-  public List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments) {
-    List<SegmentContext> segmentContexts = new ArrayList<>(selectedSegments.size());
-    _partitionMetadataManagerMap.forEach((k, v) -> v.getSegmentContexts(selectedSegments, segmentContexts));
-    return segmentContexts;
+  public void setSegmentContexts(List<SegmentContext> segmentContexts) {
+    _partitionMetadataManagerMap.forEach(
+        (partitionID, upsertMetadataManager) -> upsertMetadataManager.setSegmentContexts(segmentContexts));
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -19,6 +19,7 @@
 package org.apache.pinot.segment.local.upsert;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -59,10 +60,9 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
   }
 
   @Override
-  public Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments) {
-    Map<IndexSegment, SegmentContext> segmentContexts = new HashMap<>();
-    _partitionMetadataManagerMap.forEach(
-        (k, v) -> v.getUpsertView(selectedSegments, segmentContexts));
+  public List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments) {
+    List<SegmentContext> segmentContexts = new ArrayList<>(selectedSegments.size());
+    _partitionMetadataManagerMap.forEach((k, v) -> v.getSegmentContexts(selectedSegments, segmentContexts));
     return segmentContexts;
   }
 

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/ConcurrentMapTableUpsertMetadataManager.java
@@ -20,9 +20,12 @@ package org.apache.pinot.segment.local.upsert;
 
 import java.io.IOException;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.concurrent.ThreadSafe;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 
 
 /**
@@ -53,6 +56,14 @@ public class ConcurrentMapTableUpsertMetadataManager extends BaseTableUpsertMeta
         (partitionID, upsertMetadataManager) -> partitionToPrimaryKeyCount.put(partitionID,
             upsertMetadataManager.getNumPrimaryKeys()));
     return partitionToPrimaryKeyCount;
+  }
+
+  @Override
+  public Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments) {
+    Map<IndexSegment, SegmentContext> segmentContexts = new HashMap<>();
+    _partitionMetadataManagerMap.forEach(
+        (k, v) -> v.getUpsertView(selectedSegments, segmentContexts));
+    return segmentContexts;
   }
 
   @Override

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
-import org.apache.pinot.segment.spi.IndexSegment;
 import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
@@ -54,5 +53,6 @@ public interface TableUpsertMetadataManager extends Closeable {
    */
   Map<Integer, Long> getPartitionToPrimaryKeyCount();
 
-  List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments);
+  default void setSegmentContexts(List<SegmentContext> segmentContexts) {
+  }
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -54,7 +54,5 @@ public interface TableUpsertMetadataManager extends Closeable {
    */
   Map<Integer, Long> getPartitionToPrimaryKeyCount();
 
-  default Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments) {
-    return null;
-  }
+  List<SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments);
 }

--- a/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
+++ b/pinot-segment-local/src/main/java/org/apache/pinot/segment/local/upsert/TableUpsertMetadataManager.java
@@ -19,9 +19,12 @@
 package org.apache.pinot.segment.local.upsert;
 
 import java.io.Closeable;
+import java.util.List;
 import java.util.Map;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.pinot.segment.local.data.manager.TableDataManager;
+import org.apache.pinot.segment.spi.IndexSegment;
+import org.apache.pinot.segment.spi.SegmentContext;
 import org.apache.pinot.spi.config.table.TableConfig;
 import org.apache.pinot.spi.config.table.UpsertConfig;
 import org.apache.pinot.spi.data.Schema;
@@ -50,4 +53,8 @@ public interface TableUpsertMetadataManager extends Closeable {
    * @return A {@code Map} where keys are partition id and values are count of primary keys for that specific partition
    */
   Map<Integer, Long> getPartitionToPrimaryKeyCount();
+
+  default Map<IndexSegment, SegmentContext> getSegmentContexts(List<IndexSegment> selectedSegments) {
+    return null;
+  }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentContext.java
@@ -18,6 +18,7 @@
  */
 package org.apache.pinot.segment.spi;
 
+import org.apache.pinot.segment.spi.index.mutable.ThreadSafeMutableRoaringBitmap;
 import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
@@ -27,11 +28,29 @@ public class SegmentContext {
   public SegmentContext() {
   }
 
+  public SegmentContext(IndexSegment segment) {
+    _queryableDocIdsSnapshot = getQueryableDocIdsSnapshotFromSegment(segment);
+  }
+
   public MutableRoaringBitmap getQueryableDocIdsSnapshot() {
     return _queryableDocIdsSnapshot;
   }
 
   public void setQueryableDocIdsSnapshot(MutableRoaringBitmap queryableDocIdsSnapshot) {
     _queryableDocIdsSnapshot = queryableDocIdsSnapshot;
+  }
+
+  public static MutableRoaringBitmap getQueryableDocIdsSnapshotFromSegment(IndexSegment segment) {
+    MutableRoaringBitmap queryableDocIdsSnapshot = null;
+    ThreadSafeMutableRoaringBitmap queryableDocIds = segment.getQueryableDocIds();
+    if (queryableDocIds != null) {
+      queryableDocIdsSnapshot = queryableDocIds.getMutableRoaringBitmap();
+    } else {
+      ThreadSafeMutableRoaringBitmap validDocIds = segment.getValidDocIds();
+      if (validDocIds != null) {
+        queryableDocIdsSnapshot = validDocIds.getMutableRoaringBitmap();
+      }
+    }
+    return queryableDocIdsSnapshot;
   }
 }

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentContext.java
@@ -23,13 +23,15 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
 public class SegmentContext {
+  private IndexSegment _indexSegment;
   private MutableRoaringBitmap _queryableDocIdsSnapshot = null;
 
-  public SegmentContext() {
+  public SegmentContext(IndexSegment indexSegment) {
+    _indexSegment = indexSegment;
   }
 
-  public SegmentContext(IndexSegment segment) {
-    _queryableDocIdsSnapshot = getQueryableDocIdsSnapshotFromSegment(segment);
+  public IndexSegment getIndexSegment() {
+    return _indexSegment;
   }
 
   public MutableRoaringBitmap getQueryableDocIdsSnapshot() {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentContext.java
@@ -23,7 +23,7 @@ import org.roaringbitmap.buffer.MutableRoaringBitmap;
 
 
 public class SegmentContext {
-  private IndexSegment _indexSegment;
+  private final IndexSegment _indexSegment;
   private MutableRoaringBitmap _queryableDocIdsSnapshot = null;
 
   public SegmentContext(IndexSegment indexSegment) {

--- a/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentContext.java
+++ b/pinot-segment-spi/src/main/java/org/apache/pinot/segment/spi/SegmentContext.java
@@ -1,0 +1,37 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pinot.segment.spi;
+
+import org.roaringbitmap.buffer.MutableRoaringBitmap;
+
+
+public class SegmentContext {
+  private MutableRoaringBitmap _queryableDocIdsSnapshot = null;
+
+  public SegmentContext() {
+  }
+
+  public MutableRoaringBitmap getQueryableDocIdsSnapshot() {
+    return _queryableDocIdsSnapshot;
+  }
+
+  public void setQueryableDocIdsSnapshot(MutableRoaringBitmap queryableDocIdsSnapshot) {
+    _queryableDocIdsSnapshot = queryableDocIdsSnapshot;
+  }
+}


### PR DESCRIPTION
This PR adds SegmentContext used to collect segment related context before query execution. E.g. this makes it easier to collect validDocIds for many segments together, so that we can add the support for consistent table view for upsert table easier later on.

This PR didn't change current functionalities but moved the logic of getting validDocId bitmaps upto one place, i.e. `tableDataMgr.getSegmentContexts(selectedSegments)`.